### PR TITLE
Revert `Ty` type alias in `rustc_type_ir`

### DIFF
--- a/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
@@ -78,7 +78,7 @@ pub(super) struct Canonicalizer<'a, D: SolverDelegate<Interner = I>, I: Interner
 
     /// We can simply cache based on the ty itself, because we use
     /// `ty::BoundVarIndexKind::Canonical`.
-    cache: HashMap<ty::Ty<I>, ty::Ty<I>>,
+    cache: HashMap<I::Ty, I::Ty>,
 }
 
 impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
@@ -316,7 +316,7 @@ impl<'a, D: SolverDelegate<Interner = I>, I: Interner> Canonicalizer<'a, D, I> {
         (max_universe, self.variables, var_kinds)
     }
 
-    fn inner_fold_ty(&mut self, t: ty::Ty<I>) -> ty::Ty<I> {
+    fn inner_fold_ty(&mut self, t: I::Ty) -> I::Ty {
         let kind = match t.kind() {
             ty::Infer(i) => match i {
                 ty::TyVar(vid) => {
@@ -475,7 +475,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
         Region::new_canonical_bound(self.cx(), var)
     }
 
-    fn fold_ty(&mut self, t: ty::Ty<I>) -> ty::Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         if !t.flags().intersects(NEEDS_CANONICAL) {
             t
         } else if let Some(&ty) = self.cache.get(&t) {

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -16,7 +16,7 @@ use rustc_index::IndexVec;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::relate::solver_relating::RelateExt;
 use rustc_type_ir::{
-    self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner, Ty,
+    self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner,
     TypeFoldable,
 };
 use tracing::instrument;
@@ -53,7 +53,7 @@ impl<I: Interner, T> ResponseT<I> for inspect::State<I, T> {
 pub(super) fn canonicalize_goal<D, I>(
     delegate: &D,
     goal: Goal<I, I::Predicate>,
-    opaque_types: &[(ty::OpaqueTypeKey<I>, Ty<I>)],
+    opaque_types: &[(ty::OpaqueTypeKey<I>, I::Ty)],
 ) -> (Vec<I::GenericArg>, CanonicalInput<I, I::Predicate>)
 where
     D: SolverDelegate<Interner = I>,
@@ -264,7 +264,7 @@ fn register_region_constraints<D, I>(
 
 fn register_new_opaque_types<D, I>(
     delegate: &D,
-    opaque_types: &[(ty::OpaqueTypeKey<I>, Ty<I>)],
+    opaque_types: &[(ty::OpaqueTypeKey<I>, I::Ty)],
     span: I::Span,
 ) where
     D: SolverDelegate<Interner = I>,

--- a/compiler/rustc_next_trait_solver/src/coherence.rs
+++ b/compiler/rustc_next_trait_solver/src/coherence.rs
@@ -47,7 +47,7 @@ pub enum Conflict {
 pub fn trait_ref_is_knowable<Infcx, I, E>(
     infcx: &Infcx,
     trait_ref: ty::TraitRef<I>,
-    mut lazily_normalize_ty: impl FnMut(ty::Ty<I>) -> Result<ty::Ty<I>, E>,
+    mut lazily_normalize_ty: impl FnMut(I::Ty) -> Result<I::Ty, E>,
 ) -> Result<Result<(), Conflict>, E>
 where
     Infcx: InferCtxtLike<Interner = I>,
@@ -115,14 +115,14 @@ impl From<bool> for IsFirstInputType {
 
 #[derive_where(Debug; I: Interner, T: Debug)]
 pub enum OrphanCheckErr<I: Interner, T> {
-    NonLocalInputType(Vec<(ty::Ty<I>, IsFirstInputType)>),
+    NonLocalInputType(Vec<(I::Ty, IsFirstInputType)>),
     UncoveredTyParams(UncoveredTyParams<I, T>),
 }
 
 #[derive_where(Debug; I: Interner, T: Debug)]
 pub struct UncoveredTyParams<I: Interner, T> {
     pub uncovered: T,
-    pub local_ty: Option<ty::Ty<I>>,
+    pub local_ty: Option<I::Ty>,
 }
 
 /// Checks whether a trait-ref is potentially implementable by a crate.
@@ -222,8 +222,8 @@ pub fn orphan_check_trait_ref<Infcx, I, E: Debug>(
     infcx: &Infcx,
     trait_ref: ty::TraitRef<I>,
     in_crate: InCrate,
-    lazily_normalize_ty: impl FnMut(ty::Ty<I>) -> Result<ty::Ty<I>, E>,
-) -> Result<Result<(), OrphanCheckErr<I, ty::Ty<I>>>, E>
+    lazily_normalize_ty: impl FnMut(I::Ty) -> Result<I::Ty, E>,
+) -> Result<Result<(), OrphanCheckErr<I, I::Ty>>, E>
 where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
@@ -262,14 +262,14 @@ struct OrphanChecker<'a, Infcx, I: Interner, F> {
     lazily_normalize_ty: F,
     /// Ignore orphan check failures and exclusively search for the first local type.
     search_first_local_ty: bool,
-    non_local_tys: Vec<(ty::Ty<I>, IsFirstInputType)>,
+    non_local_tys: Vec<(I::Ty, IsFirstInputType)>,
 }
 
 impl<'a, Infcx, I, F, E> OrphanChecker<'a, Infcx, I, F>
 where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
-    F: FnOnce(ty::Ty<I>) -> Result<ty::Ty<I>, E>,
+    F: FnOnce(I::Ty) -> Result<I::Ty, E>,
 {
     fn new(infcx: &'a Infcx, in_crate: InCrate, lazily_normalize_ty: F) -> Self {
         OrphanChecker {
@@ -282,15 +282,12 @@ where
         }
     }
 
-    fn found_non_local_ty(&mut self, t: ty::Ty<I>) -> ControlFlow<OrphanCheckEarlyExit<I, E>> {
+    fn found_non_local_ty(&mut self, t: I::Ty) -> ControlFlow<OrphanCheckEarlyExit<I, E>> {
         self.non_local_tys.push((t, self.in_self_ty.into()));
         ControlFlow::Continue(())
     }
 
-    fn found_uncovered_ty_param(
-        &mut self,
-        ty: ty::Ty<I>,
-    ) -> ControlFlow<OrphanCheckEarlyExit<I, E>> {
+    fn found_uncovered_ty_param(&mut self, ty: I::Ty) -> ControlFlow<OrphanCheckEarlyExit<I, E>> {
         if self.search_first_local_ty {
             return ControlFlow::Continue(());
         }
@@ -308,15 +305,15 @@ where
 
 enum OrphanCheckEarlyExit<I: Interner, E> {
     NormalizationFailure(E),
-    UncoveredTyParam(ty::Ty<I>),
-    LocalTy(ty::Ty<I>),
+    UncoveredTyParam(I::Ty),
+    LocalTy(I::Ty),
 }
 
 impl<'a, Infcx, I, F, E> TypeVisitor<I> for OrphanChecker<'a, Infcx, I, F>
 where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
-    F: FnMut(ty::Ty<I>) -> Result<ty::Ty<I>, E>,
+    F: FnMut(I::Ty) -> Result<I::Ty, E>,
 {
     type Result = ControlFlow<OrphanCheckEarlyExit<I, E>>;
 
@@ -324,7 +321,7 @@ where
         ControlFlow::Continue(())
     }
 
-    fn visit_ty(&mut self, ty: ty::Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, ty: I::Ty) -> Self::Result {
         let ty = self.infcx.shallow_resolve(ty);
         let ty = match (self.lazily_normalize_ty)(ty) {
             Ok(norm_ty) if norm_ty.is_ty_var() => ty,

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use rustc_type_ir::solve::{Certainty, Goal, NoSolution};
-use rustc_type_ir::{self as ty, InferCtxtLike, Interner, Ty, TypeFoldable};
+use rustc_type_ir::{self as ty, InferCtxtLike, Interner, TypeFoldable};
 
 pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
     type Infcx: InferCtxtLike<Interner = Self::Interner>;
@@ -70,7 +70,7 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
         def_id: <Self::Interner as Interner>::DefId,
         args: <Self::Interner as Interner>::GenericArgs,
         param_env: <Self::Interner as Interner>::ParamEnv,
-        hidden_ty: Ty<Self::Interner>,
+        hidden_ty: <Self::Interner as Interner>::Ty,
         goals: &mut Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>,
     );
 
@@ -86,8 +86,8 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
 
     fn is_transmutable(
         &self,
-        src: Ty<Self::Interner>,
-        dst: Ty<Self::Interner>,
+        src: <Self::Interner as Interner>::Ty,
+        dst: <Self::Interner as Interner>::Ty,
         assume: <Self::Interner as Interner>::Const,
     ) -> Result<Certainty, NoSolution>;
 }

--- a/compiler/rustc_next_trait_solver/src/placeholder.rs
+++ b/compiler/rustc_next_trait_solver/src/placeholder.rs
@@ -113,7 +113,7 @@ where
         }
     }
 
-    fn fold_ty(&mut self, t: ty::Ty<I>) -> ty::Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         match t.kind() {
             ty::Bound(ty::BoundVarIndexKind::Bound(debruijn), _)
                 if debruijn.as_usize() + 1

--- a/compiler/rustc_next_trait_solver/src/resolve.rs
+++ b/compiler/rustc_next_trait_solver/src/resolve.rs
@@ -1,7 +1,7 @@
 use rustc_type_ir::data_structures::DelayedMap;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::{
-    self as ty, InferCtxtLike, Interner, Ty, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    self as ty, InferCtxtLike, Interner, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeVisitableExt,
 };
 
@@ -19,7 +19,7 @@ where
     delegate: &'a D,
     /// We're able to use a cache here as the folder does not have any
     /// mutable state.
-    cache: DelayedMap<Ty<I>, Ty<I>>,
+    cache: DelayedMap<I::Ty, I::Ty>,
 }
 
 pub fn eager_resolve_vars<D: SolverDelegate, T: TypeFoldable<D::Interner>>(
@@ -45,7 +45,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for EagerResolv
         self.delegate.cx()
     }
 
-    fn fold_ty(&mut self, t: Ty<I>) -> Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         match t.kind() {
             ty::Infer(ty::TyVar(vid)) => {
                 let resolved = self.delegate.opportunistic_resolve_ty_var(vid);

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -46,11 +46,11 @@ where
     D: SolverDelegate<Interner = I>,
     I: Interner,
 {
-    fn self_ty(self) -> ty::Ty<I>;
+    fn self_ty(self) -> I::Ty;
 
     fn trait_ref(self, cx: I) -> ty::TraitRef<I>;
 
-    fn with_replaced_self_ty(self, cx: I, self_ty: ty::Ty<I>) -> Self;
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self;
 
     fn trait_def_id(self, cx: I) -> I::TraitId;
 
@@ -683,7 +683,7 @@ where
     // hitting another overflow error something. Add a depth parameter needed later.
     fn assemble_alias_bound_candidates_recur<G: GoalKind<D>>(
         &mut self,
-        self_ty: ty::Ty<I>,
+        self_ty: I::Ty,
         goal: Goal<I, G>,
         candidates: &mut Vec<Candidate<I>>,
         consider_self_bounds: AliasBoundKind,
@@ -1017,13 +1017,13 @@ where
             struct ReplaceOpaque<I: Interner> {
                 cx: I,
                 alias_ty: ty::AliasTy<I>,
-                self_ty: ty::Ty<I>,
+                self_ty: I::Ty,
             }
             impl<I: Interner> TypeFolder<I> for ReplaceOpaque<I> {
                 fn cx(&self) -> I {
                     self.cx
                 }
-                fn fold_ty(&mut self, ty: ty::Ty<I>) -> ty::Ty<I> {
+                fn fold_ty(&mut self, ty: I::Ty) -> I::Ty {
                     if let ty::Alias(ty::Opaque, alias_ty) = ty.kind() {
                         if alias_ty == self.alias_ty {
                             return self.self_ty;
@@ -1280,7 +1280,7 @@ where
         ControlFlow::Continue(())
     }
 
-    fn visit_ty(&mut self, ty: ty::Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, ty: I::Ty) -> Self::Result {
         let ty = self.ecx.replace_bound_vars(ty, &mut self.universes);
         let Ok(ty) = self.ecx.structurally_normalize_ty(self.param_env, ty) else {
             return ControlFlow::Break(Err(NoSolution));

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -21,8 +21,8 @@ use crate::solve::{AdtDestructorKind, EvalCtxt, Goal, NoSolution};
 #[instrument(level = "trace", skip(ecx), ret)]
 pub(in crate::solve) fn instantiate_constituent_tys_for_auto_trait<D, I>(
     ecx: &EvalCtxt<'_, D>,
-    ty: ty::Ty<I>,
-) -> Result<ty::Binder<I, Vec<ty::Ty<I>>>, NoSolution>
+    ty: I::Ty,
+) -> Result<ty::Binder<I, Vec<I::Ty>>, NoSolution>
 where
     D: SolverDelegate<Interner = I>,
     I: Interner,
@@ -108,8 +108,8 @@ where
 pub(in crate::solve) fn instantiate_constituent_tys_for_sizedness_trait<D, I>(
     ecx: &EvalCtxt<'_, D>,
     sizedness: SizedTraitKind,
-    ty: ty::Ty<I>,
-) -> Result<ty::Binder<I, Vec<ty::Ty<I>>>, NoSolution>
+    ty: I::Ty,
+) -> Result<ty::Binder<I, Vec<I::Ty>>, NoSolution>
 where
     D: SolverDelegate<Interner = I>,
     I: Interner,
@@ -186,8 +186,8 @@ where
 #[instrument(level = "trace", skip(ecx), ret)]
 pub(in crate::solve) fn instantiate_constituent_tys_for_copy_clone_trait<D, I>(
     ecx: &EvalCtxt<'_, D>,
-    ty: ty::Ty<I>,
-) -> Result<ty::Binder<I, Vec<ty::Ty<I>>>, NoSolution>
+    ty: I::Ty,
+) -> Result<ty::Binder<I, Vec<I::Ty>>, NoSolution>
 where
     D: SolverDelegate<Interner = I>,
     I: Interner,
@@ -268,9 +268,9 @@ where
 // Returns a binder of the tupled inputs types and output type from a builtin callable type.
 pub(in crate::solve) fn extract_tupled_inputs_and_output_from_callable<I: Interner>(
     cx: I,
-    self_ty: ty::Ty<I>,
+    self_ty: I::Ty,
     goal_kind: ty::ClosureKind,
-) -> Result<Option<ty::Binder<I, (ty::Ty<I>, ty::Ty<I>)>>, NoSolution> {
+) -> Result<Option<ty::Binder<I, (I::Ty, I::Ty)>>, NoSolution> {
     match self_ty.kind() {
         // keep this in sync with assemble_fn_pointer_candidates until the old solver is removed.
         ty::FnDef(def_id, args) => {
@@ -408,13 +408,13 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_callable<I: Intern
 #[derive_where(Clone, Copy, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, TypeFoldable_Generic)]
 pub(in crate::solve) struct AsyncCallableRelevantTypes<I: Interner> {
-    pub tupled_inputs_ty: ty::Ty<I>,
+    pub tupled_inputs_ty: I::Ty,
     /// Type returned by calling the closure
     /// i.e. `f()`.
-    pub output_coroutine_ty: ty::Ty<I>,
+    pub output_coroutine_ty: I::Ty,
     /// Type returned by `await`ing the output
     /// i.e. `f().await`.
-    pub coroutine_return_ty: ty::Ty<I>,
+    pub coroutine_return_ty: I::Ty,
 }
 
 // Returns a binder of the tupled inputs types, output type, and coroutine type
@@ -424,7 +424,7 @@ pub(in crate::solve) struct AsyncCallableRelevantTypes<I: Interner> {
 // know the kind already, we can short-circuit this check.
 pub(in crate::solve) fn extract_tupled_inputs_and_output_from_async_callable<I: Interner>(
     cx: I,
-    self_ty: ty::Ty<I>,
+    self_ty: I::Ty,
     goal_kind: ty::ClosureKind,
     env_region: I::Region,
 ) -> Result<(ty::Binder<I, AsyncCallableRelevantTypes<I>>, Vec<I::Predicate>), NoSolution> {
@@ -608,7 +608,7 @@ fn coroutine_closure_to_certain_coroutine<I: Interner>(
     def_id: I::CoroutineClosureId,
     args: ty::CoroutineClosureArgs<I>,
     sig: ty::CoroutineClosureSignature<I>,
-) -> ty::Ty<I> {
+) -> I::Ty {
     sig.to_coroutine_given_kind_and_upvars(
         cx,
         args.parent_args(),
@@ -632,7 +632,7 @@ fn coroutine_closure_to_ambiguous_coroutine<I: Interner>(
     def_id: I::CoroutineClosureId,
     args: ty::CoroutineClosureArgs<I>,
     sig: ty::CoroutineClosureSignature<I>,
-) -> ty::Ty<I> {
+) -> I::Ty {
     let upvars_projection_def_id = cx.require_lang_item(SolverLangItem::AsyncFnKindUpvars);
     let tupled_upvars_ty = Ty::new_projection(
         cx,
@@ -664,8 +664,8 @@ fn coroutine_closure_to_ambiguous_coroutine<I: Interner>(
 #[instrument(level = "trace", skip(cx), ret)]
 pub(in crate::solve) fn extract_fn_def_from_const_callable<I: Interner>(
     cx: I,
-    self_ty: ty::Ty<I>,
-) -> Result<(ty::Binder<I, (ty::Ty<I>, ty::Ty<I>)>, I::DefId, I::GenericArgs), NoSolution> {
+    self_ty: I::Ty,
+) -> Result<(ty::Binder<I, (I::Ty, I::Ty)>, I::DefId, I::GenericArgs), NoSolution> {
     match self_ty.kind() {
         ty::FnDef(def_id, args) => {
             let sig = cx.fn_sig(def_id);
@@ -742,7 +742,7 @@ pub(in crate::solve) fn extract_fn_def_from_const_callable<I: Interner>(
 // the old solver, for as long as that exists.
 pub(in crate::solve) fn const_conditions_for_destruct<I: Interner>(
     cx: I,
-    self_ty: ty::Ty<I>,
+    self_ty: I::Ty,
 ) -> Result<Vec<ty::TraitRef<I>>, NoSolution> {
     let destruct_def_id = cx.require_trait_lang_item(SolverTraitLangItem::Destruct);
 
@@ -927,7 +927,7 @@ where
 struct ReplaceProjectionWith<'a, 'b, I: Interner, D: SolverDelegate<Interner = I>> {
     ecx: &'a mut EvalCtxt<'b, D>,
     param_env: I::ParamEnv,
-    self_ty: ty::Ty<I>,
+    self_ty: I::Ty,
     mapping: &'a HashMap<I::DefId, Vec<ty::Binder<I, ty::ProjectionPredicate<I>>>>,
     nested: Vec<Goal<I, I::Predicate>>,
 }
@@ -1013,7 +1013,7 @@ where
         self.ecx.cx()
     }
 
-    fn try_fold_ty(&mut self, ty: ty::Ty<I>) -> Result<ty::Ty<I>, Ambiguous> {
+    fn try_fold_ty(&mut self, ty: I::Ty) -> Result<I::Ty, Ambiguous> {
         if let ty::Alias(ty::Projection, alias_ty) = ty.kind()
             && let Some(term) = self.try_eagerly_replace_alias(alias_ty.into())?
         {

--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -13,7 +13,7 @@ use super::assembly::{Candidate, structural_traits};
 use crate::delegate::SolverDelegate;
 use crate::solve::{
     BuiltinImplSource, CandidateSource, Certainty, EvalCtxt, Goal, GoalSource, NoSolution,
-    QueryResult, Ty, assembly,
+    QueryResult, assembly,
 };
 
 impl<D, I> assembly::GoalKind<D> for ty::HostEffectPredicate<I>
@@ -21,7 +21,7 @@ where
     D: SolverDelegate<Interner = I>,
     I: Interner,
 {
-    fn self_ty(self) -> Ty<I> {
+    fn self_ty(self) -> I::Ty {
         self.self_ty()
     }
 
@@ -29,7 +29,7 @@ where
         self.trait_ref
     }
 
-    fn with_replaced_self_ty(self, cx: I, self_ty: Ty<I>) -> Self {
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
         self.with_replaced_self_ty(cx, self_ty)
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -10,7 +10,7 @@ use rustc_type_ir::relate::solver_relating::RelateExt;
 use rustc_type_ir::search_graph::{CandidateHeadUsages, PathKind};
 use rustc_type_ir::solve::OpaqueTypesJank;
 use rustc_type_ir::{
-    self as ty, CanonicalVarValues, InferCtxtLike, Interner, Ty, TypeFoldable, TypeFolder,
+    self as ty, CanonicalVarValues, InferCtxtLike, Interner, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
     TypingMode,
 };
@@ -781,7 +781,7 @@ where
         region
     }
 
-    pub(super) fn next_ty_infer(&mut self) -> Ty<I> {
+    pub(super) fn next_ty_infer(&mut self) -> I::Ty {
         let ty = self.delegate.next_ty_infer();
         self.inspect.add_var_value(ty);
         ty
@@ -829,7 +829,7 @@ where
             term: I::Term,
             universe_of_term: ty::UniverseIndex,
             delegate: &'a D,
-            cache: HashSet<Ty<I>>,
+            cache: HashSet<I::Ty>,
         }
 
         impl<D: SolverDelegate<Interner = I>, I: Interner> ContainsTermOrNotNameable<'_, D, I> {
@@ -846,7 +846,7 @@ where
             for ContainsTermOrNotNameable<'_, D, I>
         {
             type Result = ControlFlow<()>;
-            fn visit_ty(&mut self, t: Ty<I>) -> Self::Result {
+            fn visit_ty(&mut self, t: I::Ty) -> Self::Result {
                 if self.cache.contains(&t) {
                     return ControlFlow::Continue(());
                 }
@@ -1072,7 +1072,7 @@ where
         self.delegate.resolve_vars_if_possible(value)
     }
 
-    pub(super) fn shallow_resolve(&self, ty: Ty<I>) -> Ty<I> {
+    pub(super) fn shallow_resolve(&self, ty: I::Ty) -> I::Ty {
         self.delegate.shallow_resolve(ty)
     }
 
@@ -1092,7 +1092,7 @@ where
         args
     }
 
-    pub(super) fn register_ty_outlives(&self, ty: Ty<I>, lt: I::Region) {
+    pub(super) fn register_ty_outlives(&self, ty: I::Ty, lt: I::Region) {
         self.delegate.register_ty_outlives(ty, lt, self.origin_span);
     }
 
@@ -1134,8 +1134,8 @@ where
     pub(super) fn register_hidden_type_in_storage(
         &mut self,
         opaque_type_key: ty::OpaqueTypeKey<I>,
-        hidden_ty: Ty<I>,
-    ) -> Option<Ty<I>> {
+        hidden_ty: I::Ty,
+    ) -> Option<I::Ty> {
         self.delegate.register_hidden_type_in_storage(opaque_type_key, hidden_ty, self.origin_span)
     }
 
@@ -1144,7 +1144,7 @@ where
         opaque_def_id: I::DefId,
         opaque_args: I::GenericArgs,
         param_env: I::ParamEnv,
-        hidden_ty: Ty<I>,
+        hidden_ty: I::Ty,
     ) {
         let mut goals = Vec::new();
         self.delegate.add_item_bounds_for_hidden_type(
@@ -1170,8 +1170,8 @@ where
 
     pub(super) fn is_transmutable(
         &mut self,
-        src: Ty<I>,
-        dst: Ty<I>,
+        src: I::Ty,
+        dst: I::Ty,
         assume: I::Const,
     ) -> Result<Certainty, NoSolution> {
         self.delegate.is_transmutable(dst, src, assume)
@@ -1195,7 +1195,7 @@ where
 
     pub(crate) fn opaques_with_sub_unified_hidden_type(
         &self,
-        self_ty: Ty<I>,
+        self_ty: I::Ty,
     ) -> Vec<ty::AliasTy<I>> {
         if let ty::Infer(ty::TyVar(vid)) = self_ty.kind() {
             self.delegate.opaques_with_sub_unified_hidden_type(vid)
@@ -1389,7 +1389,7 @@ where
     ecx: &'me mut EvalCtxt<'a, D>,
     param_env: I::ParamEnv,
     normalization_goal_source: GoalSource,
-    cache: HashMap<Ty<I>, Ty<I>>,
+    cache: HashMap<I::Ty, I::Ty>,
 }
 
 impl<'me, 'a, D, I> ReplaceAliasWithInfer<'me, 'a, D, I>
@@ -1421,7 +1421,7 @@ where
         self.ecx.cx()
     }
 
-    fn fold_ty(&mut self, ty: Ty<I>) -> Ty<I> {
+    fn fold_ty(&mut self, ty: I::Ty) -> I::Ty {
         match ty.kind() {
             ty::Alias(..) if !ty.has_escaping_bound_vars() => {
                 let infer_ty = self.ecx.next_ty_infer();

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -24,7 +24,7 @@ mod trait_goals;
 use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
 pub use rustc_type_ir::solve::*;
-use rustc_type_ir::{self as ty, Interner, Ty, TyVid, TypingMode};
+use rustc_type_ir::{self as ty, Interner, TyVid, TypingMode};
 use tracing::instrument;
 
 pub use self::eval_ctxt::{
@@ -88,7 +88,7 @@ where
     #[instrument(level = "trace", skip(self))]
     fn compute_type_outlives_goal(
         &mut self,
-        goal: Goal<I, ty::OutlivesPredicate<I, Ty<I>>>,
+        goal: Goal<I, ty::OutlivesPredicate<I, I::Ty>>,
     ) -> QueryResult<I> {
         let ty::OutlivesPredicate(ty, lt) = goal.predicate;
         self.register_ty_outlives(ty, lt);
@@ -205,7 +205,7 @@ where
     #[instrument(level = "trace", skip(self), ret)]
     fn compute_const_arg_has_type_goal(
         &mut self,
-        goal: Goal<I, (I::Const, Ty<I>)>,
+        goal: Goal<I, (I::Const, I::Ty)>,
     ) -> QueryResult<I> {
         let (ct, ty) = goal.predicate;
         let ct = self.structurally_normalize_const(goal.param_env, ct)?;
@@ -315,8 +315,8 @@ where
     fn structurally_normalize_ty(
         &mut self,
         param_env: I::ParamEnv,
-        ty: Ty<I>,
-    ) -> Result<Ty<I>, NoSolution> {
+        ty: I::Ty,
+    ) -> Result<I::Ty, NoSolution> {
         self.structurally_normalize_term(param_env, ty.into()).map(|term| term.expect_ty())
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -125,7 +125,7 @@ where
     D: SolverDelegate<Interner = I>,
     I: Interner,
 {
-    fn self_ty(self) -> ty::Ty<I> {
+    fn self_ty(self) -> I::Ty {
         self.self_ty()
     }
 
@@ -133,7 +133,7 @@ where
         self.alias.trait_ref(cx)
     }
 
-    fn with_replaced_self_ty(self, cx: I, self_ty: ty::Ty<I>) -> Self {
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
         self.with_replaced_self_ty(cx, self_ty)
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -29,7 +29,7 @@ where
     D: SolverDelegate<Interner = I>,
     I: Interner,
 {
-    fn self_ty(self) -> ty::Ty<I> {
+    fn self_ty(self) -> I::Ty {
         self.self_ty()
     }
 
@@ -37,7 +37,7 @@ where
         self.trait_ref
     }
 
-    fn with_replaced_self_ty(self, cx: I, self_ty: ty::Ty<I>) -> Self {
+    fn with_replaced_self_ty(self, cx: I, self_ty: I::Ty) -> Self {
         self.with_replaced_self_ty(cx, self_ty)
     }
 
@@ -929,7 +929,7 @@ where
     /// ```
     fn consider_builtin_dyn_upcast_candidates(
         &mut self,
-        goal: Goal<I, (ty::Ty<I>, ty::Ty<I>)>,
+        goal: Goal<I, (I::Ty, I::Ty)>,
         a_data: I::BoundExistentialPredicates,
         a_region: I::Region,
         b_data: I::BoundExistentialPredicates,
@@ -977,7 +977,7 @@ where
 
     fn consider_builtin_unsize_to_dyn_candidate(
         &mut self,
-        goal: Goal<I, (ty::Ty<I>, ty::Ty<I>)>,
+        goal: Goal<I, (I::Ty, I::Ty)>,
         b_data: I::BoundExistentialPredicates,
         b_region: I::Region,
     ) -> Result<Candidate<I>, NoSolution> {
@@ -1018,7 +1018,7 @@ where
 
     fn consider_builtin_upcast_to_principal(
         &mut self,
-        goal: Goal<I, (ty::Ty<I>, ty::Ty<I>)>,
+        goal: Goal<I, (I::Ty, I::Ty)>,
         source: CandidateSource<I>,
         a_data: I::BoundExistentialPredicates,
         a_region: I::Region,
@@ -1132,9 +1132,9 @@ where
     /// `#[rustc_deny_explicit_impl]` in this case.
     fn consider_builtin_array_unsize(
         &mut self,
-        goal: Goal<I, (ty::Ty<I>, ty::Ty<I>)>,
-        a_elem_ty: ty::Ty<I>,
-        b_elem_ty: ty::Ty<I>,
+        goal: Goal<I, (I::Ty, I::Ty)>,
+        a_elem_ty: I::Ty,
+        b_elem_ty: I::Ty,
     ) -> Result<Candidate<I>, NoSolution> {
         self.eq(goal.param_env, a_elem_ty, b_elem_ty)?;
         self.probe_builtin_trait_candidate(BuiltinImplSource::Misc)
@@ -1156,7 +1156,7 @@ where
     /// ```
     fn consider_builtin_struct_unsize(
         &mut self,
-        goal: Goal<I, (ty::Ty<I>, ty::Ty<I>)>,
+        goal: Goal<I, (I::Ty, I::Ty)>,
         def: I::AdtDef,
         a_args: I::GenericArgs,
         b_args: I::GenericArgs,
@@ -1319,8 +1319,8 @@ where
         goal: Goal<I, TraitPredicate<I>>,
         constituent_tys: impl Fn(
             &EvalCtxt<'_, D>,
-            ty::Ty<I>,
-        ) -> Result<ty::Binder<I, Vec<ty::Ty<I>>>, NoSolution>,
+            I::Ty,
+        ) -> Result<ty::Binder<I, Vec<I::Ty>>, NoSolution>,
     ) -> Result<Candidate<I>, NoSolution> {
         self.probe_trait_candidate(source).enter(|ecx| {
             let goals =
@@ -1542,10 +1542,7 @@ where
         self.merge_trait_candidates(candidate_preference_mode, candidates, failed_candidate_info)
     }
 
-    fn try_stall_coroutine(
-        &mut self,
-        self_ty: ty::Ty<I>,
-    ) -> Option<Result<Candidate<I>, NoSolution>> {
+    fn try_stall_coroutine(&mut self, self_ty: I::Ty) -> Option<Result<Candidate<I>, NoSolution>> {
         if let ty::Coroutine(def_id, _) = self_ty.kind() {
             match self.typing_mode() {
                 TypingMode::Analysis {

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -16,7 +16,7 @@ use crate::fold::{FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldabl
 use crate::inherent::*;
 use crate::lift::Lift;
 use crate::visit::{Flags, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor};
-use crate::{self as ty, DebruijnIndex, Interner, Ty, UniverseIndex};
+use crate::{self as ty, DebruijnIndex, Interner, UniverseIndex};
 
 /// `Binder` is a binder for higher-ranked lifetimes or types. It is part of the
 /// compiler's representation for things like `for<'a> Fn(&'a isize)`
@@ -274,7 +274,7 @@ pub struct ValidateBoundVars<I: Interner> {
     // We only cache types because any complex const will have to step through
     // a type at some point anyways. We may encounter the same variable at
     // different levels of binding, so this can't just be `Ty`.
-    visited: SsoHashSet<(ty::DebruijnIndex, Ty<I>)>,
+    visited: SsoHashSet<(ty::DebruijnIndex, I::Ty)>,
 }
 
 impl<I: Interner> ValidateBoundVars<I> {
@@ -297,7 +297,7 @@ impl<I: Interner> TypeVisitor<I> for ValidateBoundVars<I> {
         result
     }
 
-    fn visit_ty(&mut self, t: Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, t: I::Ty) -> Self::Result {
         if t.outer_exclusive_binder() < self.binder_index
             || !self.visited.insert((self.binder_index, t))
         {
@@ -724,7 +724,7 @@ impl<'a, I: Interner> TypeFolder<I> for ArgFolder<'a, I> {
         }
     }
 
-    fn fold_ty(&mut self, t: Ty<I>) -> Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         if !t.has_param() {
             return t;
         }
@@ -753,7 +753,7 @@ impl<'a, I: Interner> TypeFolder<I> for ArgFolder<'a, I> {
 }
 
 impl<'a, I: Interner> ArgFolder<'a, I> {
-    fn ty_for_param(&self, p: I::ParamTy, source_ty: Ty<I>) -> Ty<I> {
+    fn ty_for_param(&self, p: I::ParamTy, source_ty: I::Ty) -> I::Ty {
         // Look up the type in the args. It really should be in there.
         let opt_ty = self.args.get(p.index() as usize).map(|arg| arg.kind());
         let ty = match opt_ty {
@@ -767,7 +767,7 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
 
     #[cold]
     #[inline(never)]
-    fn type_param_expected(&self, p: I::ParamTy, ty: Ty<I>, kind: ty::GenericArgKind<I>) -> ! {
+    fn type_param_expected(&self, p: I::ParamTy, ty: I::Ty, kind: ty::GenericArgKind<I>) -> ! {
         panic!(
             "expected type for `{:?}` ({:?}/{}) but found {:?} when instantiating, args={:?}",
             p,
@@ -780,7 +780,7 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
 
     #[cold]
     #[inline(never)]
-    fn type_param_out_of_range(&self, p: I::ParamTy, ty: Ty<I>) -> ! {
+    fn type_param_out_of_range(&self, p: I::ParamTy, ty: I::Ty) -> ! {
         panic!(
             "type parameter `{:?}` ({:?}/{}) out of range when instantiating, args={:?}",
             p,
@@ -1277,7 +1277,7 @@ impl<I: Interner> PlaceholderConst<I> {
         Self { universe: ui, bound, _tcx: PhantomData }
     }
 
-    pub fn find_const_ty_from_env(self, env: I::ParamEnv) -> Ty<I> {
+    pub fn find_const_ty_from_env(self, env: I::ParamEnv) -> I::Ty {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.
             match clause.kind().skip_binder() {

--- a/compiler/rustc_type_ir/src/error.rs
+++ b/compiler/rustc_type_ir/src/error.rs
@@ -2,7 +2,7 @@ use derive_where::derive_where;
 use rustc_type_ir_macros::{GenericTypeVisitable, TypeFoldable_Generic, TypeVisitable_Generic};
 
 use crate::solve::NoSolution;
-use crate::{self as ty, Interner, Ty};
+use crate::{self as ty, Interner};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[derive(TypeFoldable_Generic, TypeVisitable_Generic, GenericTypeVisitable)]
@@ -36,15 +36,15 @@ pub enum TypeError<I: Interner> {
     RegionsInsufficientlyPolymorphic(ty::BoundRegion<I>, I::Region),
     RegionsPlaceholderMismatch,
 
-    Sorts(ExpectedFound<Ty<I>>),
-    ArgumentSorts(ExpectedFound<Ty<I>>, usize),
+    Sorts(ExpectedFound<I::Ty>),
+    ArgumentSorts(ExpectedFound<I::Ty>, usize),
     Traits(ExpectedFound<I::TraitId>),
     VariadicMismatch(ExpectedFound<bool>),
 
     /// Instantiating a type variable with the given type would have
     /// created a cycle (because it appears somewhere within that
     /// type).
-    CyclicTy(Ty<I>),
+    CyclicTy(I::Ty),
     CyclicConst(I::Const),
     ProjectionMismatched(ExpectedFound<I::DefId>),
     ExistentialMismatch(ExpectedFound<I::BoundExistentialPredicates>),

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -113,7 +113,7 @@ pub enum TreatParams {
 /// ¹ meaning that if the outermost layers are different, then the whole types are also different.
 pub fn simplify_type<I: Interner>(
     cx: I,
-    ty: ty::Ty<I>,
+    ty: I::Ty,
     treat_params: TreatParams,
 ) -> Option<SimplifiedType<I::DefId>> {
     match ty.kind() {
@@ -236,16 +236,11 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
         self.args_may_unify_inner(obligation_args, impl_args, Self::STARTING_DEPTH)
     }
 
-    pub fn types_may_unify(self, lhs: ty::Ty<I>, rhs: ty::Ty<I>) -> bool {
+    pub fn types_may_unify(self, lhs: I::Ty, rhs: I::Ty) -> bool {
         self.types_may_unify_inner(lhs, rhs, Self::STARTING_DEPTH)
     }
 
-    pub fn types_may_unify_with_depth(
-        self,
-        lhs: ty::Ty<I>,
-        rhs: ty::Ty<I>,
-        depth_limit: usize,
-    ) -> bool {
+    pub fn types_may_unify_with_depth(self, lhs: I::Ty, rhs: I::Ty, depth_limit: usize) -> bool {
         self.types_may_unify_inner(lhs, rhs, depth_limit)
     }
 
@@ -273,7 +268,7 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
         })
     }
 
-    fn types_may_unify_inner(self, lhs: ty::Ty<I>, rhs: ty::Ty<I>, depth: usize) -> bool {
+    fn types_may_unify_inner(self, lhs: I::Ty, rhs: I::Ty, depth: usize) -> bool {
         if lhs == rhs {
             return true;
         }
@@ -532,7 +527,7 @@ impl<I: Interner, const INSTANTIATE_LHS_WITH_INFER: bool, const INSTANTIATE_RHS_
         }
     }
 
-    fn var_and_ty_may_unify(self, var: ty::InferTy, ty: ty::Ty<I>) -> bool {
+    fn var_and_ty_may_unify(self, var: ty::InferTy, ty: I::Ty) -> bool {
         if !ty.is_known_rigid() {
             return true;
         }

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -1,6 +1,6 @@
 use crate::inherent::*;
 use crate::visit::Flags;
-use crate::{self as ty, Interner, Ty};
+use crate::{self as ty, Interner};
 
 bitflags::bitflags! {
     /// Flags that we track on types. These flags are propagated upwards
@@ -430,7 +430,7 @@ impl<I: Interner> FlagComputation<I> {
         }
     }
 
-    fn add_ty(&mut self, ty: Ty<I>) {
+    fn add_ty(&mut self, ty: I::Ty) {
         self.add_flags(ty.flags());
         self.add_exclusive_binder(ty.outer_exclusive_binder());
     }

--- a/compiler/rustc_type_ir/src/fold.rs
+++ b/compiler/rustc_type_ir/src/fold.rs
@@ -135,7 +135,7 @@ pub trait TypeFolder<I: Interner>: Sized {
         t.super_fold_with(self)
     }
 
-    fn fold_ty(&mut self, t: ty::Ty<I>) -> ty::Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         t.super_fold_with(self)
     }
 
@@ -177,7 +177,7 @@ pub trait FallibleTypeFolder<I: Interner>: Sized {
         t.try_super_fold_with(self)
     }
 
-    fn try_fold_ty(&mut self, t: ty::Ty<I>) -> Result<ty::Ty<I>, Self::Error> {
+    fn try_fold_ty(&mut self, t: I::Ty) -> Result<I::Ty, Self::Error> {
         t.try_super_fold_with(self)
     }
 
@@ -408,7 +408,7 @@ impl<I: Interner> TypeFolder<I> for Shifter<I> {
         }
     }
 
-    fn fold_ty(&mut self, ty: ty::Ty<I>) -> ty::Ty<I> {
+    fn fold_ty(&mut self, ty: I::Ty) -> I::Ty {
         match ty.kind() {
             ty::Bound(BoundVarIndexKind::Bound(debruijn), bound_ty)
                 if debruijn >= self.current_index =>
@@ -538,7 +538,7 @@ where
         }
     }
 
-    fn fold_ty(&mut self, t: ty::Ty<I>) -> ty::Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         if t.has_type_flags(
             TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_RE_BOUND | TypeFlags::HAS_RE_ERASED,
         ) {

--- a/compiler/rustc_type_ir/src/generic_arg.rs
+++ b/compiler/rustc_type_ir/src/generic_arg.rs
@@ -3,7 +3,7 @@ use derive_where::derive_where;
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext, HashStable_NoContext};
 use rustc_type_ir_macros::GenericTypeVisitable;
 
-use crate::{Interner, Ty};
+use crate::Interner;
 
 #[derive_where(Clone, Copy, PartialEq, Debug; I: Interner)]
 #[derive(GenericTypeVisitable)]
@@ -13,7 +13,7 @@ use crate::{Interner, Ty};
 )]
 pub enum GenericArgKind<I: Interner> {
     Lifetime(I::Region),
-    Type(Ty<I>),
+    Type(I::Ty),
     Const(I::Const),
 }
 
@@ -26,7 +26,7 @@ impl<I: Interner> Eq for GenericArgKind<I> {}
     derive(Decodable_NoContext, Encodable_NoContext, HashStable_NoContext)
 )]
 pub enum TermKind<I: Interner> {
-    Ty(Ty<I>),
+    Ty(I::Ty),
     Const(I::Const),
 }
 

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -6,7 +6,7 @@ use crate::fold::TypeFoldable;
 use crate::inherent::*;
 use crate::relate::RelateResult;
 use crate::relate::combine::PredicateEmittingRelation;
-use crate::{self as ty, Interner, Ty, TyVid};
+use crate::{self as ty, Interner, TyVid};
 
 /// The current typing mode of an inference context. We unfortunately have some
 /// slightly different typing rules depending on the current context. See the
@@ -161,9 +161,12 @@ pub trait InferCtxtLike: Sized {
     fn sub_unification_table_root_var(&self, var: ty::TyVid) -> ty::TyVid;
     fn root_const_var(&self, var: ty::ConstVid) -> ty::ConstVid;
 
-    fn opportunistic_resolve_ty_var(&self, vid: ty::TyVid) -> Ty<Self::Interner>;
-    fn opportunistic_resolve_int_var(&self, vid: ty::IntVid) -> Ty<Self::Interner>;
-    fn opportunistic_resolve_float_var(&self, vid: ty::FloatVid) -> Ty<Self::Interner>;
+    fn opportunistic_resolve_ty_var(&self, vid: ty::TyVid) -> <Self::Interner as Interner>::Ty;
+    fn opportunistic_resolve_int_var(&self, vid: ty::IntVid) -> <Self::Interner as Interner>::Ty;
+    fn opportunistic_resolve_float_var(
+        &self,
+        vid: ty::FloatVid,
+    ) -> <Self::Interner as Interner>::Ty;
     fn opportunistic_resolve_ct_var(
         &self,
         vid: ty::ConstVid,
@@ -176,7 +179,7 @@ pub trait InferCtxtLike: Sized {
     fn is_changed_arg(&self, arg: <Self::Interner as Interner>::GenericArg) -> bool;
 
     fn next_region_infer(&self) -> <Self::Interner as Interner>::Region;
-    fn next_ty_infer(&self) -> Ty<Self::Interner>;
+    fn next_ty_infer(&self) -> <Self::Interner as Interner>::Ty;
     fn next_const_infer(&self) -> <Self::Interner as Interner>::Const;
     fn fresh_args_for_item(
         &self,
@@ -206,7 +209,7 @@ pub trait InferCtxtLike: Sized {
         target_is_expected: bool,
         target_vid: ty::TyVid,
         instantiation_variance: ty::Variance,
-        source_ty: Ty<Self::Interner>,
+        source_ty: <Self::Interner as Interner>::Ty,
     ) -> RelateResult<Self::Interner, ()>;
     fn instantiate_int_var_raw(&self, vid: ty::IntVid, value: ty::IntVarValue);
     fn instantiate_float_var_raw(&self, vid: ty::FloatVid, value: ty::FloatVarValue);
@@ -220,7 +223,10 @@ pub trait InferCtxtLike: Sized {
 
     fn set_tainted_by_errors(&self, e: <Self::Interner as Interner>::ErrorGuaranteed);
 
-    fn shallow_resolve(&self, ty: Ty<Self::Interner>) -> Ty<Self::Interner>;
+    fn shallow_resolve(
+        &self,
+        ty: <Self::Interner as Interner>::Ty,
+    ) -> <Self::Interner as Interner>::Ty;
     fn shallow_resolve_const(
         &self,
         ty: <Self::Interner as Interner>::Const,
@@ -248,7 +254,7 @@ pub trait InferCtxtLike: Sized {
 
     fn register_ty_outlives(
         &self,
-        ty: Ty<Self::Interner>,
+        ty: <Self::Interner as Interner>::Ty,
         r: <Self::Interner as Interner>::Region,
         span: <Self::Interner as Interner>::Span,
     );
@@ -257,26 +263,26 @@ pub trait InferCtxtLike: Sized {
     fn opaque_types_storage_num_entries(&self) -> Self::OpaqueTypeStorageEntries;
     fn clone_opaque_types_lookup_table(
         &self,
-    ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, Ty<Self::Interner>)>;
+    ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, <Self::Interner as Interner>::Ty)>;
     fn clone_duplicate_opaque_types(
         &self,
-    ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, Ty<Self::Interner>)>;
+    ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, <Self::Interner as Interner>::Ty)>;
     fn clone_opaque_types_added_since(
         &self,
         prev_entries: Self::OpaqueTypeStorageEntries,
-    ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, Ty<Self::Interner>)>;
+    ) -> Vec<(ty::OpaqueTypeKey<Self::Interner>, <Self::Interner as Interner>::Ty)>;
     fn opaques_with_sub_unified_hidden_type(&self, ty: TyVid) -> Vec<ty::AliasTy<Self::Interner>>;
 
     fn register_hidden_type_in_storage(
         &self,
         opaque_type_key: ty::OpaqueTypeKey<Self::Interner>,
-        hidden_ty: Ty<Self::Interner>,
+        hidden_ty: <Self::Interner as Interner>::Ty,
         span: <Self::Interner as Interner>::Span,
-    ) -> Option<Ty<Self::Interner>>;
+    ) -> Option<<Self::Interner as Interner>::Ty>;
     fn add_duplicate_opaque_type(
         &self,
         opaque_type_key: ty::OpaqueTypeKey<Self::Interner>,
-        hidden_ty: Ty<Self::Interner>,
+        hidden_ty: <Self::Interner as Interner>::Ty,
         span: <Self::Interner as Interner>::Span,
     );
 

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -108,7 +108,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_slice(interner: I, ty: Self) -> Self;
 
-    fn new_tup(interner: I, tys: &[ty::Ty<I>]) -> Self;
+    fn new_tup(interner: I, tys: &[I::Ty]) -> Self;
 
     fn new_tup_from_iter<It, T>(interner: I, iter: It) -> T::Output
     where
@@ -121,7 +121,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_pat(interner: I, ty: Self, pat: I::Pat) -> Self;
 
-    fn new_unsafe_binder(interner: I, ty: ty::Binder<I, ty::Ty<I>>) -> Self;
+    fn new_unsafe_binder(interner: I, ty: ty::Binder<I, I::Ty>) -> Self;
 
     fn tuple_fields(self) -> I::Tys;
 
@@ -158,7 +158,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
         self.kind().fn_sig(interner)
     }
 
-    fn discriminant_ty(self, interner: I) -> ty::Ty<I>;
+    fn discriminant_ty(self, interner: I) -> I::Ty;
 
     fn is_known_rigid(self) -> bool {
         self.kind().is_known_rigid()
@@ -198,11 +198,11 @@ pub trait Ty<I: Interner<Ty = Self>>:
 }
 
 pub trait Tys<I: Interner<Tys = Self>>:
-    Copy + Debug + Hash + Eq + SliceLike<Item = ty::Ty<I>> + TypeFoldable<I> + Default
+    Copy + Debug + Hash + Eq + SliceLike<Item = I::Ty> + TypeFoldable<I> + Default
 {
     fn inputs(self) -> I::FnInputTys;
 
-    fn output(self) -> ty::Ty<I>;
+    fn output(self) -> I::Ty;
 }
 
 pub trait Abi<I: Interner<Abi = Self>>: Copy + Debug + Hash + Eq {
@@ -290,7 +290,7 @@ pub trait Const<I: Interner<Const = Self>>:
 }
 
 pub trait ValueConst<I: Interner<ValueConst = Self>>: Copy + Debug + Hash + Eq {
-    fn ty(self) -> ty::Ty<I>;
+    fn ty(self) -> I::Ty;
     fn valtree(self) -> I::ValTree;
 }
 
@@ -310,7 +310,7 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
     + IntoKind<Kind = ty::GenericArgKind<I>>
     + TypeVisitable<I>
     + Relate<I>
-    + From<ty::Ty<I>>
+    + From<I::Ty>
     + From<I::Region>
     + From<I::Const>
     + From<I::Term>
@@ -323,11 +323,11 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
         }
     }
 
-    fn as_type(&self) -> Option<ty::Ty<I>> {
+    fn as_type(&self) -> Option<I::Ty> {
         if let ty::GenericArgKind::Type(ty) = self.kind() { Some(ty) } else { None }
     }
 
-    fn expect_ty(&self) -> ty::Ty<I> {
+    fn expect_ty(&self) -> I::Ty {
         self.as_type().expect("expected a type")
     }
 
@@ -359,11 +359,11 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
 pub trait Term<I: Interner<Term = Self>>:
     Copy + Debug + Hash + Eq + IntoKind<Kind = ty::TermKind<I>> + TypeFoldable<I> + Relate<I>
 {
-    fn as_type(&self) -> Option<ty::Ty<I>> {
+    fn as_type(&self) -> Option<I::Ty> {
         if let ty::TermKind::Ty(ty) = self.kind() { Some(ty) } else { None }
     }
 
-    fn expect_ty(&self) -> ty::Ty<I> {
+    fn expect_ty(&self) -> I::Ty {
         self.as_type().expect("expected a type, but found a const")
     }
 
@@ -413,7 +413,7 @@ pub trait GenericArgs<I: Interner<GenericArgs = Self>>:
         target: I::GenericArgs,
     ) -> I::GenericArgs;
 
-    fn type_at(self, i: usize) -> ty::Ty<I>;
+    fn type_at(self, i: usize) -> I::Ty;
 
     fn region_at(self, i: usize) -> I::Region;
 
@@ -459,7 +459,7 @@ pub trait Predicate<I: Interner<Predicate = Self>>:
     + UpcastFrom<I, ty::TraitRef<I>>
     + UpcastFrom<I, ty::Binder<I, ty::TraitRef<I>>>
     + UpcastFrom<I, ty::TraitPredicate<I>>
-    + UpcastFrom<I, ty::OutlivesPredicate<I, ty::Ty<I>>>
+    + UpcastFrom<I, ty::OutlivesPredicate<I, I::Ty>>
     + UpcastFrom<I, ty::OutlivesPredicate<I, I::Region>>
     + IntoKind<Kind = ty::Binder<I, ty::PredicateKind<I>>>
     + Elaboratable<I>
@@ -578,7 +578,7 @@ pub trait AdtDef<I: Interner>: Copy + Debug + Hash + Eq {
     /// Returns the type of the struct tail.
     ///
     /// Expects the `AdtDef` to be a struct. If it is not, then this will panic.
-    fn struct_tail_ty(self, interner: I) -> Option<ty::EarlyBinder<I, ty::Ty<I>>>;
+    fn struct_tail_ty(self, interner: I) -> Option<ty::EarlyBinder<I, I::Ty>>;
 
     fn is_phantom_data(self) -> bool;
 
@@ -591,13 +591,13 @@ pub trait AdtDef<I: Interner>: Copy + Debug + Hash + Eq {
     ) -> Option<FieldInfo<I>>;
 
     // FIXME: perhaps use `all_fields` and expose `FieldDef`.
-    fn all_field_tys(self, interner: I) -> ty::EarlyBinder<I, impl IntoIterator<Item = ty::Ty<I>>>;
+    fn all_field_tys(self, interner: I) -> ty::EarlyBinder<I, impl IntoIterator<Item = I::Ty>>;
 
     fn sizedness_constraint(
         self,
         interner: I,
         sizedness: SizedTraitKind,
-    ) -> Option<ty::EarlyBinder<I, ty::Ty<I>>>;
+    ) -> Option<ty::EarlyBinder<I, I::Ty>>;
 
     fn is_fundamental(self) -> bool;
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -31,7 +31,6 @@ pub mod outlives;
 pub mod relate;
 pub mod search_graph;
 pub mod solve;
-pub mod sty;
 pub mod walk;
 
 // These modules are not `pub` since they are glob-imported.
@@ -79,7 +78,6 @@ pub use predicate_kind::*;
 pub use region_kind::*;
 pub use rustc_ast_ir::{FloatTy, IntTy, Movability, Mutability, Pinnedness, UintTy};
 use rustc_type_ir_macros::GenericTypeVisitable;
-pub use sty::*;
 pub use ty_info::*;
 pub use ty_kind::*;
 pub use upcast::*;
@@ -445,8 +443,8 @@ impl fmt::Display for ClosureKind {
 }
 
 pub struct FieldInfo<I: Interner> {
-    pub base: Ty<I>,
-    pub ty: Ty<I>,
+    pub base: I::Ty,
+    pub ty: I::Ty,
     pub variant: Option<I::Symbol>,
     pub variant_idx: VariantIdx,
     pub name: I::Symbol,

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -8,7 +8,7 @@ use smallvec::{SmallVec, smallvec};
 use crate::data_structures::SsoHashSet;
 use crate::inherent::*;
 use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitableExt as _, TypeVisitor};
-use crate::{self as ty, Interner, Ty};
+use crate::{self as ty, Interner};
 
 #[derive_where(Debug; I: Interner)]
 pub enum Component<I: Interner> {
@@ -55,7 +55,7 @@ pub enum Component<I: Interner> {
 /// `ty0: 'a` to hold. Note that `ty0` must be a **fully resolved type**.
 pub fn push_outlives_components<I: Interner>(
     cx: I,
-    ty: Ty<I>,
+    ty: I::Ty,
     out: &mut SmallVec<[Component<I>; 4]>,
 ) {
     ty.visit_with(&mut OutlivesCollector { cx, out, visited: Default::default() });
@@ -64,14 +64,14 @@ pub fn push_outlives_components<I: Interner>(
 struct OutlivesCollector<'a, I: Interner> {
     cx: I,
     out: &'a mut SmallVec<[Component<I>; 4]>,
-    visited: SsoHashSet<Ty<I>>,
+    visited: SsoHashSet<I::Ty>,
 }
 
 impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
     #[cfg(not(feature = "nightly"))]
     type Result = ();
 
-    fn visit_ty(&mut self, ty: Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, ty: I::Ty) -> Self::Result {
         if !self.visited.insert(ty) {
             return;
         }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -101,7 +101,7 @@ impl<I: Interner> TraitRef<I> {
         )
     }
 
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         TraitRef::new(
             interner,
             self.def_id,
@@ -110,13 +110,13 @@ impl<I: Interner> TraitRef<I> {
     }
 
     #[inline]
-    pub fn self_ty(&self) -> ty::Ty<I> {
+    pub fn self_ty(&self) -> I::Ty {
         self.args.type_at(0)
     }
 }
 
 impl<I: Interner> ty::Binder<I, TraitRef<I>> {
-    pub fn self_ty(&self) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn self_ty(&self) -> ty::Binder<I, I::Ty> {
         self.map_bound_ref(|tr| tr.self_ty())
     }
 
@@ -152,7 +152,7 @@ pub struct TraitPredicate<I: Interner> {
 impl<I: Interner> Eq for TraitPredicate<I> {}
 
 impl<I: Interner> TraitPredicate<I> {
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         Self {
             trait_ref: self.trait_ref.with_replaced_self_ty(interner, self_ty),
             polarity: self.polarity,
@@ -163,7 +163,7 @@ impl<I: Interner> TraitPredicate<I> {
         self.trait_ref.def_id
     }
 
-    pub fn self_ty(self) -> ty::Ty<I> {
+    pub fn self_ty(self) -> I::Ty {
         self.trait_ref.self_ty()
     }
 }
@@ -174,7 +174,7 @@ impl<I: Interner> ty::Binder<I, TraitPredicate<I>> {
         self.skip_binder().def_id()
     }
 
-    pub fn self_ty(self) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn self_ty(self) -> ty::Binder<I, I::Ty> {
         self.map_bound(|trait_ref| trait_ref.self_ty())
     }
 
@@ -307,7 +307,7 @@ impl<I: Interner> ty::Binder<I, ExistentialPredicate<I>> {
     /// Given an existential predicate like `?Self: PartialEq<u32>` (e.g., derived from `dyn PartialEq<u32>`),
     /// and a concrete type `self_ty`, returns a full predicate where the existentially quantified variable `?Self`
     /// has been replaced with `self_ty` (e.g., `self_ty: PartialEq<u32>`, in our example).
-    pub fn with_self_ty(&self, cx: I, self_ty: ty::Ty<I>) -> I::Clause {
+    pub fn with_self_ty(&self, cx: I, self_ty: I::Ty) -> I::Clause {
         match self.skip_binder() {
             ExistentialPredicate::Trait(tr) => self.rebind(tr).with_self_ty(cx, self_ty).upcast(cx),
             ExistentialPredicate::Projection(p) => {
@@ -384,7 +384,7 @@ impl<I: Interner> ExistentialTraitRef<I> {
     /// we convert the principal trait-ref into a normal trait-ref,
     /// you must give *some* self type. A common choice is `mk_err()`
     /// or some placeholder type.
-    pub fn with_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> TraitRef<I> {
+    pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> TraitRef<I> {
         // otherwise the escaping vars would be captured by the binder
         // debug_assert!(!self_ty.has_escaping_bound_vars());
 
@@ -401,7 +401,7 @@ impl<I: Interner> ty::Binder<I, ExistentialTraitRef<I>> {
     /// we convert the principal trait-ref into a normal trait-ref,
     /// you must give *some* self type. A common choice is `mk_err()`
     /// or some placeholder type.
-    pub fn with_self_ty(&self, cx: I, self_ty: ty::Ty<I>) -> ty::Binder<I, TraitRef<I>> {
+    pub fn with_self_ty(&self, cx: I, self_ty: I::Ty) -> ty::Binder<I, TraitRef<I>> {
         self.map_bound(|trait_ref| trait_ref.with_self_ty(cx, self_ty))
     }
 }
@@ -459,7 +459,7 @@ impl<I: Interner> ExistentialProjection<I> {
         ExistentialTraitRef::new_from_args(interner, def_id.try_into().unwrap(), args)
     }
 
-    pub fn with_self_ty(&self, interner: I, self_ty: ty::Ty<I>) -> ProjectionPredicate<I> {
+    pub fn with_self_ty(&self, interner: I, self_ty: I::Ty) -> ProjectionPredicate<I> {
         // otherwise the escaping regions would be captured by the binders
         debug_assert!(!self_ty.has_escaping_bound_vars());
 
@@ -487,7 +487,7 @@ impl<I: Interner> ExistentialProjection<I> {
 }
 
 impl<I: Interner> ty::Binder<I, ExistentialProjection<I>> {
-    pub fn with_self_ty(&self, cx: I, self_ty: ty::Ty<I>) -> ty::Binder<I, ProjectionPredicate<I>> {
+    pub fn with_self_ty(&self, cx: I, self_ty: I::Ty) -> ty::Binder<I, ProjectionPredicate<I>> {
         self.map_bound(|p| p.with_self_ty(cx, self_ty))
     }
 
@@ -683,11 +683,11 @@ impl<I: Interner> AliasTerm<I> {
 
 /// The following methods work only with (trait) associated term projections.
 impl<I: Interner> AliasTerm<I> {
-    pub fn self_ty(self) -> ty::Ty<I> {
+    pub fn self_ty(self) -> I::Ty {
         self.args.type_at(0)
     }
 
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         AliasTerm::new(
             interner,
             self.def_id,
@@ -796,11 +796,11 @@ pub struct ProjectionPredicate<I: Interner> {
 impl<I: Interner> Eq for ProjectionPredicate<I> {}
 
 impl<I: Interner> ProjectionPredicate<I> {
-    pub fn self_ty(self) -> ty::Ty<I> {
+    pub fn self_ty(self) -> I::Ty {
         self.projection_term.self_ty()
     }
 
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> ProjectionPredicate<I> {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> ProjectionPredicate<I> {
         Self {
             projection_term: self.projection_term.with_replaced_self_ty(interner, self_ty),
             ..self
@@ -859,11 +859,11 @@ pub struct NormalizesTo<I: Interner> {
 impl<I: Interner> Eq for NormalizesTo<I> {}
 
 impl<I: Interner> NormalizesTo<I> {
-    pub fn self_ty(self) -> ty::Ty<I> {
+    pub fn self_ty(self) -> I::Ty {
         self.alias.self_ty()
     }
 
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> NormalizesTo<I> {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> NormalizesTo<I> {
         Self { alias: self.alias.with_replaced_self_ty(interner, self_ty), ..self }
     }
 
@@ -896,11 +896,11 @@ pub struct HostEffectPredicate<I: Interner> {
 impl<I: Interner> Eq for HostEffectPredicate<I> {}
 
 impl<I: Interner> HostEffectPredicate<I> {
-    pub fn self_ty(self) -> ty::Ty<I> {
+    pub fn self_ty(self) -> I::Ty {
         self.trait_ref.self_ty()
     }
 
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         Self { trait_ref: self.trait_ref.with_replaced_self_ty(interner, self_ty), ..self }
     }
 
@@ -915,7 +915,7 @@ impl<I: Interner> ty::Binder<I, HostEffectPredicate<I>> {
         self.skip_binder().def_id()
     }
 
-    pub fn self_ty(self) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn self_ty(self) -> ty::Binder<I, I::Ty> {
         self.map_bound(|trait_ref| trait_ref.self_ty())
     }
 
@@ -936,8 +936,8 @@ impl<I: Interner> ty::Binder<I, HostEffectPredicate<I>> {
 )]
 pub struct SubtypePredicate<I: Interner> {
     pub a_is_expected: bool,
-    pub a: ty::Ty<I>,
-    pub b: ty::Ty<I>,
+    pub a: I::Ty,
+    pub b: I::Ty,
 }
 
 impl<I: Interner> Eq for SubtypePredicate<I> {}
@@ -950,8 +950,8 @@ impl<I: Interner> Eq for SubtypePredicate<I> {}
     derive(Decodable_NoContext, Encodable_NoContext, HashStable_NoContext)
 )]
 pub struct CoercePredicate<I: Interner> {
-    pub a: ty::Ty<I>,
-    pub b: ty::Ty<I>,
+    pub a: I::Ty,
+    pub b: I::Ty,
 }
 
 impl<I: Interner> Eq for CoercePredicate<I> {}

--- a/compiler/rustc_type_ir/src/predicate_kind.rs
+++ b/compiler/rustc_type_ir/src/predicate_kind.rs
@@ -5,7 +5,7 @@ use derive_where::derive_where;
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext, HashStable_NoContext};
 use rustc_type_ir_macros::{GenericTypeVisitable, TypeFoldable_Generic, TypeVisitable_Generic};
 
-use crate::{self as ty, Interner, Ty};
+use crate::{self as ty, Interner};
 
 /// A clause is something that can appear in where bounds or be inferred
 /// by implied bounds.
@@ -25,7 +25,7 @@ pub enum ClauseKind<I: Interner> {
     RegionOutlives(ty::OutlivesPredicate<I, I::Region>),
 
     /// `where T: 'r`
-    TypeOutlives(ty::OutlivesPredicate<I, Ty<I>>),
+    TypeOutlives(ty::OutlivesPredicate<I, I::Ty>),
 
     /// `where <T as TraitRef>::Name == X`, approximately.
     /// See the `ProjectionPredicate` struct for details.
@@ -33,7 +33,7 @@ pub enum ClauseKind<I: Interner> {
 
     /// Ensures that a const generic argument to a parameter `const N: u8`
     /// is of type `u8`.
-    ConstArgHasType(I::Const, Ty<I>),
+    ConstArgHasType(I::Const, I::Ty),
 
     /// No syntax: `T` well-formed.
     WellFormed(I::Term),

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -44,7 +44,7 @@ pub enum VarianceDiagInfo<I: Interner> {
     Invariant {
         /// The generic type containing the generic parameter
         /// that changes the variance (e.g. `*mut T`, `MyStruct<T>`)
-        ty: ty::Ty<I>,
+        ty: I::Ty,
         /// The index of the generic parameter being used
         /// (e.g. `0` for `*mut T`, `1` for `MyStruct<'CovariantParam, 'InvariantParam>`)
         param_index: u32,
@@ -75,13 +75,13 @@ pub trait TypeRelation<I: Interner>: Sized {
 
     fn relate_ty_args(
         &mut self,
-        a_ty: ty::Ty<I>,
-        b_ty: ty::Ty<I>,
+        a_ty: I::Ty,
+        b_ty: I::Ty,
         ty_def_id: I::DefId,
         a_arg: I::GenericArgs,
         b_arg: I::GenericArgs,
-        mk: impl FnOnce(I::GenericArgs) -> ty::Ty<I>,
-    ) -> RelateResult<I, ty::Ty<I>>;
+        mk: impl FnOnce(I::GenericArgs) -> I::Ty,
+    ) -> RelateResult<I, I::Ty>;
 
     /// Switch variance for the purpose of relating `a` and `b`.
     fn relate_with_variance<T: Relate<I>>(
@@ -98,7 +98,7 @@ pub trait TypeRelation<I: Interner>: Sized {
     // additional hooks for other types in the future if needed
     // without making older code, which called `relate`, obsolete.
 
-    fn tys(&mut self, a: ty::Ty<I>, b: ty::Ty<I>) -> RelateResult<I, ty::Ty<I>>;
+    fn tys(&mut self, a: I::Ty, b: I::Ty) -> RelateResult<I, I::Ty>;
 
     fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region>;
 
@@ -332,9 +332,9 @@ impl<I: Interner> Relate<I> for ty::ExistentialTraitRef<I> {
 #[instrument(level = "trace", skip(relation), ret)]
 pub fn structurally_relate_tys<I: Interner, R: TypeRelation<I>>(
     relation: &mut R,
-    a: ty::Ty<I>,
-    b: ty::Ty<I>,
-) -> RelateResult<I, ty::Ty<I>> {
+    a: I::Ty,
+    b: I::Ty,
+) -> RelateResult<I, I::Ty> {
     let cx = relation.cx();
     match (a.kind(), b.kind()) {
         (ty::Infer(_), _) | (_, ty::Infer(_)) => {

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -39,15 +39,15 @@ where
     );
 
     /// Register `AliasRelate` obligation(s) that both types must be related to each other.
-    fn register_alias_relate_predicate(&mut self, a: ty::Ty<I>, b: ty::Ty<I>);
+    fn register_alias_relate_predicate(&mut self, a: I::Ty, b: I::Ty);
 }
 
 pub fn super_combine_tys<Infcx, I, R>(
     infcx: &Infcx,
     relation: &mut R,
-    a: ty::Ty<I>,
-    b: ty::Ty<I>,
-) -> RelateResult<I, ty::Ty<I>>
+    a: I::Ty,
+    b: I::Ty,
+) -> RelateResult<I, I::Ty>
 where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
@@ -226,13 +226,13 @@ where
 pub fn combine_ty_args<Infcx, I, R>(
     infcx: &Infcx,
     relation: &mut R,
-    a_ty: ty::Ty<I>,
-    b_ty: ty::Ty<I>,
+    a_ty: I::Ty,
+    b_ty: I::Ty,
     variances: I::VariancesOf,
     a_args: I::GenericArgs,
     b_args: I::GenericArgs,
-    mk: impl FnOnce(I::GenericArgs) -> ty::Ty<I>,
-) -> RelateResult<I, ty::Ty<I>>
+    mk: impl FnOnce(I::GenericArgs) -> I::Ty,
+) -> RelateResult<I, I::Ty>
 where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,

--- a/compiler/rustc_type_ir/src/relate/solver_relating.rs
+++ b/compiler/rustc_type_ir/src/relate/solver_relating.rs
@@ -5,7 +5,7 @@ use crate::data_structures::DelayedSet;
 use crate::relate::combine::combine_ty_args;
 pub use crate::relate::*;
 use crate::solve::Goal;
-use crate::{self as ty, InferCtxtLike, Interner, Ty};
+use crate::{self as ty, InferCtxtLike, Interner};
 
 pub trait RelateExt: InferCtxtLike {
     fn relate<T: Relate<Self::Interner>>(
@@ -104,7 +104,7 @@ pub struct SolverRelating<'infcx, Infcx, I: Interner> {
     /// constrain `?1` to `u32`. When using the cache entry from the
     /// first time we've related these types, this only happens when
     /// later proving the `Subtype(?0, ?1)` goal from the first relation.
-    cache: DelayedSet<(ty::Variance, Ty<I>, Ty<I>)>,
+    cache: DelayedSet<(ty::Variance, I::Ty, I::Ty)>,
 }
 
 impl<'infcx, Infcx, I> SolverRelating<'infcx, Infcx, I>
@@ -142,13 +142,13 @@ where
 
     fn relate_ty_args(
         &mut self,
-        a_ty: Ty<I>,
-        b_ty: Ty<I>,
+        a_ty: I::Ty,
+        b_ty: I::Ty,
         def_id: I::DefId,
         a_args: I::GenericArgs,
         b_args: I::GenericArgs,
-        _: impl FnOnce(I::GenericArgs) -> Ty<I>,
-    ) -> RelateResult<I, Ty<I>> {
+        _: impl FnOnce(I::GenericArgs) -> I::Ty,
+    ) -> RelateResult<I, I::Ty> {
         if self.ambient_variance == ty::Invariant {
             // Avoid fetching the variance if we are in an invariant
             // context; no need, and it can induce dependency cycles
@@ -178,7 +178,7 @@ where
     }
 
     #[instrument(skip(self), level = "trace")]
-    fn tys(&mut self, a: Ty<I>, b: Ty<I>) -> RelateResult<I, Ty<I>> {
+    fn tys(&mut self, a: I::Ty, b: I::Ty) -> RelateResult<I, I::Ty> {
         if a == b {
             return Ok(a);
         }
@@ -383,7 +383,7 @@ where
         self.goals.extend(obligations);
     }
 
-    fn register_alias_relate_predicate(&mut self, a: Ty<I>, b: Ty<I>) {
+    fn register_alias_relate_predicate(&mut self, a: I::Ty, b: I::Ty) {
         self.register_predicates([ty::Binder::dummy(match self.ambient_variance {
             ty::Covariant => ty::PredicateKind::AliasRelate(
                 a.into(),

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -11,7 +11,7 @@ use rustc_type_ir_macros::{
 
 use crate::lang_items::SolverTraitLangItem;
 use crate::search_graph::PathKind;
-use crate::{self as ty, Canonical, CanonicalVarValues, Interner, Ty, Upcast};
+use crate::{self as ty, Canonical, CanonicalVarValues, Interner, Upcast};
 
 pub type CanonicalInput<I, T = <I as Interner>::Predicate> =
     ty::CanonicalQueryInput<I, QueryInput<I, T>>;
@@ -254,7 +254,7 @@ impl<I: Interner> Eq for Response<I> {}
 #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
 pub struct ExternalConstraintsData<I: Interner> {
     pub region_constraints: Vec<ty::OutlivesPredicate<I, I::GenericArg>>,
-    pub opaque_types: Vec<(ty::OpaqueTypeKey<I>, Ty<I>)>,
+    pub opaque_types: Vec<(ty::OpaqueTypeKey<I>, I::Ty)>,
     pub normalization_nested_goals: NestedNormalizationGoals<I>,
 }
 

--- a/compiler/rustc_type_ir/src/sty/mod.rs
+++ b/compiler/rustc_type_ir/src/sty/mod.rs
@@ -1,3 +1,0 @@
-/// This type is temporary and exists to cut down the bloat of further PR's
-/// moving `struct Ty` from `rustc_middle` to `rustc_type_ir`.
-pub type Ty<I> = <I as crate::interner::Interner>::Ty;

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -100,7 +100,7 @@ pub enum TyKind<I: Interner> {
     Str,
 
     /// An array with the given length. Written as `[T; N]`.
-    Array(ty::Ty<I>, I::Const),
+    Array(I::Ty, I::Const),
 
     /// A pattern newtype.
     ///
@@ -109,17 +109,17 @@ pub enum TyKind<I: Interner> {
     /// Only `Copy` and `Clone` will automatically get implemented for pattern types.
     /// Auto-traits treat this as if it were an aggregate with a single nested type.
     /// Only supports integer range patterns for now.
-    Pat(ty::Ty<I>, I::Pat),
+    Pat(I::Ty, I::Pat),
 
     /// The pointee of an array slice. Written as `[T]`.
-    Slice(ty::Ty<I>),
+    Slice(I::Ty),
 
     /// A raw pointer. Written as `*mut T` or `*const T`
-    RawPtr(ty::Ty<I>, Mutability),
+    RawPtr(I::Ty, Mutability),
 
     /// A reference; a pointer with an associated lifetime. Written as
     /// `&'a mut T` or `&'a T`.
-    Ref(I::Region, ty::Ty<I>, Mutability),
+    Ref(I::Region, I::Ty, Mutability),
 
     /// The anonymous type of a function declaration/definition.
     ///
@@ -469,18 +469,18 @@ impl<I: Interner> AliasTy<I> {
         matches!(self.kind(interner), AliasTyKind::Opaque)
     }
 
-    pub fn to_ty(self, interner: I) -> ty::Ty<I> {
+    pub fn to_ty(self, interner: I) -> I::Ty {
         Ty::new_alias(interner, self.kind(interner), self)
     }
 }
 
 /// The following methods work only with (trait) associated type projections.
 impl<I: Interner> AliasTy<I> {
-    pub fn self_ty(self) -> ty::Ty<I> {
+    pub fn self_ty(self) -> I::Ty {
         self.args.type_at(0)
     }
 
-    pub fn with_replaced_self_ty(self, interner: I, self_ty: ty::Ty<I>) -> Self {
+    pub fn with_replaced_self_ty(self, interner: I, self_ty: I::Ty) -> Self {
         AliasTy::new(
             interner,
             self.def_id,
@@ -735,7 +735,7 @@ impl fmt::Debug for InferTy {
 )]
 #[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic)]
 pub struct TypeAndMut<I: Interner> {
-    pub ty: ty::Ty<I>,
+    pub ty: I::Ty,
     pub mutbl: Mutability,
 }
 
@@ -765,7 +765,7 @@ impl<I: Interner> FnSig<I> {
         self.inputs_and_output.inputs()
     }
 
-    pub fn output(self) -> ty::Ty<I> {
+    pub fn output(self) -> I::Ty {
         self.inputs_and_output.output()
     }
 
@@ -783,7 +783,7 @@ impl<I: Interner> ty::Binder<I, FnSig<I>> {
 
     #[inline]
     #[track_caller]
-    pub fn input(self, index: usize) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn input(self, index: usize) -> ty::Binder<I, I::Ty> {
         self.map_bound(|fn_sig| fn_sig.inputs().get(index).unwrap())
     }
 
@@ -792,7 +792,7 @@ impl<I: Interner> ty::Binder<I, FnSig<I>> {
     }
 
     #[inline]
-    pub fn output(self) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn output(self) -> ty::Binder<I, I::Ty> {
         self.map_bound(|fn_sig| fn_sig.output())
     }
 
@@ -856,21 +856,21 @@ impl<I: Interner> fmt::Debug for FnSig<I> {
 }
 
 // FIXME: this is a distinct type because we need to define `Encode`/`Decode`
-// impls in this crate for `Binder<I, ty::Ty<I>>`.
+// impls in this crate for `Binder<I, I::Ty>`.
 #[derive_where(Clone, Copy, PartialEq, Hash; I: Interner)]
 #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
 #[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic, Lift_Generic)]
-pub struct UnsafeBinderInner<I: Interner>(ty::Binder<I, ty::Ty<I>>);
+pub struct UnsafeBinderInner<I: Interner>(ty::Binder<I, I::Ty>);
 
 impl<I: Interner> Eq for UnsafeBinderInner<I> {}
 
-impl<I: Interner> From<ty::Binder<I, ty::Ty<I>>> for UnsafeBinderInner<I> {
-    fn from(value: ty::Binder<I, ty::Ty<I>>) -> Self {
+impl<I: Interner> From<ty::Binder<I, I::Ty>> for UnsafeBinderInner<I> {
+    fn from(value: ty::Binder<I, I::Ty>) -> Self {
         UnsafeBinderInner(value)
     }
 }
 
-impl<I: Interner> From<UnsafeBinderInner<I>> for ty::Binder<I, ty::Ty<I>> {
+impl<I: Interner> From<UnsafeBinderInner<I>> for ty::Binder<I, I::Ty> {
     fn from(value: UnsafeBinderInner<I>) -> Self {
         value.0
     }
@@ -883,7 +883,7 @@ impl<I: Interner> fmt::Debug for UnsafeBinderInner<I> {
 }
 
 impl<I: Interner> Deref for UnsafeBinderInner<I> {
-    type Target = ty::Binder<I, ty::Ty<I>>;
+    type Target = ty::Binder<I, I::Ty>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -894,7 +894,7 @@ impl<I: Interner> Deref for UnsafeBinderInner<I> {
 impl<I: Interner, E: rustc_serialize::Encoder> rustc_serialize::Encodable<E>
     for UnsafeBinderInner<I>
 where
-    ty::Ty<I>: rustc_serialize::Encodable<E>,
+    I::Ty: rustc_serialize::Encodable<E>,
     I::BoundVarKinds: rustc_serialize::Encodable<E>,
 {
     fn encode(&self, e: &mut E) {
@@ -907,7 +907,7 @@ where
 impl<I: Interner, D: rustc_serialize::Decoder> rustc_serialize::Decodable<D>
     for UnsafeBinderInner<I>
 where
-    ty::Ty<I>: TypeVisitable<I> + rustc_serialize::Decodable<D>,
+    I::Ty: TypeVisitable<I> + rustc_serialize::Decodable<D>,
     I::BoundVarKinds: rustc_serialize::Decodable<D>,
 {
     fn decode(decoder: &mut D) -> Self {
@@ -937,7 +937,7 @@ impl<I: Interner> FnSigTys<I> {
         self.inputs_and_output.inputs()
     }
 
-    pub fn output(self) -> ty::Ty<I> {
+    pub fn output(self) -> I::Ty {
         self.inputs_and_output.output()
     }
 }
@@ -960,7 +960,7 @@ impl<I: Interner> ty::Binder<I, FnSigTys<I>> {
 
     #[inline]
     #[track_caller]
-    pub fn input(self, index: usize) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn input(self, index: usize) -> ty::Binder<I, I::Ty> {
         self.map_bound(|sig_tys| sig_tys.inputs().get(index).unwrap())
     }
 
@@ -969,7 +969,7 @@ impl<I: Interner> ty::Binder<I, FnSigTys<I>> {
     }
 
     #[inline]
-    pub fn output(self) -> ty::Binder<I, ty::Ty<I>> {
+    pub fn output(self) -> ty::Binder<I, I::Ty> {
         self.map_bound(|sig_tys| sig_tys.output())
     }
 }

--- a/compiler/rustc_type_ir/src/ty_kind/closure.rs
+++ b/compiler/rustc_type_ir/src/ty_kind/closure.rs
@@ -121,13 +121,13 @@ pub struct ClosureArgsParts<I: Interner> {
     /// This is the args of the typeck root.
     pub parent_args: I::GenericArgsSlice,
     /// Represents the maximum calling capability of the closure.
-    pub closure_kind_ty: ty::Ty<I>,
+    pub closure_kind_ty: I::Ty,
     /// Captures the closure's signature. This closure signature is "tupled", and
     /// thus has a peculiar signature of `extern "rust-call" fn((Args, ...)) -> Ty`.
-    pub closure_sig_as_fn_ptr_ty: ty::Ty<I>,
+    pub closure_sig_as_fn_ptr_ty: I::Ty,
     /// The upvars captured by the closure. Remains an inference variable
     /// until the upvar analysis, which happens late in HIR typeck.
-    pub tupled_upvars_ty: ty::Ty<I>,
+    pub tupled_upvars_ty: I::Ty,
 }
 
 impl<I: Interner> ClosureArgs<I> {
@@ -169,14 +169,14 @@ impl<I: Interner> ClosureArgs<I> {
 
     /// Returns the tuple type representing the upvars for this closure.
     #[inline]
-    pub fn tupled_upvars_ty(self) -> ty::Ty<I> {
+    pub fn tupled_upvars_ty(self) -> I::Ty {
         self.split().tupled_upvars_ty
     }
 
     /// Returns the closure kind for this closure; may return a type
     /// variable during inference. To get the closure kind during
     /// inference, use `infcx.closure_kind(args)`.
-    pub fn kind_ty(self) -> ty::Ty<I> {
+    pub fn kind_ty(self) -> I::Ty {
         self.split().closure_kind_ty
     }
 
@@ -185,7 +185,7 @@ impl<I: Interner> ClosureArgs<I> {
     // FIXME(eddyb) this should be unnecessary, as the shallowly resolved
     // type is known at the time of the creation of `ClosureArgs`,
     // see `rustc_hir_analysis::check::closure`.
-    pub fn sig_as_fn_ptr_ty(self) -> ty::Ty<I> {
+    pub fn sig_as_fn_ptr_ty(self) -> I::Ty {
         self.split().closure_sig_as_fn_ptr_ty
     }
 
@@ -223,7 +223,7 @@ pub struct CoroutineClosureArgsParts<I: Interner> {
     /// This is the args of the typeck root.
     pub parent_args: I::GenericArgsSlice,
     /// Represents the maximum calling capability of the closure.
-    pub closure_kind_ty: ty::Ty<I>,
+    pub closure_kind_ty: I::Ty,
     /// Represents all of the relevant parts of the coroutine returned by this
     /// coroutine-closure. This signature parts type will have the general
     /// shape of `fn(tupled_inputs, resume_ty) -> (return_ty, yield_ty)`, where
@@ -232,10 +232,10 @@ pub struct CoroutineClosureArgsParts<I: Interner> {
     ///
     /// Use `coroutine_closure_sig` to break up this type rather than using it
     /// yourself.
-    pub signature_parts_ty: ty::Ty<I>,
+    pub signature_parts_ty: I::Ty,
     /// The upvars captured by the closure. Remains an inference variable
     /// until the upvar analysis, which happens late in HIR typeck.
-    pub tupled_upvars_ty: ty::Ty<I>,
+    pub tupled_upvars_ty: I::Ty,
     /// a function pointer that has the shape `for<'env> fn() -> (&'env T, ...)`.
     /// This allows us to represent the binder of the self-captures of the closure.
     ///
@@ -243,7 +243,7 @@ pub struct CoroutineClosureArgsParts<I: Interner> {
     /// from the closure's upvars, this will be `for<'env> fn() -> (&'env String,)`,
     /// while the `tupled_upvars_ty`, representing the by-move version of the same
     /// captures, will be `(String,)`.
-    pub coroutine_captures_by_ref_ty: ty::Ty<I>,
+    pub coroutine_captures_by_ref_ty: I::Ty,
 }
 
 impl<I: Interner> CoroutineClosureArgs<I> {
@@ -277,11 +277,11 @@ impl<I: Interner> CoroutineClosureArgs<I> {
     }
 
     #[inline]
-    pub fn tupled_upvars_ty(self) -> ty::Ty<I> {
+    pub fn tupled_upvars_ty(self) -> I::Ty {
         self.split().tupled_upvars_ty
     }
 
-    pub fn kind_ty(self) -> ty::Ty<I> {
+    pub fn kind_ty(self) -> I::Ty {
         self.split().closure_kind_ty
     }
 
@@ -289,7 +289,7 @@ impl<I: Interner> CoroutineClosureArgs<I> {
         self.kind_ty().to_opt_closure_kind().unwrap()
     }
 
-    pub fn signature_parts_ty(self) -> ty::Ty<I> {
+    pub fn signature_parts_ty(self) -> I::Ty {
         self.split().signature_parts_ty
     }
 
@@ -314,7 +314,7 @@ impl<I: Interner> CoroutineClosureArgs<I> {
         })
     }
 
-    pub fn coroutine_captures_by_ref_ty(self) -> ty::Ty<I> {
+    pub fn coroutine_captures_by_ref_ty(self) -> I::Ty {
         self.split().coroutine_captures_by_ref_ty
     }
 
@@ -358,10 +358,10 @@ impl<I: Interner> TypeVisitor<I> for HasRegionsBoundAt {
 #[derive_where(Clone, Copy, PartialEq, Hash, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic)]
 pub struct CoroutineClosureSignature<I: Interner> {
-    pub tupled_inputs_ty: ty::Ty<I>,
-    pub resume_ty: ty::Ty<I>,
-    pub yield_ty: ty::Ty<I>,
-    pub return_ty: ty::Ty<I>,
+    pub tupled_inputs_ty: I::Ty,
+    pub resume_ty: I::Ty,
+    pub yield_ty: I::Ty,
+    pub return_ty: I::Ty,
 
     // Like the `fn_sig_as_fn_ptr_ty` of a regular closure, these types
     // never actually differ. But we save them rather than recreating them
@@ -393,10 +393,10 @@ impl<I: Interner> CoroutineClosureSignature<I> {
         self,
         cx: I,
         parent_args: I::GenericArgsSlice,
-        coroutine_kind_ty: ty::Ty<I>,
+        coroutine_kind_ty: I::Ty,
         coroutine_def_id: I::CoroutineId,
-        tupled_upvars_ty: ty::Ty<I>,
-    ) -> ty::Ty<I> {
+        tupled_upvars_ty: I::Ty,
+    ) -> I::Ty {
         let coroutine_args = ty::CoroutineArgs::new(
             cx,
             ty::CoroutineArgsParts {
@@ -424,9 +424,9 @@ impl<I: Interner> CoroutineClosureSignature<I> {
         coroutine_def_id: I::CoroutineId,
         goal_kind: ty::ClosureKind,
         env_region: I::Region,
-        closure_tupled_upvars_ty: ty::Ty<I>,
-        coroutine_captures_by_ref_ty: ty::Ty<I>,
-    ) -> ty::Ty<I> {
+        closure_tupled_upvars_ty: I::Ty,
+        coroutine_captures_by_ref_ty: I::Ty,
+    ) -> I::Ty {
         let tupled_upvars_ty = Self::tupled_upvars_by_closure_kind(
             cx,
             goal_kind,
@@ -457,11 +457,11 @@ impl<I: Interner> CoroutineClosureSignature<I> {
     pub fn tupled_upvars_by_closure_kind(
         cx: I,
         kind: ty::ClosureKind,
-        tupled_inputs_ty: ty::Ty<I>,
-        closure_tupled_upvars_ty: ty::Ty<I>,
-        coroutine_captures_by_ref_ty: ty::Ty<I>,
+        tupled_inputs_ty: I::Ty,
+        closure_tupled_upvars_ty: I::Ty,
+        coroutine_captures_by_ref_ty: I::Ty,
         env_region: I::Region,
-    ) -> ty::Ty<I> {
+    ) -> I::Ty {
         match kind {
             ty::ClosureKind::Fn | ty::ClosureKind::FnMut => {
                 let ty::FnPtr(sig_tys, _) = coroutine_captures_by_ref_ty.kind() else {
@@ -503,7 +503,7 @@ struct FoldEscapingRegions<I: Interner> {
 
     // Depends on `debruijn` because we may have types with regions of different
     // debruijn depths depending on the binders we've entered.
-    cache: DelayedMap<(ty::DebruijnIndex, ty::Ty<I>), ty::Ty<I>>,
+    cache: DelayedMap<(ty::DebruijnIndex, I::Ty), I::Ty>,
 }
 
 impl<I: Interner> TypeFolder<I> for FoldEscapingRegions<I> {
@@ -511,7 +511,7 @@ impl<I: Interner> TypeFolder<I> for FoldEscapingRegions<I> {
         self.interner
     }
 
-    fn fold_ty(&mut self, t: ty::Ty<I>) -> ty::Ty<I> {
+    fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
         if !t.has_vars_bound_at_or_above(self.debruijn) {
             t
         } else if let Some(&t) = self.cache.get(&(self.debruijn, t)) {
@@ -553,9 +553,9 @@ impl<I: Interner> TypeFolder<I> for FoldEscapingRegions<I> {
 #[derive_where(Clone, Copy, PartialEq, Hash, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic)]
 pub struct GenSig<I: Interner> {
-    pub resume_ty: ty::Ty<I>,
-    pub yield_ty: ty::Ty<I>,
-    pub return_ty: ty::Ty<I>,
+    pub resume_ty: I::Ty,
+    pub yield_ty: I::Ty,
+    pub return_ty: I::Ty,
 }
 
 impl<I: Interner> Eq for GenSig<I> {}
@@ -581,15 +581,15 @@ pub struct CoroutineArgsParts<I: Interner> {
     /// kind: `i8`/`i16`/`i32`.
     ///
     /// For regular coroutines, this field will always just be `()`.
-    pub kind_ty: ty::Ty<I>,
+    pub kind_ty: I::Ty,
 
-    pub resume_ty: ty::Ty<I>,
-    pub yield_ty: ty::Ty<I>,
-    pub return_ty: ty::Ty<I>,
+    pub resume_ty: I::Ty,
+    pub yield_ty: I::Ty,
+    pub return_ty: I::Ty,
 
     /// The upvars captured by the closure. Remains an inference variable
     /// until the upvar analysis, which happens late in HIR typeck.
-    pub tupled_upvars_ty: ty::Ty<I>,
+    pub tupled_upvars_ty: I::Ty,
 }
 
 impl<I: Interner> CoroutineArgs<I> {
@@ -619,7 +619,7 @@ impl<I: Interner> CoroutineArgs<I> {
     }
 
     // Returns the kind of the coroutine. See docs on the `kind_ty` field.
-    pub fn kind_ty(self) -> ty::Ty<I> {
+    pub fn kind_ty(self) -> I::Ty {
         self.split().kind_ty
     }
 
@@ -638,22 +638,22 @@ impl<I: Interner> CoroutineArgs<I> {
 
     /// Returns the tuple type representing the upvars for this coroutine.
     #[inline]
-    pub fn tupled_upvars_ty(self) -> ty::Ty<I> {
+    pub fn tupled_upvars_ty(self) -> I::Ty {
         self.split().tupled_upvars_ty
     }
 
     /// Returns the type representing the resume type of the coroutine.
-    pub fn resume_ty(self) -> ty::Ty<I> {
+    pub fn resume_ty(self) -> I::Ty {
         self.split().resume_ty
     }
 
     /// Returns the type representing the yield type of the coroutine.
-    pub fn yield_ty(self) -> ty::Ty<I> {
+    pub fn yield_ty(self) -> I::Ty {
         self.split().yield_ty
     }
 
     /// Returns the type representing the return type of the coroutine.
-    pub fn return_ty(self) -> ty::Ty<I> {
+    pub fn return_ty(self) -> I::Ty {
         self.split().return_ty
     }
 

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -52,7 +52,7 @@ use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
 use crate::inherent::*;
-use crate::{self as ty, Interner, Ty, TypeFlags};
+use crate::{self as ty, Interner, TypeFlags};
 
 /// This trait is implemented for every type that can be visited,
 /// providing the skeleton of the traversal.
@@ -98,7 +98,7 @@ pub trait TypeVisitor<I: Interner>: Sized {
         t.super_visit_with(self)
     }
 
-    fn visit_ty(&mut self, t: Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, t: I::Ty) -> Self::Result {
         t.super_visit_with(self)
     }
 
@@ -417,7 +417,7 @@ impl<I: Interner> TypeVisitor<I> for HasTypeFlagsVisitor {
     }
 
     #[inline]
-    fn visit_ty(&mut self, t: Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, t: I::Ty) -> Self::Result {
         // Note: no `super_visit_with` call.
         let flags = t.flags();
         if flags.intersects(self.flags) {
@@ -522,7 +522,7 @@ impl<I: Interner> TypeVisitor<I> for HasEscapingVarsVisitor {
     }
 
     #[inline]
-    fn visit_ty(&mut self, t: Ty<I>) -> Self::Result {
+    fn visit_ty(&mut self, t: I::Ty) -> Self::Result {
         // If the outer-exclusive-binder is *strictly greater* than
         // `outer_index`, that means that `t` contains some content
         // bound at `outer_index` or above (because


### PR DESCRIPTION
Reverting (rust-lang/rust#154270) the creation and use of `Ty` type alias in `rustc_type_ir` that was causing problems with Rust Analyser, see [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/.23154270.20.28Ty.20alias.29.20triggers.20many.20bogus.20RA.20errors/with/583209227) for more

r? @lcnr 
