### PR TITLE
Update cargo submodule

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -566,6 +566,7 @@ impl Builder<'_> {
 
         if !has_modern_jobserver {
             cargo.env_remove("MAKEFLAGS");
+            cargo.env_remove("MFLAGS");
         }
 
         cargo


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154734)*
<!-- homu-ignore:end -->

15 commits in 888f675344eb1cf2308fd53183e667bdd2c58e51..a357df4c26fc14514e66aae2a269456b5545c7db
2026-03-30 16:59:25 +0000 to 2026-04-03 16:47:15 +0000
- chore: downgrade to libz-sys@1.1.24 (rust-lang/cargo#16833)
- feat: add frame-pointers profile option (rust-lang/cargo#16742)
- upgrade to gix@0.81.0 (rust-lang/cargo#16828)
- refactor(network): use async for registry network operations (rust-lang/cargo#16745)
- fix(compile): Don't hide hard warnings with build.warnings=allow (rust-lang/cargo#16827)
- chore: Upgrade incompatible dependencies (rust-lang/cargo#16825)
- fix(compile): build.warnings=allow should not hide denied diagnostics (rust-lang/cargo#16824)
- fix(install): Ignore resolver.lockfile-path (rust-lang/cargo#16823)
- chore(deps): update compatible (rust-lang/cargo#16820)
- refactor(compile): Consolidate output options (rust-lang/cargo#16821)
- refactor: Export public dependencies from internal crates (rust-lang/cargo#16819)
- refactor(progress): Make the code more approachable (rust-lang/cargo#16813)
- Simplified build script bin names in new layout (rust-lang/cargo#16812)
- fix: set CARGO env var during rustc -vV probe (rust-lang/cargo#16811)
- Split out `cargo-util-terminal` (rust-lang/cargo#16809)
