### PR TITLE
Use interior mutability for `StableHashingContext::caching_source_map`.

### DIFF
--- a/compiler/rustc_abi/src/extern_abi.rs
+++ b/compiler/rustc_abi/src/extern_abi.rs
@@ -217,9 +217,9 @@ impl Hash for ExternAbi {
 }
 
 #[cfg(feature = "nightly")]
-impl<C> HashStable<C> for ExternAbi {
+impl<Hcx> HashStable<Hcx> for ExternAbi {
     #[inline]
-    fn hash_stable(&self, _: &mut C, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _: &Hcx, hasher: &mut StableHasher) {
         Hash::hash(self, hasher);
     }
 }

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -121,7 +121,7 @@ impl PartialEq<&[Symbol]> for Path {
 }
 
 impl<Hcx: rustc_span::HashStableContext> HashStable<Hcx> for Path {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.segments.len().hash_stable(hcx, hasher);
         for segment in &self.segments {
             segment.ident.hash_stable(hcx, hasher);

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -139,7 +139,7 @@ impl<D: SpanDecoder> Decodable<D> for LazyAttrTokenStream {
 }
 
 impl<Hcx> HashStable<Hcx> for LazyAttrTokenStream {
-    fn hash_stable(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {
+    fn hash_stable(&self, _hcx: &Hcx, _hasher: &mut StableHasher) {
         panic!("Attempted to compute stable hash for LazyAttrTokenStream");
     }
 }
@@ -828,7 +828,7 @@ impl<Hcx> HashStable<Hcx> for TokenStream
 where
     Hcx: crate::HashStableContext,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         for sub_tt in self.iter() {
             sub_tt.hash_stable(hcx, hasher);
         }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -602,9 +602,9 @@ fn compute_hir_hash(
         .collect();
     hir_body_nodes.sort_unstable_by_key(|bn| bn.0);
 
-    tcx.with_stable_hashing_context(|mut hcx| {
+    tcx.with_stable_hashing_context(|hcx| {
         let mut stable_hasher = StableHasher::new();
-        hir_body_nodes.hash_stable(&mut hcx, &mut stable_hasher);
+        hir_body_nodes.hash_stable(&hcx, &mut stable_hasher);
         stable_hasher.finish()
     })
 }

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -46,7 +46,7 @@ enum OngoingModuleCodegen {
 }
 
 impl<Hcx> HashStable<Hcx> for OngoingModuleCodegen {
-    fn hash_stable(&self, _: &mut Hcx, _: &mut StableHasher) {
+    fn hash_stable(&self, _: &Hcx, _: &mut StableHasher) {
         // do nothing
     }
 }

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -302,9 +302,9 @@ impl<'ll, 'tcx> ConstCodegenMethods for CodegenCx<'ll, 'tcx> {
                             };
                             if !self.sess().fewer_names() && llvm::get_value_name(value).is_empty()
                             {
-                                let hash = self.tcx.with_stable_hashing_context(|mut hcx| {
+                                let hash = self.tcx.with_stable_hashing_context(|hcx| {
                                     let mut hasher = StableHasher::new();
-                                    alloc.hash_stable(&mut hcx, &mut hasher);
+                                    alloc.hash_stable(&hcx, &mut hasher);
                                     hasher.finish::<Hash128>()
                                 });
                                 llvm::set_value_name(

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -103,7 +103,7 @@ mod temp_stable_hash_impls {
     use crate::ModuleCodegen;
 
     impl<Hcx, M> HashStable<Hcx> for ModuleCodegen<M> {
-        fn hash_stable(&self, _: &mut Hcx, _: &mut StableHasher) {
+        fn hash_stable(&self, _: &Hcx, _: &mut StableHasher) {
             // do nothing
         }
     }

--- a/compiler/rustc_data_structures/src/intern.rs
+++ b/compiler/rustc_data_structures/src/intern.rs
@@ -107,7 +107,7 @@ impl<T, Hcx> HashStable<Hcx> for Interned<'_, T>
 where
     T: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.0.hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/packed.rs
+++ b/compiler/rustc_data_structures/src/packed.rs
@@ -62,7 +62,7 @@ impl fmt::UpperHex for Pu128 {
 
 impl<Hcx> HashStable<Hcx> for Pu128 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         { self.0 }.hash_stable(hcx, hasher)
     }
 }

--- a/compiler/rustc_data_structures/src/sorted_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map.rs
@@ -349,7 +349,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for SortedMap<K, V> {
 
 impl<K: HashStable<Hcx> + StableOrd, V: HashStable<Hcx>, Hcx> HashStable<Hcx> for SortedMap<K, V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.data.hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -42,7 +42,7 @@ pub use rustc_stable_hash::{
 ///   `StableHasher` takes care of endianness and `isize`/`usize` platform
 ///   differences.
 pub trait HashStable<Hcx> {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher);
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher);
 }
 
 /// Implement this for types that can be turned into stable keys like, for
@@ -138,7 +138,7 @@ macro_rules! impl_stable_traits_for_trivial_type {
     ($t:ty) => {
         impl<Hcx> $crate::stable_hasher::HashStable<Hcx> for $t {
             #[inline]
-            fn hash_stable(&self, _: &mut Hcx, hasher: &mut $crate::stable_hasher::StableHasher) {
+            fn hash_stable(&self, _: &Hcx, hasher: &mut $crate::stable_hasher::StableHasher) {
                 ::std::hash::Hash::hash(self, hasher);
             }
         }
@@ -179,7 +179,7 @@ impl_stable_traits_for_trivial_type!(Hash64);
 // hashing we want to hash the full 128-bit hash.
 impl<Hcx> HashStable<Hcx> for Hash128 {
     #[inline]
-    fn hash_stable(&self, _: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _: &Hcx, hasher: &mut StableHasher) {
         self.as_u128().hash(hasher);
     }
 }
@@ -193,38 +193,38 @@ impl StableOrd for Hash128 {
 }
 
 impl<Hcx> HashStable<Hcx> for ! {
-    fn hash_stable(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {
+    fn hash_stable(&self, _hcx: &Hcx, _hasher: &mut StableHasher) {
         unreachable!()
     }
 }
 
 impl<Hcx, T> HashStable<Hcx> for PhantomData<T> {
-    fn hash_stable(&self, _hcx: &mut Hcx, _hasher: &mut StableHasher) {}
+    fn hash_stable(&self, _hcx: &Hcx, _hasher: &mut StableHasher) {}
 }
 
 impl<Hcx> HashStable<Hcx> for NonZero<u32> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.get().hash_stable(hcx, hasher)
     }
 }
 
 impl<Hcx> HashStable<Hcx> for NonZero<usize> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.get().hash_stable(hcx, hasher)
     }
 }
 
 impl<Hcx> HashStable<Hcx> for f32 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         let val: u32 = self.to_bits();
         val.hash_stable(hcx, hasher);
     }
 }
 
 impl<Hcx> HashStable<Hcx> for f64 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         let val: u64 = self.to_bits();
         val.hash_stable(hcx, hasher);
     }
@@ -232,21 +232,21 @@ impl<Hcx> HashStable<Hcx> for f64 {
 
 impl<Hcx> HashStable<Hcx> for ::std::cmp::Ordering {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         (*self as i8).hash_stable(hcx, hasher);
     }
 }
 
 impl<T1: HashStable<Hcx>, Hcx> HashStable<Hcx> for (T1,) {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         let (ref _0,) = *self;
         _0.hash_stable(hcx, hasher);
     }
 }
 
 impl<T1: HashStable<Hcx>, T2: HashStable<Hcx>, Hcx> HashStable<Hcx> for (T1, T2) {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         let (ref _0, ref _1) = *self;
         _0.hash_stable(hcx, hasher);
         _1.hash_stable(hcx, hasher);
@@ -267,7 +267,7 @@ where
     T2: HashStable<Hcx>,
     T3: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         let (ref _0, ref _1, ref _2) = *self;
         _0.hash_stable(hcx, hasher);
         _1.hash_stable(hcx, hasher);
@@ -291,7 +291,7 @@ where
     T3: HashStable<Hcx>,
     T4: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         let (ref _0, ref _1, ref _2, ref _3) = *self;
         _0.hash_stable(hcx, hasher);
         _1.hash_stable(hcx, hasher);
@@ -312,7 +312,7 @@ impl<T1: StableOrd, T2: StableOrd, T3: StableOrd, T4: StableOrd> StableOrd for (
 }
 
 impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for [T] {
-    default fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    default fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for item in self {
             item.hash_stable(hcx, hasher);
@@ -321,7 +321,7 @@ impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for [T] {
 }
 
 impl<Hcx> HashStable<Hcx> for [u8] {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         hasher.write(self);
     }
@@ -329,7 +329,7 @@ impl<Hcx> HashStable<Hcx> for [u8] {
 
 impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for Vec<T> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self[..].hash_stable(hcx, hasher);
     }
 }
@@ -341,7 +341,7 @@ where
     R: BuildHasher,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for kv in self {
             kv.hash_stable(hcx, hasher);
@@ -355,7 +355,7 @@ where
     R: BuildHasher,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for key in self {
             key.hash_stable(hcx, hasher);
@@ -368,35 +368,35 @@ where
     A: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self[..].hash_stable(hcx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<Hcx>, Hcx> HashStable<Hcx> for Box<T> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<Hcx>, Hcx> HashStable<Hcx> for ::std::rc::Rc<T> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<Hcx>, Hcx> HashStable<Hcx> for ::std::sync::Arc<T> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher);
     }
 }
 
 impl<Hcx> HashStable<Hcx> for str {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.as_bytes().hash_stable(hcx, hasher);
     }
 }
@@ -411,7 +411,7 @@ impl StableOrd for &str {
 
 impl<Hcx> HashStable<Hcx> for String {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self[..].hash_stable(hcx, hasher);
     }
 }
@@ -442,7 +442,7 @@ impl<Hcx, T1: ToStableHashKey<Hcx>, T2: ToStableHashKey<Hcx>> ToStableHashKey<Hc
 
 impl<Hcx> HashStable<Hcx> for bool {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         (if *self { 1u8 } else { 0u8 }).hash_stable(hcx, hasher);
     }
 }
@@ -459,7 +459,7 @@ where
     T: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         if let Some(ref value) = *self {
             1u8.hash_stable(hcx, hasher);
             value.hash_stable(hcx, hasher);
@@ -482,7 +482,7 @@ where
     T2: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             Ok(ref x) => x.hash_stable(hcx, hasher),
@@ -496,14 +496,14 @@ where
     T: HashStable<Hcx> + ?Sized,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher);
     }
 }
 
 impl<T, Hcx> HashStable<Hcx> for ::std::mem::Discriminant<T> {
     #[inline]
-    fn hash_stable(&self, _: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _: &Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
@@ -513,7 +513,7 @@ where
     T: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.start().hash_stable(hcx, hasher);
         self.end().hash_stable(hcx, hasher);
     }
@@ -523,7 +523,7 @@ impl<I: Idx, T, Hcx> HashStable<Hcx> for IndexSlice<I, T>
 where
     T: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for v in &self.raw {
             v.hash_stable(hcx, hasher);
@@ -535,7 +535,7 @@ impl<I: Idx, T, Hcx> HashStable<Hcx> for IndexVec<I, T>
 where
     T: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for v in &self.raw {
             v.hash_stable(hcx, hasher);
@@ -544,13 +544,13 @@ where
 }
 
 impl<I: Idx, Hcx> HashStable<Hcx> for DenseBitSet<I> {
-    fn hash_stable(&self, _hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _hcx: &Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
 
 impl<R: Idx, C: Idx, Hcx> HashStable<Hcx> for bit_set::BitMatrix<R, C> {
-    fn hash_stable(&self, _hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _hcx: &Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
@@ -571,7 +571,7 @@ where
     K: HashStable<Hcx> + StableOrd,
     V: HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for entry in self.iter() {
             entry.hash_stable(hcx, hasher);
@@ -583,7 +583,7 @@ impl<K, Hcx> HashStable<Hcx> for ::std::collections::BTreeSet<K>
 where
     K: HashStable<Hcx> + StableOrd,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for entry in self.iter() {
             entry.hash_stable(hcx, hasher);

--- a/compiler/rustc_data_structures/src/stable_hasher/tests.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher/tests.rs
@@ -45,7 +45,7 @@ fn test_attribute_permutation() {
             }
 
             impl<Hcx> HashStable<Hcx> for Foo {
-                fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+                fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
                     self.a.hash_stable(hcx, hasher);
                     self.b.hash_stable(hcx, hasher);
                 }

--- a/compiler/rustc_data_structures/src/steal.rs
+++ b/compiler/rustc_data_structures/src/steal.rs
@@ -72,7 +72,7 @@ impl<T> Steal<T> {
 }
 
 impl<Hcx, T: HashStable<Hcx>> HashStable<Hcx> for Steal<T> {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.borrow().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -267,7 +267,7 @@ where
     P: HashStable<Hcx> + Aligned + ?Sized,
     T: Tag + HashStable<Hcx>,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.pointer().hash_stable(hcx, hasher);
         self.tag().hash_stable(hcx, hasher);
     }

--- a/compiler/rustc_data_structures/src/tagged_ptr/tests.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/tests.rs
@@ -33,7 +33,7 @@ unsafe impl Tag for Tag2 {
 }
 
 impl<Hcx> crate::stable_hasher::HashStable<Hcx> for Tag2 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut crate::stable_hasher::StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut crate::stable_hasher::StableHasher) {
         (*self as u8).hash_stable(hcx, hasher);
     }
 }
@@ -65,13 +65,13 @@ fn smoke() {
 fn stable_hash_hashes_as_tuple() {
     let hash_packed = {
         let mut hasher = StableHasher::new();
-        TaggedRef::new(&12, Tag2::B11).hash_stable(&mut (), &mut hasher);
+        TaggedRef::new(&12, Tag2::B11).hash_stable(&(), &mut hasher);
         hasher.finish::<Hash128>()
     };
 
     let hash_tupled = {
         let mut hasher = StableHasher::new();
-        (&12, Tag2::B11).hash_stable(&mut (), &mut hasher);
+        (&12, Tag2::B11).hash_stable(&(), &mut hasher);
         hasher.finish::<Hash128>()
     };
 

--- a/compiler/rustc_data_structures/src/unord.rs
+++ b/compiler/rustc_data_structures/src/unord.rs
@@ -417,7 +417,7 @@ impl<V: Hash + Eq, I: Iterator<Item = V>> From<UnordItems<V, I>> for UnordSet<V>
 
 impl<Hcx, V: Hash + Eq + HashStable<Hcx>> HashStable<Hcx> for UnordSet<V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         hash_iter_order_independent(self.inner.iter(), hcx, hasher);
     }
 }
@@ -640,7 +640,7 @@ where
 
 impl<Hcx, K: Hash + Eq + HashStable<Hcx>, V: HashStable<Hcx>> HashStable<Hcx> for UnordMap<K, V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         hash_iter_order_independent(self.inner.iter(), hcx, hasher);
     }
 }
@@ -703,7 +703,7 @@ impl<T, I: Iterator<Item = T>> From<UnordItems<T, I>> for UnordBag<T> {
 
 impl<Hcx, V: Hash + Eq + HashStable<Hcx>> HashStable<Hcx> for UnordBag<V> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         hash_iter_order_independent(self.inner.iter(), hcx, hasher);
     }
 }
@@ -735,7 +735,7 @@ fn hash_iter_order_independent<
     I: Iterator<Item = T> + ExactSizeIterator,
 >(
     mut it: I,
-    hcx: &mut Hcx,
+    hcx: &Hcx,
     hasher: &mut StableHasher,
 ) {
     let len = it.len();

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -145,7 +145,7 @@ macro_rules! language_item_table {
 }
 
 impl<Hcx> HashStable<Hcx> for LangItem {
-    fn hash_stable(&self, _: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, _: &Hcx, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -67,7 +67,7 @@ impl<HirCtx: crate::HashStableContext> ToStableHashKey<HirCtx> for ForeignItemId
 // in "DefPath Mode".
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'tcx> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &HirCtx, hasher: &mut StableHasher) {
         // We ignore the `nodes` and `bodies` fields since these refer to information included in
         // `hash` which is hashed in the collector and used for the crate hash.
         // `local_id_to_def_id` is also ignored because is dependent on the body, then just hashing
@@ -79,14 +79,14 @@ impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for DelayedLints {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &HirCtx, hasher: &mut StableHasher) {
         let DelayedLints { opt_hash, .. } = *self;
         opt_hash.unwrap().hash_stable(hcx, hasher);
     }
 }
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for AttributeMap<'tcx> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &HirCtx, hasher: &mut StableHasher) {
         // We ignore the `map` since it refers to information included in `opt_hash` which is
         // hashed in the collector and used for the crate hash.
         let AttributeMap { opt_hash, define_opaque: _, map: _ } = *self;
@@ -95,7 +95,7 @@ impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for AttributeMap
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for HashIgnoredAttrId {
-    fn hash_stable(&self, _hcx: &mut HirCtx, _hasher: &mut StableHasher) {
+    fn hash_stable(&self, _hcx: &HirCtx, _hasher: &mut StableHasher) {
         /* we don't hash HashIgnoredAttrId, we ignore them */
     }
 }

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -56,7 +56,7 @@ impl rustc_index::Idx for OwnerId {
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for OwnerId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -166,7 +166,11 @@ impl Parse for Newtype {
             quote! {
                 #gate_rustc_only
                 impl<'__ctx> ::rustc_data_structures::stable_hasher::HashStable<::rustc_middle::ich::StableHashingContext<'__ctx>> for #name {
-                    fn hash_stable(&self, hcx: &mut ::rustc_middle::ich::StableHashingContext<'__ctx>, hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
+                    fn hash_stable(
+                        &self,
+                        hcx: &::rustc_middle::ich::StableHashingContext<'__ctx>,
+                        hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher
+                    ) {
                         self.as_u32().hash_stable(hcx, hasher)
                     }
                 }
@@ -175,7 +179,11 @@ impl Parse for Newtype {
             quote! {
                 #gate_rustc_only
                 impl<Hcx> ::rustc_data_structures::stable_hasher::HashStable<Hcx> for #name {
-                    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
+                    fn hash_stable(
+                        &self,
+                        hcx: &Hcx,
+                        hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher
+                    ) {
                         self.as_u32().hash_stable(hcx, hasher)
                     }
                 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -140,7 +140,7 @@ impl LintExpectationId {
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for LintExpectationId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         match self {
             LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
                 hir_id.hash_stable(hcx, hasher);
@@ -623,7 +623,7 @@ impl LintId {
 
 impl<Hcx> HashStable<Hcx> for LintId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.lint_name_raw().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_macros/src/hash_stable.rs
+++ b/compiler/rustc_macros/src/hash_stable.rs
@@ -111,7 +111,7 @@ fn hash_stable_derive_with_mode(
             #[inline]
             fn hash_stable(
                 &self,
-                __hcx: &mut #context,
+                __hcx: &#context,
                 __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
                 #discriminant
                 match *self { #body }

--- a/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
@@ -41,9 +41,9 @@ where
 
     #[inline(always)]
     default fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
-        tcx.with_stable_hashing_context(|mut hcx| {
+        tcx.with_stable_hashing_context(|hcx| {
             let mut hasher = StableHasher::new();
-            self.hash_stable(&mut hcx, &mut hasher);
+            self.hash_stable(&hcx, &mut hasher);
             hasher.finish()
         })
     }

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -123,7 +123,7 @@ pub struct DepGraphData {
     debug_loaded_from_disk: Lock<FxHashSet<DepNode>>,
 }
 
-pub fn hash_result<R>(hcx: &mut StableHashingContext<'_>, result: &R) -> Fingerprint
+pub fn hash_result<R>(hcx: &StableHashingContext<'_>, result: &R) -> Fingerprint
 where
     R: for<'a> HashStable<StableHashingContext<'a>>,
 {
@@ -283,7 +283,7 @@ impl DepGraph {
         tcx: TyCtxt<'tcx>,
         task_arg: A,
         task_fn: fn(tcx: TyCtxt<'tcx>, task_arg: A) -> R,
-        hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
+        hash_result: Option<fn(&StableHashingContext<'_>, &R) -> Fingerprint>,
     ) -> (R, DepNodeIndex) {
         match self.data() {
             Some(data) => data.with_task(dep_node, tcx, task_arg, task_fn, hash_result),
@@ -334,7 +334,7 @@ impl DepGraphData {
         tcx: TyCtxt<'tcx>,
         task_arg: A,
         task_fn: fn(tcx: TyCtxt<'tcx>, task_arg: A) -> R,
-        hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
+        hash_result: Option<fn(&StableHashingContext<'_>, &R) -> Fingerprint>,
     ) -> (R, DepNodeIndex) {
         // If the following assertion triggers, it can have two reasons:
         // 1. Something is wrong with DepNode creation, either here or
@@ -452,12 +452,11 @@ impl DepGraphData {
         node: DepNode,
         edges: EdgesVec,
         result: &R,
-        hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
+        hash_result: Option<fn(&StableHashingContext<'_>, &R) -> Fingerprint>,
     ) -> DepNodeIndex {
         let hashing_timer = tcx.prof.incr_result_hashing();
-        let current_fingerprint = hash_result.map(|hash_result| {
-            tcx.with_stable_hashing_context(|mut hcx| hash_result(&mut hcx, result))
-        });
+        let current_fingerprint = hash_result
+            .map(|hash_result| tcx.with_stable_hashing_context(|hcx| hash_result(&hcx, result)));
         let dep_node_index = self.alloc_and_color_node(node, edges, current_fingerprint);
         hashing_timer.finish_with_query_invocation_id(dep_node_index.into());
         dep_node_index
@@ -577,7 +576,7 @@ impl DepGraph {
         node: DepNode,
         tcx: TyCtxt<'tcx>,
         result: &R,
-        hash_result: Option<fn(&mut StableHashingContext<'_>, &R) -> Fingerprint>,
+        hash_result: Option<fn(&StableHashingContext<'_>, &R) -> Fingerprint>,
         format_value_fn: fn(&R) -> String,
     ) -> DepNodeIndex {
         if let Some(data) = self.data.as_ref() {

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -1161,12 +1161,12 @@ pub(super) fn crate_hash(tcx: TyCtxt<'_>, _: LocalCrate) -> Svh {
         .map(DebuggerVisualizerFile::path_erased)
         .collect();
 
-    let crate_hash: Fingerprint = tcx.with_stable_hashing_context(|mut hcx| {
+    let crate_hash: Fingerprint = tcx.with_stable_hashing_context(|hcx| {
         let mut stable_hasher = StableHasher::new();
-        hir_body_hash.hash_stable(&mut hcx, &mut stable_hasher);
-        upstream_crates.hash_stable(&mut hcx, &mut stable_hasher);
-        source_file_names.hash_stable(&mut hcx, &mut stable_hasher);
-        debugger_visualizers.hash_stable(&mut hcx, &mut stable_hasher);
+        hir_body_hash.hash_stable(&hcx, &mut stable_hasher);
+        upstream_crates.hash_stable(&hcx, &mut stable_hasher);
+        source_file_names.hash_stable(&hcx, &mut stable_hasher);
+        debugger_visualizers.hash_stable(&hcx, &mut stable_hasher);
         if tcx.sess.opts.incremental.is_some() {
             let definitions = tcx.untracked().definitions.freeze();
             let mut owner_spans: Vec<_> = tcx
@@ -1180,17 +1180,17 @@ pub(super) fn crate_hash(tcx: TyCtxt<'_>, _: LocalCrate) -> Svh {
                 })
                 .collect();
             owner_spans.sort_unstable_by_key(|bn| bn.0);
-            owner_spans.hash_stable(&mut hcx, &mut stable_hasher);
+            owner_spans.hash_stable(&hcx, &mut stable_hasher);
         }
-        tcx.sess.opts.dep_tracking_hash(true).hash_stable(&mut hcx, &mut stable_hasher);
-        tcx.stable_crate_id(LOCAL_CRATE).hash_stable(&mut hcx, &mut stable_hasher);
+        tcx.sess.opts.dep_tracking_hash(true).hash_stable(&hcx, &mut stable_hasher);
+        tcx.stable_crate_id(LOCAL_CRATE).hash_stable(&hcx, &mut stable_hasher);
         // Hash visibility information since it does not appear in HIR.
         // FIXME: Figure out how to remove `visibilities_for_hashing` by hashing visibilities on
         // the fly in the resolver, storing only their accumulated hash in `ResolverGlobalCtxt`,
         // and combining it with other hashes here.
-        resolutions.visibilities_for_hashing.hash_stable(&mut hcx, &mut stable_hasher);
+        resolutions.visibilities_for_hashing.hash_stable(&hcx, &mut stable_hasher);
         with_metavar_spans(|mspans| {
-            mspans.freeze_and_get_read_spans().hash_stable(&mut hcx, &mut stable_hasher);
+            mspans.freeze_and_get_read_spans().hash_stable(&hcx, &mut stable_hasher);
         });
         stable_hasher.finish()
     });

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -78,7 +78,7 @@ impl<'hir> Crate<'hir> {
 }
 
 impl<HirCtx: HashStableContext> HashStable<HirCtx> for Crate<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &HirCtx, hasher: &mut StableHasher) {
         let Crate { opt_hir_hash, .. } = self;
         opt_hir_hash.unwrap().hash_stable(hcx, hasher)
     }
@@ -247,24 +247,24 @@ impl<'tcx> TyCtxt<'tcx> {
             };
         }
 
-        self.with_stable_hashing_context(|mut hcx| {
+        self.with_stable_hashing_context(|hcx| {
             let mut stable_hasher = StableHasher::new();
-            node.hash_stable(&mut hcx, &mut stable_hasher);
+            node.hash_stable(&hcx, &mut stable_hasher);
             // Bodies are stored out of line, so we need to pull them explicitly in the hash.
-            bodies.hash_stable(&mut hcx, &mut stable_hasher);
+            bodies.hash_stable(&hcx, &mut stable_hasher);
             let h1 = stable_hasher.finish();
 
             let mut stable_hasher = StableHasher::new();
-            attrs.hash_stable(&mut hcx, &mut stable_hasher);
+            attrs.hash_stable(&hcx, &mut stable_hasher);
 
             // Hash the defined opaque types, which are not present in the attrs.
-            define_opaque.hash_stable(&mut hcx, &mut stable_hasher);
+            define_opaque.hash_stable(&hcx, &mut stable_hasher);
 
             let h2 = stable_hasher.finish();
 
             // hash lints emitted during ast lowering
             let mut stable_hasher = StableHasher::new();
-            delayed_lints.hash_stable(&mut hcx, &mut stable_hasher);
+            delayed_lints.hash_stable(&hcx, &mut stable_hasher);
             let h3 = stable_hasher.finish();
 
             Hashes {

--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -11,7 +11,6 @@ use rustc_span::{BytePos, CachingSourceMapView, DUMMY_SP, Pos, SourceFile, Span,
 
 // Very often, we are hashing something that does not need the `CachingSourceMapView`, so we
 // initialize it lazily.
-#[derive(Clone)]
 enum CachingSourceMap<'a> {
     Unused(&'a Session),
     InUse(CachingSourceMapView<'a>),
@@ -21,7 +20,6 @@ enum CachingSourceMap<'a> {
 /// enough information to transform `DefId`s and `HirId`s into stable `DefPath`s (i.e.,
 /// a reference to the `TyCtxt`) and it holds a few caches for speeding up various
 /// things (e.g., each `DefId`/`DefPath` is only hashed once).
-#[derive(Clone)]
 pub struct StableHashingContext<'a> {
     untracked: &'a Untracked,
     // The value of `-Z incremental-ignore-spans`.

--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -1,18 +1,19 @@
+use std::cell::RefCell;
 use std::hash::Hash;
+use std::sync::Arc;
 
 use rustc_data_structures::stable_hasher::{HashStable, HashingControls, StableHasher};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::definitions::DefPathHash;
 use rustc_session::Session;
 use rustc_session::cstore::Untracked;
-use rustc_span::source_map::SourceMap;
-use rustc_span::{CachingSourceMapView, DUMMY_SP, Pos, Span};
+use rustc_span::{BytePos, CachingSourceMapView, DUMMY_SP, Pos, SourceFile, Span, SpanData};
 
 // Very often, we are hashing something that does not need the `CachingSourceMapView`, so we
 // initialize it lazily.
 #[derive(Clone)]
 enum CachingSourceMap<'a> {
-    Unused(&'a SourceMap),
+    Unused(&'a Session),
     InUse(CachingSourceMapView<'a>),
 }
 
@@ -26,7 +27,7 @@ pub struct StableHashingContext<'a> {
     // The value of `-Z incremental-ignore-spans`.
     // This field should only be used by `unstable_opts_incremental_ignore_span`
     incremental_ignore_spans: bool,
-    caching_source_map: CachingSourceMap<'a>,
+    caching_source_map: RefCell<CachingSourceMap<'a>>,
     hashing_controls: HashingControls,
 }
 
@@ -38,7 +39,7 @@ impl<'a> StableHashingContext<'a> {
         StableHashingContext {
             untracked,
             incremental_ignore_spans: sess.opts.unstable_opts.incremental_ignore_spans,
-            caching_source_map: CachingSourceMap::Unused(sess.source_map()),
+            caching_source_map: RefCell::new(CachingSourceMap::Unused(sess)),
             hashing_controls: HashingControls { hash_spans: hash_spans_initial },
         }
     }
@@ -51,13 +52,18 @@ impl<'a> StableHashingContext<'a> {
         self.hashing_controls.hash_spans = prev_hash_spans;
     }
 
-    #[inline]
-    fn source_map(&mut self) -> &mut CachingSourceMapView<'a> {
-        match self.caching_source_map {
-            CachingSourceMap::InUse(ref mut sm) => sm,
-            CachingSourceMap::Unused(sm) => {
-                self.caching_source_map = CachingSourceMap::InUse(CachingSourceMapView::new(sm));
-                self.source_map() // this recursive call will hit the `InUse` case
+    fn span_data_to_lines_and_cols(
+        &self,
+        span_data: &SpanData,
+    ) -> Option<(Arc<SourceFile>, usize, BytePos, usize, BytePos)> {
+        let mut caching_source_map = self.caching_source_map.borrow_mut();
+        match *caching_source_map {
+            CachingSourceMap::InUse(ref mut csmv) => csmv.span_data_to_lines_and_cols(span_data),
+            CachingSourceMap::Unused(sess) => {
+                let mut csmv = CachingSourceMapView::new(sess.source_map());
+                let res = csmv.span_data_to_lines_and_cols(span_data);
+                *caching_source_map = CachingSourceMap::InUse(csmv);
+                res
             }
         }
     }
@@ -120,7 +126,7 @@ impl<'a> rustc_span::HashStableContext for StableHashingContext<'a> {
         // If this is not an empty or invalid span, we want to hash the last position that belongs
         // to it, as opposed to hashing the first position past it.
         let Some((file, line_lo, col_lo, line_hi, col_hi)) =
-            self.source_map().span_data_to_lines_and_cols(&span)
+            self.span_data_to_lines_and_cols(&span)
         else {
             Hash::hash(&TAG_INVALID_SPAN, hasher);
             return;

--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -92,7 +92,7 @@ impl<'a> rustc_span::HashStableContext for StableHashingContext<'a> {
     ///
     /// IMPORTANT: changes to this method should be reflected in implementations of `SpanEncoder`.
     #[inline]
-    fn span_hash_stable(&mut self, span: Span, hasher: &mut StableHasher) {
+    fn span_hash_stable(&self, span: Span, hasher: &mut StableHasher) {
         const TAG_VALID_SPAN: u8 = 0;
         const TAG_INVALID_SPAN: u8 = 1;
         const TAG_RELATIVE_SPAN: u8 = 2;

--- a/compiler/rustc_middle/src/ich/impls_syntax.rs
+++ b/compiler/rustc_middle/src/ich/impls_syntax.rs
@@ -11,13 +11,13 @@ use super::StableHashingContext;
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::NodeId {
     #[inline]
-    fn hash_stable(&self, _: &mut StableHashingContext<'a>, _: &mut StableHasher) {
+    fn hash_stable(&self, _: &StableHashingContext<'a>, _: &mut StableHasher) {
         panic!("Node IDs should not appear in incremental state");
     }
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for [hir::Attribute] {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         if self.is_empty() {
             self.len().hash_stable(hcx, hasher);
             return;
@@ -55,7 +55,7 @@ fn is_ignored_attr(name: Symbol) -> bool {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         let SourceFile {
             name: _, // We hash the smaller stable_id instead of this
             stable_id,
@@ -105,7 +105,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
 }
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for rustc_feature::Features {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         // Unfortunately we cannot exhaustively list fields here, since the
         // struct has private fields (to ensure its invariant is maintained)
         self.enabled_lang_features().hash_stable(hcx, hasher);
@@ -114,7 +114,7 @@ impl<'tcx> HashStable<StableHashingContext<'tcx>> for rustc_feature::Features {
 }
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for rustc_feature::EnabledLangFeature {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         let rustc_feature::EnabledLangFeature { gate_name, attr_sp, stable_since } = self;
         gate_name.hash_stable(hcx, hasher);
         attr_sp.hash_stable(hcx, hasher);
@@ -123,7 +123,7 @@ impl<'tcx> HashStable<StableHashingContext<'tcx>> for rustc_feature::EnabledLang
 }
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for rustc_feature::EnabledLibFeature {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         let rustc_feature::EnabledLibFeature { gate_name, attr_sp } = self;
         gate_name.hash_stable(hcx, hasher);
         attr_sp.hash_stable(hcx, hasher);

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -274,7 +274,7 @@ impl<Id> Default for EffectiveVisibilities<Id> {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for EffectiveVisibilities {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         let EffectiveVisibilities { ref map } = *self;
         map.hash_stable(hcx, hasher);
     }

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -173,5 +173,5 @@ impl<D: Decoder> Decodable<D> for Cache {
 
 impl<Hcx> HashStable<Hcx> for Cache {
     #[inline]
-    fn hash_stable(&self, _: &mut Hcx, _: &mut StableHasher) {}
+    fn hash_stable(&self, _: &Hcx, _: &mut StableHasher) {}
 }

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -330,7 +330,7 @@ impl ToStableHashKey<StableHashingContext<'_>> for MonoItem<'_> {
 
     fn to_stable_hash_key(&self, hcx: &StableHashingContext<'_>) -> Self::KeyType {
         let mut hasher = StableHasher::new();
-        self.hash_stable(&hcx.clone(), &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -330,7 +330,7 @@ impl ToStableHashKey<StableHashingContext<'_>> for MonoItem<'_> {
 
     fn to_stable_hash_key(&self, hcx: &StableHashingContext<'_>) -> Self::KeyType {
         let mut hasher = StableHasher::new();
-        self.hash_stable(&mut hcx.clone(), &mut hasher);
+        self.hash_stable(&hcx.clone(), &mut hasher);
         hasher.finish()
     }
 }

--- a/compiler/rustc_middle/src/query/inner.rs
+++ b/compiler/rustc_middle/src/query/inner.rs
@@ -128,8 +128,8 @@ pub(crate) fn query_feed<'tcx, C>(
             // That's OK if both values are the same, i.e. they have the same hash,
             // so now we check their hashes.
             if let Some(hash_value_fn) = query.hash_value_fn {
-                let (old_hash, value_hash) = tcx.with_stable_hashing_context(|ref mut hcx| {
-                    (hash_value_fn(hcx, &old), hash_value_fn(hcx, &value))
+                let (old_hash, value_hash) = tcx.with_stable_hashing_context(|hcx| {
+                    (hash_value_fn(&hcx, &old), hash_value_fn(&hcx, &value))
                 });
                 if old_hash != value_hash {
                     // We have an inconsistency. This can happen if one of the two

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -582,9 +582,9 @@ impl<'a, 'tcx> SpanDecoder for CacheDecoder<'a, 'tcx> {
             #[cfg(debug_assertions)]
             {
                 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-                let local_hash = self.tcx.with_stable_hashing_context(|mut hcx| {
+                let local_hash = self.tcx.with_stable_hashing_context(|hcx| {
                     let mut hasher = StableHasher::new();
-                    expn_id.expn_data().hash_stable(&mut hcx, &mut hasher);
+                    expn_id.expn_data().hash_stable(&hcx, &mut hasher);
                     hasher.finish()
                 });
                 debug_assert_eq!(hash.local_hash(), local_hash);

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -109,7 +109,7 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
     /// Function pointer that hashes this query's result values.
     ///
     /// For `no_hash` queries, this function pointer is None.
-    pub hash_value_fn: Option<fn(&mut StableHashingContext<'_>, &C::Value) -> Fingerprint>,
+    pub hash_value_fn: Option<fn(&StableHashingContext<'_>, &C::Value) -> Fingerprint>,
 
     /// Function pointer that handles a cycle error. `error` must be consumed, e.g. with `emit` (if
     /// it should be emitted) or `delay_as_bug` (if it need not be emitted because an alternative

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -152,7 +152,7 @@ impl Hash for AdtDefData {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for AdtDefData {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         thread_local! {
             static CACHE: RefCell<FxHashMap<(usize, HashingControls), Fingerprint>> = Default::default();
         }

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -152,7 +152,7 @@ pub struct ScalarInt {
 // Cannot derive these, as the derives take references to the fields, and we
 // can't take references to fields of packed structs.
 impl<Hcx> crate::ty::HashStable<Hcx> for ScalarInt {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut crate::ty::StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut crate::ty::StableHasher) {
         // Using a block `{self.data}` here to force a copy instead of using `self.data`
         // directly, because `hash_stable` takes `&self` and would thus borrow `self.data`.
         // Since `Self` is a packed struct, that would create a possibly unaligned reference,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -264,8 +264,8 @@ impl<'tcx> CtxtInterners<'tcx> {
             Fingerprint::ZERO
         } else {
             let mut hasher = StableHasher::new();
-            let mut hcx = StableHashingContext::new(sess, untracked);
-            val.hash_stable(&mut hcx, &mut hasher);
+            let hcx = StableHashingContext::new(sess, untracked);
+            val.hash_stable(&hcx, &mut hasher);
             hasher.finish()
         }
     }

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -19,7 +19,7 @@ impl<'a, 'tcx, H, T> HashStable<StableHashingContext<'a>> for &'tcx ty::list::Ra
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         // Note: this cache makes an *enormous* performance difference on certain benchmarks. E.g.
         // without it, compiling `diesel-2.2.10` can be 74% slower, and compiling
         // `deeply-nested-multi` can be ~4,000x slower(!)
@@ -55,21 +55,21 @@ where
     #[inline]
     fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: StableHashingContext<'a> = hcx.clone();
-        self.hash_stable(&mut hcx, &mut hasher);
+        let hcx: StableHashingContext<'a> = hcx.clone();
+        self.hash_stable(&hcx, &mut hasher);
         hasher.finish()
     }
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::GenericArg<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.kind().hash_stable(hcx, hasher);
     }
 }
 
 // AllocIds get resolved to whatever they point to (to be stable)
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         ty::tls::with_opt(|tcx| {
             trace!("hashing {:?}", *self);
             let tcx = tcx.expect("can't hash AllocIds during hir lowering");
@@ -79,7 +79,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::CtfeProvenance {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.into_parts().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -55,8 +55,7 @@ where
     #[inline]
     fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let hcx: StableHashingContext<'a> = hcx.clone();
-        self.hash_stable(&hcx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -512,7 +512,7 @@ impl<'tcx> From<Const<'tcx>> for Term<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for Term<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.kind().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_middle/src/verify_ich.rs
+++ b/compiler/rustc_middle/src/verify_ich.rs
@@ -14,16 +14,15 @@ pub fn incremental_verify_ich<'tcx, V>(
     dep_graph_data: &DepGraphData,
     result: &V,
     prev_index: SerializedDepNodeIndex,
-    hash_result: Option<fn(&mut StableHashingContext<'_>, &V) -> Fingerprint>,
+    hash_result: Option<fn(&StableHashingContext<'_>, &V) -> Fingerprint>,
     format_value: fn(&V) -> String,
 ) {
     if !dep_graph_data.is_index_green(prev_index) {
         incremental_verify_ich_not_green(tcx, prev_index)
     }
 
-    let new_hash = hash_result.map_or(Fingerprint::ZERO, |f| {
-        tcx.with_stable_hashing_context(|mut hcx| f(&mut hcx, result))
-    });
+    let new_hash = hash_result
+        .map_or(Fingerprint::ZERO, |f| tcx.with_stable_hashing_context(|hcx| f(&hcx, result)));
 
     let old_hash = dep_graph_data.prev_value_fingerprint_of(prev_index);
 

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -361,8 +361,8 @@ fn check_feedable_consistency<'tcx, C: QueryCache>(
         );
     };
 
-    let (old_hash, new_hash) = tcx.with_stable_hashing_context(|mut hcx| {
-        (hash_value_fn(&mut hcx, &cached_value), hash_value_fn(&mut hcx, value))
+    let (old_hash, new_hash) = tcx.with_stable_hashing_context(|hcx| {
+        (hash_value_fn(&hcx, &cached_value), hash_value_fn(&hcx, value))
     });
     let formatter = query.format_value;
     if old_hash != new_hash {
@@ -400,8 +400,8 @@ fn execute_job_non_incr<'tcx, C: QueryCache>(
     if cfg!(debug_assertions) {
         let _ = key.to_fingerprint(tcx);
         if let Some(hash_value_fn) = query.hash_value_fn {
-            tcx.with_stable_hashing_context(|mut hcx| {
-                hash_value_fn(&mut hcx, &value);
+            tcx.with_stable_hashing_context(|hcx| {
+                hash_value_fn(&hcx, &value);
             });
         }
     }

--- a/compiler/rustc_span/src/caching_source_map_view.rs
+++ b/compiler/rustc_span/src/caching_source_map_view.rs
@@ -82,13 +82,13 @@ impl<'sm> CachingSourceMapView<'sm> {
     pub fn span_data_to_lines_and_cols(
         &mut self,
         span_data: &SpanData,
-    ) -> Option<(&SourceFile, usize, BytePos, usize, BytePos)> {
+    ) -> Option<(Arc<SourceFile>, usize, BytePos, usize, BytePos)> {
         let lo_hit = self.line_bounds.contains(&span_data.lo);
         let hi_hit = self.line_bounds.contains(&span_data.hi);
         if lo_hit && hi_hit {
             // span_data.lo and span_data.hi are cached (i.e. both in the same line).
             return Some((
-                &self.file,
+                Arc::clone(&self.file),
                 self.line_number,
                 span_data.lo - self.line_bounds.start,
                 self.line_number,
@@ -138,7 +138,7 @@ impl<'sm> CachingSourceMapView<'sm> {
         assert!(self.file.contains(span_data.hi));
 
         Some((
-            &self.file,
+            Arc::clone(&self.file),
             lo_line_number,
             span_data.lo - lo_line_bounds.start,
             hi_line_number,

--- a/compiler/rustc_span/src/caching_source_map_view.rs
+++ b/compiler/rustc_span/src/caching_source_map_view.rs
@@ -9,7 +9,6 @@ use crate::{BytePos, Pos, RelativeBytePos, SourceFile, SpanData};
 /// succession, and this avoids expensive `SourceMap` lookups each time the cache is hit. We used
 /// to cache multiple code positions, but caching a single position ended up being simpler and
 /// faster.
-#[derive(Clone)]
 pub struct CachingSourceMapView<'sm> {
     source_map: &'sm SourceMap,
     file: Arc<SourceFile>,

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -404,21 +404,21 @@ rustc_data_structures::define_id_collections!(
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for DefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         hcx.def_path_hash(*self).hash_stable(hcx, hasher);
     }
 }
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for LocalDefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         hcx.def_path_hash(self.to_def_id()).local_hash().hash_stable(hcx, hasher);
     }
 }
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for CrateNum {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.as_def_id().to_stable_hash_key(hcx).stable_crate_id().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1102,7 +1102,7 @@ impl ExpnData {
     }
 
     #[inline]
-    fn hash_expn(&self, hcx: &mut impl HashStableContext) -> Hash64 {
+    fn hash_expn(&self, hcx: &impl HashStableContext) -> Hash64 {
         let mut hasher = StableHasher::new();
         self.hash_stable(hcx, &mut hasher);
         hasher.finish()
@@ -1482,11 +1482,11 @@ pub fn raw_encode_syntax_context(
 /// `set_expn_data`). It is *not* called for foreign `ExpnId`s deserialized
 /// from another crate's metadata - since `ExpnHash` includes the stable crate id,
 /// collisions are only possible between `ExpnId`s within the same crate.
-fn update_disambiguator(expn_data: &mut ExpnData, mut hcx: impl HashStableContext) -> ExpnHash {
+fn update_disambiguator(expn_data: &mut ExpnData, hcx: impl HashStableContext) -> ExpnHash {
     // This disambiguator should not have been set yet.
     assert_eq!(expn_data.disambiguator, 0, "Already set disambiguator for ExpnData: {expn_data:?}");
     hcx.assert_default_hashing_controls("ExpnData (disambiguator)");
-    let mut expn_hash = expn_data.hash_expn(&mut hcx);
+    let mut expn_hash = expn_data.hash_expn(&hcx);
 
     let disambiguator = HygieneData::with(|data| {
         // If this is the first ExpnData with a given hash, then keep our
@@ -1501,7 +1501,7 @@ fn update_disambiguator(expn_data: &mut ExpnData, mut hcx: impl HashStableContex
         debug!("Set disambiguator for expn_data={:?} expn_hash={:?}", expn_data, expn_hash);
 
         expn_data.disambiguator = disambiguator;
-        expn_hash = expn_data.hash_expn(&mut hcx);
+        expn_hash = expn_data.hash_expn(&hcx);
 
         // Verify that the new disambiguator makes the hash unique
         #[cfg(debug_assertions)]
@@ -1518,7 +1518,7 @@ fn update_disambiguator(expn_data: &mut ExpnData, mut hcx: impl HashStableContex
 }
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for SyntaxContext {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         const TAG_EXPANSION: u8 = 0;
         const TAG_NO_EXPANSION: u8 = 1;
 
@@ -1534,7 +1534,7 @@ impl<Hcx: HashStableContext> HashStable<Hcx> for SyntaxContext {
 }
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for ExpnId {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         hcx.assert_default_hashing_controls("ExpnId");
         let hash = if *self == ExpnId::root() {
             // Avoid fetching TLS storage for a trivial often-used value.
@@ -1548,7 +1548,7 @@ impl<Hcx: HashStableContext> HashStable<Hcx> for ExpnId {
 }
 
 impl<Hcx: HashStableContext> HashStable<Hcx> for LocalExpnId {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.to_expn_id().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2802,7 +2802,7 @@ impl InnerSpan {
 /// instead of implementing everything in rustc_middle.
 pub trait HashStableContext {
     /// The main event: stable hashing of a span.
-    fn span_hash_stable(&mut self, span: Span, hasher: &mut StableHasher);
+    fn span_hash_stable(&self, span: Span, hasher: &mut StableHasher);
 
     /// Compute a `DefPathHash`.
     fn def_path_hash(&self, def_id: DefId) -> DefPathHash;
@@ -2816,7 +2816,7 @@ impl<Hcx> HashStable<Hcx> for Span
 where
     Hcx: HashStableContext,
 {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         // `span_hash_stable` does all the work.
         hcx.span_hash_stable(*self, hasher)
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2603,7 +2603,7 @@ impl fmt::Display for Symbol {
 
 impl<Hcx> HashStable<Hcx> for Symbol {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.as_str().hash_stable(hcx, hasher);
     }
 }
@@ -2663,7 +2663,7 @@ impl fmt::Debug for ByteSymbol {
 
 impl<Hcx> HashStable<Hcx> for ByteSymbol {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         self.as_byte_str().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_symbol_mangling/src/hashed.rs
+++ b/compiler/rustc_symbol_mangling/src/hashed.rs
@@ -25,9 +25,9 @@ pub(super) fn mangle<'tcx>(
     let mut symbol = "_RNxC".to_string();
     v0::push_ident(tcx.crate_name(crate_num).as_str(), &mut symbol);
 
-    let hash = tcx.with_stable_hashing_context(|mut hcx| {
+    let hash = tcx.with_stable_hashing_context(|hcx| {
         let mut hasher = StableHasher::new();
-        full_mangling_name().hash_stable(&mut hcx, &mut hasher);
+        full_mangling_name().hash_stable(&hcx, &mut hasher);
         hasher.finish::<Hash64>().as_u64()
     });
 

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -135,7 +135,7 @@ fn get_symbol_hash<'tcx>(
         // the main symbol name is not necessarily unique; hash in the
         // compiler's internal def-path, guaranteeing each symbol has a
         // truly unique path
-        tcx.def_path_hash(def_id).hash_stable(&mut hcx, &mut hasher);
+        tcx.def_path_hash(def_id).hash_stable(&hcx, &mut hasher);
 
         // Include the main item-type. Note that, in this case, the
         // assertions about `has_param` may not hold, but this item-type

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -118,7 +118,7 @@ impl fmt::Debug for InferConst {
 
 #[cfg(feature = "nightly")]
 impl<Hcx> HashStable<Hcx> for InferConst {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         match self {
             InferConst::Var(_) => {
                 panic!("const variables should not be hashed: {self:?}")

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -50,14 +50,13 @@ pub enum SimplifiedType<DefId> {
 }
 
 #[cfg(feature = "nightly")]
-impl<Hcx: Clone, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
+impl<Hcx, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
     type KeyType = Fingerprint;
 
     #[inline]
     fn to_stable_hash_key(&self, hcx: &Hcx) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let hcx: Hcx = hcx.clone();
-        self.hash_stable(&hcx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -56,8 +56,8 @@ impl<Hcx: Clone, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType
     #[inline]
     fn to_stable_hash_key(&self, hcx: &Hcx) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: Hcx = hcx.clone();
-        self.hash_stable(&mut hcx, &mut hasher);
+        let hcx: Hcx = hcx.clone();
+        self.hash_stable(&hcx, &mut hasher);
         hasher.finish()
     }
 }

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -225,7 +225,7 @@ where
     I::Symbol: HashStable<Hcx>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         std::mem::discriminant(self).hash_stable(hcx, hasher);
         match self {
             ReErased | ReStatic | ReError(_) => {

--- a/compiler/rustc_type_ir/src/ty_info.rs
+++ b/compiler/rustc_type_ir/src/ty_info.rs
@@ -98,7 +98,7 @@ impl<T: Hash> Hash for WithCachedTypeInfo<T> {
 
 #[cfg(feature = "nightly")]
 impl<T: HashStable<Hcx>, Hcx> HashStable<Hcx> for WithCachedTypeInfo<T> {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         if self.stable_hash == Fingerprint::ZERO || cfg!(debug_assertions) {
             // No cached hash available. This can only mean that incremental is disabled.
             // We don't cache stable hashes in non-incremental mode, because they are used

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -688,7 +688,7 @@ impl UnifyKey for FloatVid {
 
 #[cfg(feature = "nightly")]
 impl<Hcx> HashStable<Hcx> for InferTy {
-    fn hash_stable(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
+    fn hash_stable(&self, hcx: &Hcx, hasher: &mut StableHasher) {
         use InferTy::*;
         std::mem::discriminant(self).hash_stable(hcx, hasher);
         match self {


### PR DESCRIPTION
This lets a lot of `&mut hcx` parameters change to `&hcx`, for symmetry with `to_hash_stable_key`, and avoids some unnecessary cloning of `StableHashingContext`. Details in individual commits.