### PR TITLE
Add a regression test for the duplicated `crate` keyword in path suggestions

### DIFF
--- a/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.rs
+++ b/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.rs
@@ -1,0 +1,20 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/115858>.
+//!
+//! The compiler used to suggest `crate::crate::unix::linux::system::Y`
+//! (duplicating the `crate` keyword) instead of `crate::unix::linux::system::Y`.
+
+pub mod unix {
+    pub mod linux {
+        pub mod utils {
+            pub fn f() {
+                let _x = crate::linux::system::Y;
+                //~^ ERROR cannot find `linux` in `crate`
+            }
+        }
+        pub mod system {
+            pub const Y: u32 = 0;
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.stderr
+++ b/tests/ui/resolve/path-suggestion-duplicated-crate-keyword.stderr
@@ -1,0 +1,23 @@
+error[E0433]: cannot find `linux` in `crate`
+  --> $DIR/path-suggestion-duplicated-crate-keyword.rs:10:33
+   |
+LL |                 let _x = crate::linux::system::Y;
+   |                                 ^^^^^ unresolved import
+   |
+help: a similar path exists
+   |
+LL |                 let _x = crate::unix::linux::system::Y;
+   |                                 ++++++
+help: consider importing this module
+   |
+LL +             use unix::linux::system;
+   |
+help: if you import `system`, refer to it directly
+   |
+LL -                 let _x = crate::linux::system::Y;
+LL +                 let _x = system::Y;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
The issue has (long) been fixed, but needs a test.

Closes rust-lang/rust#115858.