### PR TITLE
Remove `Clone` impl for `StableHashingContext`.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -175,8 +175,8 @@ fn exported_non_generic_symbols_provider_local<'tcx>(
 
     // FIXME: Sorting this is unnecessary since we are sorting later anyway.
     //        Can we skip the later sorting?
-    let sorted = tcx.with_stable_hashing_context(|hcx| {
-        tcx.reachable_non_generics(LOCAL_CRATE).to_sorted(&hcx, true)
+    let sorted = tcx.with_stable_hashing_context(|mut hcx| {
+        tcx.reachable_non_generics(LOCAL_CRATE).to_sorted(&mut hcx, true)
     });
 
     let mut symbols: Vec<_> =

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -50,7 +50,7 @@ pub trait HashStable<Hcx> {
 /// bringing maps into a predictable order before hashing them.
 pub trait ToStableHashKey<Hcx> {
     type KeyType: Ord + Sized + HashStable<Hcx>;
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType;
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Self::KeyType;
 }
 
 /// Trait for marking a type as having a sort order that is
@@ -427,7 +427,7 @@ impl StableOrd for String {
 impl<Hcx> ToStableHashKey<Hcx> for String {
     type KeyType = String;
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> Self::KeyType {
         self.clone()
     }
 }
@@ -435,7 +435,7 @@ impl<Hcx> ToStableHashKey<Hcx> for String {
 impl<Hcx, T1: ToStableHashKey<Hcx>, T2: ToStableHashKey<Hcx>> ToStableHashKey<Hcx> for (T1, T2) {
     type KeyType = (T1::KeyType, T2::KeyType);
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Self::KeyType {
         (self.0.to_stable_hash_key(hcx), self.1.to_stable_hash_key(hcx))
     }
 }

--- a/compiler/rustc_data_structures/src/unord.rs
+++ b/compiler/rustc_data_structures/src/unord.rs
@@ -143,7 +143,7 @@ impl<'a, T: Copy + 'a, I: Iterator<Item = &'a T>> UnordItems<&'a T, I> {
 
 impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     #[inline]
-    pub fn into_sorted<Hcx>(self, hcx: &Hcx) -> Vec<T>
+    pub fn into_sorted<Hcx>(self, hcx: &mut Hcx) -> Vec<T>
     where
         T: ToStableHashKey<Hcx>,
     {
@@ -168,7 +168,7 @@ impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     }
 
     #[inline]
-    pub fn collect_sorted<Hcx, C>(self, hcx: &Hcx, cache_sort_key: bool) -> C
+    pub fn collect_sorted<Hcx, C>(self, hcx: &mut Hcx, cache_sort_key: bool) -> C
     where
         T: ToStableHashKey<Hcx>,
         C: FromIterator<T> + BorrowMut<[T]>,
@@ -315,7 +315,7 @@ impl<V: Eq + Hash> UnordSet<V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `V` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn to_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> Vec<&V>
+    pub fn to_sorted<Hcx>(&self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<&V>
     where
         V: ToStableHashKey<Hcx>,
     {
@@ -357,7 +357,7 @@ impl<V: Eq + Hash> UnordSet<V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `V` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn into_sorted<Hcx>(self, hcx: &Hcx, cache_sort_key: bool) -> Vec<V>
+    pub fn into_sorted<Hcx>(self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<V>
     where
         V: ToStableHashKey<Hcx>,
     {
@@ -555,7 +555,7 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn to_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> Vec<(&K, &V)>
+    pub fn to_sorted<Hcx>(&self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<(&K, &V)>
     where
         K: ToStableHashKey<Hcx>,
     {
@@ -582,7 +582,7 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn into_sorted<Hcx>(self, hcx: &Hcx, cache_sort_key: bool) -> Vec<(K, V)>
+    pub fn into_sorted<Hcx>(self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<(K, V)>
     where
         K: ToStableHashKey<Hcx>,
     {
@@ -610,7 +610,11 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn values_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> impl Iterator<Item = &V>
+    pub fn values_sorted<Hcx>(
+        &self,
+        hcx: &mut Hcx,
+        cache_sort_key: bool,
+    ) -> impl Iterator<Item = &V>
     where
         K: ToStableHashKey<Hcx>,
     {
@@ -710,7 +714,7 @@ impl<Hcx, V: Hash + Eq + HashStable<Hcx>> HashStable<Hcx> for UnordBag<V> {
 
 #[inline]
 fn to_sorted_vec<Hcx, T, K, I>(
-    hcx: &Hcx,
+    hcx: &mut Hcx,
     iter: I,
     cache_sort_key: bool,
     extract_key: fn(&T) -> &K,

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -716,7 +716,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for Namespace {
     type KeyType = Namespace;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> Namespace {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> Namespace {
         *self
     }
 }

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -13,7 +13,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for BodyId {
     type KeyType = (DefPathHash, ItemLocalId);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> (DefPathHash, ItemLocalId) {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> (DefPathHash, ItemLocalId) {
         let BodyId { hir_id } = *self;
         hir_id.to_stable_hash_key(hcx)
     }
@@ -23,7 +23,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }
@@ -32,7 +32,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for TraitItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }
@@ -41,7 +41,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ImplItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }
@@ -50,7 +50,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ForeignItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -65,7 +65,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for OwnerId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         hcx.def_path_hash(self.to_def_id())
     }
 }
@@ -180,7 +180,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for HirId {
     type KeyType = (DefPathHash, ItemLocalId);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> (DefPathHash, ItemLocalId) {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> (DefPathHash, ItemLocalId) {
         let def_path_hash = self.owner.def_id.to_stable_hash_key(hcx);
         (def_path_hash, self.local_id)
     }
@@ -190,7 +190,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ItemLocalId {
     type KeyType = ItemLocalId;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> ItemLocalId {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> ItemLocalId {
         *self
     }
 }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -375,12 +375,12 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
 
 impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     fn eval_closure_size(&mut self) {
-        self.tcx().with_stable_hashing_context(|ref hcx| {
+        self.tcx().with_stable_hashing_context(|mut hcx| {
             let fcx_typeck_results = self.fcx.typeck_results.borrow();
 
             self.typeck_results.closure_size_eval = fcx_typeck_results
                 .closure_size_eval
-                .to_sorted(hcx, false)
+                .to_sorted(&mut hcx, false)
                 .into_iter()
                 .map(|(&closure_def_id, data)| {
                     let closure_hir_id = self.tcx().local_def_id_to_hir_id(closure_def_id);
@@ -392,12 +392,12 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 
     fn visit_min_capture_map(&mut self) {
-        self.tcx().with_stable_hashing_context(|ref hcx| {
+        self.tcx().with_stable_hashing_context(|mut hcx| {
             let fcx_typeck_results = self.fcx.typeck_results.borrow();
 
             self.typeck_results.closure_min_captures = fcx_typeck_results
                 .closure_min_captures
-                .to_sorted(hcx, false)
+                .to_sorted(&mut hcx, false)
                 .into_iter()
                 .map(|(&closure_def_id, root_min_captures)| {
                     let root_var_map_wb = root_min_captures
@@ -423,12 +423,12 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 
     fn visit_fake_reads_map(&mut self) {
-        self.tcx().with_stable_hashing_context(move |ref hcx| {
+        self.tcx().with_stable_hashing_context(move |mut hcx| {
             let fcx_typeck_results = self.fcx.typeck_results.borrow();
 
             self.typeck_results.closure_fake_reads = fcx_typeck_results
                 .closure_fake_reads
-                .to_sorted(hcx, true)
+                .to_sorted(&mut hcx, true)
                 .into_iter()
                 .map(|(&closure_def_id, fake_reads)| {
                     let resolved_fake_reads = fake_reads

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -160,7 +160,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for LintExpectationId {
     type KeyType = (DefPathHash, ItemLocalId, u16, u16);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Self::KeyType {
         match self {
             LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
                 let (def_path_hash, lint_idx) = hir_id.to_stable_hash_key(hcx);
@@ -632,7 +632,7 @@ impl<Hcx> ToStableHashKey<Hcx> for LintId {
     type KeyType = &'static str;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> &'static str {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> &'static str {
         self.lint_name_raw()
     }
 }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -254,7 +254,7 @@ impl WorkProductId {
 impl<Hcx> ToStableHashKey<Hcx> for WorkProductId {
     type KeyType = Fingerprint;
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> Self::KeyType {
         self.hash
     }
 }

--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -10,7 +10,6 @@ use rustc_span::{CachingSourceMapView, DUMMY_SP, HashStableContext, Pos, Span};
 
 // Very often, we are hashing something that does not need the `CachingSourceMapView`, so we
 // initialize it lazily.
-#[derive(Clone)]
 enum CachingSourceMap<'a> {
     Unused(&'a SourceMap),
     InUse(CachingSourceMapView<'a>),
@@ -20,7 +19,6 @@ enum CachingSourceMap<'a> {
 /// enough information to transform `DefId`s and `HirId`s into stable `DefPath`s (i.e.,
 /// a reference to the `TyCtxt`) and it holds a few caches for speeding up various
 /// things (e.g., each `DefId`/`DefPath` is only hashed once).
-#[derive(Clone)]
 pub struct StableHashingContext<'a> {
     untracked: &'a Untracked,
     // The value of `-Z incremental-ignore-spans`.

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -328,9 +328,9 @@ impl<'tcx> fmt::Display for MonoItem<'tcx> {
 impl ToStableHashKey<StableHashingContext<'_>> for MonoItem<'_> {
     type KeyType = Fingerprint;
 
-    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'_>) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &mut StableHashingContext<'_>) -> Self::KeyType {
         let mut hasher = StableHasher::new();
-        self.hash_stable(&mut hcx.clone(), &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }
@@ -584,7 +584,7 @@ impl<'tcx> CodegenUnit<'tcx> {
 impl ToStableHashKey<StableHashingContext<'_>> for CodegenUnit<'_> {
     type KeyType = String;
 
-    fn to_stable_hash_key(&self, _: &StableHashingContext<'_>) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &mut StableHashingContext<'_>) -> Self::KeyType {
         // Codegen unit names are conceptually required to be stable across
         // compilation session so that object file names match up.
         self.name.to_string()

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -53,10 +53,9 @@ where
     type KeyType = Fingerprint;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
+    fn to_stable_hash_key(&self, hcx: &mut StableHashingContext<'a>) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: StableHashingContext<'a> = hcx.clone();
-        self.hash_stable(&mut hcx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }
@@ -88,7 +87,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for region::Scope {
     type KeyType = region::Scope;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &StableHashingContext<'a>) -> region::Scope {
+    fn to_stable_hash_key(&self, _: &mut StableHashingContext<'a>) -> region::Scope {
         *self
     }
 }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1824,8 +1824,8 @@ pub(crate) fn collect_crate_mono_items<'tcx>(
 
     // The set of MonoItems was created in an inherently indeterministic order because
     // of parallelism. We sort it here to ensure that the output is deterministic.
-    let mono_items = tcx.with_stable_hashing_context(move |ref hcx| {
-        state.visited.into_inner().into_sorted(hcx, true)
+    let mono_items = tcx.with_stable_hashing_context(move |mut hcx| {
+        state.visited.into_inner().into_sorted(&mut hcx, true)
     });
 
     (mono_items, state.usage_map.into_inner())

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -286,8 +286,8 @@ where
         codegen_units.insert(cgu_name, CodegenUnit::new(cgu_name));
     }
 
-    let mut codegen_units: Vec<_> = cx.tcx.with_stable_hashing_context(|ref hcx| {
-        codegen_units.into_items().map(|(_, cgu)| cgu).collect_sorted(hcx, true)
+    let mut codegen_units: Vec<_> = cx.tcx.with_stable_hashing_context(|mut hcx| {
+        codegen_units.into_items().map(|(_, cgu)| cgu).collect_sorted(&mut hcx, true)
     });
 
     for cgu in codegen_units.iter_mut() {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1535,9 +1535,10 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         let [segment] = path else { return };
         let None = following_seg else { return };
         for rib in self.ribs[ValueNS].iter().rev() {
-            let patterns_with_skipped_bindings = self.r.tcx.with_stable_hashing_context(|hcx| {
-                rib.patterns_with_skipped_bindings.to_sorted(&hcx, true)
-            });
+            let patterns_with_skipped_bindings =
+                self.r.tcx.with_stable_hashing_context(|mut hcx| {
+                    rib.patterns_with_skipped_bindings.to_sorted(&mut hcx, true)
+                });
             for (def_id, spans) in patterns_with_skipped_bindings {
                 if let DefKind::Struct | DefKind::Variant = self.r.tcx.def_kind(*def_id)
                     && let Some(fields) = self.r.field_idents(*def_id)

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -640,7 +640,7 @@ macro_rules! define_output_types {
         impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for OutputType {
             type KeyType = Self;
 
-            fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
+            fn to_stable_hash_key(&self, _: &mut Hcx) -> Self::KeyType {
                 *self
             }
         }

--- a/compiler/rustc_span/src/caching_source_map_view.rs
+++ b/compiler/rustc_span/src/caching_source_map_view.rs
@@ -9,7 +9,6 @@ use crate::{BytePos, Pos, RelativeBytePos, SourceFile, SpanData};
 /// succession, and this avoids expensive `SourceMap` lookups each time the cache is hit. We used
 /// to cache multiple code positions, but caching a single position ended up being simpler and
 /// faster.
-#[derive(Clone)]
 pub struct CachingSourceMapView<'sm> {
     source_map: &'sm SourceMap,
     file: Arc<SourceFile>,

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -427,7 +427,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for DefId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         hcx.def_path_hash(*self)
     }
 }
@@ -436,7 +436,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for LocalDefId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         hcx.def_path_hash(self.to_def_id())
     }
 }
@@ -445,7 +445,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for CrateNum {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.as_def_id().to_stable_hash_key(hcx)
     }
 }
@@ -454,7 +454,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for DefPathHash {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> DefPathHash {
         *self
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2611,7 +2611,7 @@ impl<Hcx> HashStable<Hcx> for Symbol {
 impl<Hcx> ToStableHashKey<Hcx> for Symbol {
     type KeyType = String;
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> String {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> String {
         self.as_str().to_string()
     }
 }

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -50,14 +50,13 @@ pub enum SimplifiedType<DefId> {
 }
 
 #[cfg(feature = "nightly")]
-impl<Hcx: Clone, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
+impl<Hcx, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
     type KeyType = Fingerprint;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Fingerprint {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: Hcx = hcx.clone();
-        self.hash_stable(&mut hcx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -310,7 +310,7 @@ impl rustc_driver::Callbacks for MiriDepCompilerCalls {
             // FIXME handle this somehow in rustc itself to avoid this hack.
             local_providers.queries.exported_non_generic_symbols = |tcx, LocalCrate| {
                 let reachable_set = tcx
-                    .with_stable_hashing_context(|hcx| tcx.reachable_set(()).to_sorted(&hcx, true));
+                    .with_stable_hashing_context(|mut hcx| tcx.reachable_set(()).to_sorted(&mut hcx, true));
                 tcx.arena.alloc_from_iter(
                     // This is based on:
                     // https://github.com/rust-lang/rust/blob/2962e7c0089d5c136f4e9600b7abccfbbde4973d/compiler/rustc_codegen_ssa/src/back/symbol_export.rs#L62-L63


### PR DESCRIPTION
`HashStable::hash_stable` takes a `&mut Hcx`. In contrast, `ToStableHashKey::to_stable_hash_key` takes a `&Hcx`. But there are some places where the latter calls the former, and due to the mismatch a `clone` call is required to get a mutable `StableHashingContext`.

This commit changes `to_stable_hash_key` to instead take a `&mut Hcx`. This eliminates the mismatch, the need for the clones, and the need for the `Clone` impls.

r? @fee1-dead 
