### PR TITLE
experiment: `match` lowering: Change the column selection strategy in `pick_test()` to potentially reduce redundant tests

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1248,6 +1248,28 @@ impl<'tcx> TestableCase<'tcx> {
     fn as_range(&self) -> Option<&PatRange<'tcx>> {
         if let Self::Range(v) = self { Some(v.as_ref()) } else { None }
     }
+
+    /// Returns whether two testable cases would end up in the same test branch.
+    /// Used by `pick_test` to find the best column to test first.
+    fn same_test_branch(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                TestableCase::Variant { variant_index: a, .. },
+                TestableCase::Variant { variant_index: b, .. },
+            ) => a == b,
+            (TestableCase::Constant { value: a, .. }, TestableCase::Constant { value: b, .. }) => {
+                a == b
+            }
+            (TestableCase::Range(a), TestableCase::Range(b)) => a == b,
+            (
+                TestableCase::Slice { len: len_a, op: op_a },
+                TestableCase::Slice { len: len_b, op: op_b },
+            ) => len_a == len_b && op_a == op_b,
+            (TestableCase::Deref { temp: a, .. }, TestableCase::Deref { temp: b, .. }) => a == b,
+            (TestableCase::Never, TestableCase::Never) => true,
+            _ => false,
+        }
+    }
 }
 
 /// Sub-classification of [`TestableCase::Constant`], which helps to avoid
@@ -2158,25 +2180,66 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     /// Pick a test to run. Which test doesn't matter as long as it is guaranteed to fully match at
-    /// least one match pair. We currently simply pick the test corresponding to the first match
-    /// pair of the first candidate in the list.
-    ///
-    /// *Note:* taking the first match pair is somewhat arbitrary, and we might do better here by
-    /// choosing more carefully what to test.
-    ///
-    /// For example, consider the following possible match-pairs:
+    /// least one match pair from the first candidate. For example, consider the following possible
+    /// match-pairs:
     ///
     /// 1. `x @ Some(P)` -- we will do a [`Switch`] to decide what variant `x` has
     /// 2. `x @ 22` -- we will do a [`SwitchInt`] to decide what value `x` has
     /// 3. `x @ 3..5` -- we will do a [`Range`] test to decide what range `x` falls in
-    /// 4. etc.
+    ///
+    /// We pick the match pair from the first candidate that has the same test outcome across the
+    /// largest number of consecutive candidates. This groups candidates with a shared value into a
+    /// single branch, producing smaller match trees and better generated code. For example, given:
+    ///
+    /// ```ignore (illustrative)
+    /// match p {
+    ///     P { x: 1, y: 0 } => ..,
+    ///     P { x: 2, y: 0 } => ..,
+    ///     P { x: 3, y: 0 } => ..,
+    /// }
+    /// ```
+    ///
+    /// All three candidates share `y: 0`, so we test `y` first (consecutive count = 3). This lets
+    /// us check `y == 0` once and then switch on `x`, rather than switching on `x` first and
+    /// redundantly checking `y == 0` in every branch.
     ///
     /// [`Switch`]: TestKind::Switch
     /// [`SwitchInt`]: TestKind::SwitchInt
     /// [`Range`]: TestKind::Range
     fn pick_test(&mut self, candidates: &[&mut Candidate<'tcx>]) -> (Place<'tcx>, Test<'tcx>) {
-        // Extract the match-pair from the highest priority candidate
-        let match_pair = &candidates[0].match_pairs[0];
+        // Find the match pair from the first candidate that has the same testable value across
+        // the most consecutive candidates. This ensures that the resulting test will group the
+        // most candidates into a single branch.
+        let first = &candidates[0];
+
+        let best_index = first
+            .match_pairs
+            .iter()
+            // Or-patterns are sorted to the end and are not tested directly, so stop there.
+            .take_while(|match_pair| !matches!(match_pair.testable_case, TestableCase::Or { .. }))
+            .enumerate()
+            // For each match pair, count how many consecutive candidates share the same test.
+            .map(|(index, match_pair)| {
+                let place = match_pair.place.unwrap();
+                let count = 1 + candidates[1..]
+                    .iter()
+                    .take_while(|candidate| {
+                        candidate.match_pairs.iter().any(|candidate_match_pair| {
+                            candidate_match_pair.place == Some(place)
+                                && candidate_match_pair
+                                    .testable_case
+                                    .same_test_branch(&match_pair.testable_case)
+                        })
+                    })
+                    .count();
+                (count, index)
+            })
+            // Pick the match pair that groups the most candidates into a single branch.
+            .max_by_key(|&(count, index)| (count, std::cmp::Reverse(index)))
+            .map(|(_count, index)| index)
+            .unwrap_or(0);
+
+        let match_pair = &first.match_pairs[best_index];
         let test = self.pick_test_for_match_pair(match_pair);
         // Unwrap is ok after simplification.
         let match_place = match_pair.place.unwrap();

--- a/tests/mir-opt/building/match/struct_field_order.field_order_x_then_y.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/struct_field_order.field_order_x_then_y.SimplifyCfg-initial.after.mir
@@ -1,0 +1,60 @@
+// MIR for `field_order_x_then_y` after SimplifyCfg-initial
+
+fn field_order_x_then_y(_1: P) -> u32 {
+    debug p => _1;
+    let mut _0: u32;
+
+    bb0: {
+        PlaceMention(_1);
+        switchInt(copy (_1.1: u8)) -> [0: bb2, otherwise: bb1];
+    }
+
+    bb1: {
+        _0 = const 0_u32;
+        goto -> bb11;
+    }
+
+    bb2: {
+        switchInt(copy (_1.0: u8)) -> [1: bb3, 2: bb4, 3: bb5, 4: bb6, otherwise: bb1];
+    }
+
+    bb3: {
+        falseEdge -> [real: bb10, imaginary: bb4];
+    }
+
+    bb4: {
+        falseEdge -> [real: bb9, imaginary: bb5];
+    }
+
+    bb5: {
+        falseEdge -> [real: bb8, imaginary: bb6];
+    }
+
+    bb6: {
+        falseEdge -> [real: bb7, imaginary: bb1];
+    }
+
+    bb7: {
+        _0 = const 4_u32;
+        goto -> bb11;
+    }
+
+    bb8: {
+        _0 = const 3_u32;
+        goto -> bb11;
+    }
+
+    bb9: {
+        _0 = const 2_u32;
+        goto -> bb11;
+    }
+
+    bb10: {
+        _0 = const 1_u32;
+        goto -> bb11;
+    }
+
+    bb11: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/struct_field_order.field_order_y_then_x.SimplifyCfg-initial.after.mir
+++ b/tests/mir-opt/building/match/struct_field_order.field_order_y_then_x.SimplifyCfg-initial.after.mir
@@ -1,0 +1,60 @@
+// MIR for `field_order_y_then_x` after SimplifyCfg-initial
+
+fn field_order_y_then_x(_1: P) -> u32 {
+    debug p => _1;
+    let mut _0: u32;
+
+    bb0: {
+        PlaceMention(_1);
+        switchInt(copy (_1.1: u8)) -> [0: bb2, otherwise: bb1];
+    }
+
+    bb1: {
+        _0 = const 0_u32;
+        goto -> bb11;
+    }
+
+    bb2: {
+        switchInt(copy (_1.0: u8)) -> [1: bb3, 2: bb4, 3: bb5, 4: bb6, otherwise: bb1];
+    }
+
+    bb3: {
+        falseEdge -> [real: bb10, imaginary: bb4];
+    }
+
+    bb4: {
+        falseEdge -> [real: bb9, imaginary: bb5];
+    }
+
+    bb5: {
+        falseEdge -> [real: bb8, imaginary: bb6];
+    }
+
+    bb6: {
+        falseEdge -> [real: bb7, imaginary: bb1];
+    }
+
+    bb7: {
+        _0 = const 4_u32;
+        goto -> bb11;
+    }
+
+    bb8: {
+        _0 = const 3_u32;
+        goto -> bb11;
+    }
+
+    bb9: {
+        _0 = const 2_u32;
+        goto -> bb11;
+    }
+
+    bb10: {
+        _0 = const 1_u32;
+        goto -> bb11;
+    }
+
+    bb11: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/struct_field_order.rs
+++ b/tests/mir-opt/building/match/struct_field_order.rs
@@ -1,0 +1,47 @@
+// Test that the order of fields in struct patterns does not affect the generated MIR.
+// When all arms share the same value for a field, we should test that field first,
+// regardless of where it appears in the pattern syntax.
+// See https://github.com/rust-lang/rust/issues/111563
+
+pub struct P {
+    x: u8,
+    y: u8,
+}
+
+// EMIT_MIR struct_field_order.field_order_x_then_y.SimplifyCfg-initial.after.mir
+fn field_order_x_then_y(p: P) -> u32 {
+    // Even though `x` is listed first, `y: 0` is shared across all arms, so we should test `y`
+    // first to avoid redundant tests.
+
+    // CHECK-LABEL: fn field_order_x_then_y(
+    // First test should be on `y` (the shared field).
+    // CHECK: switchInt(copy (_1.1: u8)) ->
+    // Then test `x` inside the `y == 0` branch.
+    // CHECK: switchInt(copy (_1.0: u8)) ->
+    match p {
+        P { x: 1, y: 0 } => 1,
+        P { x: 2, y: 0 } => 2,
+        P { x: 3, y: 0 } => 3,
+        P { x: 4, y: 0 } => 4,
+        _ => 0,
+    }
+}
+
+// EMIT_MIR struct_field_order.field_order_y_then_x.SimplifyCfg-initial.after.mir
+fn field_order_y_then_x(p: P) -> u32 {
+    // Here `y` is listed first, so the compiler would have already tested `y` first
+    // even without the heuristic. The result should be identical to the above.
+
+    // CHECK-LABEL: fn field_order_y_then_x(
+    // CHECK: switchInt(copy (_1.1: u8)) ->
+    // CHECK: switchInt(copy (_1.0: u8)) ->
+    match p {
+        P { y: 0, x: 1 } => 1,
+        P { y: 0, x: 2 } => 2,
+        P { y: 0, x: 3 } => 3,
+        P { y: 0, x: 4 } => 4,
+        _ => 0,
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
At the moment, `pick_test()` always selects the first match pair of the first candidate. This could lead to suboptimal match trees when many arms share a value for a field that is not listed first in the pattern. For example, in `match p { P { x: 1, y: 0 }, P { x: 2, y: 0 }, .. }`, the compiler would switch on `x` first and then redundantly check `y == 0` in every branch.

In this PR, `pick_test()` will iterate over the first candidate's match pairs and picks the one whose testable value is shared across the largest number of consecutive candidates. In the example above, `y: 0` appears in all arms (consecutive count = 3), so we test `y` first, check it once, and then switch on `x` – producing a smaller match tree.

This is just an experiment, I expect the extra scan to have at least some impact on compile time for most programs. I suppose there’s a tension here between letting the user write `match` expressions with more control over what order of condition branches they compile to versus treating them as declarative queries where it’s the compiler’s job to find the best ordering of branches to fulfil it.