### PR TITLE
Add Enzyme to build-manifest and rustup

### DIFF
--- a/src/tools/build-manifest/README.md
+++ b/src/tools/build-manifest/README.md
@@ -36,9 +36,10 @@ Then, you can generate the manifest and add it to `build/dist`:
 cargo +nightly run --release -p build-manifest build/dist build/dist 1970-01-01 http://localhost:8000 nightly
 ```
 
-After that, generate a SHA256 stamp for the manifest file:
+After that, generate a SHA256 stamp for the manifest file, and create a symlink to point to the right directory:
 ```sh
 sha256sum build/dist/channel-rust-nightly.toml > build/dist/channel-rust-nightly.toml.sha256
+ln -s ${PWD}/build/dist build/1970-01-01
 ```
 
 And start a HTTP server from the `build` directory:

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -37,8 +37,24 @@ fn is_nightly_only(pkg: &PkgType) -> bool {
         | PkgType::JsonDocs
         | PkgType::RustcCodegenCranelift
         | PkgType::RustcCodegenGcc
-        | PkgType::Gcc { .. } => true,
-        _ => false,
+        | PkgType::Gcc { .. }
+        | PkgType::Enzyme => true,
+        PkgType::Rust
+        | PkgType::RustSrc
+        | PkgType::Rustc
+        | PkgType::RustcDev
+        | PkgType::RustcDocs
+        | PkgType::ReproducibleArtifacts
+        | PkgType::RustMingw
+        | PkgType::RustStd
+        | PkgType::Cargo
+        | PkgType::HtmlDocs
+        | PkgType::RustAnalysis
+        | PkgType::RustAnalyzer
+        | PkgType::Clippy
+        | PkgType::Rustfmt
+        | PkgType::LlvmTools
+        | PkgType::LlvmBitcodeLinker => false,
     }
 }
 
@@ -313,7 +329,8 @@ impl Builder {
                 | PkgType::RustcCodegenCranelift
                 | PkgType::RustcCodegenGcc
                 | PkgType::Gcc { .. }
-                | PkgType::LlvmBitcodeLinker => {
+                | PkgType::LlvmBitcodeLinker
+                | PkgType::Enzyme => {
                     extensions.push(host_component(pkg));
                 }
                 PkgType::RustcDev => {

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -88,6 +88,7 @@ pkg_type! {
     Gcc = "gcc"; preview = true; suffixes = [
         "x86_64-unknown-linux-gnu"
     ],
+    Enzyme = "enzyme"; preview = true,
 }
 
 impl PkgType {
@@ -126,6 +127,7 @@ impl PkgType {
             PkgType::RustMingw => true,
             PkgType::RustAnalysis => true,
             PkgType::LlvmBitcodeLinker => true,
+            PkgType::Enzyme => true,
         }
     }
 
@@ -162,6 +164,7 @@ impl PkgType {
             RustAnalysis => TARGETS,
             LlvmTools => TARGETS,
             LlvmBitcodeLinker => HOSTS,
+            Enzyme => HOSTS,
         }
     }
 


### PR DESCRIPTION
This PR adds the autodiff component (Enzyme) to build-manifest, and thus also to (nightly) Rustup.

It is marked as nightly-only and as -preview.

After this PR lands, unless I messed something up, starting with the following nightly, the following should work (on supported targets):

```bash
rustup +nightly component add enzyme
RUSTFLAGS="-Zautodiff=Enable" cargo +nightly build
```

CC @ZuseZ4

r? @Mark-Simulacrum

closes: https://github.com/rust-lang/rust/issues/145899