### PR TITLE
coretests: add argument order regression tests for min_by/max_by/minmax_by

### DIFF
--- a/library/coretests/tests/cmp.rs
+++ b/library/coretests/tests/cmp.rs
@@ -48,6 +48,37 @@ fn test_ord_min_max_by() {
     assert_eq!(cmp::max_by(2, -1, f), 2);
 }
 
+// Regression test for #136307 / #139357: ensure compare() receives (v1, v2), not (v2, v1).
+#[test]
+fn min_by_compare_argument_order() {
+    let mut order = vec![];
+    let _ = cmp::min_by(1i32, 2, |a, b| {
+        order.push((*a, *b));
+        a.cmp(b)
+    });
+    assert_eq!(order, [(1, 2)]);
+}
+
+#[test]
+fn max_by_compare_argument_order() {
+    let mut order = vec![];
+    let _ = cmp::max_by(1i32, 2, |a, b| {
+        order.push((*a, *b));
+        a.cmp(b)
+    });
+    assert_eq!(order, [(1, 2)]);
+}
+
+#[test]
+fn minmax_by_compare_argument_order() {
+    let mut order = vec![];
+    let _ = cmp::minmax_by(1i32, 2, |a, b| {
+        order.push((*a, *b));
+        a.cmp(b)
+    });
+    assert_eq!(order, [(1, 2)]);
+}
+
 #[test]
 fn test_ord_min_max_by_key() {
     let f = |x: &i32| x.abs();

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -13,6 +13,7 @@
 #![feature(char_internals)]
 #![feature(char_max_len)]
 #![feature(clone_to_uninit)]
+#![feature(cmp_minmax)]
 #![feature(const_array)]
 #![feature(const_bool)]
 #![feature(const_cell_traits)]


### PR DESCRIPTION
PR rust-lang/rust#136307 introduced a regression in min_by, max_by, and minmax_by:
the compare closure received arguments as (v2, v1) instead of (v1, v2),
contrary to the documented contract.
Although this was fixed in rust-lang/rust#139357, no regression tests were added.
This PR adds regression tests for all three functions, verifying that compare
always receives arguments in the documented order (v1, v2).
As a bonus: first coretests coverage for minmax_by.
