### PR TITLE
Clarify ascii whitespace exclusion of vertical tab in the doc

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1930,6 +1930,9 @@ impl char {
     /// U+0020 SPACE, U+0009 HORIZONTAL TAB, U+000A LINE FEED,
     /// U+000C FORM FEED, or U+000D CARRIAGE RETURN.
     ///
+    /// **Warning:** Because the list above excludes U+000B VERTICAL TAB,
+    /// `c.is_ascii_whitespace()` is **not** equivalent to `c.is_ascii() && c.is_whitespace()`.
+    ///
     /// Rust uses the WhatWG Infra Standard's [definition of ASCII
     /// whitespace][infra-aw]. There are several other definitions in
     /// wide use. For instance, [the POSIX locale][pct] includes

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1064,6 +1064,9 @@ impl u8 {
     /// U+0020 SPACE, U+0009 HORIZONTAL TAB, U+000A LINE FEED,
     /// U+000C FORM FEED, or U+000D CARRIAGE RETURN.
     ///
+    /// **Warning:** Because the list above excludes U+000B VERTICAL TAB,
+    /// `b.is_ascii_whitespace()` is **not** equivalent to `char::from(b).is_whitespace()`.
+    ///
     /// Rust uses the WhatWG Infra Standard's [definition of ASCII
     /// whitespace][infra-aw]. There are several other definitions in
     /// wide use. For instance, [the POSIX locale][pct] includes

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -223,8 +223,10 @@ impl [u8] {
     ///
     /// 'Whitespace' refers to the definition used by
     /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
-    /// the `\0x0B` byte even though it has the unicode WhiteSpace property
+    /// the `\0x0B` byte even though it has the Unicode [`White_Space`] property
     /// and is removed by [`str::trim_start`].
+    ///
+    /// [`White_Space`]: https://www.unicode.org/reports/tr44/#White_Space
     ///
     /// # Examples
     ///
@@ -254,8 +256,10 @@ impl [u8] {
     ///
     /// 'Whitespace' refers to the definition used by
     /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
-    /// the `\0x0B` byte even though it has the unicode WhiteSpace property
+    /// the `\0x0B` byte even though it has the Unicode [`White_Space`] property
     /// and is removed by [`str::trim_end`].
+    ///
+    /// [`White_Space`]: https://www.unicode.org/reports/tr44/#White_Space
     ///
     /// # Examples
     ///
@@ -286,8 +290,10 @@ impl [u8] {
     ///
     /// 'Whitespace' refers to the definition used by
     /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
-    /// the `\0x0B` byte even though it has the unicode WhiteSpace property
+    /// the `\0x0B` byte even though it has the Unicode [`White_Space`] property
     /// and is removed by [`str::trim`].
+    ///
+    /// [`White_Space`]: https://www.unicode.org/reports/tr44/#White_Space
     ///
     /// # Examples
     ///

--- a/library/core/src/slice/ascii.rs
+++ b/library/core/src/slice/ascii.rs
@@ -222,7 +222,9 @@ impl [u8] {
     /// Returns a byte slice with leading ASCII whitespace bytes removed.
     ///
     /// 'Whitespace' refers to the definition used by
-    /// [`u8::is_ascii_whitespace`].
+    /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
+    /// the `\0x0B` byte even though it has the unicode WhiteSpace property
+    /// and is removed by [`str::trim_start`].
     ///
     /// # Examples
     ///
@@ -251,7 +253,9 @@ impl [u8] {
     /// Returns a byte slice with trailing ASCII whitespace bytes removed.
     ///
     /// 'Whitespace' refers to the definition used by
-    /// [`u8::is_ascii_whitespace`].
+    /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
+    /// the `\0x0B` byte even though it has the unicode WhiteSpace property
+    /// and is removed by [`str::trim_end`].
     ///
     /// # Examples
     ///
@@ -281,7 +285,9 @@ impl [u8] {
     /// removed.
     ///
     /// 'Whitespace' refers to the definition used by
-    /// [`u8::is_ascii_whitespace`].
+    /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
+    /// the `\0x0B` byte even though it has the unicode WhiteSpace property
+    /// and is removed by [`str::trim`].
     ///
     /// # Examples
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2900,10 +2900,11 @@ impl str {
     ///
     /// 'Whitespace' refers to the definition used by
     /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
-    /// the U+000B code point even though it has the unicode WhiteSpace property
+    /// the U+000B code point even though it has the Unicode [`White_Space`] property
     /// and is removed by [`str::trim_start`].
     ///
     /// [`u8::is_ascii_whitespace`]: u8::is_ascii_whitespace
+    /// [`White_Space`]: https://www.unicode.org/reports/tr44/#White_Space
     ///
     /// # Examples
     ///
@@ -2927,10 +2928,11 @@ impl str {
     ///
     /// 'Whitespace' refers to the definition used by
     /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
-    /// the U+000B code point even though it has the unicode WhiteSpace property
+    /// the U+000B code point even though it has the Unicode [`White_Space`] property
     /// and is removed by [`str::trim_end`].
     ///
     /// [`u8::is_ascii_whitespace`]: u8::is_ascii_whitespace
+    /// [`White_Space`]: https://www.unicode.org/reports/tr44/#White_Space
     ///
     /// # Examples
     ///
@@ -2955,10 +2957,11 @@ impl str {
     ///
     /// 'Whitespace' refers to the definition used by
     /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
-    /// the U+000B code point even though it has the unicode WhiteSpace property
+    /// the U+000B code point even though it has the Unicode [`White_Space`] property
     /// and is removed by [`str::trim`].
     ///
     /// [`u8::is_ascii_whitespace`]: u8::is_ascii_whitespace
+    /// [`White_Space`]: https://www.unicode.org/reports/tr44/#White_Space
     ///
     /// # Examples
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1202,6 +1202,9 @@ impl str {
     ///
     /// This uses the same definition as [`char::is_ascii_whitespace`].
     /// To split by Unicode `Whitespace` instead, use [`split_whitespace`].
+    /// Note that because of this difference in definition, even if `s.is_ascii()`
+    /// is `true`, `s.split_ascii_whitespace()` behavior will differ from `s.split_whitespace()`
+    /// if `s` contains U+000B VERTICAL TAB.
     ///
     /// [`split_whitespace`]: str::split_whitespace
     ///
@@ -2896,7 +2899,9 @@ impl str {
     /// Returns a string slice with leading ASCII whitespace removed.
     ///
     /// 'Whitespace' refers to the definition used by
-    /// [`u8::is_ascii_whitespace`].
+    /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
+    /// the U+000B code point even though it has the unicode WhiteSpace property
+    /// and is removed by [`str::trim_start`].
     ///
     /// [`u8::is_ascii_whitespace`]: u8::is_ascii_whitespace
     ///
@@ -2921,7 +2926,9 @@ impl str {
     /// Returns a string slice with trailing ASCII whitespace removed.
     ///
     /// 'Whitespace' refers to the definition used by
-    /// [`u8::is_ascii_whitespace`].
+    /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
+    /// the U+000B code point even though it has the unicode WhiteSpace property
+    /// and is removed by [`str::trim_end`].
     ///
     /// [`u8::is_ascii_whitespace`]: u8::is_ascii_whitespace
     ///
@@ -2947,7 +2954,9 @@ impl str {
     /// removed.
     ///
     /// 'Whitespace' refers to the definition used by
-    /// [`u8::is_ascii_whitespace`].
+    /// [`u8::is_ascii_whitespace`]. Importantly, this definition excludes
+    /// the U+000B code point even though it has the unicode WhiteSpace property
+    /// and is removed by [`str::trim`].
     ///
     /// [`u8::is_ascii_whitespace`]: u8::is_ascii_whitespace
     ///


### PR DESCRIPTION
This especially means that for `c: char`, `c.is_ascii() && c.is_whitespace()` does **not** imply `c.is_ascii_whitespace()`, which can cause bug and is highly counterintuitive.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
