### PR TITLE
Stabilize `#![rustfmt::skip]`, and other inner tool attributes

### DIFF
--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -699,17 +699,30 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         // We are trying to avoid reporting this error if other related errors were reported.
         if res != Res::Err && inner_attr && !self.tcx.features().custom_inner_attributes() {
-            let is_macro = match res {
-                Res::Def(..) => true,
-                Res::NonMacroAttr(..) => false,
+            match res {
+                Res::Def(..) => {
+                    feature_err(
+                        &self.tcx.sess,
+                        sym::custom_inner_attributes,
+                        path.span,
+                        "inner macro attributes are unstable",
+                    )
+                    .emit();
+                }
+                Res::NonMacroAttr(NonMacroAttrKind::Tool) => {
+                    // Permit "tool" inner attributes, such as #![rustfmt::skip]
+                }
+                Res::NonMacroAttr(..) => {
+                    feature_err(
+                        &self.tcx.sess,
+                        sym::custom_inner_attributes,
+                        path.span,
+                        "custom inner attributes are unstable",
+                    )
+                    .emit();
+                }
                 _ => unreachable!(),
             };
-            let msg = if is_macro {
-                "inner macro attributes are unstable"
-            } else {
-                "custom inner attributes are unstable"
-            };
-            feature_err(&self.tcx.sess, sym::custom_inner_attributes, path.span, msg).emit();
         }
 
         const DIAG_ATTRS: &[Symbol] =

--- a/tests/ui/proc-macro/auxiliary/rustfmt.rs
+++ b/tests/ui/proc-macro/auxiliary/rustfmt.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn skip(_: TokenStream, input: TokenStream) -> TokenStream {
+    input
+}

--- a/tests/ui/proc-macro/auxiliary/rustfmt_2.rs
+++ b/tests/ui/proc-macro/auxiliary/rustfmt_2.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn skip(_: TokenStream, input: TokenStream) -> TokenStream {
+    panic!("must never be called");
+}

--- a/tests/ui/proc-macro/inner-attr-file-mod.rs
+++ b/tests/ui/proc-macro/inner-attr-file-mod.rs
@@ -10,9 +10,7 @@ extern crate test_macros;
 #[deny(unused_attributes)]
 mod module_with_attrs;
 //~^ ERROR file modules in proc macro input are unstable
-//~| ERROR custom inner attributes are unstable
 
 fn main() {}
 
-//~? ERROR custom inner attributes are unstable
 //~? ERROR inner macro attributes are unstable

--- a/tests/ui/proc-macro/inner-attr-file-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stderr
@@ -1,15 +1,5 @@
-error[E0658]: custom inner attributes are unstable
-  --> $DIR/module_with_attrs.rs:3:4
-   |
-LL | #![rustfmt::skip]
-   |    ^^^^^^^^^^^^^
-   |
-   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
-   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: inner macro attributes are unstable
-  --> $DIR/module_with_attrs.rs:4:4
+  --> $DIR/module_with_attrs.rs:3:4
    |
 LL | #![print_attr]
    |    ^^^^^^^^^^
@@ -28,16 +18,6 @@ LL | mod module_with_attrs;
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: custom inner attributes are unstable
-  --> $DIR/inner-attr-file-mod.rs:11:1
-   |
-LL | mod module_with_attrs;
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
-   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/proc-macro/inner-attr-file-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-file-mod.stdout
@@ -1,5 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #![rustfmt::skip] }
-PRINT-ATTR DEEP-RE-COLLECTED (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { #! [rustfmt :: skip] }
+PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs {}
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -36,42 +35,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
     Group {
         delimiter: Brace,
-        stream: TokenStream [
-            Punct {
-                ch: '#',
-                spacing: Joint,
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-            },
-            Punct {
-                ch: '!',
-                spacing: Alone,
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-            },
-            Group {
-                delimiter: Bracket,
-                stream: TokenStream [
-                    Ident {
-                        ident: "rustfmt",
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-                    },
-                    Punct {
-                        ch: ':',
-                        spacing: Joint,
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-                    },
-                    Punct {
-                        ch: ':',
-                        spacing: Alone,
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-                    },
-                    Ident {
-                        ident: "skip",
-                        span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-                    },
-                ],
-                span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
-            },
-        ],
+        stream: TokenStream [],
         span: $DIR/inner-attr-file-mod.rs:11:1: 11:23 (#0),
     },
 ]

--- a/tests/ui/proc-macro/inner-attribute-tools.rs
+++ b/tests/ui/proc-macro/inner-attribute-tools.rs
@@ -1,0 +1,10 @@
+//@ run-pass
+#![allow(unknown_diagnostic_attributes)]
+
+#![rustfmt::x]
+#![clippy::x]
+#![rust_analyzer::x]
+#![miri::x]
+#![diagnostic::x]
+
+fn main() {}

--- a/tests/ui/proc-macro/inner-tool-register-tool.rs
+++ b/tests/ui/proc-macro/inner-tool-register-tool.rs
@@ -1,0 +1,6 @@
+//@ check-pass
+#![feature(register_tool)]
+#![register_tool(foo)]
+#![foo::is_a_tool]
+
+fn main() {}

--- a/tests/ui/proc-macro/macros-from-expansion-shadowing-tool-gate.rs
+++ b/tests/ui/proc-macro/macros-from-expansion-shadowing-tool-gate.rs
@@ -1,0 +1,13 @@
+//@ proc-macro: rustfmt_2.rs
+#![rustfmt::skip]
+//~^ ERROR: `rustfmt` is ambiguous
+
+extern crate rustfmt_2;
+
+macro_rules! x {
+    () => { use rustfmt_2 as rustfmt; };
+}
+
+x!();
+
+fn main() {}

--- a/tests/ui/proc-macro/macros-from-expansion-shadowing-tool-gate.stderr
+++ b/tests/ui/proc-macro/macros-from-expansion-shadowing-tool-gate.stderr
@@ -1,0 +1,22 @@
+error[E0659]: `rustfmt` is ambiguous
+  --> $DIR/macros-from-expansion-shadowing-tool-gate.rs:2:4
+   |
+LL | #![rustfmt::skip]
+   |    ^^^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
+   = note: `rustfmt` could refer to a tool module
+note: `rustfmt` could also refer to the crate imported here
+  --> $DIR/macros-from-expansion-shadowing-tool-gate.rs:8:17
+   |
+LL |     () => { use rustfmt_2 as rustfmt; };
+   |                 ^^^^^^^^^^^^^^^^^^^^
+...
+LL | x!();
+   | ---- in this macro invocation
+   = help: use `crate::rustfmt` to refer to this crate unambiguously
+   = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/proc-macro/macros-shadowing-tools-gate.rs
+++ b/tests/ui/proc-macro/macros-shadowing-tools-gate.rs
@@ -1,0 +1,6 @@
+//@ proc-macro: rustfmt.rs
+#![feature(prelude_import)]
+#![rustfmt::skip]
+//~^ ERROR: inner macro attributes are unstable
+
+fn main() {}

--- a/tests/ui/proc-macro/macros-shadowing-tools-gate.stderr
+++ b/tests/ui/proc-macro/macros-shadowing-tools-gate.stderr
@@ -1,0 +1,13 @@
+error[E0658]: inner macro attributes are unstable
+  --> $DIR/macros-shadowing-tools-gate.rs:3:4
+   |
+LL | #![rustfmt::skip]
+   |    ^^^^^^^^^^^^^
+   |
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/proc-macro/module_with_attrs.rs
+++ b/tests/ui/proc-macro/module_with_attrs.rs
@@ -1,4 +1,3 @@
 //@ ignore-auxiliary (used by `../inner-attr-non-inline-mod.rs`)
 
-#![rustfmt::skip]
 #![print_attr]


### PR DESCRIPTION
# Stabilization report

## Summary

Custom inner attribute macros have many problems in regards to name resolution, and they will likely not be stabilized anytime soon.

Inner tool attributes, like `#![rustfmt::skip]` , do *not* have any of those problems, because these are not macros - they do not rewrite any code, they are just annotations that are interpreted by external tools.

This PR stabilizes inner tool attributes, with the primary motivation being the stabilization of `#![rustfmt::skip]`:

```rust
// NOTE: this file was @generated by `cargo xtask generate-schema-types`
#![rustfmt::skip]
```

Tracking issue of the full feature:

- https://github.com/rust-lang/rust/issues/54726

cc @rust-lang/lang @rust-lang/lang-advisors

### What is stabilized

There are currently 5 tool attributes in the compiler:

- `rust_analyzer`
- `clippy`
- `miri`
- `rustfmt`
- `diagnostic`

You will now be able to write them as inner attributes:

```rust
#![rustfmt::example]
#![clippy::example]
#![rust_analyzer::example]
#![diagnostic::example]
#![miri::example]
```

Currently, the only version of an inner tool attribute that does anything is `#![rustfmt::skip]`.

The compiler explicitly permits invalid attributes formats, and does not do any validation of them (with the exception of the `diagnostic` namespace issuing *warnings* for malformed inputs)

Regular, outer attributes versions of these tools are already stable. This PR enables writing them as inner attributes.

### What isn't stabilized

Inner macro attributes are not stabilized, because there are many unresolved questions in regards to them.

### Nightly extensions

On nightly, you can register custom tools using the `#![register_tool]` attribute. ([tracking issue](https://github.com/rust-lang/rust/issues/66079)).

Tools registered using `#![register_tool]` can be used as inner attributes.

## Feedback

### Nightly use

- [2,200](https://github.com/search?q=path%3A*.rs%20%2F%23%5C!%5C%5Brustfmt%3A%3Askip%5C%5D%2F&type=code) usages of `#![rustfmt::skip]` on GitHub

## Implementation

### Major parts

- The step that checks for inner attributes no longer errors if the attribute is from the tool namespace.

### Coverage

- [x] Using each of the inner tool attributes `#![rustfmt]`, `#![clippy]`, `#![rust_analyzer]`, `#![miri]`, `#![diagnostic]` works. Test case: `inner-attribute-tools.rs`.
- [x] If a proc-macro named `rustfmt` comes from the expansion of a macro, and `#![rustfmt]` is applied at the crate root, an ambiguity error is raised. Test case: `macros-from-expansion-shadowing-tool-gate.rs`
- [x] If there is a dependency called `rustfmt` that exports a proc-macro called `skip`, then `#![rustfmt::skip]` issues a feature gate warning for custom inner attributes. Test case: `macros-shadowing-tool-gate.rs`
- [x] Tools created with the unstable `#![register_tool]` attribute can also be called as inner attributes. Test case: `inner-tool-register-tool.rs`

## Common interactions

### Exposing other features

The tests show that inner tool attributes do not accidentally expose the `custom_inner_attributes` feature as stable.

## Reference update

https://github.com/rust-lang/reference/pull/2220/changes
