### PR TITLE
make field representing types invariant over the base type

### DIFF
--- a/library/core/src/field.rs
+++ b/library/core/src/field.rs
@@ -8,7 +8,10 @@ use crate::marker::PhantomData;
 #[expect(missing_debug_implementations)]
 #[fundamental]
 pub struct FieldRepresentingType<T: ?Sized, const VARIANT: u32, const FIELD: u32> {
-    _phantom: PhantomData<T>,
+    // We want this type to be invariant over `T`, because otherwise `field_of!(Struct<'short>,
+    // field)` is a subtype of `field_of!(Struct<'long>, field)`. This subtype relationship does not
+    // have an immediately obvious meaning and we want to prevent people from relying on it.
+    _phantom: PhantomData<fn(T) -> T>,
 }
 
 // SAFETY: `FieldRepresentingType` doesn't contain any `T`

--- a/tests/ui/field_representing_types/invariant.next.stderr
+++ b/tests/ui/field_representing_types/invariant.next.stderr
@@ -1,0 +1,34 @@
+error: lifetime may not live long enough
+  --> $DIR/invariant.rs:15:5
+   |
+LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
+   |                     --  -- lifetime `'b` defined here
+   |                     |
+   |                     lifetime `'a` defined here
+LL |     consume(x, y);
+   |     ^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+   = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
+   = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/invariant.rs:15:5
+   |
+LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
+   |                     --  -- lifetime `'b` defined here
+   |                     |
+   |                     lifetime `'a` defined here
+LL |     consume(x, y);
+   |     ^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
+   = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+help: `'a` and `'b` must be the same: replace one with the other
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/field_representing_types/invariant.old.stderr
+++ b/tests/ui/field_representing_types/invariant.old.stderr
@@ -1,0 +1,34 @@
+error: lifetime may not live long enough
+  --> $DIR/invariant.rs:15:5
+   |
+LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
+   |                     --  -- lifetime `'b` defined here
+   |                     |
+   |                     lifetime `'a` defined here
+LL |     consume(x, y);
+   |     ^^^^^^^^^^^^^ argument requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+   = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
+   = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: lifetime may not live long enough
+  --> $DIR/invariant.rs:15:5
+   |
+LL | fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
+   |                     --  -- lifetime `'b` defined here
+   |                     |
+   |                     lifetime `'a` defined here
+LL |     consume(x, y);
+   |     ^^^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'b: 'a`
+   = note: requirement occurs because of the type `field_of!(Struct<'_>, field)`, which makes the generic argument `Struct<'_>` invariant
+   = note: the struct `FieldRepresentingType<T, VARIANT, FIELD>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+help: `'a` and `'b` must be the same: replace one with the other
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/field_representing_types/invariant.rs
+++ b/tests/ui/field_representing_types/invariant.rs
@@ -1,0 +1,20 @@
+//@ revisions: old next
+//@ [next] compile-flags: -Znext-solver
+#![expect(incomplete_features)]
+#![feature(field_projections)]
+
+use std::field::field_of;
+
+pub struct Struct<'a> {
+    field: &'a (),
+}
+
+fn consume<'a>(_: field_of!(Struct<'a>, field), _: field_of!(Struct<'a>, field)) {}
+
+fn assert_invariant<'a, 'b>(x: field_of!(Struct<'a>, field), y: field_of!(Struct<'b>, field)) {
+    consume(x, y);
+    //~^ ERROR: lifetime may not live long enough
+    //~^^ ERROR: lifetime may not live long enough
+}
+
+fn main() {}


### PR DESCRIPTION
We probably don't want to have any subtype relationship between any FRTs.

Reported-by: @dvdhrm "David Rheinsberg" <david@readahead.eu>
Link: https://rust-for-linux.zulipchat.com/#narrow/channel/288089-General/topic/Multiple.20LockedBy.20with.20Single.20Lock/near/579275908

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @oli-obk