### PR TITLE
Fix attribute order implementation

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -159,9 +159,9 @@ impl<T: SingleAttributeParser<S>, S: Stage> AttributeParser<S> for Single<T, S> 
             if let Some(pa) = T::convert(cx, args) {
                 if let Some((_, used)) = group.1 {
                     T::ON_DUPLICATE.exec::<T>(cx, used, cx.attr_span);
+                } else {
+                    group.1 = Some((pa, cx.attr_span));
                 }
-
-                group.1 = Some((pa, cx.attr_span));
             }
         },
     )];

--- a/tests/ui/attributes/attr-order-deprecated.rs
+++ b/tests/ui/attributes/attr-order-deprecated.rs
@@ -1,0 +1,11 @@
+#[deprecated = "AAA"]
+//~^ NOTE also specified here
+#[deprecated = "BBB"]
+//~^ ERROR multiple `deprecated` attributes
+fn deprecated() { }
+
+fn main() {
+    deprecated();
+    //~^ WARN use of deprecated function `deprecated`: AAA [deprecated]
+    //~| NOTE `#[warn(deprecated)]` on by default
+}

--- a/tests/ui/attributes/attr-order-deprecated.stderr
+++ b/tests/ui/attributes/attr-order-deprecated.stderr
@@ -1,0 +1,22 @@
+error: multiple `deprecated` attributes
+  --> $DIR/attr-order-deprecated.rs:3:1
+   |
+LL | #[deprecated = "BBB"]
+   | ^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/attr-order-deprecated.rs:1:1
+   |
+LL | #[deprecated = "AAA"]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of deprecated function `deprecated`: AAA
+  --> $DIR/attr-order-deprecated.rs:8:5
+   |
+LL |     deprecated();
+   |     ^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/attributes/attr-order-must-use.rs
+++ b/tests/ui/attributes/attr-order-must-use.rs
@@ -1,0 +1,19 @@
+#![deny(unused)]
+//~^ NOTE lint level is defined here
+
+#[must_use = "AAA"]
+//~^ NOTE also specified here
+#[must_use = "BBB"]
+//~^ ERROR unused attribute
+//~| WARN previously accepted
+//~| NOTE `#[deny(unused_attributes)]` implied by `#[deny(unused)]`
+fn must_use() -> usize {
+    0
+}
+
+fn main() {
+    must_use();
+    //~^ ERROR unused return value of `must_use` that must be used
+    //~| NOTE AAA
+    //~| NOTE `#[deny(unused_must_use)]` implied by `#[deny(unused)]`
+}

--- a/tests/ui/attributes/attr-order-must-use.stderr
+++ b/tests/ui/attributes/attr-order-must-use.stderr
@@ -1,0 +1,34 @@
+error: unused attribute
+  --> $DIR/attr-order-must-use.rs:6:1
+   |
+LL | #[must_use = "BBB"]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/attr-order-must-use.rs:4:1
+   |
+LL | #[must_use = "AAA"]
+   | ^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+note: the lint level is defined here
+  --> $DIR/attr-order-must-use.rs:1:9
+   |
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(unused_attributes)]` implied by `#[deny(unused)]`
+
+error: unused return value of `must_use` that must be used
+  --> $DIR/attr-order-must-use.rs:15:5
+   |
+LL |     must_use();
+   |     ^^^^^^^^^^
+   |
+   = note: AAA
+   = note: `#[deny(unused_must_use)]` implied by `#[deny(unused)]`
+help: use `let _ = ...` to ignore the resulting value
+   |
+LL |     let _ = must_use();
+   |     +++++++
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/attributes/malformed-no-std.stderr
+++ b/tests/ui/attributes/malformed-no-std.stderr
@@ -101,10 +101,10 @@ LL | #![no_std(foo = "bar")]
    | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/malformed-no-std.rs:5:1
+  --> $DIR/malformed-no-std.rs:3:1
    |
-LL | #![no_std("bar")]
-   | ^^^^^^^^^^^^^^^^^
+LL | #![no_std = "foo"]
+   | ^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
   --> $DIR/malformed-no-std.rs:13:1
@@ -125,10 +125,10 @@ LL | #![no_core(foo = "bar")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/malformed-no-std.rs:13:1
+  --> $DIR/malformed-no-std.rs:11:1
    |
-LL | #![no_core("bar")]
-   | ^^^^^^^^^^^^^^^^^^
+LL | #![no_core = "foo"]
+   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors; 4 warnings emitted
 


### PR DESCRIPTION
The implementation in https://github.com/rust-lang/rust/pull/153041 contained a mistake :c
I swapped the place where the error message was on, but did not change any code for which attribute was also selected, which explains the empty crater results.
**Interestingly, the original code is broken too, before https://github.com/rust-lang/rust/pull/153041 it always took the last attribute, regardless of what the `AttributeOrder` actually was...**

Let's first see crater results before making a decision