### PR TITLE
Remove misleading 'rvalue' terminology from transmute docs

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -823,7 +823,7 @@ pub const fn forget<T: ?Sized>(_: T);
 ///     unsafe {
 ///         let ptr = slice.as_mut_ptr();
 ///         // This now has three mutable references pointing at the same
-///         // memory. `slice`, the rvalue ret.0, and the rvalue ret.1.
+///         // memory: `slice`, and the two returned mutable slices.
 ///         // `slice` is never used after `let ptr = ...`, and so one can
 ///         // treat it as "dead", and therefore, you only have two real
 ///         // mutable slices.


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust#153350

The `transmute` documentation example contained the comment:
```rust
// This now has three mutable references pointing at the same
// memory. `slice`, the rvalue ret.0, and the rvalue ret.1.
```

The term "rvalue" is not used elsewhere in standard library documentation and is confusing to readers. Additionally, there is no variable named `ret` in the code — the function returns an anonymous tuple.

Changed to:
```rust
// This now has three mutable references pointing at the same
// memory: `slice`, and the two returned mutable slices.
```