### PR TITLE
Add regression test for #152893 (EII foreign item sig ICE)

### DIFF
--- a/tests/ui/eii/ice-foreign-item-sig-152893.rs
+++ b/tests/ui/eii/ice-foreign-item-sig-152893.rs
@@ -1,0 +1,14 @@
+// Regression test for #152893
+// This used to ICE with "foreign item sig" when using #[eii]
+// on a function that shadows a struct name.
+// Now it correctly reports a name redefinition error.
+
+#![feature(extern_item_impls)]
+
+struct Foo;
+
+#[eii]
+pub fn Foo(x: u64) {}
+//~^ ERROR the name `Foo` is defined multiple times
+
+fn main() {}

--- a/tests/ui/eii/ice-foreign-item-sig-152893.stderr
+++ b/tests/ui/eii/ice-foreign-item-sig-152893.stderr
@@ -1,0 +1,14 @@
+error[E0428]: the name `Foo` is defined multiple times
+  --> $DIR/ice-foreign-item-sig-152893.rs:11:1
+   |
+LL | struct Foo;
+   | ----------- previous definition of the value `Foo` here
+...
+LL | pub fn Foo(x: u64) {}
+   | ^^^^^^^^^^^^^^^^^^ `Foo` redefined here
+   |
+   = note: `Foo` must be defined only once in the value namespace of this module
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0428`.


### PR DESCRIPTION
## Summary

Adds a regression test for rust-lang/rust#152893.

Using `#[eii]` on a function that shadows a struct name used to cause an ICE with "foreign item sig". The compiler now correctly reports a name redefinition error (`E0428`) without crashing.

## Test

`tests/ui/eii/ice-foreign-item-sig-152893.rs`

Closes rust-lang/rust#152893