### PR TITLE
Add regression test for #142913 (region parameter out of range ICE)

### DIFF
--- a/tests/ui/const-generics/generic_const_parameter_types/ice-region-param-142913.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/ice-region-param-142913.rs
@@ -1,0 +1,15 @@
+// Regression test for #142913
+// This used to ICE with "region parameter out of range when instantiating args"
+// Now it correctly reports errors without crashing.
+
+#![feature(unsized_const_params, adt_const_params, generic_const_parameter_types)]
+//~^ WARN the feature `unsized_const_params` is incomplete
+//~| WARN the feature `generic_const_parameter_types` is incomplete
+
+fn foo<'a, const N: &'a Variant = { () as isize }>() {}
+//~^ ERROR cannot find type `Variant` in this scope
+//~| ERROR defaults for generic parameters are not allowed here
+//~| ERROR anonymous constants with lifetimes in their type are not yet supported
+//~| ERROR non-primitive cast: `()` as `isize`
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/ice-region-param-142913.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/ice-region-param-142913.stderr
@@ -1,0 +1,45 @@
+error[E0425]: cannot find type `Variant` in this scope
+ --> $DIR/ice-region-param-142913.rs:9:25
+  |
+LL | fn foo<'a, const N: &'a Variant = { () as isize }>() {}
+  |                         ^^^^^^^ not found in this scope
+
+warning: the feature `unsized_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> $DIR/ice-region-param-142913.rs:5:12
+  |
+LL | #![feature(unsized_const_params, adt_const_params, generic_const_parameter_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+  = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `generic_const_parameter_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> $DIR/ice-region-param-142913.rs:5:52
+  |
+LL | #![feature(unsized_const_params, adt_const_params, generic_const_parameter_types)]
+  |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: see issue #137626 <https://github.com/rust-lang/rust/issues/137626> for more information
+
+error: defaults for generic parameters are not allowed here
+ --> $DIR/ice-region-param-142913.rs:9:12
+  |
+LL | fn foo<'a, const N: &'a Variant = { () as isize }>() {}
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+ --> $DIR/ice-region-param-142913.rs:9:35
+  |
+LL | fn foo<'a, const N: &'a Variant = { () as isize }>() {}
+  |                                   ^^^^^^^^^^^^^^^
+
+error[E0605]: non-primitive cast: `()` as `isize`
+ --> $DIR/ice-region-param-142913.rs:9:37
+  |
+LL | fn foo<'a, const N: &'a Variant = { () as isize }>() {}
+  |                                     ^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+
+error: aborting due to 4 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0425, E0605.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
## Summary

Adds a regression test for rust-lang/rust#142913.

Using `generic_const_parameter_types` with a lifetime-parameterized const default used to ICE with "region parameter out of range when instantiating args". The compiler now correctly reports errors without crashing.

## Test

`tests/ui/const-generics/generic_const_parameter_types/ice-region-param-142913.rs`

Closes rust-lang/rust#142913