### PR TITLE
Add regression test for #138891 (fresh type during canonicalization ICE)

### DIFF
--- a/tests/ui/traits/alias/ice-fresh-type-canonicalization-138891.rs
+++ b/tests/ui/traits/alias/ice-fresh-type-canonicalization-138891.rs
@@ -1,0 +1,13 @@
+// Regression test for #138891
+// This used to ICE with "encountered a fresh type during canonicalization"
+// when using a trait alias with `Self` in a dyn context with extra generic args.
+
+#![feature(trait_alias)]
+
+trait F = Fn() -> Self;
+
+fn _f3<Fut>(a: dyn F<Fut>) {}
+//~^ ERROR trait alias takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR associated type binding in trait object type mentions `Self`
+
+fn main() {}

--- a/tests/ui/traits/alias/ice-fresh-type-canonicalization-138891.stderr
+++ b/tests/ui/traits/alias/ice-fresh-type-canonicalization-138891.stderr
@@ -1,0 +1,26 @@
+error[E0107]: trait alias takes 0 generic arguments but 1 generic argument was supplied
+ --> $DIR/ice-fresh-type-canonicalization-138891.rs:9:20
+  |
+LL | fn _f3<Fut>(a: dyn F<Fut>) {}
+  |                    ^----- help: remove the unnecessary generics
+  |                    |
+  |                    expected 0 generic arguments
+  |
+note: trait alias defined here, with 0 generic parameters
+ --> $DIR/ice-fresh-type-canonicalization-138891.rs:7:7
+  |
+LL | trait F = Fn() -> Self;
+  |       ^
+
+error: associated type binding in trait object type mentions `Self`
+ --> $DIR/ice-fresh-type-canonicalization-138891.rs:9:16
+  |
+LL | trait F = Fn() -> Self;
+  |                   ---- this binding mentions `Self`
+...
+LL | fn _f3<Fut>(a: dyn F<Fut>) {}
+  |                ^^^^^^^^^^ contains a mention of `Self`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
## Summary

Adds a regression test for rust-lang/rust#138891.

Using a trait alias with `Self` as a return type in a `dyn` context with extra generic arguments used to ICE with "encountered a fresh type during canonicalization". The compiler now correctly reports:
- `E0107`: trait alias takes 0 generic arguments
- associated type binding mentions `Self`

## Test

`tests/ui/traits/alias/ice-fresh-type-canonicalization-138891.rs`

Closes rust-lang/rust#138891