### PR TITLE
Add regression test for #132055 (escaping bound vars ICE)

### DIFF
--- a/tests/ui/associated-type-bounds/ice-escaping-bound-vars-132055.rs
+++ b/tests/ui/associated-type-bounds/ice-escaping-bound-vars-132055.rs
@@ -1,0 +1,15 @@
+// Regression test for #132055
+// This used to ICE with "assertion failed: !t.has_escaping_bound_vars()"
+// when using return_type_notation with a trait that has a lifetime parameter
+// but omitting the lifetime in the bound. Now correctly reports E0106.
+
+#![feature(return_type_notation)]
+
+trait A<'a> {
+    fn method() -> impl Sized;
+}
+
+fn foo<T: A<method(..): Send>>() {}
+//~^ ERROR missing lifetime specifier
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/ice-escaping-bound-vars-132055.stderr
+++ b/tests/ui/associated-type-bounds/ice-escaping-bound-vars-132055.stderr
@@ -1,0 +1,19 @@
+error[E0106]: missing lifetime specifier
+ --> $DIR/ice-escaping-bound-vars-132055.rs:12:12
+  |
+LL | fn foo<T: A<method(..): Send>>() {}
+  |            ^ expected named lifetime parameter
+  |
+  = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+  |
+LL | fn foo<T: for<'a> A<'a, method(..): Send>>() {}
+  |           +++++++   +++
+help: consider introducing a named lifetime parameter
+  |
+LL | fn foo<'a, T: A<'a, method(..): Send>>() {}
+  |        +++      +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
## Summary

Adds a regression test for rust-lang/rust#132055.

Using `return_type_notation` with a trait that has a lifetime parameter but omitting the lifetime in the bound used to ICE with "assertion failed: !t.has_escaping_bound_vars()". The compiler now correctly reports `E0106` (missing lifetime specifier) without crashing.

## Test

`tests/ui/associated-type-bounds/ice-escaping-bound-vars-132055.rs`

Closes rust-lang/rust#132055