### PR TITLE
Add regression test for #119316 (closure in const generic default ICE)

### DIFF
--- a/tests/ui/const-generics/generic_const_exprs/ice-closure-const-default-119316.rs
+++ b/tests/ui/const-generics/generic_const_exprs/ice-closure-const-default-119316.rs
@@ -1,0 +1,12 @@
+// Regression test for #119316
+// This used to ICE with "expected type of closure to be a closure"
+// when using a closure as a const generic default with generic_const_exprs.
+// Now it correctly reports a type mismatch error.
+
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete
+
+struct Bug<const N: usize = { || 0 }>;
+//~^ ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/ice-closure-const-default-119316.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/ice-closure-const-default-119316.stderr
@@ -1,0 +1,25 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> $DIR/ice-closure-const-default-119316.rs:6:12
+  |
+LL | #![feature(generic_const_exprs)]
+  |            ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+  = note: `#[warn(incomplete_features)]` on by default
+
+error[E0308]: mismatched types
+ --> $DIR/ice-closure-const-default-119316.rs:8:31
+  |
+LL | struct Bug<const N: usize = { || 0 }>;
+  |                               ^^^^ expected `usize`, found closure
+  |
+  = note: expected type `usize`
+          found closure `{closure@$DIR/ice-closure-const-default-119316.rs:8:31: 8:33}`
+help: use parentheses to call this closure
+  |
+LL | struct Bug<const N: usize = { (|| 0)() }>;
+  |                               +    +++
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
## Summary

Adds a regression test for rust-lang/rust#119316.

Using a closure as a const generic default with `generic_const_exprs` used to ICE with "expected type of closure to be a closure". The compiler now correctly reports `E0308` (mismatched types: expected `usize`, found closure) and even suggests calling the closure.

## Test

`tests/ui/const-generics/generic_const_exprs/ice-closure-const-default-119316.rs`

Closes rust-lang/rust#119316