### PR TITLE
Add regression test for #132767 (try_normalize_erasing_regions ICE)

### DIFF
--- a/tests/ui/traits/ice-normalize-erasing-regions-132767.rs
+++ b/tests/ui/traits/ice-normalize-erasing-regions-132767.rs
@@ -1,0 +1,29 @@
+// Regression test for #132767.
+// This used to ICE with "maybe try to call `try_normalize_erasing_regions`"
+// when normalizing the hidden type of `impl Trait`.
+
+trait Func {
+    type Ret;
+}
+
+impl<F: FnOnce() -> R, R> Func for F {
+    type Ret = R;
+}
+
+trait Id {}
+
+fn invalid_impl_trait() -> impl Id {}
+//~^ ERROR the trait bound `(): Id` is not satisfied
+
+struct Foo<T: Func> {
+    _func: T,
+    value: Option<<T as Func>::Ret>,
+}
+
+fn main() {
+    let foo = Foo {
+        _func: invalid_impl_trait,
+        value: None,
+    };
+    drop(foo.value);
+}

--- a/tests/ui/traits/ice-normalize-erasing-regions-132767.stderr
+++ b/tests/ui/traits/ice-normalize-erasing-regions-132767.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `(): Id` is not satisfied
+  --> $DIR/ice-normalize-erasing-regions-132767.rs:15:28
+   |
+LL | fn invalid_impl_trait() -> impl Id {}
+   |                            ^^^^^^^ the trait `Id` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/ice-normalize-erasing-regions-132767.rs:13:1
+   |
+LL | trait Id {}
+   | ^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
## Summary

Adds a regression test for rust-lang/rust#132767.

Using associated types with fn pointers and `impl Trait` return types used to ICE suggesting to call `try_normalize_erasing_regions`. The compiler now correctly reports `E0277` (trait bound not satisfied) without crashing.

## Test

`tests/ui/traits/ice-normalize-erasing-regions-132767.rs`

Closes rust-lang/rust#132767