### PR TITLE
Fix ICE when reporting host-effect errors for const Fn HRTBs in next trait solver

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -876,7 +876,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         if let Ok(Some(ImplSource::UserDefined(impl_data))) =
-            SelectionContext::new(self).select(&obligation.with(self.tcx, trait_ref.skip_binder()))
+            self.enter_forall(trait_ref, |trait_ref_for_select| {
+                SelectionContext::new(self).select(&obligation.with(self.tcx, trait_ref_for_select))
+            })
         {
             let impl_did = impl_data.impl_def_id;
             let trait_did = trait_ref.def_id();

--- a/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.rs
+++ b/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.rs
@@ -1,0 +1,12 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/151894
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(const_trait_impl)]
+
+const fn with_positive<F: for<'a> [const] Fn(&'a ())>() {}
+
+const _: () = {
+    with_positive::<()>(); //~ ERROR expected a `Fn(&'a ())` closure, found `()`
+};
+
+fn main() {}

--- a/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/const-host-effect-hrtb-no-ice.stderr
@@ -1,0 +1,16 @@
+error[E0277]: expected a `Fn(&'a ())` closure, found `()`
+  --> $DIR/const-host-effect-hrtb-no-ice.rs:9:21
+   |
+LL |     with_positive::<()>();
+   |                     ^^ expected an `Fn(&'a ())` closure, found `()`
+   |
+   = help: the trait `for<'a> Fn(&'a ())` is not implemented for `()`
+note: required by a bound in `with_positive`
+  --> $DIR/const-host-effect-hrtb-no-ice.rs:6:27
+   |
+LL | const fn with_positive<F: for<'a> [const] Fn(&'a ())>() {}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `with_positive`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Avoid leaking bound vars into the diagnostic selection path for HRTB host-effect predicates.

Closes rust-lang/rust#151894 .

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
