### PR TITLE
Post-attribute ports cleanup pt. 1

### DIFF
--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -7,7 +7,7 @@ use rustc_ast::tokenstream::DelimSpan;
 use rustc_ast::{
     self as ast, AttrArgs, Attribute, DelimArgs, MetaItem, MetaItemInner, MetaItemKind, Safety,
 };
-use rustc_errors::{Applicability, FatalError, PResult};
+use rustc_errors::{Applicability, PResult};
 use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP};
 use rustc_hir::AttrPath;
 use rustc_hir::lints::AttributeLintKind;
@@ -149,7 +149,7 @@ pub fn check_builtin_meta_item(
     }
 }
 
-fn emit_malformed_attribute(
+pub fn emit_malformed_attribute(
     psess: &ParseSess,
     style: ast::AttrStyle,
     span: Span,
@@ -209,16 +209,4 @@ fn emit_malformed_attribute(
         }
         err.emit();
     }
-}
-
-pub fn emit_fatal_malformed_builtin_attribute(
-    psess: &ParseSess,
-    attr: &Attribute,
-    name: Symbol,
-) -> ! {
-    let template = BUILTIN_ATTRIBUTE_MAP.get(&name).expect("builtin attr defined").template;
-    emit_malformed_attribute(psess, attr.style, attr.span, name, template);
-    // This is fatal, otherwise it will likely cause a cascade of other errors
-    // (and an error here is expected to be very rare).
-    FatalError.raise()
 }

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -1,7 +1,6 @@
 //! Meta-syntax validation logic of attributes for post-expansion.
 
 use std::convert::identity;
-use std::slice;
 
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::DelimSpan;
@@ -9,7 +8,7 @@ use rustc_ast::{
     self as ast, AttrArgs, Attribute, DelimArgs, MetaItem, MetaItemInner, MetaItemKind, Safety,
 };
 use rustc_errors::{Applicability, FatalError, PResult};
-use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
+use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP};
 use rustc_hir::AttrPath;
 use rustc_hir::lints::AttributeLintKind;
 use rustc_parse::parse_in;
@@ -19,43 +18,23 @@ use rustc_session::lint::builtin::ILL_FORMED_ATTRIBUTE_INPUT;
 use rustc_session::parse::ParseSess;
 use rustc_span::{Span, Symbol, sym};
 
-use crate::{AttributeParser, Late, session_diagnostics as errors};
+use crate::session_diagnostics as errors;
 
 pub fn check_attr(psess: &ParseSess, attr: &Attribute) {
-    if attr.is_doc_comment() || attr.has_name(sym::cfg_trace) || attr.has_name(sym::cfg_attr_trace)
+    // Built-in attributes are parsed in their respective attribute parsers, so can be ignored here
+    if attr.is_doc_comment()
+        || attr.name().is_some_and(|name| BUILTIN_ATTRIBUTE_MAP.contains_key(&name))
     {
         return;
     }
 
-    let builtin_attr_info = attr.name().and_then(|name| BUILTIN_ATTRIBUTE_MAP.get(&name));
-
-    // Check input tokens for built-in and key-value attributes.
-    match builtin_attr_info {
-        // `rustc_dummy` doesn't have any restrictions specific to built-in attributes.
-        Some(BuiltinAttribute { name, template, .. }) => {
-            if AttributeParser::<Late>::is_parsed_attribute(slice::from_ref(&name)) {
-                return;
-            }
-            match parse_meta(psess, attr) {
-                // Don't check safety again, we just did that
-                Ok(meta) => {
-                    check_builtin_meta_item(psess, &meta, attr.style, *name, *template, false)
-                }
-                Err(err) => {
-                    err.emit();
-                }
-            }
-        }
-        _ => {
-            let attr_item = attr.get_normal_item();
-            if let AttrArgs::Eq { .. } = attr_item.args.unparsed_ref().unwrap() {
-                // All key-value attributes are restricted to meta-item syntax.
-                match parse_meta(psess, attr) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        err.emit();
-                    }
-                }
+    let attr_item = attr.get_normal_item();
+    if let AttrArgs::Eq { .. } = attr_item.args.unparsed_ref().unwrap() {
+        // All key-value attributes are restricted to meta-item syntax.
+        match parse_meta(psess, attr) {
+            Ok(_) => {}
+            Err(err) => {
+                err.emit();
             }
         }
     }

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -603,21 +603,3 @@ pub(crate) struct TrailingMacro {
     pub is_trailing: bool,
     pub name: Ident,
 }
-
-#[derive(Diagnostic)]
-#[diag("unused attribute `{$attr_name}`")]
-pub(crate) struct UnusedBuiltinAttribute {
-    #[note(
-        "the built-in attribute `{$attr_name}` will be ignored, since it's applied to the macro invocation `{$macro_name}`"
-    )]
-    pub invoc_span: Span,
-    pub attr_name: Symbol,
-    pub macro_name: String,
-    #[suggestion(
-        "remove the attribute",
-        code = "",
-        applicability = "machine-applicable",
-        style = "tool-only"
-    )]
-    pub attr_span: Span,
-}

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -15,8 +15,8 @@ use rustc_ast::{
 use rustc_ast_pretty::pprust;
 use rustc_attr_parsing::parser::AllowExprMetavar;
 use rustc_attr_parsing::{
-    AttributeParser, CFG_TEMPLATE, Early, EvalConfigResult, ShouldEmit, eval_config_entry,
-    parse_cfg, validate_attr,
+    AttributeParser, CFG_TEMPLATE, EvalConfigResult, ShouldEmit, eval_config_entry, parse_cfg,
+    validate_attr,
 };
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
 use rustc_data_structures::stack::ensure_sufficient_stack;
@@ -30,7 +30,7 @@ use rustc_parse::parser::{
     RecoverColon, RecoverComma, Recovery, token_descr,
 };
 use rustc_session::Session;
-use rustc_session::lint::builtin::{UNUSED_ATTRIBUTES, UNUSED_DOC_COMMENTS};
+use rustc_session::lint::builtin::UNUSED_DOC_COMMENTS;
 use rustc_session::parse::feature_err;
 use rustc_span::hygiene::SyntaxContext;
 use rustc_span::{ErrorGuaranteed, FileName, Ident, LocalExpnId, Span, Symbol, sym};
@@ -2273,21 +2273,6 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     current_span,
                     self.cx.current_expansion.lint_node_id,
                     crate::errors::MacroCallUnusedDocComment { span: attr.span },
-                );
-            } else if rustc_attr_parsing::is_builtin_attr(attr)
-                && !AttributeParser::<Early>::is_parsed_attribute(&attr.path())
-            {
-                let attr_name = attr.name().unwrap();
-                self.cx.sess.psess.buffer_lint(
-                    UNUSED_ATTRIBUTES,
-                    attr.span,
-                    self.cx.current_expansion.lint_node_id,
-                    crate::errors::UnusedBuiltinAttribute {
-                        attr_name,
-                        macro_name: pprust::path_to_string(&call.path),
-                        invoc_span: call.path.span,
-                        attr_span: attr.span,
-                    },
                 );
             }
         }

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -186,6 +186,7 @@ pub(crate) fn mod_file_path_from_attr(
     attrs: &[Attribute],
     dir_path: &Path,
 ) -> Option<PathBuf> {
+    // FIXME(154781) use a parsed attribute here
     // Extract path string from first `#[path = "path_string"]` attribute.
     let first_path = attrs.iter().find(|at| at.has_name(sym::path))?;
     let Some(path_sym) = first_path.value_str() else {

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -2,7 +2,6 @@ use std::iter::once;
 use std::path::{self, Path, PathBuf};
 
 use rustc_ast::{AttrVec, Attribute, Inline, Item, ModSpans};
-use rustc_attr_parsing::validate_attr;
 use rustc_errors::{Diag, ErrorGuaranteed};
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::{exp, new_parser_from_file, unwrap_or_emit_fatal};
@@ -10,7 +9,9 @@ use rustc_session::Session;
 use rustc_session::parse::ParseSess;
 use rustc_span::{Ident, Span, sym};
 use thin_vec::ThinVec;
-
+use rustc_attr_parsing::validate_attr::emit_malformed_attribute;
+use rustc_feature::template;
+use rustc_span::fatal_error::FatalError;
 use crate::base::ModuleData;
 use crate::errors::{
     ModuleCircular, ModuleFileNotFound, ModuleInBlock, ModuleInBlockName, ModuleMultipleCandidates,
@@ -195,7 +196,11 @@ pub(crate) fn mod_file_path_from_attr(
         // Usually bad forms are checked during semantic analysis via
         // `TyCtxt::check_mod_attrs`), but by the time that runs the macro
         // is expanded, and it doesn't give an error.
-        validate_attr::emit_fatal_malformed_builtin_attribute(&sess.psess, first_path, sym::path);
+        emit_malformed_attribute(&sess.psess, first_path.style, first_path.span, sym::path, template!(
+            NameValueStr: "file",
+            "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
+        ));
+        FatalError.raise()
     };
 
     let path_str = path_sym.as_str();

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -2,16 +2,17 @@ use std::iter::once;
 use std::path::{self, Path, PathBuf};
 
 use rustc_ast::{AttrVec, Attribute, Inline, Item, ModSpans};
+use rustc_attr_parsing::validate_attr::emit_malformed_attribute;
 use rustc_errors::{Diag, ErrorGuaranteed};
+use rustc_feature::template;
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::{exp, new_parser_from_file, unwrap_or_emit_fatal};
 use rustc_session::Session;
 use rustc_session::parse::ParseSess;
+use rustc_span::fatal_error::FatalError;
 use rustc_span::{Ident, Span, sym};
 use thin_vec::ThinVec;
-use rustc_attr_parsing::validate_attr::emit_malformed_attribute;
-use rustc_feature::template;
-use rustc_span::fatal_error::FatalError;
+
 use crate::base::ModuleData;
 use crate::errors::{
     ModuleCircular, ModuleFileNotFound, ModuleInBlock, ModuleInBlockName, ModuleMultipleCandidates,
@@ -196,10 +197,16 @@ pub(crate) fn mod_file_path_from_attr(
         // Usually bad forms are checked during semantic analysis via
         // `TyCtxt::check_mod_attrs`), but by the time that runs the macro
         // is expanded, and it doesn't give an error.
-        emit_malformed_attribute(&sess.psess, first_path.style, first_path.span, sym::path, template!(
-            NameValueStr: "file",
-            "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
-        ));
+        emit_malformed_attribute(
+            &sess.psess,
+            first_path.style,
+            first_path.span,
+            sym::path,
+            template!(
+                NameValueStr: "file",
+                "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
+            ),
+        );
         FatalError.raise()
     };
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -2,7 +2,6 @@
 
 use std::sync::LazyLock;
 
-use AttributeDuplicates::*;
 use AttributeGate::*;
 use AttributeType::*;
 use rustc_data_structures::fx::FxHashMap;
@@ -74,7 +73,7 @@ pub fn find_gated_cfg(pred: impl Fn(Symbol) -> bool) -> Option<&'static GatedCfg
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AttributeType {
-    /// Normal, builtin attribute that is consumed
+    /// Normal,builtin attribute that is consumed
     /// by the compiler before the unused_attribute check
     Normal,
     /// Builtin attribute that is only allowed at the crate level
@@ -178,57 +177,6 @@ impl AttributeTemplate {
     }
 }
 
-/// How to handle multiple duplicate attributes on the same item.
-#[derive(Clone, Copy, Default)]
-pub enum AttributeDuplicates {
-    /// Duplicates of this attribute are allowed.
-    ///
-    /// This should only be used with attributes where duplicates have semantic
-    /// meaning, or some kind of "additive" behavior. For example, `#[warn(..)]`
-    /// can be specified multiple times, and it combines all the entries. Or use
-    /// this if there is validation done elsewhere.
-    #[default]
-    DuplicatesOk,
-    /// Duplicates after the first attribute will be an unused_attribute warning.
-    ///
-    /// This is usually used for "word" attributes, where they are used as a
-    /// boolean marker, like `#[used]`. It is not necessarily wrong that there
-    /// are duplicates, but the others should probably be removed.
-    WarnFollowing,
-    /// Same as `WarnFollowing`, but only issues warnings for word-style attributes.
-    ///
-    /// This is only for special cases, for example multiple `#[macro_use]` can
-    /// be warned, but multiple `#[macro_use(...)]` should not because the list
-    /// form has different meaning from the word form.
-    WarnFollowingWordOnly,
-    /// Duplicates after the first attribute will be an error.
-    ///
-    /// This should be used where duplicates would be ignored, but carry extra
-    /// meaning that could cause confusion. For example, `#[stable(since="1.0")]
-    /// #[stable(since="2.0")]`, which version should be used for `stable`?
-    ErrorFollowing,
-    /// Duplicates preceding the last instance of the attribute will be an error.
-    ///
-    /// This is the same as `ErrorFollowing`, except the last attribute is the
-    /// one that is "used". This is typically used in cases like codegen
-    /// attributes which usually only honor the last attribute.
-    ErrorPreceding,
-    /// Duplicates after the first attribute will be an unused_attribute warning
-    /// with a note that this will be an error in the future.
-    ///
-    /// This should be used for attributes that should be `ErrorFollowing`, but
-    /// because older versions of rustc silently accepted (and ignored) the
-    /// attributes, this is used to transition.
-    FutureWarnFollowing,
-    /// Duplicates preceding the last instance of the attribute will be a
-    /// warning, with a note that this will be an error in the future.
-    ///
-    /// This is the same as `FutureWarnFollowing`, except the last attribute is
-    /// the one that is "used". Ideally these can eventually migrate to
-    /// `ErrorPreceding`.
-    FutureWarnPreceding,
-}
-
 /// A convenience macro for constructing attribute templates.
 /// E.g., `template!(Word, List: "description")` means that the attribute
 /// supports forms `#[attr]` and `#[attr(description)]`.
@@ -265,42 +213,39 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $typ:expr, $duplicates:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident, $typ:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
             gate: Ungated,
-            duplicates: $duplicates,
         }
     };
-    (unsafe $attr:ident, $typ:expr, $duplicates:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             gate: Ungated,
-            duplicates: $duplicates,
         }
     };
-    ($attr:ident, $typ:expr, $duplicates:expr $(,)?) => {
+    ($attr:ident, $typ:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Normal,
             gate: Ungated,
-            duplicates: $duplicates,
         }
     };
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            duplicates: $duplicates,
+
             gate: Gated {
                 feature: sym::$gate,
                 message: $message,
@@ -309,12 +254,12 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            duplicates: $duplicates,
+
             gate: Gated {
                 feature: sym::$attr,
                 message: $message,
@@ -323,12 +268,12 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            duplicates: $duplicates,
+
             gate: Gated {
                 feature: sym::$gate,
                 message: $message,
@@ -337,12 +282,12 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            duplicates: $duplicates,
+
             gate: Gated {
                 feature: sym::$attr,
                 message: $message,
@@ -354,11 +299,10 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $typ:expr, $duplicate:expr $(,)?) => {
+    (TEST, $attr:ident, $typ:expr, $(,)?) => {
         rustc_attr!(
             $attr,
             $typ,
-            $duplicate,
             concat!(
                 "the `#[",
                 stringify!($attr),
@@ -366,12 +310,12 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $typ:expr, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            duplicates: $duplicates,
+
             gate: Gated {
                 feature: sym::rustc_attrs,
                 message: "use of an internal attribute",
@@ -397,7 +341,6 @@ pub struct BuiltinAttribute {
     pub name: Symbol,
     pub type_: AttributeType,
     pub safety: AttributeSafety,
-    pub duplicates: AttributeDuplicates,
     pub gate: AttributeGate,
 }
 
@@ -411,243 +354,194 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Conditional compilation:
     ungated!(
         cfg, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         cfg_attr, Normal,
-        DuplicatesOk,
-    ),
+            ),
 
     // Testing:
     ungated!(
         ignore, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         should_panic, Normal,
-        FutureWarnFollowing,
     ),
 
     // Macros:
     ungated!(
         automatically_derived, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         macro_use, Normal,
-        WarnFollowingWordOnly,
     ),
-    ungated!(macro_escape, Normal, WarnFollowing,), // Deprecated synonym for `macro_use`.
+    ungated!(macro_escape, Normal,), // Deprecated synonym for `macro_use`.
     ungated!(
         macro_export, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         proc_macro, Normal,
-        ErrorFollowing,
-    ),
+            ),
     ungated!(
         proc_macro_derive, Normal,
-        ErrorFollowing,
-    ),
+            ),
     ungated!(
         proc_macro_attribute, Normal,
-        ErrorFollowing,
-    ),
+            ),
 
     // Lints:
     ungated!(
         warn, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         allow, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         expect, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         forbid, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         deny, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         must_use, Normal,
-        FutureWarnFollowing,
     ),
     gated!(
-        must_not_suspend, Normal, WarnFollowing, experimental!(must_not_suspend)
+        must_not_suspend, Normal, experimental!(must_not_suspend)
     ),
     ungated!(
         deprecated, Normal,
-        ErrorFollowing,
-    ),
+            ),
 
     // Crate properties:
     ungated!(
         crate_name, CrateLevel,
-        FutureWarnFollowing,
     ),
     ungated!(
         crate_type, CrateLevel,
-        DuplicatesOk,
-    ),
+            ),
 
     // ABI, linking, symbols, and FFI
     ungated!(
         link, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         link_name, Normal,
-        FutureWarnPreceding,
     ),
     ungated!(
         no_link, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         repr, Normal,
-        DuplicatesOk,
-    ),
+            ),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, Normal, DuplicatesOk, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, Normal, DuplicatesOk, static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, Normal,fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, Normal,static_align, experimental!(rustc_align_static)),
     ungated!(
         unsafe(Edition2024) export_name, Normal,
-        FutureWarnPreceding,
     ),
     ungated!(
         unsafe(Edition2024) link_section, Normal,
-        FutureWarnPreceding,
     ),
     ungated!(
         unsafe(Edition2024) no_mangle, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         used, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         link_ordinal, Normal,
-        ErrorPreceding,
     ),
     ungated!(
         unsafe naked, Normal,
-        WarnFollowing,
-    ),
+     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
-        rustc_pass_indirectly_in_non_rustic_abis, Normal, ErrorFollowing,
-        "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
+        rustc_pass_indirectly_in_non_rustic_abis, Normal,        "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
 
     // Limits:
     ungated!(
         recursion_limit, CrateLevel,
-        FutureWarnFollowing,
     ),
     ungated!(
         type_length_limit, CrateLevel,
-        FutureWarnFollowing,
     ),
     gated!(
-        move_size_limit, CrateLevel, ErrorFollowing, large_assignments, experimental!(move_size_limit)
+        move_size_limit, CrateLevel, large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
     ungated!(
         no_main, CrateLevel,
-        WarnFollowing,
-    ),
+     ),
 
     // Modules, prelude, and resolution:
     ungated!(
         path, Normal,
-        FutureWarnFollowing,
     ),
     ungated!(
         no_std, CrateLevel,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         no_implicit_prelude, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         non_exhaustive, Normal,
-        WarnFollowing,
-    ),
+     ),
 
     // Runtime
     ungated!(
         windows_subsystem, CrateLevel,
-        FutureWarnFollowing,
     ),
     ungated!( // RFC 2070
         panic_handler, Normal,
-        WarnFollowing,
-    ),
+     ),
 
     // Code generation:
     ungated!(
         inline, Normal,
-        FutureWarnFollowing,
     ),
     ungated!(
         cold, Normal,
-        WarnFollowing,
     ),
     ungated!(
         no_builtins, CrateLevel,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         target_feature, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         track_caller, Normal,
-        WarnFollowing,
-    ),
+     ),
     ungated!(
         instruction_set, Normal,
-        ErrorPreceding,
     ),
     gated!(
         unsafe force_target_feature, Normal,
-        DuplicatesOk, effective_target_features, experimental!(force_target_feature)
+        effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
-        sanitize, Normal, ErrorPreceding,
+        sanitize, Normal,
          sanitize, experimental!(sanitize),
     ),
     gated!(
         coverage, Normal,
-        ErrorPreceding,
         coverage_attribute, experimental!(coverage)
     ),
 
     ungated!(
         doc, Normal,
-        DuplicatesOk,
-    ),
+            ),
 
     // Debugging
     ungated!(
         debugger_visualizer, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         collapse_debuginfo, Normal,
-        ErrorFollowing,
-    ),
+            ),
 
     // ==========================================================================
     // Unstable attributes:
@@ -655,61 +549,60 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, Normal, WarnFollowing, experimental!(export_stable)
+        export_stable, Normal, experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, CrateLevel, ErrorFollowing, custom_test_frameworks,
+        test_runner, CrateLevel, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
-        reexport_test_harness_main, CrateLevel, ErrorFollowing, custom_test_frameworks,
+        reexport_test_harness_main, CrateLevel, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, Normal, WarnFollowing,marker_trait_attr, experimental!(marker)
+        marker, Normal,marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, Normal, WarnFollowing,"`#[thread_local]` is an experimental feature, and does not currently handle destructors",
+        thread_local, Normal,"`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
-        no_core, CrateLevel, WarnFollowing, experimental!(no_core)
+        no_core, CrateLevel,  experimental!(no_core)
     ),
     // RFC 2412
     gated!(
-        optimize, Normal, ErrorPreceding,
+        optimize, Normal,
          optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, Normal, WarnFollowing, experimental!(ffi_pure)
+        unsafe ffi_pure, Normal, experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, Normal, WarnFollowing, experimental!(ffi_const)
+        unsafe ffi_const, Normal, experimental!(ffi_const)
     ),
     gated!(
-        register_tool, CrateLevel, DuplicatesOk,
-         experimental!(register_tool),
+        register_tool, CrateLevel,          experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
-        cfi_encoding, Normal, ErrorPreceding,
+        cfi_encoding, Normal,
          experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, Normal, ErrorFollowing, coroutines, experimental!(coroutine)
+        coroutine, Normal,coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
-        patchable_function_entry, Normal, ErrorPreceding,
+        patchable_function_entry, Normal,
          experimental!(patchable_function_entry)
     ),
 
@@ -718,10 +611,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, Normal, ErrorFollowing, loop_match, experimental!(const_continue)
+        const_continue, Normal,loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, Normal, ErrorFollowing, loop_match, experimental!(loop_match)
+        loop_match, Normal,loop_match, experimental!(loop_match)
     ),
 
     // The `#[pin_v2]` attribute is part of the `pin_ergonomics` experiment
@@ -729,7 +622,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, Normal, ErrorFollowing, pin_ergonomics, experimental!(pin_v2),
+        pin_v2, Normal,pin_ergonomics, experimental!(pin_v2),
     ),
 
     // ==========================================================================
@@ -738,58 +631,48 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     ungated!(
         feature, CrateLevel,
-        DuplicatesOk,
-    ),
+            ),
     // DuplicatesOk since it has its own validation
     ungated!(
         stable, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         unstable, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         unstable_feature_bound, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         rustc_const_unstable, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         rustc_const_stable, Normal,
-        DuplicatesOk,
-    ),
+            ),
     ungated!(
         rustc_default_body_unstable, Normal,
-        DuplicatesOk,
-    ),
+            ),
     gated!(
         allow_internal_unstable, Normal,
-        DuplicatesOk,
-        "allow_internal_unstable side-steps feature gating and stability checks",
+                "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, Normal, WarnFollowing, "allow_internal_unsafe side-steps the unsafe_code lint",
+        allow_internal_unsafe, Normal, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
         rustc_eii_foreign_item, Normal,
-        ErrorFollowing, eii_internals,
+        eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
         rustc_allowed_through_unstable_modules, Normal,
-        WarnFollowing,"rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
+        "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
-        rustc_deprecated_safe_2024, Normal,
-        ErrorFollowing,"`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
+        rustc_deprecated_safe_2024, Normal,"`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
-        rustc_pub_transparent, Normal,
-        ErrorFollowing,"used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
+        rustc_pub_transparent, Normal,"used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
 
 
@@ -797,17 +680,16 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, Normal, WarnFollowing, experimental!(fundamental)),
+    gated!(fundamental, Normal, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, WarnFollowing, dropck_eyepatch,
+        may_dangle, Normal, dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
 
     rustc_attr!(
         rustc_never_type_options,
         Normal,
-        ErrorFollowing,
-        "`rustc_never_type_options` is used to experiment with never type fallback and work on \
+                "`rustc_never_type_options` is used to experiment with never type fallback and work on \
          never type stabilization"
     ),
 
@@ -816,42 +698,42 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_allocator, Normal, WarnFollowing,
+        rustc_allocator, Normal,
     ),
     rustc_attr!(
-        rustc_nounwind, Normal, WarnFollowing,
+        rustc_nounwind, Normal,
     ),
     rustc_attr!(
-        rustc_reallocator, Normal, WarnFollowing,
+        rustc_reallocator, Normal,
     ),
     rustc_attr!(
-        rustc_deallocator, Normal, WarnFollowing,
+        rustc_deallocator, Normal,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed, Normal, WarnFollowing,
+        rustc_allocator_zeroed, Normal,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed_variant, Normal, ErrorPreceding,
+        rustc_allocator_zeroed_variant, Normal,
     ),
     gated!(
-        default_lib_allocator, Normal, WarnFollowing, allocator_internals, experimental!(default_lib_allocator),
+        default_lib_allocator, Normal, allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        needs_allocator, Normal, WarnFollowing, allocator_internals, experimental!(needs_allocator),
+        needs_allocator, Normal, allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        panic_runtime, CrateLevel, WarnFollowing, experimental!(panic_runtime)
+        panic_runtime, CrateLevel,  experimental!(panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, CrateLevel, WarnFollowing, experimental!(needs_panic_runtime)
+        needs_panic_runtime, CrateLevel,  experimental!(needs_panic_runtime)
     ),
     gated!(
-        compiler_builtins, CrateLevel, WarnFollowing,
+        compiler_builtins, CrateLevel,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
-        profiler_runtime, CrateLevel, WarnFollowing,
+        profiler_runtime, CrateLevel,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
     ),
@@ -862,17 +744,16 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     gated!(
         linkage, Normal,
-        ErrorPreceding,
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
     rustc_attr!(
-        rustc_std_internal_symbol, Normal, WarnFollowing,
+        rustc_std_internal_symbol, Normal,
     ),
     rustc_attr!(
-        rustc_objc_class, Normal, ErrorPreceding,
+        rustc_objc_class, Normal,
     ),
     rustc_attr!(
-        rustc_objc_selector, Normal, ErrorPreceding,
+        rustc_objc_selector, Normal,
     ),
 
     // ==========================================================================
@@ -881,32 +762,29 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_builtin_macro, Normal,
-        ErrorFollowing,
-    ),
+            ),
     rustc_attr!(
-        rustc_proc_macro_decls, Normal, WarnFollowing,
+        rustc_proc_macro_decls, Normal,
     ),
     rustc_attr!(
         rustc_macro_transparency, Normal,
-        ErrorFollowing, "used internally for testing macro hygiene",
+        "used internally for testing macro hygiene",
     ),
     rustc_attr!(
         rustc_autodiff, Normal,
-        DuplicatesOk,
-    ),
+            ),
     rustc_attr!(
         rustc_offload_kernel, Normal,
-        DuplicatesOk,
-    ),
+            ),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
     ungated!(
-        cfg_trace, Normal, DuplicatesOk
+        cfg_trace, Normal
     ),
     ungated!(
-        cfg_attr_trace, Normal, DuplicatesOk
+        cfg_attr_trace, Normal
     ),
 
     // ==========================================================================
@@ -914,74 +792,64 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_on_unimplemented, Normal,
-        ErrorFollowing,"see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
+        rustc_on_unimplemented, Normal,"see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
         rustc_confusables, Normal,
-        ErrorFollowing,
-    ),
+            ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
         rustc_conversion_suggestion, Normal,
-        WarnFollowing,
-    ),
+     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
         rustc_trivial_field_reads, Normal,
-        WarnFollowing,
-    ),
+     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_query_instability, Normal,
-        WarnFollowing,
-    ),
+     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_untracked_query_information, Normal,
-        WarnFollowing,
-    ),
+     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_ty, Normal,
-        WarnFollowing,
-    ),
+     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_deny_field_access, Normal,
-        WarnFollowing,
-    ),
+     ),
 
     // ==========================================================================
     // Internal attributes, Const related:
     // ==========================================================================
 
     rustc_attr!(
-        rustc_promotable, Normal, WarnFollowing, ),
+        rustc_promotable, Normal, ),
     rustc_attr!(
-        rustc_legacy_const_generics, Normal, ErrorFollowing,
-    ),
+        rustc_legacy_const_generics, Normal,    ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
-        rustc_do_not_const_check, Normal, WarnFollowing, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
+        rustc_do_not_const_check, Normal, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
         rustc_const_stable_indirect, Normal,
-        WarnFollowing,"this is an internal implementation detail",
+        "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_intrinsic_const_stable_indirect, Normal,
-        WarnFollowing,  "this is an internal implementation detail",
+          "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_allow_const_fn_unstable, Normal,
-        DuplicatesOk,
-        "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
+                "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
     // ==========================================================================
@@ -989,22 +857,19 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_layout_scalar_valid_range_start, Normal, ErrorFollowing,
-        "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
+        rustc_layout_scalar_valid_range_start, Normal,        "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_layout_scalar_valid_range_end, Normal, ErrorFollowing,
-        "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
+        rustc_layout_scalar_valid_range_end, Normal,        "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_simd_monomorphize_lane_limit, Normal, ErrorFollowing,
-        "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
+        rustc_simd_monomorphize_lane_limit, Normal,        "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
-        rustc_nonnull_optimization_guaranteed, Normal, WarnFollowing,
+        rustc_nonnull_optimization_guaranteed, Normal,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; \
@@ -1015,59 +880,51 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, Normal, DuplicatesOk, lang_items,
+        lang, Normal,lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
-        rustc_as_ptr, Normal, ErrorFollowing,
-        "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
+        rustc_as_ptr, Normal,        "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
-        rustc_should_not_be_called_on_const_items, Normal, ErrorFollowing,
-        "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
+        rustc_should_not_be_called_on_const_items, Normal,        "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
-        rustc_pass_by_value, Normal, ErrorFollowing,
-        "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
+        rustc_pass_by_value, Normal,        "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
-        rustc_never_returns_null_ptr, Normal, ErrorFollowing,
-        "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
+        rustc_never_returns_null_ptr, Normal,        "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, AttributeType::Normal, ErrorFollowing,"`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
+        rustc_no_implicit_autorefs, AttributeType::Normal, "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, AttributeType::CrateLevel, ErrorFollowing,"`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
+        rustc_coherence_is_core, AttributeType::CrateLevel,  "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, AttributeType::Normal, WarnFollowing,"`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
+        rustc_coinductive, AttributeType::Normal,"`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, AttributeType::Normal, ErrorFollowing,"`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
+        rustc_allow_incoherent_impl, AttributeType::Normal, "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, AttributeType::CrateLevel, ErrorFollowing,"`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
+        rustc_preserve_ub_checks, AttributeType::CrateLevel,  "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
-        AttributeType::Normal,
-        ErrorFollowing,"`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
+        AttributeType::Normal,"`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
     rustc_attr!(
         rustc_dyn_incompatible_trait,
-        AttributeType::Normal,
-        ErrorFollowing,"`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
+        AttributeType::Normal,"`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
-        rustc_has_incoherent_inherent_impls, AttributeType::Normal,
-        ErrorFollowing,"`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
+        rustc_has_incoherent_inherent_impls, AttributeType::Normal,"`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
-        rustc_non_const_trait_method, AttributeType::Normal,
-        ErrorFollowing,"`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
+        rustc_non_const_trait_method, AttributeType::Normal,"`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
     ),
 
@@ -1075,7 +932,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         name: sym::rustc_diagnostic_item,
         type_: Normal,
         safety: AttributeSafety::Normal,
-        duplicates: ErrorFollowing,gate: Gated {
+        gate: Gated {
             feature: sym::rustc_attrs,
             message: "use of an internal attribute",
             check: Features::rustc_attrs,
@@ -1085,203 +942,158 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, Normal, WarnFollowing, "`#[prelude_import]` is for use by rustc only",
+        prelude_import, Normal, "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, Normal, WarnFollowing,unboxed_closures, "unboxed_closures are still evolving",
+        rustc_paren_sugar, Normal,unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, Normal, WarnFollowing,"the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
+        rustc_inherit_overflow_checks, Normal,"the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
-        rustc_reservation_impl, Normal,
-        ErrorFollowing,"the `#[rustc_reservation_impl]` attribute is internally used \
+        rustc_reservation_impl, Normal,"the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
-        rustc_test_marker, Normal, WarnFollowing, "the `#[rustc_test_marker]` attribute is used internally to track tests",
+        rustc_test_marker, Normal, "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
         rustc_unsafe_specialization_marker, Normal,
-        WarnFollowing,"the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
+        "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
         rustc_specialization_trait, Normal,
-        WarnFollowing,"the `#[rustc_specialization_trait]` attribute is used to check specializations"
+        "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, Normal, WarnFollowing,"the `#[rustc_main]` attribute is used internally to specify test entry point function",
+        rustc_main, Normal,"the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
-        rustc_skip_during_method_dispatch, Normal, ErrorFollowing,
-        "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
+        rustc_skip_during_method_dispatch, Normal,        "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
     rustc_attr!(
-        rustc_must_implement_one_of, Normal,
-        ErrorFollowing,"the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
+        rustc_must_implement_one_of, Normal,"the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
-        rustc_doc_primitive, Normal, ErrorFollowing, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
+        rustc_doc_primitive, Normal,"the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, Normal, ErrorFollowing, intrinsics,
+        rustc_intrinsic, Normal,intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, Normal, WarnFollowing,"`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
+        rustc_no_mir_inline, Normal,"`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, Normal, WarnFollowing,"`#[rustc_force_inline]` forces a free function to be inlined"
+        rustc_force_inline, Normal,"`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, Normal, WarnFollowing,"`#[rustc_scalable_vector]` defines a scalable vector type"
+        rustc_scalable_vector, Normal,"`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
 
     // ==========================================================================
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, Normal, WarnFollowing,),
+    rustc_attr!(TEST, rustc_effective_visibility, Normal,),
     rustc_attr!(
         TEST, rustc_dump_inferred_outlives, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_capture_analysis, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_insignificant_dtor, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_no_implicit_bounds, CrateLevel,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_strict_coherence, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_variances, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_variances_of_opaques, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_hidden_type_of_opaques, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_layout, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_abi, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_regions, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_delayed_bug_from_inside_query, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_user_args, Normal,
-        WarnFollowing,
+     ),
+    rustc_attr!(
+        TEST, rustc_evaluate_where_clauses, Normal,
     ),
     rustc_attr!(
-        TEST, rustc_evaluate_where_clauses, Normal, WarnFollowing,
-    ),
+        TEST, rustc_if_this_changed, Normal,    ),
     rustc_attr!(
-        TEST, rustc_if_this_changed, Normal, DuplicatesOk,
-    ),
-    rustc_attr!(
-        TEST, rustc_then_this_would_need, Normal, DuplicatesOk,
-    ),
+        TEST, rustc_then_this_would_need, Normal,    ),
     rustc_attr!(
         TEST, rustc_clean, Normal,
-        DuplicatesOk,
-    ),
+            ),
     rustc_attr!(
         TEST, rustc_partition_reused, Normal,
-        DuplicatesOk,
-    ),
+            ),
     rustc_attr!(
         TEST, rustc_partition_codegened, Normal,
-        DuplicatesOk,
-    ),
+            ),
     rustc_attr!(
         TEST, rustc_expected_cgu_reuse, Normal,
-        DuplicatesOk,
-    ),
+            ),
     rustc_attr!(
         TEST, rustc_symbol_name, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_def_path, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_mir, Normal,
-        DuplicatesOk,
-    ),
+            ),
     gated!(
-        custom_mir, Normal,
-        ErrorFollowing,"the `#[custom_mir]` attribute is just used for the Rust test suite",
+        custom_mir, Normal,"the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
         TEST, rustc_dump_item_bounds, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_predicates, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_def_parents, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_object_lifetime_defaults, Normal,
-        WarnFollowing,
-    ),
+     ),
     rustc_attr!(
         TEST, rustc_dump_vtable, Normal,
-        WarnFollowing,
-    ),
-    rustc_attr!(
-        TEST, rustc_dummy, Normal,
-        DuplicatesOk,
-    ),
-    rustc_attr!(
-        TEST, pattern_complexity_limit, CrateLevel,
-        ErrorFollowing,
-    ),
+     ),
+    rustc_attr!(TEST, rustc_dummy, Normal,),
+    rustc_attr!(TEST, pattern_complexity_limit, CrateLevel, ),
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {
     BUILTIN_ATTRIBUTE_MAP.get(&name).is_some()
-}
-
-pub fn is_valid_for_get_attr(name: Symbol) -> bool {
-    BUILTIN_ATTRIBUTE_MAP.get(&name).is_some_and(|attr| match attr.duplicates {
-        WarnFollowing | ErrorFollowing | ErrorPreceding | FutureWarnFollowing
-        | FutureWarnPreceding => true,
-        DuplicatesOk | WarnFollowingWordOnly => false,
-    })
 }
 
 pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>> =

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -278,7 +278,7 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $(,)?) => {
+    (TEST, $attr:ident $(,)?) => {
         rustc_attr!(    $attr,
             concat!(
                 "the `#[",
@@ -287,7 +287,7 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $($notes:expr),* $(,)?) => {
+    ($attr:ident $(, $notes:expr)* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Normal,
@@ -326,98 +326,100 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     // Conditional compilation:
-    ungated!(cfg,),
-    ungated!(cfg_attr,),
+    ungated!(cfg),
+    ungated!(cfg_attr),
 
     // Testing:
-    ungated!(ignore,),
-    ungated!(should_panic,),
+    ungated!(ignore),
+    ungated!(should_panic),
 
     // Macros:
-    ungated!(automatically_derived,),
-    ungated!(macro_use,),
-    ungated!(macro_escape,), // Deprecated synonym for `macro_use`.
-    ungated!(macro_export,),
-    ungated!(proc_macro,),
-    ungated!(proc_macro_derive,),
-    ungated!(proc_macro_attribute,),
+    ungated!(automatically_derived),
+    ungated!(macro_use),
+    ungated!(macro_escape), // Deprecated synonym for `macro_use`.
+    ungated!(macro_export),
+    ungated!(proc_macro),
+    ungated!(proc_macro_derive),
+    ungated!(proc_macro_attribute),
 
     // Lints:
-    ungated!(warn,),
-    ungated!(allow,),
-    ungated!(expect,),
-    ungated!(forbid,),
-    ungated!(deny,),
-    ungated!(must_use,),
+    ungated!(warn),
+    ungated!(allow),
+    ungated!(expect),
+    ungated!(forbid),
+    ungated!(deny),
+    ungated!(must_use),
     gated!(must_not_suspend, experimental!(must_not_suspend)),
-    ungated!(deprecated,),
+    ungated!(deprecated),
 
     // Crate properties:
-    ungated!(crate_name,),
-    ungated!(crate_type,),
+    ungated!(crate_name),
+    ungated!(crate_type),
 
     // ABI, linking, symbols, and FFI
-    ungated!(link,),
-    ungated!(link_name,),
-    ungated!(no_link,),
-    ungated!(repr,),
+    ungated!(link),
+    ungated!(link_name),
+    ungated!(no_link),
+    ungated!(repr),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
     gated!(rustc_align,fn_align, experimental!(rustc_align)),
     gated!(rustc_align_static,static_align, experimental!(rustc_align_static)),
-    ungated!(unsafe(Edition2024) export_name,),
-    ungated!(unsafe(Edition2024) link_section,),
-    ungated!(unsafe(Edition2024) no_mangle,),
-    ungated!(used,),
-    ungated!(link_ordinal,),
-    ungated!(unsafe naked,),
+    ungated!(unsafe(Edition2024) export_name),
+    ungated!(unsafe(Edition2024) link_section),
+    ungated!(unsafe(Edition2024) no_mangle),
+    ungated!(used),
+    ungated!(link_ordinal),
+    ungated!(unsafe naked),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(rustc_pass_indirectly_in_non_rustic_abis, "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"),
 
     // Limits:
-    ungated!(recursion_limit,),
-    ungated!(type_length_limit,),
+    ungated!(recursion_limit),
+    ungated!(type_length_limit),
     gated!(
         move_size_limit, large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
-    ungated!(no_main,),
+    ungated!(no_main),
 
     // Modules, prelude, and resolution:
-    ungated!(path,),
-    ungated!(no_std,),
-    ungated!(no_implicit_prelude,),
-    ungated!(non_exhaustive,),
+    ungated!(path),
+    ungated!(no_std),
+    ungated!(no_implicit_prelude),
+    ungated!(non_exhaustive),
 
     // Runtime
-    ungated!(windows_subsystem,),
+    ungated!(windows_subsystem),
     ungated!(// RFC 2070
-        panic_handler,),
+        panic_handler
+    ),
 
     // Code generation:
-    ungated!(inline,),
-    ungated!(cold,),
-    ungated!(no_builtins,),
-    ungated!(target_feature,),
-    ungated!(track_caller,),
-    ungated!(instruction_set,),
+    ungated!(inline),
+    ungated!(cold),
+    ungated!(no_builtins),
+    ungated!(target_feature),
+    ungated!(track_caller),
+    ungated!(instruction_set),
     gated!(
         unsafe force_target_feature,
         effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
         sanitize,
-         sanitize, experimental!(sanitize),),
+        sanitize, experimental!(sanitize)
+    ),
     gated!(
         coverage,
         coverage_attribute, experimental!(coverage)
     ),
 
-    ungated!(doc,),
+    ungated!(doc),
 
     // Debugging
-    ungated!(debugger_visualizer,),
-    ungated!(collapse_debuginfo,),
+    ungated!(debugger_visualizer),
+    ungated!(collapse_debuginfo),
 
     // ==========================================================================
     // Unstable attributes:
@@ -431,18 +433,21 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Testing:
     gated!(
         test_runner, custom_test_frameworks,
-        "custom test frameworks are an unstable feature",),
+        "custom test frameworks are an unstable feature"
+    ),
 
     gated!(
         reexport_test_harness_main, custom_test_frameworks,
-        "custom test frameworks are an unstable feature",),
+        "custom test frameworks are an unstable feature"
+    ),
 
     // RFC #1268
     gated!(
         marker,marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local,"`#[thread_local]` is an experimental feature, and does not currently handle destructors",),
+        thread_local,"`#[thread_local]` is an experimental feature, and does not currently handle destructors"
+    ),
     gated!(
         no_core, experimental!(no_core)
     ),
@@ -459,7 +464,8 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         unsafe ffi_const, experimental!(ffi_const)
     ),
     gated!(
-        register_tool, experimental!(register_tool),),
+        register_tool, experimental!(register_tool)
+    ),
     // `#[cfi_encoding = ""]`
     gated!(
         cfi_encoding,
@@ -501,14 +507,14 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================
 
-    ungated!(feature,),
+    ungated!(feature),
     // DuplicatesOk since it has its own validation
-    ungated!(stable,),
-    ungated!(unstable,),
-    ungated!(unstable_feature_bound,),
-    ungated!(rustc_const_unstable,),
-    ungated!(rustc_const_stable,),
-    ungated!(rustc_default_body_unstable,),
+    ungated!(stable),
+    ungated!(unstable),
+    ungated!(unstable_feature_bound),
+    ungated!(rustc_const_unstable),
+    ungated!(rustc_const_stable),
+    ungated!(rustc_default_body_unstable),
     gated!(
         allow_internal_unstable,
         "allow_internal_unstable side-steps feature gating and stability checks",
@@ -538,7 +544,8 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     gated!(fundamental, experimental!(fundamental)),
     gated!(
         may_dangle, dropck_eyepatch,
-        "`may_dangle` has unstable semantics and may be removed in the future",),
+        "`may_dangle` has unstable semantics and may be removed in the future"
+    ),
 
     rustc_attr!(rustc_never_type_options,
         "`rustc_never_type_options` is used to experiment with never type fallback and work on \
@@ -549,12 +556,12 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Runtime related:
     // ==========================================================================
 
-    rustc_attr!(rustc_allocator,),
-    rustc_attr!(rustc_nounwind,),
-    rustc_attr!(rustc_reallocator,),
-    rustc_attr!(rustc_deallocator,),
-    rustc_attr!(rustc_allocator_zeroed,),
-    rustc_attr!(rustc_allocator_zeroed_variant,),
+    rustc_attr!(rustc_allocator),
+    rustc_attr!(rustc_nounwind),
+    rustc_attr!(rustc_reallocator),
+    rustc_attr!(rustc_deallocator),
+    rustc_attr!(rustc_allocator_zeroed),
+    rustc_attr!(rustc_allocator_zeroed_variant),
     gated!(
         default_lib_allocator, allocator_internals, experimental!(default_lib_allocator),
     ),
@@ -570,11 +577,13 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     gated!(
         compiler_builtins,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
-        which contains compiler-rt intrinsics and will never be stable",),
+        which contains compiler-rt intrinsics and will never be stable"
+    ),
     gated!(
         profiler_runtime,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
-        which contains the profiler runtime and will never be stable",),
+        which contains the profiler runtime and will never be stable"
+    ),
 
     // ==========================================================================
     // Internal attributes, Linkage:
@@ -582,21 +591,23 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     gated!(
         linkage,
-        "the `linkage` attribute is experimental and not portable across platforms",),
-    rustc_attr!(rustc_std_internal_symbol,),
-    rustc_attr!(rustc_objc_class,),
-    rustc_attr!(rustc_objc_selector,),
+        "the `linkage` attribute is experimental and not portable across platforms"
+    ),
+    rustc_attr!(rustc_std_internal_symbol),
+    rustc_attr!(rustc_objc_class),
+    rustc_attr!(rustc_objc_selector),
 
     // ==========================================================================
     // Internal attributes, Macro related:
     // ==========================================================================
 
-    rustc_attr!(rustc_builtin_macro,),
-    rustc_attr!(rustc_proc_macro_decls,),
+    rustc_attr!(rustc_builtin_macro),
+    rustc_attr!(rustc_proc_macro_decls),
     rustc_attr!(rustc_macro_transparency,
-        "used internally for testing macro hygiene",),
-    rustc_attr!(rustc_autodiff,),
-    rustc_attr!(rustc_offload_kernel,),
+        "used internally for testing macro hygiene"
+    ),
+    rustc_attr!(rustc_autodiff),
+    rustc_attr!(rustc_offload_kernel),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
@@ -612,37 +623,37 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(rustc_on_unimplemented,"see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
-    rustc_attr!(rustc_confusables,),
+    rustc_attr!(rustc_confusables),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
-    rustc_attr!(rustc_conversion_suggestion,),
+    rustc_attr!(rustc_conversion_suggestion),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
-    rustc_attr!(rustc_trivial_field_reads,),
+    rustc_attr!(rustc_trivial_field_reads),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
-    rustc_attr!(rustc_lint_query_instability,),
+    rustc_attr!(rustc_lint_query_instability),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
-    rustc_attr!(rustc_lint_untracked_query_information,),
+    rustc_attr!(rustc_lint_untracked_query_information),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
-    rustc_attr!(rustc_lint_opt_ty,),
+    rustc_attr!(rustc_lint_opt_ty),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
-    rustc_attr!(rustc_lint_opt_deny_field_access,),
+    rustc_attr!(rustc_lint_opt_deny_field_access),
 
     // ==========================================================================
     // Internal attributes, Const related:
     // ==========================================================================
 
-    rustc_attr!(rustc_promotable,),
-    rustc_attr!(rustc_legacy_const_generics,),
+    rustc_attr!(rustc_promotable),
+    rustc_attr!(rustc_legacy_const_generics),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
-    rustc_attr!(rustc_do_not_const_check, "`#[rustc_do_not_const_check]` skips const-check for this function's body",),
+    rustc_attr!(rustc_do_not_const_check, "`#[rustc_do_not_const_check]` skips const-check for this function's body"),
     rustc_attr!(rustc_const_stable_indirect,
-        "this is an internal implementation detail",),
+        "this is an internal implementation detail"),
     rustc_attr!(rustc_intrinsic_const_stable_indirect,
-          "this is an internal implementation detail",),
+          "this is an internal implementation detail"),
     rustc_attr!(rustc_allow_const_fn_unstable,
                 "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
@@ -652,40 +663,33 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(rustc_layout_scalar_valid_range_start, "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
-        niche optimizations in the standard library",),
+        niche optimizations in the standard library"),
     rustc_attr!(rustc_layout_scalar_valid_range_end, "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
-        niche optimizations in the standard library",),
+        niche optimizations in the standard library"),
     rustc_attr!(rustc_simd_monomorphize_lane_limit, "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
-        for better error messages",),
+        for better error messages"),
     rustc_attr!(rustc_nonnull_optimization_guaranteed,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; \
-        it is your responsibility to ensure that the attribute is only used on types that are optimized",),
+        it is your responsibility to ensure that the attribute is only used on types that are optimized"),
 
     // ==========================================================================
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
         lang,lang_items,
-        "lang items are subject to change",),
-    rustc_attr!(rustc_as_ptr, "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
+        "lang items are subject to change"
     ),
-    rustc_attr!(rustc_should_not_be_called_on_const_items, "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
-    ),
-    rustc_attr!(rustc_pass_by_value, "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
-    ),
-    rustc_attr!(rustc_never_returns_null_ptr, "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
-    ),
-    rustc_attr!(rustc_no_implicit_autorefs, "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
-    ),
-    rustc_attr!(rustc_coherence_is_core, "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
-    ),
-    rustc_attr!(rustc_coinductive, "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
-    ),
-    rustc_attr!(rustc_allow_incoherent_impl, "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
-    ),
-    rustc_attr!(rustc_preserve_ub_checks, "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",),
+    rustc_attr!(rustc_as_ptr, "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"),
+    rustc_attr!(rustc_should_not_be_called_on_const_items, "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"),
+    rustc_attr!(rustc_pass_by_value, "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"),
+    rustc_attr!(rustc_never_returns_null_ptr, "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"),
+    rustc_attr!(rustc_no_implicit_autorefs, "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"),
+    rustc_attr!(rustc_coherence_is_core, "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"),
+    rustc_attr!(rustc_coinductive, "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"),
+    rustc_attr!(rustc_allow_incoherent_impl, "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"),
+    rustc_attr!(rustc_preserve_ub_checks, "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR"),
     rustc_attr!(rustc_deny_explicit_impl,
         "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
@@ -720,18 +724,19 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     rustc_attr!(rustc_inherit_overflow_checks,"the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
-        across crates",),
+        across crates"
+    ),
     rustc_attr!(rustc_reservation_impl,"the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
-    rustc_attr!(rustc_test_marker, "the `#[rustc_test_marker]` attribute is used internally to track tests",),
+    rustc_attr!(rustc_test_marker, "the `#[rustc_test_marker]` attribute is used internally to track tests"),
     rustc_attr!(rustc_unsafe_specialization_marker,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(rustc_specialization_trait,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
-    rustc_attr!(rustc_main,"the `#[rustc_main]` attribute is used internally to specify test entry point function",),
+    rustc_attr!(rustc_main,"the `#[rustc_main]` attribute is used internally to specify test entry point function"),
     rustc_attr!(rustc_skip_during_method_dispatch, "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
@@ -745,7 +750,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     gated!(
         rustc_intrinsic,intrinsics,
-        "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",),
+        "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items"),
     rustc_attr!(rustc_no_mir_inline,"`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(rustc_force_inline,"`#[rustc_force_inline]` forces a free function to be inlined"),
@@ -755,38 +760,38 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility,),
-    rustc_attr!(TEST, rustc_dump_inferred_outlives,),
-    rustc_attr!(TEST, rustc_capture_analysis,),
-    rustc_attr!(TEST, rustc_insignificant_dtor,),
-    rustc_attr!(TEST, rustc_no_implicit_bounds,),
-    rustc_attr!(TEST, rustc_strict_coherence,),
-    rustc_attr!(TEST, rustc_dump_variances,),
-    rustc_attr!(TEST, rustc_dump_variances_of_opaques,),
-    rustc_attr!(TEST, rustc_hidden_type_of_opaques,),
-    rustc_attr!(TEST, rustc_layout,),
-    rustc_attr!(TEST, rustc_abi,),
-    rustc_attr!(TEST, rustc_regions,),
-    rustc_attr!(TEST, rustc_delayed_bug_from_inside_query,),
-    rustc_attr!(TEST, rustc_dump_user_args,),
-    rustc_attr!(TEST, rustc_evaluate_where_clauses,),
-    rustc_attr!(TEST, rustc_if_this_changed,),
-    rustc_attr!(TEST, rustc_then_this_would_need,),
-    rustc_attr!(TEST, rustc_clean,),
-    rustc_attr!(TEST, rustc_partition_reused,),
-    rustc_attr!(TEST, rustc_partition_codegened,),
-    rustc_attr!(TEST, rustc_expected_cgu_reuse,),
-    rustc_attr!(TEST, rustc_symbol_name,),
-    rustc_attr!(TEST, rustc_def_path,),
-    rustc_attr!(TEST, rustc_mir,),
-    gated!(custom_mir,"the `#[custom_mir]` attribute is just used for the Rust test suite",),
-    rustc_attr!(TEST, rustc_dump_item_bounds,),
-    rustc_attr!(TEST, rustc_dump_predicates,),
-    rustc_attr!(TEST, rustc_dump_def_parents,),
-    rustc_attr!(TEST, rustc_dump_object_lifetime_defaults,),
-    rustc_attr!(TEST, rustc_dump_vtable,),
-    rustc_attr!(TEST, rustc_dummy,),
-    rustc_attr!(TEST, pattern_complexity_limit,),
+    rustc_attr!(TEST, rustc_effective_visibility),
+    rustc_attr!(TEST, rustc_dump_inferred_outlives),
+    rustc_attr!(TEST, rustc_capture_analysis),
+    rustc_attr!(TEST, rustc_insignificant_dtor),
+    rustc_attr!(TEST, rustc_no_implicit_bounds),
+    rustc_attr!(TEST, rustc_strict_coherence),
+    rustc_attr!(TEST, rustc_dump_variances),
+    rustc_attr!(TEST, rustc_dump_variances_of_opaques),
+    rustc_attr!(TEST, rustc_hidden_type_of_opaques),
+    rustc_attr!(TEST, rustc_layout),
+    rustc_attr!(TEST, rustc_abi),
+    rustc_attr!(TEST, rustc_regions),
+    rustc_attr!(TEST, rustc_delayed_bug_from_inside_query),
+    rustc_attr!(TEST, rustc_dump_user_args),
+    rustc_attr!(TEST, rustc_evaluate_where_clauses),
+    rustc_attr!(TEST, rustc_if_this_changed),
+    rustc_attr!(TEST, rustc_then_this_would_need),
+    rustc_attr!(TEST, rustc_clean),
+    rustc_attr!(TEST, rustc_partition_reused),
+    rustc_attr!(TEST, rustc_partition_codegened),
+    rustc_attr!(TEST, rustc_expected_cgu_reuse),
+    rustc_attr!(TEST, rustc_symbol_name),
+    rustc_attr!(TEST, rustc_def_path),
+    rustc_attr!(TEST, rustc_mir),
+    gated!(custom_mir,"the `#[custom_mir]` attribute is just used for the Rust test suite"),
+    rustc_attr!(TEST, rustc_dump_item_bounds),
+    rustc_attr!(TEST, rustc_dump_predicates),
+    rustc_attr!(TEST, rustc_dump_def_parents),
+    rustc_attr!(TEST, rustc_dump_object_lifetime_defaults),
+    rustc_attr!(TEST, rustc_dump_vtable),
+    rustc_attr!(TEST, rustc_dummy),
+    rustc_attr!(TEST, pattern_complexity_limit),
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -3,7 +3,6 @@
 use std::sync::LazyLock;
 
 use AttributeGate::*;
-use AttributeType::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::AttrStyle;
 use rustc_span::edition::Edition;
@@ -70,15 +69,6 @@ pub fn find_gated_cfg(pred: impl Fn(Symbol) -> bool) -> Option<&'static GatedCfg
 // If you change this, please modify `src/doc/unstable-book` as well. You must
 // move that documentation into the relevant place in the other docs, and
 // remove the chapter on the flag.
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum AttributeType {
-    /// Normal,builtin attribute that is consumed
-    /// by the compiler before the unused_attribute check
-    Normal,
-    /// Builtin attribute that is only allowed at the crate level
-    CrateLevel,
-}
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AttributeSafety {
@@ -213,37 +203,29 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $typ:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
             gate: Ungated,
         }
     };
-    (unsafe $attr:ident, $typ:expr $(,)?) => {
+    (unsafe $attr:ident $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             gate: Ungated,
         }
     };
-    ($attr:ident, $typ:expr $(,)?) => {
-        BuiltinAttribute {
-            name: sym::$attr,
-            type_: $typ,
-            safety: AttributeSafety::Normal,
-            gate: Ungated,
-        }
+    ($attr:ident $(,)?) => {
+        BuiltinAttribute { name: sym::$attr, safety: AttributeSafety::Normal, gate: Ungated }
     };
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $typ:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
 
             gate: Gated {
@@ -254,10 +236,9 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $typ:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
 
             gate: Gated {
@@ -268,10 +249,9 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Normal,
 
             gate: Gated {
@@ -282,10 +262,9 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $message:expr $(,)?) => {
+    ($attr:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Normal,
 
             gate: Gated {
@@ -299,10 +278,8 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $typ:expr, $(,)?) => {
-        rustc_attr!(
-            $attr,
-            $typ,
+    (TEST, $attr:ident, $(,)?) => {
+        rustc_attr!(    $attr,
             concat!(
                 "the `#[",
                 stringify!($attr),
@@ -310,12 +287,10 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $typ:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            type_: $typ,
             safety: AttributeSafety::Normal,
-
             gate: Gated {
                 feature: sym::rustc_attrs,
                 message: "use of an internal attribute",
@@ -339,7 +314,6 @@ macro_rules! experimental {
 
 pub struct BuiltinAttribute {
     pub name: Symbol,
-    pub type_: AttributeType,
     pub safety: AttributeSafety,
     pub gate: AttributeGate,
 }
@@ -352,196 +326,98 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     // Conditional compilation:
-    ungated!(
-        cfg, Normal,
-            ),
-    ungated!(
-        cfg_attr, Normal,
-            ),
+    ungated!(cfg,),
+    ungated!(cfg_attr,),
 
     // Testing:
-    ungated!(
-        ignore, Normal,
-     ),
-    ungated!(
-        should_panic, Normal,
-    ),
+    ungated!(ignore,),
+    ungated!(should_panic,),
 
     // Macros:
-    ungated!(
-        automatically_derived, Normal,
-     ),
-    ungated!(
-        macro_use, Normal,
-    ),
-    ungated!(macro_escape, Normal,), // Deprecated synonym for `macro_use`.
-    ungated!(
-        macro_export, Normal,
-     ),
-    ungated!(
-        proc_macro, Normal,
-            ),
-    ungated!(
-        proc_macro_derive, Normal,
-            ),
-    ungated!(
-        proc_macro_attribute, Normal,
-            ),
+    ungated!(automatically_derived,),
+    ungated!(macro_use,),
+    ungated!(macro_escape,), // Deprecated synonym for `macro_use`.
+    ungated!(macro_export,),
+    ungated!(proc_macro,),
+    ungated!(proc_macro_derive,),
+    ungated!(proc_macro_attribute,),
 
     // Lints:
-    ungated!(
-        warn, Normal,
-            ),
-    ungated!(
-        allow, Normal,
-            ),
-    ungated!(
-        expect, Normal,
-            ),
-    ungated!(
-        forbid, Normal,
-            ),
-    ungated!(
-        deny, Normal,
-            ),
-    ungated!(
-        must_use, Normal,
-    ),
-    gated!(
-        must_not_suspend, Normal, experimental!(must_not_suspend)
-    ),
-    ungated!(
-        deprecated, Normal,
-            ),
+    ungated!(warn,),
+    ungated!(allow,),
+    ungated!(expect,),
+    ungated!(forbid,),
+    ungated!(deny,),
+    ungated!(must_use,),
+    gated!(must_not_suspend, experimental!(must_not_suspend)),
+    ungated!(deprecated,),
 
     // Crate properties:
-    ungated!(
-        crate_name, CrateLevel,
-    ),
-    ungated!(
-        crate_type, CrateLevel,
-            ),
+    ungated!(crate_name,),
+    ungated!(crate_type,),
 
     // ABI, linking, symbols, and FFI
-    ungated!(
-        link, Normal,
-            ),
-    ungated!(
-        link_name, Normal,
-    ),
-    ungated!(
-        no_link, Normal,
-     ),
-    ungated!(
-        repr, Normal,
-            ),
+    ungated!(link,),
+    ungated!(link_name,),
+    ungated!(no_link,),
+    ungated!(repr,),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, Normal,fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, Normal,static_align, experimental!(rustc_align_static)),
-    ungated!(
-        unsafe(Edition2024) export_name, Normal,
-    ),
-    ungated!(
-        unsafe(Edition2024) link_section, Normal,
-    ),
-    ungated!(
-        unsafe(Edition2024) no_mangle, Normal,
-     ),
-    ungated!(
-        used, Normal,
-     ),
-    ungated!(
-        link_ordinal, Normal,
-    ),
-    ungated!(
-        unsafe naked, Normal,
-     ),
+    gated!(rustc_align,fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static,static_align, experimental!(rustc_align_static)),
+    ungated!(unsafe(Edition2024) export_name,),
+    ungated!(unsafe(Edition2024) link_section,),
+    ungated!(unsafe(Edition2024) no_mangle,),
+    ungated!(used,),
+    ungated!(link_ordinal,),
+    ungated!(unsafe naked,),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
-    rustc_attr!(
-        rustc_pass_indirectly_in_non_rustic_abis, Normal,        "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
-    ),
+    rustc_attr!(rustc_pass_indirectly_in_non_rustic_abis, "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"),
 
     // Limits:
-    ungated!(
-        recursion_limit, CrateLevel,
-    ),
-    ungated!(
-        type_length_limit, CrateLevel,
-    ),
+    ungated!(recursion_limit,),
+    ungated!(type_length_limit,),
     gated!(
-        move_size_limit, CrateLevel, large_assignments, experimental!(move_size_limit)
+        move_size_limit, large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
-    ungated!(
-        no_main, CrateLevel,
-     ),
+    ungated!(no_main,),
 
     // Modules, prelude, and resolution:
-    ungated!(
-        path, Normal,
-    ),
-    ungated!(
-        no_std, CrateLevel,
-     ),
-    ungated!(
-        no_implicit_prelude, Normal,
-     ),
-    ungated!(
-        non_exhaustive, Normal,
-     ),
+    ungated!(path,),
+    ungated!(no_std,),
+    ungated!(no_implicit_prelude,),
+    ungated!(non_exhaustive,),
 
     // Runtime
-    ungated!(
-        windows_subsystem, CrateLevel,
-    ),
-    ungated!( // RFC 2070
-        panic_handler, Normal,
-     ),
+    ungated!(windows_subsystem,),
+    ungated!(// RFC 2070
+        panic_handler,),
 
     // Code generation:
-    ungated!(
-        inline, Normal,
-    ),
-    ungated!(
-        cold, Normal,
-    ),
-    ungated!(
-        no_builtins, CrateLevel,
-     ),
-    ungated!(
-        target_feature, Normal,
-            ),
-    ungated!(
-        track_caller, Normal,
-     ),
-    ungated!(
-        instruction_set, Normal,
-    ),
+    ungated!(inline,),
+    ungated!(cold,),
+    ungated!(no_builtins,),
+    ungated!(target_feature,),
+    ungated!(track_caller,),
+    ungated!(instruction_set,),
     gated!(
-        unsafe force_target_feature, Normal,
+        unsafe force_target_feature,
         effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
-        sanitize, Normal,
-         sanitize, experimental!(sanitize),
-    ),
+        sanitize,
+         sanitize, experimental!(sanitize),),
     gated!(
-        coverage, Normal,
+        coverage,
         coverage_attribute, experimental!(coverage)
     ),
 
-    ungated!(
-        doc, Normal,
-            ),
+    ungated!(doc,),
 
     // Debugging
-    ungated!(
-        debugger_visualizer, Normal,
-            ),
-    ungated!(
-        collapse_debuginfo, Normal,
-            ),
+    ungated!(debugger_visualizer,),
+    ungated!(collapse_debuginfo,),
 
     // ==========================================================================
     // Unstable attributes:
@@ -549,60 +425,56 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, Normal, experimental!(export_stable)
+        export_stable, experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, CrateLevel, custom_test_frameworks,
-        "custom test frameworks are an unstable feature",
-    ),
+        test_runner, custom_test_frameworks,
+        "custom test frameworks are an unstable feature",),
 
     gated!(
-        reexport_test_harness_main, CrateLevel, custom_test_frameworks,
-        "custom test frameworks are an unstable feature",
-    ),
+        reexport_test_harness_main, custom_test_frameworks,
+        "custom test frameworks are an unstable feature",),
 
     // RFC #1268
     gated!(
-        marker, Normal,marker_trait_attr, experimental!(marker)
+        marker,marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, Normal,"`#[thread_local]` is an experimental feature, and does not currently handle destructors",
-    ),
+        thread_local,"`#[thread_local]` is an experimental feature, and does not currently handle destructors",),
     gated!(
-        no_core, CrateLevel,  experimental!(no_core)
+        no_core, experimental!(no_core)
     ),
     // RFC 2412
     gated!(
-        optimize, Normal,
+        optimize,
          optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, Normal, experimental!(ffi_pure)
+        unsafe ffi_pure, experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, Normal, experimental!(ffi_const)
+        unsafe ffi_const, experimental!(ffi_const)
     ),
     gated!(
-        register_tool, CrateLevel,          experimental!(register_tool),
-    ),
+        register_tool, experimental!(register_tool),),
     // `#[cfi_encoding = ""]`
     gated!(
-        cfi_encoding, Normal,
+        cfi_encoding,
          experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, Normal,coroutines, experimental!(coroutine)
+        coroutine,coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
-        patchable_function_entry, Normal,
+        patchable_function_entry,
          experimental!(patchable_function_entry)
     ),
 
@@ -611,10 +483,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, Normal,loop_match, experimental!(const_continue)
+        const_continue,loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, Normal,loop_match, experimental!(loop_match)
+        loop_match,loop_match, experimental!(loop_match)
     ),
 
     // The `#[pin_v2]` attribute is part of the `pin_ergonomics` experiment
@@ -622,57 +494,40 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, Normal,pin_ergonomics, experimental!(pin_v2),
+        pin_v2,pin_ergonomics, experimental!(pin_v2),
     ),
 
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================
 
-    ungated!(
-        feature, CrateLevel,
-            ),
+    ungated!(feature,),
     // DuplicatesOk since it has its own validation
-    ungated!(
-        stable, Normal,
-            ),
-    ungated!(
-        unstable, Normal,
-            ),
-    ungated!(
-        unstable_feature_bound, Normal,
-            ),
-    ungated!(
-        rustc_const_unstable, Normal,
-            ),
-    ungated!(
-        rustc_const_stable, Normal,
-            ),
-    ungated!(
-        rustc_default_body_unstable, Normal,
-            ),
+    ungated!(stable,),
+    ungated!(unstable,),
+    ungated!(unstable_feature_bound,),
+    ungated!(rustc_const_unstable,),
+    ungated!(rustc_const_stable,),
+    ungated!(rustc_default_body_unstable,),
     gated!(
-        allow_internal_unstable, Normal,
-                "allow_internal_unstable side-steps feature gating and stability checks",
+        allow_internal_unstable,
+        "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, Normal, "allow_internal_unsafe side-steps the unsafe_code lint",
+        allow_internal_unsafe, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
-        rustc_eii_foreign_item, Normal,
+        rustc_eii_foreign_item,
         eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
-    rustc_attr!(
-        rustc_allowed_through_unstable_modules, Normal,
+    rustc_attr!(rustc_allowed_through_unstable_modules,
         "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
-    rustc_attr!(
-        rustc_deprecated_safe_2024, Normal,"`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
+    rustc_attr!(rustc_deprecated_safe_2024,"`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
-    rustc_attr!(
-        rustc_pub_transparent, Normal,"used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
+    rustc_attr!(rustc_pub_transparent,"used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
 
 
@@ -680,16 +535,13 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, Normal, experimental!(fundamental)),
+    gated!(fundamental, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, dropck_eyepatch,
-        "`may_dangle` has unstable semantics and may be removed in the future",
-    ),
+        may_dangle, dropck_eyepatch,
+        "`may_dangle` has unstable semantics and may be removed in the future",),
 
-    rustc_attr!(
-        rustc_never_type_options,
-        Normal,
-                "`rustc_never_type_options` is used to experiment with never type fallback and work on \
+    rustc_attr!(rustc_never_type_options,
+        "`rustc_never_type_options` is used to experiment with never type fallback and work on \
          never type stabilization"
     ),
 
@@ -697,158 +549,101 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Runtime related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_allocator, Normal,
-    ),
-    rustc_attr!(
-        rustc_nounwind, Normal,
-    ),
-    rustc_attr!(
-        rustc_reallocator, Normal,
-    ),
-    rustc_attr!(
-        rustc_deallocator, Normal,
-    ),
-    rustc_attr!(
-        rustc_allocator_zeroed, Normal,
-    ),
-    rustc_attr!(
-        rustc_allocator_zeroed_variant, Normal,
+    rustc_attr!(rustc_allocator,),
+    rustc_attr!(rustc_nounwind,),
+    rustc_attr!(rustc_reallocator,),
+    rustc_attr!(rustc_deallocator,),
+    rustc_attr!(rustc_allocator_zeroed,),
+    rustc_attr!(rustc_allocator_zeroed_variant,),
+    gated!(
+        default_lib_allocator, allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        default_lib_allocator, Normal, allocator_internals, experimental!(default_lib_allocator),
+        needs_allocator, allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        needs_allocator, Normal, allocator_internals, experimental!(needs_allocator),
+        panic_runtime, experimental!(panic_runtime)
     ),
     gated!(
-        panic_runtime, CrateLevel,  experimental!(panic_runtime)
+        needs_panic_runtime, experimental!(needs_panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, CrateLevel,  experimental!(needs_panic_runtime)
-    ),
-    gated!(
-        compiler_builtins, CrateLevel,
+        compiler_builtins,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
-        which contains compiler-rt intrinsics and will never be stable",
-    ),
+        which contains compiler-rt intrinsics and will never be stable",),
     gated!(
-        profiler_runtime, CrateLevel,
+        profiler_runtime,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
-        which contains the profiler runtime and will never be stable",
-    ),
+        which contains the profiler runtime and will never be stable",),
 
     // ==========================================================================
     // Internal attributes, Linkage:
     // ==========================================================================
 
     gated!(
-        linkage, Normal,
-        "the `linkage` attribute is experimental and not portable across platforms",
-    ),
-    rustc_attr!(
-        rustc_std_internal_symbol, Normal,
-    ),
-    rustc_attr!(
-        rustc_objc_class, Normal,
-    ),
-    rustc_attr!(
-        rustc_objc_selector, Normal,
-    ),
+        linkage,
+        "the `linkage` attribute is experimental and not portable across platforms",),
+    rustc_attr!(rustc_std_internal_symbol,),
+    rustc_attr!(rustc_objc_class,),
+    rustc_attr!(rustc_objc_selector,),
 
     // ==========================================================================
     // Internal attributes, Macro related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_builtin_macro, Normal,
-            ),
-    rustc_attr!(
-        rustc_proc_macro_decls, Normal,
-    ),
-    rustc_attr!(
-        rustc_macro_transparency, Normal,
-        "used internally for testing macro hygiene",
-    ),
-    rustc_attr!(
-        rustc_autodiff, Normal,
-            ),
-    rustc_attr!(
-        rustc_offload_kernel, Normal,
-            ),
+    rustc_attr!(rustc_builtin_macro,),
+    rustc_attr!(rustc_proc_macro_decls,),
+    rustc_attr!(rustc_macro_transparency,
+        "used internally for testing macro hygiene",),
+    rustc_attr!(rustc_autodiff,),
+    rustc_attr!(rustc_offload_kernel,),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
-    ungated!(
-        cfg_trace, Normal
+    ungated!(cfg_trace
     ),
-    ungated!(
-        cfg_attr_trace, Normal
+    ungated!(cfg_attr_trace
     ),
 
     // ==========================================================================
     // Internal attributes, Diagnostics related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_on_unimplemented, Normal,"see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
+    rustc_attr!(rustc_on_unimplemented,"see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
-    rustc_attr!(
-        rustc_confusables, Normal,
-            ),
+    rustc_attr!(rustc_confusables,),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
-    rustc_attr!(
-        rustc_conversion_suggestion, Normal,
-     ),
+    rustc_attr!(rustc_conversion_suggestion,),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
-    rustc_attr!(
-        rustc_trivial_field_reads, Normal,
-     ),
+    rustc_attr!(rustc_trivial_field_reads,),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
-    rustc_attr!(
-        rustc_lint_query_instability, Normal,
-     ),
+    rustc_attr!(rustc_lint_query_instability,),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
-    rustc_attr!(
-        rustc_lint_untracked_query_information, Normal,
-     ),
+    rustc_attr!(rustc_lint_untracked_query_information,),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
-    rustc_attr!(
-        rustc_lint_opt_ty, Normal,
-     ),
+    rustc_attr!(rustc_lint_opt_ty,),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
-    rustc_attr!(
-        rustc_lint_opt_deny_field_access, Normal,
-     ),
+    rustc_attr!(rustc_lint_opt_deny_field_access,),
 
     // ==========================================================================
     // Internal attributes, Const related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_promotable, Normal, ),
-    rustc_attr!(
-        rustc_legacy_const_generics, Normal,    ),
+    rustc_attr!(rustc_promotable,),
+    rustc_attr!(rustc_legacy_const_generics,),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
-    rustc_attr!(
-        rustc_do_not_const_check, Normal, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
-    ),
-    rustc_attr!(
-        rustc_const_stable_indirect, Normal,
-        "this is an internal implementation detail",
-    ),
-    rustc_attr!(
-        rustc_intrinsic_const_stable_indirect, Normal,
-          "this is an internal implementation detail",
-    ),
-    rustc_attr!(
-        rustc_allow_const_fn_unstable, Normal,
+    rustc_attr!(rustc_do_not_const_check, "`#[rustc_do_not_const_check]` skips const-check for this function's body",),
+    rustc_attr!(rustc_const_stable_indirect,
+        "this is an internal implementation detail",),
+    rustc_attr!(rustc_intrinsic_const_stable_indirect,
+          "this is an internal implementation detail",),
+    rustc_attr!(rustc_allow_const_fn_unstable,
                 "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
@@ -856,81 +651,57 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Layout related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_layout_scalar_valid_range_start, Normal,        "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
-        niche optimizations in the standard library",
-    ),
-    rustc_attr!(
-        rustc_layout_scalar_valid_range_end, Normal,        "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
-        niche optimizations in the standard library",
-    ),
-    rustc_attr!(
-        rustc_simd_monomorphize_lane_limit, Normal,        "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
-        for better error messages",
-    ),
-    rustc_attr!(
-        rustc_nonnull_optimization_guaranteed, Normal,
+    rustc_attr!(rustc_layout_scalar_valid_range_start, "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
+        niche optimizations in the standard library",),
+    rustc_attr!(rustc_layout_scalar_valid_range_end, "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
+        niche optimizations in the standard library",),
+    rustc_attr!(rustc_simd_monomorphize_lane_limit, "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
+        for better error messages",),
+    rustc_attr!(rustc_nonnull_optimization_guaranteed,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; \
-        it is your responsibility to ensure that the attribute is only used on types that are optimized",
-    ),
+        it is your responsibility to ensure that the attribute is only used on types that are optimized",),
 
     // ==========================================================================
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, Normal,lang_items,
-        "lang items are subject to change",
+        lang,lang_items,
+        "lang items are subject to change",),
+    rustc_attr!(rustc_as_ptr, "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
-    rustc_attr!(
-        rustc_as_ptr, Normal,        "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
+    rustc_attr!(rustc_should_not_be_called_on_const_items, "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
-    rustc_attr!(
-        rustc_should_not_be_called_on_const_items, Normal,        "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
+    rustc_attr!(rustc_pass_by_value, "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
-    rustc_attr!(
-        rustc_pass_by_value, Normal,        "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
+    rustc_attr!(rustc_never_returns_null_ptr, "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
-    rustc_attr!(
-        rustc_never_returns_null_ptr, Normal,        "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
+    rustc_attr!(rustc_no_implicit_autorefs, "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
-    rustc_attr!(
-        rustc_no_implicit_autorefs, AttributeType::Normal, "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
+    rustc_attr!(rustc_coherence_is_core, "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
-    rustc_attr!(
-        rustc_coherence_is_core, AttributeType::CrateLevel,  "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
+    rustc_attr!(rustc_coinductive, "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
-    rustc_attr!(
-        rustc_coinductive, AttributeType::Normal,"`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
+    rustc_attr!(rustc_allow_incoherent_impl, "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
-    rustc_attr!(
-        rustc_allow_incoherent_impl, AttributeType::Normal, "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
+    rustc_attr!(rustc_preserve_ub_checks, "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",),
+    rustc_attr!(rustc_deny_explicit_impl,
+        "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
-    rustc_attr!(
-        rustc_preserve_ub_checks, AttributeType::CrateLevel,  "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
-    ),
-    rustc_attr!(
-        rustc_deny_explicit_impl,
-        AttributeType::Normal,"`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
-    ),
-    rustc_attr!(
-        rustc_dyn_incompatible_trait,
-        AttributeType::Normal,"`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
+    rustc_attr!(rustc_dyn_incompatible_trait,
+        "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
-    rustc_attr!(
-        rustc_has_incoherent_inherent_impls, AttributeType::Normal,"`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
+    rustc_attr!(rustc_has_incoherent_inherent_impls, "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
-    rustc_attr!(
-        rustc_non_const_trait_method, AttributeType::Normal,"`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
+    rustc_attr!(rustc_non_const_trait_method, "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
     ),
 
     BuiltinAttribute {
         name: sym::rustc_diagnostic_item,
-        type_: Normal,
         safety: AttributeSafety::Normal,
         gate: Gated {
             feature: sym::rustc_attrs,
@@ -942,154 +713,80 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, Normal, "`#[prelude_import]` is for use by rustc only",
+        prelude_import, "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, Normal,unboxed_closures, "unboxed_closures are still evolving",
+        rustc_paren_sugar,unboxed_closures, "unboxed_closures are still evolving",
     ),
-    rustc_attr!(
-        rustc_inherit_overflow_checks, Normal,"the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
+    rustc_attr!(rustc_inherit_overflow_checks,"the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
-        across crates",
-    ),
-    rustc_attr!(
-        rustc_reservation_impl, Normal,"the `#[rustc_reservation_impl]` attribute is internally used \
+        across crates",),
+    rustc_attr!(rustc_reservation_impl,"the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
-    rustc_attr!(
-        rustc_test_marker, Normal, "the `#[rustc_test_marker]` attribute is used internally to track tests",
-    ),
-    rustc_attr!(
-        rustc_unsafe_specialization_marker, Normal,
+    rustc_attr!(rustc_test_marker, "the `#[rustc_test_marker]` attribute is used internally to track tests",),
+    rustc_attr!(rustc_unsafe_specialization_marker,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
-    rustc_attr!(
-        rustc_specialization_trait, Normal,
+    rustc_attr!(rustc_specialization_trait,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
-    rustc_attr!(
-        rustc_main, Normal,"the `#[rustc_main]` attribute is used internally to specify test entry point function",
-    ),
-    rustc_attr!(
-        rustc_skip_during_method_dispatch, Normal,        "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
+    rustc_attr!(rustc_main,"the `#[rustc_main]` attribute is used internally to specify test entry point function",),
+    rustc_attr!(rustc_skip_during_method_dispatch, "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
-    rustc_attr!(
-        rustc_must_implement_one_of, Normal,"the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
+    rustc_attr!(rustc_must_implement_one_of,"the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
-    rustc_attr!(
-        rustc_doc_primitive, Normal,"the `#[rustc_doc_primitive]` attribute is used by the standard library \
+    rustc_attr!(rustc_doc_primitive,"the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, Normal,intrinsics,
-        "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
+        rustc_intrinsic,intrinsics,
+        "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",),
+    rustc_attr!(rustc_no_mir_inline,"`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
-    rustc_attr!(
-        rustc_no_mir_inline, Normal,"`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
-    ),
-    rustc_attr!(
-        rustc_force_inline, Normal,"`#[rustc_force_inline]` forces a free function to be inlined"
-    ),
-    rustc_attr!(
-        rustc_scalable_vector, Normal,"`#[rustc_scalable_vector]` defines a scalable vector type"
-    ),
+    rustc_attr!(rustc_force_inline,"`#[rustc_force_inline]` forces a free function to be inlined"),
+    rustc_attr!(rustc_scalable_vector,"`#[rustc_scalable_vector]` defines a scalable vector type"),
 
     // ==========================================================================
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, Normal,),
-    rustc_attr!(
-        TEST, rustc_dump_inferred_outlives, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_capture_analysis, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_insignificant_dtor, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_no_implicit_bounds, CrateLevel,
-     ),
-    rustc_attr!(
-        TEST, rustc_strict_coherence, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_variances, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_variances_of_opaques, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_hidden_type_of_opaques, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_layout, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_abi, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_regions, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_delayed_bug_from_inside_query, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_user_args, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_evaluate_where_clauses, Normal,
-    ),
-    rustc_attr!(
-        TEST, rustc_if_this_changed, Normal,    ),
-    rustc_attr!(
-        TEST, rustc_then_this_would_need, Normal,    ),
-    rustc_attr!(
-        TEST, rustc_clean, Normal,
-            ),
-    rustc_attr!(
-        TEST, rustc_partition_reused, Normal,
-            ),
-    rustc_attr!(
-        TEST, rustc_partition_codegened, Normal,
-            ),
-    rustc_attr!(
-        TEST, rustc_expected_cgu_reuse, Normal,
-            ),
-    rustc_attr!(
-        TEST, rustc_symbol_name, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_def_path, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_mir, Normal,
-            ),
-    gated!(
-        custom_mir, Normal,"the `#[custom_mir]` attribute is just used for the Rust test suite",
-    ),
-    rustc_attr!(
-        TEST, rustc_dump_item_bounds, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_predicates, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_def_parents, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_object_lifetime_defaults, Normal,
-     ),
-    rustc_attr!(
-        TEST, rustc_dump_vtable, Normal,
-     ),
-    rustc_attr!(TEST, rustc_dummy, Normal,),
-    rustc_attr!(TEST, pattern_complexity_limit, CrateLevel, ),
+    rustc_attr!(TEST, rustc_effective_visibility,),
+    rustc_attr!(TEST, rustc_dump_inferred_outlives,),
+    rustc_attr!(TEST, rustc_capture_analysis,),
+    rustc_attr!(TEST, rustc_insignificant_dtor,),
+    rustc_attr!(TEST, rustc_no_implicit_bounds,),
+    rustc_attr!(TEST, rustc_strict_coherence,),
+    rustc_attr!(TEST, rustc_dump_variances,),
+    rustc_attr!(TEST, rustc_dump_variances_of_opaques,),
+    rustc_attr!(TEST, rustc_hidden_type_of_opaques,),
+    rustc_attr!(TEST, rustc_layout,),
+    rustc_attr!(TEST, rustc_abi,),
+    rustc_attr!(TEST, rustc_regions,),
+    rustc_attr!(TEST, rustc_delayed_bug_from_inside_query,),
+    rustc_attr!(TEST, rustc_dump_user_args,),
+    rustc_attr!(TEST, rustc_evaluate_where_clauses,),
+    rustc_attr!(TEST, rustc_if_this_changed,),
+    rustc_attr!(TEST, rustc_then_this_would_need,),
+    rustc_attr!(TEST, rustc_clean,),
+    rustc_attr!(TEST, rustc_partition_reused,),
+    rustc_attr!(TEST, rustc_partition_codegened,),
+    rustc_attr!(TEST, rustc_expected_cgu_reuse,),
+    rustc_attr!(TEST, rustc_symbol_name,),
+    rustc_attr!(TEST, rustc_def_path,),
+    rustc_attr!(TEST, rustc_mir,),
+    gated!(custom_mir,"the `#[custom_mir]` attribute is just used for the Rust test suite",),
+    rustc_attr!(TEST, rustc_dump_item_bounds,),
+    rustc_attr!(TEST, rustc_dump_predicates,),
+    rustc_attr!(TEST, rustc_dump_def_parents,),
+    rustc_attr!(TEST, rustc_dump_object_lifetime_defaults,),
+    rustc_attr!(TEST, rustc_dump_vtable,),
+    rustc_attr!(TEST, rustc_dummy,),
+    rustc_attr!(TEST, pattern_complexity_limit,),
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -7,7 +7,6 @@ use AttributeGate::*;
 use AttributeType::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::AttrStyle;
-use rustc_hir::attrs::EncodeCrossCrate;
 use rustc_span::edition::Edition;
 use rustc_span::{Symbol, sym};
 
@@ -266,30 +265,27 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident, $typ:expr, $duplicates:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
             gate: Ungated,
             duplicates: $duplicates,
         }
     };
-    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $duplicates:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             gate: Ungated,
             duplicates: $duplicates,
         }
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             gate: Ungated,
@@ -299,10 +295,9 @@ macro_rules! ungated {
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             duplicates: $duplicates,
@@ -314,10 +309,9 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             duplicates: $duplicates,
@@ -329,10 +323,9 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             duplicates: $duplicates,
@@ -344,10 +337,9 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             duplicates: $duplicates,
@@ -362,12 +354,11 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $typ:expr, $duplicate:expr, $encode_cross_crate:expr $(,)?) => {
+    (TEST, $attr:ident, $typ:expr, $duplicate:expr $(,)?) => {
         rustc_attr!(
             $attr,
             $typ,
             $duplicate,
-            $encode_cross_crate,
             concat!(
                 "the `#[",
                 stringify!($attr),
@@ -375,10 +366,9 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             duplicates: $duplicates,
@@ -405,11 +395,6 @@ macro_rules! experimental {
 
 pub struct BuiltinAttribute {
     pub name: Symbol,
-    /// Whether this attribute is encode cross crate.
-    ///
-    /// If so, it is encoded in the crate metadata.
-    /// Otherwise, it can only be used in the local crate.
-    pub encode_cross_crate: EncodeCrossCrate,
     pub type_: AttributeType,
     pub safety: AttributeSafety,
     pub duplicates: AttributeDuplicates,
@@ -426,245 +411,242 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Conditional compilation:
     ungated!(
         cfg, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     ungated!(
         cfg_attr, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
 
     // Testing:
     ungated!(
         ignore, Normal,
-        WarnFollowing, EncodeCrossCrate::No,
+        WarnFollowing,
     ),
     ungated!(
         should_panic, Normal,
-        FutureWarnFollowing, EncodeCrossCrate::No,
+        FutureWarnFollowing,
     ),
 
     // Macros:
     ungated!(
         automatically_derived, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     ungated!(
         macro_use, Normal,
-        WarnFollowingWordOnly, EncodeCrossCrate::No,
+        WarnFollowingWordOnly,
     ),
-    ungated!(macro_escape, Normal, WarnFollowing, EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
+    ungated!(macro_escape, Normal, WarnFollowing,), // Deprecated synonym for `macro_use`.
     ungated!(
         macro_export, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     ungated!(
         proc_macro, Normal,
-        ErrorFollowing, EncodeCrossCrate::No
+        ErrorFollowing,
     ),
     ungated!(
         proc_macro_derive, Normal,
-        ErrorFollowing, EncodeCrossCrate::No,
+        ErrorFollowing,
     ),
     ungated!(
         proc_macro_attribute, Normal,
-        ErrorFollowing, EncodeCrossCrate::No
+        ErrorFollowing,
     ),
 
     // Lints:
     ungated!(
         warn, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         allow, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         expect, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         forbid, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     ungated!(
         deny, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     ungated!(
         must_use, Normal,
-        FutureWarnFollowing, EncodeCrossCrate::Yes
+        FutureWarnFollowing,
     ),
     gated!(
-        must_not_suspend, Normal, WarnFollowing,
-        EncodeCrossCrate::Yes, experimental!(must_not_suspend)
+        must_not_suspend, Normal, WarnFollowing, experimental!(must_not_suspend)
     ),
     ungated!(
         deprecated, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes
+        ErrorFollowing,
     ),
 
     // Crate properties:
     ungated!(
         crate_name, CrateLevel,
-        FutureWarnFollowing, EncodeCrossCrate::No,
+        FutureWarnFollowing,
     ),
     ungated!(
         crate_type, CrateLevel,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
 
     // ABI, linking, symbols, and FFI
     ungated!(
         link, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         link_name, Normal,
-        FutureWarnPreceding, EncodeCrossCrate::Yes
+        FutureWarnPreceding,
     ),
     ungated!(
         no_link, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     ungated!(
         repr, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, Normal, DuplicatesOk, EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, Normal, DuplicatesOk, EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, Normal, DuplicatesOk, fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, Normal, DuplicatesOk, static_align, experimental!(rustc_align_static)),
     ungated!(
         unsafe(Edition2024) export_name, Normal,
-        FutureWarnPreceding, EncodeCrossCrate::No
+        FutureWarnPreceding,
     ),
     ungated!(
         unsafe(Edition2024) link_section, Normal,
-        FutureWarnPreceding, EncodeCrossCrate::No
+        FutureWarnPreceding,
     ),
     ungated!(
         unsafe(Edition2024) no_mangle, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     ungated!(
         used, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     ungated!(
         link_ordinal, Normal,
-        ErrorPreceding, EncodeCrossCrate::Yes
+        ErrorPreceding,
     ),
     ungated!(
         unsafe naked, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
         rustc_pass_indirectly_in_non_rustic_abis, Normal, ErrorFollowing,
-        EncodeCrossCrate::No,
         "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
 
     // Limits:
     ungated!(
         recursion_limit, CrateLevel,
-        FutureWarnFollowing, EncodeCrossCrate::No
+        FutureWarnFollowing,
     ),
     ungated!(
         type_length_limit, CrateLevel,
-        FutureWarnFollowing, EncodeCrossCrate::No
+        FutureWarnFollowing,
     ),
     gated!(
-        move_size_limit, CrateLevel, ErrorFollowing,
-        EncodeCrossCrate::No, large_assignments, experimental!(move_size_limit)
+        move_size_limit, CrateLevel, ErrorFollowing, large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
     ungated!(
         no_main, CrateLevel,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
 
     // Modules, prelude, and resolution:
     ungated!(
         path, Normal,
-        FutureWarnFollowing, EncodeCrossCrate::No
+        FutureWarnFollowing,
     ),
     ungated!(
         no_std, CrateLevel,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     ungated!(
         no_implicit_prelude, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     ungated!(
         non_exhaustive, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
 
     // Runtime
     ungated!(
         windows_subsystem, CrateLevel,
-        FutureWarnFollowing, EncodeCrossCrate::No
+        FutureWarnFollowing,
     ),
     ungated!( // RFC 2070
         panic_handler, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
 
     // Code generation:
     ungated!(
         inline, Normal,
-        FutureWarnFollowing, EncodeCrossCrate::No
+        FutureWarnFollowing,
     ),
     ungated!(
         cold, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     ungated!(
         no_builtins, CrateLevel,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     ungated!(
         target_feature, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         track_caller, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     ungated!(
         instruction_set, Normal,
-        ErrorPreceding, EncodeCrossCrate::No
+        ErrorPreceding,
     ),
     gated!(
         unsafe force_target_feature, Normal,
-        DuplicatesOk, EncodeCrossCrate::No, effective_target_features, experimental!(force_target_feature)
+        DuplicatesOk, effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
         sanitize, Normal, ErrorPreceding,
-        EncodeCrossCrate::No, sanitize, experimental!(sanitize),
+         sanitize, experimental!(sanitize),
     ),
     gated!(
         coverage, Normal,
-        ErrorPreceding, EncodeCrossCrate::No,
+        ErrorPreceding,
         coverage_attribute, experimental!(coverage)
     ),
 
     ungated!(
         doc, Normal,
-        DuplicatesOk, EncodeCrossCrate::Yes
+        DuplicatesOk,
     ),
 
     // Debugging
     ungated!(
         debugger_visualizer, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     ungated!(
         collapse_debuginfo, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes
+        ErrorFollowing,
     ),
 
     // ==========================================================================
@@ -673,71 +655,62 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, Normal, WarnFollowing,
-        EncodeCrossCrate::No, experimental!(export_stable)
+        export_stable, Normal, WarnFollowing, experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, CrateLevel, ErrorFollowing,
-        EncodeCrossCrate::Yes, custom_test_frameworks,
+        test_runner, CrateLevel, ErrorFollowing, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
-        reexport_test_harness_main, CrateLevel, ErrorFollowing,
-        EncodeCrossCrate::No, custom_test_frameworks,
+        reexport_test_harness_main, CrateLevel, ErrorFollowing, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, Normal, WarnFollowing, EncodeCrossCrate::No,
-        marker_trait_attr, experimental!(marker)
+        marker, Normal, WarnFollowing,marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, Normal, WarnFollowing, EncodeCrossCrate::No,
-        "`#[thread_local]` is an experimental feature, and does not currently handle destructors",
+        thread_local, Normal, WarnFollowing,"`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
-        no_core, CrateLevel, WarnFollowing,
-        EncodeCrossCrate::No, experimental!(no_core)
+        no_core, CrateLevel, WarnFollowing, experimental!(no_core)
     ),
     // RFC 2412
     gated!(
         optimize, Normal, ErrorPreceding,
-        EncodeCrossCrate::No, optimize_attribute, experimental!(optimize)
+         optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, Normal, WarnFollowing,
-        EncodeCrossCrate::No, experimental!(ffi_pure)
+        unsafe ffi_pure, Normal, WarnFollowing, experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, Normal, WarnFollowing,
-        EncodeCrossCrate::No, experimental!(ffi_const)
+        unsafe ffi_const, Normal, WarnFollowing, experimental!(ffi_const)
     ),
     gated!(
         register_tool, CrateLevel, DuplicatesOk,
-        EncodeCrossCrate::No, experimental!(register_tool),
+         experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
         cfi_encoding, Normal, ErrorPreceding,
-        EncodeCrossCrate::Yes, experimental!(cfi_encoding)
+         experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, Normal, ErrorFollowing,
-        EncodeCrossCrate::No, coroutines, experimental!(coroutine)
+        coroutine, Normal, ErrorFollowing, coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
         patchable_function_entry, Normal, ErrorPreceding,
-        EncodeCrossCrate::Yes, experimental!(patchable_function_entry)
+         experimental!(patchable_function_entry)
     ),
 
     // The `#[loop_match]` and `#[const_continue]` attributes are part of the
@@ -745,12 +718,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, Normal, ErrorFollowing,
-        EncodeCrossCrate::No, loop_match, experimental!(const_continue)
+        const_continue, Normal, ErrorFollowing, loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, Normal, ErrorFollowing,
-        EncodeCrossCrate::No, loop_match, experimental!(loop_match)
+        loop_match, Normal, ErrorFollowing, loop_match, experimental!(loop_match)
     ),
 
     // The `#[pin_v2]` attribute is part of the `pin_ergonomics` experiment
@@ -758,8 +729,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes, pin_ergonomics, experimental!(pin_v2),
+        pin_v2, Normal, ErrorFollowing, pin_ergonomics, experimental!(pin_v2),
     ),
 
     // ==========================================================================
@@ -768,63 +738,58 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     ungated!(
         feature, CrateLevel,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     // DuplicatesOk since it has its own validation
     ungated!(
         stable, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         unstable, Normal,
         DuplicatesOk,
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         unstable_feature_bound, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         rustc_const_unstable, Normal,
-        DuplicatesOk, EncodeCrossCrate::Yes
+        DuplicatesOk,
     ),
     ungated!(
         rustc_const_stable, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
     ),
     ungated!(
         rustc_default_body_unstable, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     gated!(
         allow_internal_unstable, Normal,
-        DuplicatesOk, EncodeCrossCrate::Yes,
+        DuplicatesOk,
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, Normal, WarnFollowing,
-        EncodeCrossCrate::No, "allow_internal_unsafe side-steps the unsafe_code lint",
+        allow_internal_unsafe, Normal, WarnFollowing, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
         rustc_eii_foreign_item, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes, eii_internals,
+        ErrorFollowing, eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
         rustc_allowed_through_unstable_modules, Normal,
-        WarnFollowing, EncodeCrossCrate::No,
-        "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
+        WarnFollowing,"rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
         rustc_deprecated_safe_2024, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes,
-        "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
+        ErrorFollowing,"`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
         rustc_pub_transparent, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes,
-        "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
+        ErrorFollowing,"used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
 
 
@@ -832,10 +797,9 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, Normal, WarnFollowing, EncodeCrossCrate::Yes, experimental!(fundamental)),
+    gated!(fundamental, Normal, WarnFollowing, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, WarnFollowing,
-        EncodeCrossCrate::No, dropck_eyepatch,
+        may_dangle, Normal, WarnFollowing, dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
 
@@ -843,7 +807,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_never_type_options,
         Normal,
         ErrorFollowing,
-        EncodeCrossCrate::No,
         "`rustc_never_type_options` is used to experiment with never type fallback and work on \
          never type stabilization"
     ),
@@ -854,53 +817,41 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_allocator, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_nounwind, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_reallocator, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_deallocator, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_allocator_zeroed, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_allocator_zeroed_variant, Normal, ErrorPreceding,
-        EncodeCrossCrate::Yes,
     ),
     gated!(
-        default_lib_allocator, Normal, WarnFollowing,
-        EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),
+        default_lib_allocator, Normal, WarnFollowing, allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        needs_allocator, Normal, WarnFollowing,
-        EncodeCrossCrate::No, allocator_internals, experimental!(needs_allocator),
+        needs_allocator, Normal, WarnFollowing, allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        panic_runtime, CrateLevel, WarnFollowing,
-        EncodeCrossCrate::No, experimental!(panic_runtime)
+        panic_runtime, CrateLevel, WarnFollowing, experimental!(panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, CrateLevel, WarnFollowing,
-        EncodeCrossCrate::No, experimental!(needs_panic_runtime)
+        needs_panic_runtime, CrateLevel, WarnFollowing, experimental!(needs_panic_runtime)
     ),
     gated!(
         compiler_builtins, CrateLevel, WarnFollowing,
-        EncodeCrossCrate::No,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
         profiler_runtime, CrateLevel, WarnFollowing,
-        EncodeCrossCrate::No,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
     ),
@@ -911,20 +862,17 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     gated!(
         linkage, Normal,
-        ErrorPreceding, EncodeCrossCrate::No,
+        ErrorPreceding,
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
     rustc_attr!(
         rustc_std_internal_symbol, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_objc_class, Normal, ErrorPreceding,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_objc_selector, Normal, ErrorPreceding,
-        EncodeCrossCrate::No,
     ),
 
     // ==========================================================================
@@ -934,38 +882,31 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(
         rustc_builtin_macro, Normal,
         ErrorFollowing,
-        EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
         rustc_proc_macro_decls, Normal, WarnFollowing,
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_macro_transparency, Normal,
-        ErrorFollowing,
-        EncodeCrossCrate::Yes, "used internally for testing macro hygiene",
+        ErrorFollowing, "used internally for testing macro hygiene",
     ),
     rustc_attr!(
         rustc_autodiff, Normal,
         DuplicatesOk,
-        EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
         rustc_offload_kernel, Normal,
         DuplicatesOk,
-        EncodeCrossCrate::Yes,
     ),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
     ungated!(
-        cfg_trace, Normal, DuplicatesOk,
-        EncodeCrossCrate::Yes
+        cfg_trace, Normal, DuplicatesOk
     ),
     ungated!(
-        cfg_attr_trace, Normal, DuplicatesOk,
-        EncodeCrossCrate::No
+        cfg_attr_trace, Normal, DuplicatesOk
     ),
 
     // ==========================================================================
@@ -974,47 +915,46 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_on_unimplemented, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes,
-        "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
+        ErrorFollowing,"see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
         rustc_confusables, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes,
+        ErrorFollowing,
     ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
         rustc_conversion_suggestion, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes,
+        WarnFollowing,
     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
         rustc_trivial_field_reads, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes,
+        WarnFollowing,
     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_query_instability, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes,
+        WarnFollowing,
     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_untracked_query_information, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes,
+        WarnFollowing,
     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_ty, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes,
+        WarnFollowing,
     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_deny_field_access, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes,
+        WarnFollowing,
     ),
 
     // ==========================================================================
@@ -1022,30 +962,25 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_promotable, Normal, WarnFollowing,
-        EncodeCrossCrate::No, ),
+        rustc_promotable, Normal, WarnFollowing, ),
     rustc_attr!(
         rustc_legacy_const_generics, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
     ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
-        rustc_do_not_const_check, Normal, WarnFollowing,
-        EncodeCrossCrate::Yes, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
+        rustc_do_not_const_check, Normal, WarnFollowing, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
         rustc_const_stable_indirect, Normal,
-        WarnFollowing,
-        EncodeCrossCrate::No,
-        "this is an internal implementation detail",
+        WarnFollowing,"this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_intrinsic_const_stable_indirect, Normal,
-        WarnFollowing, EncodeCrossCrate::No,  "this is an internal implementation detail",
+        WarnFollowing,  "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_allow_const_fn_unstable, Normal,
-        DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk,
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
@@ -1055,25 +990,21 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_layout_scalar_valid_range_start, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
         rustc_layout_scalar_valid_range_end, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
         rustc_simd_monomorphize_lane_limit, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
         rustc_nonnull_optimization_guaranteed, Normal, WarnFollowing,
-        EncodeCrossCrate::Yes,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; \
@@ -1084,85 +1015,67 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, Normal, DuplicatesOk, EncodeCrossCrate::No, lang_items,
+        lang, Normal, DuplicatesOk, lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
         rustc_as_ptr, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
         rustc_should_not_be_called_on_const_items, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
         rustc_pass_by_value, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
         rustc_never_returns_null_ptr, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes,
         "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, AttributeType::Normal, ErrorFollowing, EncodeCrossCrate::Yes,
-        "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
+        rustc_no_implicit_autorefs, AttributeType::Normal, ErrorFollowing,"`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, AttributeType::CrateLevel, ErrorFollowing, EncodeCrossCrate::No,
-        "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
+        rustc_coherence_is_core, AttributeType::CrateLevel, ErrorFollowing,"`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, AttributeType::Normal, WarnFollowing, EncodeCrossCrate::No,
-        "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
+        rustc_coinductive, AttributeType::Normal, WarnFollowing,"`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, AttributeType::Normal, ErrorFollowing, EncodeCrossCrate::No,
-        "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
+        rustc_allow_incoherent_impl, AttributeType::Normal, ErrorFollowing,"`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, AttributeType::CrateLevel, ErrorFollowing, EncodeCrossCrate::No,
-        "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
+        rustc_preserve_ub_checks, AttributeType::CrateLevel, ErrorFollowing,"`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
         AttributeType::Normal,
-        ErrorFollowing,
-        EncodeCrossCrate::No,
-        "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
+        ErrorFollowing,"`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
     rustc_attr!(
         rustc_dyn_incompatible_trait,
         AttributeType::Normal,
-        ErrorFollowing,
-        EncodeCrossCrate::No,
-        "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
+        ErrorFollowing,"`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
         rustc_has_incoherent_inherent_impls, AttributeType::Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes,
-        "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
+        ErrorFollowing,"`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
         rustc_non_const_trait_method, AttributeType::Normal,
-        ErrorFollowing, EncodeCrossCrate::No,
-        "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
+        ErrorFollowing,"`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
     ),
 
     BuiltinAttribute {
         name: sym::rustc_diagnostic_item,
-        // FIXME: This can be `true` once we always use `tcx.is_diagnostic_item`.
-        encode_cross_crate: EncodeCrossCrate::Yes,
         type_: Normal,
         safety: AttributeSafety::Normal,
-        duplicates: ErrorFollowing,
-        gate: Gated {
+        duplicates: ErrorFollowing,gate: Gated {
             feature: sym::rustc_attrs,
             message: "use of an internal attribute",
             check: Features::rustc_attrs,
@@ -1172,224 +1085,195 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, Normal, WarnFollowing,
-        EncodeCrossCrate::No, "`#[prelude_import]` is for use by rustc only",
+        prelude_import, Normal, WarnFollowing, "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, Normal, WarnFollowing, EncodeCrossCrate::No,
-        unboxed_closures, "unboxed_closures are still evolving",
+        rustc_paren_sugar, Normal, WarnFollowing,unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, Normal, WarnFollowing, EncodeCrossCrate::No,
-        "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
+        rustc_inherit_overflow_checks, Normal, WarnFollowing,"the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
         rustc_reservation_impl, Normal,
-        ErrorFollowing, EncodeCrossCrate::Yes,
-        "the `#[rustc_reservation_impl]` attribute is internally used \
+        ErrorFollowing,"the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
-        rustc_test_marker, Normal, WarnFollowing,
-        EncodeCrossCrate::No, "the `#[rustc_test_marker]` attribute is used internally to track tests",
+        rustc_test_marker, Normal, WarnFollowing, "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
         rustc_unsafe_specialization_marker, Normal,
-        WarnFollowing, EncodeCrossCrate::No,
-        "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
+        WarnFollowing,"the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
         rustc_specialization_trait, Normal,
-        WarnFollowing, EncodeCrossCrate::No,
-        "the `#[rustc_specialization_trait]` attribute is used to check specializations"
+        WarnFollowing,"the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, Normal, WarnFollowing, EncodeCrossCrate::No,
-        "the `#[rustc_main]` attribute is used internally to specify test entry point function",
+        rustc_main, Normal, WarnFollowing,"the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
         rustc_skip_during_method_dispatch, Normal, ErrorFollowing,
-        EncodeCrossCrate::No,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
     rustc_attr!(
         rustc_must_implement_one_of, Normal,
-        ErrorFollowing, EncodeCrossCrate::No,
-        "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
+        ErrorFollowing,"the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
-        rustc_doc_primitive, Normal, ErrorFollowing,
-        EncodeCrossCrate::Yes, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
+        rustc_doc_primitive, Normal, ErrorFollowing, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, Normal, ErrorFollowing, EncodeCrossCrate::Yes, intrinsics,
+        rustc_intrinsic, Normal, ErrorFollowing, intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, Normal, WarnFollowing, EncodeCrossCrate::Yes,
-        "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
+        rustc_no_mir_inline, Normal, WarnFollowing,"`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, Normal, WarnFollowing, EncodeCrossCrate::Yes,
-        "`#[rustc_force_inline]` forces a free function to be inlined"
+        rustc_force_inline, Normal, WarnFollowing,"`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, Normal, WarnFollowing, EncodeCrossCrate::Yes,
-        "`#[rustc_scalable_vector]` defines a scalable vector type"
+        rustc_scalable_vector, Normal, WarnFollowing,"`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
 
     // ==========================================================================
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, Normal, WarnFollowing, EncodeCrossCrate::Yes),
+    rustc_attr!(TEST, rustc_effective_visibility, Normal, WarnFollowing,),
     rustc_attr!(
         TEST, rustc_dump_inferred_outlives, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_capture_analysis, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_insignificant_dtor, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_no_implicit_bounds, CrateLevel,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_strict_coherence, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_variances, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_variances_of_opaques, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_hidden_type_of_opaques, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_layout, Normal,
-        WarnFollowing, EncodeCrossCrate::Yes
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_abi, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_regions, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_delayed_bug_from_inside_query, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_user_args, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_evaluate_where_clauses, Normal, WarnFollowing,
-        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_if_this_changed, Normal, DuplicatesOk,
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_then_this_would_need, Normal, DuplicatesOk,
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_clean, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     rustc_attr!(
         TEST, rustc_partition_reused, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     rustc_attr!(
         TEST, rustc_partition_codegened, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     rustc_attr!(
         TEST, rustc_expected_cgu_reuse, Normal,
         DuplicatesOk,
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_symbol_name, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_def_path, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_mir, Normal,
-        DuplicatesOk, EncodeCrossCrate::Yes
+        DuplicatesOk,
     ),
     gated!(
         custom_mir, Normal,
-        ErrorFollowing, EncodeCrossCrate::No,
-        "the `#[custom_mir]` attribute is just used for the Rust test suite",
+        ErrorFollowing,"the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
         TEST, rustc_dump_item_bounds, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_predicates, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_def_parents, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_object_lifetime_defaults, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dump_vtable, Normal,
-        WarnFollowing, EncodeCrossCrate::No
+        WarnFollowing,
     ),
     rustc_attr!(
         TEST, rustc_dummy, Normal,
-        DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk,
     ),
     rustc_attr!(
         TEST, pattern_complexity_limit, CrateLevel,
-        ErrorFollowing, EncodeCrossCrate::No,
+        ErrorFollowing,
     ),
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {
     BUILTIN_ATTRIBUTE_MAP.get(&name).is_some()
-}
-
-/// Whether this builtin attribute is encoded cross crate.
-/// This means it can be used cross crate.
-pub fn encode_cross_crate(name: Symbol) -> bool {
-    if let Some(attr) = BUILTIN_ATTRIBUTE_MAP.get(&name) {
-        attr.encode_cross_crate == EncodeCrossCrate::Yes
-    } else {
-        true
-    }
 }
 
 pub fn is_valid_for_get_attr(name: Symbol) -> bool {

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -78,7 +78,6 @@ pub enum AttributeType {
     /// Normal, builtin attribute that is consumed
     /// by the compiler before the unused_attribute check
     Normal,
-
     /// Builtin attribute that is only allowed at the crate level
     CrateLevel,
 }
@@ -87,7 +86,6 @@ pub enum AttributeType {
 pub enum AttributeSafety {
     /// Normal attribute that does not need `#[unsafe(...)]`
     Normal,
-
     /// Unsafe attribute that requires safety obligations to be discharged.
     ///
     /// An error is emitted when `#[unsafe(...)]` is omitted, except when the attribute's edition
@@ -268,35 +266,32 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
-            template: $tpl,
             gate: Ungated,
             duplicates: $duplicates,
         }
     };
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            template: $tpl,
             gate: Ungated,
             duplicates: $duplicates,
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             gate: Ungated,
             duplicates: $duplicates,
         }
@@ -304,13 +299,12 @@ macro_rules! ungated {
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            template: $tpl,
             duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$gate,
@@ -320,13 +314,12 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            template: $tpl,
             duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$attr,
@@ -336,13 +329,12 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$gate,
@@ -352,13 +344,12 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$attr,
@@ -371,11 +362,10 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $typ:expr, $tpl:expr, $duplicate:expr, $encode_cross_crate:expr $(,)?) => {
+    (TEST, $attr:ident, $typ:expr, $duplicate:expr, $encode_cross_crate:expr $(,)?) => {
         rustc_attr!(
             $attr,
             $typ,
-            $tpl,
             $duplicate,
             $encode_cross_crate,
             concat!(
@@ -385,13 +375,12 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $typ:expr, $duplicates:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             duplicates: $duplicates,
             gate: Gated {
                 feature: sym::rustc_attrs,
@@ -423,7 +412,6 @@ pub struct BuiltinAttribute {
     pub encode_cross_crate: EncodeCrossCrate,
     pub type_: AttributeType,
     pub safety: AttributeSafety,
-    pub template: AttributeTemplate,
     pub duplicates: AttributeDuplicates,
     pub gate: AttributeGate,
 }
@@ -438,240 +426,141 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Conditional compilation:
     ungated!(
         cfg, Normal,
-        template!(
-            List: &["predicate"],
-            "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute"
-        ),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     ungated!(
         cfg_attr, Normal,
-        template!(
-            List: &["predicate, attr1, attr2, ..."],
-            "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
-        ),
         DuplicatesOk, EncodeCrossCrate::No
     ),
 
     // Testing:
     ungated!(
         ignore, Normal,
-        template!(
-            Word,
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
-        ),
         WarnFollowing, EncodeCrossCrate::No,
     ),
     ungated!(
         should_panic, Normal,
-        template!(
-            Word,
-            List: &[r#"expected = "reason""#],
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
-        ),
         FutureWarnFollowing, EncodeCrossCrate::No,
     ),
 
     // Macros:
     ungated!(
         automatically_derived, Normal,
-        template!(
-            Word,
-            "https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute"
-        ),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     ungated!(
         macro_use, Normal,
-        template!(
-            Word,
-            List: &["name1, name2, ..."],
-            "https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute"
-        ),
         WarnFollowingWordOnly, EncodeCrossCrate::No,
     ),
-    ungated!(macro_escape, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
+    ungated!(macro_escape, Normal, WarnFollowing, EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
     ungated!(
         macro_export, Normal,
-        template!(
-            Word,
-            List: &["local_inner_macros"],
-            "https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope"
-        ),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     ungated!(
         proc_macro, Normal,
-        template!(
-            Word,
-            "https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros"),
         ErrorFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         proc_macro_derive, Normal,
-        template!(
-            List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
-            "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
-        ),
         ErrorFollowing, EncodeCrossCrate::No,
     ),
     ungated!(
         proc_macro_attribute, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros"),
         ErrorFollowing, EncodeCrossCrate::No
     ),
 
     // Lints:
     ungated!(
         warn, Normal,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
         allow, Normal,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
         expect, Normal,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
         forbid, Normal,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     ungated!(
         deny, Normal,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     ungated!(
         must_use, Normal,
-        template!(
-            Word,
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
-        ),
         FutureWarnFollowing, EncodeCrossCrate::Yes
     ),
     gated!(
-        must_not_suspend, Normal, template!(Word, NameValueStr: "reason"), WarnFollowing,
+        must_not_suspend, Normal, WarnFollowing,
         EncodeCrossCrate::Yes, experimental!(must_not_suspend)
     ),
     ungated!(
         deprecated, Normal,
-        template!(
-            Word,
-            List: &[r#"/*opt*/ since = "version", /*opt*/ note = "reason""#],
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"
-        ),
         ErrorFollowing, EncodeCrossCrate::Yes
     ),
 
     // Crate properties:
     ungated!(
         crate_name, CrateLevel,
-        template!(
-            NameValueStr: "name",
-            "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-crate_name-attribute"
-        ),
         FutureWarnFollowing, EncodeCrossCrate::No,
     ),
     ungated!(
         crate_type, CrateLevel,
-        template!(
-            NameValueStr: ["bin", "lib", "dylib", "cdylib", "rlib", "staticlib", "sdylib", "proc-macro"],
-            "https://doc.rust-lang.org/reference/linkage.html"
-        ),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
 
     // ABI, linking, symbols, and FFI
     ungated!(
         link, Normal,
-        template!(List: &[
-            r#"name = "...""#,
-            r#"name = "...", kind = "dylib|static|...""#,
-            r#"name = "...", wasm_import_module = "...""#,
-            r#"name = "...", import_name_type = "decorated|noprefix|undecorated""#,
-            r#"name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated""#,
-        ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute"),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
         link_name, Normal,
-        template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"),
         FutureWarnPreceding, EncodeCrossCrate::Yes
     ),
     ungated!(
         no_link, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         repr, Normal,
-        template!(
-            List: &["C", "Rust", "transparent", "align(...)", "packed(...)", "<integer type>"],
-            "https://doc.rust-lang.org/reference/type-layout.html#representations"
-        ),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, Normal, template!(List: &["alignment"]), DuplicatesOk, EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, Normal, template!(List: &["alignment"]), DuplicatesOk, EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, Normal, DuplicatesOk, EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, Normal, DuplicatesOk, EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
     ungated!(
         unsafe(Edition2024) export_name, Normal,
-        template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute"),
         FutureWarnPreceding, EncodeCrossCrate::No
     ),
     ungated!(
         unsafe(Edition2024) link_section, Normal,
-        template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"),
         FutureWarnPreceding, EncodeCrossCrate::No
     ),
     ungated!(
         unsafe(Edition2024) no_mangle, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         used, Normal,
-        template!(Word, List: &["compiler", "linker"], "https://doc.rust-lang.org/reference/abi.html#the-used-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         link_ordinal, Normal,
-        template!(List: &["ordinal"], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"),
         ErrorPreceding, EncodeCrossCrate::Yes
     ),
     ungated!(
         unsafe naked, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-naked-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
-        rustc_pass_indirectly_in_non_rustic_abis, Normal, template!(Word), ErrorFollowing,
+        rustc_pass_indirectly_in_non_rustic_abis, Normal, ErrorFollowing,
         EncodeCrossCrate::No,
         "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
@@ -679,134 +568,102 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Limits:
     ungated!(
         recursion_limit, CrateLevel,
-        template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute"),
         FutureWarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         type_length_limit, CrateLevel,
-        template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-type_length_limit-attribute"),
         FutureWarnFollowing, EncodeCrossCrate::No
     ),
     gated!(
-        move_size_limit, CrateLevel, template!(NameValueStr: "N"), ErrorFollowing,
+        move_size_limit, CrateLevel, ErrorFollowing,
         EncodeCrossCrate::No, large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
     ungated!(
         no_main, CrateLevel,
-        template!(Word, "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-no_main-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
 
     // Modules, prelude, and resolution:
     ungated!(
         path, Normal,
-        template!(NameValueStr: "file", "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"),
         FutureWarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         no_std, CrateLevel,
-        template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         no_implicit_prelude, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         non_exhaustive, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
 
     // Runtime
     ungated!(
         windows_subsystem, CrateLevel,
-        template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute"),
         FutureWarnFollowing, EncodeCrossCrate::No
     ),
     ungated!( // RFC 2070
         panic_handler, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/panic.html#the-panic_handler-attribute"),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
 
     // Code generation:
     ungated!(
         inline, Normal,
-        template!(
-            Word,
-            List: &["always", "never"],
-            "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
-        ),
         FutureWarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         cold, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-cold-attribute"),
         WarnFollowing, EncodeCrossCrate::No
     ),
     ungated!(
         no_builtins, CrateLevel,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-no_builtins-attribute"),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     ungated!(
         target_feature, Normal,
-        template!(List: &[r#"enable = "name""#], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
         track_caller, Normal,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute"),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     ungated!(
         instruction_set, Normal,
-        template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute"),
         ErrorPreceding, EncodeCrossCrate::No
     ),
     gated!(
-        unsafe force_target_feature, Normal, template!(List: &[r#"enable = "name""#]),
+        unsafe force_target_feature, Normal,
         DuplicatesOk, EncodeCrossCrate::No, effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
-        sanitize, Normal, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]), ErrorPreceding,
+        sanitize, Normal, ErrorPreceding,
         EncodeCrossCrate::No, sanitize, experimental!(sanitize),
     ),
     gated!(
-        coverage, Normal, template!(OneOf: &[sym::off, sym::on]),
+        coverage, Normal,
         ErrorPreceding, EncodeCrossCrate::No,
         coverage_attribute, experimental!(coverage)
     ),
 
     ungated!(
         doc, Normal,
-        template!(
-            List: &["hidden", "inline"],
-            NameValueStr: "string",
-            "https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html"
-        ),
         DuplicatesOk, EncodeCrossCrate::Yes
     ),
 
     // Debugging
     ungated!(
         debugger_visualizer, Normal,
-        template!(
-            List: &[r#"natvis_file = "...", gdb_script_file = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute"
-        ),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     ungated!(
         collapse_debuginfo, Normal,
-        template!(
-            List: &["no", "external", "yes"],
-            "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
-        ),
         ErrorFollowing, EncodeCrossCrate::Yes
     ),
 
@@ -816,70 +673,70 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, Normal, template!(Word), WarnFollowing,
+        export_stable, Normal, WarnFollowing,
         EncodeCrossCrate::No, experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, CrateLevel, template!(List: &["path"]), ErrorFollowing,
+        test_runner, CrateLevel, ErrorFollowing,
         EncodeCrossCrate::Yes, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
-        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"), ErrorFollowing,
+        reexport_test_harness_main, CrateLevel, ErrorFollowing,
         EncodeCrossCrate::No, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        marker, Normal, WarnFollowing, EncodeCrossCrate::No,
         marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        thread_local, Normal, WarnFollowing, EncodeCrossCrate::No,
         "`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
-        no_core, CrateLevel, template!(Word), WarnFollowing,
+        no_core, CrateLevel, WarnFollowing,
         EncodeCrossCrate::No, experimental!(no_core)
     ),
     // RFC 2412
     gated!(
-        optimize, Normal, template!(List: &["none", "size", "speed"]), ErrorPreceding,
+        optimize, Normal, ErrorPreceding,
         EncodeCrossCrate::No, optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, Normal, template!(Word), WarnFollowing,
+        unsafe ffi_pure, Normal, WarnFollowing,
         EncodeCrossCrate::No, experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, Normal, template!(Word), WarnFollowing,
+        unsafe ffi_const, Normal, WarnFollowing,
         EncodeCrossCrate::No, experimental!(ffi_const)
     ),
     gated!(
-        register_tool, CrateLevel, template!(List: &["tool1, tool2, ..."]), DuplicatesOk,
+        register_tool, CrateLevel, DuplicatesOk,
         EncodeCrossCrate::No, experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
-        cfi_encoding, Normal, template!(NameValueStr: "encoding"), ErrorPreceding,
+        cfi_encoding, Normal, ErrorPreceding,
         EncodeCrossCrate::Yes, experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, Normal, template!(Word), ErrorFollowing,
+        coroutine, Normal, ErrorFollowing,
         EncodeCrossCrate::No, coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
-        patchable_function_entry, Normal, template!(List: &["prefix_nops = m, entry_nops = n"]), ErrorPreceding,
+        patchable_function_entry, Normal, ErrorPreceding,
         EncodeCrossCrate::Yes, experimental!(patchable_function_entry)
     ),
 
@@ -888,11 +745,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, Normal, template!(Word), ErrorFollowing,
+        const_continue, Normal, ErrorFollowing,
         EncodeCrossCrate::No, loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, Normal, template!(Word), ErrorFollowing,
+        loop_match, Normal, ErrorFollowing,
         EncodeCrossCrate::No, loop_match, experimental!(loop_match)
     ),
 
@@ -901,7 +758,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, Normal, template!(Word), ErrorFollowing,
+        pin_v2, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes, pin_ergonomics, experimental!(pin_v2),
     ),
 
@@ -911,62 +768,61 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     ungated!(
         feature, CrateLevel,
-        template!(List: &["name1, name2, ..."]), DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk, EncodeCrossCrate::No,
     ),
     // DuplicatesOk since it has its own validation
     ungated!(
         stable, Normal,
-        template!(List: &[r#"feature = "name", since = "version""#]), DuplicatesOk, EncodeCrossCrate::No,
-    ),
-    ungated!(
-        unstable, Normal,
-        template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]), DuplicatesOk,
-        EncodeCrossCrate::Yes
-    ),
-    ungated!(
-        unstable_feature_bound, Normal, template!(Word, List: &["feat1, feat2, ..."]),
         DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
-        rustc_const_unstable, Normal, template!(List: &[r#"feature = "name""#]),
+        unstable, Normal,
+        DuplicatesOk,
+        EncodeCrossCrate::Yes
+    ),
+    ungated!(
+        unstable_feature_bound, Normal,
+        DuplicatesOk, EncodeCrossCrate::No,
+    ),
+    ungated!(
+        rustc_const_unstable, Normal,
         DuplicatesOk, EncodeCrossCrate::Yes
     ),
     ungated!(
         rustc_const_stable, Normal,
-        template!(List: &[r#"feature = "name""#]), DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk, EncodeCrossCrate::No,
     ),
     ungated!(
         rustc_default_body_unstable, Normal,
-        template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     gated!(
-        allow_internal_unstable, Normal, template!(Word, List: &["feat1, feat2, ..."]),
+        allow_internal_unstable, Normal,
         DuplicatesOk, EncodeCrossCrate::Yes,
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, Normal, template!(Word), WarnFollowing,
+        allow_internal_unsafe, Normal, WarnFollowing,
         EncodeCrossCrate::No, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
-        rustc_eii_foreign_item, Normal, template!(Word),
+        rustc_eii_foreign_item, Normal,
         ErrorFollowing, EncodeCrossCrate::Yes, eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
-        rustc_allowed_through_unstable_modules, Normal, template!(NameValueStr: "deprecation message"),
+        rustc_allowed_through_unstable_modules, Normal,
         WarnFollowing, EncodeCrossCrate::No,
         "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
-        rustc_deprecated_safe_2024, Normal, template!(List: &[r#"audit_that = "...""#]),
+        rustc_deprecated_safe_2024, Normal,
         ErrorFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
-        rustc_pub_transparent, Normal, template!(Word),
+        rustc_pub_transparent, Normal,
         ErrorFollowing, EncodeCrossCrate::Yes,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
@@ -976,9 +832,9 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes, experimental!(fundamental)),
+    gated!(fundamental, Normal, WarnFollowing, EncodeCrossCrate::Yes, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, template!(Word), WarnFollowing,
+        may_dangle, Normal, WarnFollowing,
         EncodeCrossCrate::No, dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
@@ -986,13 +842,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(
         rustc_never_type_options,
         Normal,
-        template!(List: &[
-            "",
-            r#"fallback = "unit""#,
-            r#"fallback = "niko""#,
-            r#"fallback = "never""#,
-            r#"fallback = "no""#,
-        ]),
         ErrorFollowing,
         EncodeCrossCrate::No,
         "`rustc_never_type_options` is used to experiment with never type fallback and work on \
@@ -1004,53 +853,53 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_allocator, Normal, template!(Word), WarnFollowing,
+        rustc_allocator, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_nounwind, Normal, template!(Word), WarnFollowing,
+        rustc_nounwind, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_reallocator, Normal, template!(Word), WarnFollowing,
+        rustc_reallocator, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_deallocator, Normal, template!(Word), WarnFollowing,
+        rustc_deallocator, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed, Normal, template!(Word), WarnFollowing,
+        rustc_allocator_zeroed, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed_variant, Normal, template!(NameValueStr: "function"), ErrorPreceding,
+        rustc_allocator_zeroed_variant, Normal, ErrorPreceding,
         EncodeCrossCrate::Yes,
     ),
     gated!(
-        default_lib_allocator, Normal, template!(Word), WarnFollowing,
+        default_lib_allocator, Normal, WarnFollowing,
         EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        needs_allocator, Normal, template!(Word), WarnFollowing,
+        needs_allocator, Normal, WarnFollowing,
         EncodeCrossCrate::No, allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        panic_runtime, CrateLevel, template!(Word), WarnFollowing,
+        panic_runtime, CrateLevel, WarnFollowing,
         EncodeCrossCrate::No, experimental!(panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, CrateLevel, template!(Word), WarnFollowing,
+        needs_panic_runtime, CrateLevel, WarnFollowing,
         EncodeCrossCrate::No, experimental!(needs_panic_runtime)
     ),
     gated!(
-        compiler_builtins, CrateLevel, template!(Word), WarnFollowing,
+        compiler_builtins, CrateLevel, WarnFollowing,
         EncodeCrossCrate::No,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
-        profiler_runtime, CrateLevel, template!(Word), WarnFollowing,
+        profiler_runtime, CrateLevel, WarnFollowing,
         EncodeCrossCrate::No,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
@@ -1061,30 +910,20 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     gated!(
-        linkage, Normal, template!(NameValueStr: [
-            "available_externally",
-            "common",
-            "extern_weak",
-            "external",
-            "internal",
-            "linkonce",
-            "linkonce_odr",
-            "weak",
-            "weak_odr",
-        ], "https://doc.rust-lang.org/reference/linkage.html"),
+        linkage, Normal,
         ErrorPreceding, EncodeCrossCrate::No,
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
     rustc_attr!(
-        rustc_std_internal_symbol, Normal, template!(Word), WarnFollowing,
+        rustc_std_internal_symbol, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_objc_class, Normal, template!(NameValueStr: "ClassName"), ErrorPreceding,
+        rustc_objc_class, Normal, ErrorPreceding,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_objc_selector, Normal, template!(NameValueStr: "methodName"), ErrorPreceding,
+        rustc_objc_selector, Normal, ErrorPreceding,
         EncodeCrossCrate::No,
     ),
 
@@ -1094,26 +933,26 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_builtin_macro, Normal,
-        template!(Word, List: &["name", "name, /*opt*/ attributes(name1, name2, ...)"]), ErrorFollowing,
+        ErrorFollowing,
         EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
-        rustc_proc_macro_decls, Normal, template!(Word), WarnFollowing,
+        rustc_proc_macro_decls, Normal, WarnFollowing,
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_macro_transparency, Normal,
-        template!(NameValueStr: ["transparent", "semiopaque", "opaque"]), ErrorFollowing,
+        ErrorFollowing,
         EncodeCrossCrate::Yes, "used internally for testing macro hygiene",
     ),
     rustc_attr!(
         rustc_autodiff, Normal,
-        template!(Word, List: &[r#""...""#]), DuplicatesOk,
+        DuplicatesOk,
         EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
         rustc_offload_kernel, Normal,
-        template!(Word), DuplicatesOk,
+        DuplicatesOk,
         EncodeCrossCrate::Yes,
     ),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
@@ -1121,11 +960,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
     ungated!(
-        cfg_trace, Normal, template!(Word /* irrelevant */), DuplicatesOk,
+        cfg_trace, Normal, DuplicatesOk,
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        cfg_attr_trace, Normal, template!(Word /* irrelevant */), DuplicatesOk,
+        cfg_attr_trace, Normal, DuplicatesOk,
         EncodeCrossCrate::No
     ),
 
@@ -1135,51 +974,46 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_on_unimplemented, Normal,
-        template!(
-            List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#],
-            NameValueStr: "message"
-        ),
         ErrorFollowing, EncodeCrossCrate::Yes,
         "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
         rustc_confusables, Normal,
-        template!(List: &[r#""name1", "name2", ..."#]),
         ErrorFollowing, EncodeCrossCrate::Yes,
     ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
-        rustc_conversion_suggestion, Normal, template!(Word),
+        rustc_conversion_suggestion, Normal,
         WarnFollowing, EncodeCrossCrate::Yes,
     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
-        rustc_trivial_field_reads, Normal, template!(Word),
+        rustc_trivial_field_reads, Normal,
         WarnFollowing, EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
-        rustc_lint_query_instability, Normal, template!(Word),
+        rustc_lint_query_instability, Normal,
         WarnFollowing, EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
-        rustc_lint_untracked_query_information, Normal, template!(Word),
+        rustc_lint_untracked_query_information, Normal,
         WarnFollowing, EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
-        rustc_lint_opt_ty, Normal, template!(Word),
+        rustc_lint_opt_ty, Normal,
         WarnFollowing, EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
-        rustc_lint_opt_deny_field_access, Normal, template!(List: &["message"]),
+        rustc_lint_opt_deny_field_access, Normal,
         WarnFollowing, EncodeCrossCrate::Yes,
     ),
 
@@ -1188,31 +1022,30 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_promotable, Normal, template!(Word), WarnFollowing,
+        rustc_promotable, Normal, WarnFollowing,
         EncodeCrossCrate::No, ),
     rustc_attr!(
-        rustc_legacy_const_generics, Normal, template!(List: &["N"]), ErrorFollowing,
+        rustc_legacy_const_generics, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
     ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
-        rustc_do_not_const_check, Normal, template!(Word), WarnFollowing,
+        rustc_do_not_const_check, Normal, WarnFollowing,
         EncodeCrossCrate::Yes, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
         rustc_const_stable_indirect, Normal,
-        template!(Word),
         WarnFollowing,
         EncodeCrossCrate::No,
         "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_intrinsic_const_stable_indirect, Normal,
-        template!(Word), WarnFollowing, EncodeCrossCrate::No,  "this is an internal implementation detail",
+        WarnFollowing, EncodeCrossCrate::No,  "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_allow_const_fn_unstable, Normal,
-        template!(Word, List: &["feat1, feat2, ..."]), DuplicatesOk, EncodeCrossCrate::No,
+        DuplicatesOk, EncodeCrossCrate::No,
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
@@ -1221,25 +1054,25 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_layout_scalar_valid_range_start, Normal, template!(List: &["value"]), ErrorFollowing,
+        rustc_layout_scalar_valid_range_start, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_layout_scalar_valid_range_end, Normal, template!(List: &["value"]), ErrorFollowing,
+        rustc_layout_scalar_valid_range_end, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_simd_monomorphize_lane_limit, Normal, template!(NameValueStr: "N"), ErrorFollowing,
+        rustc_simd_monomorphize_lane_limit, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
-        rustc_nonnull_optimization_guaranteed, Normal, template!(Word), WarnFollowing,
+        rustc_nonnull_optimization_guaranteed, Normal, WarnFollowing,
         EncodeCrossCrate::Yes,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
@@ -1251,53 +1084,52 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, Normal, template!(NameValueStr: "name"), DuplicatesOk, EncodeCrossCrate::No, lang_items,
+        lang, Normal, DuplicatesOk, EncodeCrossCrate::No, lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
-        rustc_as_ptr, Normal, template!(Word), ErrorFollowing,
+        rustc_as_ptr, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
-        rustc_should_not_be_called_on_const_items, Normal, template!(Word), ErrorFollowing,
+        rustc_should_not_be_called_on_const_items, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
-        rustc_pass_by_value, Normal, template!(Word), ErrorFollowing,
+        rustc_pass_by_value, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
-        rustc_never_returns_null_ptr, Normal, template!(Word), ErrorFollowing,
+        rustc_never_returns_null_ptr, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes,
         "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, AttributeType::Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::Yes,
+        rustc_no_implicit_autorefs, AttributeType::Normal, ErrorFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, AttributeType::CrateLevel, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
+        rustc_coherence_is_core, AttributeType::CrateLevel, ErrorFollowing, EncodeCrossCrate::No,
         "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, AttributeType::Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_coinductive, AttributeType::Normal, WarnFollowing, EncodeCrossCrate::No,
         "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, AttributeType::Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
+        rustc_allow_incoherent_impl, AttributeType::Normal, ErrorFollowing, EncodeCrossCrate::No,
         "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, AttributeType::CrateLevel, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
+        rustc_preserve_ub_checks, AttributeType::CrateLevel, ErrorFollowing, EncodeCrossCrate::No,
         "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
         AttributeType::Normal,
-        template!(Word),
         ErrorFollowing,
         EncodeCrossCrate::No,
         "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
@@ -1305,20 +1137,19 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(
         rustc_dyn_incompatible_trait,
         AttributeType::Normal,
-        template!(Word),
         ErrorFollowing,
         EncodeCrossCrate::No,
         "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
-        rustc_has_incoherent_inherent_impls, AttributeType::Normal, template!(Word),
+        rustc_has_incoherent_inherent_impls, AttributeType::Normal,
         ErrorFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
-        rustc_non_const_trait_method, AttributeType::Normal, template!(Word),
+        rustc_non_const_trait_method, AttributeType::Normal,
         ErrorFollowing, EncodeCrossCrate::No,
         "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
@@ -1330,7 +1161,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         encode_cross_crate: EncodeCrossCrate::Yes,
         type_: Normal,
         safety: AttributeSafety::Normal,
-        template: template!(NameValueStr: "name"),
         duplicates: ErrorFollowing,
         gate: Gated {
             feature: sym::rustc_attrs,
@@ -1342,76 +1172,76 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, Normal, template!(Word), WarnFollowing,
+        prelude_import, Normal, WarnFollowing,
         EncodeCrossCrate::No, "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_paren_sugar, Normal, WarnFollowing, EncodeCrossCrate::No,
         unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_inherit_overflow_checks, Normal, WarnFollowing, EncodeCrossCrate::No,
         "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
         rustc_reservation_impl, Normal,
-        template!(NameValueStr: "reservation message"), ErrorFollowing, EncodeCrossCrate::Yes,
+        ErrorFollowing, EncodeCrossCrate::Yes,
         "the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
-        rustc_test_marker, Normal, template!(NameValueStr: "name"), WarnFollowing,
+        rustc_test_marker, Normal, WarnFollowing,
         EncodeCrossCrate::No, "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
-        rustc_unsafe_specialization_marker, Normal, template!(Word),
+        rustc_unsafe_specialization_marker, Normal,
         WarnFollowing, EncodeCrossCrate::No,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_specialization_trait, Normal, template!(Word),
+        rustc_specialization_trait, Normal,
         WarnFollowing, EncodeCrossCrate::No,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_main, Normal, WarnFollowing, EncodeCrossCrate::No,
         "the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
-        rustc_skip_during_method_dispatch, Normal, template!(List: &["array, boxed_slice"]), ErrorFollowing,
+        rustc_skip_during_method_dispatch, Normal, ErrorFollowing,
         EncodeCrossCrate::No,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
     rustc_attr!(
-        rustc_must_implement_one_of, Normal, template!(List: &["function1, function2, ..."]),
+        rustc_must_implement_one_of, Normal,
         ErrorFollowing, EncodeCrossCrate::No,
         "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
-        rustc_doc_primitive, Normal, template!(NameValueStr: "primitive name"), ErrorFollowing,
+        rustc_doc_primitive, Normal, ErrorFollowing,
         EncodeCrossCrate::Yes, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::Yes, intrinsics,
+        rustc_intrinsic, Normal, ErrorFollowing, EncodeCrossCrate::Yes, intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_no_mir_inline, Normal, WarnFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, Normal, template!(Word, NameValueStr: "reason"), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_force_inline, Normal, WarnFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, Normal, template!(List: &["count"]), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_scalable_vector, Normal, WarnFollowing, EncodeCrossCrate::Yes,
         "`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
 
@@ -1419,133 +1249,131 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes),
+    rustc_attr!(TEST, rustc_effective_visibility, Normal, WarnFollowing, EncodeCrossCrate::Yes),
     rustc_attr!(
-        TEST, rustc_dump_inferred_outlives, Normal, template!(Word),
+        TEST, rustc_dump_inferred_outlives, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_capture_analysis, Normal, template!(Word),
+        TEST, rustc_capture_analysis, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_insignificant_dtor, Normal, template!(Word),
+        TEST, rustc_insignificant_dtor, Normal,
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_no_implicit_bounds, CrateLevel, template!(Word),
+        TEST, rustc_no_implicit_bounds, CrateLevel,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_strict_coherence, Normal, template!(Word),
+        TEST, rustc_strict_coherence, Normal,
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_dump_variances, Normal, template!(Word),
+        TEST, rustc_dump_variances, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_variances_of_opaques, Normal, template!(Word),
+        TEST, rustc_dump_variances_of_opaques, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_hidden_type_of_opaques, Normal, template!(Word),
+        TEST, rustc_hidden_type_of_opaques, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_layout, Normal, template!(List: &["field1, field2, ..."]),
+        TEST, rustc_layout, Normal,
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_abi, Normal, template!(List: &["field1, field2, ..."]),
+        TEST, rustc_abi, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_regions, Normal, template!(Word),
+        TEST, rustc_regions, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_delayed_bug_from_inside_query, Normal,
-        template!(Word),
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_user_args, Normal, template!(Word),
+        TEST, rustc_dump_user_args, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_evaluate_where_clauses, Normal, template!(Word), WarnFollowing,
+        TEST, rustc_evaluate_where_clauses, Normal, WarnFollowing,
         EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_if_this_changed, Normal, template!(Word, List: &["DepNode"]), DuplicatesOk,
+        TEST, rustc_if_this_changed, Normal, DuplicatesOk,
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_then_this_would_need, Normal, template!(List: &["DepNode"]), DuplicatesOk,
+        TEST, rustc_then_this_would_need, Normal, DuplicatesOk,
         EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_clean, Normal,
-        template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]),
         DuplicatesOk, EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_partition_reused, Normal,
-        template!(List: &[r#"cfg = "...", module = "...""#]), DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk, EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_partition_codegened, Normal,
-        template!(List: &[r#"cfg = "...", module = "...""#]), DuplicatesOk, EncodeCrossCrate::No
+        DuplicatesOk, EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_expected_cgu_reuse, Normal,
-        template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]), DuplicatesOk,
+        DuplicatesOk,
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_symbol_name, Normal, template!(Word),
+        TEST, rustc_symbol_name, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_def_path, Normal, template!(Word),
+        TEST, rustc_def_path, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_mir, Normal, template!(List: &["arg1, arg2, ..."]),
+        TEST, rustc_mir, Normal,
         DuplicatesOk, EncodeCrossCrate::Yes
     ),
     gated!(
-        custom_mir, Normal, template!(List: &[r#"dialect = "...", phase = "...""#]),
+        custom_mir, Normal,
         ErrorFollowing, EncodeCrossCrate::No,
         "the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
-        TEST, rustc_dump_item_bounds, Normal, template!(Word),
+        TEST, rustc_dump_item_bounds, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_predicates, Normal, template!(Word),
+        TEST, rustc_dump_predicates, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_def_parents, Normal, template!(Word),
+        TEST, rustc_dump_def_parents, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_object_lifetime_defaults, Normal, template!(Word),
+        TEST, rustc_dump_object_lifetime_defaults, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_vtable, Normal, template!(Word),
+        TEST, rustc_dump_vtable, Normal,
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dummy, Normal, template!(Word /* doesn't matter*/),
+        TEST, rustc_dummy, Normal,
         DuplicatesOk, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, pattern_complexity_limit, CrateLevel, template!(NameValueStr: "N"),
+        TEST, pattern_complexity_limit, CrateLevel,
         ErrorFollowing, EncodeCrossCrate::No,
     ),
 ];

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -129,9 +129,9 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
-    AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, AttributeType,
-    BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg,
-    is_builtin_attr_name, is_stable_diagnostic_attribute,
+    AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, BUILTIN_ATTRIBUTE_MAP,
+    BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg, is_builtin_attr_name,
+    is_stable_diagnostic_attribute,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -131,8 +131,7 @@ pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
     AttrSuggestionStyle, AttributeDuplicates, AttributeGate, AttributeSafety, AttributeTemplate,
     AttributeType, BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg,
-    encode_cross_crate, find_gated_cfg, is_builtin_attr_name, is_stable_diagnostic_attribute,
-    is_valid_for_get_attr,
+    find_gated_cfg, is_builtin_attr_name, is_stable_diagnostic_attribute, is_valid_for_get_attr,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -129,9 +129,9 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
-    AttrSuggestionStyle, AttributeDuplicates, AttributeGate, AttributeSafety, AttributeTemplate,
-    AttributeType, BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg,
-    find_gated_cfg, is_builtin_attr_name, is_stable_diagnostic_attribute, is_valid_for_get_attr,
+    AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, AttributeType,
+    BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg,
+    is_builtin_attr_name, is_stable_diagnostic_attribute,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -864,10 +864,6 @@ fn analyze_attr(attr: &hir::Attribute, state: &mut AnalyzeAttrState<'_>) -> bool
         && p.encode_cross_crate() == EncodeCrossCrate::No
     {
         // Attributes not marked encode-cross-crate don't need to be encoded for downstream crates.
-    } else if let Some(name) = attr.name()
-        && !rustc_feature::encode_cross_crate(name)
-    {
-        // Attributes not marked encode-cross-crate don't need to be encoded for downstream crates.
     } else if let hir::Attribute::Parsed(AttributeKind::DocComment { .. }) = attr {
         // We keep all doc comments reachable to rustdoc because they might be "imported" into
         // downstream crates if they use `#[doc(inline)]` to copy an item's documentation into

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1725,13 +1725,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[deprecated = "Though there are valid usecases for this method, especially when your attribute is not a parsed attribute, usually you want to call rustc_hir::find_attr! instead."]
     pub fn get_attr(self, did: impl Into<DefId>, attr: Symbol) -> Option<&'tcx hir::Attribute> {
-        if cfg!(debug_assertions) && !rustc_feature::is_valid_for_get_attr(attr) {
-            let did: DefId = did.into();
-            bug!("get_attr: unexpected called with DefId `{:?}`, attr `{:?}`", did, attr);
-        } else {
-            #[allow(deprecated)]
-            self.get_attrs(did, attr).next()
-        }
+        #[allow(deprecated)]
+        self.get_attrs(did, attr).next()
     }
 
     /// Determines whether an item is annotated with an attribute.

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -6,17 +6,15 @@
 //! item.
 
 use std::cell::Cell;
-use std::collections::hash_map::Entry;
 use std::slice;
 
 use rustc_abi::ExternAbi;
 use rustc_ast::ast;
 use rustc_attr_parsing::{AttributeParser, Late};
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
-use rustc_feature::{AttributeDuplicates, AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
+use rustc_feature::{AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_hir::attrs::{
     AttributeKind, CrateType, DocAttribute, DocInline, EiiDecl, EiiImpl, EiiImplResolution,
@@ -137,7 +135,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         target: Target,
         item: Option<ItemLike<'_>>,
     ) {
-        let mut seen = FxHashMap::default();
         let attrs = self.tcx.hir_attrs(hir_id);
         for attr in attrs {
             match attr {
@@ -449,19 +446,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 }
             }
 
-            if let Attribute::Unparsed(unparsed_attr) = attr
-                && let Some(BuiltinAttribute { duplicates, .. }) =
-                    attr.name().and_then(|name| BUILTIN_ATTRIBUTE_MAP.get(&name))
-            {
-                check_duplicates(
-                    self.tcx,
-                    unparsed_attr.span,
-                    attr,
-                    hir_id,
-                    *duplicates,
-                    &mut seen,
-                );
-            }
             self.check_unused_attribute(hir_id, attr)
         }
 
@@ -1992,67 +1976,6 @@ fn check_mod_attrs(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
 
 pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers { check_mod_attrs, ..*providers };
-}
-
-// FIXME(jdonszelmann): remove, check during parsing
-fn check_duplicates(
-    tcx: TyCtxt<'_>,
-    attr_span: Span,
-    attr: &Attribute,
-    hir_id: HirId,
-    duplicates: AttributeDuplicates,
-    seen: &mut FxHashMap<Symbol, Span>,
-) {
-    use AttributeDuplicates::*;
-    if matches!(duplicates, WarnFollowingWordOnly) && !attr.is_word() {
-        return;
-    }
-    let attr_name = attr.name().unwrap();
-    match duplicates {
-        DuplicatesOk => {}
-        WarnFollowing | FutureWarnFollowing | WarnFollowingWordOnly | FutureWarnPreceding => {
-            match seen.entry(attr_name) {
-                Entry::Occupied(mut entry) => {
-                    let (this, other) = if matches!(duplicates, FutureWarnPreceding) {
-                        let to_remove = entry.insert(attr_span);
-                        (to_remove, attr_span)
-                    } else {
-                        (attr_span, *entry.get())
-                    };
-                    tcx.emit_node_span_lint(
-                        UNUSED_ATTRIBUTES,
-                        hir_id,
-                        this,
-                        errors::UnusedDuplicate {
-                            this,
-                            other,
-                            warning: matches!(
-                                duplicates,
-                                FutureWarnFollowing | FutureWarnPreceding
-                            ),
-                        },
-                    );
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(attr_span);
-                }
-            }
-        }
-        ErrorFollowing | ErrorPreceding => match seen.entry(attr_name) {
-            Entry::Occupied(mut entry) => {
-                let (this, other) = if matches!(duplicates, ErrorPreceding) {
-                    let to_remove = entry.insert(attr_span);
-                    (to_remove, attr_span)
-                } else {
-                    (attr_span, *entry.get())
-                };
-                tcx.dcx().emit_err(errors::UnusedMultiple { this, other, name: attr_name });
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(attr_span);
-            }
-        },
-    }
 }
 
 fn doc_fake_variadic_is_allowed_self_ty(self_ty: &hir::Ty<'_>) -> bool {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -14,7 +14,7 @@ use rustc_attr_parsing::{AttributeParser, Late};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
-use rustc_feature::{AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
+use rustc_feature::BUILTIN_ATTRIBUTE_MAP;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_hir::attrs::{
     AttributeKind, CrateType, DocAttribute, DocInline, EiiDecl, EiiImpl, EiiImplResolution,
@@ -397,51 +397,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             }
                         }
                         [] => unreachable!(),
-                    }
-                }
-            }
-
-            if hir_id != CRATE_HIR_ID {
-                match attr {
-                    Attribute::Parsed(_) => { /* Already validated. */ }
-                    Attribute::Unparsed(attr) => {
-                        // FIXME(jdonszelmann): remove once all crate-level attrs are parsed and caught by
-                        // the above
-                        if let Some(BuiltinAttribute { type_: AttributeType::CrateLevel, .. }) =
-                            attr.path
-                                .segments
-                                .first()
-                                .and_then(|name| BUILTIN_ATTRIBUTE_MAP.get(&name))
-                        {
-                            match attr.style {
-                                ast::AttrStyle::Outer => {
-                                    let attr_span = attr.span;
-                                    let bang_position = self
-                                        .tcx
-                                        .sess
-                                        .source_map()
-                                        .span_until_char(attr_span, '[')
-                                        .shrink_to_hi();
-
-                                    self.tcx.emit_node_span_lint(
-                                        UNUSED_ATTRIBUTES,
-                                        hir_id,
-                                        attr.span,
-                                        errors::OuterCrateLevelAttr {
-                                            suggestion: errors::OuterCrateLevelAttrSuggestion {
-                                                bang_position,
-                                            },
-                                        },
-                                    )
-                                }
-                                ast::AttrStyle::Inner => self.tcx.emit_node_span_lint(
-                                    UNUSED_ATTRIBUTES,
-                                    hir_id,
-                                    attr.span,
-                                    errors::InnerCrateLevelAttr,
-                                ),
-                            }
-                        }
                     }
                 }
             }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -327,30 +327,6 @@ pub(crate) struct InvalidMayDangle {
 }
 
 #[derive(Diagnostic)]
-#[diag("unused attribute")]
-pub(crate) struct UnusedDuplicate {
-    #[suggestion("remove this attribute", code = "", applicability = "machine-applicable")]
-    pub this: Span,
-    #[note("attribute also specified here")]
-    pub other: Span,
-    #[warning(
-        "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
-    )]
-    pub warning: bool,
-}
-
-#[derive(Diagnostic)]
-#[diag("multiple `{$name}` attributes")]
-pub(crate) struct UnusedMultiple {
-    #[primary_span]
-    #[suggestion("remove this attribute", code = "", applicability = "machine-applicable")]
-    pub this: Span,
-    #[note("attribute also specified here")]
-    pub other: Span,
-    pub name: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag("this `#[deprecated]` annotation has no effect")]
 pub(crate) struct DeprecatedAnnotationHasNoEffect {
     #[suggestion(


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154808)*
<!-- homu-ignore:end -->

r? @jdonszelmann 

This cleans up some checks I could find were for non-parsed attributes, and works towards removing BUILTIN_ATTRIBUTES

All commits do one thing and every commit passes tests, so best reviewed commit by commit 