### PR TITLE
Fix ICE for inherent associated type mismatches

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -606,6 +606,9 @@ impl<T> Trait<T> for X {
         ty: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
+        if !matches!(proj_ty.kind, ty::AliasTyKind::Projection { .. }) {
+            return false;
+        }
         let Some(body_owner_def_id) = body_owner_def_id else {
             return false;
         };

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -606,6 +606,7 @@ impl<T> Trait<T> for X {
         ty: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
+        // FIXME(inherent_associated_types): Extend this to support `ty::Inherent`, too.
         if !matches!(proj_ty.kind, ty::AliasTyKind::Projection { .. }) {
             return false;
         }

--- a/tests/ui/associated-inherent-types/next-solver-opaque-inherent-fn-ptr-issue-155204.rs
+++ b/tests/ui/associated-inherent-types/next-solver-opaque-inherent-fn-ptr-issue-155204.rs
@@ -1,0 +1,18 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/155204>
+//@compile-flags: -Znext-solver=globally
+#![feature(inherent_associated_types)]
+pub struct Windows<T> {}
+//~^ ERROR type parameter `T` is never used
+
+impl<T> Windows<fn(&())> {
+    //~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+    type AssocType = impl Send;
+    //~^ ERROR `impl Trait` in associated types is unstable
+    //~| ERROR unconstrained opaque type
+    fn ret(&self) -> Self::AssocType {
+        //~^ ERROR type annotations needed
+        ()
+        //~^ ERROR mismatched types
+    }
+}
+//~^ ERROR `main` function not found

--- a/tests/ui/associated-inherent-types/next-solver-opaque-inherent-fn-ptr-issue-155204.stderr
+++ b/tests/ui/associated-inherent-types/next-solver-opaque-inherent-fn-ptr-issue-155204.stderr
@@ -1,0 +1,63 @@
+error[E0658]: `impl Trait` in associated types is unstable
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:9:22
+   |
+LL |     type AssocType = impl Send;
+   |                      ^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0601]: `main` function not found in crate `next_solver_opaque_inherent_fn_ptr_issue_155204`
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:17:2
+   |
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs`
+
+error[E0392]: type parameter `T` is never used
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:4:20
+   |
+LL | pub struct Windows<T> {}
+   |                    ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:7:6
+   |
+LL | impl<T> Windows<fn(&())> {
+   |      ^ unconstrained type parameter
+
+error[E0282]: type annotations needed
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:12:22
+   |
+LL |     fn ret(&self) -> Self::AssocType {
+   |                      ^^^^^^^^^^^^^^^ cannot infer type
+
+error: unconstrained opaque type
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:9:22
+   |
+LL |     type AssocType = impl Send;
+   |                      ^^^^^^^^^
+   |
+   = note: `AssocType` must be used in combination with a concrete type within the same impl
+
+error[E0308]: mismatched types
+  --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:14:9
+   |
+LL |     fn ret(&self) -> Self::AssocType {
+   |                      --------------- expected `Windows<for<'a> fn(&'a ())>::AssocType` because of return type
+LL |
+LL |         ()
+   |         ^^ types differ
+   |
+   = note: expected associated type `Windows<for<'a> fn(&'a ())>::AssocType`
+                    found unit type `()`
+   = help: consider constraining the associated type `Windows<for<'a> fn(&'a ())>::AssocType` to `()` or calling a method that returns `Windows<for<'a> fn(&'a ())>::AssocType`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0207, E0282, E0308, E0392, E0601, E0658.
+For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/associated-inherent-types/next-solver-opaque-inherent-no-ice.rs
+++ b/tests/ui/associated-inherent-types/next-solver-opaque-inherent-no-ice.rs
@@ -1,0 +1,17 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/154333>
+//@compile-flags: -Znext-solver=globally
+#![feature(inherent_associated_types)]
+
+struct Foo;
+impl<const X: y> Foo {
+    //~^ ERROR the const parameter `X` is not constrained by the impl trait, self type, or predicates
+    //~| ERROR cannot find type `y` in this scope
+    type ImplTrait = impl Clone;
+    //~^ ERROR `impl Trait` in associated types is unstable
+    //~| ERROR unconstrained opaque type
+    fn f() -> Self::ImplTrait {
+        ()
+        //~^ ERROR mismatched types
+    }
+}
+//~^ ERROR `main` function not found

--- a/tests/ui/associated-inherent-types/next-solver-opaque-inherent-no-ice.stderr
+++ b/tests/ui/associated-inherent-types/next-solver-opaque-inherent-no-ice.stderr
@@ -1,0 +1,56 @@
+error[E0425]: cannot find type `y` in this scope
+  --> $DIR/next-solver-opaque-inherent-no-ice.rs:6:15
+   |
+LL | impl<const X: y> Foo {
+   |               ^ not found in this scope
+
+error[E0658]: `impl Trait` in associated types is unstable
+  --> $DIR/next-solver-opaque-inherent-no-ice.rs:9:22
+   |
+LL |     type ImplTrait = impl Clone;
+   |                      ^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0601]: `main` function not found in crate `next_solver_opaque_inherent_no_ice`
+  --> $DIR/next-solver-opaque-inherent-no-ice.rs:16:2
+   |
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/next-solver-opaque-inherent-no-ice.rs`
+
+error[E0207]: the const parameter `X` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/next-solver-opaque-inherent-no-ice.rs:6:6
+   |
+LL | impl<const X: y> Foo {
+   |      ^^^^^^^^^^ unconstrained const parameter
+   |
+   = note: expressions using a const parameter must map each value to a distinct output value
+   = note: proving the result of expressions other than the parameter are unique is not supported
+
+error: unconstrained opaque type
+  --> $DIR/next-solver-opaque-inherent-no-ice.rs:9:22
+   |
+LL |     type ImplTrait = impl Clone;
+   |                      ^^^^^^^^^^
+   |
+   = note: `ImplTrait` must be used in combination with a concrete type within the same impl
+
+error[E0308]: mismatched types
+  --> $DIR/next-solver-opaque-inherent-no-ice.rs:13:9
+   |
+LL |     fn f() -> Self::ImplTrait {
+   |               --------------- expected `Foo::ImplTrait` because of return type
+LL |         ()
+   |         ^^ types differ
+   |
+   = note: expected associated type `Foo::ImplTrait`
+                    found unit type `()`
+   = help: consider constraining the associated type `Foo::ImplTrait` to `()` or calling a method that returns `Foo::ImplTrait`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0207, E0308, E0425, E0601, E0658.
+For more information about an error, try `rustc --explain E0207`.


### PR DESCRIPTION
Avoid projection-only suggestions for inherent associated types.

Closes rust-lang/rust#154333 
Closes rust-lang/rust#155204

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
