### PR TITLE
Add three tests for fixed issues (two ICEs and one coherence checking failure that now passes)

### DIFF
--- a/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.rs
+++ b/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/119382>.
+//!
+//! The `-Wrust-2021-incompatible-closure-captures` lint used to ICE
+//! when applied to erroneous code.
+
+//@ edition: 2018
+//@ compile-flags: -Wrust-2021-incompatible-closure-captures
+
+struct V(&mut i32);
+//~^ ERROR missing lifetime specifier
+
+fn nested(v: &V) {
+    || {
+        V(_somename) = v;
+        //~^ ERROR cannot find value `_somename` in this scope
+        //~| ERROR mismatched types
+        v.0 = 0;
+    };
+}
+
+fn main() {}

--- a/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.stderr
+++ b/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.stderr
@@ -1,0 +1,34 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/closure-2021-captures-lint-field-projection-ice-119382.rs:9:10
+   |
+LL | struct V(&mut i32);
+   |          ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | struct V<'a>(&'a mut i32);
+   |         ++++  ++
+
+error[E0425]: cannot find value `_somename` in this scope
+  --> $DIR/closure-2021-captures-lint-field-projection-ice-119382.rs:14:11
+   |
+LL |         V(_somename) = v;
+   |           ^^^^^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+  --> $DIR/closure-2021-captures-lint-field-projection-ice-119382.rs:14:9
+   |
+LL |         V(_somename) = v;
+   |         ^^^^^^^^^^^^   - this expression has type `&V`
+   |         |
+   |         expected `&V`, found `V`
+   |
+help: consider dereferencing to access the inner value using the `Deref` trait
+   |
+LL |         V(_somename) = &*v;
+   |                        ++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0308, E0425.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/coherence/negative-coherence-ref-negative-impl.rs
+++ b/tests/ui/coherence/negative-coherence-ref-negative-impl.rs
@@ -1,0 +1,15 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/112588>.
+
+//@ check-pass
+
+#![feature(negative_impls, with_negative_coherence)]
+
+trait Trait {}
+impl<T: ?Sized> !Trait for &T {}
+
+trait OtherTrait<T> {}
+
+impl<T: Trait> OtherTrait<T> for T {}
+impl<T, U> OtherTrait<&U> for &T {}
+
+fn main() {}

--- a/tests/ui/generic-associated-types/ice-add-outlives-bounds-unexpected-regions-113793.rs
+++ b/tests/ui/generic-associated-types/ice-add-outlives-bounds-unexpected-regions-113793.rs
@@ -1,0 +1,26 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/113793>.
+//!
+//! Using a GAT with a self-referential lifetime bound (`'b: 'b`) in a
+//! fully-qualified path with anonymous lifetimes used to ICE.
+
+//@ check-pass
+
+trait Gat {
+    type FooArg<'a, 'b: 'b>;
+}
+
+impl Gat for () {
+    type FooArg<'a, 'b: 'b> = &'a dyn ToString;
+}
+
+struct Test;
+
+impl Iterator for Test {
+    type Item = Box<dyn Fn(<() as Gat>::FooArg<'_, '_>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes rust-lang/rust#112588.
Closes rust-lang/rust#113793.
Closes rust-lang/rust#119382.