### PR TITLE
constify `Step for NonZero<u*>`

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -513,7 +513,8 @@ macro_rules! step_nonzero_impls {
         $(
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
-            impl Step for NonZero<$narrower> {
+            #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
+            impl const Step for NonZero<$narrower> {
                 step_nonzero_identical_methods!($narrower);
 
                 #[inline]
@@ -538,7 +539,8 @@ macro_rules! step_nonzero_impls {
         $(
             #[allow(unreachable_patterns)]
             #[unstable(feature = "step_trait", reason = "recently redesigned", issue = "42168")]
-            impl Step for NonZero<$wider> {
+            #[rustc_const_unstable(feature = "step_trait", issue = "42168")]
+            impl const Step for NonZero<$wider> {
                 step_nonzero_identical_methods!($wider);
 
                 #[inline]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -184,7 +184,8 @@ impl_nonzero_auto_trait!(Unpin);
 impl_nonzero_auto_trait!(UnwindSafe);
 
 #[stable(feature = "nonzero", since = "1.28.0")]
-impl<T> Clone for NonZero<T>
+#[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+impl<T> const Clone for NonZero<T>
 where
     T: ZeroablePrimitive,
 {
@@ -202,7 +203,8 @@ impl<T> Copy for NonZero<T> where T: ZeroablePrimitive {}
 
 #[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
-unsafe impl<T> TrivialClone for NonZero<T> where T: ZeroablePrimitive {}
+#[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+unsafe impl<T> const TrivialClone for NonZero<T> where T: ZeroablePrimitive {}
 
 #[stable(feature = "nonzero", since = "1.28.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/42168

I missed the constification of `Step for NonZero<u*>` in the recent https://github.com/rust-lang/rust/pull/153821, so here they are.

Had to constify the `Clone` / `TrivialClone` impls along the way https://github.com/rust-lang/rust/issues/142757 . 
