### PR TITLE
Improve implementation of remove_dir_all_recursive for unix

### DIFF
--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)] // not used on all platforms
+use alloc_crate::collections::VecDeque;
 
 use crate::io::{self, Error, ErrorKind};
 use crate::path::{Path, PathBuf};
@@ -29,27 +30,48 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
 
 pub fn remove_dir_all(path: &Path) -> io::Result<()> {
     let filetype = fs::symlink_metadata(path)?.file_type();
-    if filetype.is_symlink() { fs::remove_file(path) } else { remove_dir_all_recursive(path) }
+    if filetype.is_symlink() { fs::remove_file(path) } else { remove_dir_all_iterative(path) }
 }
 
-fn remove_dir_all_recursive(path: &Path) -> io::Result<()> {
-    for child in fs::read_dir(path)? {
-        let result: io::Result<()> = try {
-            let child = child?;
-            if child.file_type()?.is_dir() {
-                remove_dir_all_recursive(&child.path())?;
-            } else {
-                fs::remove_file(&child.path())?;
+fn remove_dir_all_iterative(path: &Path) -> io::Result<()> {
+    // In unix/windows/solid/hermit/motor/uefi implementation of ReadDir struct, there is a field
+    // called `root` that contains the directory path that we are reading directory entries
+    // from. This makes holding a PathBuf in this tuple redundant since we only need this to remove
+    // the directory when we have exhausted the ReadDir iterator; if we can expose that field
+    // in the ReadDir struct through a method that return &Path, we can reduce memory usage
+    // allocated to this VecDeque.
+
+    let mut directories = VecDeque::new();
+    directories.push_front((path.to_path_buf(), fs::read_dir(path)?));
+
+    while !directories.is_empty() {
+        let (parent_path, read_dir) = &mut directories[0];
+        let child = read_dir.next();
+        if let Some(child) = child {
+            let result: io::Result<()> = try {
+                let child = child?;
+                let child_path = child.path();
+                if child.file_type()?.is_dir() {
+                    let child_readdir = fs::read_dir(&child_path)?;
+                    directories.push_front((child_path, child_readdir));
+                } else {
+                    fs::remove_file(&child_path)?;
+                }
+            };
+
+            // ignore internal NotFound errors to prevent race conditions
+            if let Err(err) = &result
+                && err.kind() != io::ErrorKind::NotFound
+            {
+                return result;
             }
-        };
-        // ignore internal NotFound errors to prevent race conditions
-        if let Err(err) = &result
-            && err.kind() != io::ErrorKind::NotFound
-        {
-            return result;
+        } else {
+            ignore_notfound(fs::remove_dir(parent_path))?;
+            directories.pop_front();
         }
     }
-    ignore_notfound(fs::remove_dir(path))
+
+    Ok(())
 }
 
 pub fn exists(path: &Path) -> io::Result<bool> {


### PR DESCRIPTION
This PR essentially changes the underlying `remove_dir_all` implementation used by unix and I believe uefi platforms from a recursive-based approach to an iterative version. The order it removes directories and files from the recursive version should be preserved in this iterative version. I'm curious if this iterative approach could show any performance improvement over the current recursive based approach that `remove_dir_all` has on unix/uefi platforms.

I also made a comment on how this iterative-based approach is redundantly holding a `PathBuf` in the tuple (which could incur a big allocation cost if we are removing deeply nested directories). This could be optimized if we are able to retrieve a reference to the path that `ReadDir` struct is holding, as it contains this information in its `InnerReadDir`'s `root` field; I believe this would also make the iterative approach allocate less memory than the recursive approach as we would only need the main directory/nested directories `&Path` values when we are removing it.

I can make an ACP for `ReadDir` struct root path to be accessible via a method if that would be appropriate.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
