### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_incremental/src/lib.rs
+++ b/compiler/rustc_incremental/src/lib.rs
@@ -10,9 +10,8 @@ mod errors;
 mod persist;
 
 pub use persist::{
-    LoadResult, copy_cgu_workproduct_to_incr_comp_cache_dir, finalize_session_directory,
-    in_incr_comp_dir, in_incr_comp_dir_sess, load_query_result_cache, save_work_product_index,
-    setup_dep_graph,
+    copy_cgu_workproduct_to_incr_comp_cache_dir, finalize_session_directory, in_incr_comp_dir,
+    in_incr_comp_dir_sess, load_query_result_cache, save_work_product_index, setup_dep_graph,
 };
 use rustc_middle::util::Providers;
 

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -215,9 +215,7 @@ pub(crate) fn prepare_session_directory(
     crate_name: Symbol,
     stable_crate_id: StableCrateId,
 ) {
-    if sess.opts.incremental.is_none() {
-        return;
-    }
+    assert!(sess.opts.incremental.is_some());
 
     let _timer = sess.timer("incr_comp_prepare_session_directory");
 

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -7,8 +7,8 @@ use rustc_data_structures::unord::UnordMap;
 use rustc_hashes::Hash64;
 use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProductMap};
 use rustc_middle::query::on_disk_cache::OnDiskCache;
-use rustc_serialize::Decodable;
-use rustc_serialize::opaque::MemDecoder;
+use rustc_serialize::opaque::{FileEncoder, MemDecoder};
+use rustc_serialize::{Decodable, Encodable};
 use rustc_session::config::IncrementalStateAssertion;
 use rustc_session::{Session, StableCrateId};
 use rustc_span::Symbol;
@@ -16,7 +16,6 @@ use tracing::{debug, warn};
 
 use super::data::*;
 use super::fs::*;
-use super::save::build_dep_graph;
 use super::{file_format, work_product};
 use crate::errors;
 use crate::persist::file_format::{OpenFile, OpenFileError};
@@ -232,4 +231,39 @@ pub fn setup_dep_graph(
         build_dep_graph(sess, prev_graph, prev_work_products)
     })
     .unwrap_or_else(DepGraph::new_disabled)
+}
+
+/// Builds the dependency graph.
+///
+/// This function creates the *staging dep-graph*. When the dep-graph is modified by a query
+/// execution, the new dependency information is not kept in memory but directly
+/// output to this file. `save_dep_graph` then finalizes the staging dep-graph
+/// and moves it to the permanent dep-graph path
+pub(crate) fn build_dep_graph(
+    sess: &Session,
+    prev_graph: Arc<SerializedDepGraph>,
+    prev_work_products: WorkProductMap,
+) -> Option<DepGraph> {
+    if sess.opts.incremental.is_none() {
+        // No incremental compilation.
+        return None;
+    }
+
+    // Stream the dep-graph to an alternate file, to avoid overwriting anything in case of errors.
+    let path_buf = staging_dep_graph_path(sess);
+
+    let mut encoder = match FileEncoder::new(&path_buf) {
+        Ok(encoder) => encoder,
+        Err(err) => {
+            sess.dcx().emit_err(errors::CreateDepGraph { path: &path_buf, err });
+            return None;
+        }
+    };
+
+    file_format::write_file_header(&mut encoder, sess);
+
+    // First encode the commandline arguments hash
+    sess.opts.dep_tracking_hash(false).encode(&mut encoder);
+
+    Some(DepGraph::new(sess, prev_graph, prev_work_products, encoder))
 }

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -1,5 +1,6 @@
 //! Code to load the dep-graph from files.
 
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -22,16 +23,13 @@ use crate::persist::file_format::{OpenFile, OpenFileError};
 
 #[derive(Debug)]
 /// Represents the result of an attempt to load incremental compilation data.
-pub enum LoadResult<T> {
+enum LoadResult {
     /// Loading was successful.
-    Ok {
-        #[allow(missing_docs)]
-        data: T,
-    },
+    Ok { prev_graph: Arc<SerializedDepGraph>, prev_work_products: WorkProductMap },
     /// The file either didn't exist or was produced by an incompatible compiler version.
     DataOutOfDate,
-    /// Loading the dep graph failed.
-    LoadDepGraph(PathBuf, std::io::Error),
+    /// Loading failed due to an unexpected I/O error.
+    IoError { path: PathBuf, err: io::Error },
 }
 
 fn delete_dirty_work_product(sess: &Session, swp: SerializedWorkProduct) {
@@ -39,7 +37,7 @@ fn delete_dirty_work_product(sess: &Session, swp: SerializedWorkProduct) {
     work_product::delete_workproduct_files(sess, &swp.work_product);
 }
 
-fn load_dep_graph(sess: &Session) -> LoadResult<(Arc<SerializedDepGraph>, WorkProductMap)> {
+fn load_dep_graph(sess: &Session) -> LoadResult {
     assert!(sess.opts.incremental.is_some());
 
     let _timer = sess.prof.generic_activity("incr_comp_prepare_load_dep_graph");
@@ -92,7 +90,7 @@ fn load_dep_graph(sess: &Session) -> LoadResult<(Arc<SerializedDepGraph>, WorkPr
 
     match file_format::open_incremental_file(sess, &path) {
         Err(OpenFileError::NotFoundOrHeaderMismatch) => LoadResult::DataOutOfDate,
-        Err(OpenFileError::IoError { err }) => LoadResult::LoadDepGraph(path.to_owned(), err),
+        Err(OpenFileError::IoError { err }) => LoadResult::IoError { path: path.to_owned(), err },
         Ok(OpenFile { mmap, start_pos }) => {
             let Ok(mut decoder) = MemDecoder::new(&mmap, start_pos) else {
                 sess.dcx().emit_warn(errors::CorruptFile { path: &path });
@@ -114,9 +112,9 @@ fn load_dep_graph(sess: &Session) -> LoadResult<(Arc<SerializedDepGraph>, WorkPr
                 return LoadResult::DataOutOfDate;
             }
 
-            let dep_graph = SerializedDepGraph::decode(&mut decoder);
+            let prev_graph = SerializedDepGraph::decode(&mut decoder);
 
-            LoadResult::Ok { data: (dep_graph, prev_work_products) }
+            LoadResult::Ok { prev_graph, prev_work_products }
         }
     }
 }
@@ -150,14 +148,14 @@ pub fn load_query_result_cache(sess: &Session) -> Option<OnDiskCache> {
 
 /// Emits a fatal error if the assertion in `-Zassert-incr-state` doesn't match
 /// the outcome of trying to load previous-session state.
-fn maybe_assert_incr_state(sess: &Session, load_result: &LoadResult<impl Sized>) {
+fn maybe_assert_incr_state(sess: &Session, load_result: &LoadResult) {
     // Return immediately if there's nothing to assert.
     let Some(assertion) = sess.opts.unstable_opts.assert_incr_state else { return };
 
     // Match exhaustively to make sure we don't miss any cases.
     let loaded = match load_result {
         LoadResult::Ok { .. } => true,
-        LoadResult::DataOutOfDate | LoadResult::LoadDepGraph(..) => false,
+        LoadResult::DataOutOfDate | LoadResult::IoError { .. } => false,
     };
 
     match assertion {
@@ -206,7 +204,7 @@ pub fn setup_dep_graph(
     maybe_assert_incr_state(sess, &load_result);
 
     let (prev_graph, prev_work_products) = match load_result {
-        LoadResult::LoadDepGraph(path, err) => {
+        LoadResult::IoError { path, err } => {
             sess.dcx().emit_warn(errors::LoadDepGraph { path, err });
             Default::default()
         }
@@ -216,7 +214,7 @@ pub fn setup_dep_graph(
             }
             Default::default()
         }
-        LoadResult::Ok { data } => data,
+        LoadResult::Ok { prev_graph, prev_work_products } => (prev_graph, prev_work_products),
     };
 
     // Stream the dep-graph to an alternate file, to avoid overwriting anything in case of errors.

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -34,41 +34,13 @@ pub enum LoadResult<T> {
     LoadDepGraph(PathBuf, std::io::Error),
 }
 
-impl<T: Default> LoadResult<T> {
-    /// Accesses the data returned in [`LoadResult::Ok`].
-    pub fn open(self, sess: &Session) -> T {
-        // Emit a fatal error if `-Zassert-incr-state` is present and unsatisfied.
-        maybe_assert_incr_state(sess, &self);
-
-        match self {
-            LoadResult::LoadDepGraph(path, err) => {
-                sess.dcx().emit_warn(errors::LoadDepGraph { path, err });
-                Default::default()
-            }
-            LoadResult::DataOutOfDate => {
-                if let Err(err) = delete_all_session_dir_contents(sess) {
-                    sess.dcx()
-                        .emit_err(errors::DeleteIncompatible { path: dep_graph_path(sess), err });
-                }
-                Default::default()
-            }
-            LoadResult::Ok { data } => data,
-        }
-    }
-}
-
 fn delete_dirty_work_product(sess: &Session, swp: SerializedWorkProduct) {
     debug!("delete_dirty_work_product({:?})", swp);
     work_product::delete_workproduct_files(sess, &swp.work_product);
 }
 
 fn load_dep_graph(sess: &Session) -> LoadResult<(Arc<SerializedDepGraph>, WorkProductMap)> {
-    let prof = sess.prof.clone();
-
-    if sess.opts.incremental.is_none() {
-        // No incremental compilation.
-        return LoadResult::Ok { data: Default::default() };
-    }
+    assert!(sess.opts.incremental.is_some());
 
     let _timer = sess.prof.generic_activity("incr_comp_prepare_load_dep_graph");
 
@@ -116,7 +88,7 @@ fn load_dep_graph(sess: &Session) -> LoadResult<(Arc<SerializedDepGraph>, WorkPr
         }
     }
 
-    let _prof_timer = prof.generic_activity("incr_comp_load_dep_graph");
+    let _prof_timer = sess.prof.generic_activity("incr_comp_load_dep_graph");
 
     match file_format::open_incremental_file(sess, &path) {
         Err(OpenFileError::NotFoundOrHeaderMismatch) => LoadResult::DataOutOfDate,
@@ -202,68 +174,64 @@ fn maybe_assert_incr_state(sess: &Session, load_result: &LoadResult<impl Sized>)
     }
 }
 
-/// Setups the dependency graph by loading an existing graph from disk and set up streaming of a
-/// new graph to an incremental session directory.
+/// Loads the previous session's dependency graph from disk if possible, and
+/// sets up streaming output for the current session's dep graph data into an
+/// incremental session directory.
+///
+/// In non-incremental mode, a dummy dep graph is returned immediately.
 pub fn setup_dep_graph(
     sess: &Session,
     crate_name: Symbol,
     stable_crate_id: StableCrateId,
 ) -> DepGraph {
+    if sess.opts.incremental.is_none() {
+        return DepGraph::new_disabled();
+    }
+
     // `load_dep_graph` can only be called after `prepare_session_directory`.
     prepare_session_directory(sess, crate_name, stable_crate_id);
+    // Try to load the previous session's dep graph and work products.
+    let load_result = load_dep_graph(sess);
 
-    let res = sess.opts.build_dep_graph().then(|| load_dep_graph(sess));
+    sess.time("incr_comp_garbage_collect_session_directories", || {
+        if let Err(e) = garbage_collect_session_directories(sess) {
+            warn!(
+                "Error while trying to garbage collect incremental compilation \
+                cache directory: {e}",
+            );
+        }
+    });
 
-    if sess.opts.incremental.is_some() {
-        sess.time("incr_comp_garbage_collect_session_directories", || {
-            if let Err(e) = garbage_collect_session_directories(sess) {
-                warn!(
-                    "Error while trying to garbage collect incremental \
-                     compilation cache directory: {}",
-                    e
-                );
+    // Emit a fatal error if `-Zassert-incr-state` is present and unsatisfied.
+    maybe_assert_incr_state(sess, &load_result);
+
+    let (prev_graph, prev_work_products) = match load_result {
+        LoadResult::LoadDepGraph(path, err) => {
+            sess.dcx().emit_warn(errors::LoadDepGraph { path, err });
+            Default::default()
+        }
+        LoadResult::DataOutOfDate => {
+            if let Err(err) = delete_all_session_dir_contents(sess) {
+                sess.dcx().emit_err(errors::DeleteIncompatible { path: dep_graph_path(sess), err });
             }
-        });
-    }
-
-    res.and_then(|result| {
-        let (prev_graph, prev_work_products) = result.open(sess);
-        build_dep_graph(sess, prev_graph, prev_work_products)
-    })
-    .unwrap_or_else(DepGraph::new_disabled)
-}
-
-/// Builds the dependency graph.
-///
-/// This function creates the *staging dep-graph*. When the dep-graph is modified by a query
-/// execution, the new dependency information is not kept in memory but directly
-/// output to this file. `save_dep_graph` then finalizes the staging dep-graph
-/// and moves it to the permanent dep-graph path
-pub(crate) fn build_dep_graph(
-    sess: &Session,
-    prev_graph: Arc<SerializedDepGraph>,
-    prev_work_products: WorkProductMap,
-) -> Option<DepGraph> {
-    if sess.opts.incremental.is_none() {
-        // No incremental compilation.
-        return None;
-    }
+            Default::default()
+        }
+        LoadResult::Ok { data } => data,
+    };
 
     // Stream the dep-graph to an alternate file, to avoid overwriting anything in case of errors.
     let path_buf = staging_dep_graph_path(sess);
 
-    let mut encoder = match FileEncoder::new(&path_buf) {
-        Ok(encoder) => encoder,
-        Err(err) => {
-            sess.dcx().emit_err(errors::CreateDepGraph { path: &path_buf, err });
-            return None;
-        }
-    };
+    let mut encoder = FileEncoder::new(&path_buf).unwrap_or_else(|err| {
+        // We're in incremental mode but couldn't set up streaming output of the dep graph.
+        // Exit immediately instead of continuing in an inconsistent and untested state.
+        sess.dcx().emit_fatal(errors::CreateDepGraph { path: &path_buf, err })
+    });
 
     file_format::write_file_header(&mut encoder, sess);
 
     // First encode the commandline arguments hash
     sess.opts.dep_tracking_hash(false).encode(&mut encoder);
 
-    Some(DepGraph::new(sess, prev_graph, prev_work_products, encoder))
+    DepGraph::new(sess, prev_graph, prev_work_products, encoder)
 }

--- a/compiler/rustc_incremental/src/persist/mod.rs
+++ b/compiler/rustc_incremental/src/persist/mod.rs
@@ -11,7 +11,7 @@ mod save;
 mod work_product;
 
 pub use fs::{finalize_session_directory, in_incr_comp_dir, in_incr_comp_dir_sess};
-pub use load::{LoadResult, load_query_result_cache, setup_dep_graph};
+pub use load::{load_query_result_cache, setup_dep_graph};
 pub(crate) use save::save_dep_graph;
 pub use save::save_work_product_index;
 pub use work_product::copy_cgu_workproduct_to_incr_comp_cache_dir;

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -1,11 +1,8 @@
 use std::fs;
-use std::sync::Arc;
 
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sync::par_join;
-use rustc_middle::dep_graph::{
-    DepGraph, SerializedDepGraph, WorkProduct, WorkProductId, WorkProductMap,
-};
+use rustc_middle::dep_graph::{DepGraph, WorkProduct, WorkProductId};
 use rustc_middle::query::on_disk_cache;
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::Encodable as RustcEncodable;
@@ -148,39 +145,4 @@ fn encode_work_product_index(
         .collect();
 
     serialized_products.encode(encoder)
-}
-
-/// Builds the dependency graph.
-///
-/// This function creates the *staging dep-graph*. When the dep-graph is modified by a query
-/// execution, the new dependency information is not kept in memory but directly
-/// output to this file. `save_dep_graph` then finalizes the staging dep-graph
-/// and moves it to the permanent dep-graph path
-pub(crate) fn build_dep_graph(
-    sess: &Session,
-    prev_graph: Arc<SerializedDepGraph>,
-    prev_work_products: WorkProductMap,
-) -> Option<DepGraph> {
-    if sess.opts.incremental.is_none() {
-        // No incremental compilation.
-        return None;
-    }
-
-    // Stream the dep-graph to an alternate file, to avoid overwriting anything in case of errors.
-    let path_buf = staging_dep_graph_path(sess);
-
-    let mut encoder = match FileEncoder::new(&path_buf) {
-        Ok(encoder) => encoder,
-        Err(err) => {
-            sess.dcx().emit_err(errors::CreateDepGraph { path: &path_buf, err });
-            return None;
-        }
-    };
-
-    file_format::write_file_header(&mut encoder, sess);
-
-    // First encode the commandline arguments hash
-    sess.opts.dep_tracking_hash(false).encode(&mut encoder);
-
-    Some(DepGraph::new(sess, prev_graph, prev_work_products, encoder))
 }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -121,19 +121,7 @@ impl DepNode {
     where
         Key: DepNodeKey<'tcx>,
     {
-        let dep_node = DepNode { kind, key_fingerprint: key.to_fingerprint(tcx).into() };
-
-        #[cfg(debug_assertions)]
-        {
-            if !tcx.key_fingerprint_style(kind).is_maybe_recoverable()
-                && (tcx.sess.opts.unstable_opts.incremental_info
-                    || tcx.sess.opts.unstable_opts.query_dep_graph)
-            {
-                tcx.dep_graph.register_dep_node_debug_str(dep_node, || key.to_debug_str(tcx));
-            }
-        }
-
-        dep_node
+        DepNode { kind, key_fingerprint: key.to_fingerprint(tcx).into() }
     }
 
     /// Construct a DepNode from the given DepKind and DefPathHash. This
@@ -151,24 +139,16 @@ impl DepNode {
 
 impl fmt::Debug for DepNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}(", self.kind)?;
-
         tls::with_opt(|opt_tcx| {
-            if let Some(tcx) = opt_tcx {
-                if let Some(def_id) = self.extract_def_id(tcx) {
-                    write!(f, "{}", tcx.def_path_debug_str(def_id))?;
-                } else if let Some(ref s) = tcx.dep_graph.dep_node_debug_str(*self) {
-                    write!(f, "{s}")?;
-                } else {
-                    write!(f, "{}", self.key_fingerprint)?;
-                }
+            if let Some(tcx) = opt_tcx
+                && let Some(def_id) = self.extract_def_id(tcx)
+            {
+                write!(f, "{:?}({})", self.kind, tcx.def_path_debug_str(def_id))?;
             } else {
-                write!(f, "{}", self.key_fingerprint)?;
+                write!(f, "{:?}({})", self.kind, self.key_fingerprint)?;
             }
             Ok(())
-        })?;
-
-        write!(f, ")")
+        })
     }
 }
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node_key.rs
@@ -18,8 +18,6 @@ pub trait DepNodeKey<'tcx>: Debug + Sized {
     /// in `DepNode`.
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint;
 
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String;
-
     /// This method tries to recover the query key from the given `DepNode`,
     /// something which is needed when forcing `DepNode`s during red-green
     /// evaluation. The query system will only call this method if
@@ -46,14 +44,6 @@ where
             self.hash_stable(&mut hcx, &mut hasher);
             hasher.finish()
         })
-    }
-
-    #[inline(always)]
-    default fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        // Make sure to print dep node params with reduced queries since printing
-        // may themselves call queries, which may lead to (possibly untracked!)
-        // query cycles.
-        tcx.with_reduced_queries(|| format!("{self:?}"))
     }
 
     #[inline(always)]
@@ -91,11 +81,6 @@ impl<'tcx> DepNodeKey<'tcx> for DefId {
     }
 
     #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        tcx.def_path_str(*self)
-    }
-
-    #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
         dep_node.extract_def_id(tcx)
     }
@@ -110,11 +95,6 @@ impl<'tcx> DepNodeKey<'tcx> for LocalDefId {
     #[inline(always)]
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
         self.to_def_id().to_fingerprint(tcx)
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
     }
 
     #[inline(always)]
@@ -135,11 +115,6 @@ impl<'tcx> DepNodeKey<'tcx> for OwnerId {
     }
 
     #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
-    }
-
-    #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
         dep_node.extract_def_id(tcx).map(|id| OwnerId { def_id: id.expect_local() })
     }
@@ -155,11 +130,6 @@ impl<'tcx> DepNodeKey<'tcx> for CrateNum {
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
         let def_id = self.as_def_id();
         def_id.to_fingerprint(tcx)
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        tcx.crate_name(*self).to_string()
     }
 
     #[inline(always)]
@@ -186,13 +156,6 @@ impl<'tcx> DepNodeKey<'tcx> for (DefId, DefId) {
 
         def_path_hash_0.0.combine(def_path_hash_1.0)
     }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        let (def_id_0, def_id_1) = *self;
-
-        format!("({}, {})", tcx.def_path_debug_str(def_id_0), tcx.def_path_debug_str(def_id_1))
-    }
 }
 
 impl<'tcx> DepNodeKey<'tcx> for HirId {
@@ -213,12 +176,6 @@ impl<'tcx> DepNodeKey<'tcx> for HirId {
             def_path_hash.local_hash(),
             local_id.as_u32() as u64,
         )
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        let HirId { owner, local_id } = *self;
-        format!("{}.{}", tcx.def_path_str(owner), local_id.as_u32())
     }
 
     #[inline(always)]
@@ -250,11 +207,6 @@ impl<'tcx> DepNodeKey<'tcx> for ModDefId {
     }
 
     #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
-    }
-
-    #[inline(always)]
     fn try_recover_key(tcx: TyCtxt<'tcx>, dep_node: &DepNode) -> Option<Self> {
         DefId::try_recover_key(tcx, dep_node).map(ModDefId::new_unchecked)
     }
@@ -269,11 +221,6 @@ impl<'tcx> DepNodeKey<'tcx> for LocalModDefId {
     #[inline(always)]
     fn to_fingerprint(&self, tcx: TyCtxt<'tcx>) -> Fingerprint {
         self.to_def_id().to_fingerprint(tcx)
-    }
-
-    #[inline(always)]
-    fn to_debug_str(&self, tcx: TyCtxt<'tcx>) -> String {
-        self.to_def_id().to_debug_str(tcx)
     }
 
     #[inline(always)]

--- a/compiler/rustc_middle/src/dep_graph/graph.rs
+++ b/compiler/rustc_middle/src/dep_graph/graph.rs
@@ -115,8 +115,6 @@ pub struct DepGraphData {
     /// this map. We can later look for and extract that data.
     previous_work_products: WorkProductMap,
 
-    dep_node_debug: Lock<FxHashMap<DepNode, String>>,
-
     /// Used by incremental compilation tests to assert that
     /// a particular query result was decoded from disk
     /// (not just marked green)
@@ -173,7 +171,6 @@ impl DepGraph {
         DepGraph {
             data: Some(Arc::new(DepGraphData {
                 previous_work_products: prev_work_products,
-                dep_node_debug: Default::default(),
                 current,
                 previous: prev_graph,
                 colors,
@@ -848,31 +845,6 @@ impl DepGraph {
             .lock()
             .iter()
             .any(|node| node.kind == dep_kind)
-    }
-
-    #[cfg(debug_assertions)]
-    #[inline(always)]
-    pub(crate) fn register_dep_node_debug_str<F>(&self, dep_node: DepNode, debug_str_gen: F)
-    where
-        F: FnOnce() -> String,
-    {
-        // Early queries (e.g., `-Z query-dep-graph` on empty crates) can reach here
-        // before the graph is initialized. Return early to prevent an ICE.
-        let data = match &self.data {
-            Some(d) => d,
-            None => return,
-        };
-        let dep_node_debug = &data.dep_node_debug;
-
-        if dep_node_debug.borrow().contains_key(&dep_node) {
-            return;
-        }
-        let debug_str = self.with_ignore(debug_str_gen);
-        dep_node_debug.borrow_mut().insert(dep_node, debug_str);
-    }
-
-    pub(crate) fn dep_node_debug_str(&self, dep_node: DepNode) -> Option<String> {
-        self.data.as_ref()?.dep_node_debug.borrow().get(&dep_node).cloned()
     }
 
     fn node_color(&self, dep_node: &DepNode) -> DepNodeColor {

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -14,7 +14,7 @@ use self::graph::{MarkFrame, print_markframe_trace};
 pub use self::retained::RetainedDepGraph;
 pub use self::serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 pub use crate::dep_graph::debug::{DepNodeFilter, EdgeFilter};
-use crate::ty::print::with_reduced_queries;
+pub use crate::ty::print::with_reduced_queries;
 use crate::ty::{self, TyCtxt};
 
 mod debug;
@@ -83,10 +83,6 @@ impl<'tcx> TyCtxt<'tcx> {
     #[inline]
     pub fn dep_kind_vtable(self, dk: DepKind) -> &'tcx DepKindVTable<'tcx> {
         &self.dep_kind_vtables[dk.as_usize()]
-    }
-
-    fn with_reduced_queries<T>(self, f: impl FnOnce() -> T) -> T {
-        with_reduced_queries!(f())
     }
 
     #[inline(always)]

--- a/tests/ui/borrowck/async-trait-proposes-let-binding.rs
+++ b/tests/ui/borrowck/async-trait-proposes-let-binding.rs
@@ -1,0 +1,16 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/119686>.
+//@ edition: 2024
+struct A;
+pub trait Trait1 {
+    async fn func() -> ();
+}
+
+impl Trait1 for A {
+    async fn func() -> () {
+        let p = std::convert::identity(&("".to_string()));
+        //~^ ERROR temporary value dropped while borrowed
+        let _q = p;
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/async-trait-proposes-let-binding.stderr
+++ b/tests/ui/borrowck/async-trait-proposes-let-binding.stderr
@@ -1,0 +1,16 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/async-trait-proposes-let-binding.rs:10:41
+   |
+LL |         let p = std::convert::identity(&("".to_string()));
+   |                                         ^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                                         |
+   |                                         creates a temporary value which is freed while still in use
+LL |
+LL |         let _q = p;
+   |                  - borrow later used here
+   |
+   = note: consider using a `let` binding to create a longer lived value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.

--- a/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.rs
+++ b/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/119382>.
+//!
+//! The `-Wrust-2021-incompatible-closure-captures` lint used to ICE
+//! when applied to erroneous code.
+
+//@ edition: 2018
+//@ compile-flags: -Wrust-2021-incompatible-closure-captures
+
+struct V(&mut i32);
+//~^ ERROR missing lifetime specifier
+
+fn nested(v: &V) {
+    || {
+        V(_somename) = v;
+        //~^ ERROR cannot find value `_somename` in this scope
+        //~| ERROR mismatched types
+        v.0 = 0;
+    };
+}
+
+fn main() {}

--- a/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.stderr
+++ b/tests/ui/closures/closure-2021-captures-lint-field-projection-ice-119382.stderr
@@ -1,0 +1,34 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/closure-2021-captures-lint-field-projection-ice-119382.rs:9:10
+   |
+LL | struct V(&mut i32);
+   |          ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | struct V<'a>(&'a mut i32);
+   |         ++++  ++
+
+error[E0425]: cannot find value `_somename` in this scope
+  --> $DIR/closure-2021-captures-lint-field-projection-ice-119382.rs:14:11
+   |
+LL |         V(_somename) = v;
+   |           ^^^^^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+  --> $DIR/closure-2021-captures-lint-field-projection-ice-119382.rs:14:9
+   |
+LL |         V(_somename) = v;
+   |         ^^^^^^^^^^^^   - this expression has type `&V`
+   |         |
+   |         expected `&V`, found `V`
+   |
+help: consider dereferencing to access the inner value using the `Deref` trait
+   |
+LL |         V(_somename) = &*v;
+   |                        ++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0308, E0425.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/coherence/negative-coherence-ref-negative-impl.rs
+++ b/tests/ui/coherence/negative-coherence-ref-negative-impl.rs
@@ -1,0 +1,15 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/112588>.
+
+//@ check-pass
+
+#![feature(negative_impls, with_negative_coherence)]
+
+trait Trait {}
+impl<T: ?Sized> !Trait for &T {}
+
+trait OtherTrait<T> {}
+
+impl<T: Trait> OtherTrait<T> for T {}
+impl<T, U> OtherTrait<&U> for &T {}
+
+fn main() {}

--- a/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.rs
+++ b/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.rs
@@ -1,11 +1,17 @@
 #![feature(extern_item_impls)]
 
 // Regression test for <https://github.com/rust-lang/rust/issues/153502>:
+// Regression test for <https://github.com/rust-lang/rust/issues/152893>:
 
 struct Foo(i32);
+struct Bar;
 
 #[eii]
 pub fn Foo(x: u64) {}
 //~^ ERROR the name `Foo` is defined multiple times
+
+#[eii]
+pub fn Bar(x: u64) {}
+//~^ ERROR the name `Bar` is defined multiple times
 
 fn main() {}

--- a/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.stderr
+++ b/tests/ui/eii/duplicate/eii-declaration-conflicts-with-constructor.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/eii-declaration-conflicts-with-constructor.rs:8:1
+  --> $DIR/eii-declaration-conflicts-with-constructor.rs:10:1
    |
 LL | struct Foo(i32);
    | ---------------- previous definition of the value `Foo` here
@@ -9,6 +9,17 @@ LL | pub fn Foo(x: u64) {}
    |
    = note: `Foo` must be defined only once in the value namespace of this module
 
-error: aborting due to 1 previous error
+error[E0428]: the name `Bar` is defined multiple times
+  --> $DIR/eii-declaration-conflicts-with-constructor.rs:14:1
+   |
+LL | struct Bar;
+   | ----------- previous definition of the value `Bar` here
+...
+LL | pub fn Bar(x: u64) {}
+   | ^^^^^^^^^^^^^^^^^^ `Bar` redefined here
+   |
+   = note: `Bar` must be defined only once in the value namespace of this module
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0428`.

--- a/tests/ui/generic-associated-types/ice-add-outlives-bounds-unexpected-regions-113793.rs
+++ b/tests/ui/generic-associated-types/ice-add-outlives-bounds-unexpected-regions-113793.rs
@@ -1,0 +1,26 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/113793>.
+//!
+//! Using a GAT with a self-referential lifetime bound (`'b: 'b`) in a
+//! fully-qualified path with anonymous lifetimes used to ICE.
+
+//@ check-pass
+
+trait Gat {
+    type FooArg<'a, 'b: 'b>;
+}
+
+impl Gat for () {
+    type FooArg<'a, 'b: 'b> = &'a dyn ToString;
+}
+
+struct Test;
+
+impl Iterator for Test {
+    type Item = Box<dyn Fn(<() as Gat>::FooArg<'_, '_>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154529 (Make `setup_dep_graph` incremental-only and more straightforward )
 - rust-lang/rust#154565 (Remove `DepGraphData::dep_node_debug`.)
 - rust-lang/rust#154799 (add regression test for EII declaration conflicting with constructor)
 - rust-lang/rust#154807 (add regression test for 119686)
 - rust-lang/rust#154821 (Add three tests for fixed issues (two ICEs and one coherence checking failure that now passes))

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154529,154565,154799,154807,154821)
<!-- homu-ignore:end -->

