### PR TITLE
allow `windows-gnu` targets to embed gdb visualizer scripts

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -99,7 +99,7 @@ pub(crate) fn opts() -> TargetOptions {
         late_link_args_dynamic,
         late_link_args_static,
         abi_return_struct_as_int: true,
-        emit_debug_gdb_scripts: false,
+        emit_debug_gdb_scripts: true,
         requires_uwtable: true,
         eh_frame_header: false,
         debuginfo_kind: DebuginfoKind::Dwarf,

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -42,7 +42,7 @@ pub(crate) fn opts() -> TargetOptions {
         link_self_contained: LinkSelfContainedDefault::InferredForMingw,
         late_link_args,
         abi_return_struct_as_int: true,
-        emit_debug_gdb_scripts: false,
+        emit_debug_gdb_scripts: true,
         requires_uwtable: true,
         eh_frame_header: false,
         no_default_libraries: false,


### PR DESCRIPTION
Pretty straigthforward, works exactly the same as any other `*-gnu` target so i'm not sure why it wasn't enabled already.