### PR TITLE
Fix `compiletest` path-related issues on Windows

### DIFF
--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -252,7 +252,6 @@ def main():
         print("Aborting.", file=sys.stderr)
         sys.exit(1)
     finally:
-        debugger.Terminate()
         script_file.close()
 
 

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -455,6 +455,8 @@ impl TestCx<'_> {
         // Path containing `lldb_batchmode.py`, so that the `script` command can import it.
         let rust_pp_module_abs_path = self.config.src_root.join("src/etc");
         let pythonpath = with_pythonpath_prepended(&rust_pp_module_abs_path);
+        // make sure `PATH` points to all the dlls necessary to run the debugee
+        let path = prepend_to_path(&self.config.target_run_lib_path);
 
         let mut cmd = Command::new(lldb);
         cmd.arg("--one-line")
@@ -462,7 +464,8 @@ impl TestCx<'_> {
             .env("LLDB_BATCHMODE_TARGET_PATH", test_executable)
             .env("LLDB_BATCHMODE_SCRIPT_PATH", debugger_script)
             .env("PYTHONUNBUFFERED", "1") // Help debugging #78665
-            .env("PYTHONPATH", pythonpath);
+            .env("PYTHONPATH", pythonpath)
+            .env("PATH", path);
 
         self.run_command_to_procres(&mut cmd)
     }
@@ -471,7 +474,29 @@ impl TestCx<'_> {
 fn with_pythonpath_prepended(some_path: &Utf8Path) -> String {
     // FIXME: we are propagating `PYTHONPATH` from the environment, not a compiletest flag!
     if let Ok(pp) = std::env::var("PYTHONPATH") {
-        format!("{pp}:{some_path}")
+        #[cfg(target_os = "windows")]
+        {
+            format!("{pp};{some_path}")
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            format!("{pp}:{some_path}")
+        }
+    } else {
+        some_path.to_string()
+    }
+}
+
+fn prepend_to_path(some_path: &Utf8Path) -> String {
+    if let Ok(path) = std::env::var("PATH") {
+        #[cfg(target_os = "windows")]
+        {
+            format!("{some_path};{path}")
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            format!("{some_path}:{path}")
+        }
     } else {
         some_path.to_string()
     }


### PR DESCRIPTION
fixes the issues mentioned [here](https://github.com/rust-lang/rust/pull/147552#issuecomment-4178431869). With these changes I'm able to run `./x test tests/debuginfo` on `x86_64-pc-windows-gnu` without any issues.

As mentioned in the link though, there are 3 tests that currently fail when run on windows, but that pass on whatever CI targets actually run `tests/debuginfo`.

I'm not sure if `target_run_lib_path` really needs to be prepended on all targets (it absolutely does for Windows though), but i figure it can't hurt. Also made sure the path separators are correct per-platform.

The `lldb_batchmode` change prevents the tests from hanging forever. I'm not 100% sure why this hasn't been a problem so far. Maybe just due to the version of LLDB used on the test runner? I haven't done too much testing, but the situation is...weird. I opened [an issue about it in the LLVM repo](https://github.com/llvm/llvm-project/issues/190516).


