### PR TITLE
Promote `char::is_case_ignorable` from perma-unstable to unstable

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -93,6 +93,7 @@
 #![feature(async_iterator)]
 #![feature(bstr)]
 #![feature(bstr_internals)]
+#![feature(case_ignorable)]
 #![feature(cast_maybe_uninit)]
 #![feature(cell_get_cloned)]
 #![feature(char_internals)]

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1074,18 +1074,20 @@ impl char {
         self > '\u{02FF}' && unicode::Grapheme_Extend(self)
     }
 
-    /// Returns `true` if this `char` has the `Case_Ignorable` property.
+    /// Returns `true` if this `char` has the `Case_Ignorable` property. This narrow-use property
+    /// is used to implement context-dependent casing for the Greek letter sigma (uppercase Σ),
+    /// which has two lowercase forms.
     ///
-    /// `Case_Ignorable` is described in Chapter 4 (Character Properties) of the [Unicode Standard] and
-    /// specified in the [Unicode Character Database][ucd] [`DerivedCoreProperties.txt`].
+    /// `Case_Ignorable` is [described][D136] in Chapter 3 (Conformance) of the Unicode Core Specification,
+    /// and specified in the [Unicode Character Database][ucd] [`DerivedCoreProperties.txt`];
+    /// see those resources for more information.
     ///
-    /// [Unicode Standard]: https://www.unicode.org/versions/latest/
+    /// [D136]: https://www.unicode.org/versions/latest/core-spec/chapter-3/#G63116
     /// [ucd]: https://www.unicode.org/reports/tr44/
     /// [`DerivedCoreProperties.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt
     #[must_use]
     #[inline]
-    #[doc(hidden)]
-    #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
+    #[unstable(feature = "case_ignorable", issue = "154848")]
     pub fn is_case_ignorable(self) -> bool {
         if self.is_ascii() {
             matches!(self, '\'' | '.' | ':' | '^' | '`')


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

(Take two of https://github.com/rust-lang/rust/pull/154658, which was closed when GitHub Codespaces somehow managed to squash the entire commit history of rust-lang/rust into one commit)

This function is currently used in the implementation of `str::to_lowercase()`. There is no reason to restrict it to the stdlib, though. Reimplementations of string casing for types other than `str` -> `String` shouldn't need to waste space with a duplicate copy of this table.

@rustbot label A-unicode T-libs-api

r? @Mark-Simulacrum