### PR TITLE
ast_validation: scalable vectors okay for rustdoc

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1379,7 +1379,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             this.dcx()
                                 .emit_err(errors::ScalableVectorNotTupleStruct { span: item.span });
                         }
-                        if !self.sess.target.arch.supports_scalable_vectors() {
+                        if !self.sess.target.arch.supports_scalable_vectors()
+                            && !self.sess.opts.actually_rustdoc
+                        {
                             this.dcx().emit_err(errors::ScalableVectorBadArch { span: attr.span });
                         }
                     }


### PR DESCRIPTION
Scalable vector types in `core_arch` are cfg'd for aarch64 and for rustdoc, which can successfully document these types given any `--target` (`core_arch` CI uses `i686-unknown-linux-gnu`) - this shouldn't trigger the "scalable vectors not supported on arch" error.

This fixes the CI failure in rust-lang/stdarch#2071.