### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -175,8 +175,8 @@ fn exported_non_generic_symbols_provider_local<'tcx>(
 
     // FIXME: Sorting this is unnecessary since we are sorting later anyway.
     //        Can we skip the later sorting?
-    let sorted = tcx.with_stable_hashing_context(|hcx| {
-        tcx.reachable_non_generics(LOCAL_CRATE).to_sorted(&hcx, true)
+    let sorted = tcx.with_stable_hashing_context(|mut hcx| {
+        tcx.reachable_non_generics(LOCAL_CRATE).to_sorted(&mut hcx, true)
     });
 
     let mut symbols: Vec<_> =

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -50,7 +50,7 @@ pub trait HashStable<Hcx> {
 /// bringing maps into a predictable order before hashing them.
 pub trait ToStableHashKey<Hcx> {
     type KeyType: Ord + Sized + HashStable<Hcx>;
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType;
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Self::KeyType;
 }
 
 /// Trait for marking a type as having a sort order that is
@@ -427,7 +427,7 @@ impl StableOrd for String {
 impl<Hcx> ToStableHashKey<Hcx> for String {
     type KeyType = String;
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> Self::KeyType {
         self.clone()
     }
 }
@@ -435,7 +435,7 @@ impl<Hcx> ToStableHashKey<Hcx> for String {
 impl<Hcx, T1: ToStableHashKey<Hcx>, T2: ToStableHashKey<Hcx>> ToStableHashKey<Hcx> for (T1, T2) {
     type KeyType = (T1::KeyType, T2::KeyType);
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Self::KeyType {
         (self.0.to_stable_hash_key(hcx), self.1.to_stable_hash_key(hcx))
     }
 }

--- a/compiler/rustc_data_structures/src/unord.rs
+++ b/compiler/rustc_data_structures/src/unord.rs
@@ -143,7 +143,7 @@ impl<'a, T: Copy + 'a, I: Iterator<Item = &'a T>> UnordItems<&'a T, I> {
 
 impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     #[inline]
-    pub fn into_sorted<Hcx>(self, hcx: &Hcx) -> Vec<T>
+    pub fn into_sorted<Hcx>(self, hcx: &mut Hcx) -> Vec<T>
     where
         T: ToStableHashKey<Hcx>,
     {
@@ -168,7 +168,7 @@ impl<T, I: Iterator<Item = T>> UnordItems<T, I> {
     }
 
     #[inline]
-    pub fn collect_sorted<Hcx, C>(self, hcx: &Hcx, cache_sort_key: bool) -> C
+    pub fn collect_sorted<Hcx, C>(self, hcx: &mut Hcx, cache_sort_key: bool) -> C
     where
         T: ToStableHashKey<Hcx>,
         C: FromIterator<T> + BorrowMut<[T]>,
@@ -315,7 +315,7 @@ impl<V: Eq + Hash> UnordSet<V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `V` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn to_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> Vec<&V>
+    pub fn to_sorted<Hcx>(&self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<&V>
     where
         V: ToStableHashKey<Hcx>,
     {
@@ -357,7 +357,7 @@ impl<V: Eq + Hash> UnordSet<V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `V` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn into_sorted<Hcx>(self, hcx: &Hcx, cache_sort_key: bool) -> Vec<V>
+    pub fn into_sorted<Hcx>(self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<V>
     where
         V: ToStableHashKey<Hcx>,
     {
@@ -555,7 +555,7 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn to_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> Vec<(&K, &V)>
+    pub fn to_sorted<Hcx>(&self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<(&K, &V)>
     where
         K: ToStableHashKey<Hcx>,
     {
@@ -582,7 +582,7 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn into_sorted<Hcx>(self, hcx: &Hcx, cache_sort_key: bool) -> Vec<(K, V)>
+    pub fn into_sorted<Hcx>(self, hcx: &mut Hcx, cache_sort_key: bool) -> Vec<(K, V)>
     where
         K: ToStableHashKey<Hcx>,
     {
@@ -610,7 +610,11 @@ impl<K: Eq + Hash, V> UnordMap<K, V> {
     /// `cache_sort_key` when the [ToStableHashKey::to_stable_hash_key] implementation
     /// for `K` is expensive (e.g. a `DefId -> DefPathHash` lookup).
     #[inline]
-    pub fn values_sorted<Hcx>(&self, hcx: &Hcx, cache_sort_key: bool) -> impl Iterator<Item = &V>
+    pub fn values_sorted<Hcx>(
+        &self,
+        hcx: &mut Hcx,
+        cache_sort_key: bool,
+    ) -> impl Iterator<Item = &V>
     where
         K: ToStableHashKey<Hcx>,
     {
@@ -710,7 +714,7 @@ impl<Hcx, V: Hash + Eq + HashStable<Hcx>> HashStable<Hcx> for UnordBag<V> {
 
 #[inline]
 fn to_sorted_vec<Hcx, T, K, I>(
-    hcx: &Hcx,
+    hcx: &mut Hcx,
     iter: I,
     cache_sort_key: bool,
     extract_key: fn(&T) -> &K,

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -716,7 +716,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for Namespace {
     type KeyType = Namespace;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> Namespace {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> Namespace {
         *self
     }
 }

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -13,7 +13,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for BodyId {
     type KeyType = (DefPathHash, ItemLocalId);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> (DefPathHash, ItemLocalId) {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> (DefPathHash, ItemLocalId) {
         let BodyId { hir_id } = *self;
         hir_id.to_stable_hash_key(hcx)
     }
@@ -23,7 +23,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }
@@ -32,7 +32,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for TraitItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }
@@ -41,7 +41,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ImplItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }
@@ -50,7 +50,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ForeignItemId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.owner_id.def_id.to_stable_hash_key(hcx)
     }
 }

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -65,7 +65,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for OwnerId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         hcx.def_path_hash(self.to_def_id())
     }
 }
@@ -180,7 +180,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for HirId {
     type KeyType = (DefPathHash, ItemLocalId);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> (DefPathHash, ItemLocalId) {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> (DefPathHash, ItemLocalId) {
         let def_path_hash = self.owner.def_id.to_stable_hash_key(hcx);
         (def_path_hash, self.local_id)
     }
@@ -190,7 +190,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for ItemLocalId {
     type KeyType = ItemLocalId;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> ItemLocalId {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> ItemLocalId {
         *self
     }
 }

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -375,12 +375,12 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
 
 impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     fn eval_closure_size(&mut self) {
-        self.tcx().with_stable_hashing_context(|ref hcx| {
+        self.tcx().with_stable_hashing_context(|mut hcx| {
             let fcx_typeck_results = self.fcx.typeck_results.borrow();
 
             self.typeck_results.closure_size_eval = fcx_typeck_results
                 .closure_size_eval
-                .to_sorted(hcx, false)
+                .to_sorted(&mut hcx, false)
                 .into_iter()
                 .map(|(&closure_def_id, data)| {
                     let closure_hir_id = self.tcx().local_def_id_to_hir_id(closure_def_id);
@@ -392,12 +392,12 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 
     fn visit_min_capture_map(&mut self) {
-        self.tcx().with_stable_hashing_context(|ref hcx| {
+        self.tcx().with_stable_hashing_context(|mut hcx| {
             let fcx_typeck_results = self.fcx.typeck_results.borrow();
 
             self.typeck_results.closure_min_captures = fcx_typeck_results
                 .closure_min_captures
-                .to_sorted(hcx, false)
+                .to_sorted(&mut hcx, false)
                 .into_iter()
                 .map(|(&closure_def_id, root_min_captures)| {
                     let root_var_map_wb = root_min_captures
@@ -423,12 +423,12 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 
     fn visit_fake_reads_map(&mut self) {
-        self.tcx().with_stable_hashing_context(move |ref hcx| {
+        self.tcx().with_stable_hashing_context(move |mut hcx| {
             let fcx_typeck_results = self.fcx.typeck_results.borrow();
 
             self.typeck_results.closure_fake_reads = fcx_typeck_results
                 .closure_fake_reads
-                .to_sorted(hcx, true)
+                .to_sorted(&mut hcx, true)
                 .into_iter()
                 .map(|(&closure_def_id, fake_reads)| {
                     let resolved_fake_reads = fake_reads

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2718,12 +2718,13 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    #[cfg_attr(bootstrap, doc = "```rust")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,compile_fail")]
     /// enum Void {}
     /// unsafe extern {
     ///     static EXTERN: Void;
     /// }
-    /// ```
+    #[doc = "```"]
     ///
     /// {{produces}}
     ///
@@ -2734,10 +2735,11 @@ declare_lint! {
     /// compiler which assumes that there are no initialized uninhabited places (such as locals or
     /// statics). This was accidentally allowed, but is being phased out.
     pub UNINHABITED_STATIC,
-    Warn,
+    Deny,
     "uninhabited static",
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #74840),
+        report_in_deps: true,
     };
 }
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -160,7 +160,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for LintExpectationId {
     type KeyType = (DefPathHash, ItemLocalId, u16, u16);
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Self::KeyType {
         match self {
             LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
                 let (def_path_hash, lint_idx) = hir_id.to_stable_hash_key(hcx);
@@ -632,7 +632,7 @@ impl<Hcx> ToStableHashKey<Hcx> for LintId {
     type KeyType = &'static str;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> &'static str {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> &'static str {
         self.lint_name_raw()
     }
 }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -254,7 +254,7 @@ impl WorkProductId {
 impl<Hcx> ToStableHashKey<Hcx> for WorkProductId {
     type KeyType = Fingerprint;
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> Self::KeyType {
         self.hash
     }
 }

--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -10,7 +10,6 @@ use rustc_span::{CachingSourceMapView, DUMMY_SP, HashStableContext, Pos, Span};
 
 // Very often, we are hashing something that does not need the `CachingSourceMapView`, so we
 // initialize it lazily.
-#[derive(Clone)]
 enum CachingSourceMap<'a> {
     Unused(&'a SourceMap),
     InUse(CachingSourceMapView<'a>),
@@ -20,7 +19,6 @@ enum CachingSourceMap<'a> {
 /// enough information to transform `DefId`s and `HirId`s into stable `DefPath`s (i.e.,
 /// a reference to the `TyCtxt`) and it holds a few caches for speeding up various
 /// things (e.g., each `DefId`/`DefPath` is only hashed once).
-#[derive(Clone)]
 pub struct StableHashingContext<'a> {
     untracked: &'a Untracked,
     // The value of `-Z incremental-ignore-spans`.

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -328,9 +328,9 @@ impl<'tcx> fmt::Display for MonoItem<'tcx> {
 impl ToStableHashKey<StableHashingContext<'_>> for MonoItem<'_> {
     type KeyType = Fingerprint;
 
-    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'_>) -> Self::KeyType {
+    fn to_stable_hash_key(&self, hcx: &mut StableHashingContext<'_>) -> Self::KeyType {
         let mut hasher = StableHasher::new();
-        self.hash_stable(&mut hcx.clone(), &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }
@@ -584,7 +584,7 @@ impl<'tcx> CodegenUnit<'tcx> {
 impl ToStableHashKey<StableHashingContext<'_>> for CodegenUnit<'_> {
     type KeyType = String;
 
-    fn to_stable_hash_key(&self, _: &StableHashingContext<'_>) -> Self::KeyType {
+    fn to_stable_hash_key(&self, _: &mut StableHashingContext<'_>) -> Self::KeyType {
         // Codegen unit names are conceptually required to be stable across
         // compilation session so that object file names match up.
         self.name.to_string()

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -53,10 +53,9 @@ where
     type KeyType = Fingerprint;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &StableHashingContext<'a>) -> Fingerprint {
+    fn to_stable_hash_key(&self, hcx: &mut StableHashingContext<'a>) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: StableHashingContext<'a> = hcx.clone();
-        self.hash_stable(&mut hcx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }
@@ -88,7 +87,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for region::Scope {
     type KeyType = region::Scope;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &StableHashingContext<'a>) -> region::Scope {
+    fn to_stable_hash_key(&self, _: &mut StableHashingContext<'a>) -> region::Scope {
         *self
     }
 }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1824,8 +1824,8 @@ pub(crate) fn collect_crate_mono_items<'tcx>(
 
     // The set of MonoItems was created in an inherently indeterministic order because
     // of parallelism. We sort it here to ensure that the output is deterministic.
-    let mono_items = tcx.with_stable_hashing_context(move |ref hcx| {
-        state.visited.into_inner().into_sorted(hcx, true)
+    let mono_items = tcx.with_stable_hashing_context(move |mut hcx| {
+        state.visited.into_inner().into_sorted(&mut hcx, true)
     });
 
     (mono_items, state.usage_map.into_inner())

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -286,8 +286,8 @@ where
         codegen_units.insert(cgu_name, CodegenUnit::new(cgu_name));
     }
 
-    let mut codegen_units: Vec<_> = cx.tcx.with_stable_hashing_context(|ref hcx| {
-        codegen_units.into_items().map(|(_, cgu)| cgu).collect_sorted(hcx, true)
+    let mut codegen_units: Vec<_> = cx.tcx.with_stable_hashing_context(|mut hcx| {
+        codegen_units.into_items().map(|(_, cgu)| cgu).collect_sorted(&mut hcx, true)
     });
 
     for cgu in codegen_units.iter_mut() {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1535,9 +1535,10 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         let [segment] = path else { return };
         let None = following_seg else { return };
         for rib in self.ribs[ValueNS].iter().rev() {
-            let patterns_with_skipped_bindings = self.r.tcx.with_stable_hashing_context(|hcx| {
-                rib.patterns_with_skipped_bindings.to_sorted(&hcx, true)
-            });
+            let patterns_with_skipped_bindings =
+                self.r.tcx.with_stable_hashing_context(|mut hcx| {
+                    rib.patterns_with_skipped_bindings.to_sorted(&mut hcx, true)
+                });
             for (def_id, spans) in patterns_with_skipped_bindings {
                 if let DefKind::Struct | DefKind::Variant = self.r.tcx.def_kind(*def_id)
                     && let Some(fields) = self.r.field_idents(*def_id)

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -640,7 +640,7 @@ macro_rules! define_output_types {
         impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for OutputType {
             type KeyType = Self;
 
-            fn to_stable_hash_key(&self, _: &Hcx) -> Self::KeyType {
+            fn to_stable_hash_key(&self, _: &mut Hcx) -> Self::KeyType {
                 *self
             }
         }

--- a/compiler/rustc_span/src/caching_source_map_view.rs
+++ b/compiler/rustc_span/src/caching_source_map_view.rs
@@ -9,7 +9,6 @@ use crate::{BytePos, Pos, RelativeBytePos, SourceFile, SpanData};
 /// succession, and this avoids expensive `SourceMap` lookups each time the cache is hit. We used
 /// to cache multiple code positions, but caching a single position ended up being simpler and
 /// faster.
-#[derive(Clone)]
 pub struct CachingSourceMapView<'sm> {
     source_map: &'sm SourceMap,
     file: Arc<SourceFile>,

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -427,7 +427,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for DefId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         hcx.def_path_hash(*self)
     }
 }
@@ -436,7 +436,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for LocalDefId {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         hcx.def_path_hash(self.to_def_id())
     }
 }
@@ -445,7 +445,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for CrateNum {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> DefPathHash {
         self.as_def_id().to_stable_hash_key(hcx)
     }
 }
@@ -454,7 +454,7 @@ impl<Hcx: HashStableContext> ToStableHashKey<Hcx> for DefPathHash {
     type KeyType = DefPathHash;
 
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> DefPathHash {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> DefPathHash {
         *self
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2611,7 +2611,7 @@ impl<Hcx> HashStable<Hcx> for Symbol {
 impl<Hcx> ToStableHashKey<Hcx> for Symbol {
     type KeyType = String;
     #[inline]
-    fn to_stable_hash_key(&self, _: &Hcx) -> String {
+    fn to_stable_hash_key(&self, _: &mut Hcx) -> String {
         self.as_str().to_string()
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -55,7 +55,7 @@ use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_errors::{Applicability, Diag, DiagStyledString, IntoDiagArg, StringPart, pluralize};
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::DefId;
+use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::DefineOpaqueTypes;
@@ -1793,12 +1793,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         }
 
-        self.note_and_explain_type_err(diag, terr, cause, span, cause.body_id.to_def_id());
+        let body_owner_def_id = (cause.body_id != CRATE_DEF_ID).then(|| cause.body_id.to_def_id());
+        self.note_and_explain_type_err(diag, terr, cause, span, body_owner_def_id);
         if let Some(exp_found) = exp_found
             && let exp_found = TypeError::Sorts(exp_found)
             && exp_found != terr
         {
-            self.note_and_explain_type_err(diag, exp_found, cause, span, cause.body_id.to_def_id());
+            self.note_and_explain_type_err(diag, exp_found, cause, span, body_owner_def_id);
         }
 
         if let Some(ValuePairs::TraitRefs(exp_found)) = values

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs
@@ -22,11 +22,13 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
         err: TypeError<'tcx>,
         cause: &ObligationCause<'tcx>,
         sp: Span,
-        body_owner_def_id: DefId,
+        body_owner_def_id: Option<DefId>,
     ) {
         debug!("note_and_explain_type_err err={:?} cause={:?}", err, cause);
 
         let tcx = self.tcx;
+
+        let body_generics = body_owner_def_id.map(|def_id| tcx.generics_of(def_id));
 
         match err {
             TypeError::ArgumentSorts(values, _) | TypeError::Sorts(values) => {
@@ -64,14 +66,15 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                         }
                     }
                     (ty::Param(expected), ty::Param(found)) => {
-                        let generics = tcx.generics_of(body_owner_def_id);
-                        let e_span = tcx.def_span(generics.type_param(expected, tcx).def_id);
-                        if !sp.contains(e_span) {
-                            diag.span_label(e_span, "expected type parameter");
-                        }
-                        let f_span = tcx.def_span(generics.type_param(found, tcx).def_id);
-                        if !sp.contains(f_span) {
-                            diag.span_label(f_span, "found type parameter");
+                        if let Some(generics) = body_generics {
+                            let e_span = tcx.def_span(generics.type_param(expected, tcx).def_id);
+                            if !sp.contains(e_span) {
+                                diag.span_label(e_span, "expected type parameter");
+                            }
+                            let f_span = tcx.def_span(generics.type_param(found, tcx).def_id);
+                            if !sp.contains(f_span) {
+                                diag.span_label(f_span, "found type parameter");
+                            }
                         }
                         diag.note(
                             "a type parameter was expected, but a different one was found; \
@@ -92,9 +95,10 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     // FIXME(inherent_associated_types): Extend this to support `ty::Inherent`, too.
                     (ty::Param(p), ty::Alias(ty::Projection, proj))
                     | (ty::Alias(ty::Projection, proj), ty::Param(p))
-                        if !tcx.is_impl_trait_in_trait(proj.def_id) =>
+                        if !tcx.is_impl_trait_in_trait(proj.def_id)
+                            && let Some(generics) = body_generics =>
                     {
-                        let param = tcx.generics_of(body_owner_def_id).type_param(p, tcx);
+                        let param = generics.type_param(p, tcx);
                         let p_def_id = param.def_id;
                         let p_span = tcx.def_span(p_def_id);
                         let expected = match (values.expected.kind(), values.found.kind()) {
@@ -106,9 +110,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                             diag.span_label(p_span, format!("{expected}this type parameter"));
                         }
                         let param_def_id = match *proj.self_ty().kind() {
-                            ty::Param(param) => {
-                                tcx.generics_of(body_owner_def_id).type_param(param, tcx).def_id
-                            }
+                            ty::Param(param) => generics.type_param(param, tcx).def_id,
                             _ => p_def_id,
                         };
                         let parent = param_def_id.as_local().and_then(|id| {
@@ -188,15 +190,16 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                     }
                     (ty::Param(p), ty::Dynamic(..) | ty::Alias(ty::Opaque, ..))
                     | (ty::Dynamic(..) | ty::Alias(ty::Opaque, ..), ty::Param(p)) => {
-                        let generics = tcx.generics_of(body_owner_def_id);
-                        let p_span = tcx.def_span(generics.type_param(p, tcx).def_id);
-                        let expected = match (values.expected.kind(), values.found.kind()) {
-                            (ty::Param(_), _) => "expected ",
-                            (_, ty::Param(_)) => "found ",
-                            _ => "",
-                        };
-                        if !sp.contains(p_span) {
-                            diag.span_label(p_span, format!("{expected}this type parameter"));
+                        if let Some(generics) = body_generics {
+                            let p_span = tcx.def_span(generics.type_param(p, tcx).def_id);
+                            let expected = match (values.expected.kind(), values.found.kind()) {
+                                (ty::Param(_), _) => "expected ",
+                                (_, ty::Param(_)) => "found ",
+                                _ => "",
+                            };
+                            if !sp.contains(p_span) {
+                                diag.span_label(p_span, format!("{expected}this type parameter"));
+                            }
                         }
                         diag.help("type parameters must be constrained to match other types");
                         if diag.code.is_some_and(|code| tcx.sess.teach(code)) {
@@ -236,18 +239,18 @@ impl<T> Trait<T> for X {
                         ty::Param(p),
                         ty::Closure(..) | ty::CoroutineClosure(..) | ty::Coroutine(..),
                     ) => {
-                        let generics = tcx.generics_of(body_owner_def_id);
-                        let p_span = tcx.def_span(generics.type_param(p, tcx).def_id);
-                        if !sp.contains(p_span) {
-                            diag.span_label(p_span, "expected this type parameter");
+                        if let Some(generics) = body_generics {
+                            let p_span = tcx.def_span(generics.type_param(p, tcx).def_id);
+                            if !sp.contains(p_span) {
+                                diag.span_label(p_span, "expected this type parameter");
+                            }
                         }
                         diag.help(format!(
                             "every closure has a distinct type and so could not always match the \
                              caller-chosen type of parameter `{p}`"
                         ));
                     }
-                    (ty::Param(p), _) | (_, ty::Param(p)) => {
-                        let generics = tcx.generics_of(body_owner_def_id);
+                    (ty::Param(p), _) | (_, ty::Param(p)) if let Some(generics) = body_generics => {
                         let p_span = tcx.def_span(generics.type_param(p, tcx).def_id);
                         let expected = match (values.expected.kind(), values.found.kind()) {
                             (ty::Param(_), _) => "expected ",
@@ -366,7 +369,8 @@ impl<T> Trait<T> for X {
                     }
                     (_, ty::Alias(ty::Opaque, opaque_ty))
                     | (ty::Alias(ty::Opaque, opaque_ty), _) => {
-                        if opaque_ty.def_id.is_local()
+                        if let Some(body_owner_def_id) = body_owner_def_id
+                            && opaque_ty.def_id.is_local()
                             && matches!(
                                 tcx.def_kind(body_owner_def_id),
                                 DefKind::Fn
@@ -560,11 +564,14 @@ impl<T> Trait<T> for X {
         &self,
         diag: &mut Diag<'_>,
         msg: impl Fn() -> String,
-        body_owner_def_id: DefId,
+        body_owner_def_id: Option<DefId>,
         proj_ty: ty::AliasTy<'tcx>,
         ty: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
+        let Some(body_owner_def_id) = body_owner_def_id else {
+            return false;
+        };
         let assoc = tcx.associated_item(proj_ty.def_id);
         let (trait_ref, assoc_args) = proj_ty.trait_ref_and_own_args(tcx);
         let Some(item) = tcx.hir_get_if_local(body_owner_def_id) else {
@@ -611,7 +618,7 @@ impl<T> Trait<T> for X {
             _ => return false,
         };
         let parent = tcx.hir_get_parent_item(hir_id).def_id;
-        self.suggest_constraint(diag, msg, parent.into(), proj_ty, ty)
+        self.suggest_constraint(diag, msg, Some(parent.into()), proj_ty, ty)
     }
 
     /// An associated type was expected and a different type was found.
@@ -632,7 +639,7 @@ impl<T> Trait<T> for X {
         diag: &mut Diag<'_>,
         proj_ty: ty::AliasTy<'tcx>,
         values: ExpectedFound<Ty<'tcx>>,
-        body_owner_def_id: DefId,
+        body_owner_def_id: Option<DefId>,
         cause_code: &ObligationCauseCode<'_>,
     ) {
         let tcx = self.tcx;
@@ -653,7 +660,7 @@ impl<T> Trait<T> for X {
             )
         };
 
-        let body_owner = tcx.hir_get_if_local(body_owner_def_id);
+        let body_owner = body_owner_def_id.and_then(|id| tcx.hir_get_if_local(id));
         let current_method_ident = body_owner.and_then(|n| n.ident()).map(|i| i.name);
 
         // We don't want to suggest calling an assoc fn in a scope where that isn't feasible.
@@ -835,12 +842,12 @@ fn foo(&self) -> Self::T { String::new() }
     fn point_at_associated_type(
         &self,
         diag: &mut Diag<'_>,
-        body_owner_def_id: DefId,
+        body_owner_def_id: Option<DefId>,
         found: Ty<'tcx>,
     ) -> bool {
         let tcx = self.tcx;
 
-        let Some(def_id) = body_owner_def_id.as_local() else {
+        let Some(def_id) = body_owner_def_id.and_then(|id| id.as_local()) else {
             return false;
         };
 
@@ -852,7 +859,7 @@ fn foo(&self) -> Self::T { String::new() }
 
         debug!("expected_projection parent item {:?}", item);
 
-        let param_env = tcx.param_env(body_owner_def_id);
+        let param_env = tcx.param_env(def_id);
 
         if let DefKind::Trait | DefKind::Impl { .. } = tcx.def_kind(parent_id) {
             let assoc_items = tcx.associated_items(parent_id);

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -50,14 +50,13 @@ pub enum SimplifiedType<DefId> {
 }
 
 #[cfg(feature = "nightly")]
-impl<Hcx: Clone, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
+impl<Hcx, DefId: HashStable<Hcx>> ToStableHashKey<Hcx> for SimplifiedType<DefId> {
     type KeyType = Fingerprint;
 
     #[inline]
-    fn to_stable_hash_key(&self, hcx: &Hcx) -> Fingerprint {
+    fn to_stable_hash_key(&self, hcx: &mut Hcx) -> Fingerprint {
         let mut hasher = StableHasher::new();
-        let mut hcx: Hcx = hcx.clone();
-        self.hash_stable(&mut hcx, &mut hasher);
+        self.hash_stable(hcx, &mut hasher);
         hasher.finish()
     }
 }

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -310,7 +310,7 @@ impl rustc_driver::Callbacks for MiriDepCompilerCalls {
             // FIXME handle this somehow in rustc itself to avoid this hack.
             local_providers.queries.exported_non_generic_symbols = |tcx, LocalCrate| {
                 let reachable_set = tcx
-                    .with_stable_hashing_context(|hcx| tcx.reachable_set(()).to_sorted(&hcx, true));
+                    .with_stable_hashing_context(|mut hcx| tcx.reachable_set(()).to_sorted(&mut hcx, true));
                 tcx.arena.alloc_from_iter(
                     // This is based on:
                     // https://github.com/rust-lang/rust/blob/2962e7c0089d5c136f4e9600b7abccfbbde4973d/compiler/rustc_codegen_ssa/src/back/symbol_export.rs#L62-L63

--- a/tests/assembly-llvm/riscv-redundant-memory-stores.rs
+++ b/tests/assembly-llvm/riscv-redundant-memory-stores.rs
@@ -1,0 +1,33 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/149762>:
+
+//@ assembly-output: emit-asm
+//@ compile-flags: -Copt-level=3 --target riscv64gc-unknown-linux-gnu
+//@ needs-llvm-components: riscv
+//@ only-riscv64
+
+pub struct SomeComplexType {
+    a: u64,
+    b: u64,
+    c: u64,
+}
+
+// CHECK-LABEL: with_mut_param
+#[no_mangle]
+pub fn with_mut_param(mut a: SomeComplexType) -> SomeComplexType {
+    // CHECK: ld a2, 0(a1)
+    // CHECK-NEXT: ld a3, 8(a1)
+    // CHECK-NEXT: ld a4, 16(a1)
+    // CHECK-NEXT: addi a2, a2, 10
+    // CHECK-NEXT: addi a3, a3, 2
+    // CHECK-NEXT: sd a2, 0(a1)
+    // CHECK-NEXT: sd a3, 8(a1)
+    // CHECK-NEXT: sd a2, 0(a0)
+    // CHECK-NEXT: sd a3, 8(a0)
+    // CHECK-NEXT: sd a4, 16(a0)
+    // CHECK-NEXT: ret
+    a.a += 10;
+    a.b += 2;
+    a
+}
+
+fn main() {}

--- a/tests/ui/dyn-compatibility/ice-generics-of-crate-root-152335.rs
+++ b/tests/ui/dyn-compatibility/ice-generics-of-crate-root-152335.rs
@@ -1,0 +1,40 @@
+// Regression test for #152335.
+// The compiler used to ICE in `generics_of` when `note_and_explain_type_err`
+// was called with `CRATE_DEF_ID` as the body owner during dyn-compatibility
+// checking. This happened because `ObligationCause::dummy()` sets `body_id`
+// to `CRATE_DEF_ID`, and error reporting tried to look up generics on it.
+
+struct ActuallySuper;
+
+trait Super<B = Self> {
+    type Assoc;
+}
+
+trait Dyn {}
+impl<T, U> Dyn for dyn Foo<T, U> + '_ {}
+//~^ ERROR the trait `Foo` is not dyn compatible
+
+trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+//~^ ERROR type mismatch resolving
+//~| ERROR the size for values of type `Self` cannot be known
+where
+    <Self as Mirror>::Assoc: Super,
+    //~^ ERROR type mismatch resolving
+    //~| ERROR the size for values of type `Self` cannot be known
+    //~| ERROR type mismatch resolving
+    //~| ERROR the size for values of type `Self` cannot be known
+{
+    fn transmute(&self, t: T) -> <Self as B>::Assoc;
+    //~^ ERROR cannot find trait `B` in this scope
+    //~| ERROR type mismatch resolving
+    //~| ERROR the size for values of type `Self` cannot be known
+    //~| ERROR type mismatch resolving
+    //~| ERROR the size for values of type `Self` cannot be known
+}
+
+trait Mirror {
+    type Assoc: ?Sized;
+}
+impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+//~^ ERROR not all trait items implemented
+//~| ERROR `main` function not found

--- a/tests/ui/dyn-compatibility/ice-generics-of-crate-root-152335.stderr
+++ b/tests/ui/dyn-compatibility/ice-generics-of-crate-root-152335.stderr
@@ -1,0 +1,236 @@
+error[E0405]: cannot find trait `B` in this scope
+  --> $DIR/ice-generics-of-crate-root-152335.rs:27:43
+   |
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc;
+   |                                           ^ not found in this scope
+
+error[E0601]: `main` function not found in crate `ice_generics_of_crate_root_152335`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:57
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |                                                         ^ consider adding a `main` function to `$DIR/ice-generics-of-crate-root-152335.rs`
+
+error[E0271]: type mismatch resolving `<Self as Super<ActuallySuper>>::Assoc == Self`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:27:5
+   |
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `Self`, found type parameter `T`
+   |
+   = note: expected type parameter `Self`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |                              ---------   ^^^^^^     ^
+   |                              |
+   |                              unsatisfied trait bound introduced here
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/ice-generics-of-crate-root-152335.rs:27:5
+   |
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |      -                                   ^^^^^^     ^
+   |      |
+   |      unsatisfied trait bound implicitly introduced here
+
+error[E0038]: the trait `Foo` is not dyn compatible
+  --> $DIR/ice-generics-of-crate-root-152335.rs:14:20
+   |
+LL | impl<T, U> Dyn for dyn Foo<T, U> + '_ {}
+   |                    ^^^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/ice-generics-of-crate-root-152335.rs:21:30
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+   |       --- this trait is not dyn compatible...
+...
+LL |     <Self as Mirror>::Assoc: Super,
+   |                              ^^^^^ ...because it uses `Self` as a type parameter
+
+error[E0271]: type mismatch resolving `<Self as Super<ActuallySuper>>::Assoc == Self`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:17:1
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `Self`, found type parameter `T`
+   |
+   = note: expected type parameter `Self`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |                              ---------   ^^^^^^     ^
+   |                              |
+   |                              unsatisfied trait bound introduced here
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/ice-generics-of-crate-root-152335.rs:17:1
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |      -                                   ^^^^^^     ^
+   |      |
+   |      unsatisfied trait bound implicitly introduced here
+help: consider further restricting `Self`
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T> + Sized
+   |                                                  +++++++
+
+error[E0271]: type mismatch resolving `<Self as Super<ActuallySuper>>::Assoc == Self`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:21:30
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+   | ------------------------------------------------
+   | |         |
+   | |         found type parameter
+   | expected type parameter
+...
+LL |     <Self as Mirror>::Assoc: Super,
+   |                              ^^^^^ expected type parameter `Self`, found type parameter `T`
+   |
+   = note: expected type parameter `Self`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |                              ---------   ^^^^^^     ^
+   |                              |
+   |                              unsatisfied trait bound introduced here
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/ice-generics-of-crate-root-152335.rs:21:30
+   |
+LL |     <Self as Mirror>::Assoc: Super,
+   |                              ^^^^^ doesn't have a size known at compile-time
+   |
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |      -                                   ^^^^^^     ^
+   |      |
+   |      unsatisfied trait bound implicitly introduced here
+help: consider further restricting `Self`
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T> + Sized
+   |                                                  +++++++
+
+error[E0046]: not all trait items implemented, missing: `Assoc`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:1
+   |
+LL |     type Assoc: ?Sized;
+   |     ------------------ `Assoc` from trait
+LL | }
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Assoc` in implementation
+
+error[E0271]: type mismatch resolving `<Self as Super<ActuallySuper>>::Assoc == Self`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:27:5
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+   | ------------------------------------------------
+   | |         |
+   | |         found type parameter
+   | expected type parameter
+...
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `Self`, found type parameter `T`
+   |
+   = note: expected type parameter `Self`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |                              ---------   ^^^^^^     ^
+   |                              |
+   |                              unsatisfied trait bound introduced here
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/ice-generics-of-crate-root-152335.rs:27:5
+   |
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |      -                                   ^^^^^^     ^
+   |      |
+   |      unsatisfied trait bound implicitly introduced here
+help: consider further restricting `Self`
+   |
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc where Self: Sized;
+   |                                                     +++++++++++++++++
+
+error[E0271]: type mismatch resolving `<Self as Super<ActuallySuper>>::Assoc == Self`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:21:30
+   |
+LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
+   | ------------------------------------------------
+   | |         |
+   | |         found type parameter
+   | expected type parameter
+...
+LL |     <Self as Mirror>::Assoc: Super,
+   |                              ^^^^^ expected type parameter `Self`, found type parameter `T`
+   |
+   = note: expected type parameter `Self`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |                              ---------   ^^^^^^     ^
+   |                              |
+   |                              unsatisfied trait bound introduced here
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/ice-generics-of-crate-root-152335.rs:21:30
+   |
+LL |     <Self as Mirror>::Assoc: Super,
+   |                              ^^^^^ doesn't have a size known at compile-time
+   |
+note: required for `Self` to implement `Mirror`
+  --> $DIR/ice-generics-of-crate-root-152335.rs:38:42
+   |
+LL | impl<T: Super<ActuallySuper, Assoc = T>> Mirror for T {}
+   |      -                                   ^^^^^^     ^
+   |      |
+   |      unsatisfied trait bound implicitly introduced here
+help: consider further restricting `Self`
+   |
+LL |     fn transmute(&self, t: T) -> <Self as B>::Assoc where Self: Sized;
+   |                                                     +++++++++++++++++
+
+error: aborting due to 14 previous errors
+
+Some errors have detailed explanations: E0038, E0046, E0271, E0277, E0405, E0601.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/statics/uninhabited-static.rs
+++ b/tests/ui/statics/uninhabited-static.rs
@@ -1,5 +1,4 @@
 #![feature(never_type)]
-#![deny(uninhabited_static)]
 
 enum Void {}
 extern "C" {

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -1,5 +1,5 @@
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:12:1
+  --> $DIR/uninhabited-static.rs:11:1
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^
@@ -7,14 +7,10 @@ LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    = note: uninhabited statics cannot be initialized, and any access would be an immediate error
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
-note: the lint level is defined here
-  --> $DIR/uninhabited-static.rs:2:9
-   |
-LL | #![deny(uninhabited_static)]
-   |         ^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:15:1
+  --> $DIR/uninhabited-static.rs:14:1
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    | ^^^^^^^^^^^^^^^^^^^
@@ -24,7 +20,7 @@ LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:6:5
+  --> $DIR/uninhabited-static.rs:5:5
    |
 LL |     static VOID: Void;
    |     ^^^^^^^^^^^^^^^^^
@@ -34,7 +30,7 @@ LL |     static VOID: Void;
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
 error: static of uninhabited type
-  --> $DIR/uninhabited-static.rs:8:5
+  --> $DIR/uninhabited-static.rs:7:5
    |
 LL |     static NEVER: !;
    |     ^^^^^^^^^^^^^^^
@@ -44,13 +40,13 @@ LL |     static NEVER: !;
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
 error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
-  --> $DIR/uninhabited-static.rs:12:31
+  --> $DIR/uninhabited-static.rs:11:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
 error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
-  --> $DIR/uninhabited-static.rs:15:32
+  --> $DIR/uninhabited-static.rs:14:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `NEVER2` failed here
@@ -58,3 +54,51 @@ LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
 error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0080`.
+Future incompatibility report: Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:11:1
+   |
+LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:14:1
+   |
+LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:5:5
+   |
+LL |     static VOID: Void;
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: static of uninhabited type
+  --> $DIR/uninhabited-static.rs:7:5
+   |
+LL |     static NEVER: !;
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: uninhabited statics cannot be initialized, and any access would be an immediate error
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
+   = note: `#[deny(uninhabited_static)]` (part of `#[deny(future_incompatible)]`) on by default
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152853 (deny-by-default & report in deps `uninhabited_static`)
 - rust-lang/rust#153615 (fixed generics of crate node ICE)
 - rust-lang/rust#154744 (Remove `Clone` impl for `StableHashingContext`.)
 - rust-lang/rust#154841 (add regression test for Redundant memory strores with mut parameters …)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152853,153615,154744,154841)
<!-- homu-ignore:end -->

