### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1379,7 +1379,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                             this.dcx()
                                 .emit_err(errors::ScalableVectorNotTupleStruct { span: item.span });
                         }
-                        if !self.sess.target.arch.supports_scalable_vectors() {
+                        if !self.sess.target.arch.supports_scalable_vectors()
+                            && !self.sess.opts.actually_rustdoc
+                        {
                             this.dcx().emit_err(errors::ScalableVectorBadArch { span: attr.span });
                         }
                     }

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -665,7 +665,11 @@ impl DocParser {
                 let span = cx.attr_span;
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    AttributeLintKind::IllFormedAttributeInput { suggestions, docs: None },
+                    AttributeLintKind::IllFormedAttributeInput {
+                        suggestions,
+                        docs: None,
+                        help: None,
+                    },
                     span,
                 );
             }

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -27,8 +27,15 @@ impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
                     };
                     Some(str_value)
                 }
-                ArgParser::List(_) => {
-                    cx.adcx().warn_ill_formed_attribute_input(ILL_FORMED_ATTRIBUTE_INPUT);
+                ArgParser::List(list) => {
+                    let help = list.single().and_then(|item| item.meta_item()).and_then(|item| {
+                        item.args().no_args().ok()?;
+                        Some(item.path().to_string())
+                    });
+                    cx.adcx().warn_ill_formed_attribute_input_with_help(
+                        ILL_FORMED_ATTRIBUTE_INPUT,
+                        help,
+                    );
                     return None;
                 }
             },

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -830,11 +830,18 @@ where
     }
 
     pub(crate) fn warn_ill_formed_attribute_input(&mut self, lint: &'static Lint) {
+        self.warn_ill_formed_attribute_input_with_help(lint, None)
+    }
+    pub(crate) fn warn_ill_formed_attribute_input_with_help(
+        &mut self,
+        lint: &'static Lint,
+        help: Option<String>,
+    ) {
         let suggestions = self.suggestions();
         let span = self.attr_span;
         self.emit_lint(
             lint,
-            AttributeLintKind::IllFormedAttributeInput { suggestions, docs: None },
+            AttributeLintKind::IllFormedAttributeInput { suggestions, docs: None, help },
             span,
         );
     }

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -211,6 +211,7 @@ fn emit_malformed_attribute(
             BuiltinLintDiag::AttributeLint(AttributeLintKind::IllFormedAttributeInput {
                 suggestions: suggestions.clone(),
                 docs: template.docs,
+                help: None,
             }),
         );
     } else {

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -914,12 +914,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if show_assign_sugg {
             struct LetVisitor {
                 decl_span: Span,
-                sugg_span: Option<Span>,
+                sugg: Option<(Span, bool)>,
             }
 
             impl<'v> Visitor<'v> for LetVisitor {
                 fn visit_stmt(&mut self, ex: &'v hir::Stmt<'v>) {
-                    if self.sugg_span.is_some() {
+                    if self.sugg.is_some() {
                         return;
                     }
 
@@ -927,19 +927,23 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     // but we could suggest `todo!()` for all uninitialized bindings in the pattern
                     if let hir::StmtKind::Let(hir::LetStmt { span, ty, init: None, pat, .. }) =
                         &ex.kind
-                        && let hir::PatKind::Binding(..) = pat.kind
+                        && let hir::PatKind::Binding(binding_mode, ..) = pat.kind
                         && span.contains(self.decl_span)
                     {
-                        self.sugg_span = ty.map_or(Some(self.decl_span), |ty| Some(ty.span));
+                        // Insert after the whole binding pattern so suggestions stay valid for
+                        // bindings with `@` subpatterns like `ref mut x @ v`.
+                        let strip_ref = matches!(binding_mode.0, hir::ByRef::Yes(..));
+                        self.sugg =
+                            ty.map_or(Some((pat.span, strip_ref)), |ty| Some((ty.span, strip_ref)));
                     }
                     hir::intravisit::walk_stmt(self, ex);
                 }
             }
 
-            let mut visitor = LetVisitor { decl_span, sugg_span: None };
+            let mut visitor = LetVisitor { decl_span, sugg: None };
             visitor.visit_body(&body);
-            if let Some(span) = visitor.sugg_span {
-                self.suggest_assign_value(&mut err, moved_place, span);
+            if let Some((span, strip_ref)) = visitor.sugg {
+                self.suggest_assign_value(&mut err, moved_place, span, strip_ref);
             }
         }
         err
@@ -950,8 +954,12 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         err: &mut Diag<'_>,
         moved_place: PlaceRef<'tcx>,
         sugg_span: Span,
+        strip_ref: bool,
     ) {
-        let ty = moved_place.ty(self.body, self.infcx.tcx).ty;
+        let mut ty = moved_place.ty(self.body, self.infcx.tcx).ty;
+        if strip_ref && let ty::Ref(_, inner, _) = ty.kind() {
+            ty = *inner;
+        }
         debug!("ty: {:?}, kind: {:?}", ty, ty.kind());
 
         let Some(assign_value) = self.infcx.err_ctxt().ty_kind_suggestion(self.infcx.param_env, ty)

--- a/compiler/rustc_codegen_gcc/src/back/lto.rs
+++ b/compiler/rustc_codegen_gcc/src/back/lto.rs
@@ -31,7 +31,6 @@ use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_errors::{DiagCtxt, DiagCtxtHandle};
 use rustc_log::tracing::info;
-use rustc_session::config::Lto;
 use tempfile::{TempDir, tempdir};
 
 use crate::back::write::{codegen, save_temp_bitcode};
@@ -45,11 +44,7 @@ struct LtoData {
     tmp_path: TempDir,
 }
 
-fn prepare_lto(
-    cgcx: &CodegenContext,
-    each_linked_rlib_for_lto: &[PathBuf],
-    dcx: DiagCtxtHandle<'_>,
-) -> LtoData {
+fn prepare_lto(each_linked_rlib_for_lto: &[PathBuf], dcx: DiagCtxtHandle<'_>) -> LtoData {
     let tmp_path = match tempdir() {
         Ok(tmp_path) => tmp_path,
         Err(error) => {
@@ -64,32 +59,30 @@ fn prepare_lto(
     // We save off all the bytecode and GCC module file path for later processing
     // with either fat or thin LTO
     let mut upstream_modules = Vec::new();
-    if cgcx.lto != Lto::ThinLocal {
-        for path in each_linked_rlib_for_lto {
-            let archive_data = unsafe {
-                Mmap::map(File::open(path).expect("couldn't open rlib")).expect("couldn't map rlib")
-            };
-            let archive = ArchiveFile::parse(&*archive_data).expect("wanted an rlib");
-            let obj_files = archive
-                .members()
-                .filter_map(|child| {
-                    child.ok().and_then(|c| {
-                        std::str::from_utf8(c.name()).ok().map(|name| (name.trim(), c))
-                    })
-                })
-                .filter(|&(name, _)| looks_like_rust_object_file(name));
-            for (name, child) in obj_files {
-                info!("adding bitcode from {}", name);
-                let path = tmp_path.path().join(name);
-                match save_as_file(child.data(&*archive_data).expect("corrupt rlib"), &path) {
-                    Ok(()) => {
-                        let buffer = ModuleBuffer::new(path);
-                        let module = SerializedModule::Local(buffer);
-                        upstream_modules.push((module, CString::new(name).unwrap()));
-                    }
-                    Err(e) => {
-                        dcx.emit_fatal(e);
-                    }
+    for path in each_linked_rlib_for_lto {
+        let archive_data = unsafe {
+            Mmap::map(File::open(path).expect("couldn't open rlib")).expect("couldn't map rlib")
+        };
+        let archive = ArchiveFile::parse(&*archive_data).expect("wanted an rlib");
+        let obj_files = archive
+            .members()
+            .filter_map(|child| {
+                child
+                    .ok()
+                    .and_then(|c| std::str::from_utf8(c.name()).ok().map(|name| (name.trim(), c)))
+            })
+            .filter(|&(name, _)| looks_like_rust_object_file(name));
+        for (name, child) in obj_files {
+            info!("adding bitcode from {}", name);
+            let path = tmp_path.path().join(name);
+            match save_as_file(child.data(&*archive_data).expect("corrupt rlib"), &path) {
+                Ok(()) => {
+                    let buffer = ModuleBuffer::new(path);
+                    let module = SerializedModule::Local(buffer);
+                    upstream_modules.push((module, CString::new(name).unwrap()));
+                }
+                Err(e) => {
+                    dcx.emit_fatal(e);
                 }
             }
         }
@@ -115,7 +108,7 @@ pub(crate) fn run_fat(
 ) -> CompiledModule {
     let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
     let dcx = dcx.handle();
-    let lto_data = prepare_lto(cgcx, each_linked_rlib_for_lto, dcx);
+    let lto_data = prepare_lto(each_linked_rlib_for_lto, dcx);
     /*let symbols_below_threshold =
     lto_data.symbols_below_threshold.iter().map(|c| c.as_ptr()).collect::<Vec<_>>();*/
     fat_lto(

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -81,9 +81,9 @@ use gccjit::{CType, Context, OptimizationLevel};
 #[cfg(feature = "master")]
 use gccjit::{TargetInfo, Version};
 use rustc_ast::expand::allocator::AllocatorMethod;
-use rustc_codegen_ssa::back::lto::{SerializedModule, ThinModule};
+use rustc_codegen_ssa::back::lto::ThinModule;
 use rustc_codegen_ssa::back::write::{
-    CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryFn,
+    CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryFn, ThinLtoInput,
 };
 use rustc_codegen_ssa::base::codegen_crate;
 use rustc_codegen_ssa::target_features::cfg_target_feature;
@@ -449,8 +449,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         // FIXME(bjorn3): Limit LTO exports to these symbols
         _exported_symbols_for_lto: &[String],
         _each_linked_rlib_for_lto: &[PathBuf],
-        _modules: Vec<(String, Self::ModuleBuffer)>,
-        _cached_modules: Vec<(SerializedModule<Self::ModuleBuffer>, WorkProduct)>,
+        _modules: Vec<ThinLtoInput<Self>>,
     ) -> (Vec<ThinModule<Self>>, Vec<WorkProduct>) {
         unreachable!()
     }

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -297,7 +297,7 @@ fn fat_lto(
 
         // For all serialized bitcode files we parse them and link them in as we did
         // above, this is all mostly handled in C++.
-        let mut linker = Linker::new(llmod);
+        let linker = unsafe { llvm::LLVMRustLinkerNew(llmod) };
         for (bc_decoded, name) in serialized_modules {
             let _timer = prof
                 .generic_activity_with_arg_recorder("LLVM_fat_lto_link_module", |recorder| {
@@ -305,11 +305,19 @@ fn fat_lto(
                 });
             info!("linking {:?}", name);
             let data = bc_decoded.data();
-            linker
-                .add(data)
-                .unwrap_or_else(|()| write::llvm_err(dcx, LlvmError::LoadBitcode { name }));
+
+            unsafe {
+                if !llvm::LLVMRustLinkerAdd(
+                    linker,
+                    data.as_ptr() as *const libc::c_char,
+                    data.len(),
+                ) {
+                    llvm::LLVMRustLinkerFree(linker);
+                    write::llvm_err(dcx, LlvmError::LoadBitcode { name })
+                }
+            }
         }
-        drop(linker);
+        unsafe { llvm::LLVMRustLinkerFree(linker) };
         save_temp_bitcode(cgcx, &module, "lto.input");
 
         // Internalize everything below threshold to help strip out more modules and such.
@@ -325,36 +333,6 @@ fn fat_lto(
     }
 
     module
-}
-
-pub(crate) struct Linker<'a>(&'a mut llvm::Linker<'a>);
-
-impl<'a> Linker<'a> {
-    pub(crate) fn new(llmod: &'a llvm::Module) -> Self {
-        unsafe { Linker(llvm::LLVMRustLinkerNew(llmod)) }
-    }
-
-    pub(crate) fn add(&mut self, bytecode: &[u8]) -> Result<(), ()> {
-        unsafe {
-            if llvm::LLVMRustLinkerAdd(
-                self.0,
-                bytecode.as_ptr() as *const libc::c_char,
-                bytecode.len(),
-            ) {
-                Ok(())
-            } else {
-                Err(())
-            }
-        }
-    }
-}
-
-impl Drop for Linker<'_> {
-    fn drop(&mut self) {
-        unsafe {
-            llvm::LLVMRustLinkerFree(&mut *(self.0 as *mut _));
-        }
-    }
 }
 
 /// Prepare "thin" LTO to get run on these modules.

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -20,7 +20,7 @@ use rustc_errors::{DiagCtxt, DiagCtxtHandle};
 use rustc_hir::attrs::SanitizerSet;
 use rustc_middle::bug;
 use rustc_middle::dep_graph::WorkProduct;
-use rustc_session::config::{self, Lto};
+use rustc_session::config;
 use tracing::{debug, info};
 
 use crate::back::write::{
@@ -90,33 +90,31 @@ fn prepare_lto(
     // We save off all the bytecode and LLVM module ids for later processing
     // with either fat or thin LTO
     let mut upstream_modules = Vec::new();
-    if cgcx.lto != Lto::ThinLocal {
-        for path in each_linked_rlib_for_lto {
-            let archive_data = unsafe {
-                Mmap::map(std::fs::File::open(&path).expect("couldn't open rlib"))
-                    .expect("couldn't map rlib")
-            };
-            let archive = ArchiveFile::parse(&*archive_data).expect("wanted an rlib");
-            let obj_files = archive
-                .members()
-                .filter_map(|child| {
-                    child.ok().and_then(|c| {
-                        std::str::from_utf8(c.name()).ok().map(|name| (name.trim(), c))
-                    })
-                })
-                .filter(|&(name, _)| looks_like_rust_object_file(name));
-            for (name, child) in obj_files {
-                info!("adding bitcode from {}", name);
-                match get_bitcode_slice_from_object_data(
-                    child.data(&*archive_data).expect("corrupt rlib"),
-                    cgcx,
-                ) {
-                    Ok(data) => {
-                        let module = SerializedModule::FromRlib(data.to_vec());
-                        upstream_modules.push((module, CString::new(name).unwrap()));
-                    }
-                    Err(e) => dcx.emit_fatal(e),
+    for path in each_linked_rlib_for_lto {
+        let archive_data = unsafe {
+            Mmap::map(std::fs::File::open(&path).expect("couldn't open rlib"))
+                .expect("couldn't map rlib")
+        };
+        let archive = ArchiveFile::parse(&*archive_data).expect("wanted an rlib");
+        let obj_files = archive
+            .members()
+            .filter_map(|child| {
+                child
+                    .ok()
+                    .and_then(|c| std::str::from_utf8(c.name()).ok().map(|name| (name.trim(), c)))
+            })
+            .filter(|&(name, _)| looks_like_rust_object_file(name));
+        for (name, child) in obj_files {
+            info!("adding bitcode from {}", name);
+            match get_bitcode_slice_from_object_data(
+                child.data(&*archive_data).expect("corrupt rlib"),
+                cgcx,
+            ) {
+                Ok(data) => {
+                    let module = SerializedModule::FromRlib(data.to_vec());
+                    upstream_modules.push((module, CString::new(name).unwrap()));
                 }
+                Err(e) => dcx.emit_fatal(e),
             }
         }
     }

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -9,7 +9,7 @@ use object::read::archive::ArchiveFile;
 use object::{Object, ObjectSection};
 use rustc_codegen_ssa::back::lto::{SerializedModule, ThinModule, ThinShared};
 use rustc_codegen_ssa::back::write::{
-    CodegenContext, FatLtoInput, SharedEmitter, TargetMachineFactoryFn,
+    CodegenContext, FatLtoInput, SharedEmitter, TargetMachineFactoryFn, ThinLtoInput,
 };
 use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::{CompiledModule, ModuleCodegen, ModuleKind, looks_like_rust_object_file};
@@ -185,8 +185,7 @@ pub(crate) fn run_thin(
     dcx: DiagCtxtHandle<'_>,
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
-    modules: Vec<(String, ModuleBuffer)>,
-    cached_modules: Vec<(SerializedModule<ModuleBuffer>, WorkProduct)>,
+    modules: Vec<ThinLtoInput<LlvmCodegenBackend>>,
 ) -> (Vec<ThinModule<LlvmCodegenBackend>>, Vec<WorkProduct>) {
     let (symbols_below_threshold, upstream_modules) =
         prepare_lto(cgcx, exported_symbols_for_lto, each_linked_rlib_for_lto, dcx);
@@ -198,7 +197,7 @@ pub(crate) fn run_thin(
                       is deferred to the linker"
         );
     }
-    thin_lto(cgcx, prof, dcx, modules, upstream_modules, cached_modules, &symbols_below_threshold)
+    thin_lto(cgcx, prof, dcx, modules, upstream_modules, &symbols_below_threshold)
 }
 
 fn fat_lto(
@@ -392,24 +391,35 @@ fn thin_lto(
     cgcx: &CodegenContext,
     prof: &SelfProfilerRef,
     dcx: DiagCtxtHandle<'_>,
-    modules: Vec<(String, ModuleBuffer)>,
+    modules: Vec<ThinLtoInput<LlvmCodegenBackend>>,
     serialized_modules: Vec<(SerializedModule<ModuleBuffer>, CString)>,
-    cached_modules: Vec<(SerializedModule<ModuleBuffer>, WorkProduct)>,
     symbols_below_threshold: &[*const libc::c_char],
 ) -> (Vec<ThinModule<LlvmCodegenBackend>>, Vec<WorkProduct>) {
     let _timer = prof.generic_activity("LLVM_thin_lto_global_analysis");
     unsafe {
         info!("going for that thin, thin LTO");
 
-        let green_modules: FxHashMap<_, _> =
-            cached_modules.iter().map(|(_, wp)| (wp.cgu_name.clone(), wp.clone())).collect();
+        let green_modules: FxHashMap<_, _> = modules
+            .iter()
+            .filter_map(|module| {
+                if let ThinLtoInput::Green { wp, .. } = module {
+                    Some((wp.cgu_name.clone(), wp.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-        let full_scope_len = modules.len() + serialized_modules.len() + cached_modules.len();
+        let full_scope_len = modules.len();
         let mut thin_buffers = Vec::with_capacity(modules.len());
         let mut module_names = Vec::with_capacity(full_scope_len);
         let mut thin_modules = Vec::with_capacity(full_scope_len);
 
-        for (i, (name, buffer)) in modules.into_iter().enumerate() {
+        for (i, module) in modules.into_iter().enumerate() {
+            let (name, buffer) = match module {
+                ThinLtoInput::Red { name, buffer } => (name, buffer),
+                ThinLtoInput::Green { wp, buffer } => (wp.cgu_name, buffer),
+            };
             info!("local module: {} - {}", i, name);
             let cname = CString::new(name.as_bytes()).unwrap();
             thin_modules.push(llvm::ThinLTOModule {
@@ -437,19 +447,15 @@ fn thin_lto(
         //        incremental ThinLTO first where we could actually avoid
         //        looking at upstream modules entirely sometimes (the contents,
         //        we must always unconditionally look at the index).
-        let mut serialized = Vec::with_capacity(serialized_modules.len() + cached_modules.len());
 
-        let cached_modules =
-            cached_modules.into_iter().map(|(sm, wp)| (sm, CString::new(wp.cgu_name).unwrap()));
-
-        for (module, name) in serialized_modules.into_iter().chain(cached_modules) {
-            info!("upstream or cached module {:?}", name);
+        for (module, name) in serialized_modules {
+            info!("upstream module {:?}", name);
             thin_modules.push(llvm::ThinLTOModule {
                 identifier: name.as_ptr(),
                 data: module.data().as_ptr(),
                 len: module.data().len(),
             });
-            serialized.push(module);
+            thin_buffers.push(module);
             module_names.push(name);
         }
 
@@ -498,12 +504,7 @@ fn thin_lto(
         // also put all memory referenced by the C++ data (buffers, ids, etc)
         // into the arc as well. After this we'll create a thin module
         // codegen per module in this data.
-        let shared = Arc::new(ThinShared {
-            data,
-            thin_buffers,
-            serialized_modules: serialized,
-            module_names,
-        });
+        let shared = Arc::new(ThinShared { data, modules: thin_buffers, module_names });
 
         let mut copy_jobs = vec![];
         let mut opt_jobs = vec![];

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -25,10 +25,10 @@ use back::write::{create_informational_target_machine, create_target_machine};
 use context::SimpleCx;
 use llvm_util::target_config;
 use rustc_ast::expand::allocator::AllocatorMethod;
-use rustc_codegen_ssa::back::lto::{SerializedModule, ThinModule};
+use rustc_codegen_ssa::back::lto::ThinModule;
 use rustc_codegen_ssa::back::write::{
     CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryConfig,
-    TargetMachineFactoryFn,
+    TargetMachineFactoryFn, ThinLtoInput,
 };
 use rustc_codegen_ssa::traits::*;
 use rustc_codegen_ssa::{CompiledModule, CompiledModules, CrateInfo, ModuleCodegen, TargetConfig};
@@ -163,8 +163,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         dcx: DiagCtxtHandle<'_>,
         exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
-        modules: Vec<(String, Self::ModuleBuffer)>,
-        cached_modules: Vec<(SerializedModule<Self::ModuleBuffer>, WorkProduct)>,
+        modules: Vec<ThinLtoInput<Self>>,
     ) -> (Vec<ThinModule<Self>>, Vec<WorkProduct>) {
         back::lto::run_thin(
             cgcx,
@@ -173,7 +172,6 @@ impl WriteBackendMethods for LlvmCodegenBackend {
             exported_symbols_for_lto,
             each_linked_rlib_for_lto,
             modules,
-            cached_modules,
         )
     }
     fn optimize(

--- a/compiler/rustc_codegen_ssa/src/back/lto.rs
+++ b/compiler/rustc_codegen_ssa/src/back/lto.rs
@@ -32,18 +32,13 @@ impl<B: WriteBackendMethods> ThinModule<B> {
     }
 
     pub fn data(&self) -> &[u8] {
-        let a = self.shared.thin_buffers.get(self.idx).map(|b| b.data());
-        a.unwrap_or_else(|| {
-            let len = self.shared.thin_buffers.len();
-            self.shared.serialized_modules[self.idx - len].data()
-        })
+        self.shared.modules[self.idx].data()
     }
 }
 
 pub struct ThinShared<B: WriteBackendMethods> {
     pub data: B::ThinData,
-    pub thin_buffers: Vec<B::ModuleBuffer>,
-    pub serialized_modules: Vec<SerializedModule<B::ModuleBuffer>>,
+    pub modules: Vec<SerializedModule<B::ModuleBuffer>>,
     pub module_names: Vec<CString>,
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/lto.rs
+++ b/compiler/rustc_codegen_ssa/src/back/lto.rs
@@ -110,11 +110,9 @@ pub(super) fn exported_symbols_for_lto(
 
     // If we're performing LTO for the entire crate graph, then for each of our
     // upstream dependencies, include their exported symbols.
-    if tcx.sess.lto() != Lto::ThinLocal {
-        for &cnum in each_linked_rlib_for_lto {
-            let _timer = tcx.prof.generic_activity("lto_generate_symbols_below_threshold");
-            symbols_below_threshold.extend(copy_symbols(cnum));
-        }
+    for &cnum in each_linked_rlib_for_lto {
+        let _timer = tcx.prof.generic_activity("lto_generate_symbols_below_threshold");
+        symbols_below_threshold.extend(copy_symbols(cnum));
     }
 
     // Mark allocator shim symbols as exported only if they were generated.

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1264,13 +1264,16 @@ fn start_executing_work<B: ExtraBackendMethods>(
 
     let mut each_linked_rlib_for_lto = Vec::new();
     let mut each_linked_rlib_file_for_lto = Vec::new();
-    drop(link::each_linked_rlib(crate_info, None, &mut |cnum, path| {
-        if link::ignored_for_lto(sess, crate_info, cnum) {
-            return;
-        }
-        each_linked_rlib_for_lto.push(cnum);
-        each_linked_rlib_file_for_lto.push(path.to_path_buf());
-    }));
+    if sess.lto() != Lto::No && sess.lto() != Lto::ThinLocal {
+        drop(link::each_linked_rlib(crate_info, None, &mut |cnum, path| {
+            if link::ignored_for_lto(sess, crate_info, cnum) {
+                return;
+            }
+
+            each_linked_rlib_for_lto.push(cnum);
+            each_linked_rlib_file_for_lto.push(path.to_path_buf());
+        }));
+    }
 
     // Compute the set of symbols we need to retain when doing LTO (if we need to)
     let exported_symbols_for_lto =

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -398,8 +398,6 @@ enum MaybeLtoModules<B: WriteBackendMethods> {
         exported_symbols_for_lto: Arc<Vec<String>>,
         each_linked_rlib_file_for_lto: Vec<PathBuf>,
         needs_fat_lto: Vec<FatLtoInput<B>>,
-        lto_import_only_modules:
-            Vec<(SerializedModule<<B as WriteBackendMethods>::ModuleBuffer>, WorkProduct)>,
     },
     ThinLto {
         cgcx: CodegenContext,
@@ -973,8 +971,7 @@ fn do_fat_lto<B: WriteBackendMethods>(
     tm_factory: TargetMachineFactoryFn<B>,
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
-    mut needs_fat_lto: Vec<FatLtoInput<B>>,
-    import_only_modules: Vec<(SerializedModule<B::ModuleBuffer>, WorkProduct)>,
+    needs_fat_lto: Vec<FatLtoInput<B>>,
 ) -> CompiledModule {
     let _timer = prof.verbose_generic_activity("LLVM_fatlto");
 
@@ -982,10 +979,6 @@ fn do_fat_lto<B: WriteBackendMethods>(
     let dcx = dcx.handle();
 
     check_lto_allowed(&cgcx, dcx);
-
-    for (module, wp) in import_only_modules {
-        needs_fat_lto.push(FatLtoInput::Serialized { name: wp.cgu_name, buffer: module })
-    }
 
     B::optimize_and_codegen_fat_lto(
         cgcx,
@@ -1769,12 +1762,15 @@ fn start_executing_work<B: ExtraBackendMethods>(
                 needs_fat_lto.push(FatLtoInput::InMemory(allocator_module));
             }
 
+            for (module, wp) in lto_import_only_modules {
+                needs_fat_lto.push(FatLtoInput::Serialized { name: wp.cgu_name, buffer: module })
+            }
+
             return Ok(MaybeLtoModules::FatLto {
                 cgcx,
                 exported_symbols_for_lto,
                 each_linked_rlib_file_for_lto,
                 needs_fat_lto,
-                lto_import_only_modules,
             });
         } else if !needs_thin_lto.is_empty() || !lto_import_only_modules.is_empty() {
             assert!(compiled_modules.is_empty());
@@ -2176,7 +2172,6 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
                 exported_symbols_for_lto,
                 each_linked_rlib_file_for_lto,
                 needs_fat_lto,
-                lto_import_only_modules,
             } => {
                 let tm_factory = self.backend.target_machine_factory(
                     sess,
@@ -2193,7 +2188,6 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
                         &exported_symbols_for_lto,
                         &each_linked_rlib_file_for_lto,
                         needs_fat_lto,
-                        lto_import_only_modules,
                     )],
                     allocator_module: None,
                 }

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -359,8 +359,7 @@ fn generate_thin_lto_work<B: WriteBackendMethods>(
     dcx: DiagCtxtHandle<'_>,
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
-    needs_thin_lto: Vec<(String, B::ModuleBuffer)>,
-    import_only_modules: Vec<(SerializedModule<B::ModuleBuffer>, WorkProduct)>,
+    needs_thin_lto: Vec<ThinLtoInput<B>>,
 ) -> Vec<(ThinLtoWorkItem<B>, u64)> {
     let _prof_timer = prof.generic_activity("codegen_thin_generate_lto_work");
 
@@ -371,7 +370,6 @@ fn generate_thin_lto_work<B: WriteBackendMethods>(
         exported_symbols_for_lto,
         each_linked_rlib_for_lto,
         needs_thin_lto,
-        import_only_modules,
     );
     lto_modules
         .into_iter()
@@ -403,9 +401,7 @@ enum MaybeLtoModules<B: WriteBackendMethods> {
         cgcx: CodegenContext,
         exported_symbols_for_lto: Arc<Vec<String>>,
         each_linked_rlib_file_for_lto: Vec<PathBuf>,
-        needs_thin_lto: Vec<(String, <B as WriteBackendMethods>::ModuleBuffer)>,
-        lto_import_only_modules:
-            Vec<(SerializedModule<<B as WriteBackendMethods>::ModuleBuffer>, WorkProduct)>,
+        needs_thin_lto: Vec<ThinLtoInput<B>>,
     },
 }
 
@@ -785,6 +781,11 @@ pub enum FatLtoInput<B: WriteBackendMethods> {
     InMemory(ModuleCodegen<B::Module>),
 }
 
+pub enum ThinLtoInput<B: WriteBackendMethods> {
+    Red { name: String, buffer: SerializedModule<B::ModuleBuffer> },
+    Green { wp: WorkProduct, buffer: SerializedModule<B::ModuleBuffer> },
+}
+
 /// Actual LTO type we end up choosing based on multiple factors.
 pub(crate) enum ComputedLtoType {
     No,
@@ -998,11 +999,7 @@ fn do_thin_lto<B: WriteBackendMethods>(
     tm_factory: TargetMachineFactoryFn<B>,
     exported_symbols_for_lto: Arc<Vec<String>>,
     each_linked_rlib_for_lto: Vec<PathBuf>,
-    needs_thin_lto: Vec<(String, <B as WriteBackendMethods>::ModuleBuffer)>,
-    lto_import_only_modules: Vec<(
-        SerializedModule<<B as WriteBackendMethods>::ModuleBuffer>,
-        WorkProduct,
-    )>,
+    needs_thin_lto: Vec<ThinLtoInput<B>>,
 ) -> Vec<CompiledModule> {
     let _timer = prof.verbose_generic_activity("LLVM_thinlto");
 
@@ -1039,7 +1036,6 @@ fn do_thin_lto<B: WriteBackendMethods>(
         &exported_symbols_for_lto,
         &each_linked_rlib_for_lto,
         needs_thin_lto,
-        lto_import_only_modules,
     ) {
         let insertion_index =
             work_items.binary_search_by_key(&cost, |&(_, cost)| cost).unwrap_or_else(|e| e);
@@ -1719,7 +1715,10 @@ fn start_executing_work<B: ExtraBackendMethods>(
                         }
                         Ok(WorkItemResult::NeedsThinLto(name, thin_buffer)) => {
                             assert!(needs_fat_lto.is_empty());
-                            needs_thin_lto.push((name, thin_buffer));
+                            needs_thin_lto.push(ThinLtoInput::Red {
+                                name,
+                                buffer: SerializedModule::Local(thin_buffer),
+                            });
                         }
                         Err(Some(WorkerFatalError)) => {
                             // Like `CodegenAborted`, wait for remaining work to finish.
@@ -1776,6 +1775,10 @@ fn start_executing_work<B: ExtraBackendMethods>(
             assert!(compiled_modules.is_empty());
             assert!(needs_fat_lto.is_empty());
 
+            for (buffer, wp) in lto_import_only_modules {
+                needs_thin_lto.push(ThinLtoInput::Green { wp, buffer })
+            }
+
             if cgcx.lto == Lto::ThinLocal {
                 compiled_modules.extend(do_thin_lto::<B>(
                     &cgcx,
@@ -1785,12 +1788,14 @@ fn start_executing_work<B: ExtraBackendMethods>(
                     exported_symbols_for_lto,
                     each_linked_rlib_file_for_lto,
                     needs_thin_lto,
-                    lto_import_only_modules,
                 ));
             } else {
                 if let Some(allocator_module) = allocator_module.take() {
                     let thin_buffer = B::serialize_module(allocator_module.module_llvm, true);
-                    needs_thin_lto.push((allocator_module.name, thin_buffer));
+                    needs_thin_lto.push(ThinLtoInput::Red {
+                        name: allocator_module.name,
+                        buffer: SerializedModule::Local(thin_buffer),
+                    });
                 }
 
                 return Ok(MaybeLtoModules::ThinLto {
@@ -1798,7 +1803,6 @@ fn start_executing_work<B: ExtraBackendMethods>(
                     exported_symbols_for_lto,
                     each_linked_rlib_file_for_lto,
                     needs_thin_lto,
-                    lto_import_only_modules,
                 });
             }
         }
@@ -2197,7 +2201,6 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
                 exported_symbols_for_lto,
                 each_linked_rlib_file_for_lto,
                 needs_thin_lto,
-                lto_import_only_modules,
             } => {
                 let tm_factory = self.backend.target_machine_factory(
                     sess,
@@ -2214,7 +2217,6 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
                         exported_symbols_for_lto,
                         each_linked_rlib_file_for_lto,
                         needs_thin_lto,
-                        lto_import_only_modules,
                     ),
                     allocator_module: None,
                 }

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -597,30 +597,28 @@ pub fn produce_final_output_artifacts(
     // Clean up unwanted temporary files.
 
     // We create the following files by default:
-    //  - #crate#.#module-name#.bc
-    //  - #crate#.#module-name#.o
-    //  - #crate#.crate.metadata.bc
-    //  - #crate#.crate.metadata.o
-    //  - #crate#.o (linked from crate.##.o)
-    //  - #crate#.bc (copied from crate.##.bc)
+    //  - #crate#.#module-name#.rcgu.bc
+    //  - #crate#.#module-name#.rcgu.o
+    //  - #crate#.o (linked from crate.##.rcgu.o)
+    //  - #crate#.bc (copied from crate.##.rcgu.bc)
     // We may create additional files if requested by the user (through
     // `-C save-temps` or `--emit=` flags).
 
     if !sess.opts.cg.save_temps {
-        // Remove the temporary .#module-name#.o objects. If the user didn't
+        // Remove the temporary .#module-name#.rcgu.o objects. If the user didn't
         // explicitly request bitcode (with --emit=bc), and the bitcode is not
         // needed for building an rlib, then we must remove .#module-name#.bc as
         // well.
 
-        // Specific rules for keeping .#module-name#.bc:
+        // Specific rules for keeping .#module-name#.rcgu.bc:
         //  - If the user requested bitcode (`user_wants_bitcode`), and
         //    codegen_units > 1, then keep it.
         //  - If the user requested bitcode but codegen_units == 1, then we
-        //    can toss .#module-name#.bc because we copied it to .bc earlier.
+        //    can toss .#module-name#.rcgu.bc because we copied it to .bc earlier.
         //  - If we're not building an rlib and the user didn't request
-        //    bitcode, then delete .#module-name#.bc.
+        //    bitcode, then delete .#module-name#.rcgu.bc.
         // If you change how this works, also update back::link::link_rlib,
-        // where .#module-name#.bc files are (maybe) deleted after making an
+        // where .#module-name#.rcgu.bc files are (maybe) deleted after making an
         // rlib.
         let needs_crate_object = crate_output.outputs.contains_key(&OutputType::Exe);
 
@@ -680,7 +678,6 @@ pub fn produce_final_output_artifacts(
 
     // We leave the following files around by default:
     //  - #crate#.o
-    //  - #crate#.crate.metadata.o
     //  - #crate#.bc
     // These are used in linking steps and will be cleaned up afterward.
 }

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -6,9 +6,9 @@ use rustc_errors::DiagCtxtHandle;
 use rustc_middle::dep_graph::WorkProduct;
 use rustc_session::{Session, config};
 
-use crate::back::lto::{SerializedModule, ThinModule};
+use crate::back::lto::ThinModule;
 use crate::back::write::{
-    CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryFn,
+    CodegenContext, FatLtoInput, ModuleConfig, SharedEmitter, TargetMachineFactoryFn, ThinLtoInput,
 };
 use crate::{CompiledModule, ModuleCodegen};
 
@@ -47,8 +47,7 @@ pub trait WriteBackendMethods: Clone + 'static {
         dcx: DiagCtxtHandle<'_>,
         exported_symbols_for_lto: &[String],
         each_linked_rlib_for_lto: &[PathBuf],
-        modules: Vec<(String, Self::ModuleBuffer)>,
-        cached_modules: Vec<(SerializedModule<Self::ModuleBuffer>, WorkProduct)>,
+        modules: Vec<ThinLtoInput<Self>>,
     ) -> (Vec<ThinModule<Self>>, Vec<WorkProduct>);
     fn optimize(
         cgcx: &CodegenContext,

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -137,7 +137,7 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             &AttributeLintKind::UnusedDuplicate { this, other, warning } => {
                 lints::UnusedDuplicate { this, other, warning }.into_diag(dcx, level)
             }
-            AttributeLintKind::IllFormedAttributeInput { suggestions, docs } => {
+            AttributeLintKind::IllFormedAttributeInput { suggestions, docs, help } => {
                 lints::IllFormedAttributeInput {
                     num_suggestions: suggestions.len(),
                     suggestions: DiagArgValue::StrListSepByAnd(
@@ -145,6 +145,7 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
                     ),
                     has_docs: docs.is_some(),
                     docs: docs.unwrap_or(""),
+                    help: help.clone().map(|h| lints::IllFormedAttributeInputHelp { lint: h }),
                 }
                 .into_diag(dcx, level)
             }

--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -316,9 +316,27 @@ pub(super) fn unexpected_cfg_value(
     let is_from_cargo = rustc_session::utils::was_invoked_from_cargo();
     let is_from_external_macro = name_span.in_external_macro(sess.source_map());
 
-    // Show the full list if all possible values for a given name, but don't do it
-    // for names as the possibilities could be very long
-    let code_sugg = if !possibilities.is_empty() {
+    let code_sugg = if let Some((value, _)) = value
+        && sess.psess.check_config.well_known_names.contains(&name)
+        && let valid_names = possible_well_known_names_for_cfg_value(sess, value)
+        && !valid_names.is_empty()
+    {
+        // Suggest changing the name to something for which `value` is an expected value.
+        let max_suggestions = 3;
+        let suggestions = valid_names
+            .iter()
+            .take(max_suggestions)
+            .copied()
+            .map(|name| lints::unexpected_cfg_value::ChangeNameSuggestion {
+                span: name_span,
+                name,
+                value,
+            })
+            .collect::<Vec<_>>();
+        lints::unexpected_cfg_value::CodeSuggestion::ChangeName { suggestions }
+    } else if !possibilities.is_empty() {
+        // Show the full list if all possible values for a given name, but don't do it
+        // for names as the possibilities could be very long
         let expected_values = {
             let (possibilities, and_more) = sort_and_truncate_possibilities(
                 sess,
@@ -418,4 +436,23 @@ pub(super) fn unexpected_cfg_value(
         has_value: value.is_some(),
         value: value.map_or_else(String::new, |(v, _span)| v.to_string()),
     }
+}
+
+/// Ordering of the output is not stable, use this only in diagnostic code.
+fn possible_well_known_names_for_cfg_value(sess: &Session, value: Symbol) -> Vec<Symbol> {
+    #[allow(rustc::potential_query_instability)]
+    sess.psess
+        .check_config
+        .well_known_names
+        .iter()
+        .filter(|name| {
+            sess.psess
+                .check_config
+                .expecteds
+                .get(*name)
+                .map(|expected_values| expected_values.contains(&Some(value)))
+                .unwrap_or_default()
+        })
+        .copied()
+        .collect()
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2904,6 +2904,10 @@ pub(crate) mod unexpected_cfg_value {
 
             name: Symbol,
         },
+        ChangeName {
+            #[subdiagnostic]
+            suggestions: Vec<ChangeNameSuggestion>,
+        },
     }
 
     #[derive(Subdiagnostic)]
@@ -2959,6 +2963,20 @@ pub(crate) mod unexpected_cfg_value {
         pub have_none_possibility: bool,
         pub possibilities: DiagSymbolList,
         pub and_more: usize,
+    }
+
+    #[derive(Subdiagnostic)]
+    #[suggestion(
+        "`{$value}` is an expected value for `{$name}`",
+        code = "{name}",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
+    pub(crate) struct ChangeNameSuggestion {
+        #[primary_span]
+        pub span: Span,
+        pub name: Symbol,
+        pub value: Symbol,
     }
 
     #[derive(Subdiagnostic)]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3009,6 +3009,16 @@ pub(crate) struct IllFormedAttributeInput {
     #[note("for more information, visit <{$docs}>")]
     pub has_docs: bool,
     pub docs: &'static str,
+    #[subdiagnostic]
+    pub help: Option<IllFormedAttributeInputHelp>,
+}
+
+#[derive(Subdiagnostic)]
+#[help(
+    "if you meant to silence a warning, consider using #![allow({$lint})] or #![expect({$lint})]"
+)]
+pub(crate) struct IllFormedAttributeInputHelp {
+    pub lint: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -690,6 +690,7 @@ pub enum AttributeLintKind {
     IllFormedAttributeInput {
         suggestions: Vec<String>,
         docs: Option<&'static str>,
+        help: Option<String>,
     },
     EmptyAttribute {
         first_span: Span,

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1630,6 +1630,9 @@ impl<'tcx> Ty<'tcx> {
             TyKind::Coroutine(def_id, args) => {
                 Some(args.as_coroutine().variant_range(*def_id, tcx))
             }
+            TyKind::UnsafeBinder(bound_ty) => {
+                tcx.instantiate_bound_regions_with_erased((*bound_ty).into()).variant_range(tcx)
+            }
             _ => None,
         }
     }
@@ -1651,6 +1654,9 @@ impl<'tcx> Ty<'tcx> {
             TyKind::Coroutine(def_id, args) => {
                 Some(args.as_coroutine().discriminant_for_variant(*def_id, tcx, variant_index))
             }
+            TyKind::UnsafeBinder(bound_ty) => tcx
+                .instantiate_bound_regions_with_erased((*bound_ty).into())
+                .discriminant_for_variant(tcx, variant_index),
             _ => None,
         }
     }
@@ -1669,6 +1675,9 @@ impl<'tcx> Ty<'tcx> {
             }
 
             ty::Pat(ty, _) => ty.discriminant_ty(tcx),
+            ty::UnsafeBinder(bound_ty) => {
+                tcx.instantiate_bound_regions_with_erased((*bound_ty).into()).discriminant_ty(tcx)
+            }
 
             ty::Bool
             | ty::Char
@@ -1690,7 +1699,6 @@ impl<'tcx> Ty<'tcx> {
             | ty::CoroutineWitness(..)
             | ty::Never
             | ty::Tuple(_)
-            | ty::UnsafeBinder(_)
             | ty::Error(_)
             | ty::Infer(IntVar(_) | FloatVar(_)) => tcx.types.u8,
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -192,7 +192,22 @@ impl<'a> Parser<'a> {
 
             // At this point, we have failed to parse an item.
             if !matches!(vis.kind, VisibilityKind::Inherited) {
-                this.dcx().emit_err(errors::VisibilityNotFollowedByItem { span: vis.span, vis });
+                let mut err = this
+                    .dcx()
+                    .create_err(errors::VisibilityNotFollowedByItem { span: vis.span, vis });
+                if let Some((ident, _)) = this.token.ident()
+                    && !ident.is_used_keyword()
+                    && let Some((similar_kw, is_incorrect_case)) = ident
+                        .name
+                        .find_similar(&rustc_span::symbol::used_keywords(|| ident.span.edition()))
+                {
+                    err.subdiagnostic(errors::MisspelledKw {
+                        similar_kw: similar_kw.to_string(),
+                        span: ident.span,
+                        is_incorrect_case,
+                    });
+                }
+                err.emit();
             }
 
             if let Defaultness::Default(span) = def {

--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -65,6 +65,13 @@ impl<T: Eq + Hash> ExpectedValues<T> {
             ExpectedValues::Any => false,
         }
     }
+
+    pub fn contains(&self, value: &Option<T>) -> bool {
+        match self {
+            ExpectedValues::Some(expecteds) => expecteds.contains(value),
+            ExpectedValues::Any => false,
+        }
+    }
 }
 
 impl<T: Eq + Hash> Extend<T> for ExpectedValues<T> {

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -93,6 +93,7 @@
 #![feature(async_iterator)]
 #![feature(bstr)]
 #![feature(bstr_internals)]
+#![feature(case_ignorable)]
 #![feature(cast_maybe_uninit)]
 #![feature(cell_get_cloned)]
 #![feature(char_internals)]

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1074,18 +1074,20 @@ impl char {
         self > '\u{02FF}' && unicode::Grapheme_Extend(self)
     }
 
-    /// Returns `true` if this `char` has the `Case_Ignorable` property.
+    /// Returns `true` if this `char` has the `Case_Ignorable` property. This narrow-use property
+    /// is used to implement context-dependent casing for the Greek letter sigma (uppercase Σ),
+    /// which has two lowercase forms.
     ///
-    /// `Case_Ignorable` is described in Chapter 4 (Character Properties) of the [Unicode Standard] and
-    /// specified in the [Unicode Character Database][ucd] [`DerivedCoreProperties.txt`].
+    /// `Case_Ignorable` is [described][D136] in Chapter 3 (Conformance) of the Unicode Core Specification,
+    /// and specified in the [Unicode Character Database][ucd] [`DerivedCoreProperties.txt`];
+    /// see those resources for more information.
     ///
-    /// [Unicode Standard]: https://www.unicode.org/versions/latest/
+    /// [D136]: https://www.unicode.org/versions/latest/core-spec/chapter-3/#G63116
     /// [ucd]: https://www.unicode.org/reports/tr44/
     /// [`DerivedCoreProperties.txt`]: https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt
     #[must_use]
     #[inline]
-    #[doc(hidden)]
-    #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
+    #[unstable(feature = "case_ignorable", issue = "154848")]
     pub fn is_case_ignorable(self) -> bool {
         if self.is_ascii() {
             matches!(self, '\'' | '.' | ':' | '^' | '`')

--- a/tests/ui/cfg/suggest-alternative-name-on-target.rs
+++ b/tests/ui/cfg/suggest-alternative-name-on-target.rs
@@ -1,0 +1,38 @@
+#![deny(unexpected_cfgs)]
+//~^ NOTE lint level is defined here
+
+// target arch used in `target_abi`
+#[cfg(target_abi = "arm")]
+//~^ ERROR unexpected `cfg` condition value:
+//~| NOTE see <https://doc.rust-lang.org
+//~| NOTE expected values for `target_abi` are
+struct A;
+
+// target env used in `target_arch`
+#[cfg(target_arch = "gnu")]
+//~^ ERROR unexpected `cfg` condition value:
+//~| NOTE see <https://doc.rust-lang.org
+//~| NOTE expected values for `target_arch` are
+struct B;
+
+// target os used in `target_env`
+#[cfg(target_env = "openbsd")]
+//~^ ERROR unexpected `cfg` condition value:
+//~| NOTE see <https://doc.rust-lang.org
+//~| NOTE expected values for `target_env` are
+struct C;
+
+// target abi used in `target_os`
+#[cfg(target_os = "eabi")]
+//~^ ERROR unexpected `cfg` condition value:
+//~| NOTE see <https://doc.rust-lang.org
+//~| NOTE expected values for `target_os` are
+struct D;
+
+#[cfg(target_abi = "windows")]
+//~^ ERROR unexpected `cfg` condition value:
+//~| NOTE see <https://doc.rust-lang.org
+//~| NOTE expected values for `target_abi` are
+struct E;
+
+fn main() {}

--- a/tests/ui/cfg/suggest-alternative-name-on-target.rs
+++ b/tests/ui/cfg/suggest-alternative-name-on-target.rs
@@ -5,34 +5,35 @@
 #[cfg(target_abi = "arm")]
 //~^ ERROR unexpected `cfg` condition value:
 //~| NOTE see <https://doc.rust-lang.org
-//~| NOTE expected values for `target_abi` are
+//~| HELP `arm` is an expected value for `target_arch`
 struct A;
 
 // target env used in `target_arch`
 #[cfg(target_arch = "gnu")]
 //~^ ERROR unexpected `cfg` condition value:
 //~| NOTE see <https://doc.rust-lang.org
-//~| NOTE expected values for `target_arch` are
+//~| HELP `gnu` is an expected value for `target_env`
 struct B;
 
 // target os used in `target_env`
 #[cfg(target_env = "openbsd")]
 //~^ ERROR unexpected `cfg` condition value:
 //~| NOTE see <https://doc.rust-lang.org
-//~| NOTE expected values for `target_env` are
+//~| HELP `openbsd` is an expected value for `target_os`
 struct C;
 
 // target abi used in `target_os`
 #[cfg(target_os = "eabi")]
 //~^ ERROR unexpected `cfg` condition value:
 //~| NOTE see <https://doc.rust-lang.org
-//~| NOTE expected values for `target_os` are
+//~| HELP `eabi` is an expected value for `target_abi`
 struct D;
 
 #[cfg(target_abi = "windows")]
 //~^ ERROR unexpected `cfg` condition value:
 //~| NOTE see <https://doc.rust-lang.org
-//~| NOTE expected values for `target_abi` are
+//~| HELP `windows` is an expected value for `target_os`
+//~| HELP `windows` is an expected value for `target_family`
 struct E;
 
 fn main() {}

--- a/tests/ui/cfg/suggest-alternative-name-on-target.stderr
+++ b/tests/ui/cfg/suggest-alternative-name-on-target.stderr
@@ -4,13 +4,17 @@ error: unexpected `cfg` condition value: `arm`
 LL | #[cfg(target_abi = "arm")]
    |       ^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 note: the lint level is defined here
   --> $DIR/suggest-alternative-name-on-target.rs:1:9
    |
 LL | #![deny(unexpected_cfgs)]
    |         ^^^^^^^^^^^^^^^
+help: `arm` is an expected value for `target_arch`
+   |
+LL - #[cfg(target_abi = "arm")]
+LL + #[cfg(target_arch = "arm")]
+   |
 
 error: unexpected `cfg` condition value: `gnu`
   --> $DIR/suggest-alternative-name-on-target.rs:12:7
@@ -18,8 +22,12 @@ error: unexpected `cfg` condition value: `gnu`
 LL | #[cfg(target_arch = "gnu")]
    |       ^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_arch` are: `aarch64`, `amdgpu`, `arm`, `arm64ec`, `avr`, `bpf`, `csky`, `hexagon`, `loongarch32`, `loongarch64`, `m68k`, `mips`, `mips32r6`, `mips64`, `mips64r6`, `msp430`, `nvptx64`, `powerpc`, `powerpc64`, `riscv32`, `riscv64`, `s390x`, `sparc`, `sparc64`, `wasm32`, `wasm64`, `x86`, `x86_64`, and `xtensa`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+help: `gnu` is an expected value for `target_env`
+   |
+LL - #[cfg(target_arch = "gnu")]
+LL + #[cfg(target_env = "gnu")]
+   |
 
 error: unexpected `cfg` condition value: `openbsd`
   --> $DIR/suggest-alternative-name-on-target.rs:19:7
@@ -27,8 +35,12 @@ error: unexpected `cfg` condition value: `openbsd`
 LL | #[cfg(target_env = "openbsd")]
    |       ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_env` are: ``, `gnu`, `macabi`, `mlibc`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `nto80`, `ohos`, `p1`, `p2`, `p3`, `relibc`, `sgx`, `sim`, `uclibc`, and `v5`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+help: `openbsd` is an expected value for `target_os`
+   |
+LL - #[cfg(target_env = "openbsd")]
+LL + #[cfg(target_os = "openbsd")]
+   |
 
 error: unexpected `cfg` condition value: `eabi`
   --> $DIR/suggest-alternative-name-on-target.rs:26:7
@@ -36,8 +48,30 @@ error: unexpected `cfg` condition value: `eabi`
 LL | #[cfg(target_os = "eabi")]
    |       ^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `helenos`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `lynxos178`, `macos`, `managarm`, `motor`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `qurt`, `redox`, `rtems`, `solaris`, and `solid_asp3` and 14 more
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+help: `eabi` is an expected value for `target_abi`
+   |
+LL - #[cfg(target_os = "eabi")]
+LL + #[cfg(target_abi = "eabi")]
+   |
 
-error: aborting due to 4 previous errors
+error: unexpected `cfg` condition value: `windows`
+  --> $DIR/suggest-alternative-name-on-target.rs:32:7
+   |
+LL | #[cfg(target_abi = "windows")]
+   |       ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+help: `windows` is an expected value for `target_os`
+   |
+LL - #[cfg(target_abi = "windows")]
+LL + #[cfg(target_os = "windows")]
+   |
+help: `windows` is an expected value for `target_family`
+   |
+LL - #[cfg(target_abi = "windows")]
+LL + #[cfg(target_family = "windows")]
+   |
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/cfg/suggest-alternative-name-on-target.stderr
+++ b/tests/ui/cfg/suggest-alternative-name-on-target.stderr
@@ -1,0 +1,43 @@
+error: unexpected `cfg` condition value: `arm`
+  --> $DIR/suggest-alternative-name-on-target.rs:5:7
+   |
+LL | #[cfg(target_abi = "arm")]
+   |       ^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `target_abi` are: ``, `abi64`, `abiv2`, `abiv2hf`, `eabi`, `eabihf`, `elfv1`, `elfv2`, `fortanix`, `ilp32`, `ilp32e`, `llvm`, `macabi`, `sim`, `softfloat`, `spe`, `uwp`, `vec-extabi`, and `x32`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+note: the lint level is defined here
+  --> $DIR/suggest-alternative-name-on-target.rs:1:9
+   |
+LL | #![deny(unexpected_cfgs)]
+   |         ^^^^^^^^^^^^^^^
+
+error: unexpected `cfg` condition value: `gnu`
+  --> $DIR/suggest-alternative-name-on-target.rs:12:7
+   |
+LL | #[cfg(target_arch = "gnu")]
+   |       ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `target_arch` are: `aarch64`, `amdgpu`, `arm`, `arm64ec`, `avr`, `bpf`, `csky`, `hexagon`, `loongarch32`, `loongarch64`, `m68k`, `mips`, `mips32r6`, `mips64`, `mips64r6`, `msp430`, `nvptx64`, `powerpc`, `powerpc64`, `riscv32`, `riscv64`, `s390x`, `sparc`, `sparc64`, `wasm32`, `wasm64`, `x86`, `x86_64`, and `xtensa`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+error: unexpected `cfg` condition value: `openbsd`
+  --> $DIR/suggest-alternative-name-on-target.rs:19:7
+   |
+LL | #[cfg(target_env = "openbsd")]
+   |       ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `target_env` are: ``, `gnu`, `macabi`, `mlibc`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `nto80`, `ohos`, `p1`, `p2`, `p3`, `relibc`, `sgx`, `sim`, `uclibc`, and `v5`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+error: unexpected `cfg` condition value: `eabi`
+  --> $DIR/suggest-alternative-name-on-target.rs:26:7
+   |
+LL | #[cfg(target_os = "eabi")]
+   |       ^^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `helenos`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `lynxos178`, `macos`, `managarm`, `motor`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `qurt`, `redox`, `rtems`, `solaris`, and `solid_asp3` and 14 more
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/malformed/ignore-with-lint-name.rs
+++ b/tests/ui/malformed/ignore-with-lint-name.rs
@@ -1,0 +1,6 @@
+#[ignore(clippy::single_match)]
+//~^ ERROR valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
+//~| HELP if you meant to silence a warning, consider using #![allow(clippy::single_match)] or #![expect(clippy::single_match)]
+//~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+fn main() {}

--- a/tests/ui/malformed/ignore-with-lint-name.stderr
+++ b/tests/ui/malformed/ignore-with-lint-name.stderr
@@ -1,0 +1,25 @@
+error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
+  --> $DIR/ignore-with-lint-name.rs:1:1
+   |
+LL | #[ignore(clippy::single_match)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you meant to silence a warning, consider using #![allow(clippy::single_match)] or #![expect(clippy::single_match)]
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: aborting due to 1 previous error
+
+Future incompatibility report: Future breakage diagnostic:
+error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
+  --> $DIR/ignore-with-lint-name.rs:1:1
+   |
+LL | #[ignore(clippy::single_match)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: if you meant to silence a warning, consider using #![allow(clippy::single_match)] or #![expect(clippy::single_match)]
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/moves/assign-value-after-at-pattern-issue-145564.fixed
+++ b/tests/ui/moves/assign-value-after-at-pattern-issue-145564.fixed
@@ -1,0 +1,19 @@
+//@ run-rustfix
+#![allow(unused_variables)]
+
+fn main() {
+    let ref mut x @ _v = 42;
+    *x = 1; //~ ERROR used binding `x` isn't initialized
+
+    let a @ _b: i32 = 42;
+    println!("{}", a); //~ ERROR used binding `a` isn't initialized
+
+    let ref c @ _d: i32 = 42;
+    println!("{:?}", c); //~ ERROR used binding `c` isn't initialized
+
+    let ref e: i32 = 42;
+    println!("{:?}", e); //~ ERROR used binding `e` isn't initialized
+
+    let ref mut y = 42;
+    *y = 1; //~ ERROR used binding `y` isn't initialized
+}

--- a/tests/ui/moves/assign-value-after-at-pattern-issue-145564.rs
+++ b/tests/ui/moves/assign-value-after-at-pattern-issue-145564.rs
@@ -1,0 +1,19 @@
+//@ run-rustfix
+#![allow(unused_variables)]
+
+fn main() {
+    let ref mut x @ _v;
+    *x = 1; //~ ERROR used binding `x` isn't initialized
+
+    let a @ _b: i32;
+    println!("{}", a); //~ ERROR used binding `a` isn't initialized
+
+    let ref c @ _d: i32;
+    println!("{:?}", c); //~ ERROR used binding `c` isn't initialized
+
+    let ref e: i32;
+    println!("{:?}", e); //~ ERROR used binding `e` isn't initialized
+
+    let ref mut y;
+    *y = 1; //~ ERROR used binding `y` isn't initialized
+}

--- a/tests/ui/moves/assign-value-after-at-pattern-issue-145564.stderr
+++ b/tests/ui/moves/assign-value-after-at-pattern-issue-145564.stderr
@@ -1,0 +1,68 @@
+error[E0381]: used binding `x` isn't initialized
+  --> $DIR/assign-value-after-at-pattern-issue-145564.rs:6:5
+   |
+LL |     let ref mut x @ _v;
+   |         --------- binding declared here but left uninitialized
+LL |     *x = 1;
+   |     ^^^^^^ `x` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let ref mut x @ _v = 42;
+   |                        ++++
+
+error[E0381]: used binding `a` isn't initialized
+  --> $DIR/assign-value-after-at-pattern-issue-145564.rs:9:20
+   |
+LL |     let a @ _b: i32;
+   |         - binding declared here but left uninitialized
+LL |     println!("{}", a);
+   |                    ^ `a` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let a @ _b: i32 = 42;
+   |                     ++++
+
+error[E0381]: used binding `c` isn't initialized
+  --> $DIR/assign-value-after-at-pattern-issue-145564.rs:12:22
+   |
+LL |     let ref c @ _d: i32;
+   |         ----- binding declared here but left uninitialized
+LL |     println!("{:?}", c);
+   |                      ^ `c` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let ref c @ _d: i32 = 42;
+   |                         ++++
+
+error[E0381]: used binding `e` isn't initialized
+  --> $DIR/assign-value-after-at-pattern-issue-145564.rs:15:22
+   |
+LL |     let ref e: i32;
+   |         ----- binding declared here but left uninitialized
+LL |     println!("{:?}", e);
+   |                      ^ `e` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let ref e: i32 = 42;
+   |                    ++++
+
+error[E0381]: used binding `y` isn't initialized
+  --> $DIR/assign-value-after-at-pattern-issue-145564.rs:18:5
+   |
+LL |     let ref mut y;
+   |         --------- binding declared here but left uninitialized
+LL |     *y = 1;
+   |     ^^^^^^ `y` used here but it isn't initialized
+   |
+help: consider assigning a value
+   |
+LL |     let ref mut y = 42;
+   |                   ++++
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0381`.

--- a/tests/ui/parser/misspelled-keywords/pub-const-fn.rs
+++ b/tests/ui/parser/misspelled-keywords/pub-const-fn.rs
@@ -1,0 +1,5 @@
+pub cnst fn code() {}
+//~^ ERROR visibility `pub` is not followed by an item
+//~| ERROR expected item, found `cnst`
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/pub-const-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/pub-const-fn.stderr
@@ -1,0 +1,22 @@
+error: visibility `pub` is not followed by an item
+  --> $DIR/pub-const-fn.rs:1:1
+   |
+LL | pub cnst fn code() {}
+   | ^^^ the visibility
+   |
+   = help: you likely meant to define an item, e.g., `pub fn foo() {}`
+help: there is a keyword `const` with a similar name
+   |
+LL | pub const fn code() {}
+   |      +
+
+error: expected item, found `cnst`
+  --> $DIR/pub-const-fn.rs:1:5
+   |
+LL | pub cnst fn code() {}
+   |     ^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/unsafe-binders/discriminant-for-variant.rs
+++ b/tests/ui/unsafe-binders/discriminant-for-variant.rs
@@ -1,0 +1,11 @@
+#![feature(unsafe_binders)]
+
+const None: Option<unsafe<> Option<Box<dyn Send>>> = None;
+//~^ ERROR the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+//~| ERROR the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+
+fn main() {
+    match None {
+        _ => {}
+    }
+}

--- a/tests/ui/unsafe-binders/discriminant-for-variant.stderr
+++ b/tests/ui/unsafe-binders/discriminant-for-variant.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+  --> $DIR/discriminant-for-variant.rs:3:13
+   |
+LL | const None: Option<unsafe<> Option<Box<dyn Send>>> = None;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<(dyn Send + 'static)>`
+   |
+   = note: required for `Option<Box<(dyn Send + 'static)>>` to implement `Copy`
+
+error[E0277]: the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+  --> $DIR/discriminant-for-variant.rs:3:54
+   |
+LL | const None: Option<unsafe<> Option<Box<dyn Send>>> = None;
+   |                                                      ^^^^ the trait `Copy` is not implemented for `Box<(dyn Send + 'static)>`
+   |
+   = note: required for `Option<Box<(dyn Send + 'static)>>` to implement `Copy`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153440 (Various LTO cleanups)
 - rust-lang/rust#151899 (Constify fold, reduce and last for iterator)
 - rust-lang/rust#154561 (Suggest similar keyword when visibility is not followed by an item)
 - rust-lang/rust#154657 (Fix pattern assignment suggestions for uninitialized bindings)
 - rust-lang/rust#154717 (Fix ICE in unsafe binder discriminant helpers)
 - rust-lang/rust#154722 (fix(lints): Improve `ill_formed_attribute_input` with better help message)
 - rust-lang/rust#154777 (`#[cfg]`: suggest alternative `target_` name when the value does not match)
 - rust-lang/rust#154849 (Promote `char::is_case_ignorable` from perma-unstable to unstable)
 - rust-lang/rust#154850 (ast_validation: scalable vectors okay for rustdoc)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153440,151899,154561,154657,154717,154722,154777,154849,154850)
<!-- homu-ignore:end -->

