### PR TITLE
Fix ICE for inherited const conditions on const closures

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -530,15 +530,8 @@ fn evaluate_host_effect_for_fn_goal<'tcx>(
 
         ty::Closure(def, args) => {
             // For now we limit ourselves to closures without binders. The next solver can handle them.
-            let sig =
-                args.as_closure().sig().no_bound_vars().ok_or(EvaluationFailure::NoSolution)?;
-            (
-                def,
-                tcx.mk_args_from_iter(
-                    [ty::GenericArg::from(*sig.inputs().get(0).unwrap()), sig.output().into()]
-                        .into_iter(),
-                ),
-            )
+            args.as_closure().sig().no_bound_vars().ok_or(EvaluationFailure::NoSolution)?;
+            (def, args)
         }
 
         // Everything else needs explicit impls or cannot have an impl

--- a/tests/ui/traits/const-traits/const-closure-inherited-const-condition.rs
+++ b/tests/ui/traits/const-traits/const-closure-inherited-const-condition.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ revisions: next old
+//@[next] compile-flags: -Znext-solver
+
+#![feature(const_closures, const_trait_impl)]
+
+const trait Foo {}
+
+const fn qux<T: [const] Foo>() { (const || {})() }
+
+fn main() {}


### PR DESCRIPTION
Synchronize `evaluate_host_effect_for_fn_goal` with the behavior of `extract_fn_def_from_const_callable` in new solver.

Closes rust-lang/rust#153861 .
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
