### PR TITLE
attr parsing: make sure we pass the right target when errors could be emitted

### DIFF
--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -64,6 +64,7 @@ impl<'sess> AttributeParser<'sess, Early> {
             sym,
             target_span,
             target_node_id,
+            Target::Crate, // Does not matter, we're not going to emit errors anyways
             features,
             ShouldEmit::Nothing,
         )
@@ -79,6 +80,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         sym: Symbol,
         target_span: Span,
         target_node_id: NodeId,
+        target: Target,
         features: Option<&'sess Features>,
         should_emit: ShouldEmit,
     ) -> Option<Attribute> {
@@ -86,7 +88,7 @@ impl<'sess> AttributeParser<'sess, Early> {
             sess,
             attrs,
             Some(sym),
-            Target::Crate, // Does not matter, we're not going to emit errors anyways
+            target,
             target_span,
             target_node_id,
             features,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -22,7 +22,7 @@ use rustc_hir::def_id::{LOCAL_CRATE, StableCrateId, StableCrateIdMap};
 use rustc_hir::definitions::Definitions;
 use rustc_hir::limit::Limit;
 use rustc_hir::lints::DelayedLint;
-use rustc_hir::{Attribute, MaybeOwner, find_attr};
+use rustc_hir::{Attribute, MaybeOwner, Target, find_attr};
 use rustc_incremental::setup_dep_graph;
 use rustc_lint::{
     BufferedEarlyLint, DecorateAttrLint, EarlyCheckNode, LintStore, unerased_lint_store,
@@ -1372,6 +1372,7 @@ pub(crate) fn parse_crate_name(
             sym::crate_name,
             DUMMY_SP,
             rustc_ast::node_id::CRATE_NODE_ID,
+            Target::Crate,
             None,
             emit_errors,
         )?
@@ -1421,6 +1422,7 @@ pub fn collect_crate_types(
                 sym::crate_type,
                 crate_span,
                 CRATE_NODE_ID,
+                Target::Crate,
                 None,
                 ShouldEmit::EarlyFatal { also_emit_lints: false },
             )
@@ -1477,6 +1479,7 @@ fn get_recursion_limit(krate_attrs: &[ast::Attribute], sess: &Session) -> Limit 
         sym::recursion_limit,
         DUMMY_SP,
         rustc_ast::node_id::CRATE_NODE_ID,
+        Target::Crate,
         None,
         // errors are fatal here, but lints aren't.
         // If things aren't fatal we continue, and will parse this again.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Found this while debugging something on https://github.com/rust-lang/rust/pull/154590. AFAIK there is no user-observable change, but the code was definitely wrong (I tested it by adding an `assert!(matches!(should_emit, ShouldEmit::Nothing));` at the beginning of `parse_limited_should_emit`.

I did a bit of archeology and it looks like this was introduced in https://github.com/rust-lang/rust/pull/137729. I couldn't find any reason for this from the discussion that occurred back then.

r? jdonszelmann 
<!-- homu-ignore:end -->
