### PR TITLE
Don't store `pattern_ty` in `TestableCase`

### DIFF
--- a/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -152,6 +152,7 @@ impl<'tcx> MatchPairTree<'tcx> {
             }
 
             PatKind::Range(ref range) => {
+                assert_eq!(pattern.ty, range.ty);
                 if range.is_full_range(cx.tcx) == Some(true) {
                     None
                 } else {
@@ -380,7 +381,6 @@ impl<'tcx> MatchPairTree<'tcx> {
                 place,
                 testable_case,
                 subpairs,
-                pattern_ty: pattern.ty,
                 pattern_span: pattern.span,
             })
         } else {

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -1277,7 +1277,7 @@ enum PatConstKind {
 /// tested, and a test to perform on that place.
 ///
 /// Each node also has a list of subpairs (possibly empty) that must also match,
-/// and a reference to the THIR pattern it represents.
+/// and some additional information from the THIR pattern it represents.
 #[derive(Debug, Clone)]
 pub(crate) struct MatchPairTree<'tcx> {
     /// This place...
@@ -1301,9 +1301,7 @@ pub(crate) struct MatchPairTree<'tcx> {
     /// that tests its field for the value `3`.
     subpairs: Vec<Self>,
 
-    /// Type field of the pattern this node was created from.
-    pattern_ty: Ty<'tcx>,
-    /// Span field of the pattern this node was created from.
+    /// Span field of the THIR pattern this node was created from.
     pattern_span: Span,
 }
 

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -44,10 +44,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 TestKind::ScalarEq { value }
             }
 
-            TestableCase::Range(ref range) => {
-                assert_eq!(range.ty, match_pair.pattern_ty);
-                TestKind::Range(Arc::clone(range))
-            }
+            TestableCase::Range(ref range) => TestKind::Range(Arc::clone(range)),
 
             TestableCase::Slice { len, op } => TestKind::SliceLen { len, op },
 


### PR DESCRIPTION
This field's only remaining use was in an assertion, but we can perform the same assertion earlier when constructing `TestableCase::Range`.

---

For background, the `pattern_ty` field was introduced in https://github.com/rust-lang/rust/pull/136435 to replace a reference to the full THIR pattern node. Since then, most uses of `pattern_ty` were removed by https://github.com/rust-lang/rust/pull/150238.