### PR TITLE
Fix ICE in ptr_metadata_ty_or_tail for recursive associated types

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1769,8 +1769,9 @@ impl<'tcx> Ty<'tcx> {
 
             | ty::UnsafeBinder(_) => todo!("FIXME(unsafe_binder)"),
 
-            ty::Infer(ty::TyVar(_))
-            | ty::Pat(..)
+            ty::Infer(ty::TyVar(_)) => Ok(tcx.types.unit),
+
+            ty::Pat(..)
             | ty::Bound(..)
             | ty::Placeholder(..)
             | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => bug!(

--- a/tests/ui/associated-types/ptr-metadata-recursive-assoc-type-ice-153431.rs
+++ b/tests/ui/associated-types/ptr-metadata-recursive-assoc-type-ice-153431.rs
@@ -1,0 +1,24 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/153431>.
+// Used to ICE in `ptr_metadata_ty_or_tail` when computing pointer metadata
+// for a struct whose tail field has a recursive associated type.
+//~^^^ ERROR overflow evaluating the requirement `<Bar as Trait>::Assoc2 == _`
+
+trait Trait {
+    type Assoc2;
+}
+
+struct Bar;
+impl Trait for Bar {
+    type Assoc2 = Result<(), <Bar as Trait>::Assoc2>;
+    //~^ ERROR overflow evaluating the requirement `<Bar as Trait>::Assoc2 == _`
+}
+
+struct Foo {
+    field: <Bar as Trait>::Assoc2,
+    //~^ ERROR overflow evaluating the requirement `<Bar as Trait>::Assoc2 == _`
+}
+
+static BAR: u8 = 42;
+static FOO2: &Foo = unsafe { std::mem::transmute(&BAR) };
+
+fn main() {}

--- a/tests/ui/associated-types/ptr-metadata-recursive-assoc-type-ice-153431.stderr
+++ b/tests/ui/associated-types/ptr-metadata-recursive-assoc-type-ice-153431.stderr
@@ -1,0 +1,17 @@
+error[E0275]: overflow evaluating the requirement `<Bar as Trait>::Assoc2 == _`
+  --> $DIR/ptr-metadata-recursive-assoc-type-ice-153431.rs:12:19
+   |
+LL |     type Assoc2 = Result<(), <Bar as Trait>::Assoc2>;
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0275]: overflow evaluating the requirement `<Bar as Trait>::Assoc2 == _`
+  --> $DIR/ptr-metadata-recursive-assoc-type-ice-153431.rs:17:12
+   |
+LL |     field: <Bar as Trait>::Assoc2,
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0275]: overflow evaluating the requirement `<Bar as Trait>::Assoc2 == _`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Fixes rust-lang/rust#153431.

When a struct's tail field has a recursive associated type, normalization
overflows and `normalize_projection_term` returns a fresh inference variable
(`TyVar`) instead of the original alias. This `TyVar` escapes `struct_tail_raw`
and reaches `ptr_metadata_ty_or_tail`, which had no arm for it and called
`bug!`.

Fix by handling `ty::Infer(ty::TyVar(_))` the same way as `ty::Error(_)`,
return `Ok(tcx.types.unit)` since the overflow error has already been reported.
