### PR TITLE
Stabilize check-cfg suggestions for symbol

### DIFF
--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -438,10 +438,10 @@ pub(super) fn unexpected_cfg_value(
     }
 }
 
-/// Ordering of the output is not stable, use this only in diagnostic code.
 fn possible_well_known_names_for_cfg_value(sess: &Session, value: Symbol) -> Vec<Symbol> {
     #[allow(rustc::potential_query_instability)]
-    sess.psess
+    let mut names = sess
+        .psess
         .check_config
         .well_known_names
         .iter()
@@ -454,5 +454,7 @@ fn possible_well_known_names_for_cfg_value(sess: &Session, value: Symbol) -> Vec
                 .unwrap_or_default()
         })
         .copied()
-        .collect()
+        .collect::<Vec<_>>();
+    names.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    names
 }

--- a/tests/ui/cfg/suggest-alternative-name-on-target.rs
+++ b/tests/ui/cfg/suggest-alternative-name-on-target.rs
@@ -32,8 +32,8 @@ struct D;
 #[cfg(target_abi = "windows")]
 //~^ ERROR unexpected `cfg` condition value:
 //~| NOTE see <https://doc.rust-lang.org
-//~| HELP `windows` is an expected value for `target_os`
 //~| HELP `windows` is an expected value for `target_family`
+//~| HELP `windows` is an expected value for `target_os`
 struct E;
 
 fn main() {}

--- a/tests/ui/cfg/suggest-alternative-name-on-target.stderr
+++ b/tests/ui/cfg/suggest-alternative-name-on-target.stderr
@@ -62,15 +62,15 @@ LL | #[cfg(target_abi = "windows")]
    |       ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
-help: `windows` is an expected value for `target_os`
-   |
-LL - #[cfg(target_abi = "windows")]
-LL + #[cfg(target_os = "windows")]
-   |
 help: `windows` is an expected value for `target_family`
    |
 LL - #[cfg(target_abi = "windows")]
 LL + #[cfg(target_family = "windows")]
+   |
+help: `windows` is an expected value for `target_os`
+   |
+LL - #[cfg(target_abi = "windows")]
+LL + #[cfg(target_os = "windows")]
    |
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
When I was working on https://github.com/rust-lang/rust/pull/154794, I found a weird CI fail https://github.com/rust-lang/rust/pull/154794#issuecomment-4192269333, I finally found this caused by unstable cfg suggestions by using `FxHashSet`(from PR https://github.com/rust-lang/rust/pull/154777). Because my PR by luck insert a new symbol, which makes the final diagnostic order changed.

It's a standalone issue, so it's better to fix in a separate PR.
