### PR TITLE
implement `StructuralPartialEq` for `MaybeDangling`

### DIFF
--- a/library/core/src/mem/maybe_dangling.rs
+++ b/library/core/src/mem/maybe_dangling.rs
@@ -1,5 +1,6 @@
 #![unstable(feature = "maybe_dangling", issue = "118166")]
 
+use crate::marker::StructuralPartialEq;
 use crate::{mem, ptr};
 
 /// Allows wrapped [references] and [boxes] to dangle.
@@ -109,3 +110,5 @@ impl<P: ?Sized> MaybeDangling<P> {
         x
     }
 }
+
+impl<T: ?Sized> StructuralPartialEq for MaybeDangling<T> {}

--- a/tests/ui/consts/manually_drop_structural_eq.rs
+++ b/tests/ui/consts/manually_drop_structural_eq.rs
@@ -1,0 +1,16 @@
+// Check that `ManuallyDrop` types can be used as a constant when matching.
+// I.e. that `ManuallyDrop` implements `StructuralPartialEq`.
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/154890>.
+//
+//@ check-pass
+use std::mem::ManuallyDrop;
+
+fn main() {
+    const X: ManuallyDrop<u32> = ManuallyDrop::new(1);
+
+    match ManuallyDrop::new(1) {
+        X => println!("blah"),
+        _ => println!("bleh"),
+    }
+}


### PR DESCRIPTION
This fixes -- a stable-to-stable regression where constants of type `ManuallyDrop<T>` would not be allowed to be used as a pattern due to `MaybeDangling<T>` in `ManuallyDrop<T>` not implementing `StructuralPartialEq`.

Fixes https://github.com/rust-lang/rust/issues/154890

I'm sorry, @theemathas, I forgot to address your [comment](https://github.com/rust-lang/rust/pull/149614#discussion_r2587340079) :sob: