### PR TITLE
borrowck: Apply `user_arg_index` nomenclature more broadly

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -499,18 +499,18 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
         fr: RegionVid,
     ) -> Option<RegionName> {
         let implicit_inputs = self.regioncx.universal_regions().defining_ty.implicit_inputs();
-        let argument_index = self.regioncx.get_argument_index_for_region(self.infcx.tcx, fr)?;
+        let user_arg_index = self.regioncx.get_user_arg_index_for_region(self.infcx.tcx, fr)?;
 
         let arg_ty = self.regioncx.universal_regions().unnormalized_input_tys
-            [implicit_inputs + argument_index];
+            [implicit_inputs + user_arg_index];
         let (_, span) = self.regioncx.get_argument_name_and_span_for_region(
             self.body,
             self.local_names(),
-            argument_index,
+            user_arg_index,
         );
 
         let highlight = self
-            .get_argument_hir_ty_for_highlighting(argument_index)
+            .get_argument_hir_ty_for_highlighting(user_arg_index)
             .and_then(|arg_hir_ty| self.highlight_if_we_can_match_hir_ty(fr, arg_ty, arg_hir_ty))
             .unwrap_or_else(|| {
                 // `highlight_if_we_cannot_match_hir_ty` needs to know the number we will give to
@@ -528,10 +528,11 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
 
     fn get_argument_hir_ty_for_highlighting(
         &self,
-        argument_index: usize,
+        user_arg_index: usize,
     ) -> Option<&hir::Ty<'tcx>> {
         let fn_decl = self.infcx.tcx.hir_fn_decl_by_hir_id(self.mir_hir_id())?;
-        let argument_hir_ty: &hir::Ty<'_> = fn_decl.inputs.get(argument_index)?;
+        // Closures don't have implicit self arguments in HIR, so use `user_arg_index` directly.
+        let argument_hir_ty: &hir::Ty<'_> = fn_decl.inputs.get(user_arg_index)?;
         match argument_hir_ty.kind {
             // This indicates a variable with no type annotation, like
             // `|x|`... in that case, we can't highlight the type but

--- a/compiler/rustc_borrowck/src/diagnostics/var_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/var_name.rs
@@ -31,7 +31,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             })
             .or_else(|| {
                 debug!("get_var_name_and_span_for_region: attempting argument");
-                self.get_argument_index_for_region(tcx, fr).and_then(|index| {
+                self.get_user_arg_index_for_region(tcx, fr).and_then(|index| {
                     let local = self.user_arg_index_to_local(body, index);
                     if body_uses_local(body, local) {
                         Some(self.get_argument_name_and_span_for_region(body, local_names, index))
@@ -93,26 +93,26 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ///
     /// N.B., in the case of a closure, the index is indexing into the signature as seen by the
     /// user - in particular, index 0 is not the implicit self parameter.
-    pub(crate) fn get_argument_index_for_region(
+    pub(crate) fn get_user_arg_index_for_region(
         &self,
         tcx: TyCtxt<'tcx>,
         fr: RegionVid,
     ) -> Option<usize> {
         let implicit_inputs = self.universal_regions().defining_ty.implicit_inputs();
-        let argument_index =
+        let user_arg_index =
             self.universal_regions().unnormalized_input_tys.iter().skip(implicit_inputs).position(
                 |arg_ty| {
-                    debug!("get_argument_index_for_region: arg_ty = {arg_ty:?}");
+                    debug!("get_user_arg_index_for_region: arg_ty = {arg_ty:?}");
                     tcx.any_free_region_meets(arg_ty, |r| r.as_var() == fr)
                 },
             )?;
 
         debug!(
-            "get_argument_index_for_region: found {fr:?} in argument {argument_index} which has type {:?}",
-            self.universal_regions().unnormalized_input_tys[argument_index],
+            "get_user_arg_index_for_region: found {fr:?} in argument {user_arg_index} which has type {:?}",
+            self.universal_regions().unnormalized_input_tys[user_arg_index],
         );
 
-        Some(argument_index)
+        Some(user_arg_index)
     }
 
     /// Given the index of an argument as seen from the user (i.e. excluding
@@ -128,9 +128,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         &self,
         body: &Body<'tcx>,
         local_names: &IndexSlice<Local, Option<Symbol>>,
-        argument_index: usize,
+        user_arg_index: usize,
     ) -> (Option<Symbol>, Span) {
-        let argument_local = self.user_arg_index_to_local(body, argument_index);
+        let argument_local = self.user_arg_index_to_local(body, user_arg_index);
         debug!("get_argument_name_and_span_for_region: argument_local={argument_local:?}");
 
         let argument_name = local_names[argument_local];

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -79,6 +79,9 @@ pub(crate) struct UniversalRegions<'tcx> {
     ///
     /// N.B., associated types in these types have not been normalized,
     /// as the name suggests. =)
+    ///
+    /// N.B., in the case of a closure, index 0 is the implicit self parameter,
+    /// and not the first input as seen by the user.
     pub unnormalized_input_tys: &'tcx [Ty<'tcx>],
 
     pub yield_ty: Option<Ty<'tcx>>,


### PR DESCRIPTION
No change in behavior. Only renames and a couple of added comments.

As requested here: https://github.com/rust-lang/rust/pull/154674#discussion_r3027381648

r? jdonszelmann
