### PR TITLE
Fix ICE: Scalar layout for non-primitive non-enum type unsafe binder

### DIFF
--- a/compiler/rustc_ty_utils/src/layout/invariant.rs
+++ b/compiler/rustc_ty_utils/src/layout/invariant.rs
@@ -1,8 +1,8 @@
 use std::assert_matches;
 
 use rustc_abi::{BackendRepr, FieldsShape, Scalar, Size, TagEncoding, Variants};
-use rustc_middle::bug;
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutCx, TyAndLayout};
+use rustc_middle::{bug, ty};
 
 /// Enforce some basic invariants on layouts.
 pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayout<'tcx>) {
@@ -52,6 +52,14 @@ pub(super) fn layout_sanity_check<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayou
     }
 
     fn skip_newtypes<'tcx>(cx: &LayoutCx<'tcx>, layout: &TyAndLayout<'tcx>) -> TyAndLayout<'tcx> {
+        match *layout.ty.kind() {
+            ty::UnsafeBinder(bound_ty) => {
+                let ty = cx.tcx().instantiate_bound_regions_with_erased(bound_ty.into());
+                return skip_newtypes(cx, &TyAndLayout { ty, ..*layout });
+            }
+            _ => {}
+        }
+
         if matches!(layout.layout.variants(), Variants::Multiple { .. }) {
             // Definitely not a newtype of anything.
             return *layout;

--- a/tests/ui/unsafe-binders/layout-invariant.rs
+++ b/tests/ui/unsafe-binders/layout-invariant.rs
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/rust-lang/rust/issues/154426
+#![feature(unsafe_binders)]
+
+#[derive(Copy, Clone)]
+struct Adt<'a> {
+    a: &'a String,
+}
+
+const None: Option<unsafe<> Option<unsafe<'a> Adt<'a>>> = None;
+//~^ ERROR the trait bound `unsafe<'a> Adt<'a>: Copy` is not satisfied
+//~| ERROR the trait bound `unsafe<'a> Adt<'a>: Copy` is not satisfied
+
+fn main() {
+    match None {
+        _ => {}
+    };
+}

--- a/tests/ui/unsafe-binders/layout-invariant.stderr
+++ b/tests/ui/unsafe-binders/layout-invariant.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `unsafe<'a> Adt<'a>: Copy` is not satisfied
+  --> $DIR/layout-invariant.rs:9:13
+   |
+LL | const None: Option<unsafe<> Option<unsafe<'a> Adt<'a>>> = None;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `unsafe<'a> Adt<'a>`
+   |
+   = note: required for `Option<unsafe<'a> Adt<'a>>` to implement `Copy`
+
+error[E0277]: the trait bound `unsafe<'a> Adt<'a>: Copy` is not satisfied
+  --> $DIR/layout-invariant.rs:9:59
+   |
+LL | const None: Option<unsafe<> Option<unsafe<'a> Adt<'a>>> = None;
+   |                                                           ^^^^ the trait `Copy` is not implemented for `unsafe<'a> Adt<'a>`
+   |
+   = note: required for `Option<unsafe<'a> Adt<'a>>` to implement `Copy`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
`UnsafeBinder` uses the inner layout, but the debug layout check still looked at the outer type. Check the inner type first so this does not ICE.

Tracking issue: rust-lang/rust#130516
Closes: rust-lang/rust#154426 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
