### PR TITLE
continuation of the task 154452: fix doc with methods `_in`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -700,6 +700,7 @@ impl<T, A: Allocator> Box<T, A> {
     ///
     /// ```
     /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::System;
     ///
     /// let x = Box::pin_in(1, System);

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -830,10 +830,10 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
+    /// #![feature(allocator_api)]
     ///
-    /// use std::collections::VecDeque;
     /// use std::alloc::Global;
+    /// use std::collections::VecDeque;
     ///
     /// let deque: VecDeque<i32> = VecDeque::new_in(Global);
     /// ```
@@ -848,10 +848,10 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
+    /// #![feature(allocator_api)]
     ///
-    /// use std::collections::VecDeque;
     /// use std::alloc::Global;
+    /// use std::collections::VecDeque;
     ///
     /// let deque: VecDeque<i32> = VecDeque::with_capacity_in(10, Global);
     /// ```

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -859,6 +859,37 @@ impl<T, A: Allocator> Rc<T, A> {
     ///
     /// [`new_cyclic`]: Rc::new_cyclic
     /// [`upgrade`]: Weak::upgrade
+    ///
+    /// ```
+    /// # #![allow(dead_code)]
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::Global;
+    /// use std::rc::{Rc, Weak};
+    ///
+    /// struct Gadget {
+    ///     me: Weak<Gadget>,
+    /// }
+    ///
+    /// impl Gadget {
+    ///     /// Constructs a reference counted Gadget.
+    ///     fn new() -> Rc<Self> {
+    ///         // `me` is a `Weak<Gadget>` pointing at the new allocation of the
+    ///         // `Rc` we're constructing.
+    ///         Rc::new_cyclic_in(|me| {
+    ///                 // Create the actual struct here.
+    ///                 Gadget { me: me.clone() }
+    ///             },
+    ///             Global,
+    ///         )
+    ///     }
+    ///
+    ///     /// Returns a reference counted pointer to Self.
+    ///     fn me(&self) -> Rc<Self> {
+    ///         self.me.upgrade().unwrap()
+    ///     }
+    /// }
+    /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub fn new_cyclic_in<F>(data_fn: F, alloc: A) -> Rc<T, A>
@@ -1014,6 +1045,17 @@ impl<T, A: Allocator> Rc<T, A> {
 
     /// Constructs a new `Pin<Rc<T>>` in the provided allocator. If `T` does not implement `Unpin`, then
     /// `value` will be pinned in memory and unable to be moved.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::System;
+    /// use std::rc::Rc;
+    ///
+    /// let x = Rc::pin_in(1, System);
+    /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[inline]
@@ -3233,9 +3275,12 @@ impl<T, A: Allocator> Weak<T, A> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::Global;
     /// use std::rc::Weak;
     ///
-    /// let empty: Weak<i64> = Weak::new();
+    /// let empty: Weak<i64> = Weak::new_in(Global);
     /// assert!(empty.upgrade().is_none());
     /// ```
     #[inline]
@@ -3450,6 +3495,9 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::System;
     /// use std::rc::{Rc, Weak};
     ///
     /// let strong = Rc::new("hello".to_owned());
@@ -3459,13 +3507,13 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     ///
     /// assert_eq!(2, Rc::weak_count(&strong));
     ///
-    /// assert_eq!("hello", &*unsafe { Weak::from_raw(raw_1) }.upgrade().unwrap());
+    /// assert_eq!("hello", &*unsafe { Weak::from_raw_in(raw_1, System) }.upgrade().unwrap());
     /// assert_eq!(1, Rc::weak_count(&strong));
     ///
     /// drop(strong);
     ///
     /// // Decrement the last weak count.
-    /// assert!(unsafe { Weak::from_raw(raw_2) }.upgrade().is_none());
+    /// assert!(unsafe { Weak::from_raw_in(raw_2, System) }.upgrade().is_none());
     /// ```
     ///
     /// [`into_raw`]: Weak::into_raw
@@ -4310,6 +4358,17 @@ impl<T, A: Allocator> UniqueRc<T, A> {
     /// these weak references will fail before the `UniqueRc` has been converted into an [`Rc`].
     /// After converting the `UniqueRc` into an [`Rc`], any weak references created beforehand will
     /// point to the new [`Rc`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(unique_rc_arc)]
+    ///
+    /// use std::alloc::System;
+    /// use std::rc::UniqueRc;
+    ///
+    /// let x = UniqueRc::new_in(1, System);
+    /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "unique_rc_arc", issue = "112566")]
     pub fn new_in(value: T, alloc: A) -> Self {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -881,6 +881,37 @@ impl<T, A: Allocator> Arc<T, A> {
     ///
     /// [`new_cyclic`]: Arc::new_cyclic
     /// [`upgrade`]: Weak::upgrade
+    ///
+    /// ```
+    /// # #![allow(dead_code)]
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::Global;
+    /// use std::sync::{Arc, Weak};
+    ///
+    /// struct Gadget {
+    ///     me: Weak<Gadget>,
+    /// }
+    ///
+    /// impl Gadget {
+    ///     /// Constructs a reference counted Gadget.
+    ///     fn new() -> Arc<Self> {
+    ///         // `me` is a `Weak<Gadget>` pointing at the new allocation of the
+    ///         // `Arc` we're constructing.
+    ///         Arc::new_cyclic_in(|me| {
+    ///                 // Create the actual struct here.
+    ///                 Gadget { me: me.clone() }
+    ///             },
+    ///             Global,
+    ///         )
+    ///     }
+    ///
+    ///     /// Returns a reference counted pointer to Self.
+    ///     fn me(&self) -> Arc<Self> {
+    ///         self.me.upgrade().unwrap()
+    ///     }
+    /// }
+    /// ```
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
@@ -946,6 +977,17 @@ impl<T, A: Allocator> Arc<T, A> {
 
     /// Constructs a new `Pin<Arc<T, A>>` in the provided allocator. If `T` does not implement `Unpin`,
     /// then `data` will be pinned in memory and unable to be moved.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::System;
+    /// use std::sync::Arc;
+    ///
+    /// let x = Arc::pin_in(1, System);
+    /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[inline]
@@ -958,6 +1000,17 @@ impl<T, A: Allocator> Arc<T, A> {
 
     /// Constructs a new `Pin<Arc<T, A>>` in the provided allocator, return an error if allocation
     /// fails.
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::System;
+    /// use std::sync::Arc;
+    ///
+    /// let x = Arc::try_pin_in(1, System)?;
+    /// # Ok::<(), std::alloc::AllocError>(())
+    /// ```
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub fn try_pin_in(data: T, alloc: A) -> Result<Pin<Arc<T, A>>, AllocError>
@@ -3185,6 +3238,9 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::System;
     /// use std::sync::{Arc, Weak};
     ///
     /// let strong = Arc::new("hello".to_owned());
@@ -3194,13 +3250,13 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     ///
     /// assert_eq!(2, Arc::weak_count(&strong));
     ///
-    /// assert_eq!("hello", &*unsafe { Weak::from_raw(raw_1) }.upgrade().unwrap());
+    /// assert_eq!("hello", &*unsafe { Weak::from_raw_in(raw_1, System) }.upgrade().unwrap());
     /// assert_eq!(1, Arc::weak_count(&strong));
     ///
     /// drop(strong);
     ///
     /// // Decrement the last weak count.
-    /// assert!(unsafe { Weak::from_raw(raw_2) }.upgrade().is_none());
+    /// assert!(unsafe { Weak::from_raw_in(raw_2, System) }.upgrade().is_none());
     /// ```
     ///
     /// [`new`]: Weak::new
@@ -4742,6 +4798,17 @@ impl<T, A: Allocator> UniqueArc<T, A> {
     /// these weak references will fail before the `UniqueArc` has been converted into an [`Arc`].
     /// After converting the `UniqueArc` into an [`Arc`], any weak references created beforehand will
     /// point to the new [`Arc`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(unique_rc_arc)]
+    ///
+    /// use std::alloc::System;
+    /// use std::sync::UniqueArc;
+    ///
+    /// let x = UniqueArc::new_in(1, System);
+    /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "unique_rc_arc", issue = "112566")]
     #[must_use]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1081,6 +1081,17 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// Returns an error if the capacity exceeds `isize::MAX` _bytes_,
     /// or if the allocator reports allocation failure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(allocator_api)]
+    ///
+    /// use std::alloc::System;
+    ///
+    /// let x: Vec<i32, _> = Vec::try_with_capacity_in(10, System)?;
+    /// # Ok::<(), std::collections::TryReserveError>(())
+    /// ```
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "try_with_capacity", issue = "91913")]

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -301,9 +301,10 @@ impl<K, V, A: Allocator> HashMap<K, V, RandomState, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
-    /// use std::collections::HashMap;
+    /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
+    /// use std::collections::HashMap;
     ///
     /// let map: HashMap<i32, i32> = HashMap::new_in(Global);
     /// ```
@@ -324,9 +325,10 @@ impl<K, V, A: Allocator> HashMap<K, V, RandomState, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
-    /// use std::collections::HashMap;
+    /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
+    /// use std::collections::HashMap;
     ///
     /// let map: HashMap<i32, i32> = HashMap::with_capacity_in(10, Global);
     /// ```
@@ -421,6 +423,7 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     ///
     /// ```
     /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
     /// use std::collections::HashMap;
     /// use std::hash::RandomState;
@@ -454,6 +457,7 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     ///
     /// ```
     /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
     /// use std::collections::HashMap;
     /// use std::hash::RandomState;

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -179,7 +179,8 @@ impl<T, A: Allocator> HashSet<T, RandomState, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
+    /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
     /// use std::collections::HashSet;
     ///
@@ -201,9 +202,10 @@ impl<T, A: Allocator> HashSet<T, RandomState, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
-    /// use std::collections::HashSet;
+    /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
+    /// use std::collections::HashSet;
     ///
     /// let set: HashSet<i32> = HashSet::with_capacity_in(10, Global);
     /// ```
@@ -297,7 +299,8 @@ impl<T, S, A: Allocator> HashSet<T, S, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
+    /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
     /// use std::collections::HashSet;
     /// use std::hash::RandomState;
@@ -330,7 +333,8 @@ impl<T, S, A: Allocator> HashSet<T, S, A> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(allocator_api)]
+    /// #![feature(allocator_api)]
+    ///
     /// use std::alloc::Global;
     /// use std::collections::HashSet;
     /// use std::hash::RandomState;


### PR DESCRIPTION
I would like to complete the task by documenting all structures using in. Supplemented by Weak Rc Arc UniqueRc and others

continue rust-lang/rust#154452