### PR TITLE
Derive `Eq`, `Ord`, `Hash` for `MaybeDangling`

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -1,6 +1,4 @@
-use crate::cmp::Ordering;
-use crate::hash::{Hash, Hasher};
-use crate::marker::{Destruct, StructuralPartialEq};
+use crate::marker::Destruct;
 use crate::mem::MaybeDangling;
 use crate::ops::{Deref, DerefMut, DerefPure};
 use crate::ptr;
@@ -155,7 +153,7 @@ use crate::ptr;
 /// [`MaybeUninit`]: crate::mem::MaybeUninit
 #[stable(feature = "manually_drop", since = "1.20.0")]
 #[lang = "manually_drop"]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 #[rustc_pub_transparent]
 pub struct ManuallyDrop<T: ?Sized> {
@@ -289,37 +287,3 @@ impl<T: ?Sized> const DerefMut for ManuallyDrop<T> {
 
 #[unstable(feature = "deref_pure_trait", issue = "87121")]
 unsafe impl<T: ?Sized> DerefPure for ManuallyDrop<T> {}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: ?Sized + Eq> Eq for ManuallyDrop<T> {}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: ?Sized + PartialEq> PartialEq for ManuallyDrop<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.value.as_ref().eq(other.value.as_ref())
-    }
-}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: ?Sized> StructuralPartialEq for ManuallyDrop<T> {}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: ?Sized + Ord> Ord for ManuallyDrop<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.value.as_ref().cmp(other.value.as_ref())
-    }
-}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: ?Sized + PartialOrd> PartialOrd for ManuallyDrop<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.value.as_ref().partial_cmp(other.value.as_ref())
-    }
-}
-
-#[stable(feature = "manually_drop", since = "1.20.0")]
-impl<T: ?Sized + Hash> Hash for ManuallyDrop<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.as_ref().hash(state);
-    }
-}

--- a/library/core/src/mem/maybe_dangling.rs
+++ b/library/core/src/mem/maybe_dangling.rs
@@ -1,6 +1,5 @@
 #![unstable(feature = "maybe_dangling", issue = "118166")]
 
-use crate::marker::StructuralPartialEq;
 use crate::{mem, ptr};
 
 /// Allows wrapped [references] and [boxes] to dangle.
@@ -69,7 +68,7 @@ use crate::{mem, ptr};
 /// [`ManuallyDrop`]: crate::mem::ManuallyDrop
 #[repr(transparent)]
 #[rustc_pub_transparent]
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[lang = "maybe_dangling"]
 pub struct MaybeDangling<P: ?Sized>(P);
 
@@ -110,5 +109,3 @@ impl<P: ?Sized> MaybeDangling<P> {
         x
     }
 }
-
-impl<T: ?Sized> StructuralPartialEq for MaybeDangling<T> {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154905)*
<!-- homu-ignore:end -->

We have these, along with `Deref` and `DerefMut`, for `ManuallyDrop`. So if we accept that precedent, `MaybeDangling` should have those traits as well. Also, having `PartialEq` allows structures containing a `MaybeDangling` field to derive `StructuralPartialEq`.

On the other hand, there's an argument that accessing the `MaybeDangling` contents is potentially dangerous, and should therefore always be explicit. The RFC left this open, so we need a T-libs-api decision.

@rustbot label T-libs-api

Tracking issue: rust-lang/rust#118166