### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_hir/src/attrs/diagnostic.rs
+++ b/compiler/rustc_hir/src/attrs/diagnostic.rs
@@ -6,7 +6,7 @@ pub use rustc_ast::attr::data_structures::*;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic, PrintAttribute};
 use rustc_span::{DesugaringKind, Span, Symbol, kw};
 use thin_vec::ThinVec;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::attrs::PrintAttribute;
 
@@ -58,7 +58,9 @@ impl Directive {
         args: &FormatArgs,
     ) -> CustomDiagnostic {
         let this = &args.this;
-        info!("eval({self:?}, this={this}, options={condition_options:?}, args ={args:?})");
+        debug!(
+            "Directive::eval({self:?}, this={this}, options={condition_options:?}, args ={args:?})"
+        );
 
         let Some(condition_options) = condition_options else {
             debug_assert!(

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -442,9 +442,11 @@ impl Subdiagnostic for RegionOriginNote<'_> {
                 label_or_note(diag, span, msg);
             }
             RegionOriginNote::WithName { span, msg, name, continues } => {
-                diag.arg("name", name);
-                diag.arg("continues", continues);
-                label_or_note(diag, span, msg);
+                label_or_note(
+                    diag,
+                    span,
+                    msg.arg("name", name).arg("continues", continues).format(),
+                );
             }
             RegionOriginNote::WithRequirement {
                 span,

--- a/tests/ui/regions/impl-trait-lifetime-conflict-hashmap-keys.rs
+++ b/tests/ui/regions/impl-trait-lifetime-conflict-hashmap-keys.rs
@@ -1,0 +1,19 @@
+// Regression test for https://github.com/rust-lang/rust/issues/152936
+
+use std::collections::hash_map::{HashMap, Keys};
+use std::marker::PhantomData;
+
+trait MapAssertion<'a, K, V, R> {
+    fn key_set(&self) -> Subject<Keys<K, V>, (), R>;
+}
+
+struct Subject<'a, T, V, R>(PhantomData<(&'a T, V, R)>);
+
+impl<'a, K, V, R> MapAssertion<'a, K, V, R> for Subject<'a, HashMap<K, V>, (), R> {
+    fn key_set(&self) -> Subject<'static, Keys<K, V>, (), R> {
+        //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter '_ in generic type due to conflicting requirements
+        //~| ERROR mismatched types
+    }
+}
+
+fn main() {}

--- a/tests/ui/regions/impl-trait-lifetime-conflict-hashmap-keys.stderr
+++ b/tests/ui/regions/impl-trait-lifetime-conflict-hashmap-keys.stderr
@@ -1,0 +1,43 @@
+error[E0803]: cannot infer an appropriate lifetime for lifetime parameter '_ in generic type due to conflicting requirements
+  --> $DIR/impl-trait-lifetime-conflict-hashmap-keys.rs:13:5
+   |
+LL |     fn key_set(&self) -> Subject<'static, Keys<K, V>, (), R> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
+  --> $DIR/impl-trait-lifetime-conflict-hashmap-keys.rs:12:6
+   |
+LL | impl<'a, K, V, R> MapAssertion<'a, K, V, R> for Subject<'a, HashMap<K, V>, (), R> {
+   |      ^^
+note: ...so that the reference type `&Subject<'a, HashMap<K, V>, (), R>` does not outlive the data it points at
+  --> $DIR/impl-trait-lifetime-conflict-hashmap-keys.rs:13:5
+   |
+LL |     fn key_set(&self) -> Subject<'static, Keys<K, V>, (), R> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: but, the lifetime must be valid for the static lifetime...
+note: ...so that the type `std::collections::hash_map::Keys<'_, K, V>` will meet its required lifetime bounds...
+  --> $DIR/impl-trait-lifetime-conflict-hashmap-keys.rs:13:5
+   |
+LL |     fn key_set(&self) -> Subject<'static, Keys<K, V>, (), R> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...that is required by this bound
+  --> $DIR/impl-trait-lifetime-conflict-hashmap-keys.rs:10:29
+   |
+LL | struct Subject<'a, T, V, R>(PhantomData<(&'a T, V, R)>);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/impl-trait-lifetime-conflict-hashmap-keys.rs:13:26
+   |
+LL |     fn key_set(&self) -> Subject<'static, Keys<K, V>, (), R> {
+   |        -------           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Subject<'_, Keys<'_, K, V>, (), R>`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected struct `Subject<'static, std::collections::hash_map::Keys<'_, K, V>, (), R>`
+           found unit type `()`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0803.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154875 (Avoid duplicate diagnostic args in `RegionOriginNote::WithName`)
 - rust-lang/rust#154898 (Use debug! instead of info!)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154875,154898)
<!-- homu-ignore:end -->

