### PR TITLE
Allow compilation recovery after emitting lint attr parsing error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,6 +4210,7 @@ dependencies = [
  "rustc_infer",
  "rustc_macros",
  "rustc_middle",
+ "rustc_parse",
  "rustc_parse_format",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -19,6 +19,7 @@ rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_middle = { path = "../rustc_middle" }
+rustc_parse = { path = "../rustc_parse" }
 rustc_parse_format = { path = "../rustc_parse_format" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -9,6 +9,7 @@ use rustc_ast::{self as ast, AttrVec, HasAttrs};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
 use rustc_feature::Features;
+use rustc_hir::Target;
 use rustc_middle::ty::{RegisteredTools, TyCtxt};
 use rustc_session::Session;
 use rustc_session::lint::LintPass;
@@ -68,12 +69,13 @@ impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
         id: ast::NodeId,
         attrs: &'_ [ast::Attribute],
         f: F,
+        target: Target,
         target_span: Span,
     ) where
         F: FnOnce(&mut Self),
     {
         debug!(?id);
-        let push = self.context.builder.push(attrs, id, target_span);
+        let push = self.context.builder.push(attrs, id, target, target_span);
 
         debug!("early context: enter_attrs({:?})", attrs);
         lint_callback!(self, check_attributes, attrs);
@@ -99,6 +101,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 lint_callback!(cx, check_param, param);
                 ast_visit::walk_param(cx, param);
             },
+            Target::Param,
             param.span,
         );
     }
@@ -112,6 +115,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 ast_visit::walk_item(cx, it);
                 lint_callback!(cx, check_item_post, it);
             },
+            Target::from_ast_item(it),
             it.span,
         )
     }
@@ -123,6 +127,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
             |cx| {
                 ast_visit::walk_item(cx, it);
             },
+            Target::from_foreign_item_kind(&it.kind),
             it.span,
         )
     }
@@ -140,6 +145,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
             |cx| {
                 ast_visit::walk_pat_field(cx, field);
             },
+            Target::PatField,
             field.span,
         );
     }
@@ -153,6 +159,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 ast_visit::walk_expr(cx, e);
                 lint_callback!(cx, check_expr_post, e);
             },
+            Target::Expression,
             e.span,
         )
     }
@@ -164,6 +171,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
             |cx| {
                 ast_visit::walk_expr_field(cx, f);
             },
+            Target::ExprField,
             f.span,
         )
     }
@@ -184,6 +192,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 lint_callback!(cx, check_stmt, s);
                 ast_visit::walk_stmt(cx, s);
             },
+            Target::Statement,
             s.span,
         );
     }
@@ -200,6 +209,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
             |cx| {
                 ast_visit::walk_field_def(cx, s);
             },
+            Target::Field,
             s.span,
         )
     }
@@ -212,6 +222,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 lint_callback!(cx, check_variant, v);
                 ast_visit::walk_variant(cx, v);
             },
+            Target::Variant,
             v.span,
         )
     }
@@ -233,6 +244,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 lint_callback!(cx, check_local, l);
                 ast_visit::walk_local(cx, l);
             },
+            Target::Expression,
             l.span,
         )
     }
@@ -250,6 +262,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 lint_callback!(cx, check_arm, a);
                 ast_visit::walk_arm(cx, a);
             },
+            Target::Arm,
             a.span,
         )
     }
@@ -260,6 +273,17 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
     }
 
     fn visit_generic_param(&mut self, param: &'ast ast::GenericParam) {
+        let (kind, has_default) = match &param.kind {
+            ast::GenericParamKind::Const { default, .. } => {
+                (rustc_hir::target::GenericParamKind::Const, default.is_some())
+            }
+            ast::GenericParamKind::Type { default, .. } => {
+                (rustc_hir::target::GenericParamKind::Type, default.is_some())
+            }
+            ast::GenericParamKind::Lifetime => {
+                (rustc_hir::target::GenericParamKind::Lifetime, false)
+            }
+        };
         self.with_lint_attrs(
             param.id,
             &param.attrs,
@@ -267,6 +291,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                 lint_callback!(cx, check_generic_param, param);
                 ast_visit::walk_generic_param(cx, param);
             },
+            Target::GenericParam { kind, has_default },
             param.span(),
         );
     }
@@ -310,6 +335,7 @@ impl<'ast, 'ecx, 'tcx, T: EarlyLintPass> ast_visit::Visitor<'ast>
                     }
                 }
             },
+            Target::from_assoc_item_kind(&item.kind, ctxt),
             item.span,
         );
     }
@@ -366,6 +392,7 @@ crate::early_lint_methods!(impl_early_lint_pass, []);
 pub trait EarlyCheckNode<'a>: Copy {
     fn id(self) -> ast::NodeId;
     fn attrs(self) -> &'a [ast::Attribute];
+    fn target(self) -> Target;
     fn check<'ecx, 'tcx, T: EarlyLintPass>(self, cx: &mut EarlyContextAndPass<'ecx, 'tcx, T>);
 }
 
@@ -375,6 +402,9 @@ impl<'a> EarlyCheckNode<'a> for (&'a ast::Crate, &'a [ast::Attribute]) {
     }
     fn attrs(self) -> &'a [ast::Attribute] {
         self.1
+    }
+    fn target(self) -> Target {
+        Target::Crate
     }
     fn check<'ecx, 'tcx, T: EarlyLintPass>(self, cx: &mut EarlyContextAndPass<'ecx, 'tcx, T>) {
         lint_callback!(cx, check_crate, self.0);
@@ -389,6 +419,10 @@ impl<'a> EarlyCheckNode<'a> for (ast::NodeId, &'a [Box<ast::Item>]) {
     }
     fn attrs(self) -> &'a [ast::Attribute] {
         &[]
+    }
+    // This is never read
+    fn target(self) -> Target {
+        Target::Fn
     }
     fn check<'ecx, 'tcx, T: EarlyLintPass>(self, cx: &mut EarlyContextAndPass<'ecx, 'tcx, T>) {
         walk_list!(cx, visit_item, self.1);
@@ -439,7 +473,13 @@ fn check_ast_node_inner<'a, T: EarlyLintPass>(
 ) {
     let mut cx = EarlyContextAndPass { context, tcx, pass };
 
-    cx.with_lint_attrs(check_node.id(), check_node.attrs(), |cx| check_node.check(cx), DUMMY_SP);
+    cx.with_lint_attrs(
+        check_node.id(),
+        check_node.attrs(),
+        |cx| check_node.check(cx),
+        Target::Crate,
+        DUMMY_SP,
+    );
 
     // All of the buffered lints should have been emitted at this point.
     // If not, that means that we somehow buffered a lint for a node id

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -441,6 +441,7 @@ impl<'s> LintLevelsBuilder<'s, TopDown> {
         &mut self,
         attrs: &[ast::Attribute],
         node_id: NodeId,
+        target: Target,
         target_span: Span,
     ) -> BuilderPush {
         let prev = self.provider.cur;
@@ -451,7 +452,7 @@ impl<'s> LintLevelsBuilder<'s, TopDown> {
                 self.sess,
                 attrs,
                 ALLOW_LISTED_ATTRS,
-                Target::Fn,
+                target,
                 target_span,
                 node_id,
                 Some(self.features),

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -17,6 +17,7 @@ use rustc_middle::lint::{
 };
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{RegisteredTools, TyCtxt};
+use rustc_parse::parser::Recovery;
 use rustc_session::Session;
 use rustc_session::lint::builtin::{
     self, FORBIDDEN_LINT_GROUPS, RENAMED_AND_REMOVED_LINTS, SINGLE_USE_LIFETIMES,
@@ -405,7 +406,7 @@ impl<'s> LintLevelsBuilder<'s, TopDown> {
             DUMMY_SP,
             DUMMY_NODE_ID,
             Some(features),
-            rustc_attr_parsing::ShouldEmit::Nothing,
+            rustc_attr_parsing::ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
             registered_tools,
         );
 
@@ -454,7 +455,7 @@ impl<'s> LintLevelsBuilder<'s, TopDown> {
                 target_span,
                 node_id,
                 Some(self.features),
-                rustc_attr_parsing::ShouldEmit::Nothing,
+                rustc_attr_parsing::ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
                 self.registered_tools,
             );
 

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -1,3 +1,102 @@
+error[E0539]: malformed `allow` attribute input
+  --> $DIR/malformed-attrs.rs:180:1
+   |
+LL | #[allow]
+   | ^^-----^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[allow(lint1)]
+   |        +++++++
+LL | #[allow(lint1, lint2, ...)]
+   |        +++++++++++++++++++
+LL | #[allow(lint1, lint2, lint3, reason = "...")]
+   |        +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `expect` attribute input
+  --> $DIR/malformed-attrs.rs:182:1
+   |
+LL | #[expect]
+   | ^^------^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[expect(lint1)]
+   |         +++++++
+LL | #[expect(lint1, lint2, ...)]
+   |         +++++++++++++++++++
+LL | #[expect(lint1, lint2, lint3, reason = "...")]
+   |         +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `warn` attribute input
+  --> $DIR/malformed-attrs.rs:184:1
+   |
+LL | #[warn]
+   | ^^----^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[warn(lint1)]
+   |       +++++++
+LL | #[warn(lint1, lint2, ...)]
+   |       +++++++++++++++++++
+LL | #[warn(lint1, lint2, lint3, reason = "...")]
+   |       +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `deny` attribute input
+  --> $DIR/malformed-attrs.rs:186:1
+   |
+LL | #[deny]
+   | ^^----^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[deny(lint1)]
+   |       +++++++
+LL | #[deny(lint1, lint2, ...)]
+   |       +++++++++++++++++++
+LL | #[deny(lint1, lint2, lint3, reason = "...")]
+   |       +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `forbid` attribute input
+  --> $DIR/malformed-attrs.rs:188:1
+   |
+LL | #[forbid]
+   | ^^------^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[forbid(lint1)]
+   |         +++++++
+LL | #[forbid(lint1, lint2, ...)]
+   |         +++++++++++++++++++
+LL | #[forbid(lint1, lint2, lint3, reason = "...")]
+   |         +++++++++++++++++++++++++++++++++++++
+
+error[E0565]: malformed `automatically_derived` attribute input
+  --> $DIR/malformed-attrs.rs:192:1
+   |
+LL | #[automatically_derived = 18]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^----^
+   | |                       |
+   | |                       didn't expect any arguments here
+   | help: must be of the form: `#[automatically_derived]`
+
 error[E0539]: malformed `cfg` attribute input
   --> $DIR/malformed-attrs.rs:106:1
    |
@@ -52,6 +151,112 @@ LL | #[allow_internal_unsafe = 1]
    |
    = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0539]: malformed `allow` attribute input
+  --> $DIR/malformed-attrs.rs:180:1
+   |
+LL | #[allow]
+   | ^^-----^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[allow(lint1)]
+   |        +++++++
+LL | #[allow(lint1, lint2, ...)]
+   |        +++++++++++++++++++
+LL | #[allow(lint1, lint2, lint3, reason = "...")]
+   |        +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `expect` attribute input
+  --> $DIR/malformed-attrs.rs:182:1
+   |
+LL | #[expect]
+   | ^^------^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[expect(lint1)]
+   |         +++++++
+LL | #[expect(lint1, lint2, ...)]
+   |         +++++++++++++++++++
+LL | #[expect(lint1, lint2, lint3, reason = "...")]
+   |         +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `warn` attribute input
+  --> $DIR/malformed-attrs.rs:184:1
+   |
+LL | #[warn]
+   | ^^----^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[warn(lint1)]
+   |       +++++++
+LL | #[warn(lint1, lint2, ...)]
+   |       +++++++++++++++++++
+LL | #[warn(lint1, lint2, lint3, reason = "...")]
+   |       +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `deny` attribute input
+  --> $DIR/malformed-attrs.rs:186:1
+   |
+LL | #[deny]
+   | ^^----^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[deny(lint1)]
+   |       +++++++
+LL | #[deny(lint1, lint2, ...)]
+   |       +++++++++++++++++++
+LL | #[deny(lint1, lint2, lint3, reason = "...")]
+   |       +++++++++++++++++++++++++++++++++++++
+
+error[E0539]: malformed `forbid` attribute input
+  --> $DIR/malformed-attrs.rs:188:1
+   |
+LL | #[forbid]
+   | ^^------^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[forbid(lint1)]
+   |         +++++++
+LL | #[forbid(lint1, lint2, ...)]
+   |         +++++++++++++++++++
+LL | #[forbid(lint1, lint2, lint3, reason = "...")]
+   |         +++++++++++++++++++++++++++++++++++++
+
+error[E0565]: malformed `automatically_derived` attribute input
+  --> $DIR/malformed-attrs.rs:192:1
+   |
+LL | #[automatically_derived = 18]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^----^
+   | |                       |
+   | |                       didn't expect any arguments here
+   | help: must be of the form: `#[automatically_derived]`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0539]: malformed `windows_subsystem` attribute input
   --> $DIR/malformed-attrs.rs:26:1
@@ -522,6 +727,7 @@ LL | #[allow]
    |   expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[allow(lint1)]
@@ -540,6 +746,7 @@ LL | #[expect]
    |   expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[expect(lint1)]
@@ -558,6 +765,7 @@ LL | #[warn]
    |   expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[warn(lint1)]
@@ -576,6 +784,7 @@ LL | #[deny]
    |   expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[deny(lint1)]
@@ -594,6 +803,7 @@ LL | #[forbid]
    |   expected this to be a list
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL | #[forbid(lint1)]
@@ -622,6 +832,8 @@ LL | #[automatically_derived = 18]
    | |                       |
    | |                       didn't expect any arguments here
    | help: must be of the form: `#[automatically_derived]`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0565]: malformed `non_exhaustive` attribute input
   --> $DIR/malformed-attrs.rs:200:1
@@ -855,7 +1067,7 @@ LL |     #[coroutine = 63] || {}
    = note: expected unit type `()`
               found coroutine `{coroutine@$DIR/malformed-attrs.rs:115:23: 115:25}`
 
-error: aborting due to 75 previous errors; 8 warnings emitted
+error: aborting due to 87 previous errors; 8 warnings emitted
 
 Some errors have detailed explanations: E0308, E0463, E0539, E0565, E0658, E0805.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/attributes/malformed-expect.rs
+++ b/tests/ui/attributes/malformed-expect.rs
@@ -1,0 +1,10 @@
+// Regression test for #154800 and #154847
+//@ compile-flags: --crate-type=lib
+
+#[expect]
+//~^ ERROR malformed
+#[cfg(false)]
+fn main() {
+    let _ : fn(#[expect[]] i32);
+    //~^ ERROR wrong meta list delimiters
+}

--- a/tests/ui/attributes/malformed-expect.stderr
+++ b/tests/ui/attributes/malformed-expect.stderr
@@ -1,0 +1,33 @@
+error[E0539]: malformed `expect` attribute input
+  --> $DIR/malformed-expect.rs:4:1
+   |
+LL | #[expect]
+   | ^^------^
+   |   |
+   |   expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL | #[expect(lint1)]
+   |         +++++++
+LL | #[expect(lint1, lint2, ...)]
+   |         +++++++++++++++++++
+LL | #[expect(lint1, lint2, lint3, reason = "...")]
+   |         +++++++++++++++++++++++++++++++++++++
+
+error: wrong meta list delimiters
+  --> $DIR/malformed-expect.rs:8:24
+   |
+LL |     let _ : fn(#[expect[]] i32);
+   |                        ^^
+   |
+help: the delimiters should be `(` and `)`
+   |
+LL -     let _ : fn(#[expect[]] i32);
+LL +     let _ : fn(#[expect()] i32);
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/statement-attribute-validation.stderr
+++ b/tests/ui/attributes/statement-attribute-validation.stderr
@@ -5,7 +5,29 @@ LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
 
 error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:8:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
   --> $DIR/statement-attribute-validation.rs:13:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:13:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:16:16
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
@@ -15,9 +37,25 @@ error: expected one of `(`, `,`, `::`, or `=`, found `-`
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected one of `(`, `,`, `::`, or `=`, found `-`
   --> $DIR/statement-attribute-validation.rs:21:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:21:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:24:16
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
@@ -27,9 +65,25 @@ error: expected one of `(`, `,`, `::`, or `=`, found `-`
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected one of `(`, `,`, `::`, or `=`, found `-`
   --> $DIR/statement-attribute-validation.rs:27:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:27:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:30:16
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
@@ -39,9 +93,25 @@ error: expected one of `(`, `,`, `::`, or `=`, found `-`
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected one of `(`, `,`, `::`, or `=`, found `-`
   --> $DIR/statement-attribute-validation.rs:33:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:33:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:36:16
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
@@ -51,6 +121,224 @@ error: expected one of `(`, `,`, `::`, or `=`, found `-`
    |
 LL |     #[allow(two-words)]
    |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 9 previous errors
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:8:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:8:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:13:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:13:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:16:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:16:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:21:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:21:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:24:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:24:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:27:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:27:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:30:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:30:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:33:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:33:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:36:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:36:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:8:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:13:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:16:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:21:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:24:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:27:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:30:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:33:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: expected one of `(`, `,`, `::`, or `=`, found `-`
+  --> $DIR/statement-attribute-validation.rs:36:16
+   |
+LL |     #[allow(two-words)]
+   |                ^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 45 previous errors
 

--- a/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/proc-unsafe-attributes.stderr
@@ -1,3 +1,19 @@
+error: `allow` is not an unsafe attribute
+  --> $DIR/proc-unsafe-attributes.rs:23:3
+   |
+LL | #[unsafe(allow(dead_code))]
+   |   ^^^^^^ this is not an unsafe attribute
+   |
+   = note: extraneous unsafe is not allowed in attributes
+
+error: `allow` is not an unsafe attribute
+  --> $DIR/proc-unsafe-attributes.rs:27:3
+   |
+LL | #[unsafe(allow(unsafe(dead_code)))]
+   |   ^^^^^^ this is not an unsafe attribute
+   |
+   = note: extraneous unsafe is not allowed in attributes
+
 error: expected identifier, found keyword `unsafe`
   --> $DIR/proc-unsafe-attributes.rs:27:16
    |
@@ -8,6 +24,27 @@ help: escape `unsafe` to use it as an identifier
    |
 LL | #[unsafe(allow(r#unsafe(dead_code)))]
    |                ++
+
+error[E0565]: malformed `allow` attribute input
+  --> $DIR/proc-unsafe-attributes.rs:27:1
+   |
+LL | #[unsafe(allow(unsafe(dead_code)))]
+   | ^^^^^^^^^^^^^^^^^^^^^-----------^^^
+   |                      |
+   |                      didn't expect any arguments here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[unsafe(allow(unsafe(dead_code)))]
+LL + #[allow(lint1)]
+   |
+LL - #[unsafe(allow(unsafe(dead_code)))]
+LL + #[allow(lint1, lint2, ...)]
+   |
+LL - #[unsafe(allow(unsafe(dead_code)))]
+LL + #[allow(lint1, lint2, lint3, reason = "...")]
+   |
 
 error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
   --> $DIR/proc-unsafe-attributes.rs:1:1
@@ -33,6 +70,24 @@ error: the `#[proc_macro_attribute]` attribute is only usable with crates of the
 LL | #[unsafe(proc_macro_attribute)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: `allow` is not an unsafe attribute
+  --> $DIR/proc-unsafe-attributes.rs:23:3
+   |
+LL | #[unsafe(allow(dead_code))]
+   |   ^^^^^^ this is not an unsafe attribute
+   |
+   = note: extraneous unsafe is not allowed in attributes
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `allow` is not an unsafe attribute
+  --> $DIR/proc-unsafe-attributes.rs:27:3
+   |
+LL | #[unsafe(allow(unsafe(dead_code)))]
+   |   ^^^^^^ this is not an unsafe attribute
+   |
+   = note: extraneous unsafe is not allowed in attributes
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: expected identifier, found keyword `unsafe`
   --> $DIR/proc-unsafe-attributes.rs:27:16
    |
@@ -44,6 +99,28 @@ help: escape `unsafe` to use it as an identifier
    |
 LL | #[unsafe(allow(r#unsafe(dead_code)))]
    |                ++
+
+error[E0565]: malformed `allow` attribute input
+  --> $DIR/proc-unsafe-attributes.rs:27:1
+   |
+LL | #[unsafe(allow(unsafe(dead_code)))]
+   | ^^^^^^^^^^^^^^^^^^^^^-----------^^^
+   |                      |
+   |                      didn't expect any arguments here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[unsafe(allow(unsafe(dead_code)))]
+LL + #[allow(lint1)]
+   |
+LL - #[unsafe(allow(unsafe(dead_code)))]
+LL + #[allow(lint1, lint2, ...)]
+   |
+LL - #[unsafe(allow(unsafe(dead_code)))]
+LL + #[allow(lint1, lint2, lint3, reason = "...")]
+   |
 
 error: `proc_macro` is not an unsafe attribute
   --> $DIR/proc-unsafe-attributes.rs:1:3
@@ -105,6 +182,7 @@ LL | #[unsafe(allow(dead_code))]
    |   ^^^^^^ this is not an unsafe attribute
    |
    = note: extraneous unsafe is not allowed in attributes
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `allow` is not an unsafe attribute
   --> $DIR/proc-unsafe-attributes.rs:27:3
@@ -113,6 +191,7 @@ LL | #[unsafe(allow(unsafe(dead_code)))]
    |   ^^^^^^ this is not an unsafe attribute
    |
    = note: extraneous unsafe is not allowed in attributes
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected identifier, found keyword `unsafe`
   --> $DIR/proc-unsafe-attributes.rs:27:16
@@ -135,6 +214,7 @@ LL | #[unsafe(allow(unsafe(dead_code)))]
    |                      didn't expect any arguments here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[unsafe(allow(unsafe(dead_code)))]
@@ -147,6 +227,6 @@ LL - #[unsafe(allow(unsafe(dead_code)))]
 LL + #[allow(lint1, lint2, lint3, reason = "...")]
    |
 
-error: aborting due to 15 previous errors
+error: aborting due to 21 previous errors
 
 For more information about this error, try `rustc --explain E0565`.

--- a/tests/ui/closures/2229_closure_analysis/migrations/old_name.stderr
+++ b/tests/ui/closures/2229_closure_analysis/migrations/old_name.stderr
@@ -6,5 +6,13 @@ LL | #![allow(disjoint_capture_migration)]
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
-warning: 1 warning emitted
+warning: lint `disjoint_capture_migration` has been renamed to `rust_2021_incompatible_closure_captures`
+  --> $DIR/old_name.rs:6:10
+   |
+LL | #![allow(disjoint_capture_migration)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rust_2021_incompatible_closure_captures`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
 

--- a/tests/ui/diagnostic-flags/deduplicate-diagnostics.deduplicate.stderr
+++ b/tests/ui/diagnostic-flags/deduplicate-diagnostics.deduplicate.stderr
@@ -1,9 +1,3 @@
-error: cannot find derive macro `Unresolved` in this scope
-  --> $DIR/deduplicate-diagnostics.rs:6:10
-   |
-LL | #[derive(Unresolved)]
-   |          ^^^^^^^^^^
-
 error[E0539]: malformed `deny` attribute input
   --> $DIR/deduplicate-diagnostics.rs:10:1
    |
@@ -24,6 +18,12 @@ LL + #[deny(lint1, lint2, ...)]
 LL - #[deny("literal")]
 LL + #[deny(lint1, lint2, lint3, reason = "...")]
    |
+
+error: cannot find derive macro `Unresolved` in this scope
+  --> $DIR/deduplicate-diagnostics.rs:6:10
+   |
+LL | #[derive(Unresolved)]
+   |          ^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/diagnostic-flags/deduplicate-diagnostics.duplicate.stderr
+++ b/tests/ui/diagnostic-flags/deduplicate-diagnostics.duplicate.stderr
@@ -1,3 +1,24 @@
+error[E0539]: malformed `deny` attribute input
+  --> $DIR/deduplicate-diagnostics.rs:10:1
+   |
+LL | #[deny("literal")]
+   | ^^^^^^^---------^^
+   |        |
+   |        expected a valid identifier here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[deny("literal")]
+LL + #[deny(lint1)]
+   |
+LL - #[deny("literal")]
+LL + #[deny(lint1, lint2, ...)]
+   |
+LL - #[deny("literal")]
+LL + #[deny(lint1, lint2, lint3, reason = "...")]
+   |
+
 error: cannot find derive macro `Unresolved` in this scope
   --> $DIR/deduplicate-diagnostics.rs:6:10
    |
@@ -21,6 +42,7 @@ LL | #[deny("literal")]
    |        expected a valid identifier here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: try changing it to one of the following valid forms of the attribute
    |
 LL - #[deny("literal")]
@@ -33,6 +55,28 @@ LL - #[deny("literal")]
 LL + #[deny(lint1, lint2, lint3, reason = "...")]
    |
 
-error: aborting due to 3 previous errors
+error[E0539]: malformed `deny` attribute input
+  --> $DIR/deduplicate-diagnostics.rs:10:1
+   |
+LL | #[deny("literal")]
+   | ^^^^^^^---------^^
+   |        |
+   |        expected a valid identifier here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[deny("literal")]
+LL + #[deny(lint1)]
+   |
+LL - #[deny("literal")]
+LL + #[deny(lint1, lint2, ...)]
+   |
+LL - #[deny("literal")]
+LL + #[deny(lint1, lint2, lint3, reason = "...")]
+   |
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -1,3 +1,11 @@
+error: `#[automatically_derived]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:22:1
+   |
+LL | #![automatically_derived]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+
 error[E0658]: use of an internal attribute
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:1
    |
@@ -7,6 +15,15 @@ LL | #![rustc_main]
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: the `#[rustc_main]` attribute is an internal implementation detail that will never be stable
    = note: the `#[rustc_main]` attribute is used internally to specify test entry point function
+
+error: `#[automatically_derived]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:22:1
+   |
+LL | #![automatically_derived]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `#[macro_export]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:9:1
@@ -54,6 +71,7 @@ LL | #![automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: `#[automatically_derived]` can only be applied to trait impl blocks
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `#[no_link]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:30:1
@@ -360,7 +378,7 @@ LL | #![no_mangle]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[no_mangle]` can be applied to functions and statics
 
-error: aborting due to 37 previous errors; 6 warnings emitted
+error: aborting due to 39 previous errors; 6 warnings emitted
 
 Some errors have detailed explanations: E0517, E0658.
 For more information about an error, try `rustc --explain E0517`.

--- a/tests/ui/lint/dangling-pointers-from-temporaries/cstring-as-param.stderr
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/cstring-as-param.stderr
@@ -6,5 +6,13 @@ LL | #![deny(temporary_cstring_as_ptr)]
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
-warning: 1 warning emitted
+warning: lint `temporary_cstring_as_ptr` has been renamed to `dangling_pointers_from_temporaries`
+  --> $DIR/cstring-as-param.rs:3:9
+   |
+LL | #![deny(temporary_cstring_as_ptr)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `dangling_pointers_from_temporaries`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
 

--- a/tests/ui/lint/dangling-pointers-from-temporaries/cstring-as-ptr.stderr
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/cstring-as-ptr.stderr
@@ -6,6 +6,14 @@ LL | #![deny(temporary_cstring_as_ptr)]
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
+warning: lint `temporary_cstring_as_ptr` has been renamed to `dangling_pointers_from_temporaries`
+  --> $DIR/cstring-as-ptr.rs:2:9
+   |
+LL | #![deny(temporary_cstring_as_ptr)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `dangling_pointers_from_temporaries`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: this creates a dangling pointer because temporary `CString` is dropped at end of statement
   --> $DIR/cstring-as-ptr.rs:15:48
    |
@@ -41,5 +49,5 @@ LL |     mymacro!();
    = note: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
    = note: this error originates in the macro `mymacro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/ui/lint/issue-97094.stderr
+++ b/tests/ui/lint/issue-97094.stderr
@@ -1,8 +1,8 @@
-error: unknown lint: `nonex_lint_mod`
-  --> $DIR/issue-97094.rs:10:24
+error: unknown lint: `nonex_lint_top_level`
+  --> $DIR/issue-97094.rs:5:25
    |
-LL | #[cfg_attr(true, allow(nonex_lint_mod))]
-   |                        ^^^^^^^^^^^^^^
+LL | #![cfg_attr(true, allow(nonex_lint_top_level))]
+   |                         ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/issue-97094.rs:1:9
@@ -10,6 +10,20 @@ note: the lint level is defined here
 LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(unknown_lints)]` implied by `#[deny(warnings)]`
+
+error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
+  --> $DIR/issue-97094.rs:7:25
+   |
+LL | #![cfg_attr(true, allow(bare_trait_object))]
+   |                         ^^^^^^^^^^^^^^^^^ help: use the new name: `bare_trait_objects`
+   |
+   = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`
+
+error: unknown lint: `nonex_lint_mod`
+  --> $DIR/issue-97094.rs:10:24
+   |
+LL | #[cfg_attr(true, allow(nonex_lint_mod))]
+   |                        ^^^^^^^^^^^^^^
 
 error: unknown lint: `nonex_lint_mod_inner`
   --> $DIR/issue-97094.rs:13:29
@@ -40,6 +54,8 @@ error: unknown lint: `nonex_lint_top_level`
    |
 LL | #![cfg_attr(true, allow(nonex_lint_top_level))]
    |                         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
   --> $DIR/issue-97094.rs:7:25
@@ -47,7 +63,7 @@ error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
 LL | #![cfg_attr(true, allow(bare_trait_object))]
    |                         ^^^^^^^^^^^^^^^^^ help: use the new name: `bare_trait_objects`
    |
-   = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 7 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/lint/lint-malformed.stderr
+++ b/tests/ui/lint/lint-malformed.stderr
@@ -40,6 +40,94 @@ LL - #![allow(bar = "baz")]
 LL + #![allow(lint1, lint2, lint3, reason = "...")]
    |
 
-error: aborting due to 2 previous errors
+error[E0539]: malformed `deny` attribute input
+  --> $DIR/lint-malformed.rs:1:1
+   |
+LL | #![deny = "foo"]
+   | ^^^^^^^^-------^
+   |         |
+   |         expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #![deny = "foo"]
+LL + #![deny(lint1)]
+   |
+LL - #![deny = "foo"]
+LL + #![deny(lint1, lint2, ...)]
+   |
+LL - #![deny = "foo"]
+LL + #![deny(lint1, lint2, lint3, reason = "...")]
+   |
+
+error[E0539]: malformed `allow` attribute input
+  --> $DIR/lint-malformed.rs:2:1
+   |
+LL | #![allow(bar = "baz")]
+   | ^^^^^^^^^-----------^^
+   |          |
+   |          the only valid argument here is `reason`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #![allow(bar = "baz")]
+LL + #![allow(lint1)]
+   |
+LL - #![allow(bar = "baz")]
+LL + #![allow(lint1, lint2, ...)]
+   |
+LL - #![allow(bar = "baz")]
+LL + #![allow(lint1, lint2, lint3, reason = "...")]
+   |
+
+error[E0539]: malformed `deny` attribute input
+  --> $DIR/lint-malformed.rs:1:1
+   |
+LL | #![deny = "foo"]
+   | ^^^^^^^^-------^
+   |         |
+   |         expected this to be a list
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #![deny = "foo"]
+LL + #![deny(lint1)]
+   |
+LL - #![deny = "foo"]
+LL + #![deny(lint1, lint2, ...)]
+   |
+LL - #![deny = "foo"]
+LL + #![deny(lint1, lint2, lint3, reason = "...")]
+   |
+
+error[E0539]: malformed `allow` attribute input
+  --> $DIR/lint-malformed.rs:2:1
+   |
+LL | #![allow(bar = "baz")]
+   | ^^^^^^^^^-----------^^
+   |          |
+   |          the only valid argument here is `reason`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes>
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #![allow(bar = "baz")]
+LL + #![allow(lint1)]
+   |
+LL - #![allow(bar = "baz")]
+LL + #![allow(lint1, lint2, ...)]
+   |
+LL - #![allow(bar = "baz")]
+LL + #![allow(lint1, lint2, lint3, reason = "...")]
+   |
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/lint/lint-unknown-lint.stderr
+++ b/tests/ui/lint/lint-unknown-lint.stderr
@@ -22,5 +22,29 @@ error: unknown lint: `rust_2018_idiots`
 LL | #![deny(rust_2018_idiots)]
    |         ^^^^^^^^^^^^^^^^ help: did you mean: `rust_2018_idioms`
 
-error: aborting due to 3 previous errors
+error: unknown lint: `not_a_real_lint`
+  --> $DIR/lint-unknown-lint.rs:3:10
+   |
+LL | #![allow(not_a_real_lint)]
+   |          ^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unknown lint: `dead_cod`
+  --> $DIR/lint-unknown-lint.rs:5:9
+   |
+LL | #![deny(dead_cod)]
+   |         ^^^^^^^^ help: did you mean: `dead_code`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unknown lint: `rust_2018_idiots`
+  --> $DIR/lint-unknown-lint.rs:9:9
+   |
+LL | #![deny(rust_2018_idiots)]
+   |         ^^^^^^^^^^^^^^^^ help: did you mean: `rust_2018_idioms`
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/register-tool-lint.stderr
+++ b/tests/ui/lint/register-tool-lint.stderr
@@ -6,6 +6,24 @@ LL | #![warn(abc::my_lint)]
    |
    = help: add `#![register_tool(abc)]` to the crate root
 
-error: aborting due to 1 previous error
+error[E0710]: unknown tool name `abc` found in scoped lint: `abc::my_lint`
+  --> $DIR/register-tool-lint.rs:5:9
+   |
+LL | #![warn(abc::my_lint)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(abc)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0710]: unknown tool name `abc` found in scoped lint: `abc::my_lint`
+  --> $DIR/register-tool-lint.rs:5:9
+   |
+LL | #![warn(abc::my_lint)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(abc)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0710`.

--- a/tests/ui/lint/removed-lints/ptr_cast_add_auto_to_object.stderr
+++ b/tests/ui/lint/removed-lints/ptr_cast_add_auto_to_object.stderr
@@ -6,5 +6,13 @@ LL | #![deny(ptr_cast_add_auto_to_object)]
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
-warning: 1 warning emitted
+warning: lint `ptr_cast_add_auto_to_object` has been removed: converted into hard error, see issue #127323 <https://github.com/rust-lang/rust/issues/127323> for more information
+  --> $DIR/ptr_cast_add_auto_to_object.rs:3:9
+   |
+LL | #![deny(ptr_cast_add_auto_to_object)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
 

--- a/tests/ui/lint/removed-lints/undefined_naked_function_abi.stderr
+++ b/tests/ui/lint/removed-lints/undefined_naked_function_abi.stderr
@@ -6,5 +6,13 @@ LL | #![deny(undefined_naked_function_abi)]
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
-warning: 1 warning emitted
+warning: lint `undefined_naked_function_abi` has been removed: converted into hard error, see PR #139001 <https://github.com/rust-lang/rust/issues/139001> for more information
+  --> $DIR/undefined_naked_function_abi.rs:3:9
+   |
+LL | #![deny(undefined_naked_function_abi)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
 

--- a/tests/ui/lint/renamed-lints-still-apply.stderr
+++ b/tests/ui/lint/renamed-lints-still-apply.stderr
@@ -1,3 +1,11 @@
+warning: lint `single_use_lifetime` has been renamed to `single_use_lifetimes`
+  --> $DIR/renamed-lints-still-apply.rs:2:9
+   |
+LL | #![deny(single_use_lifetime)]
+   |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `single_use_lifetimes`
+   |
+   = note: `#[warn(renamed_and_removed_lints)]` on by default
+
 error: lifetime parameter `'a` only used once
   --> $DIR/renamed-lints-still-apply.rs:6:9
    |
@@ -23,7 +31,7 @@ warning: lint `single_use_lifetime` has been renamed to `single_use_lifetimes`
 LL | #![deny(single_use_lifetime)]
    |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `single_use_lifetimes`
    |
-   = note: `#[warn(renamed_and_removed_lints)]` on by default
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error; 2 warnings emitted
 

--- a/tests/ui/lint/rustdoc-group.stderr
+++ b/tests/ui/lint/rustdoc-group.stderr
@@ -6,5 +6,13 @@ LL | #![deny(rustdoc)]
    |
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
-warning: 1 warning emitted
+warning: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/rustdoc-group.rs:3:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 2 warnings emitted
 

--- a/tests/ui/lint/rustdoc-renamed.stderr
+++ b/tests/ui/lint/rustdoc-renamed.stderr
@@ -10,5 +10,13 @@ note: the lint level is defined here
 LL | #![deny(renamed_and_removed_lints)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: lint `intra_doc_link_resolution_failure` has been removed: use `rustdoc::broken_intra_doc_links` instead
+  --> $DIR/rustdoc-renamed.rs:11:9
+   |
+LL | #![deny(intra_doc_link_resolution_failure)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/lint/unused/empty-attributes.stderr
+++ b/tests/ui/lint/unused/empty-attributes.stderr
@@ -1,31 +1,15 @@
 error: unused attribute
-  --> $DIR/empty-attributes.rs:9:1
-   |
-LL | #[repr()]
-   | ^^^^^^^^^ help: remove this attribute
-   |
-   = note: using `repr` with an empty list has no effect
-note: the lint level is defined here
-  --> $DIR/empty-attributes.rs:1:9
-   |
-LL | #![deny(unused_attributes)]
-   |         ^^^^^^^^^^^^^^^^^
-
-error: unused attribute
-  --> $DIR/empty-attributes.rs:12:1
-   |
-LL | #[target_feature()]
-   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
-   |
-   = note: using `target_feature` with an empty list has no effect
-
-error: unused attribute
   --> $DIR/empty-attributes.rs:2:1
    |
 LL | #![allow()]
    | ^^^^^^^^^^^ help: remove this attribute
    |
    = note: using `allow` with an empty list has no effect
+note: the lint level is defined here
+  --> $DIR/empty-attributes.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
 
 error: unused attribute
   --> $DIR/empty-attributes.rs:3:1
@@ -60,6 +44,67 @@ LL | #![forbid()]
    = note: using `forbid` with an empty list has no effect
 
 error: unused attribute
+  --> $DIR/empty-attributes.rs:9:1
+   |
+LL | #[repr()]
+   | ^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `repr` with an empty list has no effect
+
+error: unused attribute
+  --> $DIR/empty-attributes.rs:12:1
+   |
+LL | #[target_feature()]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `target_feature` with an empty list has no effect
+
+error: unused attribute
+  --> $DIR/empty-attributes.rs:2:1
+   |
+LL | #![allow()]
+   | ^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `allow` with an empty list has no effect
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
+  --> $DIR/empty-attributes.rs:3:1
+   |
+LL | #![expect()]
+   | ^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `expect` with an empty list has no effect
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
+  --> $DIR/empty-attributes.rs:4:1
+   |
+LL | #![warn()]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `warn` with an empty list has no effect
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
+  --> $DIR/empty-attributes.rs:5:1
+   |
+LL | #![deny()]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `deny` with an empty list has no effect
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
+  --> $DIR/empty-attributes.rs:6:1
+   |
+LL | #![forbid()]
+   | ^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: using `forbid` with an empty list has no effect
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: unused attribute
   --> $DIR/empty-attributes.rs:7:1
    |
 LL | #![feature()]
@@ -67,5 +112,5 @@ LL | #![feature()]
    |
    = note: using `feature` with an empty list has no effect
 
-error: aborting due to 8 previous errors
+error: aborting due to 13 previous errors
 

--- a/tests/ui/lint/unused/unused-attr-duplicate.stderr
+++ b/tests/ui/lint/unused/unused-attr-duplicate.stderr
@@ -17,6 +17,18 @@ LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: unused attribute
+  --> $DIR/unused-attr-duplicate.rs:76:1
+   |
+LL | #[automatically_derived]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/unused-attr-duplicate.rs:75:1
+   |
+LL | #[automatically_derived]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:37:1
    |
 LL | #[no_link]
@@ -126,6 +138,7 @@ note: attribute also specified here
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: unused attribute
   --> $DIR/unused-attr-duplicate.rs:80:1
@@ -316,5 +329,5 @@ note: attribute also specified here
 LL | #![no_builtins]
    | ^^^^^^^^^^^^^^^
 
-error: aborting due to 25 previous errors
+error: aborting due to 26 previous errors
 

--- a/tests/ui/malformed/malformed-meta-delim.stderr
+++ b/tests/ui/malformed/malformed-meta-delim.stderr
@@ -22,5 +22,57 @@ LL - #[allow [ foo_lint ] ]
 LL + #[allow ( foo_lint ) ]
    |
 
-error: aborting due to 2 previous errors
+error: wrong meta list delimiters
+  --> $DIR/malformed-meta-delim.rs:3:9
+   |
+LL | #[allow { foo_lint } ]
+   |         ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: the delimiters should be `(` and `)`
+   |
+LL - #[allow { foo_lint } ]
+LL + #[allow ( foo_lint ) ]
+   |
+
+error: wrong meta list delimiters
+  --> $DIR/malformed-meta-delim.rs:8:9
+   |
+LL | #[allow [ foo_lint ] ]
+   |         ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: the delimiters should be `(` and `)`
+   |
+LL - #[allow [ foo_lint ] ]
+LL + #[allow ( foo_lint ) ]
+   |
+
+error: wrong meta list delimiters
+  --> $DIR/malformed-meta-delim.rs:3:9
+   |
+LL | #[allow { foo_lint } ]
+   |         ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: the delimiters should be `(` and `)`
+   |
+LL - #[allow { foo_lint } ]
+LL + #[allow ( foo_lint ) ]
+   |
+
+error: wrong meta list delimiters
+  --> $DIR/malformed-meta-delim.rs:8:9
+   |
+LL | #[allow [ foo_lint ] ]
+   |         ^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: the delimiters should be `(` and `)`
+   |
+LL - #[allow [ foo_lint ] ]
+LL + #[allow ( foo_lint ) ]
+   |
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/tool-attributes/tool_lints-fail.stderr
+++ b/tests/ui/tool-attributes/tool_lints-fail.stderr
@@ -10,5 +10,13 @@ note: the lint level is defined here
 LL | #![deny(unknown_lints)]
    |         ^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: unknown lint: `clippy`
+  --> $DIR/tool_lints-fail.rs:6:9
+   |
+LL | #![deny(clippy)]
+   |         ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/tool-attributes/tool_lints.stderr
+++ b/tests/ui/tool-attributes/tool_lints.stderr
@@ -6,6 +6,24 @@ LL | #[warn(foo::bar)]
    |
    = help: add `#![register_tool(foo)]` to the crate root
 
-error: aborting due to 1 previous error
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/tool_lints.rs:1:8
+   |
+LL | #[warn(foo::bar)]
+   |        ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/tool_lints.rs:1:8
+   |
+LL | #[warn(foo::bar)]
+   |        ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0710`.

--- a/tests/ui/tool-attributes/unknown-lint-tool-name.stderr
+++ b/tests/ui/tool-attributes/unknown-lint-tool-name.stderr
@@ -14,6 +14,42 @@ LL | #[allow(foo::bar)]
    |
    = help: add `#![register_tool(foo)]` to the crate root
 
-error: aborting due to 2 previous errors
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/unknown-lint-tool-name.rs:1:9
+   |
+LL | #![deny(foo::bar)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/unknown-lint-tool-name.rs:4:9
+   |
+LL | #[allow(foo::bar)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/unknown-lint-tool-name.rs:1:9
+   |
+LL | #![deny(foo::bar)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/unknown-lint-tool-name.rs:4:9
+   |
+LL | #[allow(foo::bar)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0710`.


### PR DESCRIPTION
Fixes rust-lang/rust#154800 and adds regression test