### PR TITLE
Fix elided lifetime resolution & trait object lifetime defaulting for enum variant paths

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1691,7 +1691,9 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
         // which requires object lifetime defaults.
         let type_def_id = match res {
             Res::Def(DefKind::AssocTy, def_id) if depth == 1 => Some(self.tcx.parent(def_id)),
-            Res::Def(DefKind::Variant, def_id) if depth == 0 => Some(self.tcx.parent(def_id)),
+            Res::Def(DefKind::Variant, def_id) if depth == 0 || depth == 1 => {
+                Some(self.tcx.parent(def_id))
+            }
             Res::Def(
                 DefKind::Struct
                 | DefKind::Union

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2158,7 +2158,15 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 Res::Def(DefKind::AssocTy, def_id) if i + 2 == proj_start => {
                     self.r.tcx.parent(def_id)
                 }
-                Res::Def(DefKind::Variant, def_id) if i + 1 == proj_start => {
+                Res::Def(DefKind::Variant, def_id)
+                    if i + 2 == proj_start && segment.has_generic_args =>
+                {
+                    self.r.tcx.parent(def_id)
+                }
+                Res::Def(DefKind::Variant, def_id)
+                    if i + 1 == proj_start
+                        && !i.checked_sub(1).is_some_and(|i| path[i].has_generic_args) =>
+                {
                     self.r.tcx.parent(def_id)
                 }
                 Res::Def(DefKind::Struct, def_id)

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -353,8 +353,7 @@ enum VisResolutionError<'a> {
 struct Segment {
     ident: Ident,
     id: Option<NodeId>,
-    /// Signals whether this `PathSegment` has generic arguments. Used to avoid providing
-    /// nonsensical suggestions.
+    /// Signals whether this `PathSegment` has generic arguments.
     has_generic_args: bool,
     /// Signals whether this `PathSegment` has lifetime arguments.
     has_lifetime_args: bool,

--- a/tests/ui/lifetimes/no-lt-elision-in-variant-path-seg-as-enum-path-seg-has-gen-args.rs
+++ b/tests/ui/lifetimes/no-lt-elision-in-variant-path-seg-as-enum-path-seg-has-gen-args.rs
@@ -1,0 +1,37 @@
+// Given an enum `Enum` with lifetime parameters, we used to lower `Enum::<…>::Variant {}` to
+// `Enum::<…>::Variant::<'_, …> {}`, i.e., synthesize `'_` lifetime args for enum variants
+// even if generic args were already passed to the enum itself.
+// Obviously, these conflicting generic arg lists were then rejected later on (by HIR ty lowering).
+//
+// Now we no longer do. Why do we synthesize these lifetimes for struct variant paths in the first
+// place while we don't do it for unit & tuple variants? Well, we later HIR-ty-lower the former in
+// "type mode" while we lower the latter in "value mode". In "type mode", we won't infer
+// elided lifetimes if the generic arg lists contains non-lifetime args which is undesirable here.
+//
+// issue: <https://github.com/rust-lang/rust/issues/108224>
+//@ check-pass
+
+fn scope<'any>() {
+    enum Ty0<'a> {
+        Unit,
+        Tuple,
+        Struct {},
+
+        Carry(&'a ()),
+    }
+
+    enum Ty1<'a, T: ?Sized> {
+        Variant,
+
+        Carry(&'a T),
+    }
+
+    let _ = Ty0::<'_>::Unit {};
+    let _ = Ty0::<'static>::Tuple {};
+    let _ = Ty0::<'any>::Struct {};
+
+    let _ = Ty1::</*'_, */()>::Variant {};
+    let _ = Ty1::<'any, ()>::Variant {};
+}
+
+fn main() {}

--- a/tests/ui/object-lifetime/object-lifetime-default-enum-variant.rs
+++ b/tests/ui/object-lifetime/object-lifetime-default-enum-variant.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+
+enum Enum<'a, T: 'a + AbideBy<'a> + ?Sized> {
+    Variant,
+
+    Carry(&'a T),
+}
+
+fn scope<'any>() {
+    // We elaborate `dyn Trait` to `dyn Trait + 'any` due to bound `'a` on `T`.
+    let _ = Enum::Variant::<'any, dyn Trait> {};
+
+    // Similarly here.
+    let _ = Enum::<'any, dyn Trait>::Variant {};
+}
+
+trait Trait {}
+
+// We use this to test that a given trait object lifetime bound is
+// *exactly equal* to a given lifetime (not longer, not shorter).
+trait AbideBy<'a> {}
+impl<'a> AbideBy<'a> for dyn Trait + 'a {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154918)*
<!-- homu-ignore:end -->

Context: https://github.com/rust-lang/rust/pull/129543#discussion_r3035614838.
Fixes rust-lang/rust#108224.

I consider this to be a minor bug fix that doesn't demand a (T-types) FCP.

r? @lcnr or reassign