### PR TITLE
c-b: Export inverse hyperbolic trigonometric functions

### DIFF
--- a/library/compiler-builtins/compiler-builtins/src/math/mod.rs
+++ b/library/compiler-builtins/compiler-builtins/src/math/mod.rs
@@ -144,8 +144,12 @@ pub mod partial_availability {
     libm_intrinsics! {
         fn acos(x: f64) -> f64;
         fn acosf(n: f32) -> f32;
+        fn acosh(x: f64) -> f64;
+        fn acoshf(x: f32) -> f32;
         fn asin(x: f64) -> f64;
         fn asinf(n: f32) -> f32;
+        fn asinh(x: f64) -> f64;
+        fn asinhf(x: f32) -> f32;
         fn atan(x: f64) -> f64;
         fn atan2(x: f64, y: f64) -> f64;
         fn atan2f(a: f32, b: f32) -> f32;


### PR DESCRIPTION
Since a1feab16381b ("Use libm for acosh and asinh"), the standard library may link these functions to get a more accurate approximation; however, some targets do not have the needed symbols available. Add them to the compiler-builtins export list to make sure the fallback is usable.

Closes: https://github.com/rust-lang/rust/issues/154919

<!-- homu-ignore:start -->
r? @Amanieu
<!-- homu-ignore:end -->
