### PR TITLE
Add `const Default` impls for `LazyCell` and `LazyLock`

### DIFF
--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -346,7 +346,8 @@ impl<T, F: FnOnce() -> T> DerefMut for LazyCell<T, F> {
 }
 
 #[stable(feature = "lazy_cell", since = "1.80.0")]
-impl<T: Default> Default for LazyCell<T> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T: Default> const Default for LazyCell<T> {
     /// Creates a new lazy value using `Default` as the initializing function.
     #[inline]
     fn default() -> LazyCell<T> {

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -375,7 +375,8 @@ impl<T, F: FnOnce() -> T> DerefMut for LazyLock<T, F> {
 }
 
 #[stable(feature = "lazy_cell", since = "1.80.0")]
-impl<T: Default> Default for LazyLock<T> {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl<T: Default> const Default for LazyLock<T> {
     /// Creates a new lazy value using `Default` as the initializing function.
     #[inline]
     fn default() -> LazyLock<T> {

--- a/library/std/tests/sync/lazy_lock.rs
+++ b/library/std/tests/sync/lazy_lock.rs
@@ -34,6 +34,15 @@ fn lazy_default() {
 }
 
 #[test]
+fn const_lazy_default() {
+    // using Box as it cannot be initialized in const contexts
+    const X: LazyLock<Box<u8>> = <_>::default();
+    const Y: LazyCell<Box<u8>> = <_>::default();
+    assert_eq!(**X, 0);
+    assert_eq!(**Y, 0);
+}
+
+#[test]
 #[cfg_attr(any(target_os = "emscripten", target_os = "wasi"), ignore)] // no threads
 fn sync_lazy_new() {
     static CALLED: AtomicUsize = AtomicUsize::new(0);

--- a/library/std/tests/sync/lib.rs
+++ b/library/std/tests/sync/lib.rs
@@ -1,3 +1,5 @@
+#![feature(const_default)]
+#![feature(const_trait_impl)]
 #![feature(mapped_lock_guards)]
 #![feature(mpmc_channel)]
 #![feature(oneshot_channel)]


### PR DESCRIPTION
Follow up to these commits by @estebank https://github.com/rust-lang/rust/pull/134628 and https://github.com/rust-lang/rust/pull/151190.
Tracking issue https://github.com/rust-lang/rust/issues/143894.

cc @fmease @fee1-dead @oli-obk

This enables `static L: LazyLock<D> = Default::default()`  for any type `D: Default` which is safe as `D::default()` is only evaluated at runtime.