### PR TITLE
Add getters for `rustc_pattern_analysis::constructor::Slice` fields

### DIFF
--- a/compiler/rustc_pattern_analysis/src/constructor.rs
+++ b/compiler/rustc_pattern_analysis/src/constructor.rs
@@ -495,6 +495,15 @@ impl Slice {
         other.kind.covers_length(self.arity())
     }
 
+    // Getters. They are used by rust-analyzer.
+    pub fn array_len(self) -> Option<usize> {
+        self.array_len
+    }
+
+    pub fn kind(self) -> SliceKind {
+        self.kind
+    }
+
     /// This computes constructor splitting for variable-length slices, as explained at the top of
     /// the file.
     ///


### PR DESCRIPTION
rust-analyzer needs that.

r? @Nadrieril

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
