### PR TITLE
Add Sized supertrait for CoerceUnsized and DispatchFromDyn

### DIFF
--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -33,7 +33,7 @@ use crate::marker::{PointeeSized, Unsize};
 /// [nomicon-coerce]: ../../nomicon/coercions.html
 #[unstable(feature = "coerce_unsized", issue = "18598")]
 #[lang = "coerce_unsized"]
-pub trait CoerceUnsized<T: PointeeSized> {
+pub trait CoerceUnsized<T: PointeeSized>: Sized {
     // Empty.
 }
 
@@ -116,7 +116,7 @@ impl<T: PointeeSized + Unsize<U>, U: PointeeSized> CoerceUnsized<*const U> for *
 /// [^1]: Formerly known as *object safety*.
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 #[lang = "dispatch_from_dyn"]
-pub trait DispatchFromDyn<T> {
+pub trait DispatchFromDyn<T>: Sized {
     // Empty.
 }
 

--- a/tests/ui/self/arbitrary-self-types-dyn-receiver.rs
+++ b/tests/ui/self/arbitrary-self-types-dyn-receiver.rs
@@ -1,0 +1,21 @@
+//@ run-pass
+#![feature(arbitrary_self_types)]
+
+use std::ops::Receiver;
+
+trait Trait {
+    fn foo(self: &dyn Receiver<Target=Self>);
+}
+
+struct Thing;
+impl Trait for Thing {
+    fn foo(self: &dyn Receiver<Target=Self>) {
+        println!("huh???");
+    }
+}
+
+fn main() {
+    let x = Box::new(Thing);
+    let y: &dyn Receiver<Target=Thing> = &x;
+    y.foo();
+}

--- a/tests/ui/traits/dyn-coerce-unsized-ice.rs
+++ b/tests/ui/traits/dyn-coerce-unsized-ice.rs
@@ -1,0 +1,16 @@
+// Regression test for:
+// https://github.com/rust-lang/rust/issues/149094#issuecomment-4191071539
+#![feature(coerce_unsized, unsized_fn_params)]
+#![expect(internal_features)]
+
+use std::ops::CoerceUnsized;
+
+pub trait Trait {}
+
+pub fn foo(x: dyn CoerceUnsized<*const dyn Trait>) -> *const dyn Trait {
+//~^ ERROR: the trait `CoerceUnsized` is not dyn compatible [E0038]
+    x
+//~^ ERROR: the size for values of type `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)` cannot be known at compilation time [E0277]
+}
+
+fn main() {}

--- a/tests/ui/traits/dyn-coerce-unsized-ice.stderr
+++ b/tests/ui/traits/dyn-coerce-unsized-ice.stderr
@@ -1,0 +1,23 @@
+error[E0038]: the trait `CoerceUnsized` is not dyn compatible
+  --> $DIR/dyn-coerce-unsized-ice.rs:10:15
+   |
+LL | pub fn foo(x: dyn CoerceUnsized<*const dyn Trait>) -> *const dyn Trait {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CoerceUnsized` is not dyn compatible
+   |
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+
+error[E0277]: the size for values of type `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-coerce-unsized-ice.rs:12:5
+   |
+LL |     x
+   |     ^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)`
+   = note: required for the cast from `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)` to `*const (dyn Trait + 'static)`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0038, E0277.
+For more information about an error, try `rustc --explain E0038`.


### PR DESCRIPTION
This is part of rust-lang/rust#149094. I did not include `Receiver` because I think it is correct to allow non-sized receivers.