### PR TITLE
Small refactor of `arena_cache` query values

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -1202,7 +1202,7 @@ rustc_queries! {
     /// Return the live symbols in the crate for dead code check.
     ///
     /// The second return value maps from ADTs to ignored derived traits (e.g. Debug and Clone).
-    query live_symbols_and_ignored_derived_traits(_: ()) -> &'tcx Result<(
+    query live_symbols_and_ignored_derived_traits(_: ()) -> Result<&'tcx (
         LocalDefIdSet,
         LocalDefIdMap<FxIndexSet<DefId>>,
     ), ErrorGuaranteed> {
@@ -1292,7 +1292,7 @@ rustc_queries! {
 
     /// Return the set of (transitive) callees that may result in a recursive call to `key`,
     /// if we were able to walk all callees.
-    query mir_callgraph_cyclic(key: LocalDefId) -> &'tcx Option<UnordSet<LocalDefId>> {
+    query mir_callgraph_cyclic(key: LocalDefId) -> Option<&'tcx UnordSet<LocalDefId>> {
         arena_cache
         desc {
             "computing (transitive) callees of `{}` that may recurse",

--- a/compiler/rustc_middle/src/query/arena_cached.rs
+++ b/compiler/rustc_middle/src/query/arena_cached.rs
@@ -1,6 +1,7 @@
 use std::mem;
 
 use rustc_arena::TypedArena;
+use rustc_span::ErrorGuaranteed;
 
 use crate::ty::TyCtxt;
 
@@ -47,6 +48,21 @@ impl<'tcx, T> ArenaCached<'tcx> for Option<&'tcx T> {
         value: Option<T>,
     ) -> Self {
         // Don't store None in the arena, and wrap the allocated reference in Some.
+        try { do_alloc(tcx, typed_arena, value?) }
+    }
+}
+
+impl<'tcx, T> ArenaCached<'tcx> for Result<&'tcx T, ErrorGuaranteed> {
+    type Provided = Result<T, ErrorGuaranteed>;
+    /// The provide value is `Result<T, ErrorGuaranteed>`, but we only store `T` in the arena.
+    type Allocated = T;
+
+    fn alloc_in_arena(
+        tcx: TyCtxt<'tcx>,
+        typed_arena: &'tcx TypedArena<T>,
+        value: Result<T, ErrorGuaranteed>,
+    ) -> Self {
+        // Don't store Err(ErrorGuaranteed) in the arena, and wrap the allocated reference in Ok.
         try { do_alloc(tcx, typed_arena, value?) }
     }
 }


### PR DESCRIPTION
Query modifier `arena_cache` automatically allocates only `Some` variant of query's value of type `Option<&'tcx T>`, so `mir_callgraph_cyclic` should've been doing it from the beginning. The same could be said for any `Result<&'tcx T, ErrorGuaranteed>` as `ErrorGuaranteed` is a zero sized type, but that requires adding a new `ArenaCached` implementation.