### PR TITLE
Merge BuildReducedGraphVisitor into DefPathVisitor

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1069,7 +1069,11 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     }
 
     /// Constructs the reduced graph for one foreign item.
-    fn build_reduced_graph_for_foreign_item(&mut self, item: &ForeignItem, ident: Ident) {
+    pub(crate) fn build_reduced_graph_for_foreign_item(
+        &mut self,
+        item: &ForeignItem,
+        ident: Ident,
+    ) {
         let feed = self.r.feed(item.id);
         let local_def_id = feed.key();
         let def_id = local_def_id.to_def_id();
@@ -1230,7 +1234,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
 
     /// Visit invocation in context in which it can emit a named item (possibly `macro_rules`)
     /// directly into its parent scope's module.
-    fn visit_invoc_in_module(&mut self, id: NodeId) -> MacroRulesScopeRef<'ra> {
+    pub(crate) fn visit_invoc_in_module(&mut self, id: NodeId) -> MacroRulesScopeRef<'ra> {
         let invoc_id = self.visit_invoc(id);
         self.parent_scope.module.unexpanded_invocations.borrow_mut(self.r).insert(invoc_id);
         self.r.arenas.alloc_macro_rules_scope(MacroRulesScope::Invocation(invoc_id))
@@ -1425,20 +1429,6 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         }
     }
 
-    fn visit_foreign_item(&mut self, foreign_item: &'a ForeignItem) {
-        let ident = match foreign_item.kind {
-            ForeignItemKind::Static(box StaticItem { ident, .. })
-            | ForeignItemKind::Fn(box Fn { ident, .. })
-            | ForeignItemKind::TyAlias(box TyAlias { ident, .. }) => ident,
-            ForeignItemKind::MacCall(_) => {
-                self.visit_invoc_in_module(foreign_item.id);
-                return;
-            }
-        };
-
-        self.build_reduced_graph_for_foreign_item(foreign_item, ident);
-        visit::walk_item(self, foreign_item);
-    }
 
     fn visit_block(&mut self, block: &'a Block) {
         let orig_current_module = self.parent_scope.module;

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1384,7 +1384,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     method!(visit_pat: ast::Pat, ast::PatKind::MacCall, walk_pat);
     method!(visit_ty: ast::Ty, ast::TyKind::MacCall, walk_ty);
 
-    fn visit_item(&mut self, item: &'a Item) {
+    pub(crate) fn brg_visit_item(&mut self, item: &'a Item) {
         let orig_module_scope = self.parent_scope.module;
         self.parent_scope.macro_rules = match item.kind {
             ItemKind::MacroDef(..) => {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1505,14 +1505,6 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         visit::walk_attribute(self, attr);
     }
 
-    fn visit_generic_param(&mut self, param: &'a ast::GenericParam) {
-        if param.is_placeholder {
-            self.visit_invoc(param.id);
-        } else {
-            visit::walk_generic_param(self, param);
-        }
-    }
-
     fn visit_field_def(&mut self, sf: &'a ast::FieldDef) {
         if sf.is_placeholder {
             self.visit_invoc(sf.id);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1225,7 +1225,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         false
     }
 
-    fn visit_invoc(&mut self, id: NodeId) -> LocalExpnId {
+    pub(crate) fn visit_invoc(&mut self, id: NodeId) -> LocalExpnId {
         let invoc_id = id.placeholder_to_expn_id();
         let old_parent_scope = self.r.invocation_parent_scopes.insert(invoc_id, self.parent_scope);
         assert!(old_parent_scope.is_none(), "invocation data is reset for an invocation");
@@ -1505,43 +1505,11 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         visit::walk_attribute(self, attr);
     }
 
-    fn visit_arm(&mut self, arm: &'a ast::Arm) {
-        if arm.is_placeholder {
-            self.visit_invoc(arm.id);
-        } else {
-            visit::walk_arm(self, arm);
-        }
-    }
-
-    fn visit_expr_field(&mut self, f: &'a ast::ExprField) {
-        if f.is_placeholder {
-            self.visit_invoc(f.id);
-        } else {
-            visit::walk_expr_field(self, f);
-        }
-    }
-
-    fn visit_pat_field(&mut self, fp: &'a ast::PatField) {
-        if fp.is_placeholder {
-            self.visit_invoc(fp.id);
-        } else {
-            visit::walk_pat_field(self, fp);
-        }
-    }
-
     fn visit_generic_param(&mut self, param: &'a ast::GenericParam) {
         if param.is_placeholder {
             self.visit_invoc(param.id);
         } else {
             visit::walk_generic_param(self, param);
-        }
-    }
-
-    fn visit_param(&mut self, p: &'a ast::Param) {
-        if p.is_placeholder {
-            self.visit_invoc(p.id);
-        } else {
-            visit::walk_param(self, p);
         }
     }
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -31,7 +31,7 @@ use thin_vec::ThinVec;
 use tracing::debug;
 
 use crate::Namespace::{MacroNS, TypeNS, ValueNS};
-use crate::def_collector::collect_definitions;
+use crate::def_collector::{DefCollector, collect_definitions};
 use crate::diagnostics::StructCtor;
 use crate::imports::{ImportData, ImportKind, OnUnknownData};
 use crate::macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
@@ -242,10 +242,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         fragment: &AstFragment,
         parent_scope: ParentScope<'ra>,
     ) -> MacroRulesScopeRef<'ra> {
-        collect_definitions(self, fragment, parent_scope.expansion);
-        let mut visitor = BuildReducedGraphVisitor { r: self, parent_scope };
-        fragment.visit_with(&mut visitor);
-        visitor.parent_scope.macro_rules
+        collect_definitions(self, fragment, parent_scope)
     }
 
     pub(crate) fn build_reduced_graph_external(&self, module: ExternModule<'ra>) {
@@ -364,18 +361,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 }
 
-struct BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
-    r: &'a mut Resolver<'ra, 'tcx>,
-    parent_scope: ParentScope<'ra>,
-}
-
-impl<'ra, 'tcx> AsMut<Resolver<'ra, 'tcx>> for BuildReducedGraphVisitor<'_, 'ra, 'tcx> {
+impl<'ra, 'tcx> AsMut<Resolver<'ra, 'tcx>> for DefCollector<'_, 'ra, 'tcx> {
     fn as_mut(&mut self) -> &mut Resolver<'ra, 'tcx> {
         self.r
     }
 }
 
-impl<'a, 'ra, 'tcx> BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
+impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     fn res(&self, def_id: impl Into<DefId>) -> Res {
         let def_id = def_id.into();
         Res::Def(self.r.tcx.def_kind(def_id), def_id)
@@ -1387,7 +1379,7 @@ macro_rules! method {
     };
 }
 
-impl<'a, 'ra, 'tcx> Visitor<'a> for BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
+impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     method!(visit_expr: ast::Expr, ast::ExprKind::MacCall, walk_expr);
     method!(visit_pat: ast::Pat, ast::PatKind::MacCall, walk_pat);
     method!(visit_ty: ast::Ty, ast::TyKind::MacCall, walk_ty);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1425,7 +1425,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         self.parent_scope.macro_rules = self.visit_invoc_in_module(stmt.id);
     }
 
-    fn visit_block(&mut self, block: &'a Block) {
+    pub(crate) fn brg_visit_block(&mut self, block: &'a Block) {
         let orig_current_module = self.parent_scope.module;
         let orig_current_macro_rules_scope = self.parent_scope.macro_rules;
         self.build_reduced_graph_for_block(block);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1434,7 +1434,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         self.parent_scope.macro_rules = orig_current_macro_rules_scope;
     }
 
-    fn visit_assoc_item(&mut self, item: &'a AssocItem, ctxt: AssocCtxt) {
+    pub(crate) fn brg_visit_assoc_item(&mut self, item: &'a AssocItem, ctxt: AssocCtxt) {
         let (ident, ns) = match item.kind {
             AssocItemKind::Const(box ConstItem { ident, .. })
             | AssocItemKind::Fn(box Fn { ident, .. })

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1517,12 +1517,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
 
     // Constructs the reduced graph for one variant. Variants exist in the
     // type and value namespaces.
-    fn visit_variant(&mut self, variant: &'a ast::Variant) {
-        if variant.is_placeholder {
-            self.visit_invoc_in_module(variant.id);
-            return;
-        }
-
+    pub(crate) fn brg_visit_variant(&mut self, variant: &'a ast::Variant) {
         let parent = self.parent_scope.module.expect_local();
         let expn_id = self.parent_scope.expansion;
         let ident = variant.ident;

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -15,7 +15,6 @@ use rustc_ast::{
 use rustc_attr_parsing as attr;
 use rustc_attr_parsing::AttributeParser;
 use rustc_expand::base::ResolverExpand;
-use rustc_expand::expand::AstFragment;
 use rustc_hir::Attribute;
 use rustc_hir::attrs::{AttributeKind, MacroUseArgs};
 use rustc_hir::def::{self, *};
@@ -31,7 +30,7 @@ use thin_vec::ThinVec;
 use tracing::debug;
 
 use crate::Namespace::{MacroNS, TypeNS, ValueNS};
-use crate::def_collector::{DefCollector, collect_definitions};
+use crate::def_collector::DefCollector;
 use crate::diagnostics::StructCtor;
 use crate::imports::{ImportData, ImportKind, OnUnknownData};
 use crate::macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
@@ -235,14 +234,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
             self.all_crate_macros_already_registered = true;
         }
-    }
-
-    pub(crate) fn build_reduced_graph(
-        &mut self,
-        fragment: &AstFragment,
-        parent_scope: ParentScope<'ra>,
-    ) -> MacroRulesScopeRef<'ra> {
-        collect_definitions(self, fragment, parent_scope)
     }
 
     pub(crate) fn build_reduced_graph_external(&self, module: ExternModule<'ra>) {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1418,28 +1418,8 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
 
             AssocItemKind::Type(box TyAlias { ident, .. }) => (ident, TypeNS),
 
-            AssocItemKind::MacCall(_) => {
-                match ctxt {
-                    AssocCtxt::Trait => {
-                        self.visit_invoc_in_module(item.id);
-                    }
-                    AssocCtxt::Impl { .. } => {
-                        let invoc_id = item.id.placeholder_to_expn_id();
-                        if !self.r.glob_delegation_invoc_ids.contains(&invoc_id) {
-                            self.r
-                                .impl_unexpanded_invocations
-                                .entry(self.r.invocation_parent(invoc_id))
-                                .or_default()
-                                .insert(invoc_id);
-                        }
-                        self.visit_invoc(item.id);
-                    }
-                }
-                return;
-            }
-
-            AssocItemKind::DelegationMac(..) => {
-                span_bug!(item.span, "delegation mac should already have been removed")
+            AssocItemKind::MacCall(_) | AssocItemKind::DelegationMac(..) => {
+                span_bug!(item.span, "{item:#?} should already have been removed")
             }
         };
         let vis = self.resolve_visibility(&item.vis);
@@ -1470,6 +1450,29 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         }
 
         visit::walk_assoc_item(self, item, ctxt);
+    }
+
+    pub(crate) fn visit_assoc_item_mac_call(
+        &mut self,
+        item: &'a Item<AssocItemKind>,
+        ctxt: AssocCtxt,
+    ) {
+        match ctxt {
+            AssocCtxt::Trait => {
+                self.visit_invoc_in_module(item.id);
+            }
+            AssocCtxt::Impl { .. } => {
+                let invoc_id = item.id.placeholder_to_expn_id();
+                if !self.r.glob_delegation_invoc_ids.contains(&invoc_id) {
+                    self.r
+                        .impl_unexpanded_invocations
+                        .entry(self.r.invocation_parent(invoc_id))
+                        .or_default()
+                        .insert(invoc_id);
+                }
+                self.visit_invoc(item.id);
+            }
+        }
     }
 
     pub(crate) fn brg_visit_attribute(&mut self, attr: &'a ast::Attribute) {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1371,23 +1371,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     }
 }
 
-macro_rules! method {
-    ($visit:ident: $ty:ty, $invoc:path, $walk:ident) => {
-        fn $visit(&mut self, node: &'a $ty) {
-            if let $invoc(..) = node.kind {
-                self.visit_invoc(node.id);
-            } else {
-                visit::$walk(self, node);
-            }
-        }
-    };
-}
-
 impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
-    method!(visit_expr: ast::Expr, ast::ExprKind::MacCall, walk_expr);
-    method!(visit_pat: ast::Pat, ast::PatKind::MacCall, walk_pat);
-    method!(visit_ty: ast::Ty, ast::TyKind::MacCall, walk_ty);
-
     pub(crate) fn brg_visit_item(&mut self, item: &'a Item) {
         let orig_module_scope = self.parent_scope.module;
         self.parent_scope.macro_rules = match item.kind {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1205,7 +1205,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     }
 
     /// Returns `true` if this attribute list contains `macro_use`.
-    fn contains_macro_use(&self, attrs: &[ast::Attribute]) -> bool {
+    pub(crate) fn contains_macro_use(&self, attrs: &[ast::Attribute]) -> bool {
         for attr in attrs {
             if attr.has_name(sym::macro_escape) {
                 let inner_attribute = matches!(attr.style, ast::AttrStyle::Inner);
@@ -1556,17 +1556,5 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         self.insert_field_visibilities_local(def_id.to_def_id(), variant.data.fields());
 
         visit::walk_variant(self, variant);
-    }
-
-    fn visit_crate(&mut self, krate: &'a ast::Crate) {
-        if krate.is_placeholder {
-            self.visit_invoc_in_module(krate.id);
-        } else {
-            // Visit attributes after items for backward compatibility.
-            // This way they can use `macro_rules` defined later.
-            visit::walk_list!(self, visit_item, &krate.items);
-            visit::walk_list!(self, visit_attribute, &krate.attrs);
-            self.contains_macro_use(&krate.attrs);
-        }
     }
 }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1480,7 +1480,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         visit::walk_assoc_item(self, item, ctxt);
     }
 
-    fn visit_attribute(&mut self, attr: &'a ast::Attribute) {
+    pub(crate) fn brg_visit_attribute(&mut self, attr: &'a ast::Attribute) {
         if !attr.is_doc_comment() && attr::is_builtin_attr(attr) {
             self.r
                 .builtin_attrs

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1421,14 +1421,9 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         self.parent_scope.module = orig_module_scope;
     }
 
-    fn visit_stmt(&mut self, stmt: &'a ast::Stmt) {
-        if let ast::StmtKind::MacCall(..) = stmt.kind {
-            self.parent_scope.macro_rules = self.visit_invoc_in_module(stmt.id);
-        } else {
-            visit::walk_stmt(self, stmt);
-        }
+    pub(crate) fn brg_visit_stmt_mac_call(&mut self, stmt: &'a ast::Stmt) {
+        self.parent_scope.macro_rules = self.visit_invoc_in_module(stmt.id);
     }
-
 
     fn visit_block(&mut self, block: &'a Block) {
         let orig_current_module = self.parent_scope.module;

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -747,6 +747,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             }
             ast::UseTreeKind::Nested { ref items, .. } => {
                 for &(ref tree, id) in items {
+                    self.create_def(id, None, DefKind::Use, use_tree.span());
                     self.build_reduced_graph_for_use_tree(
                         // This particular use tree
                         tree, id, &prefix, true, false, // The whole `use` item

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1410,18 +1410,13 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         self.parent_scope.macro_rules = orig_current_macro_rules_scope;
     }
 
-    pub(crate) fn brg_visit_assoc_item(&mut self, item: &'a AssocItem, ctxt: AssocCtxt) {
-        let (ident, ns) = match item.kind {
-            AssocItemKind::Const(box ConstItem { ident, .. })
-            | AssocItemKind::Fn(box Fn { ident, .. })
-            | AssocItemKind::Delegation(box Delegation { ident, .. }) => (ident, ValueNS),
-
-            AssocItemKind::Type(box TyAlias { ident, .. }) => (ident, TypeNS),
-
-            AssocItemKind::MacCall(_) | AssocItemKind::DelegationMac(..) => {
-                span_bug!(item.span, "{item:#?} should already have been removed")
-            }
-        };
+    pub(crate) fn brg_visit_assoc_item(
+        &mut self,
+        item: &'a AssocItem,
+        ctxt: AssocCtxt,
+        ident: Ident,
+        ns: Namespace,
+    ) {
         let vis = self.resolve_visibility(&item.vis);
         let feed = self.r.feed(item.id);
         let local_def_id = feed.key();

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1505,14 +1505,10 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         visit::walk_attribute(self, attr);
     }
 
-    fn visit_field_def(&mut self, sf: &'a ast::FieldDef) {
-        if sf.is_placeholder {
-            self.visit_invoc(sf.id);
-        } else {
-            let vis = self.resolve_visibility(&sf.vis);
-            self.r.feed_visibility(self.r.feed(sf.id), vis);
-            visit::walk_field_def(self, sf);
-        }
+    pub(crate) fn brg_visit_field_def(&mut self, sf: &'a ast::FieldDef) {
+        let vis = self.resolve_visibility(&sf.vis);
+        self.r.feed_visibility(self.r.feed(sf.id), vis);
+        visit::walk_field_def(self, sf);
     }
 
     // Constructs the reduced graph for one variant. Variants exist in the

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1558,14 +1558,6 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         visit::walk_variant(self, variant);
     }
 
-    fn visit_where_predicate(&mut self, p: &'a ast::WherePredicate) {
-        if p.is_placeholder {
-            self.visit_invoc(p.id);
-        } else {
-            visit::walk_where_predicate(self, p);
-        }
-    }
-
     fn visit_crate(&mut self, krate: &'a ast::Crate) {
         if krate.is_placeholder {
             self.visit_invoc_in_module(krate.id);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -12,7 +12,6 @@ use rustc_ast::{
     self as ast, AssocItem, AssocItemKind, Block, ConstItem, Delegation, Fn, ForeignItem,
     ForeignItemKind, Inline, Item, ItemKind, NodeId, StaticItem, StmtKind, TraitAlias, TyAlias,
 };
-use rustc_attr_parsing as attr;
 use rustc_attr_parsing::AttributeParser;
 use rustc_expand::base::ResolverExpand;
 use rustc_hir::Attribute;
@@ -1468,15 +1467,6 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                 self.visit_invoc(item.id);
             }
         }
-    }
-
-    pub(crate) fn brg_visit_attribute(&mut self, attr: &'a ast::Attribute) {
-        if !attr.is_doc_comment() && attr::is_builtin_attr(attr) {
-            self.r
-                .builtin_attrs
-                .push((attr.get_normal_item().path.segments[0].ident, self.parent_scope));
-        }
-        visit::walk_attribute(self, attr);
     }
 
     pub(crate) fn brg_visit_field_def(&mut self, sf: &'a ast::FieldDef) {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -97,10 +97,11 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             let old_index = self.r.placeholder_field_indices.insert(field.id, index(self));
             assert!(old_index.is_none(), "placeholder field index is reset for a node ID");
             self.visit_macro_invoc(field.id);
+            self.visit_invoc(field.id);
         } else {
             let name = field.ident.map_or_else(|| sym::integer(index(self)), |ident| ident.name);
             let def = self.create_def(field.id, Some(name), DefKind::Field, field.span);
-            self.with_parent(def, |this| visit::walk_field_def(this, field));
+            self.with_parent(def, |this| this.brg_visit_field_def(field));
         }
     }
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -291,12 +291,19 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             }
             ForeignItemKind::Fn(box Fn { ident, .. }) => (ident, DefKind::Fn),
             ForeignItemKind::TyAlias(box TyAlias { ident, .. }) => (ident, DefKind::ForeignTy),
-            ForeignItemKind::MacCall(_) => return self.visit_macro_invoc(fi.id),
+            ForeignItemKind::MacCall(_) => {
+                self.visit_invoc_in_module(fi.id);
+                self.visit_macro_invoc(fi.id);
+                return;
+            }
         };
 
         let def = self.create_def(fi.id, Some(ident.name), def_kind, fi.span);
 
-        self.with_parent(def, |this| visit::walk_item(this, fi));
+        self.with_parent(def, |this| {
+            this.build_reduced_graph_for_foreign_item(fi, ident);
+            visit::walk_item(this, fi)
+        });
     }
 
     fn visit_variant(&mut self, v: &'a Variant) {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -312,7 +312,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_variant(&mut self, v: &'a Variant) {
         if v.is_placeholder {
-            return self.visit_macro_invoc(v.id);
+            self.visit_macro_invoc(v.id);
+            self.visit_invoc_in_module(v.id);
+            return;
         }
         let def = self.create_def(v.id, Some(v.ident.name), DefKind::Variant, v.span);
         self.with_parent(def, |this| {
@@ -324,7 +326,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     v.span,
                 );
             }
-            visit::walk_variant(this, v)
+            this.brg_visit_variant(v);
         });
     }
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -348,6 +348,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     fn visit_generic_param(&mut self, param: &'a GenericParam) {
         if param.is_placeholder {
             self.visit_macro_invoc(param.id);
+            self.visit_invoc(param.id);
             return;
         }
         let def_kind = match param.kind {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -400,7 +400,10 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_pat(&mut self, pat: &'a Pat) {
         match pat.kind {
-            PatKind::MacCall(..) => self.visit_macro_invoc(pat.id),
+            PatKind::MacCall(..) => {
+                self.visit_macro_invoc(pat.id);
+                self.visit_invoc(pat.id);
+            }
             _ => visit::walk_pat(self, pat),
         }
     }
@@ -434,7 +437,11 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         debug!(?self.invocation_parent);
 
         let parent_def = match &expr.kind {
-            ExprKind::MacCall(..) => return self.visit_macro_invoc(expr.id),
+            ExprKind::MacCall(..) => {
+                self.visit_macro_invoc(expr.id);
+                self.visit_invoc(expr.id);
+                return;
+            }
             ExprKind::Closure(..) | ExprKind::Gen(..) => {
                 self.create_def(expr.id, None, DefKind::Closure, expr.span)
             }
@@ -486,7 +493,10 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_ty(&mut self, ty: &'a Ty) {
         match ty.kind {
-            TyKind::MacCall(..) => self.visit_macro_invoc(ty.id),
+            TyKind::MacCall(..) => {
+                self.visit_macro_invoc(ty.id);
+                self.visit_invoc(ty.id);
+            }
             TyKind::ImplTrait(opaque_id, _) => {
                 let name = *self
                     .r

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -212,6 +212,10 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         });
     }
 
+    fn visit_block(&mut self, block: &'a Block) {
+        self.brg_visit_block(block);
+    }
+
     fn visit_fn(&mut self, fn_kind: FnKind<'a>, _: &AttrVec, span: Span, _: NodeId) {
         match fn_kind {
             FnKind::Fn(

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -271,11 +271,6 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         }
     }
 
-    fn visit_nested_use_tree(&mut self, use_tree: &'a UseTree, id: NodeId) {
-        self.create_def(id, None, DefKind::Use, use_tree.span());
-        visit::walk_use_tree(self, use_tree);
-    }
-
     fn visit_foreign_item(&mut self, fi: &'a ForeignItem) {
         let (ident, def_kind) = match fi.kind {
             ForeignItemKind::Static(box StaticItem {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -2,6 +2,7 @@ use std::mem;
 
 use rustc_ast::visit::FnKind;
 use rustc_ast::*;
+use rustc_attr_parsing as attr;
 use rustc_attr_parsing::{AttributeParser, Early, OmitDoc, ShouldEmit};
 use rustc_expand::expand::AstFragment;
 use rustc_hir as hir;
@@ -593,7 +594,12 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_attribute(&mut self, attr: &'a Attribute) {
         let orig_in_attr = mem::replace(&mut self.invocation_parent.in_attr, true);
-        self.brg_visit_attribute(attr);
+        if !attr.is_doc_comment() && attr::is_builtin_attr(attr) {
+            self.r
+                .builtin_attrs
+                .push((attr.get_normal_item().path.segments[0].ident, self.parent_scope));
+        }
+        visit::walk_attribute(self, attr);
         self.invocation_parent.in_attr = orig_in_attr;
     }
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -380,7 +380,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             ),
             AssocItemKind::Type(box TyAlias { ident, .. }) => (*ident, DefKind::AssocTy),
             AssocItemKind::MacCall(..) => {
-                return self.visit_macro_invoc(i.id);
+                self.visit_macro_invoc(i.id);
+                self.brg_visit_assoc_item(i, ctxt);
+                return;
             }
             AssocItemKind::DelegationMac(..) => {
                 span_bug!(i.span, "degation mac invoc should have already been handled")
@@ -388,7 +390,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         };
 
         let def = self.create_def(i.id, Some(ident.name), def_kind, i.span);
-        self.with_parent(def, |this| visit::walk_assoc_item(this, i, ctxt));
+        self.with_parent(def, |this| this.brg_visit_assoc_item(i, ctxt));
     }
 
     fn visit_pat(&mut self, pat: &'a Pat) {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -9,7 +9,6 @@ use rustc_hir::Target;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::span_bug;
-use rustc_span::hygiene::LocalExpnId;
 use rustc_span::{Span, Symbol, sym};
 use tracing::{debug, instrument};
 
@@ -21,10 +20,9 @@ pub(crate) fn collect_definitions<'ra>(
     fragment: &AstFragment,
     parent_scope: ParentScope<'ra>,
 ) -> MacroRulesScopeRef<'ra> {
-    let expansion = parent_scope.expansion;
-    let invocation_parent = resolver.invocation_parents[&expansion];
+    let invocation_parent = resolver.invocation_parents[&parent_scope.expansion];
     debug!("new fragment to visit with invocation_parent: {invocation_parent:?}");
-    let mut visitor = DefCollector { r: resolver, expansion, invocation_parent, parent_scope };
+    let mut visitor = DefCollector { r: resolver, invocation_parent, parent_scope };
     fragment.visit_with(&mut visitor);
     visitor.parent_scope.macro_rules
 }
@@ -33,7 +31,6 @@ pub(crate) fn collect_definitions<'ra>(
 pub(crate) struct DefCollector<'a, 'ra, 'tcx> {
     pub(crate) r: &'a mut Resolver<'ra, 'tcx>,
     invocation_parent: InvocationParent,
-    expansion: LocalExpnId,
     pub(crate) parent_scope: ParentScope<'ra>,
 }
 
@@ -56,7 +53,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                 node_id,
                 name,
                 def_kind,
-                self.expansion.to_expn_id(),
+                self.parent_scope.expansion.to_expn_id(),
                 span.with_parent(None),
             )
             .def_id()
@@ -88,7 +85,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     fn collect_field(&mut self, field: &'a FieldDef, index: Option<usize>) {
         let index = |this: &Self| {
             index.unwrap_or_else(|| {
-                let node_id = NodeId::placeholder_from_expn_id(this.expansion);
+                let node_id = NodeId::placeholder_from_expn_id(this.parent_scope.expansion);
                 this.r.placeholder_field_indices[&node_id]
             })
         };

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -378,7 +378,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             AssocItemKind::Type(box TyAlias { ident, .. }) => (*ident, DefKind::AssocTy),
             AssocItemKind::MacCall(..) => {
                 self.visit_macro_invoc(i.id);
-                self.brg_visit_assoc_item(i, ctxt);
+                self.visit_assoc_item_mac_call(i, ctxt);
                 return;
             }
             AssocItemKind::DelegationMac(..) => {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -38,7 +38,7 @@ pub(crate) struct DefCollector<'a, 'ra, 'tcx> {
 }
 
 impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
-    fn create_def(
+    pub(super) fn create_def(
         &mut self,
         node_id: NodeId,
         name: Option<Symbol>,
@@ -595,9 +595,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         }
     }
 
-    fn visit_attribute(&mut self, attr: &'a Attribute) -> Self::Result {
+    fn visit_attribute(&mut self, attr: &'a Attribute) {
         let orig_in_attr = mem::replace(&mut self.invocation_parent.in_attr, true);
-        visit::walk_attribute(self, attr);
+        self.brg_visit_attribute(attr);
         self.invocation_parent.in_attr = orig_in_attr;
     }
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -174,10 +174,13 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             ItemKind::GlobalAsm(..) => DefKind::GlobalAsm,
             ItemKind::Use(_) => {
                 self.create_def(i.id, None, DefKind::Use, i.span);
-                return visit::walk_item(self, i);
+                self.brg_visit_item(i);
+                return;
             }
             ItemKind::MacCall(..) | ItemKind::DelegationMac(..) => {
-                return self.visit_macro_invoc(i.id);
+                self.visit_macro_invoc(i.id);
+                self.brg_visit_item(i);
+                return;
             }
         };
         let def_id =
@@ -204,7 +207,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     }
                     _ => {}
                 }
-                visit::walk_item(this, i);
+                this.brg_visit_item(i);
             })
         });
     }

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -504,7 +504,10 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt.kind {
-            StmtKind::MacCall(..) => self.visit_macro_invoc(stmt.id),
+            StmtKind::MacCall(..) => {
+                self.brg_visit_stmt_mac_call(stmt);
+                self.visit_macro_invoc(stmt.id)
+            }
             // FIXME(impl_trait_in_bindings): We don't really have a good way of
             // introducing the right `ImplTraitContext` here for all the cases we
             // care about, in case we want to introduce ITIB to other positions

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -330,7 +330,8 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_where_predicate(&mut self, pred: &'a WherePredicate) {
         if pred.is_placeholder {
-            self.visit_macro_invoc(pred.id)
+            self.visit_macro_invoc(pred.id);
+            self.visit_invoc(pred.id);
         } else {
             visit::walk_where_predicate(self, pred)
         }

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -6,6 +6,7 @@ use rustc_attr_parsing::{AttributeParser, Early, OmitDoc, ShouldEmit};
 use rustc_expand::expand::AstFragment;
 use rustc_hir as hir;
 use rustc_hir::Target;
+use rustc_hir::def::Namespace::{TypeNS, ValueNS};
 use rustc_hir::def::{CtorKind, CtorOf, DefKind};
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::span_bug;
@@ -366,16 +367,19 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     }
 
     fn visit_assoc_item(&mut self, i: &'a AssocItem, ctxt: visit::AssocCtxt) {
-        let (ident, def_kind) = match &i.kind {
+        let (ident, def_kind, ns) = match &i.kind {
             AssocItemKind::Fn(box Fn { ident, .. })
-            | AssocItemKind::Delegation(box Delegation { ident, .. }) => (*ident, DefKind::AssocFn),
+            | AssocItemKind::Delegation(box Delegation { ident, .. }) => {
+                (*ident, DefKind::AssocFn, ValueNS)
+            }
             AssocItemKind::Const(box ConstItem { ident, rhs_kind, .. }) => (
                 *ident,
                 DefKind::AssocConst {
                     is_type_const: matches!(rhs_kind, ConstItemRhsKind::TypeConst { .. }),
                 },
+                ValueNS,
             ),
-            AssocItemKind::Type(box TyAlias { ident, .. }) => (*ident, DefKind::AssocTy),
+            AssocItemKind::Type(box TyAlias { ident, .. }) => (*ident, DefKind::AssocTy, TypeNS),
             AssocItemKind::MacCall(..) => {
                 self.visit_macro_invoc(i.id);
                 self.visit_assoc_item_mac_call(i, ctxt);
@@ -387,7 +391,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         };
 
         let def = self.create_def(i.id, Some(ident.name), def_kind, i.span);
-        self.with_parent(def, |this| this.brg_visit_assoc_item(i, ctxt));
+        self.with_parent(def, |this| this.brg_visit_assoc_item(i, ctxt, ident, ns));
     }
 
     fn visit_pat(&mut self, pat: &'a Pat) {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -22,13 +22,13 @@ pub(crate) fn collect_definitions(
 ) {
     let invocation_parent = resolver.invocation_parents[&expansion];
     debug!("new fragment to visit with invocation_parent: {invocation_parent:?}");
-    let mut visitor = DefCollector { resolver, expansion, invocation_parent };
+    let mut visitor = DefCollector { r: resolver, expansion, invocation_parent };
     fragment.visit_with(&mut visitor);
 }
 
 /// Creates `DefId`s for nodes in the AST.
 struct DefCollector<'a, 'ra, 'tcx> {
-    resolver: &'a mut Resolver<'ra, 'tcx>,
+    r: &'a mut Resolver<'ra, 'tcx>,
     invocation_parent: InvocationParent,
     expansion: LocalExpnId,
 }
@@ -46,7 +46,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             "create_def(node_id={:?}, def_kind={:?}, parent_def={:?})",
             node_id, def_kind, parent_def
         );
-        self.resolver
+        self.r
             .create_def(
                 parent_def,
                 node_id,
@@ -85,12 +85,12 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         let index = |this: &Self| {
             index.unwrap_or_else(|| {
                 let node_id = NodeId::placeholder_from_expn_id(this.expansion);
-                this.resolver.placeholder_field_indices[&node_id]
+                this.r.placeholder_field_indices[&node_id]
             })
         };
 
         if field.is_placeholder {
-            let old_index = self.resolver.placeholder_field_indices.insert(field.id, index(self));
+            let old_index = self.r.placeholder_field_indices.insert(field.id, index(self));
             assert!(old_index.is_none(), "placeholder field index is reset for a node ID");
             self.visit_macro_invoc(field.id);
         } else {
@@ -105,7 +105,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         debug!(?self.invocation_parent);
 
         let id = id.placeholder_to_expn_id();
-        let old_parent = self.resolver.invocation_parents.insert(id, self.invocation_parent);
+        let old_parent = self.r.invocation_parents.insert(id, self.invocation_parent);
         assert!(old_parent.is_none(), "parent `LocalDefId` is reset for an invocation");
     }
 }
@@ -144,8 +144,8 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 // FIXME(jdonszelmann) don't care about tools here maybe? Just parse what we can.
                 // Does that prevents errors from happening? maybe
                 let mut parser = AttributeParser::<'_, Early>::new(
-                    &self.resolver.tcx.sess,
-                    self.resolver.tcx.features(),
+                    &self.r.tcx.sess,
+                    self.r.tcx.features(),
                     Vec::new(),
                     Early { emit_errors: ShouldEmit::Nothing },
                 );
@@ -162,8 +162,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     },
                 );
 
-                let macro_data =
-                    self.resolver.compile_macro(def, *ident, &attrs, i.span, i.id, edition);
+                let macro_data = self.r.compile_macro(def, *ident, &attrs, i.span, i.id, edition);
                 let macro_kinds = macro_data.ext.macro_kinds();
                 opt_macro_data = Some(macro_data);
                 DefKind::Macro(macro_kinds)
@@ -181,7 +180,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             self.create_def(i.id, i.kind.ident().map(|ident| ident.name), def_kind, i.span);
 
         if let Some(macro_data) = opt_macro_data {
-            self.resolver.new_local_macro(def_id, macro_data);
+            self.r.new_local_macro(def_id, macro_data);
         }
 
         self.with_parent(def_id, |this| {
@@ -385,7 +384,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         // `MgcaDisambiguation::Direct` is set even when MGCA is disabled, so
         // to avoid affecting stable we have to feature gate the not creating
         // anon consts
-        if !self.resolver.tcx.features().min_generic_const_args() {
+        if !self.r.tcx.features().min_generic_const_args() {
             let parent =
                 self.create_def(constant.id, None, DefKind::AnonConst, constant.value.span);
             return self.with_parent(parent, |this| visit::walk_anon_const(this, constant));
@@ -465,7 +464,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
             TyKind::MacCall(..) => self.visit_macro_invoc(ty.id),
             TyKind::ImplTrait(opaque_id, _) => {
                 let name = *self
-                    .resolver
+                    .r
                     .impl_trait_names
                     .get(&ty.id)
                     .unwrap_or_else(|| span_bug!(ty.span, "expected this opaque to be named"));

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -571,9 +571,14 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_crate(&mut self, krate: &'a Crate) {
         if krate.is_placeholder {
-            self.visit_macro_invoc(krate.id)
+            self.visit_macro_invoc(krate.id);
+            self.visit_invoc_in_module(krate.id);
         } else {
-            visit::walk_crate(self, krate)
+            // Visit attributes after items for backward compatibility.
+            // This way they can use `macro_rules` defined later.
+            visit::walk_list!(self, visit_item, &krate.items);
+            visit::walk_list!(self, visit_attribute, &krate.attrs);
+            self.contains_macro_use(&krate.attrs);
         }
     }
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -526,12 +526,18 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     }
 
     fn visit_arm(&mut self, arm: &'a Arm) {
-        if arm.is_placeholder { self.visit_macro_invoc(arm.id) } else { visit::walk_arm(self, arm) }
+        if arm.is_placeholder {
+            self.visit_macro_invoc(arm.id);
+            self.visit_invoc(arm.id);
+        } else {
+            visit::walk_arm(self, arm)
+        }
     }
 
     fn visit_expr_field(&mut self, f: &'a ExprField) {
         if f.is_placeholder {
-            self.visit_macro_invoc(f.id)
+            self.visit_macro_invoc(f.id);
+            self.visit_invoc(f.id);
         } else {
             visit::walk_expr_field(self, f)
         }
@@ -539,7 +545,8 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_pat_field(&mut self, fp: &'a PatField) {
         if fp.is_placeholder {
-            self.visit_macro_invoc(fp.id)
+            self.visit_macro_invoc(fp.id);
+            self.visit_invoc(fp.id);
         } else {
             visit::walk_pat_field(self, fp)
         }
@@ -547,7 +554,8 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
 
     fn visit_param(&mut self, p: &'a Param) {
         if p.is_placeholder {
-            self.visit_macro_invoc(p.id)
+            self.visit_macro_invoc(p.id);
+            self.visit_invoc(p.id);
         } else {
             self.with_impl_trait(ImplTraitContext::Universal, |this| visit::walk_param(this, p))
         }

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -13,24 +13,28 @@ use rustc_span::hygiene::LocalExpnId;
 use rustc_span::{Span, Symbol, sym};
 use tracing::{debug, instrument};
 
-use crate::{ConstArgContext, ImplTraitContext, InvocationParent, Resolver};
+use crate::macros::MacroRulesScopeRef;
+use crate::{ConstArgContext, ImplTraitContext, InvocationParent, ParentScope, Resolver};
 
-pub(crate) fn collect_definitions(
-    resolver: &mut Resolver<'_, '_>,
+pub(crate) fn collect_definitions<'ra>(
+    resolver: &mut Resolver<'ra, '_>,
     fragment: &AstFragment,
-    expansion: LocalExpnId,
-) {
+    parent_scope: ParentScope<'ra>,
+) -> MacroRulesScopeRef<'ra> {
+    let expansion = parent_scope.expansion;
     let invocation_parent = resolver.invocation_parents[&expansion];
     debug!("new fragment to visit with invocation_parent: {invocation_parent:?}");
-    let mut visitor = DefCollector { r: resolver, expansion, invocation_parent };
+    let mut visitor = DefCollector { r: resolver, expansion, invocation_parent, parent_scope };
     fragment.visit_with(&mut visitor);
+    visitor.parent_scope.macro_rules
 }
 
 /// Creates `DefId`s for nodes in the AST.
-struct DefCollector<'a, 'ra, 'tcx> {
-    r: &'a mut Resolver<'ra, 'tcx>,
+pub(crate) struct DefCollector<'a, 'ra, 'tcx> {
+    pub(crate) r: &'a mut Resolver<'ra, 'tcx>,
     invocation_parent: InvocationParent,
     expansion: LocalExpnId,
+    pub(crate) parent_scope: ParentScope<'ra>,
 }
 
 impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -34,6 +34,7 @@ use rustc_span::hygiene::{self, AstPass, ExpnData, ExpnKind, LocalExpnId, MacroK
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 
 use crate::Namespace::*;
+use crate::def_collector::collect_definitions;
 use crate::errors::{
     self, AddAsNonDerive, CannotDetermineMacroResolution, CannotFindIdentInThisScope,
     MacroExpectedFound, RemoveSurroundingDerive,
@@ -189,7 +190,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
         // Integrate the new AST fragment into all the definition and module structures.
         // We are inside the `expansion` now, but other parent scope components are still the same.
         let parent_scope = ParentScope { expansion, ..self.invocation_parent_scopes[&expansion] };
-        let output_macro_rules_scope = self.build_reduced_graph(fragment, parent_scope);
+        let output_macro_rules_scope = collect_definitions(self, fragment, parent_scope);
         self.output_macro_rules_scopes.insert(expansion, output_macro_rules_scope);
 
         parent_scope.module.unexpanded_invocations.borrow_mut(self).remove(&expansion);

--- a/tests/ui/resolve/pub-in-path-153848.stderr
+++ b/tests/ui/resolve/pub-in-path-153848.stderr
@@ -4,13 +4,6 @@ error[E0433]: cannot find module or crate `a` in the crate root
 LL | pub(in a) mod aa {
    |        ^ use of unresolved module or unlinked crate `a`
    |
-note: found an item that was configured out
-  --> $DIR/pub-in-path-153848.rs:7:16
-   |
-LL |     #[cfg(test)]
-   |           ---- the item is gated here
-LL |     use super::a;
-   |                ^
 help: you might be missing a crate named `a`, add it to your project and import it in your code
    |
 LL + extern crate a;


### PR DESCRIPTION
These two visitors run right after each other on the same immutable AST. There's also a hash map for transferring the TyCtxtFeed created in the def collector to the BRG when it visits the same items. There are possibly more avenues for sharing logic, but I want to keep this PR simple.

only opening for perf runs for now. I'm still investigating how to ensure that future changes don't introduce subtle bugs by forgetting that def collection and reduced graph building are one pass now

Best reviewed commit-by-commit. I took a lot of care for making the individual changes reviewable, but all the `Merge *` commits aren't able to compile libcore until the last one.