### PR TITLE
library: no `cfg(target_arch)` on scalable intrinsics

### DIFF
--- a/library/core/src/intrinsics/simd/scalable.rs
+++ b/library/core/src/intrinsics/simd/scalable.rs
@@ -19,7 +19,6 @@
 /// * Not be `NaN`
 /// * Not be infinite
 /// * Be representable in the return type, after truncating off its fractional part
-#[cfg(target_arch = "aarch64")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub unsafe fn sve_cast<T, U>(x: T) -> U;
@@ -31,7 +30,6 @@ pub unsafe fn sve_cast<T, U>(x: T) -> U;
 /// type `SVec`.
 ///
 /// Corresponds to Clang's `__builtin_sve_svcreate2*` builtins.
-#[cfg(target_arch = "aarch64")]
 #[rustc_nounwind]
 #[rustc_intrinsic]
 pub unsafe fn sve_tuple_create2<SVec, SVecTup>(x0: SVec, x1: SVec) -> SVecTup;
@@ -43,7 +41,6 @@ pub unsafe fn sve_tuple_create2<SVec, SVecTup>(x0: SVec, x1: SVec) -> SVecTup;
 /// type `SVec`.
 ///
 /// Corresponds to Clang's `__builtin_sve_svcreate3*` builtins.
-#[cfg(target_arch = "aarch64")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub unsafe fn sve_tuple_create3<SVec, SVecTup>(x0: SVec, x1: SVec, x2: SVec) -> SVecTup;
@@ -55,7 +52,6 @@ pub unsafe fn sve_tuple_create3<SVec, SVecTup>(x0: SVec, x1: SVec, x2: SVec) -> 
 /// type `SVec`.
 ///
 /// Corresponds to Clang's `__builtin_sve_svcreate4*` builtins.
-#[cfg(target_arch = "aarch64")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub unsafe fn sve_tuple_create4<SVec, SVecTup>(x0: SVec, x1: SVec, x2: SVec, x3: SVec) -> SVecTup;
@@ -71,7 +67,6 @@ pub unsafe fn sve_tuple_create4<SVec, SVecTup>(x0: SVec, x1: SVec, x2: SVec, x3:
 /// # Safety
 ///
 /// `IDX` must be in-bounds of the tuple.
-#[cfg(target_arch = "aarch64")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub unsafe fn sve_tuple_get<SVecTup, SVec, const IDX: i32>(tuple: SVecTup) -> SVec;
@@ -87,7 +82,6 @@ pub unsafe fn sve_tuple_get<SVecTup, SVec, const IDX: i32>(tuple: SVecTup) -> SV
 /// # Safety
 ///
 /// `IDX` must be in-bounds of the tuple.
-#[cfg(target_arch = "aarch64")]
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub unsafe fn sve_tuple_set<SVecTup, SVec, const IDX: i32>(tuple: SVecTup, x: SVec) -> SVecTup;


### PR DESCRIPTION
These intrinsics don't technically need to be limited to a specific architecture, they'll probably only make sense to use on AArch64, but this just makes it harder to use them in stdarch where it is appropriate (such as on `arm64ec`): requiring a rustc patch to land and be on nightly before stdarch work can proceed. So let's just not `cfg` them at all, they're perma-unstable anyway.

Fixes CI failure in rust-lang/stdarch#2071
