### PR TITLE
Fix pattern types rendering in rustdoc

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1808,7 +1808,15 @@ pub(crate) fn clean_ty<'tcx>(ty: &hir::Ty<'tcx>, cx: &mut DocContext<'tcx>) -> T
             BorrowedRef { lifetime, mutability: m.mutbl, type_: Box::new(clean_ty(m.ty, cx)) }
         }
         TyKind::Slice(ty) => Slice(Box::new(clean_ty(ty, cx))),
-        TyKind::Pat(ty, pat) => Type::Pat(Box::new(clean_ty(ty, cx)), format!("{pat:?}").into()),
+        TyKind::Pat(inner_ty, pat) => {
+            // Local HIR pattern types should print the same way as cross-crate inlined ones,
+            // so lower to the canonical `rustc_middle::ty::Pattern` representation first.
+            let pat = match lower_ty(cx.tcx, ty).kind() {
+                ty::Pat(_, pat) => format!("{pat:?}").into_boxed_str(),
+                _ => format!("{pat:?}").into(),
+            };
+            Type::Pat(Box::new(clean_ty(inner_ty, cx)), pat)
+        }
         TyKind::FieldOf(ty, hir::TyFieldPath { variant, field }) => {
             let field_str = if let Some(variant) = variant {
                 format!("{variant}.{field}")

--- a/tests/rustdoc-html/pattern-types-implementors.rs
+++ b/tests/rustdoc-html/pattern-types-implementors.rs
@@ -1,0 +1,12 @@
+#![feature(pattern_types, pattern_type_macro)]
+#![crate_name = "pattern_types_implementors"]
+
+use std::pat::pattern_type;
+
+pub trait MyTrait {}
+
+impl MyTrait for pattern_type!(*const u8 is !null) {}
+
+//@ has pattern_types_implementors/trait.MyTrait.html
+//@ has - '//*[@id="implementors-list"]/*[@class="impl"]' 'impl MyTrait for *const u8 is !null'
+//@ !has - '//*[@id="implementors-list"]/*[@class="impl"]' 'TyPat {'


### PR DESCRIPTION
Closes rust-lang/rust#150889 .

`core` was rendering local pattern-type impls through `clean_ty`, which formatted `rustc_hir::TyPat` with derived Debug, while inlined docs go through `clean_middle_ty` and get the pretty-printed `rustc_middle::ty::Pattern`.
Lower local HIR pattern types before formatting so both paths share the same canonical pattern printer and stop exposing `TyPat { ... }` in implementors.

#### Current result: 
<img width="1133" height="738" alt="截屏2026-04-07 22 47 26" src="https://github.com/user-attachments/assets/bb5f8942-30b1-400a-a0a0-f581da5bb59f" />


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
