### PR TITLE
rustc_target: add riscv64a23-unknown-none-elf target (Tier 3)

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1706,6 +1706,7 @@ supported_targets! {
     ("riscv64im-unknown-none-elf", riscv64im_unknown_none_elf),
     ("riscv64imac-unknown-none-elf", riscv64imac_unknown_none_elf),
     ("riscv64gc-unknown-none-elf", riscv64gc_unknown_none_elf),
+    ("riscv64a23-unknown-none-elf", riscv64a23_unknown_none_elf),
     ("riscv64gc-unknown-linux-gnu", riscv64gc_unknown_linux_gnu),
     ("riscv64gc-unknown-linux-musl", riscv64gc_unknown_linux_musl),
     ("riscv64a23-unknown-linux-gnu", riscv64a23_unknown_linux_gnu),

--- a/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_none_elf.rs
@@ -1,0 +1,65 @@
+use crate::spec::{
+    Arch, Cc, CodeModel, LinkerFlavor, Lld, LlvmAbi, PanicStrategy, RelocModel, SanitizerSet,
+    Target, TargetMetadata, TargetOptions,
+};
+
+/// Bare-metal RISC-V target following the RVA23U64 mandatory profile.
+///
+/// RVA23U64 is the 2023 application-class mandatory profile for 64-bit
+/// RISC-V user-mode code.  It includes:
+///
+///   - `I`, `M`, `A`, `F`, `D`, `C` (standard IMAFC + compressed)
+///   - `Zicsr`, `Zifencei`  (CSR access and instruction-stream fence)
+///   - `Zba`, `Zbb`, `Zbs`  (bit-manipulation, Bitmanip subset)
+///   - `Zic64b`             (64-byte cache-block operations)
+///   - `Ziccamoa`           (atomics at cache-block granularity)
+///   - `Ziccif`             (instruction-fetch ordering)
+///   - `Zicclsm`            (misaligned load/store support)
+///   - `Ziccrse`            (reservation-set events)
+///   - `Za64rs`             (64-byte reservation-set size)
+///   - `Zawrs`              (WRS.STO / WRS.NTO wait-on-reservation-set)
+///   - `Zfhmin`             (half-precision load/store and convert)
+///   - `Zkt`                (constant-time instructions)
+///   - `Zvbb`, `Zvfhmin`    (vector bit-manip and half-precision vector ops)
+///   - `Zvkn`               (NIST crypto suite for RVV)
+///   - `Zvkt`               (vector constant-time instructions)
+///   - `V` (and `Zvl128b`)  (standard 128-bit+ vector extension)
+///
+/// This target is intended for capability-native, bare-metal kernel and
+/// runtime development on modern server-class RISC-V hardware (e.g. the
+/// Dominion and Feox projects).  It uses the same conservative link model
+/// as `riscv64gc-unknown-none-elf` (static PIC, medium code model, abort
+/// on panic) so that it integrates cleanly with bare-metal linker scripts.
+pub(crate) fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
+        metadata: TargetMetadata {
+            description: Some("Bare RISC-V (RVA23U64 mandatory profile)".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        llvm_target: "riscv64".into(),
+        pointer_width: 64,
+        arch: Arch::RiscV64,
+
+        options: TargetOptions {
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            linker: Some("rust-lld".into()),
+            llvm_abiname: LlvmAbi::Lp64d,
+            // Use the LLVM RVA23U64 feature string so that the backend can
+            // select the correct instruction scheduling model and
+            // auto-vectorisation decisions.
+            cpu: "generic-rv64".into(),
+            features: "+rva23u64".into(),
+            max_atomic_width: Some(64),
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            code_model: Some(CodeModel::Medium),
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            supported_sanitizers: SanitizerSet::KERNELADDRESS | SanitizerSet::SHADOWCALLSTACK,
+            ..Default::default()
+        },
+    }
+}


### PR DESCRIPTION
The RVA23U64 mandatory profile is the 2023 application-class baseline for 64-bit RISC-V. It includes Zba/Zbb/Zbs bit-manipulation, Zfhmin half-precision, Zawrs wait-on-reservation-set, Zic64b/Ziccamoa cache operations, the full V vector extension, and several crypto profiles.

riscv64gc-unknown-none-elf exists but targets generic-rv64 without any of these extensions. The corresponding Linux target riscv64a23-unknown-linux-gnu was added previously; this adds the bare- metal none-elf variant for kernel and runtime development targeting modern server-class RISC-V hardware.

Target properties mirror riscv64gc-unknown-none-elf: LLD linker, static relocation model, medium code model, panic=abort, no std. Adds KernelAddress and ShadowCallStack sanitizer support.

Tier: 3 (no host tools, no std)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
