### PR TITLE
Test(lib/sync): Fix `test_rwlock_max_readers` for x86 Win7

### DIFF
--- a/library/std/tests/sync/rwlock.rs
+++ b/library/std/tests/sync/rwlock.rs
@@ -917,18 +917,22 @@ fn test_rwlock_max_readers() {
             target_os = "fuchsia",
             all(target_family = "wasm", target_feature = "atomics"),
             target_os = "hermit",
-        target_os = "motor",
+            target_os = "motor",
         ) => {
             (1 << 30) - 2
         },
         any(
             target_family = "unix",
-            all(target_os = "windows", target_vendor = "win7"),
+            all(target_os = "windows", target_vendor = "win7", target_pointer_width = "64"),
             all(target_vendor = "fortanix", target_env = "sgx"),
             target_os = "xous",
             target_os = "teeos",
         ) => {
             u32::MAX
+        },
+        // Otherwise a form of deadlock is observed.
+        all(target_os = "windows", target_vendor = "win7", target_pointer_width = "32") => {
+            (1 << 28) - 1
         },
         target_os = "solid_asp3" => {
             (1 << 30)


### PR DESCRIPTION
The test recently added in rust-lang/rust#153555 currently systematically deadlocks when running it under i686 Windows 7, but not x86_64 that passes it fine. This therefore fixes the test for the target.

Empirically, the correct value for `MAX_READERS` seems to be `2^28 - 1`: removing the `- 1` re-introduces the deadlock, at least under our testing environment. This fix thus uses this value. However, I have no real justification to support that, because I find myself a bit at a loss when comparing the implementation details, the comment added above the test and what the current value is; some help would therefore be nice in this aspect. Also, the value change is restricted to 32-bit Win7 as there is no evidence to support it should be done for other targets.

cc @roblabla

@rustbot label O-windows-msvc O-windows-7 O-x86_32 A-atomic T-libs