### PR TITLE
rustdoc: preserve `doc(cfg)` on locally re-exported type aliases

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -205,7 +205,8 @@ fn generate_item_with_correct_attrs(
             attrs.extend(get_all_import_attributes(cx, import_id, def_id, is_inline));
             is_inline = is_inline || import_is_inline;
         }
-        add_without_unwanted_attributes(&mut attrs, target_attrs, is_inline, None);
+        let keep_target_cfg = is_inline || matches!(kind, ItemKind::TypeAliasItem(..));
+        add_without_unwanted_attributes(&mut attrs, target_attrs, keep_target_cfg, None);
         attrs
     } else {
         // We only keep the item's attributes.

--- a/tests/rustdoc-html/reexport/type-alias-reexport.rs
+++ b/tests/rustdoc-html/reexport/type-alias-reexport.rs
@@ -1,0 +1,34 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/154921>.
+// This test ensures that auto-generated and explicit `doc(cfg)` attributes are correctly
+// preserved for locally re-exported type aliases.
+
+//@ compile-flags: --cfg feature="foo"
+
+#![crate_name = "foo"]
+#![feature(doc_cfg)]
+
+mod inner {
+    #[cfg(feature = "foo")]
+    pub type One = u32;
+
+    #[doc(cfg(feature = "foo"))]
+    pub type Two = u32;
+}
+
+//@ has 'foo/index.html'
+// There should be two items in the type aliases table.
+//@ count - '//*[@class="item-table"]/dt' 2
+// Both of them should have the portability badge in the module index.
+//@ count - '//*[@class="item-table"]/dt/*[@class="stab portability"]' 2
+
+//@ has 'foo/type.One.html'
+// Check that the individual type page has the portability badge.
+//@ count - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' 1
+//@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' 'foo'
+
+//@ has 'foo/type.Two.html'
+// Check the explicit doc(cfg) type page as well.
+//@ count - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' 1
+//@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' 'foo'
+
+pub use self::inner::{One, Two};


### PR DESCRIPTION
When a type alias is locally re-exported from a private module (an implicit inline), rustdoc drops its `cfg` attributes because it treats it like a standard un-inlined re-export. Since type aliases have no inner fields to carry the `cfg` badge (unlike structs or enums), the portability info is lost entirely.

This patch explicitly preserves the target's `cfg` metadata when the generated item is a `TypeAliasItem`, ensuring the portability badge renders correctly without breaking standard cross-crate re-export behavior.

Fixes rust-lang/rust#154921 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
