### PR TITLE
Enable statx on supported musl versions

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -6,7 +6,7 @@
 #[cfg(test)]
 mod tests;
 
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(target_os = "linux")]
 use libc::c_char;
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),
@@ -93,7 +93,7 @@ use crate::sys::fd::FileDesc;
 pub use crate::sys::fs::common::exists;
 use crate::sys::helpers::run_path_with_cstr;
 use crate::sys::time::SystemTime;
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(target_os = "linux")]
 use crate::sys::weak::syscall;
 #[cfg(target_os = "android")]
 use crate::sys::weak::weak;
@@ -102,14 +102,14 @@ use crate::{mem, ptr};
 
 pub struct File(FileDesc);
 
-// FIXME: This should be available on Linux with all `target_env`.
-// But currently only glibc exposes `statx` fn and structs.
-// We don't want to import unverified raw C structs here directly.
+// statx is available on Linux when:
+//   - target_env = "gnu": added in glibc >= 2.28
+//   - target_env = "musl": added in musl >= 1.2.5
 // https://github.com/rust-lang/rust/pull/67774
 macro_rules! cfg_has_statx {
     ({ $($then_tt:tt)* } else { $($else_tt:tt)* }) => {
         cfg_select! {
-            all(target_os = "linux", target_env = "gnu") => {
+            target_os = "linux" => {
                 $($then_tt)*
             }
             _ => {
@@ -118,7 +118,7 @@ macro_rules! cfg_has_statx {
         }
     };
     ($($block_inner:tt)*) => {
-        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        #[cfg(target_os = "linux")]
         {
             $($block_inner)*
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154981)*
<!-- homu-ignore:end -->

Rust has feature-gated fs statx calls to gnu libc only. This feature was [added to musl libc](https://musl.libc.org/releases.html) in the 1.2.5 release, which was in turn [included](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/#update-bundled-musl-to-1-2-5) in Rust 1.93.0, see https://github.com/rust-lang/rust/pull/142682

There is a stale feature gate that is still blocking access to statx calls, even though this is now available in musl libc through the libc crate v0.2.175+, see https://github.com/rust-lang/libc/pull/3976

This PR enables the feature. Note that this will likely cause build breakages anywhere rustix is used, and the issue has already popped up in the rustix repo https://github.com/bytecodealliance/rustix/issues/1496 for archs that never supported musl <1.2.5

This is my first PR here and I need some help coordinating between all these moving parts. @Gankra could you help maybe? Thanks!

More refs:
https://github.com/rust-lang/rust/pull/67774
https://github.com/vectordotdev/vector/issues/23813
https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/98199

r? @Gankra 