### PR TITLE
target: support scalable vectors on arm64ec

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1957,11 +1957,10 @@ impl Arch {
         use Arch::*;
 
         match self {
-            AArch64 | RiscV32 | RiscV64 => true,
-            AmdGpu | Arm | Arm64EC | Avr | Bpf | CSky | Hexagon | LoongArch32 | LoongArch64
-            | M68k | Mips | Mips32r6 | Mips64 | Mips64r6 | Msp430 | Nvptx64 | PowerPC
-            | PowerPC64 | S390x | Sparc | Sparc64 | SpirV | Wasm32 | Wasm64 | X86 | X86_64
-            | Xtensa | Other(_) => false,
+            Arm64EC | AArch64 | RiscV32 | RiscV64 => true,
+            AmdGpu | Arm | Avr | Bpf | CSky | Hexagon | LoongArch32 | LoongArch64 | M68k | Mips
+            | Mips32r6 | Mips64 | Mips64r6 | Msp430 | Nvptx64 | PowerPC | PowerPC64 | S390x
+            | Sparc | Sparc64 | SpirV | Wasm32 | Wasm64 | X86 | X86_64 | Xtensa | Other(_) => false,
         }
     }
 }


### PR DESCRIPTION
This architecture is also AArch64, just with a different ABI, and so supports scalable vectors too.

This is part of what is becoming a series of small PRs which fix CI failures in rust-lang/stdarch#2071 once they reach nightly.