### PR TITLE
Move Region from rustc_middle to rustc_type_ir

### DIFF
--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -9,7 +9,7 @@ use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, Body, Local, Location, traversal};
 use rustc_middle::ty::data_structures::IndexSet;
-use rustc_middle::ty::{RegionVid, TyCtxt};
+use rustc_middle::ty::{RegionUtilitiesExt, RegionVid, TyCtxt};
 use rustc_middle::{bug, span_bug, ty};
 use rustc_mir_dataflow::move_paths::MoveData;
 use smallvec::{SmallVec, smallvec};

--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -14,7 +14,8 @@ use rustc_infer::traits::query::{
 };
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::{
-    self, RePlaceholder, Region, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex,
+    self, RePlaceholder, Region, RegionExt, RegionUtilitiesExt, RegionVid, Ty, TyCtxt,
+    TypeFoldable, UniverseIndex,
 };
 use rustc_span::Span;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -26,7 +26,7 @@ use rustc_middle::mir::{
 };
 use rustc_middle::ty::print::PrintTraitRefExt as _;
 use rustc_middle::ty::{
-    self, PredicateKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor, Upcast,
+    self, PredicateKind, RegionUtilitiesExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor, Upcast,
     suggest_constraining_type_params,
 };
 use rustc_mir_dataflow::move_paths::{Init, InitKind, InitLocation, MoveOutIndex, MovePathIndex};

--- a/compiler/rustc_borrowck/src/diagnostics/find_use.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_use.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_middle::mir::visit::{PlaceContext, Visitor};
 use rustc_middle::mir::{self, Body, Local, Location};
-use rustc_middle::ty::{RegionVid, TyCtxt};
+use rustc_middle::ty::{RegionUtilitiesExt, RegionVid, TyCtxt};
 
 use crate::def_use::{self, DefUse};
 use crate::region_infer::{Cause, RegionInferenceContext};

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -15,7 +15,8 @@ use rustc_middle::bug;
 use rustc_middle::hir::place::PlaceBase;
 use rustc_middle::mir::{AnnotationSource, ConstraintCategory, ReturnConstraint};
 use rustc_middle::ty::{
-    self, GenericArgs, Region, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitor, fold_regions,
+    self, GenericArgs, Region, RegionUtilitiesExt, RegionVid, Ty, TyCtxt, TypeFoldable,
+    TypeVisitor, fold_regions,
 };
 use rustc_span::{Ident, Span, kw};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -6,7 +6,9 @@ use rustc_errors::{Diag, EmissionGuarantee};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::ty::print::RegionHighlightMode;
-use rustc_middle::ty::{self, GenericArgKind, GenericArgsRef, RegionVid, Ty, Unnormalized};
+use rustc_middle::ty::{
+    self, GenericArgKind, GenericArgsRef, RegionUtilitiesExt, RegionVid, Ty, Unnormalized,
+};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;

--- a/compiler/rustc_borrowck/src/diagnostics/var_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/var_name.rs
@@ -1,7 +1,7 @@
 use rustc_index::IndexSlice;
 use rustc_middle::mir::visit::{PlaceContext, VisitPlacesWith, Visitor};
 use rustc_middle::mir::{Body, Local, Place};
-use rustc_middle::ty::{self, RegionVid, TyCtxt};
+use rustc_middle::ty::{self, RegionUtilitiesExt, RegionVid, TyCtxt};
 use rustc_span::{Span, Symbol};
 use tracing::debug;
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -38,7 +38,8 @@ use rustc_infer::infer::{
 use rustc_middle::mir::*;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{
-    self, ParamEnv, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitable, TypingMode, fold_regions,
+    self, ParamEnv, RegionUtilitiesExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitable,
+    TypingMode, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_mir_dataflow::impls::{EverInitializedPlaces, MaybeUninitializedPlaces};

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -12,7 +12,7 @@ use rustc_index::IndexSlice;
 use rustc_middle::mir::pretty::PrettyPrintMirOptions;
 use rustc_middle::mir::{Body, MirDumper, PassWhere, Promoted};
 use rustc_middle::ty::print::with_no_trimmed_paths;
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, RegionExt, TyCtxt};
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_session::config::MirIncludeSpans;

--- a/compiler/rustc_borrowck/src/polonius/dump.rs
+++ b/compiler/rustc_borrowck/src/polonius/dump.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_index::IndexVec;
 use rustc_middle::mir::pretty::{MirDumper, PassWhere, PrettyPrintMirOptions};
 use rustc_middle::mir::{Body, Location};
-use rustc_middle::ty::{RegionVid, TyCtxt};
+use rustc_middle::ty::{RegionUtilitiesExt, RegionVid, TyCtxt};
 use rustc_mir_dataflow::points::PointIndex;
 use rustc_session::config::MirIncludeSpans;
 

--- a/compiler/rustc_borrowck/src/polonius/liveness_constraints.rs
+++ b/compiler/rustc_borrowck/src/polonius/liveness_constraints.rs
@@ -4,7 +4,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty::relate::{
     self, Relate, RelateResult, TypeRelation, relate_args_with_variances,
 };
-use rustc_middle::ty::{self, RegionVid, Ty, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{self, RegionUtilitiesExt, RegionVid, Ty, TyCtxt, TypeVisitable};
 
 use super::{ConstraintDirection, PoloniusContext};
 use crate::universal_regions::UniversalRegions;

--- a/compiler/rustc_borrowck/src/region_infer/graphviz.rs
+++ b/compiler/rustc_borrowck/src/region_infer/graphviz.rs
@@ -7,7 +7,7 @@ use std::io::{self, Write};
 
 use itertools::Itertools;
 use rustc_graphviz as dot;
-use rustc_middle::ty::UniverseIndex;
+use rustc_middle::ty::{RegionUtilitiesExt, UniverseIndex};
 
 use super::*;
 

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -17,7 +17,9 @@ use rustc_middle::mir::{
     TerminatorKind,
 };
 use rustc_middle::traits::{ObligationCause, ObligationCauseCode};
-use rustc_middle::ty::{self, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex, fold_regions};
+use rustc_middle::ty::{
+    self, RegionExt, RegionVid, Ty, TyCtxt, TypeFoldable, UniverseIndex, fold_regions,
+};
 use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::{DUMMY_SP, Span};

--- a/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs
@@ -11,8 +11,9 @@ use rustc_macros::extension;
 use rustc_middle::mir::{Body, ConstraintCategory};
 use rustc_middle::ty::{
     self, DefiningScopeKind, DefinitionSiteHiddenType, FallibleTypeFolder, Flags, GenericArg,
-    GenericArgsRef, OpaqueTypeKey, ProvisionalHiddenType, Region, RegionVid, Ty, TyCtxt,
-    TypeFoldable, TypeSuperFoldable, TypeVisitableExt, Unnormalized, fold_regions,
+    GenericArgsRef, OpaqueTypeKey, ProvisionalHiddenType, Region, RegionExt, RegionUtilitiesExt,
+    RegionVid, Ty, TyCtxt, TypeFoldable, TypeSuperFoldable, TypeVisitableExt, Unnormalized,
+    fold_regions,
 };
 use rustc_mir_dataflow::points::DenseLocationMap;
 use rustc_span::Span;

--- a/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
+++ b/compiler/rustc_borrowck/src/type_check/constraint_conversion.rs
@@ -8,7 +8,8 @@ use rustc_infer::infer::region_constraints::{GenericKind, VerifyBound};
 use rustc_infer::traits::query::type_op::Normalize;
 use rustc_middle::bug;
 use rustc_middle::ty::{
-    self, GenericArgKind, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, elaborate, fold_regions,
+    self, GenericArgKind, RegionExt, RegionUtilitiesExt, Ty, TyCtxt, TypeFoldable,
+    TypeVisitableExt, elaborate, fold_regions,
 };
 use rustc_span::Span;
 use rustc_trait_selection::traits::query::type_op::TypeOpOutput;

--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -4,7 +4,9 @@ use rustc_middle::mir::visit::{TyContext, Visitor};
 use rustc_middle::mir::{Body, Local, Location, SourceInfo};
 use rustc_middle::span_bug;
 use rustc_middle::ty::relate::Relate;
-use rustc_middle::ty::{GenericArgsRef, Region, RegionVid, Ty, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{
+    GenericArgsRef, Region, RegionUtilitiesExt, RegionVid, Ty, TyCtxt, TypeVisitable,
+};
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::points::DenseLocationMap;
 use tracing::debug;

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -26,8 +26,9 @@ use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::{
-    self, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, GenericArgsRef, Ty, TyCtxt,
-    TypeVisitableExt, UserArgs, UserTypeAnnotationIndex, fold_regions,
+    self, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, GenericArgsRef,
+    RegionUtilitiesExt, Ty, TyCtxt, TypeVisitableExt, UserArgs, UserTypeAnnotationIndex,
+    fold_regions,
 };
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::points::DenseLocationMap;

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -10,7 +10,7 @@ use rustc_middle::traits::ObligationCause;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::relate::combine::{combine_ty_args, super_combine_consts, super_combine_tys};
 use rustc_middle::ty::relate::relate_args_invariantly;
-use rustc_middle::ty::{self, FnMutDelegate, Ty, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{self, FnMutDelegate, RegionUtilitiesExt, Ty, TyCtxt, TypeVisitableExt};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol, sym};
 use tracing::{debug, instrument};

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -26,8 +26,8 @@ use rustc_macros::extension;
 use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionVid, Ty,
-    TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
+    self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionExt,
+    RegionUtilitiesExt, RegionVid, Ty, TyCtxt, TypeFoldable, TypeVisitableExt, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{ErrorGuaranteed, kw, sym};

--- a/compiler/rustc_hir_analysis/src/check/always_applicable.rs
+++ b/compiler/rustc_hir_analysis/src/check/always_applicable.rs
@@ -11,7 +11,7 @@ use rustc_infer::infer::{RegionResolutionError, TyCtxtInferExt};
 use rustc_infer::traits::{ObligationCause, ObligationCauseCode};
 use rustc_middle::span_bug;
 use rustc_middle::ty::util::CheckRegions;
-use rustc_middle::ty::{self, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode};
+use rustc_middle::ty::{self, GenericArgsRef, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_span::sym;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
 use rustc_trait_selection::traits::{self, ObligationCtxt};

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -14,9 +14,9 @@ use rustc_infer::infer::{self, BoundRegionConversionTime, InferCtxt, TyCtxtInfer
 use rustc_infer::traits::util;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
-    self, BottomUpFolder, GenericArgs, GenericParamDefKind, Generics, Ty, TyCtxt, TypeFoldable,
-    TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
-    Unnormalized, Upcast,
+    self, BottomUpFolder, GenericArgs, GenericParamDefKind, Generics, RegionExt,
+    RegionUtilitiesExt, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable,
+    TypeVisitableExt, TypeVisitor, TypingMode, Unnormalized, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{BytePos, DUMMY_SP, Span};

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -88,7 +88,8 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::print::with_types_for_signature;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericArgsRef, OutlivesPredicate, Region, Ty, TyCtxt, TypingMode,
+    self, GenericArgs, GenericArgsRef, OutlivesPredicate, Region, RegionUtilitiesExt, Ty, TyCtxt,
+    TypingMode,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::diagnostics::feature_err;

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -22,9 +22,9 @@ use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::traits::solve::NoSolution;
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
 use rustc_middle::ty::{
-    self, GenericArgKind, GenericArgs, GenericParamDefKind, Ty, TyCtxt, TypeFlags, TypeFoldable,
-    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, Unnormalized,
-    Upcast,
+    self, GenericArgKind, GenericArgs, GenericParamDefKind, RegionExt, RegionUtilitiesExt, Ty,
+    TyCtxt, TypeFlags, TypeFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
+    TypeVisitor, TypingMode, Unnormalized, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::diagnostics::feature_err;

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -32,8 +32,8 @@ use rustc_infer::traits::{DynCompatibilityViolation, ObligationCause};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
 use rustc_middle::ty::{
-    self, AdtKind, Const, IsSuggestable, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
-    fold_regions,
+    self, AdtKind, Const, IsSuggestable, RegionExt, Ty, TyCtxt, TypeVisitableExt, TypingMode,
+    Unnormalized, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -7,7 +7,8 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::find_attr;
 use rustc_middle::ty::{
-    self, GenericPredicates, ImplTraitInTraitData, Ty, TyCtxt, TypeVisitable, TypeVisitor, Upcast,
+    self, GenericPredicates, ImplTraitInTraitData, RegionExt, Ty, TyCtxt, TypeVisitable,
+    TypeVisitor, Upcast,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::{DUMMY_SP, Ident, Span};

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -9,7 +9,8 @@ use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{DelegationSelfTyPropagationKind, PathSegment};
 use rustc_middle::ty::{
-    self, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
+    self, EarlyBinder, RegionExt, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    TypeVisitableExt,
 };
 use rustc_span::{ErrorGuaranteed, Span, kw};
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_trait.rs
@@ -11,8 +11,8 @@ use rustc_hir::{self as hir, HirId, LangItem};
 use rustc_lint_defs::builtin::{BARE_TRAIT_OBJECTS, UNUSED_ASSOCIATED_TYPE_BOUNDS};
 use rustc_middle::ty::elaborate::ClauseWithSupertraitSpan;
 use rustc_middle::ty::{
-    self, BottomUpFolder, ExistentialPredicateStableCmpExt as _, Ty, TyCtxt, TypeFoldable,
-    TypeVisitableExt, Upcast,
+    self, BottomUpFolder, ExistentialPredicateStableCmpExt as _, RegionUtilitiesExt, Ty, TyCtxt,
+    TypeFoldable, TypeVisitableExt, Upcast,
 };
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::{ErrorGuaranteed, Span};

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -39,7 +39,7 @@ use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::middle::stability::AllowUnstable;
 use rustc_middle::ty::{
     self, Const, FnSigKind, GenericArgKind, GenericArgsRef, GenericParamDefKind, LitToConstInput,
-    Ty, TyCtxt, TypeSuperFoldable, TypeVisitableExt, TypingMode, Unnormalized, Upcast,
+    RegionExt, Ty, TyCtxt, TypeSuperFoldable, TypeVisitableExt, TypingMode, Unnormalized, Upcast,
     const_lit_matches_ty, fold_regions,
 };
 use rustc_middle::{bug, span_bug};

--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -72,7 +72,8 @@ use rustc_infer::traits::ObligationCause;
 use rustc_infer::traits::specialization_graph::Node;
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
 use rustc_middle::ty::{
-    self, GenericArg, GenericArgs, GenericArgsRef, TyCtxt, TypeVisitableExt, TypingMode,
+    self, GenericArg, GenericArgs, GenericArgsRef, RegionUtilitiesExt, TyCtxt, TypeVisitableExt,
+    TypingMode,
 };
 use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -31,7 +31,9 @@ use rustc_middle::ty::print::{
     PrintTraitRefExt as _, with_crate_prefix, with_forced_trimmed_paths,
     with_no_visible_paths_if_doc_hidden,
 };
-use rustc_middle::ty::{self, GenericArgKind, IsSuggestable, Ty, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{
+    self, GenericArgKind, IsSuggestable, RegionExt, Ty, TyCtxt, TypeVisitableExt,
+};
 use rustc_span::def_id::DefIdSet;
 use rustc_span::{
     DUMMY_SP, ErrorGuaranteed, ExpnKind, FileName, Ident, MacroKind, Span, Symbol, edit_distance,

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -10,8 +10,8 @@ use rustc_data_structures::sso::SsoHashMap;
 use rustc_index::Idx;
 use rustc_middle::bug;
 use rustc_middle::ty::{
-    self, BoundVar, Flags, GenericArg, InferConst, List, Ty, TyCtxt, TypeFlags, TypeFoldable,
-    TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingModeEqWrapper,
+    self, BoundVar, Flags, GenericArg, InferConst, List, RegionUtilitiesExt, Ty, TyCtxt, TypeFlags,
+    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypingModeEqWrapper,
 };
 use smallvec::SmallVec;
 use tracing::debug;

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -14,7 +14,9 @@ use rustc_index::{Idx, IndexVec};
 use rustc_middle::arena::ArenaAllocatable;
 use rustc_middle::bug;
 use rustc_middle::infer::canonical::{CanonicalVarKind, QueryRegionConstraint};
-use rustc_middle::ty::{self, BoundVar, GenericArg, GenericArgKind, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{
+    self, BoundVar, GenericArg, GenericArgKind, RegionUtilitiesExt, Ty, TyCtxt, TypeFoldable,
+};
 use tracing::{debug, instrument};
 
 use crate::infer::canonical::instantiate::{CanonicalExt, instantiate_value};

--- a/compiler/rustc_infer/src/infer/free_regions.rs
+++ b/compiler/rustc_infer/src/infer/free_regions.rs
@@ -4,7 +4,7 @@
 //! and use that to decide when one free region outlives another, and so forth.
 
 use rustc_data_structures::transitive_relation::TransitiveRelation;
-use rustc_middle::ty::{Region, TyCtxt};
+use rustc_middle::ty::{Region, RegionUtilitiesExt, TyCtxt};
 use tracing::debug;
 
 /// Combines a `FreeRegionMap` and a `TyCtxt`.

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/indexed_edges.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/indexed_edges.rs
@@ -1,4 +1,5 @@
 use rustc_index::IndexVec;
+use rustc_middle::ty::RegionUtilitiesExt;
 use rustc_type_ir::RegionVid;
 
 use crate::infer::SubregionOrigin;

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::unord::UnordSet;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::ty::{
     self, ReBound, ReEarlyParam, ReErased, ReError, ReLateParam, RePlaceholder, ReStatic, ReVar,
-    Region, RegionVid, Ty, TyCtxt, TypeFoldable, fold_regions,
+    Region, RegionUtilitiesExt, RegionVid, Ty, TyCtxt, TypeFoldable, fold_regions,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::Span;

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -29,8 +29,9 @@ use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
     self, BoundVarReplacerDelegate, ConstVid, FloatVid, GenericArg, GenericArgKind, GenericArgs,
     GenericArgsRef, GenericParamDefKind, InferConst, IntVid, OpaqueTypeKey, ProvisionalHiddenType,
-    PseudoCanonicalInput, Term, TermKind, Ty, TyCtxt, TyVid, TypeFoldable, TypeFolder,
-    TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypingEnv, TypingMode, fold_regions,
+    PseudoCanonicalInput, RegionExt, RegionUtilitiesExt, Term, TermKind, Ty, TyCtxt, TyVid,
+    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitable, TypeVisitableExt, TypingEnv,
+    TypingMode, fold_regions,
 };
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_type_ir::MayBeErased;

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -66,8 +66,8 @@ use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{
-    self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesPredicate, Region, RegionVid, Ty, TyCtxt,
-    TypeFoldable as _, TypeVisitableExt,
+    self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesPredicate, Region, RegionExt, RegionVid,
+    Ty, TyCtxt, TypeFoldable as _, TypeVisitableExt,
 };
 use rustc_span::Span;
 use smallvec::smallvec;

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -8,7 +8,9 @@ use rustc_data_structures::undo_log::UndoLogs;
 use rustc_data_structures::unify as ut;
 use rustc_index::IndexVec;
 use rustc_macros::{TypeFoldable, TypeVisitable};
-use rustc_middle::ty::{self, ReBound, ReStatic, ReVar, Region, RegionVid, Ty, TyCtxt};
+use rustc_middle::ty::{
+    self, ReBound, ReStatic, ReVar, Region, RegionExt, RegionUtilitiesExt, RegionVid, Ty, TyCtxt,
+};
 use rustc_middle::{bug, span_bug};
 use tracing::{debug, instrument};
 

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -16,8 +16,8 @@ use rustc_middle::ty::relate::{
     structurally_relate_tys,
 };
 use rustc_middle::ty::{
-    self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
-    Unnormalized,
+    self, RegionExt, RegionUtilitiesExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
+    TypeVisitableExt, TypeVisitor, Unnormalized,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint::fcw;

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -402,11 +402,6 @@ impl<'a> BlobDecodeContext<'a> {
 impl<'a, 'tcx> TyDecoder<'tcx> for MetadataDecodeContext<'a, 'tcx> {
     const CLEAR_CROSS_CRATE: bool = true;
 
-    #[inline]
-    fn interner(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
-
     fn cached_ty_for_shorthand<F>(&mut self, shorthand: usize, or_insert_with: F) -> Ty<'tcx>
     where
         F: FnOnce(&mut Self) -> Ty<'tcx>,
@@ -440,6 +435,15 @@ impl<'a, 'tcx> TyDecoder<'tcx> for MetadataDecodeContext<'a, 'tcx> {
     fn decode_alloc_id(&mut self) -> rustc_middle::mir::interpret::AllocId {
         let ads = self.alloc_decoding_session;
         ads.decode_alloc_id(self)
+    }
+}
+
+impl<'a, 'tcx> rustc_middle::ty::InternerDecoder for MetadataDecodeContext<'a, 'tcx> {
+    type Interner = TyCtxt<'tcx>;
+
+    #[inline]
+    fn interner(&self) -> TyCtxt<'tcx> {
+        self.tcx
     }
 }
 

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -489,11 +489,6 @@ where
 impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     const CLEAR_CROSS_CRATE: bool = false;
 
-    #[inline]
-    fn interner(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
-
     fn cached_ty_for_shorthand<F>(&mut self, shorthand: usize, or_insert_with: F) -> Ty<'tcx>
     where
         F: FnOnce(&mut Self) -> Ty<'tcx>,
@@ -528,6 +523,15 @@ impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     fn decode_alloc_id(&mut self) -> interpret::AllocId {
         let alloc_decoding_session = self.alloc_decoding_session;
         alloc_decoding_session.decode_alloc_id(self)
+    }
+}
+
+impl<'a, 'tcx> rustc_type_ir::InternerDecoder for CacheDecoder<'a, 'tcx> {
+    type Interner = TyCtxt<'tcx>;
+
+    #[inline]
+    fn interner(&self) -> Self::Interner {
+        self.tcx
     }
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -41,10 +41,10 @@ pub trait TyEncoder<'tcx>: SpanEncoder {
     fn encode_alloc_id(&mut self, alloc_id: &AllocId);
 }
 
-pub trait TyDecoder<'tcx>: SpanDecoder {
+pub trait TyDecoder<'tcx>:
+    SpanDecoder + rustc_type_ir::InternerDecoder<Interner = TyCtxt<'tcx>>
+{
     const CLEAR_CROSS_CRATE: bool;
-
-    fn interner(&self) -> TyCtxt<'tcx>;
 
     fn cached_ty_for_shorthand<F>(&mut self, shorthand: usize, or_insert_with: F) -> Ty<'tcx>
     where
@@ -155,12 +155,6 @@ impl<'tcx, E: TyEncoder<'tcx>> Encodable<E> for ty::Predicate<'tcx> {
 impl<'tcx, E: TyEncoder<'tcx>> Encodable<E> for ty::Clause<'tcx> {
     fn encode(&self, e: &mut E) {
         self.as_predicate().encode(e);
-    }
-}
-
-impl<'tcx, E: TyEncoder<'tcx>> Encodable<E> for ty::Region<'tcx> {
-    fn encode(&self, e: &mut E) {
-        self.kind().encode(e);
     }
 }
 
@@ -294,12 +288,6 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for mir::Place<'tcx> {
             (0..len).map::<mir::PlaceElem<'tcx>, _>(|_| Decodable::decode(decoder)),
         );
         mir::Place { local, projection }
-    }
-}
-
-impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Region<'tcx> {
-    fn decode(decoder: &mut D) -> Self {
-        ty::Region::new_from_kind(decoder.interner(), Decodable::decode(decoder))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -65,6 +65,7 @@ use crate::thir::Thir;
 use crate::traits;
 use crate::traits::solve::{ExternalConstraints, ExternalConstraintsData, PredefinedOpaques};
 use crate::ty::predicate::ExistentialPredicateStableCmpExt as _;
+use crate::ty::region::{RegionExt, RegionUtilitiesExt};
 use crate::ty::{
     self, AdtDef, AdtDefData, AdtKind, Binder, Clause, Clauses, Const, FnSigKind, GenericArg,
     GenericArgs, GenericArgsRef, GenericParamDefKind, List, ListWithCachedTypeInfo, ParamConst,
@@ -1700,7 +1701,6 @@ macro_rules! nop_list_lift {
 }
 
 nop_lift! { type_; Ty<'a> => Ty<'tcx> }
-nop_lift! { region; Region<'a> => Region<'tcx> }
 nop_lift! { const_; Const<'a> => Const<'tcx> }
 nop_lift! { pat; Pattern<'a> => Pattern<'tcx> }
 nop_lift! { const_allocation; ConstAllocation<'a> => ConstAllocation<'tcx> }
@@ -1708,6 +1708,18 @@ nop_lift! { predicate; Predicate<'a> => Predicate<'tcx> }
 nop_lift! { predicate; Clause<'a> => Clause<'tcx> }
 nop_lift! { layout; Layout<'a> => Layout<'tcx> }
 nop_lift! { valtree; ValTree<'a> => ValTree<'tcx> }
+
+impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for Interned<'a, RegionKind<'a>> {
+    type Lifted = Interned<'tcx, RegionKind<'tcx>>;
+
+    #[track_caller]
+    fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Self::Lifted {
+        assert!(tcx.interners.region.contains_pointer_to(&InternedInSet(&*self.0)));
+        // SAFETY: we just checked that `self` is interned in this `TyCtxt`, so
+        // its pointee is valid for the entire lifetime of the target `TyCtxt`.
+        unsafe { mem::transmute(self) }
+    }
+}
 
 nop_list_lift! { type_lists; Ty<'a> => Ty<'tcx> }
 nop_list_lift! { clauses: ListWithCachedTypeInfo; Clause<'a> => Clause<'tcx> }

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -115,8 +115,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type ExprConst = ty::Expr<'tcx>;
     type ValTree = ty::ValTree<'tcx>;
     type ScalarInt = ty::ScalarInt;
-
-    type Region = Region<'tcx>;
+    type InternedRegionKind = Interned<'tcx, ty::RegionKind<'tcx>>;
     type EarlyParamRegion = ty::EarlyParamRegion;
     type LateParamRegion = ty::LateParamRegion;
 
@@ -794,6 +793,54 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.opt_item_name(id).unwrap_or_else(|| {
             bug!("item_name: no name for {:?}", self.def_path(id));
         })
+    }
+
+    fn get_anon_re_bounds_lifetime(self, idx: usize, var_idx: usize) -> Option<Region<'tcx>> {
+        if let Some(inner) = self.lifetimes.anon_re_bounds.get(idx) {
+            inner.get(var_idx).copied()
+        } else {
+            None
+        }
+    }
+
+    fn get_anon_re_canonical_bounds_lifetime(self, idx: usize) -> Option<Region<'tcx>> {
+        self.lifetimes.anon_re_canonical_bounds.get(idx).copied()
+    }
+
+    fn get_re_static_lifetime(self) -> Region<'tcx> {
+        self.lifetimes.re_static
+    }
+
+    fn intern_region(self, region_kind: RegionKind<'tcx>) -> Region<'tcx> {
+        self.intern_region(region_kind)
+    }
+
+    fn intern_bound_region(
+        self,
+        debruijn: DebruijnIndex,
+        bound_region: BoundRegion<'tcx>,
+    ) -> Region<'tcx> {
+        // Use a pre-interned one when possible.
+        if let ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon } = bound_region
+            && let Some(inner) = self.lifetimes.anon_re_bounds.get(debruijn.as_usize())
+            && let Some(re) = inner.get(var.as_usize()).copied()
+        {
+            re
+        } else {
+            self.intern_region(ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), bound_region))
+        }
+    }
+
+    fn intern_canonical_bound(self, var: BoundVar) -> Region<'tcx> {
+        // Use a pre-interned one when possible.
+        if let Some(re) = self.lifetimes.anon_re_canonical_bounds.get(var.as_usize()).copied() {
+            re
+        } else {
+            self.intern_region(ty::ReBound(
+                ty::BoundVarIndexKind::Canonical,
+                BoundRegion { var, kind: ty::BoundRegionKind::Anon },
+            ))
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -3,6 +3,7 @@
 use std::ops::ControlFlow;
 use std::{debug_assert_matches, fmt};
 
+use rustc_data_structures::intern::Interned;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, DefKind};
@@ -11,7 +12,8 @@ use rustc_hir::lang_items::LangItem;
 use rustc_span::{DUMMY_SP, Span, Symbol};
 use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::{
-    CollectAndApply, Interner, TypeFoldable, Unnormalized, VisitorResult, search_graph,
+    BoundVar, CollectAndApply, DebruijnIndex, Interner, TypeFoldable, Unnormalized, VisitorResult,
+    search_graph,
 };
 
 use crate::dep_graph::{DepKind, DepNodeIndex};
@@ -21,8 +23,8 @@ use crate::traits::solve::{
     self, CanonicalInput, ExternalConstraints, ExternalConstraintsData, QueryResult, inspect,
 };
 use crate::ty::{
-    self, Clause, Const, List, ParamTy, Pattern, PolyExistentialPredicate, Predicate, Region, Ty,
-    TyCtxt,
+    self, BoundRegion, Clause, Const, List, ParamTy, Pattern, PolyExistentialPredicate, Predicate,
+    Region, RegionKind, Ty, TyCtxt,
 };
 
 #[allow(rustc::usage_of_ty_tykind)]
@@ -841,6 +843,15 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
                 BoundRegion { var, kind: ty::BoundRegionKind::Anon },
             ))
         }
+    }
+}
+
+impl<'tcx, T: std::fmt::Debug + Clone + Copy> rustc_type_ir::intern::Interned<TyCtxt<'tcx>>
+    for Interned<'tcx, T>
+{
+    type Value = T;
+    fn get(self) -> T {
+        *self.0
     }
 }
 

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -4,9 +4,7 @@ use std::fmt::Write;
 use std::ops::ControlFlow;
 
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_errors::{
-    Applicability, Diag, DiagArgValue, IntoDiagArg, into_diag_arg_using_display, listify, pluralize,
-};
+use rustc_errors::{Applicability, Diag, DiagArgValue, IntoDiagArg, listify, pluralize};
 use rustc_hir::def::{DefKind, Namespace};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir, AmbigArg, LangItem, PredicateOrigin, WherePredicateKind};
@@ -35,10 +33,6 @@ impl IntoDiagArg for Instance<'_> {
             DiagArgValue::Str(std::borrow::Cow::Owned(instance))
         })
     }
-}
-
-into_diag_arg_using_display! {
-    ty::Region<'_>,
 }
 
 impl<'tcx> Ty<'tcx> {

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -2,6 +2,7 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::def_id::DefId;
 use rustc_type_ir::data_structures::DelayedMap;
 
+use crate::ty::region::RegionExt;
 use crate::ty::{
     self, Binder, BoundTy, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeVisitableExt,

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -7,6 +7,7 @@ use tracing::instrument;
 
 use super::{Clause, InstantiatedPredicates, ParamConst, ParamTy, Ty, TyCtxt, Unnormalized};
 use crate::ty;
+use crate::ty::region::RegionExt;
 use crate::ty::{EarlyBinder, GenericArgsRef};
 
 #[derive(Clone, Debug, TyEncodable, TyDecodable, StableHash)]

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -101,7 +101,8 @@ pub use self::predicate::{
     TraitRef, TypeOutlivesPredicate,
 };
 pub use self::region::{
-    EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionKind, RegionVid,
+    EarlyParamRegion, LateParamRegion, LateParamRegionKind, Region, RegionExt, RegionKind,
+    RegionUtilitiesExt, RegionVid,
 };
 pub use self::sty::{
     Alias, AliasTy, AliasTyKind, Article, Binder, BoundConst, BoundRegion, BoundRegionKind,

--- a/compiler/rustc_middle/src/ty/opaque_types.rs
+++ b/compiler/rustc_middle/src/ty/opaque_types.rs
@@ -5,7 +5,8 @@ use tracing::{debug, instrument, trace};
 
 use crate::error::ConstNotUsedTraitAlias;
 use crate::ty::{
-    self, GenericArg, GenericArgKind, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    self, GenericArg, GenericArgKind, RegionExt, Ty, TyCtxt, TypeFoldable, TypeFolder,
+    TypeSuperFoldable,
 };
 
 pub type OpaqueTypeKey<'tcx> = rustc_type_ir::OpaqueTypeKey<TyCtxt<'tcx>>;
@@ -133,7 +134,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ReverseMapper<'tcx> {
                         self.span,
                         format!(
                             "lifetime `{r}` is part of concrete type but not used in \
-                             parameter list of the `impl Trait` type alias"
+                             parameter list of the `impl Trait` type alias",
                         ),
                     )
                     .emit();

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -24,6 +24,7 @@ use smallvec::SmallVec;
 use super::*;
 use crate::mir::interpret::{AllocRange, GlobalAlloc, Pointer, Provenance, Scalar};
 use crate::query::{IntoQueryKey, Providers};
+use crate::ty::region::{RegionExt, RegionUtilitiesExt};
 use crate::ty::{
     ConstInt, Expr, GenericArgKind, ParamConst, ScalarInt, Term, TermKind, TraitPredicate,
     TypeFoldable, TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
@@ -3208,7 +3209,6 @@ macro_rules! define_print_and_forward_display {
 }
 
 forward_display_to_print! {
-    ty::Region<'tcx>,
     Ty<'tcx>,
     &'tcx ty::List<ty::PolyExistentialPredicate<'tcx>>,
     ty::Const<'tcx>

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -1,45 +1,19 @@
-use rustc_data_structures::intern::Interned;
 use rustc_errors::MultiSpan;
 use rustc_hir::def_id::DefId;
-use rustc_macros::{StableHash, TyDecodable, TyEncodable};
+use rustc_macros::{StableHash, TyDecodable, TyEncodable, extension};
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Symbol, kw, sym};
-use rustc_type_ir::RegionKind as IrRegionKind;
 pub use rustc_type_ir::RegionVid;
-use tracing::debug;
+use rustc_type_ir::{Region as IrRegion, RegionKind as IrRegionKind};
 
-use crate::ty::{self, BoundVar, TyCtxt, TypeFlags};
+use crate::ty::{self, BoundVar, TyCtxt};
 
+pub type Region<'tcx> = IrRegion<TyCtxt<'tcx>>;
 pub type RegionKind<'tcx> = IrRegionKind<TyCtxt<'tcx>>;
 
-/// Use this rather than `RegionKind`, whenever possible.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, StableHash)]
-#[rustc_pass_by_value]
-pub struct Region<'tcx>(pub Interned<'tcx, RegionKind<'tcx>>);
-
-impl<'tcx> rustc_type_ir::inherent::IntoKind for Region<'tcx> {
-    type Kind = RegionKind<'tcx>;
-
-    fn kind(self) -> RegionKind<'tcx> {
-        *self.0.0
-    }
-}
-
-impl<'tcx> rustc_type_ir::Flags for Region<'tcx> {
-    fn flags(&self) -> TypeFlags {
-        self.type_flags()
-    }
-
-    fn outer_exclusive_binder(&self) -> ty::DebruijnIndex {
-        match self.kind() {
-            ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) => debruijn.shifted_in(1),
-            _ => ty::INNERMOST,
-        }
-    }
-}
-
+#[extension(pub trait RegionExt<'tcx>)]
 impl<'tcx> Region<'tcx> {
     #[inline]
-    pub fn new_early_param(
+    fn new_early_param(
         tcx: TyCtxt<'tcx>,
         early_bound_region: ty::EarlyParamRegion,
     ) -> Region<'tcx> {
@@ -47,47 +21,13 @@ impl<'tcx> Region<'tcx> {
     }
 
     #[inline]
-    pub fn new_bound(
-        tcx: TyCtxt<'tcx>,
-        debruijn: ty::DebruijnIndex,
-        bound_region: ty::BoundRegion<'tcx>,
-    ) -> Region<'tcx> {
-        // Use a pre-interned one when possible.
-        if let ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon } = bound_region
-            && let Some(inner) = tcx.lifetimes.anon_re_bounds.get(debruijn.as_usize())
-            && let Some(re) = inner.get(var.as_usize()).copied()
-        {
-            re
-        } else {
-            tcx.intern_region(ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), bound_region))
-        }
-    }
-
-    #[inline]
-    pub fn new_canonical_bound(tcx: TyCtxt<'tcx>, var: ty::BoundVar) -> Region<'tcx> {
-        // Use a pre-interned one when possible.
-        if let Some(re) = tcx.lifetimes.anon_re_canonical_bounds.get(var.as_usize()).copied() {
-            re
-        } else {
-            tcx.intern_region(ty::ReBound(
-                ty::BoundVarIndexKind::Canonical,
-                ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon },
-            ))
-        }
-    }
-
-    #[inline]
-    pub fn new_late_param(
-        tcx: TyCtxt<'tcx>,
-        scope: DefId,
-        kind: LateParamRegionKind,
-    ) -> Region<'tcx> {
+    fn new_late_param(tcx: TyCtxt<'tcx>, scope: DefId, kind: LateParamRegionKind) -> Region<'tcx> {
         let data = LateParamRegion { scope, kind };
         tcx.intern_region(ty::ReLateParam(data))
     }
 
     #[inline]
-    pub fn new_var(tcx: TyCtxt<'tcx>, v: ty::RegionVid) -> Region<'tcx> {
+    fn new_var(tcx: TyCtxt<'tcx>, v: ty::RegionVid) -> Region<'tcx> {
         // Use a pre-interned one when possible.
         tcx.lifetimes
             .re_vars
@@ -96,24 +36,16 @@ impl<'tcx> Region<'tcx> {
             .unwrap_or_else(|| tcx.intern_region(ty::ReVar(v)))
     }
 
-    #[inline]
-    pub fn new_placeholder(
-        tcx: TyCtxt<'tcx>,
-        placeholder: ty::PlaceholderRegion<'tcx>,
-    ) -> Region<'tcx> {
-        tcx.intern_region(ty::RePlaceholder(placeholder))
-    }
-
     /// Constructs a `RegionKind::ReError` region.
     #[track_caller]
-    pub fn new_error(tcx: TyCtxt<'tcx>, guar: ErrorGuaranteed) -> Region<'tcx> {
+    fn new_error(tcx: TyCtxt<'tcx>, guar: ErrorGuaranteed) -> Region<'tcx> {
         tcx.intern_region(ty::ReError(guar))
     }
 
     /// Constructs a `RegionKind::ReError` region and registers a delayed bug to ensure it gets
     /// used.
     #[track_caller]
-    pub fn new_error_misc(tcx: TyCtxt<'tcx>) -> Region<'tcx> {
+    fn new_error_misc(tcx: TyCtxt<'tcx>) -> Region<'tcx> {
         Region::new_error_with_message(
             tcx,
             DUMMY_SP,
@@ -124,7 +56,7 @@ impl<'tcx> Region<'tcx> {
     /// Constructs a `RegionKind::ReError` region and registers a delayed bug with the given `msg`
     /// to ensure it gets used.
     #[track_caller]
-    pub fn new_error_with_message<S: Into<MultiSpan>>(
+    fn new_error_with_message<S: Into<MultiSpan>>(
         tcx: TyCtxt<'tcx>,
         span: S,
         msg: &'static str,
@@ -135,7 +67,7 @@ impl<'tcx> Region<'tcx> {
 
     /// Avoid this in favour of more specific `new_*` methods, where possible,
     /// to avoid the cost of the `match`.
-    pub fn new_from_kind(tcx: TyCtxt<'tcx>, kind: RegionKind<'tcx>) -> Region<'tcx> {
+    fn new_from_kind(tcx: TyCtxt<'tcx>, kind: RegionKind<'tcx>) -> Region<'tcx> {
         match kind {
             ty::ReEarlyParam(region) => Region::new_early_param(tcx, region),
             ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), region) => {
@@ -156,39 +88,10 @@ impl<'tcx> Region<'tcx> {
     }
 }
 
-impl<'tcx> rustc_type_ir::inherent::Region<TyCtxt<'tcx>> for Region<'tcx> {
-    fn new_bound(
-        interner: TyCtxt<'tcx>,
-        debruijn: ty::DebruijnIndex,
-        var: ty::BoundRegion<'tcx>,
-    ) -> Self {
-        Region::new_bound(interner, debruijn, var)
-    }
-
-    fn new_anon_bound(tcx: TyCtxt<'tcx>, debruijn: ty::DebruijnIndex, var: ty::BoundVar) -> Self {
-        Region::new_bound(tcx, debruijn, ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon })
-    }
-
-    fn new_canonical_bound(tcx: TyCtxt<'tcx>, var: rustc_type_ir::BoundVar) -> Self {
-        Region::new_canonical_bound(tcx, var)
-    }
-
-    fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderRegion<'tcx>) -> Self {
-        Region::new_placeholder(tcx, placeholder)
-    }
-
-    fn new_static(tcx: TyCtxt<'tcx>) -> Self {
-        tcx.lifetimes.re_static
-    }
-}
-
 /// Region utilities
+#[extension(pub trait RegionUtilitiesExt<'tcx>)]
 impl<'tcx> Region<'tcx> {
-    pub fn kind(self) -> RegionKind<'tcx> {
-        *self.0.0
-    }
-
-    pub fn get_name(self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
+    fn get_name(self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
         match self.kind() {
             ty::ReEarlyParam(ebr) => ebr.is_named().then_some(ebr.name),
             ty::ReBound(_, br) => br.kind.get_name(tcx),
@@ -199,7 +102,7 @@ impl<'tcx> Region<'tcx> {
         }
     }
 
-    pub fn get_name_or_anon(self, tcx: TyCtxt<'tcx>) -> Symbol {
+    fn get_name_or_anon(self, tcx: TyCtxt<'tcx>) -> Symbol {
         match self.get_name(tcx) {
             Some(name) => name,
             None => sym::anon,
@@ -207,7 +110,7 @@ impl<'tcx> Region<'tcx> {
     }
 
     /// Is this region named by the user?
-    pub fn is_named(self, tcx: TyCtxt<'tcx>) -> bool {
+    fn is_named(self, tcx: TyCtxt<'tcx>) -> bool {
         match self.kind() {
             ty::ReEarlyParam(ebr) => ebr.is_named(),
             ty::ReBound(_, br) => br.kind.is_named(tcx),
@@ -221,94 +124,42 @@ impl<'tcx> Region<'tcx> {
     }
 
     #[inline]
-    pub fn is_error(self) -> bool {
+    fn is_error(self) -> bool {
         matches!(self.kind(), ty::ReError(_))
     }
 
     #[inline]
-    pub fn is_static(self) -> bool {
+    fn is_static(self) -> bool {
         matches!(self.kind(), ty::ReStatic)
     }
 
     #[inline]
-    pub fn is_erased(self) -> bool {
+    fn is_erased(self) -> bool {
         matches!(self.kind(), ty::ReErased)
     }
 
     #[inline]
-    pub fn is_bound(self) -> bool {
-        matches!(self.kind(), ty::ReBound(..))
-    }
-
-    #[inline]
-    pub fn is_placeholder(self) -> bool {
+    fn is_placeholder(self) -> bool {
         matches!(self.kind(), ty::RePlaceholder(..))
     }
 
     #[inline]
-    pub fn bound_at_or_above_binder(self, index: ty::DebruijnIndex) -> bool {
+    fn bound_at_or_above_binder(self, index: ty::DebruijnIndex) -> bool {
         match self.kind() {
             ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) => debruijn >= index,
             _ => false,
         }
     }
 
-    pub fn type_flags(self) -> TypeFlags {
-        let mut flags = TypeFlags::empty();
-
-        match self.kind() {
-            ty::ReVar(..) => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
-                flags = flags | TypeFlags::HAS_RE_INFER;
-            }
-            ty::RePlaceholder(..) => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
-                flags = flags | TypeFlags::HAS_RE_PLACEHOLDER;
-            }
-            ty::ReEarlyParam(..) => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
-                flags = flags | TypeFlags::HAS_RE_PARAM;
-            }
-            ty::ReLateParam { .. } => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
-            }
-            ty::ReStatic => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-            }
-            ty::ReBound(ty::BoundVarIndexKind::Canonical, _) => {
-                flags = flags | TypeFlags::HAS_RE_BOUND;
-                flags = flags | TypeFlags::HAS_CANONICAL_BOUND;
-            }
-            ty::ReBound(ty::BoundVarIndexKind::Bound(..), _) => {
-                flags = flags | TypeFlags::HAS_RE_BOUND;
-            }
-            ty::ReErased => {
-                flags = flags | TypeFlags::HAS_RE_ERASED;
-            }
-            ty::ReError(_) => {
-                flags = flags | TypeFlags::HAS_FREE_REGIONS;
-                flags = flags | TypeFlags::HAS_RE_ERROR;
-            }
-        }
-
-        debug!("type_flags({:?}) = {:?}", self, flags);
-
-        flags
-    }
-
     /// True for free regions other than `'static`.
-    pub fn is_param(self) -> bool {
+    fn is_param(self) -> bool {
         matches!(self.kind(), ty::ReEarlyParam(_) | ty::ReLateParam(_))
     }
 
     /// True for free region in the current context.
     ///
     /// This is the case for `'static` and param regions.
-    pub fn is_free(self) -> bool {
+    fn is_free(self) -> bool {
         match self.kind() {
             ty::ReStatic | ty::ReEarlyParam(..) | ty::ReLateParam(..) => true,
             ty::ReVar(..)
@@ -319,11 +170,11 @@ impl<'tcx> Region<'tcx> {
         }
     }
 
-    pub fn is_var(self) -> bool {
+    fn is_var(self) -> bool {
         matches!(self.kind(), ty::ReVar(_))
     }
 
-    pub fn as_var(self) -> RegionVid {
+    fn as_var(self) -> RegionVid {
         match self.kind() {
             ty::ReVar(vid) => vid,
             _ => bug!("expected region {:?} to be of kind ReVar", self),
@@ -332,7 +183,7 @@ impl<'tcx> Region<'tcx> {
 
     /// Given some item `binding_item`, check if this region is a generic parameter introduced by it
     /// or one of the parent generics. Returns the `DefId` of the parameter definition if so.
-    pub fn opt_param_def_id(self, tcx: TyCtxt<'tcx>, binding_item: DefId) -> Option<DefId> {
+    fn opt_param_def_id(self, tcx: TyCtxt<'tcx>, binding_item: DefId) -> Option<DefId> {
         match self.kind() {
             ty::ReEarlyParam(ebr) => {
                 Some(tcx.generics_of(binding_item).region_param(ebr, tcx).def_id)

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -98,16 +98,6 @@ impl<'tcx> Relate<TyCtxt<'tcx>> for ty::GenericArgsRef<'tcx> {
     }
 }
 
-impl<'tcx> Relate<TyCtxt<'tcx>> for ty::Region<'tcx> {
-    fn relate<R: TypeRelation<TyCtxt<'tcx>>>(
-        relation: &mut R,
-        a: ty::Region<'tcx>,
-        b: ty::Region<'tcx>,
-    ) -> RelateResult<'tcx, ty::Region<'tcx>> {
-        relation.regions(a, b)
-    }
-}
-
 impl<'tcx> Relate<TyCtxt<'tcx>> for ty::Const<'tcx> {
     fn relate<R: TypeRelation<TyCtxt<'tcx>>>(
         relation: &mut R,

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -11,7 +11,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_span::Spanned;
 use rustc_type_ir::{ConstKind, TypeFolder, VisitorResult, try_visit};
 
-use super::{GenericArg, GenericArgKind, Pattern, Region};
+use super::{GenericArg, GenericArgKind, Pattern};
 use crate::mir::PlaceElem;
 use crate::ty::print::{FmtPrinter, Printer, with_no_trimmed_paths};
 use crate::ty::{
@@ -169,12 +169,6 @@ impl<'tcx> fmt::Debug for GenericArg<'tcx> {
     }
 }
 
-impl<'tcx> fmt::Debug for Region<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.kind())
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // Atomic structs
 //
@@ -266,6 +260,12 @@ TrivialTypeTraversalAndLiftImpls! {
     crate::ty::instance::ReifyReason,
     rustc_hir::def_id::DefId,
     // tidy-alphabetical-end
+}
+
+TrivialLiftImpls! {
+    rustc_span::ErrorGuaranteed,
+    ty::EarlyParamRegion,
+    ty::LateParamRegion,
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -482,25 +482,6 @@ impl<'tcx> TypeSuperVisitable<TyCtxt<'tcx>> for Ty<'tcx> {
             | ty::Never
             | ty::Foreign(..) => V::Result::output(),
         }
-    }
-}
-
-impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Region<'tcx> {
-    fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
-        self,
-        folder: &mut F,
-    ) -> Result<Self, F::Error> {
-        folder.try_fold_region(self)
-    }
-
-    fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
-        folder.fold_region(self)
-    }
-}
-
-impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Region<'tcx> {
-    fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
-        visitor.visit_region(*self)
     }
 }
 

--- a/compiler/rustc_mir_transform/src/promote_consts.rs
+++ b/compiler/rustc_mir_transform/src/promote_consts.rs
@@ -22,7 +22,7 @@ use rustc_hir::def::DefKind;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::mir::visit::{MutVisitor, MutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, GenericArgs, List, Ty, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{self, GenericArgs, List, RegionUtilitiesExt, Ty, TyCtxt, TypeVisitableExt};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_span::{Span, Spanned};
 use tracing::{debug, instrument};

--- a/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/canonicalizer.rs
@@ -3,7 +3,7 @@ use rustc_type_ir::inherent::*;
 use rustc_type_ir::solve::{Goal, QueryInput};
 use rustc_type_ir::{
     self as ty, Canonical, CanonicalParamEnvCacheEntry, CanonicalVarKind, Flags, InferCtxtLike,
-    Interner, PlaceholderConst, PlaceholderType, TypeFlags, TypeFoldable, TypeFolder,
+    Interner, PlaceholderConst, PlaceholderType, Region, TypeFlags, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeVisitableExt,
 };
 
@@ -409,7 +409,7 @@ impl<D: SolverDelegate<Interner = I>, I: Interner> TypeFolder<I> for Canonicaliz
         self.delegate.cx()
     }
 
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         // We canonicalize free regions from the input into placeholder regions so that
         // region constraints created in nested contexts can be propagated back to the
         // caller, instead of unifying them.

--- a/compiler/rustc_next_trait_solver/src/canonical/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/canonical/mod.rs
@@ -18,7 +18,7 @@ use rustc_type_ir::relate::{
     self, Relate, RelateResult, TypeRelation, VarianceDiagInfo, relate_args_invariantly,
 };
 use rustc_type_ir::{
-    self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner,
+    self as ty, Canonical, CanonicalVarKind, CanonicalVarValues, InferCtxtLike, Interner, Region,
     TypeFoldable, TypingMode, TypingModeEqWrapper,
 };
 use tracing::instrument;
@@ -379,7 +379,7 @@ where
     }
 
     #[instrument(skip(self), level = "trace")]
-    fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region> {
+    fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>> {
         self.infcx.equate_regions(a, b, VisibleForLeakCheck::Yes, self.span);
 
         Ok(a)

--- a/compiler/rustc_next_trait_solver/src/coherence.rs
+++ b/compiler/rustc_next_trait_solver/src/coherence.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::{
-    self as ty, InferCtxtLike, Interner, TrivialTypeTraversalImpls, TypeVisitable,
+    self as ty, InferCtxtLike, Interner, Region, TrivialTypeTraversalImpls, TypeVisitable,
     TypeVisitableExt, TypeVisitor,
 };
 use tracing::instrument;
@@ -317,7 +317,7 @@ where
 {
     type Result = ControlFlow<OrphanCheckEarlyExit<I, E>>;
 
-    fn visit_region(&mut self, _r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, _r: Region<I>) -> Self::Result {
         ControlFlow::Continue(())
     }
 

--- a/compiler/rustc_next_trait_solver/src/placeholder.rs
+++ b/compiler/rustc_next_trait_solver/src/placeholder.rs
@@ -4,7 +4,7 @@ use rustc_type_ir::data_structures::IndexMap;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::{
     self as ty, InferCtxtLike, Interner, PlaceholderConst, PlaceholderRegion, PlaceholderType,
-    TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
+    Region, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
 use tracing::debug;
 
@@ -91,7 +91,7 @@ where
         t
     }
 
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         match r.kind() {
             ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _)
                 if debruijn.as_usize()
@@ -224,7 +224,7 @@ where
         t
     }
 
-    fn fold_region(&mut self, r0: I::Region) -> I::Region {
+    fn fold_region(&mut self, r0: Region<I>) -> Region<I> {
         let r1 = match r0.kind() {
             ty::ReVar(vid) => self.infcx.opportunistic_resolve_lt_var(vid),
             _ => r0,

--- a/compiler/rustc_next_trait_solver/src/resolve.rs
+++ b/compiler/rustc_next_trait_solver/src/resolve.rs
@@ -1,7 +1,7 @@
 use rustc_type_ir::data_structures::DelayedMap;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::{
-    self as ty, InferCtxtLike, Interner, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    self as ty, InferCtxtLike, Interner, Region, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeVisitableExt,
 };
 
@@ -70,7 +70,7 @@ impl<Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeFolder<I> for EagerRes
         }
     }
 
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         match r.kind() {
             ty::ReVar(vid) => self.delegate.opportunistic_resolve_lt_var(vid),
             _ => r,

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -14,7 +14,7 @@ use rustc_type_ir::solve::{
     RerunNonErased, RerunReason, RerunResultExt, SizedTraitKind, StalledOnCoroutines,
 };
 use rustc_type_ir::{
-    self as ty, AliasTy, Interner, MayBeErased, TypeFlags, TypeFoldable, TypeFolder,
+    self as ty, AliasTy, Interner, MayBeErased, Region, TypeFlags, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
     TypingMode, Unnormalized, Upcast, elaborate,
 };
@@ -1432,7 +1432,7 @@ where
         }
     }
 
-    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, r: Region<I>) -> Self::Result {
         match self.ecx.eager_resolve_region(r).kind() {
             ty::ReStatic | ty::ReError(_) | ty::ReBound(..) => ControlFlow::Continue(()),
             ty::RePlaceholder(p) => {

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -8,7 +8,7 @@ use rustc_type_ir::lang_items::{SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::solve::inspect::ProbeKind;
 use rustc_type_ir::{
-    self as ty, Binder, FallibleTypeFolder, Interner, Movability, Mutability, TypeFoldable,
+    self as ty, Binder, FallibleTypeFolder, Interner, Movability, Mutability, Region, TypeFoldable,
     TypeSuperFoldable, Unnormalized, Upcast as _, elaborate,
 };
 use rustc_type_ir_macros::{TypeFoldable_Generic, TypeVisitable_Generic};
@@ -442,7 +442,7 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_async_callable<I: 
     cx: I,
     self_ty: I::Ty,
     goal_kind: ty::ClosureKind,
-    env_region: I::Region,
+    env_region: Region<I>,
 ) -> Result<(ty::Binder<I, AsyncCallableRelevantTypes<I>>, Vec<I::Predicate>), NoSolution> {
     match self_ty.kind() {
         ty::CoroutineClosure(def_id, args) => {
@@ -625,7 +625,7 @@ fn fn_item_to_async_callable<I: Interner>(
 fn coroutine_closure_to_certain_coroutine<I: Interner>(
     cx: I,
     goal_kind: ty::ClosureKind,
-    goal_region: I::Region,
+    goal_region: Region<I>,
     def_id: I::CoroutineClosureId,
     args: ty::CoroutineClosureArgs<I>,
     sig: ty::CoroutineClosureSignature<I>,
@@ -649,7 +649,7 @@ fn coroutine_closure_to_certain_coroutine<I: Interner>(
 fn coroutine_closure_to_ambiguous_coroutine<I: Interner>(
     cx: I,
     goal_kind: ty::ClosureKind,
-    goal_region: I::Region,
+    goal_region: Region<I>,
     def_id: I::CoroutineClosureId,
     args: ty::CoroutineClosureArgs<I>,
     sig: ty::CoroutineClosureSignature<I>,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -16,7 +16,7 @@ use rustc_type_ir::solve::{
 };
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, ClauseKind, InferCtxtLike, Interner, MayBeErased,
-    OpaqueTypeKey, PredicateKind, TypeFoldable, TypeSuperVisitable, TypeVisitable,
+    OpaqueTypeKey, PredicateKind, Region, TypeFoldable, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor, TypingMode,
 };
 use tracing::{Level, debug, instrument, trace, warn};
@@ -926,7 +926,7 @@ where
         Ok(())
     }
 
-    pub(super) fn next_region_var(&mut self) -> I::Region {
+    pub(super) fn next_region_var(&mut self) -> Region<I> {
         let region = self.delegate.next_region_infer();
         self.inspect.add_var_value(region);
         region
@@ -1191,7 +1191,7 @@ where
         self.delegate.shallow_resolve(ty)
     }
 
-    pub(super) fn eager_resolve_region(&self, r: I::Region) -> I::Region {
+    pub(super) fn eager_resolve_region(&self, r: Region<I>) -> Region<I> {
         if let ty::ReVar(vid) = r.kind() {
             self.delegate.opportunistic_resolve_lt_var(vid)
         } else {
@@ -1211,14 +1211,14 @@ where
         self.delegate.register_solver_region_constraint(c);
     }
 
-    pub(super) fn register_ty_outlives(&self, ty: I::Ty, lt: I::Region) {
+    pub(super) fn register_ty_outlives(&self, ty: I::Ty, lt: Region<I>) {
         self.delegate.register_ty_outlives(ty, lt, self.origin_span);
     }
 
     pub(super) fn register_region_outlives(
         &self,
-        a: I::Region,
-        b: I::Region,
+        a: Region<I>,
+        b: Region<I>,
         vis: VisibleForLeakCheck,
     ) {
         // `'a: 'b` ==> `'b <= 'a`

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/solver_region_constraints.rs
@@ -11,7 +11,7 @@ use rustc_type_ir::region_constraint::{
     Assumptions, RegionConstraint, eagerly_handle_placeholders_in_universe,
 };
 use rustc_type_ir::{
-    AliasTy, Binder, ClauseKind, InferCtxtLike, Interner, OutlivesPredicate, TypeVisitable,
+    AliasTy, Binder, ClauseKind, InferCtxtLike, Interner, OutlivesPredicate, Region, TypeVisitable,
     TypeVisitableExt, TypeVisitor, UniverseIndex, max_universe,
 };
 use tracing::{debug, instrument};
@@ -155,7 +155,7 @@ where
     pub(in crate::solve) fn destructure_type_outlives(
         &mut self,
         ty: I::Ty,
-        r: I::Region,
+        r: Region<I>,
     ) -> RegionConstraint<I> {
         let mut components = Default::default();
         push_outlives_components(self.cx(), ty, &mut components);
@@ -165,14 +165,14 @@ where
     fn destructure_components(
         &mut self,
         components: &[Component<I>],
-        r: I::Region,
+        r: Region<I>,
     ) -> RegionConstraint<I> {
         RegionConstraint::And(
             components.into_iter().map(|c| self.destructure_component(c, r)).collect(),
         )
     }
 
-    fn destructure_component(&mut self, c: &Component<I>, r: I::Region) -> RegionConstraint<I> {
+    fn destructure_component(&mut self, c: &Component<I>, r: Region<I>) -> RegionConstraint<I> {
         use Component::*;
         match c {
             Region(c_r) => RegionConstraint::RegionOutlives(*c_r, r),
@@ -197,7 +197,7 @@ where
     fn destructure_alias_outlives(
         &mut self,
         alias: AliasTy<I>,
-        r: I::Region,
+        r: Region<I>,
     ) -> RegionConstraint<I> {
         let item_bounds =
             rustc_type_ir::outlives::declared_bounds_from_definition(self.cx(), alias)

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -23,7 +23,7 @@ mod trait_goals;
 use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
 pub use rustc_type_ir::solve::*;
-use rustc_type_ir::{self as ty, Interner};
+use rustc_type_ir::{self as ty, Interner, Region};
 use tracing::instrument;
 
 pub use self::eval_ctxt::{
@@ -105,7 +105,7 @@ where
     #[instrument(level = "trace", skip(self))]
     fn compute_region_outlives_goal(
         &mut self,
-        goal: Goal<I, ty::OutlivesPredicate<I, I::Region>>,
+        goal: Goal<I, ty::OutlivesPredicate<I, Region<I>>>,
     ) -> QueryResultOrRerunNonErased<I> {
         let ty::OutlivesPredicate(a, b) = goal.predicate;
 

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to.rs
@@ -8,7 +8,7 @@ use rustc_type_ir::solve::{
     RerunNonErased, RerunReason, RerunResultExt,
 };
 use rustc_type_ir::{
-    self as ty, FieldInfo, Interner, NormalizesTo, PredicateKind, Unnormalized, Upcast as _,
+    self as ty, FieldInfo, Interner, NormalizesTo, PredicateKind, Region, Unnormalized, Upcast as _,
 };
 use tracing::instrument;
 

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -10,8 +10,9 @@ use rustc_type_ir::solve::{
     RerunReason, RerunResultExt, SizedTraitKind,
 };
 use rustc_type_ir::{
-    self as ty, FieldInfo, Interner, MayBeErased, Movability, PredicatePolarity, TraitPredicate,
-    TraitRef, TypeVisitableExt as _, TypingMode, Unnormalized, Upcast as _, elaborate,
+    self as ty, FieldInfo, Interner, MayBeErased, Movability, PredicatePolarity, Region,
+    TraitPredicate, TraitRef, TypeVisitableExt as _, TypingMode, Unnormalized, Upcast as _,
+    elaborate,
 };
 use tracing::{debug, instrument, trace, warn};
 
@@ -952,9 +953,9 @@ where
         &mut self,
         goal: Goal<I, (I::Ty, I::Ty)>,
         a_data: I::BoundExistentialPredicates,
-        a_region: I::Region,
+        a_region: Region<I>,
         b_data: I::BoundExistentialPredicates,
-        b_region: I::Region,
+        b_region: Region<I>,
     ) -> Vec<Candidate<I>> {
         let cx = self.cx();
         let Goal { predicate: (a_ty, _b_ty), .. } = goal;
@@ -1000,7 +1001,7 @@ where
         &mut self,
         goal: Goal<I, (I::Ty, I::Ty)>,
         b_data: I::BoundExistentialPredicates,
-        b_region: I::Region,
+        b_region: Region<I>,
     ) -> Result<Candidate<I>, NoSolutionOrRerunNonErased> {
         let cx = self.cx();
         let Goal { predicate: (a_ty, _), .. } = goal;
@@ -1042,9 +1043,9 @@ where
         goal: Goal<I, (I::Ty, I::Ty)>,
         source: CandidateSource<I>,
         a_data: I::BoundExistentialPredicates,
-        a_region: I::Region,
+        a_region: Region<I>,
         b_data: I::BoundExistentialPredicates,
-        b_region: I::Region,
+        b_region: Region<I>,
         upcast_principal: Option<ty::Binder<I, ty::ExistentialTraitRef<I>>>,
     ) -> Result<Candidate<I>, NoSolutionOrRerunNonErased> {
         let param_env = goal.param_env;

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -17,8 +17,8 @@ use rustc_middle::bug;
 use rustc_middle::ty::layout::IntegerExt;
 use rustc_middle::ty::print::{Print, PrintError, Printer};
 use rustc_middle::ty::{
-    self, FloatTy, GenericArg, GenericArgKind, Instance, IntTy, ReifyReason, Ty, TyCtxt,
-    TypeVisitable, TypeVisitableExt, UintTy, Unnormalized,
+    self, FloatTy, GenericArg, GenericArgKind, Instance, IntTy, RegionUtilitiesExt, ReifyReason,
+    Ty, TyCtxt, TypeVisitable, TypeVisitableExt, UintTy, Unnormalized,
 };
 use rustc_span::sym;
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -64,8 +64,8 @@ use rustc_middle::traits::PatternOriginExpr;
 use rustc_middle::ty::error::{ExpectedFound, TypeError, TypeErrorToStringExt};
 use rustc_middle::ty::print::{PrintTraitRefExt as _, WrapBinderMode, with_forced_trimmed_paths};
 use rustc_middle::ty::{
-    self, List, Mutability, ParamEnv, Region, Ty, TyCtxt, TypeFoldable, TypeSuperVisitable,
-    TypeVisitable, TypeVisitableExt, Unnormalized,
+    self, List, Mutability, ParamEnv, Region, RegionUtilitiesExt, Ty, TyCtxt, TypeFoldable,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, Unnormalized,
 };
 use rustc_span::{BytePos, DUMMY_SP, DesugaringKind, Pos, Span, sym};
 use thin_vec::ThinVec;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/mismatched_static_lifetime.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/mismatched_static_lifetime.rs
@@ -6,7 +6,7 @@ use rustc_errors::{ErrorGuaranteed, MultiSpan};
 use rustc_hir as hir;
 use rustc_hir::intravisit::VisitorExt;
 use rustc_middle::bug;
-use rustc_middle::ty::TypeVisitor;
+use rustc_middle::ty::{RegionUtilitiesExt, TypeVisitor};
 use tracing::debug;
 
 use crate::diagnostics::{

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
@@ -3,6 +3,7 @@
 
 use rustc_errors::Diag;
 use rustc_middle::ty;
+use rustc_middle::ty::RegionUtilitiesExt;
 use tracing::debug;
 
 use crate::diagnostics::ExplicitLifetimeRequired;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -9,7 +9,10 @@ use rustc_hir::limit::Limit;
 use rustc_middle::bug;
 use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::print::{FmtPrinter, Print, PrintTraitRefExt as _, RegionHighlightMode};
-use rustc_middle::ty::{self, GenericArgsRef, IsSuggestable, RePlaceholder, Region, TyCtxt};
+use rustc_middle::ty::{
+    self, GenericArgsRef, IsSuggestable, RePlaceholder, Region, RegionExt, RegionUtilitiesExt,
+    TyCtxt,
+};
 use tracing::{debug, instrument};
 
 use crate::diagnostics::{

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -8,7 +8,7 @@ use rustc_hir::{
     self as hir, AmbigArg, GenericBound, GenericParam, GenericParamKind, Item, ItemKind, Lifetime,
     LifetimeKind, LifetimeParamKind, MissingLifetimeKind, Node, TyKind,
 };
-use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor};
+use rustc_middle::ty::{self, RegionUtilitiesExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitor};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{Ident, Span};
 use tracing::debug;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
@@ -10,7 +10,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::traits::ObligationCauseCode;
 use rustc_middle::ty::error::ExpectedFound;
 use rustc_middle::ty::print::RegionHighlightMode;
-use rustc_middle::ty::{self, TyCtxt, TypeVisitable};
+use rustc_middle::ty::{self, RegionUtilitiesExt, TyCtxt, TypeVisitable};
 use rustc_span::{Ident, Span};
 use tracing::debug;
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -13,7 +13,7 @@ use rustc_middle::traits::ObligationCauseCode;
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::print::RegionHighlightMode;
 use rustc_middle::ty::{
-    self, IsSuggestable, Region, Ty, TyCtxt, TypeVisitableExt as _, Upcast as _,
+    self, IsSuggestable, Region, RegionUtilitiesExt, Ty, TyCtxt, TypeVisitableExt as _, Upcast as _,
 };
 use rustc_span::{BytePos, ErrorGuaranteed, Span, Symbol, kw, sym};
 use tracing::{debug, instrument};

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -4,8 +4,8 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
 use rustc_middle::ty::{
-    self, DefiningScopeKind, GenericArgKind, GenericArgs, OpaqueTypeKey, Ty, TyCtxt,
-    TypeVisitableExt, TypingMode, fold_regions,
+    self, DefiningScopeKind, GenericArgKind, GenericArgs, OpaqueTypeKey, RegionUtilitiesExt, Ty,
+    TyCtxt, TypeVisitableExt, TypingMode, fold_regions,
 };
 use rustc_span::{ErrorGuaranteed, Span};
 

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -8,7 +8,7 @@ use rustc_data_structures::fx::{FxIndexMap, FxIndexSet, IndexEntry};
 use rustc_data_structures::unord::UnordSet;
 use rustc_hir::def_id::CRATE_DEF_ID;
 use rustc_infer::infer::DefineOpaqueTypes;
-use rustc_middle::ty::{Region, RegionVid};
+use rustc_middle::ty::{Region, RegionUtilitiesExt, RegionVid};
 use rustc_span::DUMMY_SP;
 use tracing::debug;
 

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -19,8 +19,8 @@ use rustc_middle::traits::solve::{CandidateSource, Certainty, Goal};
 use rustc_middle::traits::specialization_graph::OverlapMode;
 use rustc_middle::ty::fast_reject::DeepRejectCtxt;
 use rustc_middle::ty::{
-    self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode,
-    Unnormalized,
+    self, RegionUtilitiesExt, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
+    TypeVisitor, TypingMode, Unnormalized,
 };
 pub use rustc_next_trait_solver::coherence::*;
 use rustc_next_trait_solver::solve::SolverDelegateEvalExt;

--- a/compiler/rustc_ty_utils/src/implied_bounds.rs
+++ b/compiler/rustc_ty_utils/src/implied_bounds.rs
@@ -5,7 +5,7 @@ use rustc_hir as hir;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{self, Ty, TyCtxt, Unnormalized, fold_regions};
+use rustc_middle::ty::{self, RegionExt, Ty, TyCtxt, Unnormalized, fold_regions};
 use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
 

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -6,8 +6,8 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::bug;
 use rustc_middle::query::Providers;
 use rustc_middle::ty::{
-    self, SizedTraitKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor, Unnormalized,
-    Upcast, fold_regions,
+    self, RegionExt, SizedTraitKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor,
+    Unnormalized, Upcast, fold_regions,
 };
 use rustc_span::DUMMY_SP;
 use rustc_span::def_id::{CRATE_DEF_ID, DefId, LocalDefId};

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -15,7 +15,7 @@ use crate::data_structures::SsoHashSet;
 use crate::fold::{FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable};
 use crate::inherent::*;
 use crate::visit::{Flags, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor};
-use crate::{self as ty, DebruijnIndex, Interner, UniverseIndex, Unnormalized};
+use crate::{self as ty, DebruijnIndex, Interner, Region, UniverseIndex, Unnormalized};
 
 /// `Binder` is a binder for higher-ranked lifetimes or types. It is part of the
 /// compiler's representation for things like `for<'a> Fn(&'a isize)`
@@ -23,8 +23,6 @@ use crate::{self as ty, DebruijnIndex, Interner, UniverseIndex, Unnormalized};
 ///
 /// See <https://rustc-dev-guide.rust-lang.org/ty_module/instantiating_binders.html>
 /// for more details.
-///
-/// `Decodable` and `Encodable` are implemented for `Binder<T>` using the `impl_binder_encode_decode!` macro.
 #[derive_where(Clone, Copy, Hash, PartialEq, Debug; I: Interner, T)]
 #[derive(GenericTypeVisitable, Lift_Generic)]
 #[cfg_attr(feature = "nightly", derive(StableHash_NoContext))]
@@ -34,71 +32,6 @@ pub struct Binder<I: Interner, T> {
 }
 
 impl<I: Interner, T: Eq> Eq for Binder<I, T> {}
-
-#[cfg(feature = "nightly")]
-macro_rules! impl_binder_encode_decode {
-    ($($t:ty),+ $(,)?) => {
-        $(
-            impl<I: Interner, E: rustc_serialize::Encoder> rustc_serialize::Encodable<E> for ty::Binder<I, $t>
-            where
-                $t: rustc_serialize::Encodable<E>,
-                I::BoundVarKinds: rustc_serialize::Encodable<E>,
-            {
-                fn encode(&self, e: &mut E) {
-                    self.bound_vars().encode(e);
-                    self.as_ref().skip_binder().encode(e);
-                }
-            }
-            impl<I: Interner, D: rustc_serialize::Decoder> rustc_serialize::Decodable<D> for ty::Binder<I, $t>
-            where
-                $t: TypeVisitable<I> + rustc_serialize::Decodable<D>,
-                I::BoundVarKinds: rustc_serialize::Decodable<D>,
-            {
-                fn decode(decoder: &mut D) -> Self {
-                    let bound_vars = rustc_serialize::Decodable::decode(decoder);
-                    ty::Binder::bind_with_vars(rustc_serialize::Decodable::decode(decoder), bound_vars)
-                }
-            }
-        )*
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl_binder_encode_decode! {
-    ty::FnSig<I>,
-    ty::FnSigTys<I>,
-    ty::TraitPredicate<I>,
-    ty::ExistentialPredicate<I>,
-    ty::TraitRef<I>,
-    ty::ExistentialTraitRef<I>,
-    ty::HostEffectPredicate<I>,
-}
-
-#[cfg(feature = "nightly")]
-impl<T: GenericArgs<I>, I: Interner<GenericArgs = T>, E: rustc_serialize::Encoder>
-    rustc_serialize::Encodable<E> for ty::Binder<I, T>
-where
-    T: rustc_serialize::Encodable<E>,
-    I::BoundVarKinds: rustc_serialize::Encodable<E>,
-{
-    fn encode(&self, e: &mut E) {
-        self.bound_vars().encode(e);
-        self.as_ref().skip_binder().encode(e);
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<T: GenericArgs<I>, I: Interner<GenericArgs = T>, D: rustc_serialize::Decoder>
-    rustc_serialize::Decodable<D> for ty::Binder<I, T>
-where
-    T: TypeVisitable<I> + rustc_serialize::Decodable<D>,
-    I::BoundVarKinds: rustc_serialize::Decodable<D>,
-{
-    fn decode(decoder: &mut D) -> Self {
-        let bound_vars = rustc_serialize::Decodable::decode(decoder);
-        ty::Binder::bind_with_vars(rustc_serialize::Decodable::decode(decoder), bound_vars)
-    }
-}
 
 impl<I: Interner, T> Binder<I, T>
 where
@@ -347,7 +280,7 @@ impl<I: Interner> TypeVisitor<I> for ValidateBoundVars<I> {
         c.super_visit_with(self)
     }
 
-    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, r: Region<I>) -> Self::Result {
         match r.kind() {
             ty::ReBound(index, br) if index == ty::BoundVarIndexKind::Bound(self.binder_index) => {
                 let idx = br.var().as_usize();
@@ -762,7 +695,7 @@ impl<'a, I: Interner> TypeFolder<I> for ArgFolder<'a, I> {
         t
     }
 
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         // Note: This routine only handles regions that are bound on
         // type declarations and other outer declarations, not those
         // bound in *fn types*. Region instantiation of the bound
@@ -900,7 +833,7 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
     fn region_param_expected(
         &self,
         ebr: I::EarlyParamRegion,
-        r: I::Region,
+        r: Region<I>,
         kind: ty::GenericArgKind<I>,
     ) -> ! {
         panic!(
@@ -915,7 +848,7 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
 
     #[cold]
     #[inline(never)]
-    fn region_param_out_of_range(&self, ebr: I::EarlyParamRegion, r: I::Region) -> ! {
+    fn region_param_out_of_range(&self, ebr: I::EarlyParamRegion, r: Region<I>) -> ! {
         panic!(
             "region parameter `{:?}` ({:?}/{}) out of range when instantiating args={:?}",
             ebr,
@@ -976,7 +909,7 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
         }
     }
 
-    fn shift_region_through_binders(&self, region: I::Region) -> I::Region {
+    fn shift_region_through_binders(&self, region: Region<I>) -> Region<I> {
         if self.binders_passed == 0 || !region.has_escaping_bound_vars() {
             region
         } else {
@@ -1149,12 +1082,13 @@ impl<I: Interner> BoundVariableKind<I> {
 }
 
 #[derive_where(Clone, Copy, PartialEq, Eq, Hash; I: Interner)]
-#[derive(GenericTypeVisitable)]
+#[derive(GenericTypeVisitable, Lift_Generic)]
 #[cfg_attr(
     feature = "nightly",
     derive(Encodable_NoContext, StableHash_NoContext, Decodable_NoContext)
 )]
 pub struct BoundRegion<I: Interner> {
+    #[lift(identity)]
     pub var: ty::BoundVar,
     pub kind: BoundRegionKind<I>,
 }

--- a/compiler/rustc_type_ir/src/canonical.rs
+++ b/compiler/rustc_type_ir/src/canonical.rs
@@ -11,7 +11,7 @@ use rustc_type_ir_macros::{
 
 use crate::data_structures::HashMap;
 use crate::inherent::*;
-use crate::{self as ty, Interner, TypingModeEqWrapper, UniverseIndex};
+use crate::{self as ty, Interner, Region, TypingModeEqWrapper, UniverseIndex};
 
 #[derive_where(Clone, Hash, PartialEq, Debug; I: Interner, V)]
 #[derive_where(Copy; I: Interner, V: Copy)]

--- a/compiler/rustc_type_ir/src/elaborate.rs
+++ b/compiler/rustc_type_ir/src/elaborate.rs
@@ -6,7 +6,7 @@ use crate::data_structures::HashSet;
 use crate::inherent::*;
 use crate::lang_items::SolverTraitLangItem;
 use crate::outlives::{Component, push_outlives_components};
-use crate::{self as ty, Interner, Unnormalized, Upcast as _};
+use crate::{self as ty, Interner, Region, Unnormalized, Upcast as _};
 
 /// "Elaboration" is the process of identifying all the predicates that
 /// are implied by a source predicate. Currently, this basically means
@@ -251,7 +251,7 @@ impl<I: Interner, O: Elaboratable<I>> Elaborator<I, O> {
 fn elaborate_component_to_clause<I: Interner>(
     cx: I,
     component: Component<I>,
-    outlives_region: I::Region,
+    outlives_region: Region<I>,
 ) -> Option<ty::ClauseKind<I>> {
     match component {
         Component::Region(r) => {

--- a/compiler/rustc_type_ir/src/error.rs
+++ b/compiler/rustc_type_ir/src/error.rs
@@ -3,7 +3,7 @@ use rustc_abi::ExternAbi;
 use rustc_type_ir_macros::{GenericTypeVisitable, TypeFoldable_Generic, TypeVisitable_Generic};
 
 use crate::solve::{NoSolution, NoSolutionOrRerunNonErased};
-use crate::{self as ty, Interner};
+use crate::{self as ty, Interner, Region};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[derive(TypeFoldable_Generic, TypeVisitable_Generic, GenericTypeVisitable)]
@@ -33,8 +33,8 @@ pub enum TypeError<I: Interner> {
     ArraySize(ExpectedFound<I::Const>),
     ArgCount,
 
-    RegionsDoesNotOutlive(I::Region, I::Region),
-    RegionsInsufficientlyPolymorphic(ty::BoundRegion<I>, I::Region),
+    RegionsDoesNotOutlive(Region<I>, Region<I>),
+    RegionsInsufficientlyPolymorphic(ty::BoundRegion<I>, Region<I>),
     RegionsPlaceholderMismatch,
 
     Sorts(ExpectedFound<I::Ty>),

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -1,6 +1,6 @@
 use crate::inherent::*;
 use crate::visit::Flags;
-use crate::{self as ty, Interner};
+use crate::{self as ty, Interner, Region};
 
 bitflags::bitflags! {
     /// Flags that we track on types. These flags are propagated upwards
@@ -459,7 +459,7 @@ impl<I: Interner> FlagComputation<I> {
         }
     }
 
-    fn add_region(&mut self, r: I::Region) {
+    fn add_region(&mut self, r: Region<I>) {
         self.add_flags(r.flags());
         if let ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) = r.kind() {
             self.add_bound_var(debruijn);

--- a/compiler/rustc_type_ir/src/fold.rs
+++ b/compiler/rustc_type_ir/src/fold.rs
@@ -55,7 +55,7 @@ use tracing::{debug, instrument};
 
 use crate::inherent::*;
 use crate::visit::{TypeVisitable, TypeVisitableExt as _};
-use crate::{self as ty, BoundVarIndexKind, Interner};
+use crate::{self as ty, BoundVarIndexKind, Interner, Region};
 
 /// This trait is implemented for every type that can be folded,
 /// providing the skeleton of the traversal.
@@ -137,7 +137,7 @@ pub trait TypeFolder<I: Interner>: Sized {
 
     // The default region folder is a no-op because `Region` is non-recursive
     // and has no `super_fold_with` method to call.
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         r
     }
 
@@ -179,7 +179,7 @@ pub trait FallibleTypeFolder<I: Interner>: Sized {
 
     // The default region folder is a no-op because `Region` is non-recursive
     // and has no `super_fold_with` method to call.
-    fn try_fold_region(&mut self, r: I::Region) -> Result<I::Region, Self::Error> {
+    fn try_fold_region(&mut self, r: Region<I>) -> Result<Region<I>, Self::Error> {
         Ok(r)
     }
 
@@ -392,7 +392,7 @@ impl<I: Interner> TypeFolder<I> for Shifter<I> {
         t
     }
 
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         match r.kind() {
             ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), br)
                 if debruijn >= self.current_index =>
@@ -439,7 +439,7 @@ impl<I: Interner> TypeFolder<I> for Shifter<I> {
     }
 }
 
-pub fn shift_region<I: Interner>(cx: I, region: I::Region, amount: u32) -> I::Region {
+pub fn shift_region<I: Interner>(cx: I, region: Region<I>, amount: u32) -> Region<I> {
     match region.kind() {
         ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), br) if amount > 0 => {
             Region::new_bound(cx, debruijn.shifted_in(amount), br)
@@ -466,7 +466,7 @@ where
 pub fn fold_regions<I: Interner, T>(
     cx: I,
     value: T,
-    f: impl FnMut(I::Region, ty::DebruijnIndex) -> I::Region,
+    f: impl FnMut(Region<I>, ty::DebruijnIndex) -> Region<I>,
 ) -> T
 where
     T: TypeFoldable<I>,
@@ -505,7 +505,7 @@ impl<I, F> RegionFolder<I, F> {
 impl<I, F> TypeFolder<I> for RegionFolder<I, F>
 where
     I: Interner,
-    F: FnMut(I::Region, ty::DebruijnIndex) -> I::Region,
+    F: FnMut(Region<I>, ty::DebruijnIndex) -> Region<I>,
 {
     fn cx(&self) -> I {
         self.cx
@@ -519,7 +519,7 @@ where
     }
 
     #[instrument(skip(self), level = "debug", ret)]
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         match r.kind() {
             ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _)
                 if debruijn < self.current_index =>

--- a/compiler/rustc_type_ir/src/generic_arg.rs
+++ b/compiler/rustc_type_ir/src/generic_arg.rs
@@ -3,7 +3,7 @@ use derive_where::derive_where;
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash_NoContext};
 use rustc_type_ir_macros::GenericTypeVisitable;
 
-use crate::Interner;
+use crate::{Interner, Region};
 
 #[derive_where(Clone, Copy, PartialEq, Debug; I: Interner)]
 #[derive(GenericTypeVisitable)]
@@ -12,7 +12,7 @@ use crate::Interner;
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
 pub enum GenericArgKind<I: Interner> {
-    Lifetime(I::Region),
+    Lifetime(Region<I>),
     Type(I::Ty),
     Const(I::Const),
 }

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -10,7 +10,7 @@ use crate::inherent::*;
 use crate::relate::RelateResult;
 use crate::relate::combine::PredicateEmittingRelation;
 use crate::solve::VisibleForLeakCheck;
-use crate::{self as ty, Interner, TyVid};
+use crate::{self as ty, Interner, Region, TyVid};
 
 mod private {
     pub trait Sealed {}
@@ -386,14 +386,11 @@ pub trait InferCtxtLike: Sized {
         &self,
         vid: ty::ConstVid,
     ) -> <Self::Interner as Interner>::Const;
-    fn opportunistic_resolve_lt_var(
-        &self,
-        vid: ty::RegionVid,
-    ) -> <Self::Interner as Interner>::Region;
+    fn opportunistic_resolve_lt_var(&self, vid: ty::RegionVid) -> Region<Self::Interner>;
 
     fn is_changed_arg(&self, arg: <Self::Interner as Interner>::GenericArg) -> bool;
 
-    fn next_region_infer(&self) -> <Self::Interner as Interner>::Region;
+    fn next_region_infer(&self) -> Region<Self::Interner>;
     fn next_ty_infer(&self) -> <Self::Interner as Interner>::Ty;
     fn next_const_infer(&self) -> <Self::Interner as Interner>::Const;
     fn fresh_args_for_item(
@@ -470,16 +467,16 @@ pub trait InferCtxtLike: Sized {
 
     fn sub_regions(
         &self,
-        sub: <Self::Interner as Interner>::Region,
-        sup: <Self::Interner as Interner>::Region,
+        sub: Region<Self::Interner>,
+        sup: Region<Self::Interner>,
         vis: VisibleForLeakCheck,
         span: <Self::Interner as Interner>::Span,
     );
 
     fn equate_regions(
         &self,
-        a: <Self::Interner as Interner>::Region,
-        b: <Self::Interner as Interner>::Region,
+        a: Region<Self::Interner>,
+        b: Region<Self::Interner>,
         vis: VisibleForLeakCheck,
         span: <Self::Interner as Interner>::Span,
     );
@@ -492,7 +489,7 @@ pub trait InferCtxtLike: Sized {
     fn register_ty_outlives(
         &self,
         ty: <Self::Interner as Interner>::Ty,
-        r: <Self::Interner as Interner>::Region,
+        r: Region<Self::Interner>,
         span: <Self::Interner as Interner>::Span,
     );
 

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -14,7 +14,7 @@ use crate::relate::Relate;
 use crate::solve::{AdtDestructorKind, SizedTraitKind};
 use crate::visit::{Flags, TypeSuperVisitable, TypeVisitable};
 use crate::{
-    self as ty, ClauseKind, CollectAndApply, FieldInfo, Interner, PredicateKind, UpcastFrom,
+    self as ty, ClauseKind, CollectAndApply, FieldInfo, Interner, PredicateKind, Region, UpcastFrom,
 };
 
 #[rust_analyzer::prefer_underscore_import]
@@ -87,7 +87,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_foreign(interner: I, def_id: I::ForeignId) -> Self;
 
-    fn new_dynamic(interner: I, preds: I::BoundExistentialPredicates, region: I::Region) -> Self;
+    fn new_dynamic(interner: I, preds: I::BoundExistentialPredicates, region: Region<I>) -> Self;
 
     fn new_coroutine(interner: I, def_id: I::CoroutineId, args: I::GenericArgs) -> Self;
 
@@ -109,7 +109,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_ptr(interner: I, ty: Self, mutbl: Mutability) -> Self;
 
-    fn new_ref(interner: I, region: I::Region, ty: Self, mutbl: Mutability) -> Self;
+    fn new_ref(interner: I, region: Region<I>, ty: Self, mutbl: Mutability) -> Self;
 
     fn new_array_with_const_len(interner: I, ty: Self, len: I::Const) -> Self;
 
@@ -228,33 +228,6 @@ pub trait Safety<I: Interner<Safety = Self>>: Copy + Debug + Hash + Eq {
     fn prefix_str(self) -> &'static str;
 }
 
-#[rust_analyzer::prefer_underscore_import]
-pub trait Region<I: Interner<Region = Self>>:
-    Copy
-    + Debug
-    + Hash
-    + Eq
-    + Into<I::GenericArg>
-    + IntoKind<Kind = ty::RegionKind<I>>
-    + Flags
-    + Relate<I>
-{
-    fn new_bound(interner: I, debruijn: ty::DebruijnIndex, var: ty::BoundRegion<I>) -> Self;
-
-    fn new_anon_bound(interner: I, debruijn: ty::DebruijnIndex, var: ty::BoundVar) -> Self;
-
-    fn new_canonical_bound(interner: I, var: ty::BoundVar) -> Self;
-
-    fn new_static(interner: I) -> Self;
-
-    fn new_placeholder(interner: I, var: ty::PlaceholderRegion<I>) -> Self;
-
-    fn is_bound(self) -> bool {
-        matches!(self.kind(), ty::ReBound(..))
-    }
-}
-
-#[rust_analyzer::prefer_underscore_import]
 pub trait Const<I: Interner<Const = Self>>:
     Copy
     + Debug
@@ -325,7 +298,7 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
     + TypeVisitable<I>
     + Relate<I>
     + From<I::Ty>
-    + From<I::Region>
+    + From<Region<I>>
     + From<I::Const>
     + From<I::Term>
 {
@@ -353,11 +326,11 @@ pub trait GenericArg<I: Interner<GenericArg = Self>>:
         self.as_const().expect("expected a const")
     }
 
-    fn as_region(&self) -> Option<I::Region> {
+    fn as_region(&self) -> Option<Region<I>> {
         if let ty::GenericArgKind::Lifetime(c) = self.kind() { Some(c) } else { None }
     }
 
-    fn expect_region(&self) -> I::Region {
+    fn expect_region(&self) -> Region<I> {
         self.as_region().expect("expected a const")
     }
 
@@ -444,7 +417,7 @@ pub trait GenericArgs<I: Interner<GenericArgs = Self>>:
 
     fn type_at(self, i: usize) -> I::Ty;
 
-    fn region_at(self, i: usize) -> I::Region;
+    fn region_at(self, i: usize) -> Region<I>;
 
     fn const_at(self, i: usize) -> I::Const;
 
@@ -491,7 +464,7 @@ pub trait Predicate<I: Interner<Predicate = Self>>:
     + UpcastFrom<I, ty::TraitPredicate<I>>
     + UpcastFrom<I, ty::ProjectionPredicate<I>>
     + UpcastFrom<I, ty::OutlivesPredicate<I, I::Ty>>
-    + UpcastFrom<I, ty::OutlivesPredicate<I, I::Region>>
+    + UpcastFrom<I, ty::OutlivesPredicate<I, Region<I>>>
     + IntoKind<Kind = ty::Binder<I, ty::PredicateKind<I>>>
     + Elaboratable<I>
 {

--- a/compiler/rustc_type_ir/src/intern/mod.rs
+++ b/compiler/rustc_type_ir/src/intern/mod.rs
@@ -1,0 +1,8 @@
+use std::hash::Hash;
+
+use crate::fmt::Debug;
+
+pub trait Interned<I>: Copy + Debug + Hash + Eq + PartialEq {
+    type Value;
+    fn get(self) -> Self::Value;
+}

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -6,6 +6,8 @@ use std::ops::Deref;
 use rustc_ast_ir::Movability;
 use rustc_ast_ir::visit::VisitorResult;
 use rustc_index::bit_set::DenseBitSet;
+#[cfg(feature = "nightly")]
+use rustc_serialize::Decoder;
 
 use crate::fold::TypeFoldable;
 use crate::inherent::*;
@@ -16,7 +18,10 @@ use crate::solve::{
     AccessedOpaques, CanonicalInput, Certainty, ExternalConstraintsData, QueryResult, inspect,
 };
 use crate::visit::{Flags, TypeVisitable};
-use crate::{self as ty, CanonicalParamEnvCacheEntry, TraitRef, search_graph};
+use crate::{
+    self as ty, BoundRegion, BoundVar, CanonicalParamEnvCacheEntry, DebruijnIndex, Region,
+    RegionKind, TraitRef, search_graph,
+};
 
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_interner")]
 pub trait Interner:
@@ -180,9 +185,15 @@ pub trait Interner:
     type ScalarInt: Copy + Debug + Hash + Eq;
 
     // Kinds of regions
-    type Region: Region<Self>;
     type EarlyParamRegion: ParamLike;
     type LateParamRegion: Copy + Debug + Hash + Eq;
+
+    type InternedRegionKind: Copy
+        + Debug
+        + Hash
+        + Eq
+        + PartialEq
+        + IntoKind<Kind = RegionKind<Self>>;
 
     type RegionAssumptions: Copy
         + Debug
@@ -463,6 +474,30 @@ pub trait Interner:
     ) -> (QueryResult<Self>, Self::Probe);
 
     fn item_name(self, item_index: Self::DefId) -> Self::Symbol;
+
+    fn get_anon_re_bounds_lifetime(self, idx: usize, var_idx: usize) -> Option<Region<Self>>;
+
+    fn get_anon_re_canonical_bounds_lifetime(self, idx: usize) -> Option<Region<Self>>;
+
+    fn get_re_static_lifetime(self) -> Region<Self>;
+
+    fn intern_region(self, region_kind: RegionKind<Self>) -> Region<Self>;
+
+    fn intern_bound_region(
+        self,
+        debruijn: DebruijnIndex,
+        bound_region: BoundRegion<Self>,
+    ) -> Region<Self>;
+
+    fn intern_canonical_bound(self, var: BoundVar) -> Region<Self>;
+}
+
+/// A decoder that can reconstruct interned IR values by supplying an interner.
+#[cfg(feature = "nightly")]
+pub trait InternerDecoder: Decoder {
+    type Interner: Interner;
+
+    fn interner(&self) -> Self::Interner;
 }
 
 macro_rules! declare_lift_into {

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -6,11 +6,10 @@ use std::ops::Deref;
 use rustc_ast_ir::Movability;
 use rustc_ast_ir::visit::VisitorResult;
 use rustc_index::bit_set::DenseBitSet;
-#[cfg(feature = "nightly")]
-use rustc_serialize::Decoder;
 
 use crate::fold::TypeFoldable;
 use crate::inherent::*;
+use crate::intern::Interned;
 use crate::ir_print::IrPrint;
 use crate::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use crate::relate::Relate;
@@ -188,12 +187,7 @@ pub trait Interner:
     type EarlyParamRegion: ParamLike;
     type LateParamRegion: Copy + Debug + Hash + Eq;
 
-    type InternedRegionKind: Copy
-        + Debug
-        + Hash
-        + Eq
-        + PartialEq
-        + IntoKind<Kind = RegionKind<Self>>;
+    type InternedRegionKind: Interned<Self, Value = RegionKind<Self>>;
 
     type RegionAssumptions: Copy
         + Debug
@@ -492,14 +486,6 @@ pub trait Interner:
     fn intern_canonical_bound(self, var: BoundVar) -> Region<Self>;
 }
 
-/// A decoder that can reconstruct interned IR values by supplying an interner.
-#[cfg(feature = "nightly")]
-pub trait InternerDecoder: Decoder {
-    type Interner: Interner;
-
-    fn interner(&self) -> Self::Interner;
-}
-
 macro_rules! declare_lift_into {
     ($($assoc:ident),* $(,)?) => {
         /// An interner whose associated types can be lifted into another interner `J`.
@@ -524,16 +510,19 @@ declare_lift_into! {
     BoundVarKinds,
     Const,
     DefId,
+    EarlyParamRegion,
+    ErrorGuaranteed,
     FreeConstAliasId,
     FreeTyAliasId,
     GenericArg,
     GenericArgs,
     InherentAssocConstId,
     InherentAssocTyId,
+    InternedRegionKind,
+    LateParamRegion,
     OpaqueTyId,
     ParamEnv,
     PatList,
-    Region,
     RegionAssumptions,
     Symbol,
     Term,

--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -5,7 +5,7 @@ use crate::{AliasConst, ClosureKind};
 use crate::{
     AliasTerm, AliasTy, Binder, CoercePredicate, ExistentialProjection, ExistentialTraitRef, FnSig,
     HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate, PatternKind, Placeholder,
-    ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef,
+    ProjectionPredicate, Region, SubtypePredicate, TraitPredicate, TraitRef,
 };
 
 pub trait IrPrint<T> {
@@ -55,6 +55,15 @@ define_display_via_print!(
 
 define_debug_via_print!(TraitRef, ExistentialTraitRef, PatternKind);
 
+impl<I: Interner> fmt::Display for Region<I>
+where
+    I: IrPrint<Region<I>>,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <I as IrPrint<Region<I>>>::print(self, fmt)
+    }
+}
+
 impl<I: Interner, T> fmt::Display for OutlivesPredicate<I, T>
 where
     I: IrPrint<OutlivesPredicate<I, T>>,
@@ -95,6 +104,12 @@ mod into_diag_arg_impls {
     }
 
     impl<I: Interner> IntoDiagArg for ExistentialTraitRef<I> {
+        fn into_diag_arg(self, path: &mut Option<std::path::PathBuf>) -> DiagArgValue {
+            self.to_string().into_diag_arg(path)
+        }
+    }
+
+    impl<I: Interner + IrPrint<Region<I>>> IntoDiagArg for Region<I> {
         fn into_diag_arg(self, path: &mut Option<std::path::PathBuf>) -> DiagArgValue {
             self.to_string().into_diag_arg(path)
         }

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod fast_reject;
 #[cfg_attr(feature = "nightly", rustc_diagnostic_item = "type_ir_inherent")]
 pub mod inherent;
+pub mod intern;
 pub mod ir_print;
 pub mod lang_items;
 pub mod lift;
@@ -32,6 +33,7 @@ pub mod region_constraint;
 pub mod relate;
 pub mod search_graph;
 pub mod solve;
+pub mod sty;
 pub mod walk;
 
 // These modules are not `pub` since they are glob-imported.
@@ -52,6 +54,8 @@ mod pattern;
 mod predicate;
 mod predicate_kind;
 mod region_kind;
+#[cfg(feature = "nightly")]
+mod serialize;
 mod term_kind;
 mod ty;
 mod ty_info;
@@ -83,6 +87,9 @@ pub use predicate_kind::*;
 pub use region_kind::*;
 pub use rustc_ast_ir::{FloatTy, IntTy, Movability, Mutability, Pinnedness, UintTy};
 use rustc_type_ir_macros::GenericTypeVisitable;
+#[cfg(feature = "nightly")]
+pub use serialize::*;
+pub use sty::*;
 pub use term_kind::*;
 pub use ty::{Alias, *};
 pub use ty_info::*;

--- a/compiler/rustc_type_ir/src/opaque_ty.rs
+++ b/compiler/rustc_type_ir/src/opaque_ty.rs
@@ -4,7 +4,7 @@ use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash_NoContex
 use rustc_type_ir_macros::{GenericTypeVisitable, TypeFoldable_Generic, TypeVisitable_Generic};
 
 use crate::inherent::*;
-use crate::{self as ty, Interner};
+use crate::{self as ty, Interner, Region};
 
 #[derive_where(Clone, Copy, Hash, PartialEq, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic)]
@@ -34,7 +34,7 @@ impl<I: Interner> OpaqueTypeKey<I> {
     pub fn fold_captured_lifetime_args(
         self,
         cx: I,
-        mut f: impl FnMut(I::Region) -> I::Region,
+        mut f: impl FnMut(Region<I>) -> Region<I>,
     ) -> Self {
         let Self { def_id, args } = self;
         let variances = cx.variances_of(def_id.into());

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -8,11 +8,11 @@ use smallvec::{SmallVec, smallvec};
 use crate::data_structures::SsoHashSet;
 use crate::inherent::*;
 use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitableExt as _, TypeVisitor};
-use crate::{self as ty, AliasTy, Interner, OutlivesPredicate, Unnormalized};
+use crate::{self as ty, AliasTy, Interner, OutlivesPredicate, Region, Unnormalized};
 
 #[derive_where(Debug; I: Interner)]
 pub enum Component<I: Interner> {
-    Region(I::Region),
+    Region(Region<I>),
     Param(I::ParamTy),
     Placeholder(ty::PlaceholderType<I>),
     UnresolvedInferenceVariable(ty::InferTy),
@@ -211,7 +211,7 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
         }
     }
 
-    fn visit_region(&mut self, lt: I::Region) -> Self::Result {
+    fn visit_region(&mut self, lt: Region<I>) -> Self::Result {
         if !lt.is_bound() {
             self.out.push(Component::Region(lt));
         }
@@ -264,7 +264,7 @@ pub fn compute_alias_components_recursive<I: Interner>(
 pub fn declared_bounds_from_definition<I: Interner>(
     cx: I,
     alias_ty: AliasTy<I>,
-) -> impl Iterator<Item = I::Region> {
+) -> impl Iterator<Item = Region<I>> {
     let def_id = match alias_ty.kind {
         ty::AliasTyKind::Projection { def_id } => def_id.into(),
         ty::AliasTyKind::Inherent { def_id } => def_id.into(),

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -11,7 +11,7 @@ use rustc_type_ir_macros::{
 use crate::inherent::*;
 use crate::upcast::{Upcast, UpcastFrom};
 use crate::visit::TypeVisitableExt as _;
-use crate::{self as ty, Alias, Interner};
+use crate::{self as ty, Alias, Interner, Region};
 
 /// `A: 'region`
 #[derive_where(Clone, Hash, PartialEq, Debug; I: Interner, A)]
@@ -21,7 +21,7 @@ use crate::{self as ty, Alias, Interner};
     feature = "nightly",
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
-pub struct OutlivesPredicate<I: Interner, A>(pub A, pub I::Region);
+pub struct OutlivesPredicate<I: Interner, A>(pub A, pub Region<I>);
 
 impl<I: Interner, A: Eq> Eq for OutlivesPredicate<I, A> {}
 
@@ -35,7 +35,7 @@ impl<I: Interner, A: Eq> Eq for OutlivesPredicate<I, A> {}
     feature = "nightly",
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
-pub struct RegionEqPredicate<I: Interner>(pub I::Region, pub I::Region);
+pub struct RegionEqPredicate<I: Interner>(pub Region<I>, pub Region<I>);
 
 impl<I: Interner> RegionEqPredicate<I> {
     /// Decompose `'a == 'b` into `['a: 'b, 'b: 'a]`

--- a/compiler/rustc_type_ir/src/predicate_kind.rs
+++ b/compiler/rustc_type_ir/src/predicate_kind.rs
@@ -5,7 +5,7 @@ use derive_where::derive_where;
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash_NoContext};
 use rustc_type_ir_macros::{GenericTypeVisitable, TypeFoldable_Generic, TypeVisitable_Generic};
 
-use crate::{self as ty, Interner};
+use crate::{self as ty, Interner, Region};
 
 /// A clause is something that can appear in where bounds or be inferred
 /// by implied bounds.
@@ -22,7 +22,7 @@ pub enum ClauseKind<I: Interner> {
     Trait(ty::TraitPredicate<I>),
 
     /// `where 'a: 'r`
-    RegionOutlives(ty::OutlivesPredicate<I, I::Region>),
+    RegionOutlives(ty::OutlivesPredicate<I, Region<I>>),
 
     /// `where T: 'r`
     TypeOutlives(ty::OutlivesPredicate<I, I::Ty>),

--- a/compiler/rustc_type_ir/src/region_constraint.rs
+++ b/compiler/rustc_type_ir/src/region_constraint.rs
@@ -51,7 +51,7 @@ use crate::inherent::*;
 use crate::relate::{Relate, RelateResult, TypeRelation, VarianceDiagInfo};
 use crate::{
     AliasTy, Binder, BoundRegion, BoundVar, BoundVariableKind, DebruijnIndex, FallibleTypeFolder,
-    InferCtxtLike, Interner, IsRigid, OutlivesPredicate, RegionKind, TyKind, TypeFoldable,
+    InferCtxtLike, Interner, IsRigid, OutlivesPredicate, Region, RegionKind, TyKind, TypeFoldable,
     TypeFolder, TypeVisitable, TypeVisitor, TypingMode, UniverseIndex, Variance, VisitorResult,
     max_universe, set_aliases_to_non_rigid,
 };
@@ -59,8 +59,8 @@ use crate::{
 #[derive_where(Clone, Debug; I: Interner)]
 pub struct Assumptions<I: Interner> {
     pub type_outlives: Vec<Binder<I, OutlivesPredicate<I, I::Ty>>>,
-    pub region_outlives: TransitiveRelation<I::Region>,
-    pub inverse_region_outlives: TransitiveRelation<I::Region>,
+    pub region_outlives: TransitiveRelation<Region<I>>,
+    pub inverse_region_outlives: TransitiveRelation<Region<I>>,
 }
 
 impl<I: Interner> Assumptions<I> {
@@ -74,7 +74,7 @@ impl<I: Interner> Assumptions<I> {
 
     pub fn new(
         type_outlives: Vec<Binder<I, OutlivesPredicate<I, I::Ty>>>,
-        region_outlives: TransitiveRelation<I::Region>,
+        region_outlives: TransitiveRelation<Region<I>>,
     ) -> Self {
         Self {
             inverse_region_outlives: {
@@ -93,7 +93,7 @@ impl<I: Interner> Assumptions<I> {
 #[derive_where(Clone, Hash, PartialEq, Debug; I: Interner)]
 pub enum RegionConstraint<I: Interner> {
     Ambiguity,
-    RegionOutlives(I::Region, I::Region),
+    RegionOutlives(Region<I>, Region<I>),
     /// Requirement that a (potentially higher ranked) alias outlives some (potentially higher ranked)
     /// region due to an assumption in the environment. This cannot be satisfied via component outlives
     /// or item bounds.
@@ -103,7 +103,7 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We eagerly destructure alias outlives requirements into region outlives requirements corresponding to
     /// component outlives & item bound outlives rules, leaving only param env candidates.
-    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, I::Region)>),
+    AliasTyOutlivesViaEnv(Binder<I, (AliasTy<I>, Region<I>)>),
     /// This is an `I::Ty` for two reasons:
     /// 1. We need the type visitable impl to be able to `visit_ty` on this so canonicalization
     ///    knows about the placeholder
@@ -113,18 +113,18 @@ pub enum RegionConstraint<I: Interner> {
     ///
     /// We cannot eagerly look at assumptions as we are usually working with an incomplete set of assumptions
     /// and there may wind up being assumptions we can use to prove this when we're in a smaller universe.
-    PlaceholderTyOutlives(I::Ty, I::Region),
+    PlaceholderTyOutlives(I::Ty, Region<I>),
 
     And(Box<[RegionConstraint<I>]>),
     Or(Box<[RegionConstraint<I>]>),
 }
 
 // This is not a derived impl because a perfect derive leads to inductive
-// cycle causing the trait to never actually be implemented
+// cycle causing the trait to never actually be implemented.
 #[cfg(feature = "nightly")]
 impl<I: Interner> StableHash for RegionConstraint<I>
 where
-    I::Region: StableHash,
+    Region<I>: StableHash,
     I::Ty: StableHash,
     I::GenericArgs: StableHash,
     I::TraitAssocTyId: StableHash,
@@ -535,7 +535,7 @@ fn compute_new_region_constraints<Infcx: InferCtxtLike<Interner = I>, I: Interne
         for ub in region_flow.reachable_from(r) {
             // we want to retain any region constraints between two "placeholder-likes" where for our
             // purposes a placeholder-like is either a placeholder or variable in a lower universe
-            let is_placeholder_like = |r: I::Region| match r.kind() {
+            let is_placeholder_like = |r: Region<I>| match r.kind() {
                 RegionKind::ReLateParam(..)
                 | RegionKind::ReEarlyParam(..)
                 | RegionKind::RePlaceholder(..)
@@ -948,9 +948,9 @@ fn rewrite_type_outlives_constraints_in_universe_for_eager_placeholder_handling<
 /// Returns all regions `r2` for which `r: r2` is known to hold in
 /// the universe associated with `assumptions`
 pub fn regions_outlived_by<I: Interner>(
-    r: I::Region,
+    r: Region<I>,
     assumptions: &Assumptions<I>,
-) -> impl Iterator<Item = I::Region> {
+) -> impl Iterator<Item = Region<I>> {
     // FIXME(-Zassumptions-on-binders): do we need to be adding the reflexive edge here?
     assumptions.region_outlives.reachable_from(r).into_iter().chain([r])
 }
@@ -958,17 +958,17 @@ pub fn regions_outlived_by<I: Interner>(
 /// Returns all regions `r2` for which `r2: r` is known to hold in
 /// the universe associated with `assumptions`
 pub fn regions_outliving<I: Interner>(
-    r: I::Region,
+    r: Region<I>,
     assumptions: &Assumptions<I>,
     cx: I,
-) -> impl Iterator<Item = I::Region> {
+) -> impl Iterator<Item = Region<I>> {
     assumptions
         .inverse_region_outlives
         .reachable_from(r)
         .into_iter()
         // FIXME(-Zassumptions-on-binders): 'static may have been an input region canonicalized to something else is that important?
         // FIXME(-Zassumptions-on-binders): do we need to adding the reflexive edge here?
-        .chain([r, I::Region::new_static(cx)])
+        .chain([r, Region::new_static(cx)])
 }
 
 /// Returns all regions `r` for which `!t: r` is known to hold in
@@ -977,7 +977,7 @@ pub fn regions_outlived_by_placeholder<I: Interner>(
     t: I::Ty,
     assumptions: &Assumptions<I>,
     cx: I,
-) -> impl Iterator<Item = I::Region> {
+) -> impl Iterator<Item = Region<I>> {
     match t.kind() {
         TyKind::Placeholder(..) | TyKind::Param(..) => (),
         _ => unreachable!("non-placeholder in `regions_outlived_by_placeholder`: {t:?}"),
@@ -985,7 +985,7 @@ pub fn regions_outlived_by_placeholder<I: Interner>(
 
     assumptions.type_outlives.iter().flat_map(move |binder| match binder.no_bound_vars() {
         Some(OutlivesPredicate(ty, r)) => (ty == t).then_some(r),
-        None => Some(I::Region::new_static(cx)),
+        None => Some(Region::new_static(cx)),
     })
 }
 
@@ -1002,7 +1002,7 @@ impl<I: Interner> TypeFolder<I> for PlaceholderReplacer<I> {
         self.cx
     }
 
-    fn fold_region(&mut self, r: I::Region) -> I::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         match r.kind() {
             RegionKind::RePlaceholder(p) if p.universe == self.universe => {
                 let bound_vars_len = self.bound_vars.len();
@@ -1010,7 +1010,7 @@ impl<I: Interner> TypeFolder<I> for PlaceholderReplacer<I> {
                     var: BoundVar::from_usize(self.existing_var_count + bound_vars_len),
                     kind: p.bound.kind,
                 });
-                I::Region::new_bound(self.cx, self.current_index, *mapped_var)
+                Region::new_bound(self.cx, self.current_index, *mapped_var)
             }
             // FIXME(-Zassumptions-on-binders): We should be handling region variables here somehow
             _ => r,
@@ -1032,7 +1032,7 @@ impl<I: Interner> TypeFolder<I> for PlaceholderReplacer<I> {
 #[instrument(level = "debug", skip(infcx), ret)]
 fn alias_outlives_candidates_from_assumptions<Infcx: InferCtxtLike<Interner = I>, I: Interner>(
     infcx: &Infcx,
-    bound_outlives: Binder<I, (AliasTy<I>, I::Region)>,
+    bound_outlives: Binder<I, (AliasTy<I>, Region<I>)>,
     assumptions: &Assumptions<I>,
 ) -> RegionConstraint<I> {
     let mut candidates = Vec::new();
@@ -1115,7 +1115,7 @@ impl<'a, Infcx: InferCtxtLike<Interner = I>, I: Interner> TypeRelation<I>
         rustc_type_ir::relate::structurally_relate_tys(self, a, b)
     }
 
-    fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region> {
+    fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>> {
         if a != b {
             self.region_constraints.push(RegionConstraint::RegionOutlives(a, b));
             self.region_constraints.push(RegionConstraint::RegionOutlives(b, a));

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -7,7 +7,7 @@ use tracing::{instrument, trace};
 use crate::error::{ExpectedFound, TypeError};
 use crate::fold::TypeFoldable;
 use crate::inherent::*;
-use crate::{self as ty, Interner};
+use crate::{self as ty, Interner, Region};
 
 pub mod combine;
 pub mod solver_relating;
@@ -88,7 +88,7 @@ pub trait TypeRelation<I: Interner>: Sized {
 
     fn tys(&mut self, a: I::Ty, b: I::Ty) -> RelateResult<I, I::Ty>;
 
-    fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region>;
+    fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>>;
 
     fn consts(&mut self, a: I::Const, b: I::Const) -> RelateResult<I, I::Const>;
 

--- a/compiler/rustc_type_ir/src/relate/solver_relating.rs
+++ b/compiler/rustc_type_ir/src/relate/solver_relating.rs
@@ -5,7 +5,7 @@ use crate::data_structures::DelayedSet;
 use crate::relate::combine::combine_ty_args;
 pub use crate::relate::*;
 use crate::solve::{Goal, VisibleForLeakCheck};
-use crate::{self as ty, InferCtxtLike, Interner};
+use crate::{self as ty, InferCtxtLike, Interner, Region};
 
 pub trait RelateExt: InferCtxtLike {
     fn relate<T: Relate<Self::Interner>>(
@@ -217,7 +217,7 @@ where
     }
 
     #[instrument(skip(self), level = "trace")]
-    fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region> {
+    fn regions(&mut self, a: Region<I>, b: Region<I>) -> RelateResult<I, Region<I>> {
         match self.ambient_variance {
             // Subtype(&'a u8, &'b u8) => Outlives('a: 'b) => SubRegion('b, 'a)
             ty::Covariant => self.infcx.sub_regions(b, a, VisibleForLeakCheck::Yes, self.span),

--- a/compiler/rustc_type_ir/src/serialize.rs
+++ b/compiler/rustc_type_ir/src/serialize.rs
@@ -1,0 +1,119 @@
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+
+use crate::inherent::*;
+use crate::visit::TypeVisitable;
+use crate::{self as ty, Interner, Region, RegionKind, UnsafeBinderInner};
+
+/// A decoder that can reconstruct interned type IR values by supplying the
+/// interner that owns the decoded data.
+///
+/// Some serialized type IR wrappers only store their structural kind. When
+/// decoding, those kinds have to be re-interned instead of rebuilt as raw
+/// values, so their `Decodable` impls need access to the active interner in
+/// addition to the byte stream.
+pub trait InternerDecoder: Decoder {
+    type Interner: Interner;
+
+    fn interner(&self) -> Self::Interner;
+}
+
+macro_rules! impl_binder_encode_decode {
+    ($($t:ty),+ $(,)?) => {
+        $(
+            impl<I: Interner, E: rustc_serialize::Encoder> rustc_serialize::Encodable<E> for ty::Binder<I, $t>
+            where
+                $t: rustc_serialize::Encodable<E>,
+                I::BoundVarKinds: rustc_serialize::Encodable<E>,
+            {
+                fn encode(&self, e: &mut E) {
+                    self.bound_vars().encode(e);
+                    self.as_ref().skip_binder().encode(e);
+                }
+            }
+            impl<I: Interner, D: rustc_serialize::Decoder> rustc_serialize::Decodable<D> for ty::Binder<I, $t>
+            where
+                $t: TypeVisitable<I> + rustc_serialize::Decodable<D>,
+                I::BoundVarKinds: rustc_serialize::Decodable<D>,
+            {
+                fn decode(decoder: &mut D) -> Self {
+                    let bound_vars = rustc_serialize::Decodable::decode(decoder);
+                    ty::Binder::bind_with_vars(rustc_serialize::Decodable::decode(decoder), bound_vars)
+                }
+            }
+        )*
+    }
+}
+
+impl_binder_encode_decode! {
+    ty::FnSig<I>,
+    ty::FnSigTys<I>,
+    ty::TraitPredicate<I>,
+    ty::ExistentialPredicate<I>,
+    ty::TraitRef<I>,
+    ty::ExistentialTraitRef<I>,
+    ty::HostEffectPredicate<I>,
+}
+
+impl<T: GenericArgs<I>, I: Interner<GenericArgs = T>, E: Encoder> Encodable<E> for ty::Binder<I, T>
+where
+    T: Encodable<E>,
+    I::BoundVarKinds: Encodable<E>,
+{
+    fn encode(&self, e: &mut E) {
+        self.bound_vars().encode(e);
+        self.as_ref().skip_binder().encode(e);
+    }
+}
+
+impl<T: GenericArgs<I>, I: Interner<GenericArgs = T>, D: Decoder> Decodable<D> for ty::Binder<I, T>
+where
+    T: TypeVisitable<I> + Decodable<D>,
+    I::BoundVarKinds: Decodable<D>,
+{
+    fn decode(decoder: &mut D) -> Self {
+        let bound_vars = Decodable::decode(decoder);
+        ty::Binder::bind_with_vars(Decodable::decode(decoder), bound_vars)
+    }
+}
+
+impl<I: Interner, E: Encoder> Encodable<E> for UnsafeBinderInner<I>
+where
+    I::Ty: Encodable<E>,
+    I::BoundVarKinds: Encodable<E>,
+{
+    fn encode(&self, e: &mut E) {
+        self.bound_vars().encode(e);
+        self.as_ref().skip_binder().encode(e);
+    }
+}
+
+impl<I: Interner, D: Decoder> Decodable<D> for UnsafeBinderInner<I>
+where
+    I::Ty: TypeVisitable<I> + Decodable<D>,
+    I::BoundVarKinds: Decodable<D>,
+{
+    fn decode(decoder: &mut D) -> Self {
+        let bound_vars = Decodable::decode(decoder);
+        ty::Binder::bind_with_vars(Decodable::decode(decoder), bound_vars).into()
+    }
+}
+
+impl<I: Interner, E: Encoder> Encodable<E> for Region<I>
+where
+    RegionKind<I>: Encodable<E>,
+{
+    fn encode(&self, e: &mut E) {
+        self.kind().encode(e);
+    }
+}
+
+// Decoding a region needs an interner so it can decode a RegionKind and
+// re-intern it.
+impl<I: Interner, D: InternerDecoder<Interner = I>> Decodable<D> for Region<I>
+where
+    RegionKind<I>: Decodable<D>,
+{
+    fn decode(decoder: &mut D) -> Self {
+        decoder.interner().intern_region(Decodable::decode(decoder))
+    }
+}

--- a/compiler/rustc_type_ir/src/sty/mod.rs
+++ b/compiler/rustc_type_ir/src/sty/mod.rs
@@ -1,0 +1,191 @@
+use std::fmt;
+
+use derive_where::derive_where;
+#[cfg(feature = "nightly")]
+use rustc_data_structures::intern::Interned;
+#[cfg(feature = "nightly")]
+use rustc_macros::HashStable_NoContext;
+#[cfg(feature = "nightly")]
+use rustc_serialize::{Decodable, Encodable};
+use tracing::debug;
+
+use crate::inherent::*;
+use crate::relate::{Relate, RelateResult, TypeRelation};
+use crate::{
+    BoundRegion, BoundRegionKind, BoundVar, BoundVarIndexKind, DebruijnIndex, FallibleTypeFolder,
+    Flags, Interner, PlaceholderRegion, RegionKind, TypeFlags, TypeFoldable, TypeFolder,
+    TypeVisitable, TypeVisitor,
+};
+
+/// Use this rather than `RegionKind`, whenever possible.
+#[derive_where(Clone, Copy, PartialEq, Eq, Hash; I: Interner)]
+#[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+#[cfg_attr(feature = "nightly", rustc_pass_by_value)]
+pub struct Region<I: Interner>(pub I::InternedRegionKind);
+
+// These are only the `inherent` trait methods that have been ported across
+impl<I: Interner> Region<I> {
+    #[inline]
+    pub fn new_bound(interner: I, debruijn: DebruijnIndex, bound_region: BoundRegion<I>) -> Self {
+        interner.intern_bound_region(debruijn, bound_region)
+    }
+
+    #[inline]
+    pub fn new_anon_bound(interner: I, debruijn: DebruijnIndex, var: BoundVar) -> Self {
+        Self::new_bound(interner, debruijn, BoundRegion { var, kind: BoundRegionKind::Anon })
+    }
+
+    #[inline]
+    pub fn new_canonical_bound(interner: I, var: BoundVar) -> Self {
+        interner.intern_canonical_bound(var)
+    }
+
+    #[inline]
+    pub fn new_placeholder(interner: I, placeholder: PlaceholderRegion<I>) -> Self {
+        interner.intern_region(RegionKind::RePlaceholder(placeholder))
+    }
+
+    #[inline]
+    pub fn new_static(interner: I) -> Self {
+        interner.get_re_static_lifetime()
+    }
+
+    #[inline]
+    pub fn is_bound(self) -> bool {
+        matches!(self.0.kind(), RegionKind::ReBound(..))
+    }
+
+    #[inline]
+    pub fn type_flags(self) -> TypeFlags {
+        let mut flags = TypeFlags::empty();
+
+        match self.0.kind() {
+            RegionKind::ReVar(..) => {
+                flags = flags | TypeFlags::HAS_FREE_REGIONS;
+                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
+                flags = flags | TypeFlags::HAS_RE_INFER;
+            }
+            RegionKind::RePlaceholder(..) => {
+                flags = flags | TypeFlags::HAS_FREE_REGIONS;
+                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
+                flags = flags | TypeFlags::HAS_RE_PLACEHOLDER;
+            }
+            RegionKind::ReEarlyParam(..) => {
+                flags = flags | TypeFlags::HAS_FREE_REGIONS;
+                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
+                flags = flags | TypeFlags::HAS_RE_PARAM;
+            }
+            RegionKind::ReLateParam { .. } => {
+                flags = flags | TypeFlags::HAS_FREE_REGIONS;
+                flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
+            }
+            RegionKind::ReStatic => {
+                flags = flags | TypeFlags::HAS_FREE_REGIONS;
+            }
+            RegionKind::ReBound(BoundVarIndexKind::Canonical, _) => {
+                flags = flags | TypeFlags::HAS_RE_BOUND;
+                flags = flags | TypeFlags::HAS_CANONICAL_BOUND;
+            }
+            RegionKind::ReBound(BoundVarIndexKind::Bound(..), _) => {
+                flags = flags | TypeFlags::HAS_RE_BOUND;
+            }
+            RegionKind::ReErased => {
+                flags = flags | TypeFlags::HAS_RE_ERASED;
+            }
+            RegionKind::ReError(_) => {
+                flags = flags | TypeFlags::HAS_FREE_REGIONS;
+                flags = flags | TypeFlags::HAS_RE_ERROR;
+            }
+        }
+        debug!("type_flags({:?}) = {:?}", self, flags);
+
+        flags
+    }
+
+    #[inline]
+    pub fn kind(self) -> RegionKind<I> {
+        self.0.kind()
+    }
+}
+
+impl<I: Interner> Flags for Region<I> {
+    fn flags(&self) -> TypeFlags {
+        self.type_flags()
+    }
+
+    fn outer_exclusive_binder(&self) -> DebruijnIndex {
+        match self.kind() {
+            RegionKind::ReBound(BoundVarIndexKind::Bound(debruijn), _) => debruijn.shifted_in(1),
+            _ => crate::INNERMOST,
+        }
+    }
+}
+
+impl<I: Interner> IntoKind for Region<I> {
+    type Kind = RegionKind<I>;
+
+    fn kind(self) -> Self::Kind {
+        self.0.kind()
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<'tcx, T: Copy> IntoKind for Interned<'tcx, T> {
+    type Kind = T;
+
+    fn kind(self) -> Self::Kind {
+        *self.0
+    }
+}
+
+impl<I: Interner> Relate<I> for Region<I> {
+    fn relate<R: TypeRelation<I>>(
+        relation: &mut R,
+        a: Region<I>,
+        b: Region<I>,
+    ) -> RelateResult<I, Region<I>> {
+        relation.regions(a, b)
+    }
+}
+
+impl<I: Interner> fmt::Debug for Region<I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.kind())
+    }
+}
+
+impl<I: Interner> TypeVisitable<I> for Region<I> {
+    fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> V::Result {
+        visitor.visit_region(*self)
+    }
+}
+
+impl<I: Interner> TypeFoldable<I> for Region<I> {
+    fn try_fold_with<F: FallibleTypeFolder<I>>(self, folder: &mut F) -> Result<Self, F::Error> {
+        folder.try_fold_region(self)
+    }
+
+    fn fold_with<F: TypeFolder<I>>(self, folder: &mut F) -> Self {
+        folder.fold_region(self)
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<I: Interner, E: rustc_serialize::Encoder> Encodable<E> for Region<I>
+where
+    RegionKind<I>: Encodable<E>,
+{
+    fn encode(&self, e: &mut E) {
+        self.kind().encode(e);
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<I: Interner, D: crate::InternerDecoder<Interner = I>> Decodable<D> for Region<I>
+where
+    RegionKind<I>: Decodable<D>,
+{
+    fn decode(decoder: &mut D) -> Self {
+        decoder.interner().intern_region(Decodable::decode(decoder))
+    }
+}

--- a/compiler/rustc_type_ir/src/sty/mod.rs
+++ b/compiler/rustc_type_ir/src/sty/mod.rs
@@ -2,14 +2,12 @@ use std::fmt;
 
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
-use rustc_data_structures::intern::Interned;
-#[cfg(feature = "nightly")]
-use rustc_macros::HashStable_NoContext;
-#[cfg(feature = "nightly")]
-use rustc_serialize::{Decodable, Encodable};
+use rustc_macros::StableHash_NoContext;
+use rustc_type_ir_macros::{GenericTypeVisitable, Lift_Generic};
 use tracing::debug;
 
 use crate::inherent::*;
+use crate::intern::Interned;
 use crate::relate::{Relate, RelateResult, TypeRelation};
 use crate::{
     BoundRegion, BoundRegionKind, BoundVar, BoundVarIndexKind, DebruijnIndex, FallibleTypeFolder,
@@ -19,8 +17,9 @@ use crate::{
 
 /// Use this rather than `RegionKind`, whenever possible.
 #[derive_where(Clone, Copy, PartialEq, Eq, Hash; I: Interner)]
-#[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+#[cfg_attr(feature = "nightly", derive(StableHash_NoContext))]
 #[cfg_attr(feature = "nightly", rustc_pass_by_value)]
+#[derive(GenericTypeVisitable, Lift_Generic)]
 pub struct Region<I: Interner>(pub I::InternedRegionKind);
 
 // These are only the `inherent` trait methods that have been ported across
@@ -52,14 +51,16 @@ impl<I: Interner> Region<I> {
 
     #[inline]
     pub fn is_bound(self) -> bool {
-        matches!(self.0.kind(), RegionKind::ReBound(..))
+        matches!(self.0.get(), RegionKind::ReBound(..))
     }
 
+    // FIXME this should be made private and instead accessed via the
+    // trait Flags
     #[inline]
     pub fn type_flags(self) -> TypeFlags {
         let mut flags = TypeFlags::empty();
 
-        match self.0.kind() {
+        match self.0.get() {
             RegionKind::ReVar(..) => {
                 flags = flags | TypeFlags::HAS_FREE_REGIONS;
                 flags = flags | TypeFlags::HAS_FREE_LOCAL_REGIONS;
@@ -104,7 +105,7 @@ impl<I: Interner> Region<I> {
 
     #[inline]
     pub fn kind(self) -> RegionKind<I> {
-        self.0.kind()
+        self.0.get()
     }
 }
 
@@ -125,16 +126,7 @@ impl<I: Interner> IntoKind for Region<I> {
     type Kind = RegionKind<I>;
 
     fn kind(self) -> Self::Kind {
-        self.0.kind()
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<'tcx, T: Copy> IntoKind for Interned<'tcx, T> {
-    type Kind = T;
-
-    fn kind(self) -> Self::Kind {
-        *self.0
+        self.0.get()
     }
 }
 
@@ -167,25 +159,5 @@ impl<I: Interner> TypeFoldable<I> for Region<I> {
 
     fn fold_with<F: TypeFolder<I>>(self, folder: &mut F) -> Self {
         folder.fold_region(self)
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<I: Interner, E: rustc_serialize::Encoder> Encodable<E> for Region<I>
-where
-    RegionKind<I>: Encodable<E>,
-{
-    fn encode(&self, e: &mut E) {
-        self.kind().encode(e);
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<I: Interner, D: crate::InternerDecoder<Interner = I>> Decodable<D> for Region<I>
-where
-    RegionKind<I>: Decodable<D>,
-{
-    fn decode(decoder: &mut D) -> Self {
-        decoder.interner().intern_region(Decodable::decode(decoder))
     }
 }

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -18,11 +18,9 @@ use self::TyKind::*;
 pub use self::closure::*;
 use crate::inherent::*;
 use crate::ty::AliasTy;
-#[cfg(feature = "nightly")]
-use crate::visit::TypeVisitable;
 use crate::{
     self as ty, BoundVarIndexKind, FloatTy, FreeAliasTy, InherentAliasTy, IntTy, Interner,
-    OpaqueAliasTy, ProjectionAliasTy, UintTy, Unnormalized,
+    OpaqueAliasTy, ProjectionAliasTy, Region, UintTy, Unnormalized,
 };
 
 mod closure;
@@ -198,7 +196,7 @@ pub enum TyKind<I: Interner> {
 
     /// A reference; a pointer with an associated lifetime. Written as
     /// `&'a mut T` or `&'a T`.
-    Ref(I::Region, I::Ty, Mutability),
+    Ref(Region<I>, I::Ty, Mutability),
 
     /// The anonymous type of a function declaration/definition.
     ///
@@ -242,7 +240,7 @@ pub enum TyKind<I: Interner> {
     UnsafeBinder(UnsafeBinderInner<I>),
 
     /// A trait object. Written as `dyn for<'b> Trait<'b, Assoc = u32> + Send + 'a`.
-    Dynamic(I::BoundExistentialPredicates, I::Region),
+    Dynamic(I::BoundExistentialPredicates, Region<I>),
 
     /// The anonymous type of a closure. Used to represent the type of `|a| a`.
     ///
@@ -1296,35 +1294,6 @@ impl<I: Interner> Deref for UnsafeBinderInner<I> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<I: Interner, E: rustc_serialize::Encoder> rustc_serialize::Encodable<E>
-    for UnsafeBinderInner<I>
-where
-    I::Ty: rustc_serialize::Encodable<E>,
-    I::BoundVarKinds: rustc_serialize::Encodable<E>,
-{
-    fn encode(&self, e: &mut E) {
-        self.bound_vars().encode(e);
-        self.as_ref().skip_binder().encode(e);
-    }
-}
-
-#[cfg(feature = "nightly")]
-impl<I: Interner, D: rustc_serialize::Decoder> rustc_serialize::Decodable<D>
-    for UnsafeBinderInner<I>
-where
-    I::Ty: TypeVisitable<I> + rustc_serialize::Decodable<D>,
-    I::BoundVarKinds: rustc_serialize::Decodable<D>,
-{
-    fn decode(decoder: &mut D) -> Self {
-        let bound_vars = rustc_serialize::Decodable::decode(decoder);
-        UnsafeBinderInner(ty::Binder::bind_with_vars(
-            rustc_serialize::Decodable::decode(decoder),
-            bound_vars,
-        ))
     }
 }
 

--- a/compiler/rustc_type_ir/src/ty_kind/closure.rs
+++ b/compiler/rustc_type_ir/src/ty_kind/closure.rs
@@ -9,7 +9,7 @@ use crate::data_structures::DelayedMap;
 use crate::fold::{TypeFoldable, TypeFolder, TypeSuperFoldable, shift_region};
 use crate::inherent::*;
 use crate::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor};
-use crate::{self as ty, FnSigKind, Interner};
+use crate::{self as ty, FnSigKind, Interner, Region};
 
 /// A closure can be modeled as a struct that looks like:
 /// ```ignore (illustrative)
@@ -343,7 +343,7 @@ impl<I: Interner> TypeVisitor<I> for HasRegionsBoundAt {
         ControlFlow::Continue(())
     }
 
-    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, r: Region<I>) -> Self::Result {
         if matches!(r.kind(), ty::ReBound(ty::BoundVarIndexKind::Bound(binder), _) if self.binder == binder)
         {
             ControlFlow::Break(())
@@ -415,7 +415,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
         parent_args: I::GenericArgsSlice,
         coroutine_def_id: I::CoroutineId,
         goal_kind: ty::ClosureKind,
-        env_region: I::Region,
+        env_region: Region<I>,
         closure_tupled_upvars_ty: I::Ty,
         coroutine_captures_by_ref_ty: I::Ty,
     ) -> I::Ty {
@@ -452,7 +452,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
         tupled_inputs_ty: I::Ty,
         closure_tupled_upvars_ty: I::Ty,
         coroutine_captures_by_ref_ty: I::Ty,
-        env_region: I::Region,
+        env_region: Region<I>,
     ) -> I::Ty {
         // If either of the tupled capture types are constrained to error
         // (e.g. during typeck when the infcx is tainted), then just return
@@ -500,7 +500,7 @@ impl<I: Interner> CoroutineClosureSignature<I> {
 struct FoldEscapingRegions<I: Interner> {
     interner: I,
     debruijn: ty::DebruijnIndex,
-    region: I::Region,
+    region: Region<I>,
 
     // Depends on `debruijn` because we may have types with regions of different
     // debruijn depths depending on the binders we've entered.
@@ -534,7 +534,7 @@ impl<I: Interner> TypeFolder<I> for FoldEscapingRegions<I> {
         result
     }
 
-    fn fold_region(&mut self, r: <I as Interner>::Region) -> <I as Interner>::Region {
+    fn fold_region(&mut self, r: Region<I>) -> Region<I> {
         if let ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) = r.kind() {
             assert!(
                 debruijn <= self.debruijn,

--- a/compiler/rustc_type_ir/src/universe.rs
+++ b/compiler/rustc_type_ir/src/universe.rs
@@ -4,7 +4,7 @@ use crate::data_structures::HashSet;
 use crate::inherent::*;
 use crate::visit::TypeVisitableExt;
 use crate::{
-    ConstKind, InferCtxtLike, InferTy, Interner, RegionKind, TyKind, TypeFoldable,
+    ConstKind, InferCtxtLike, InferTy, Interner, Region, RegionKind, TyKind, TypeFoldable,
     TypeSuperVisitable, TypeVisitable, TypeVisitor, UniverseIndex,
 };
 
@@ -148,7 +148,7 @@ impl<
         }
     }
 
-    fn visit_region(&mut self, r: I::Region) {
+    fn visit_region(&mut self, r: Region<I>) {
         match r.kind() {
             RegionKind::RePlaceholder(p) if VISIT_PLACEHOLDER => {
                 self.max_universe = self.max_universe.max(p.universe)

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -52,7 +52,7 @@ use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
 use crate::inherent::*;
-use crate::{self as ty, Interner, TypeFlags};
+use crate::{self as ty, Interner, Region, TypeFlags};
 
 /// This trait is implemented for every type that can be visited,
 /// providing the skeleton of the traversal.
@@ -104,7 +104,7 @@ pub trait TypeVisitor<I: Interner>: Sized {
 
     // `Region` is non-recursive so the default region visitor has no
     // `super_visit_with` method to call.
-    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, r: Region<I>) -> Self::Result {
         if let ty::ReError(guar) = r.kind() {
             self.visit_error(guar)
         } else {
@@ -465,7 +465,7 @@ impl<I: Interner> TypeVisitor<I> for HasTypeFlagsVisitor {
     }
 
     #[inline]
-    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, r: Region<I>) -> Self::Result {
         // Note: no `super_visit_with` call, as usual for `Region`.
         if r.flags().intersects(self.flags) {
             ControlFlow::Break(FoundFlags)
@@ -572,7 +572,7 @@ impl<I: Interner> TypeVisitor<I> for HasEscapingVarsVisitor {
     }
 
     #[inline]
-    fn visit_region(&mut self, r: I::Region) -> Self::Result {
+    fn visit_region(&mut self, r: Region<I>) -> Self::Result {
         // If the region is bound by `outer_index` or anything outside
         // of outer index, then it escapes the binders we have
         // visited.

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir as hir;
 use rustc_infer::infer::region_constraints::{ConstraintKind, RegionConstraintData};
 use rustc_middle::bug;
-use rustc_middle::ty::{self, Region, Ty, fold_regions};
+use rustc_middle::ty::{self, Region, RegionUtilitiesExt, Ty, fold_regions};
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::{Symbol, kw};
 use rustc_trait_selection::traits::auto_trait::{self, RegionTarget};

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -47,7 +47,8 @@ use rustc_hir_analysis::{lower_const_arg_for_rustdoc, lower_ty};
 use rustc_middle::metadata::Reexport;
 use rustc_middle::middle::resolve_bound_vars as rbv;
 use rustc_middle::ty::{
-    self, AdtKind, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
+    self, AdtKind, GenericArgsRef, RegionUtilitiesExt, Ty, TyCtxt, TypeVisitableExt, TypingMode,
+    Unnormalized,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::ExpnKind;

--- a/src/tools/clippy/clippy_lints/src/eta_reduction.rs
+++ b/src/tools/clippy/clippy_lints/src/eta_reduction.rs
@@ -10,6 +10,7 @@ use rustc_infer::infer::TyCtxtInferExt;
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::adjustment::{Adjust, DerefAdjustKind};
 use rustc_middle::ty::{
+    RegionUtilitiesExt,
     self, Binder, ClosureKind, FnSig, GenericArg, GenericArgKind, List, Region, Ty, TypeVisitableExt, TypeckResults,
 };
 use rustc_session::declare_lint_pass;

--- a/src/tools/clippy/clippy_lints/src/operators/identity_op.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/identity_op.rs
@@ -7,6 +7,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{BinOpKind, Expr, ExprKind, Node, Path, QPath};
 use rustc_lint::LateContext;
 use rustc_middle::ty;
+use rustc_middle::ty::RegionUtilitiesExt;
 use rustc_span::{Span, SyntaxContext, kw};
 
 use super::IDENTITY_OP;

--- a/src/tools/clippy/clippy_lints/src/returns/let_and_return.rs
+++ b/src/tools/clippy/clippy_lints/src/returns/let_and_return.rs
@@ -8,7 +8,7 @@ use core::ops::ControlFlow;
 use rustc_errors::Applicability;
 use rustc_hir::{Block, Expr, PatKind, StmtKind};
 use rustc_lint::{LateContext, LintContext};
-use rustc_middle::ty::GenericArgKind;
+use rustc_middle::ty::{GenericArgKind, RegionUtilitiesExt};
 use rustc_span::edition::Edition;
 
 use super::LET_AND_RETURN;

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -108,6 +108,7 @@ use rustc_middle::mir::{AggregateKind, Operand, RETURN_PLACE, Rvalue, StatementK
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, DerefAdjustKind, PointerCoercion};
 use rustc_middle::ty::layout::IntegerExt;
 use rustc_middle::ty::{
+    RegionUtilitiesExt,
     self as rustc_ty, Binder, BorrowKind, ClosureKind, EarlyBinder, GenericArgKind, GenericArgsRef, IntTy, Ty, TyCtxt,
     TypeFlags, TypeVisitableExt, TypeckResults, UintTy, UpvarCapture,
 };


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154989)*
<!-- homu-ignore:end -->

## General notes
Probably best reviewed commit by commit. I've tried where to make the changes as isolated as possible.
- For the `pub struct Region` if we use `Interned<...>` in the definition then we'd need to add a lifetime to the `Interner` trait. As such I opted for a type `InternedRegionKind` which is `Interned<'tcx, RegionKind<'tcx>>` in the implementation. To allow calling the `kind()` method I implemented `inherent::IntoKind` for `Interned<'tcx, T>`.
- All methods from the `Region` trait in `inherent` have been moved to `compiler/rustc_type_ir/src/sty/mod.rs`.
- Had to implement `Lift` manually for `Interned<RegionKind>` (`I::InternedRegionKind`) which is a no-op.
- I'm not sure the implementation of `kind()` is correct or even should be implemented for `Interned<...>`?
- Add a small abstraction needed for decode to still re-intern `Region` and moved this along with other `encode/decode` implementations into a `serialize` file.
```
error[E0210]: type parameter `E` must be used as the type parameter for some local type (e.g., `MyStruct<E>`)
   --> compiler/rustc_middle/src/ty/codec.rs:162:12
    |
162 | impl<'tcx, E: TyEncoder<'tcx>> Encodable<E> for ty::Region<'tcx> {
    |            ^ type parameter `E` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter

error[E0210]: type parameter `D` must be used as the type parameter for some local type (e.g., `MyStruct<D>`)
   --> compiler/rustc_middle/src/ty/codec.rs:301:12
    |
301 | impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Region<'tcx> {
    |            ^ type parameter `D` must be used as the type parameter for some local type
    |
    = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
```

## `compiler/rustc_middle/src/ty/region.rs`
Generally anything that needed to access fields on `TyCtxt` have been made methods on the interner.
- `interner.lifetimes.anon_re_bounds.get(debruijn.as_usize())` for getting an interned lifetime, is now a trait method on `Interner`; `fn get_anon_re_bounds_lifetime(...)`
- `fn intern_region(...)` now a trait method on `Interner`
- `interner.lifetimes.anon_re_canonical_bounds.get(debruijn.as_usize())` required
   for `fn new_canonical_bound(...)`. Is now `fn get_anon_re_canonical_bounds_lifetime(...)`
- `interner.lifetimes.re_static` has become `fn get_re_static_lifetime()` for method `fn new_static((..)`

r? @lcnr