### PR TITLE
Support creating default Vec within a custom allocator

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -4256,12 +4256,15 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default", issue = "143894")]
-impl<T> const Default for Vec<T> {
-    /// Creates an empty `Vec<T>`.
+impl<T, A> const Default for Vec<T, A>
+where
+    A: Allocator + [const] Default,
+{
+    /// Creates an empty `Vec<T>` in the allocator `A`.
     ///
     /// The vector will not allocate until elements are pushed onto it.
-    fn default() -> Vec<T> {
-        Vec::new()
+    fn default() -> Self {
+        Vec::new_in(A::default())
     }
 }
 

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -41,6 +41,7 @@
 #![feature(macro_metavar_expr_concat)]
 #![feature(vec_peek_mut)]
 #![feature(vec_try_remove)]
+#![feature(const_default)]
 #![allow(internal_features)]
 #![deny(fuzzy_provenance_casts)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/library/alloctests/tests/vec.rs
+++ b/library/alloctests/tests/vec.rs
@@ -1105,6 +1105,33 @@ fn test_into_iter_drop_allocator() {
 }
 
 #[test]
+fn test_default_vec_in_custom_allocator() {
+    struct ReferenceCountedAllocator;
+
+    impl const Default for ReferenceCountedAllocator {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+
+    unsafe impl Allocator for ReferenceCountedAllocator {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
+            System.allocate(layout)
+        }
+
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            // Safety: Invariants passed to caller.
+            unsafe { System.deallocate(ptr, layout) }
+        }
+    }
+
+    let mut vec = Vec::<i32, ReferenceCountedAllocator>::default();
+
+    vec.push(10);
+    assert_eq!(vec.len(), 1);
+}
+
+#[test]
 fn test_into_iter_zst() {
     #[derive(Debug, Clone)]
     struct AlignedZstWithDrop([u64; 0]);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds support for calling `Default::default` for some `Vec<T, A>` as long as the `A` also implements `Default`. 