### PR TITLE
Fix ICE in next-solver TransmuteFrom candidate

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -665,6 +665,12 @@ where
             return Err(NoSolution);
         }
 
+        // Match the old solver by treating unresolved inference variables as
+        // ambiguous until `rustc_transmute` can compute their layout.
+        if goal.has_non_region_infer() {
+            return ecx.forced_ambiguity(MaybeCause::Ambiguity);
+        }
+
         ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {
             let assume = ecx.structurally_normalize_const(
                 goal.param_env,

--- a/tests/ui/traits/next-solver/transmute-from-async-closure.rs
+++ b/tests/ui/traits/next-solver/transmute-from-async-closure.rs
@@ -1,0 +1,22 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/153370>.
+
+//@ edition:2024
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(transmutability)]
+
+trait NodeImpl {}
+struct Wrap<F, P>(F, P);
+impl<F, P> Wrap<F, P> {
+    fn new(_: F) -> Self {
+        loop {}
+    }
+}
+
+impl<F, A> NodeImpl for Wrap<F, (A,)> where F: std::mem::TransmuteFrom<()> {}
+fn trigger_ice() {
+    let _: &dyn NodeImpl = &Wrap::<_, (i128,)>::new(async |_: &(), i128| 0);
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/transmute-from-async-closure.stderr
+++ b/tests/ui/traits/next-solver/transmute-from-async-closure.stderr
@@ -1,0 +1,23 @@
+error[E0283]: type annotations needed
+  --> $DIR/transmute-from-async-closure.rs:18:29
+   |
+LL |     let _: &dyn NodeImpl = &Wrap::<_, (i128,)>::new(async |_: &(), i128| 0);
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `F` declared on the struct `Wrap`
+   |
+   = note: cannot satisfy `{async closure@$DIR/transmute-from-async-closure.rs:18:53: 18:73}: TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>`
+note: required for `Wrap<{async closure@$DIR/transmute-from-async-closure.rs:18:53: 18:73}, (i128,)>` to implement `NodeImpl`
+  --> $DIR/transmute-from-async-closure.rs:16:12
+   |
+LL | impl<F, A> NodeImpl for Wrap<F, (A,)> where F: std::mem::TransmuteFrom<()> {}
+   |            ^^^^^^^^     ^^^^^^^^^^^^^          --------------------------- unsatisfied trait bound introduced here
+note: required because it appears within the type `Wrap<{async closure@$DIR/transmute-from-async-closure.rs:18:53: 18:73}, (i128,)>`
+  --> $DIR/transmute-from-async-closure.rs:9:8
+   |
+LL | struct Wrap<F, P>(F, P);
+   |        ^^^^
+   = note: required for `&Wrap<{async closure@$DIR/transmute-from-async-closure.rs:18:53: 18:73}, (i128,)>` to implement `CoerceUnsized<&dyn NodeImpl>`
+   = note: required for the cast from `&Wrap<{async closure@$DIR/transmute-from-async-closure.rs:18:53: 18:73}, (i128,)>` to `&dyn NodeImpl`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
Treat TransmuteFrom goals with non-region inference variables as ambiguous before running transmutability, matching the old solver.

Closes rust-lang/rust#153370 .

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
