### PR TITLE
Error on projection of dyn noncompat type in old trait solver

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -709,6 +709,11 @@ fn project<'cx, 'tcx>(
     if let ty::Dynamic(data, ..) = self_ty.kind() {
         if let Some(def_id) = data.principal_def_id() {
             let tcx = selcx.tcx();
+            // Delaying a bug is fine here:
+            // - In case of a dymmy span, we are in a canonical query.
+            // - `CheckAssociatedTypeBounds` means that the trait object is part of the trait's item bounds
+            //   or the impl's associated type; both are checked at their own definition
+            //   where the error is already reported with a better span.
             if !tcx.is_dyn_compatible(def_id) {
                 let span = obligation.cause.span;
                 let guar = if span.is_dummy()

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -27,6 +27,7 @@ use super::{
     SelectionError, specialization_graph, translate_args, util,
 };
 use crate::diagnostics::InherentProjectionNormalizationOverflow;
+use crate::error_reporting::traits::report_dyn_incompatibility;
 use crate::infer::{BoundRegionConversionTime, InferOk};
 use crate::traits::normalize::{normalize_with_depth, normalize_with_depth_to};
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
@@ -702,6 +703,35 @@ fn project<'cx, 'tcx>(
         )));
     }
 
+    // `<dyn Trait>::Name` is only valid when `Trait` is dyn-compatible.
+    // If it isn't, create an error at the projection site and return a tainted error term.
+    let self_ty = selcx.infcx.shallow_resolve(obligation.predicate.self_ty());
+    if let ty::Dynamic(data, ..) = self_ty.kind() {
+        if let Some(def_id) = data.principal_def_id() {
+            let tcx = selcx.tcx();
+            if !tcx.is_dyn_compatible(def_id) {
+                let span = obligation.cause.span;
+                let guar = if !span.is_dummy() {
+                    let violations = tcx.dyn_compatibility_violations(def_id);
+                    report_dyn_incompatibility(tcx, span, None, def_id, &violations).emit()
+                } else {
+                    tcx.dcx().span_delayed_bug(
+                        span,
+                        format!(
+                            "projection from non-dyn-compatible trait `{}`",
+                            tcx.def_path_str(def_id)
+                        ),
+                    )
+                };
+                return Ok(Projected::Progress(Progress::error_for_term(
+                    tcx,
+                    obligation.predicate,
+                    guar,
+                )));
+            }
+        }
+    }
+
     let mut candidates = ProjectionCandidateSet::None;
 
     // Make sure that the following procedures are kept in order. ParamEnv
@@ -852,7 +882,7 @@ fn assemble_candidates_from_object_ty<'cx, 'tcx>(
         return;
     }
 
-    let env_clauses = data
+    let env_predicates = data
         .projection_bounds()
         .filter(|bound| bound.item_def_id() == obligation.predicate.expect_projection_def_id())
         .map(|p| p.with_self_ty(tcx, object_ty).upcast(tcx));
@@ -862,7 +892,7 @@ fn assemble_candidates_from_object_ty<'cx, 'tcx>(
         obligation,
         candidate_set,
         ProjectionCandidate::Object,
-        env_clauses,
+        env_predicates,
         false,
     );
 }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -711,10 +711,11 @@ fn project<'cx, 'tcx>(
             let tcx = selcx.tcx();
             if !tcx.is_dyn_compatible(def_id) {
                 let span = obligation.cause.span;
-                let guar = if !span.is_dummy() {
-                    let violations = tcx.dyn_compatibility_violations(def_id);
-                    report_dyn_incompatibility(tcx, span, None, def_id, &violations).emit()
-                } else {
+                let guar = if span.is_dummy()
+                    || matches!(
+                        obligation.cause.code(),
+                        ObligationCauseCode::CheckAssociatedTypeBounds { .. }
+                    ) {
                     tcx.dcx().span_delayed_bug(
                         span,
                         format!(
@@ -722,6 +723,9 @@ fn project<'cx, 'tcx>(
                             tcx.def_path_str(def_id)
                         ),
                     )
+                } else {
+                    let violations = tcx.dyn_compatibility_violations(def_id);
+                    report_dyn_incompatibility(tcx, span, None, def_id, &violations).emit()
                 };
                 return Ok(Projected::Progress(Progress::error_for_term(
                     tcx,

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -846,6 +846,12 @@ fn assemble_candidates_from_object_ty<'cx, 'tcx>(
         }
         _ => return,
     };
+
+    // Projecting `dyn Trait` is only valid when `Trait` is dyn-compatible.
+    if data.principal_def_id().is_some_and(|def_id| !tcx.is_dyn_compatible(def_id)) {
+        return;
+    }
+
     let env_clauses = data
         .projection_bounds()
         .filter(|bound| bound.item_def_id() == obligation.predicate.expect_projection_def_id())

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
@@ -12,7 +12,7 @@ trait Foo: Deref<Target = W> {
 fn test(x: &dyn Foo) {
     //~^ ERROR the trait `Foo` is not dyn compatible
     x.method();
-    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~^ ERROR no method named `method` found for reference `&dyn Foo`
 }
 
 fn main() {}

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.rs
@@ -12,7 +12,6 @@ trait Foo: Deref<Target = W> {
 fn test(x: &dyn Foo) {
     //~^ ERROR the trait `Foo` is not dyn compatible
     x.method();
-    //~^ ERROR no method named `method` found for reference `&dyn Foo`
 }
 
 fn main() {}

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -25,25 +25,16 @@ LL |     fn method(self: &W) {}
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0038]: the trait `Foo` is not dyn compatible
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:5
+error[E0599]: no method named `method` found for reference `&dyn Foo` in the current scope
+  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:7
    |
 LL |     fn method(self: &W) {}
-   |                     -- help: consider changing method `method`'s `self` parameter to be `&self`: `&Self`
+   |                     -- the method might not be found because of this arbitrary self type
 ...
 LL |     x.method();
-   |     ^^^^^^^^^^ `Foo` is not dyn compatible
-   |
-note: for a trait to be dyn compatible it needs to allow building a vtable
-      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:8:21
-   |
-LL | trait Foo: Deref<Target = W> {
-   |       --- this trait is not dyn compatible...
-LL |     fn method(self: &W) {}
-   |                     ^^ ...because method `method`'s `self` parameter cannot be dispatched on
+   |       ^^^^^^ method not found in `&dyn Foo`
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0038, E0307.
+Some errors have detailed explanations: E0038, E0307, E0599.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
+++ b/tests/ui/self/dispatch-dyn-incompatible-that-does-not-deref.stderr
@@ -25,16 +25,7 @@ LL |     fn method(self: &W) {}
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0599]: no method named `method` found for reference `&dyn Foo` in the current scope
-  --> $DIR/dispatch-dyn-incompatible-that-does-not-deref.rs:14:7
-   |
-LL |     fn method(self: &W) {}
-   |                     -- the method might not be found because of this arbitrary self type
-...
-LL |     x.method();
-   |       ^^^^^^ method not found in `&dyn Foo`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0038, E0307, E0599.
+Some errors have detailed explanations: E0038, E0307.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.rs
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.rs
@@ -8,7 +8,8 @@ fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
 fn raw_pointer_in(x: &dyn Pointee<Metadata = ()>) {
     //~^ ERROR the trait `Pointee` is not dyn compatible
     unknown_sized_object_ptr_in(x)
-    //~^ ERROR the trait `Pointee` is not dyn compatible
+    //~^ ERROR type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
+    //~| ERROR the trait `Pointee` is not dyn compatible
 }
 
 fn main() {

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.rs
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.rs
@@ -8,7 +8,7 @@ fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
 fn raw_pointer_in(x: &dyn Pointee<Metadata = ()>) {
     //~^ ERROR the trait `Pointee` is not dyn compatible
     unknown_sized_object_ptr_in(x)
-    //~^ ERROR type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
+    //~^ ERROR the trait `Pointee` is not dyn compatible
     //~| ERROR the trait `Pointee` is not dyn compatible
 }
 

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
@@ -10,6 +10,22 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    |
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
+error[E0271]: type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
+  --> $DIR/ice-with-dyn-pointee-errors.rs:10:33
+   |
+LL |     unknown_sized_object_ptr_in(x)
+   |     --------------------------- ^ expected `()`, found `DynMetadata<dyn Pointee<Metadata = ()>>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: expected unit type `()`
+                 found struct `DynMetadata<dyn Pointee<Metadata = ()>>`
+note: required by a bound in `unknown_sized_object_ptr_in`
+  --> $DIR/ice-with-dyn-pointee-errors.rs:6:50
+   |
+LL | fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
+   |                                                  ^^^^^^^^^^^^^ required by this bound in `unknown_sized_object_ptr_in`
+
 error[E0038]: the trait `Pointee` is not dyn compatible
   --> $DIR/ice-with-dyn-pointee-errors.rs:10:5
    |
@@ -23,7 +39,7 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
 error[E0038]: the trait `Pointee` is not dyn compatible
-  --> $DIR/ice-with-dyn-pointee-errors.rs:15:20
+  --> $DIR/ice-with-dyn-pointee-errors.rs:16:20
    |
 LL |     raw_pointer_in(&42)
    |                    ^^^ `Pointee` is not dyn compatible
@@ -34,6 +50,7 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    |
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0038`.
+Some errors have detailed explanations: E0038, E0271.
+For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
+++ b/tests/ui/traits/ice-with-dyn-pointee-errors.stderr
@@ -10,21 +10,17 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
    |
    = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
-error[E0271]: type mismatch resolving `<dyn Pointee<Metadata = ()> as Pointee>::Metadata == ()`
-  --> $DIR/ice-with-dyn-pointee-errors.rs:10:33
+error[E0038]: the trait `Pointee` is not dyn compatible
+  --> $DIR/ice-with-dyn-pointee-errors.rs:10:5
    |
 LL |     unknown_sized_object_ptr_in(x)
-   |     --------------------------- ^ expected `()`, found `DynMetadata<dyn Pointee<Metadata = ()>>`
-   |     |
-   |     required by a bound introduced by this call
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Pointee` is not dyn compatible
    |
-   = note: expected unit type `()`
-                 found struct `DynMetadata<dyn Pointee<Metadata = ()>>`
-note: required by a bound in `unknown_sized_object_ptr_in`
-  --> $DIR/ice-with-dyn-pointee-errors.rs:6:50
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $SRC_DIR/core/src/ptr/metadata.rs:LL:COL
    |
-LL | fn unknown_sized_object_ptr_in(_: &(impl Pointee<Metadata = ()> + ?Sized)) {}
-   |                                                  ^^^^^^^^^^^^^ required by this bound in `unknown_sized_object_ptr_in`
+   = note: the trait is not dyn compatible because it opted out of dyn-compatibility
 
 error[E0038]: the trait `Pointee` is not dyn compatible
   --> $DIR/ice-with-dyn-pointee-errors.rs:10:5
@@ -52,5 +48,4 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0038, E0271.
-For more information about an error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/dyn-proj-non-dyn-compat.rs
+++ b/tests/ui/traits/object/dyn-proj-non-dyn-compat.rs
@@ -1,0 +1,20 @@
+// Check that we are not producing long error messages
+
+trait Trait {
+    type Output;
+    fn process<T>(&mut self, input: T) -> T;
+}
+
+struct MyImpl;
+
+impl Trait for MyImpl {
+    type Output = &'static str;
+    fn process<T>(&mut self, input: T) -> T { input }
+}
+
+fn make() -> impl Trait<Output = <dyn Trait<Output = &'static str> as Trait>::Output> {
+    //~^ ERROR the trait `Trait` is not dyn compatible
+    MyImpl
+}
+
+fn main() {}

--- a/tests/ui/traits/object/dyn-proj-non-dyn-compat.stderr
+++ b/tests/ui/traits/object/dyn-proj-non-dyn-compat.stderr
@@ -1,0 +1,21 @@
+error[E0038]: the trait `Trait` is not dyn compatible
+  --> $DIR/dyn-proj-non-dyn-compat.rs:15:14
+   |
+LL | fn make() -> impl Trait<Output = <dyn Trait<Output = &'static str> as Trait>::Output> {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Trait` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
+  --> $DIR/dyn-proj-non-dyn-compat.rs:5:8
+   |
+LL | trait Trait {
+   |       ----- this trait is not dyn compatible...
+LL |     type Output;
+LL |     fn process<T>(&mut self, input: T) -> T;
+   |        ^^^^^^^ ...because method `process` has generic type parameters
+   = help: consider moving `process` to another trait
+   = help: only type `MyImpl` implements `Trait`; consider using it directly instead.
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/traits/object/dyn-type-param-bound-not-checked.rs
+++ b/tests/ui/traits/object/dyn-type-param-bound-not-checked.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+// Protection against a naive fix for #152607
+
+//@ revisions: current next
+
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+trait Trait<T: Sized> {}
+
+fn foo(_: &dyn Trait<[u32]>) {}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/154992)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Trying to fix https://github.com/rust-lang/trait-system-refactor-initiative/issues/269

I am not sure that the check is placed into the right place in the code.

r? lcnr