### PR TITLE
compiletest: pass -Zunstable-options for unpretty and no-codegen paths

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -452,6 +452,7 @@ impl<'test> TestCx<'test> {
         rustc
             .arg(input)
             .args(&["-Z", &format!("unpretty={}", pretty_type)])
+            .arg("-Zunstable-options")
             .args(&["--target", &self.config.target])
             .arg("-L")
             .arg(&aux_dir)
@@ -557,6 +558,7 @@ impl<'test> TestCx<'test> {
         rustc
             .arg("-")
             .arg("-Zno-codegen")
+            .arg("-Zunstable-options")
             .arg("--out-dir")
             .arg(&out_dir)
             .arg(&format!("--target={}", target))


### PR DESCRIPTION
When using custom targets via `RUST_TARGET_PATH`, compiletest does not
consistently pass `-Zunstable-options` in all code paths.

In particular, `unpretty` and `-Zno-codegen` (typecheck) paths invoke
rustc without `-Zunstable-options`, which causes failures when the
target is not built-in.

Pass `-Zunstable-options` in these code paths to ensure consistent
behavior when using custom targets.

This primarily affects setups using custom targets without `.json`
suffix (resolved via `RUST_TARGET_PATH`).