### PR TITLE
compiletest: make some internals pub for use as a library

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -235,7 +235,7 @@ impl CodegenBackend {
 /// FIXME: audit these options to make sure we are not hashing less than necessary for build stamp
 /// (for changed test detection).
 #[derive(Debug, Clone)]
-pub(crate) struct Config {
+pub struct Config {
     /// Some [`TestMode`]s support [snapshot testing], where a *reference snapshot* of outputs (of
     /// `stdout`, `stderr`, or other form of artifacts) can be compared to the *actual output*.
     ///
@@ -1170,7 +1170,7 @@ pub(crate) fn query_rustc_output(
 
 /// Path information for a single test file.
 #[derive(Debug, Clone)]
-pub(crate) struct TestPaths {
+pub struct TestPaths {
     /// Full path to the test file.
     ///
     /// For example:
@@ -1183,7 +1183,7 @@ pub(crate) struct TestPaths {
     ///
     /// For example:
     /// - `/home/ferris/rust/tests/run-make/emit`
-    pub(crate) file: Utf8PathBuf,
+    pub file: Utf8PathBuf,
 
     /// Subset of the full path that excludes the suite directory and the
     /// test filename. For tests in the root of their test suite directory,
@@ -1192,7 +1192,7 @@ pub(crate) struct TestPaths {
     /// For example:
     /// - `file`: `/home/ferris/rust/tests/ui/warnings/hello-world.rs`
     /// - `relative_dir`: `warnings`
-    pub(crate) relative_dir: Utf8PathBuf,
+    pub relative_dir: Utf8PathBuf,
 }
 
 /// Used by `ui` tests to generate things like `foo.stderr` from `foo.rs`.

--- a/src/tools/compiletest/src/executor.rs
+++ b/src/tools/compiletest/src/executor.rs
@@ -325,26 +325,26 @@ fn get_concurrency() -> usize {
 }
 
 /// Information that was historically needed to create a libtest `TestDescAndFn`.
-pub(crate) struct CollectedTest {
-    pub(crate) desc: CollectedTestDesc,
-    pub(crate) config: Arc<Config>,
-    pub(crate) testpaths: TestPaths,
-    pub(crate) revision: Option<String>,
+pub struct CollectedTest {
+    pub desc: CollectedTestDesc,
+    pub config: Arc<Config>,
+    pub testpaths: TestPaths,
+    pub revision: Option<String>,
 }
 
 /// Information that was historically needed to create a libtest `TestDesc`.
-pub(crate) struct CollectedTestDesc {
-    pub(crate) name: String,
-    pub(crate) filterable_path: Utf8PathBuf,
-    pub(crate) ignore: bool,
-    pub(crate) ignore_message: Option<Cow<'static, str>>,
-    pub(crate) should_fail: ShouldFail,
+pub struct CollectedTestDesc {
+    pub name: String,
+    pub filterable_path: Utf8PathBuf,
+    pub ignore: bool,
+    pub ignore_message: Option<Cow<'static, str>>,
+    pub should_fail: ShouldFail,
 }
 
 /// Tests with `//@ should-fail` are tests of compiletest itself, and should
 /// be reported as successful if and only if they would have _failed_.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum ShouldFail {
+pub enum ShouldFail {
     No,
     Yes,
 }

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -33,6 +33,8 @@ use std::{env, fs, vec};
 
 use build_helper::git::{get_git_modified_files, get_git_untracked_files};
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+pub use common::{Config, TestPaths};
+pub use executor::{CollectedTest, CollectedTestDesc, ShouldFail};
 use getopts::Options;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use tracing::debug;
@@ -40,19 +42,18 @@ use walkdir::WalkDir;
 
 use self::directives::{EarlyProps, make_test_description};
 use crate::common::{
-    CodegenBackend, CompareMode, Config, Debugger, PassMode, TestMode, TestPaths, UI_EXTENSIONS,
-    expected_output_path, output_base_dir, output_relative_path,
+    CodegenBackend, CompareMode, Debugger, PassMode, TestMode, UI_EXTENSIONS, expected_output_path,
+    output_base_dir, output_relative_path,
 };
 use crate::directives::{AuxProps, DirectivesCache, FileDirectives};
 use crate::edition::parse_edition;
-use crate::executor::CollectedTest;
 
 /// Creates the `Config` instance for this invocation of compiletest.
 ///
 /// The config mostly reflects command-line arguments, but there might also be
 /// some code here that inspects environment variables or even runs executables
 /// (e.g. when discovering debugger versions).
-fn parse_config(args: Vec<String>) -> Config {
+pub fn parse_config(args: Vec<String>) -> Config {
     let mut opts = Options::new();
     opts.reqopt("", "compile-lib-path", "path to host shared libraries", "PATH")
         .reqopt("", "run-lib-path", "path to target shared libraries", "PATH")
@@ -653,7 +654,7 @@ impl TestCollector {
 /// FIXME(Zalathar): Now that we no longer rely on libtest, try to overhaul
 /// test discovery to take into account the filters/tests specified on the
 /// command-line, instead of having to enumerate everything.
-fn collect_and_make_tests(config: Arc<Config>) -> Vec<CollectedTest> {
+pub fn collect_and_make_tests(config: Arc<Config>) -> Vec<CollectedTest> {
     debug!("making tests from {}", config.src_test_suite_root);
     let common_inputs_stamp = common_inputs_stamp(&config);
     let modified_tests =


### PR DESCRIPTION
Make `Config`, `TestPaths`, `CollectedTest`, `CollectedTestDesc`, `ShouldFail`, `FileDirectives`, `parse_config` and `collect_and_make_tests` public so that external tools can depend on compiletest as a library and use its test collection infrastructure directly, without re-implementing parts of bootstrap and compiletest.

r? jackh726