### PR TITLE
core/num: Fix feature name for unstable `integer_extend_truncate` functions

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3958,7 +3958,7 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -3980,7 +3980,7 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn saturating_truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4002,7 +4002,7 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn checked_truncate<Target>(self) -> Option<Target>
             where Self: [const] traits::TruncateTarget<Target>
@@ -4021,7 +4021,7 @@ macro_rules! int_impl {
         /// ```
         #[must_use = "this returns the extended value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn extend<Target>(self) -> Target
             where Self: [const] traits::ExtendTarget<Target>

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -3,7 +3,7 @@
 
 /// Trait for types that this type can be truncated to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-#[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+#[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
 pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
     fn internal_truncate(self) -> Target;
@@ -17,7 +17,7 @@ pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
 
 /// Trait for types that this type can be truncated to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-#[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+#[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
 pub const trait ExtendTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
     fn internal_extend(self) -> Target;
@@ -40,7 +40,7 @@ macro_rules! impl_truncate {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         impl const TruncateTarget<$to> for $from {
             #[inline]
             fn internal_truncate(self) -> $to {
@@ -87,7 +87,7 @@ macro_rules! impl_extend {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         impl const ExtendTarget<$to> for $from {
             fn internal_extend(self) -> $to {
                 self as _

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -4120,7 +4120,7 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4140,7 +4140,7 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn saturating_truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4160,7 +4160,7 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn checked_truncate<Target>(self) -> Option<Target>
             where Self: [const] traits::TruncateTarget<Target>
@@ -4178,7 +4178,7 @@ macro_rules! uint_impl {
         /// ```
         #[must_use = "this returns the extended value and does not modify the original"]
         #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
         #[inline]
         pub const fn extend<Target>(self) -> Target
             where Self: [const] traits::ExtendTarget<Target>


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/154330
Feature gate: `#![feature(integer_extend_truncate)]`

---

The feature name for the const unstable attribute was accidentally transposed when const traits were added in https://github.com/rust-lang/rust/pull/154356/changes/68c833906666fb428e6a32f8006f3bc8f6a7833e.
```diff
        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
+       #[rustc_const_unstable(feature = "integer_truncate_extend", issue = "154330")]
```