### PR TITLE
meta: Add checkboxes to unsresolved questions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -83,6 +83,6 @@ It's useful to link any relevant discussions and conclusions (whether on GitHub,
 Zulip, or the internals forum) here.
 -->
 
-- None yet.
+- [ ] None yet.
 
 [^1]: https://std-dev-guide.rust-lang.org/feature-lifecycle/stabilization.html

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -55,11 +55,12 @@ for larger features an implementation could be broken up into multiple PRs.
 ### Unresolved Questions
 <!--
 Include any open questions that need to be answered before the feature can be
-stabilised.
+stabilised. It is useful to link related discussions and conculsions as they
+develop.
 -->
 
-XXX --- list all the "unresolved questions" found in the RFC to ensure they are
-not forgotten
+- [ ] list all the "unresolved questions" found in the RFC to ensure they are
+  not forgotten.
 
 ### Implementation history
 


### PR DESCRIPTION
These frequently have links to comments on closed PRs, meaning it can looks like issues have been resolved even if that isn't the case. Add checkboxes to make it more clear when a conclusion has been reached.