### PR TITLE
Clarify ASCII whitespace docs in u8::is_ascii_whitespace

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1073,6 +1073,11 @@ impl u8 {
     /// "field splitting" in the Bourne shell][bfs] considers *only*
     /// SPACE, HORIZONTAL TAB, and LINE FEED as whitespace.
     ///
+    /// Note: The Rust language parser uses a different definition of
+    /// whitespace, which includes U+000B VERTICAL TAB. The Rust standard
+    /// library (this function) does **not** include vertical tab, following
+    /// the WhatWG Infra Standard instead.
+    ///
     /// If you are writing a program that will process an existing
     /// file format, check what that format's definition of whitespace is
     /// before using this function.


### PR DESCRIPTION
Update the docs for u8::is_ascii_whitespace to make it clear
that the standard library uses WhatWG rules for ASCII whitespace,
so vertical tab (U+000B) isn’t included. Also note that the Rust
parser uses a different definition.

Ref: rust-lang/rust#154765