### PR TITLE
Add tests for three fixed issues (an LLVM crash, an ICE and poor codegen)

### DIFF
--- a/tests/codegen-llvm/enum/enum-array-index-spare-niche.rs
+++ b/tests/codegen-llvm/enum/enum-array-index-spare-niche.rs
@@ -1,0 +1,28 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/113899.
+//! When indexing into an array of an enum type with spare niches, the compiler
+//! used to emit a superfluous branch checking whether the loaded value was
+//! a niche value. Every element in the array is a valid variant, so this check
+//! is unnecessary and should be optimised away.
+
+//@ compile-flags: -Copt-level=3
+#![crate_type = "lib"]
+
+#[derive(Clone, Copy)]
+pub enum Outer {
+    A([u8; 8]),
+    B([u8; 8]),
+}
+
+pub struct Error(u8);
+
+// CHECK-LABEL: @test
+#[no_mangle]
+pub fn test(x: usize) -> Result<Outer, Error> {
+    // There should be exactly one comparison: the bounds check on `x`.
+    // There must be no second comparison checking the discriminant
+    // against the niche value used by `Option<Outer>` (from `get()`).
+    // CHECK: icmp ult
+    // CHECK-NOT: icmp
+    // CHECK: ret void
+    [Outer::A([10; 8]), Outer::B([20; 8])].get(x).copied().ok_or(Error(5))
+}

--- a/tests/ui/derives/clone-vector-element-size.rs
+++ b/tests/ui/derives/clone-vector-element-size.rs
@@ -1,0 +1,17 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/104037.
+//! LLVM used to hit an assertion "Vector elements must have same size"
+//! when compiling derived Clone with MIR optimisation level of 3.
+
+//@ build-pass
+//@ compile-flags: -Zmir-opt-level=3 -Copt-level=3
+
+#[derive(Clone)]
+pub struct Foo(Bar, u32);
+
+#[derive(Clone, Copy)]
+pub struct Bar(u8, u8, u8);
+
+fn main() {
+    let foo: Vec<Foo> = Vec::new();
+    let _ = foo.clone();
+}

--- a/tests/ui/traits/const-traits/self-receiver-type-mismatch.rs
+++ b/tests/ui/traits/const-traits/self-receiver-type-mismatch.rs
@@ -1,0 +1,24 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/112623.
+//! The const evaluator used to ICE with an assertion failure on a size mismatch
+//! when a trait impl changed the `self` receiver type from by-value to by-reference.
+
+#![feature(const_trait_impl)]
+
+const trait Func {
+    fn trigger(self) -> usize;
+}
+
+struct Cls;
+
+impl const Func for Cls {
+    fn trigger(&self, a: usize) -> usize {
+        //~^ ERROR method `trigger` has 2 parameters but the declaration in trait `Func::trigger` has 1
+        0
+    }
+}
+
+enum Bug<T = [(); Cls.trigger()]> {
+    V(T),
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/self-receiver-type-mismatch.stderr
+++ b/tests/ui/traits/const-traits/self-receiver-type-mismatch.stderr
@@ -1,0 +1,12 @@
+error[E0050]: method `trigger` has 2 parameters but the declaration in trait `Func::trigger` has 1
+  --> $DIR/self-receiver-type-mismatch.rs:14:16
+   |
+LL |     fn trigger(self) -> usize;
+   |                ---- trait requires 1 parameter
+...
+LL |     fn trigger(&self, a: usize) -> usize {
+   |                ^^^^^^^^^^^^^^^ expected 1 parameter, found 2
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0050`.


### PR DESCRIPTION
Closes rust-lang/rust#104037.
Closes rust-lang/rust#112623.
Closes rust-lang/rust#113899.