### PR TITLE
Update tracking issue number of future-incompatibility lint `unstable_syntax_pre_expansion`

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3158,7 +3158,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
-    /// #[cfg(FALSE)]
+    /// #[cfg(feature = "nightly")]
     /// macro foo() {}
     /// ```
     ///
@@ -3182,22 +3182,22 @@ declare_lint! {
     ///    ( $($tokens:tt)* ) => { $($tokens)* }
     /// }
     ///
-    /// #[cfg(FALSE)]
+    /// #[cfg(feature = "nightly")]
     /// identity! {
     ///    macro foo() {}
     /// }
     /// ```
     ///
     /// This is a [future-incompatible] lint to transition this
-    /// to a hard error in the future. See [issue #65860] for more details.
+    /// to a hard error in the future. See [issue #154045] for more details.
     ///
-    /// [issue #65860]: https://github.com/rust-lang/rust/issues/65860
+    /// [issue #154045]: https://github.com/rust-lang/rust/issues/154045
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub UNSTABLE_SYNTAX_PRE_EXPANSION,
     Warn,
     "unstable syntax can change at any point in the future, causing a hard error!",
     @future_incompatible = FutureIncompatibleInfo {
-        reason: fcw!(FutureReleaseError #65860),
+        reason: fcw!(FutureReleaseError #154045),
     };
 }
 

--- a/tests/ui/cfg/cfg-false-feature.stderr
+++ b/tests/ui/cfg/cfg-false-feature.stderr
@@ -8,7 +8,7 @@ LL |     let box _ = Box::new(0);
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: trait aliases are experimental
   --> $DIR/cfg-false-feature.rs:12:1
@@ -20,7 +20,7 @@ LL | trait A = Clone;
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/soft-feature-gate-auto_traits.stderr
+++ b/tests/ui/feature-gates/soft-feature-gate-auto_traits.stderr
@@ -8,7 +8,7 @@ LL | auto trait Foo {}
    = help: add `#![feature(auto_traits)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 1 warning emitted
 

--- a/tests/ui/feature-gates/soft-feature-gate-box_patterns.stderr
+++ b/tests/ui/feature-gates/soft-feature-gate-box_patterns.stderr
@@ -8,7 +8,7 @@ LL |     let box x;
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: box pattern syntax is experimental
   --> $DIR/soft-feature-gate-box_patterns.rs:14:18
@@ -20,7 +20,7 @@ LL |     let Packet { box x };
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/soft-feature-gate-decl_macro.stderr
+++ b/tests/ui/feature-gates/soft-feature-gate-decl_macro.stderr
@@ -8,7 +8,7 @@ LL | macro make() {}
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: `macro` is experimental
   --> $DIR/soft-feature-gate-decl_macro.rs:13:1
@@ -20,7 +20,7 @@ LL | macro create { () => {} }
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/soft-feature-gate-negative_impls.stderr
+++ b/tests/ui/feature-gates/soft-feature-gate-negative_impls.stderr
@@ -8,7 +8,7 @@ LL | impl !Trait for () {}
    = help: add `#![feature(negative_impls)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 1 warning emitted
 

--- a/tests/ui/feature-gates/soft-feature-gate-trait_alias.stderr
+++ b/tests/ui/feature-gates/soft-feature-gate-trait_alias.stderr
@@ -8,7 +8,7 @@ LL | trait Trait =;
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: trait aliases are experimental
   --> $DIR/soft-feature-gate-trait_alias.rs:13:1
@@ -20,7 +20,7 @@ LL | trait Trait<T> = Bound where T: Bound;
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/soft-feature-gate-try_blocks.stderr
+++ b/tests/ui/feature-gates/soft-feature-gate-try_blocks.stderr
@@ -8,7 +8,7 @@ LL |     try {}
    = help: add `#![feature(try_blocks)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 1 warning emitted
 

--- a/tests/ui/feature-gates/soft-syntax-gates-without-errors.stderr
+++ b/tests/ui/feature-gates/soft-syntax-gates-without-errors.stderr
@@ -8,7 +8,7 @@ LL | macro b() {}
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: `macro` is experimental
   --> $DIR/soft-syntax-gates-without-errors.rs:21:5
@@ -20,7 +20,7 @@ LL |     macro e() {}
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/or-patterns/or-patterns-syntactic-pass.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-pass.stderr
@@ -8,7 +8,7 @@ LL |     let (box 0 | 1); // Unstable; we *can* change the precedence if we want
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 1 warning emitted
 

--- a/tests/ui/pattern/rest-pat-syntactic.stderr
+++ b/tests/ui/pattern/rest-pat-syntactic.stderr
@@ -8,7 +8,7 @@ LL |     let box ..;
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: box pattern syntax is experimental
   --> $DIR/rest-pat-syntactic.rs:62:17
@@ -20,7 +20,7 @@ LL |                 box ..,
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/specialization/soft-feature-gate-specialization.default.stderr
+++ b/tests/ui/specialization/soft-feature-gate-specialization.default.stderr
@@ -8,7 +8,7 @@ LL |     default type Ty = ();
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: specialization is experimental
   --> $DIR/soft-feature-gate-specialization.rs:24:5
@@ -20,7 +20,7 @@ LL |     default const CT: () = ();
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: specialization is experimental
   --> $DIR/soft-feature-gate-specialization.rs:40:1
@@ -32,7 +32,7 @@ LL | default impl Trait for () {}
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: specialization is experimental
   --> $DIR/soft-feature-gate-specialization.rs:27:5
@@ -44,7 +44,7 @@ LL |     default fn fn_();
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: specialization is experimental
   --> $DIR/soft-feature-gate-specialization.rs:35:1
@@ -56,7 +56,7 @@ LL | default fn fn_() {}
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 5 warnings emitted
 

--- a/tests/ui/specialization/soft-feature-gate-specialization.min.stderr
+++ b/tests/ui/specialization/soft-feature-gate-specialization.min.stderr
@@ -8,7 +8,7 @@ LL |     default type Ty = ();
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: specialization is experimental
   --> $DIR/soft-feature-gate-specialization.rs:24:5
@@ -20,7 +20,7 @@ LL |     default const CT: () = ();
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: specialization is experimental
   --> $DIR/soft-feature-gate-specialization.rs:40:1
@@ -32,7 +32,7 @@ LL | default impl Trait for () {}
    = help: add `#![feature(specialization)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = warning: unstable syntax can change at any point in the future, causing a hard error!
-   = note: for more information, see issue #65860 <https://github.com/rust-lang/rust/issues/65860>
+   = note: for more information, see issue #154045 <https://github.com/rust-lang/rust/issues/154045>
 
 warning: 3 warnings emitted
 


### PR DESCRIPTION
Issue rust-lang/rust#65860 has never been a proper tracking issue, it has always been a normal issue that reported a pass→fail regression which was subsequently fixed and which elicited a discussion spanning 50 comments. Years later the formerly offending errors were reintroduced as warnings which link to said issue (see section *Pre-History* in issue rust-lang/rust#154045 for details).

A few weeks ago I closed this issue (https://github.com/rust-lang/rust/issues/65860#issuecomment-4083652176) in favor of a new super focused & structured tracking issue, rust-lang/rust#154045. That means people now have to jump through hoops to arrive at the new tracking issue which is less than ideal (it's very likely that this user had to do so: https://github.com/rust-lang/rust/issues/154045#issuecomment-4207339422), let's fix that.

Part of rust-lang/rust#154045.