### PR TITLE
Remove redundant drop terminators ahead of mir_coroutine_witnesses

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -672,6 +672,11 @@ rustc_queries! {
         desc { "promoting constants in MIR for `{}`", tcx.def_path_str(key) }
     }
 
+    query mir_post_borrowck_cleanup(key: LocalDefId) -> &'tcx Steal<mir::Body<'tcx>> {
+        no_hash
+        desc { "post borrowck cleanup of MIR for `{}`", tcx.def_path_str(key) }
+    }
+
     query closure_typeinfo(key: LocalDefId) -> ty::ClosureTypeInfo<'tcx> {
         desc {
             "finding symbols for captures of closure `{}`",

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1392,7 +1392,7 @@ pub(crate) fn mir_coroutine_witnesses<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
 ) -> Option<CoroutineLayout<'tcx>> {
-    let (body, _) = tcx.mir_promoted(def_id);
+    let body = tcx.mir_post_borrowck_cleanup(def_id);
     let body = body.borrow();
     let body = &*body;
 

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1392,7 +1392,7 @@ pub(crate) fn mir_coroutine_witnesses<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
 ) -> Option<CoroutineLayout<'tcx>> {
-    let body = tcx.mir_post_borrowck_cleanup(def_id);
+    let (body, _) = tcx.mir_promoted(def_id);
     let body = body.borrow();
     let body = &*body;
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -555,7 +555,7 @@ fn mir_drops_elaborated_and_const_checked(tcx: TyCtxt<'_>, def: LocalDefId) -> &
 
     tcx.ensure_done().check_liveness(def);
 
-    let (body, _) = tcx.mir_promoted(def);
+    let body = tcx.mir_post_borrowck_cleanup(def);
     let mut body = body.steal();
 
     if let Some(error_reported) = tainted_by_errors {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -476,7 +476,7 @@ fn mir_promoted(
     pm::run_passes(
         tcx,
         &mut body,
-        &[&promote_pass, &simplify::SimplifyCfg::PromoteConsts, &coverage::InstrumentCoverage],
+        &[&promote_pass, &simplify::SimplifyCfg::PromoteConsts, &coverage::InstrumentCoverage, &remove_dead_drops::RemoveDeadDrops],
         Some(MirPhase::Analysis(AnalysisPhase::Initial)),
         pm::Optimizations::Allowed,
     );
@@ -489,7 +489,7 @@ fn mir_promoted(
 
 fn mir_post_borrowck_cleanup(tcx: TyCtxt<'_>, def: LocalDefId) -> &Steal<Body<'_>> {
     let (body, _) = tcx.mir_promoted(def);
-    let mut body = body.borrow().clone();
+    let mut body = body.steal();
     pm::run_passes(
         tcx,
         &mut body,
@@ -558,7 +558,7 @@ fn mir_drops_elaborated_and_const_checked(tcx: TyCtxt<'_>, def: LocalDefId) -> &
 
     tcx.ensure_done().check_liveness(def);
 
-    let body = tcx.mir_post_borrowck_cleanup(def);
+    let (body, _) = tcx.mir_promoted(def);
     let mut body = body.steal();
 
     if let Some(error_reported) = tainted_by_errors {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -487,13 +487,16 @@ fn mir_promoted(
     (tcx.alloc_steal_mir(body), tcx.alloc_steal_promoted(promoted))
 }
 
-fn mir_post_borrowck_cleanup(
-    tcx: TyCtxt<'_>,
-    def: LocalDefId,
-) -> &Steal<Body<'_>> {
+fn mir_post_borrowck_cleanup(tcx: TyCtxt<'_>, def: LocalDefId) -> &Steal<Body<'_>> {
     let (body, _) = tcx.mir_promoted(def);
     let mut body = body.borrow().clone();
-    remove_dead_drops::RemoveDeadDrops.run_pass(tcx, &mut body);
+    pm::run_passes(
+        tcx,
+        &mut body,
+        &[&remove_dead_drops::RemoveDeadDrops],
+        None,
+        pm::Optimizations::Allowed,
+    );
     tcx.alloc_steal_mir(body)
 }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -171,6 +171,7 @@ declare_passes! {
     mod promote_consts : PromoteTemps;
     mod ref_prop : ReferencePropagation;
     mod remove_noop_landing_pads : RemoveNoopLandingPads;
+    mod remove_dead_drops : RemoveDeadDrops;
     mod remove_place_mention : RemovePlaceMention;
     mod remove_storage_markers : RemoveStorageMarkers;
     mod remove_uninit_drops : RemoveUninitDrops;
@@ -221,6 +222,7 @@ pub fn provide(providers: &mut Providers) {
         mir_built,
         mir_const_qualif,
         mir_promoted,
+        mir_post_borrowck_cleanup,
         mir_drops_elaborated_and_const_checked,
         mir_for_ctfe,
         mir_coroutine_witnesses: coroutine::mir_coroutine_witnesses,
@@ -483,6 +485,16 @@ fn mir_promoted(
 
     let promoted = promote_pass.promoted_fragments.into_inner();
     (tcx.alloc_steal_mir(body), tcx.alloc_steal_promoted(promoted))
+}
+
+fn mir_post_borrowck_cleanup(
+    tcx: TyCtxt<'_>,
+    def: LocalDefId,
+) -> &Steal<Body<'_>> {
+    let (body, _) = tcx.mir_promoted(def);
+    let mut body = body.borrow().clone();
+    remove_dead_drops::RemoveDeadDrops.run_pass(tcx, &mut body);
+    tcx.alloc_steal_mir(body)
 }
 
 /// Compute the MIR that is used during CTFE (and thus has no optimizations run on it)

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -12,6 +12,10 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if body.coroutine.is_none() {
+            return;
+        }
+
         let move_data = MoveData::gather_moves(body, tcx, |_| true);
 
         let mut maybe_init_cursor = MaybeInitializedPlaces::new(tcx, body, &move_data)

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -3,7 +3,7 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::{Analysis, GenKill};
 
-// use super::simplify::simplify_cfg;
+use super::simplify::simplify_cfg;
 
 pub(crate) struct RemoveDeadDrops;
 
@@ -111,7 +111,7 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
             }
 
             // Removing drop terminators may simplify the CFG, so run cleanup.
-            // simplify_cfg(tcx, body);
+            simplify_cfg(tcx, body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -4,6 +4,8 @@ use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
 use rustc_mir_dataflow::move_paths::{LookupResult, MoveData};
 use rustc_mir_dataflow::{Analysis, MaybeReachable};
 
+use super::simplify::simplify_cfg;
+
 pub(crate) struct RemoveDeadDrops;
 
 impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
@@ -42,10 +44,15 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
             }
         }
 
-        for (block, target) in dead_drops {
-            if let Some(terminator) = &mut body.basic_blocks.as_mut()[block].terminator {
-                terminator.kind = TerminatorKind::Goto { target };
+        if !dead_drops.is_empty() {
+            for (block, target) in dead_drops {
+                if let Some(terminator) = &mut body.basic_blocks.as_mut()[block].terminator {
+                    terminator.kind = TerminatorKind::Goto { target };
+                }
             }
+
+            // Removing drop terminators may simplify the CFG, so run cleanup.
+            simplify_cfg(tcx, body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -12,10 +12,6 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if body.coroutine.is_none() {
-            return;
-        }
-
         let move_data = MoveData::gather_moves(body, tcx, |_| true);
 
         let mut maybe_init_cursor = MaybeInitializedPlaces::new(tcx, body, &move_data)

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -3,7 +3,7 @@ use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::{Analysis, GenKill};
 
-use super::simplify::simplify_cfg;
+// use super::simplify::simplify_cfg;
 
 pub(crate) struct RemoveDeadDrops;
 
@@ -111,7 +111,7 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
             }
 
             // Removing drop terminators may simplify the CFG, so run cleanup.
-            simplify_cfg(tcx, body);
+            // simplify_cfg(tcx, body);
         }
     }
 }

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -14,10 +14,6 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if body.coroutine.is_none() {
-            return;
-        }
-
         let move_data = MoveData::gather_moves(body, tcx, |_| true);
 
         let mut maybe_init_cursor = MaybeInitializedPlaces::new(tcx, body, &move_data)

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -1,0 +1,51 @@
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
+use rustc_mir_dataflow::move_paths::{LookupResult, MoveData};
+use rustc_mir_dataflow::{Analysis, MaybeReachable};
+
+pub(crate) struct RemoveDeadDrops;
+
+impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
+    fn is_required(&self) -> bool {
+        true
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let move_data = MoveData::gather_moves(body, tcx, |_| true);
+
+        let mut maybe_init_cursor = MaybeInitializedPlaces::new(tcx, body, &move_data)
+            .iterate_to_fixpoint(tcx, body, None)
+            .into_results_cursor(body);
+
+        let mut dead_drops = Vec::new();
+
+        for (block, data) in body.basic_blocks.iter_enumerated() {
+            if let Some(terminator) = &data.terminator
+                && let TerminatorKind::Drop { place, target, .. } = &terminator.kind
+            {
+                let LookupResult::Exact(path) = move_data.rev_lookup.find(place.as_ref()) else {
+                    continue;
+                };
+
+                let term_location = Location { block, statement_index: data.statements.len() };
+                maybe_init_cursor.seek_before_primary_effect(term_location);
+
+                let is_dead = match maybe_init_cursor.get() {
+                    MaybeReachable::Unreachable => true,
+                    MaybeReachable::Reachable(maybe_init) => !maybe_init.contains(path),
+                };
+
+                if is_dead {
+                    dead_drops.push((block, *target));
+                }
+            }
+        }
+
+        for (block, target) in dead_drops {
+            if let Some(terminator) = &mut body.basic_blocks.as_mut()[block].terminator {
+                terminator.kind = TerminatorKind::Goto { target };
+            }
+        }
+    }
+}

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -14,6 +14,10 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if body.coroutine.is_none() {
+            return;
+        }
+
         let move_data = MoveData::gather_moves(body, tcx, |_| true);
 
         let mut maybe_init_cursor = MaybeInitializedPlaces::new(tcx, body, &move_data)

--- a/compiler/rustc_mir_transform/src/remove_dead_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_dead_drops.rs
@@ -1,12 +1,81 @@
+use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
-use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
-use rustc_mir_dataflow::move_paths::{LookupResult, MoveData};
-use rustc_mir_dataflow::{Analysis, MaybeReachable};
+use rustc_mir_dataflow::{Analysis, GenKill};
 
 use super::simplify::simplify_cfg;
 
 pub(crate) struct RemoveDeadDrops;
+
+use rustc_middle::mir::visit::*;
+
+struct MaybeInitializedLocals;
+
+/// This is conservative: If any part of a local is initialized, we mark it
+/// initialized, while we only mark uninitialized if the whole local is moved
+/// from or StorageDead.
+struct TransferFunction<'a, T> {
+    trans: &'a mut T,
+}
+
+impl<'tcx, T: GenKill<Local>> Visitor<'tcx> for TransferFunction<'_, T> {
+    fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
+        self.super_place(place, context, location);
+
+        if context.is_place_assignment() {
+            self.trans.gen_(place.local);
+        } else if matches!(
+            context,
+            PlaceContext::NonUse(NonUseContext::StorageLive | NonUseContext::StorageDead)
+        ) {
+            self.trans.kill(place.local);
+        }
+    }
+
+    fn visit_operand(&mut self, operand: &Operand<'tcx>, location: Location) {
+        self.super_operand(operand, location);
+
+        if let Operand::Move(place) = operand {
+            if place.projection.is_empty() {
+                self.trans.kill(place.local);
+            }
+        }
+    }
+}
+
+impl<'tcx> Analysis<'tcx> for MaybeInitializedLocals {
+    type Domain = DenseBitSet<Local>;
+    const NAME: &'static str = "maybe_initialized_locals";
+
+    fn bottom_value(&self, body: &Body<'tcx>) -> Self::Domain {
+        DenseBitSet::new_empty(body.local_decls.len())
+    }
+
+    fn initialize_start_block(&self, body: &Body<'tcx>, state: &mut Self::Domain) {
+        for arg in 1..=body.arg_count {
+            state.insert(Local::from_usize(arg));
+        }
+    }
+
+    fn apply_primary_statement_effect(
+        &self,
+        state: &mut Self::Domain,
+        stmt: &Statement<'tcx>,
+        location: Location,
+    ) {
+        TransferFunction { trans: state }.visit_statement(stmt, location);
+    }
+
+    fn apply_primary_terminator_effect<'mir>(
+        &self,
+        state: &mut Self::Domain,
+        terminator: &'mir Terminator<'tcx>,
+        location: Location,
+    ) -> TerminatorEdges<'mir, 'tcx> {
+        TransferFunction { trans: state }.visit_terminator(terminator, location);
+        terminator.edges()
+    }
+}
 
 impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
     fn is_required(&self) -> bool {
@@ -14,9 +83,7 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        let move_data = MoveData::gather_moves(body, tcx, |_| true);
-
-        let mut maybe_init_cursor = MaybeInitializedPlaces::new(tcx, body, &move_data)
+        let mut maybe_init_cursor = MaybeInitializedLocals
             .iterate_to_fixpoint(tcx, body, None)
             .into_results_cursor(body);
 
@@ -26,18 +93,10 @@ impl<'tcx> crate::MirPass<'tcx> for RemoveDeadDrops {
             if let Some(terminator) = &data.terminator
                 && let TerminatorKind::Drop { place, target, .. } = &terminator.kind
             {
-                let LookupResult::Exact(path) = move_data.rev_lookup.find(place.as_ref()) else {
-                    continue;
-                };
-
                 let term_location = Location { block, statement_index: data.statements.len() };
                 maybe_init_cursor.seek_before_primary_effect(term_location);
 
-                let is_dead = match maybe_init_cursor.get() {
-                    MaybeReachable::Unreachable => true,
-                    MaybeReachable::Reachable(maybe_init) => !maybe_init.contains(path),
-                };
-
+                let is_dead = !maybe_init_cursor.get().contains(place.local);
                 if is_dead {
                     dead_drops.push((block, *target));
                 }

--- a/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
+++ b/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
@@ -35,53 +35,23 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = move _4;
--         drop(_5) -> [return: bb1, unwind: bb2];
-+         goto -> bb1;
+          _5 = move _6;
+          StorageDead(_6);
+          _0 = const ();
+-         drop(_5) -> [return: bb1, unwind continue];
++         drop(_5) -> [return: bb1, unwind: bb2];
       }
   
       bb1: {
-          _5 = move _6;
--         drop(_6) -> [return: bb3, unwind: bb6];
-+         goto -> bb3;
-      }
-  
-      bb2 (cleanup): {
-          _5 = move _6;
--         drop(_6) -> [return: bb6, unwind terminate(cleanup)];
-+         goto -> bb6;
-      }
-  
-      bb3: {
-          StorageDead(_6);
-          _0 = const ();
-          drop(_5) -> [return: bb4, unwind: bb7];
-      }
-  
-      bb4: {
           StorageDead(_5);
--         drop(_4) -> [return: bb5, unwind continue];
-+         goto -> bb5;
-      }
-  
-      bb5: {
           StorageDead(_4);
           StorageDead(_2);
           StorageDead(_1);
           return;
-      }
-  
-      bb6 (cleanup): {
--         drop(_5) -> [return: bb7, unwind terminate(cleanup)];
-+         goto -> bb7;
-      }
-  
-      bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb8 (cleanup): {
-          resume;
++     }
++ 
++     bb2 (cleanup): {
++         resume;
       }
   }
   

--- a/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
+++ b/tests/mir-opt/basic_assignment.main.ElaborateDrops.diff
@@ -35,23 +35,53 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = move _4;
-          _5 = move _6;
-          StorageDead(_6);
-          _0 = const ();
--         drop(_5) -> [return: bb1, unwind continue];
-+         drop(_5) -> [return: bb1, unwind: bb2];
+-         drop(_5) -> [return: bb1, unwind: bb2];
++         goto -> bb1;
       }
   
       bb1: {
+          _5 = move _6;
+-         drop(_6) -> [return: bb3, unwind: bb6];
++         goto -> bb3;
+      }
+  
+      bb2 (cleanup): {
+          _5 = move _6;
+-         drop(_6) -> [return: bb6, unwind terminate(cleanup)];
++         goto -> bb6;
+      }
+  
+      bb3: {
+          StorageDead(_6);
+          _0 = const ();
+          drop(_5) -> [return: bb4, unwind: bb7];
+      }
+  
+      bb4: {
           StorageDead(_5);
+-         drop(_4) -> [return: bb5, unwind continue];
++         goto -> bb5;
+      }
+  
+      bb5: {
           StorageDead(_4);
           StorageDead(_2);
           StorageDead(_1);
           return;
-+     }
-+ 
-+     bb2 (cleanup): {
-+         resume;
+      }
+  
+      bb6 (cleanup): {
+-         drop(_5) -> [return: bb7, unwind terminate(cleanup)];
++         goto -> bb7;
+      }
+  
+      bb7 (cleanup): {
+-         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb8 (cleanup): {
+          resume;
       }
   }
   

--- a/tests/mir-opt/box_conditional_drop_allocator.main.ElaborateDrops.diff
+++ b/tests/mir-opt/box_conditional_drop_allocator.main.ElaborateDrops.diff
@@ -31,11 +31,11 @@
           _2 = HasDrop;
           StorageLive(_3);
           _3 = DropAllocator;
-          _1 = Box::<HasDrop, DropAllocator>::new_in(move _2, move _3) -> [return: bb1, unwind: bb11];
++         _9 = const true;
+          _1 = Box::<HasDrop, DropAllocator>::new_in(move _2, move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
-+         _9 = const true;
           StorageDead(_3);
           StorageDead(_2);
           StorageLive(_4);
@@ -47,7 +47,7 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = move (*_1);
-          _5 = std::mem::drop::<HasDrop>(move _6) -> [return: bb3, unwind: bb9];
+          _5 = std::mem::drop::<HasDrop>(move _6) -> [return: bb3, unwind: bb8];
       }
   
       bb3: {
@@ -75,7 +75,7 @@
       bb6: {
           StorageDead(_4);
 -         drop(_1) -> [return: bb7, unwind continue];
-+         goto -> bb23;
++         goto -> bb19;
       }
   
       bb7: {
@@ -85,102 +85,82 @@
       }
   
       bb8 (cleanup): {
--         drop(_8) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb10;
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb25;
       }
   
       bb9 (cleanup): {
--         drop(_6) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb10;
-      }
-  
-      bb10 (cleanup): {
--         drop(_1) -> [return: bb13, unwind terminate(cleanup)];
-+         goto -> bb29;
-      }
-  
-      bb11 (cleanup): {
--         drop(_3) -> [return: bb12, unwind terminate(cleanup)];
-+         goto -> bb12;
-      }
-  
-      bb12 (cleanup): {
--         drop(_2) -> [return: bb13, unwind terminate(cleanup)];
-+         goto -> bb13;
-      }
-  
-      bb13 (cleanup): {
           resume;
 +     }
 + 
-+     bb14: {
++     bb10: {
 +         _9 = const false;
 +         goto -> bb7;
 +     }
 + 
-+     bb15 (cleanup): {
-+         drop((_1.1: DropAllocator)) -> [return: bb13, unwind terminate(cleanup)];
++     bb11 (cleanup): {
++         drop((_1.1: DropAllocator)) -> [return: bb9, unwind terminate(cleanup)];
++     }
++ 
++     bb12 (cleanup): {
++         switchInt(copy _9) -> [0: bb9, otherwise: bb11];
++     }
++ 
++     bb13: {
++         drop((_1.1: DropAllocator)) -> [return: bb10, unwind: bb9];
++     }
++ 
++     bb14: {
++         switchInt(copy _9) -> [0: bb10, otherwise: bb13];
++     }
++ 
++     bb15: {
++         _10 = &mut _1;
++         _11 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _10) -> [return: bb14, unwind: bb12];
 +     }
 + 
 +     bb16 (cleanup): {
-+         switchInt(copy _9) -> [0: bb13, otherwise: bb15];
++         _12 = &mut _1;
++         _13 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _12) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
 +     bb17: {
-+         drop((_1.1: DropAllocator)) -> [return: bb14, unwind: bb13];
++         goto -> bb15;
 +     }
 + 
 +     bb18: {
-+         switchInt(copy _9) -> [0: bb14, otherwise: bb17];
++         _14 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
++         goto -> bb17;
 +     }
 + 
 +     bb19: {
-+         _10 = &mut _1;
-+         _11 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _10) -> [return: bb18, unwind: bb16];
++         switchInt(copy _9) -> [0: bb14, otherwise: bb18];
 +     }
 + 
 +     bb20 (cleanup): {
-+         _12 = &mut _1;
-+         _13 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _12) -> [return: bb16, unwind terminate(cleanup)];
++         drop((_1.1: DropAllocator)) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb21: {
-+         goto -> bb19;
++     bb21 (cleanup): {
++         switchInt(copy _9) -> [0: bb9, otherwise: bb20];
 +     }
 + 
-+     bb22: {
-+         _14 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
-+         goto -> bb21;
++     bb22 (cleanup): {
++         _15 = &mut _1;
++         _16 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _15) -> [return: bb21, unwind terminate(cleanup)];
 +     }
 + 
-+     bb23: {
-+         switchInt(copy _9) -> [0: bb18, otherwise: bb22];
++     bb23 (cleanup): {
++         goto -> bb22;
 +     }
 + 
 +     bb24 (cleanup): {
-+         drop((_1.1: DropAllocator)) -> [return: bb13, unwind terminate(cleanup)];
++         _17 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
++         goto -> bb23;
 +     }
 + 
 +     bb25 (cleanup): {
-+         switchInt(copy _9) -> [0: bb13, otherwise: bb24];
-+     }
-+ 
-+     bb26 (cleanup): {
-+         _15 = &mut _1;
-+         _16 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _15) -> [return: bb25, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb27 (cleanup): {
-+         goto -> bb26;
-+     }
-+ 
-+     bb28 (cleanup): {
-+         _17 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
-+         goto -> bb27;
-+     }
-+ 
-+     bb29 (cleanup): {
-+         switchInt(copy _9) -> [0: bb25, otherwise: bb28];
++         switchInt(copy _9) -> [0: bb21, otherwise: bb24];
       }
   }
   

--- a/tests/mir-opt/box_conditional_drop_allocator.main.ElaborateDrops.diff
+++ b/tests/mir-opt/box_conditional_drop_allocator.main.ElaborateDrops.diff
@@ -31,11 +31,11 @@
           _2 = HasDrop;
           StorageLive(_3);
           _3 = DropAllocator;
-+         _9 = const true;
-          _1 = Box::<HasDrop, DropAllocator>::new_in(move _2, move _3) -> [return: bb1, unwind continue];
+          _1 = Box::<HasDrop, DropAllocator>::new_in(move _2, move _3) -> [return: bb1, unwind: bb11];
       }
   
       bb1: {
++         _9 = const true;
           StorageDead(_3);
           StorageDead(_2);
           StorageLive(_4);
@@ -47,7 +47,7 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = move (*_1);
-          _5 = std::mem::drop::<HasDrop>(move _6) -> [return: bb3, unwind: bb8];
+          _5 = std::mem::drop::<HasDrop>(move _6) -> [return: bb3, unwind: bb9];
       }
   
       bb3: {
@@ -75,7 +75,7 @@
       bb6: {
           StorageDead(_4);
 -         drop(_1) -> [return: bb7, unwind continue];
-+         goto -> bb19;
++         goto -> bb23;
       }
   
       bb7: {
@@ -85,82 +85,102 @@
       }
   
       bb8 (cleanup): {
--         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb25;
+-         drop(_8) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb10;
       }
   
       bb9 (cleanup): {
+-         drop(_6) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb10;
+      }
+  
+      bb10 (cleanup): {
+-         drop(_1) -> [return: bb13, unwind terminate(cleanup)];
++         goto -> bb29;
+      }
+  
+      bb11 (cleanup): {
+-         drop(_3) -> [return: bb12, unwind terminate(cleanup)];
++         goto -> bb12;
+      }
+  
+      bb12 (cleanup): {
+-         drop(_2) -> [return: bb13, unwind terminate(cleanup)];
++         goto -> bb13;
+      }
+  
+      bb13 (cleanup): {
           resume;
 +     }
 + 
-+     bb10: {
++     bb14: {
 +         _9 = const false;
 +         goto -> bb7;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop((_1.1: DropAllocator)) -> [return: bb9, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb12 (cleanup): {
-+         switchInt(copy _9) -> [0: bb9, otherwise: bb11];
-+     }
-+ 
-+     bb13: {
-+         drop((_1.1: DropAllocator)) -> [return: bb10, unwind: bb9];
-+     }
-+ 
-+     bb14: {
-+         switchInt(copy _9) -> [0: bb10, otherwise: bb13];
-+     }
-+ 
-+     bb15: {
-+         _10 = &mut _1;
-+         _11 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _10) -> [return: bb14, unwind: bb12];
++     bb15 (cleanup): {
++         drop((_1.1: DropAllocator)) -> [return: bb13, unwind terminate(cleanup)];
 +     }
 + 
 +     bb16 (cleanup): {
-+         _12 = &mut _1;
-+         _13 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _12) -> [return: bb12, unwind terminate(cleanup)];
++         switchInt(copy _9) -> [0: bb13, otherwise: bb15];
 +     }
 + 
 +     bb17: {
-+         goto -> bb15;
++         drop((_1.1: DropAllocator)) -> [return: bb14, unwind: bb13];
 +     }
 + 
 +     bb18: {
-+         _14 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
-+         goto -> bb17;
++         switchInt(copy _9) -> [0: bb14, otherwise: bb17];
 +     }
 + 
 +     bb19: {
-+         switchInt(copy _9) -> [0: bb14, otherwise: bb18];
++         _10 = &mut _1;
++         _11 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _10) -> [return: bb18, unwind: bb16];
 +     }
 + 
 +     bb20 (cleanup): {
-+         drop((_1.1: DropAllocator)) -> [return: bb9, unwind terminate(cleanup)];
++         _12 = &mut _1;
++         _13 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _12) -> [return: bb16, unwind terminate(cleanup)];
 +     }
 + 
-+     bb21 (cleanup): {
-+         switchInt(copy _9) -> [0: bb9, otherwise: bb20];
++     bb21: {
++         goto -> bb19;
 +     }
 + 
-+     bb22 (cleanup): {
-+         _15 = &mut _1;
-+         _16 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _15) -> [return: bb21, unwind terminate(cleanup)];
++     bb22: {
++         _14 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
++         goto -> bb21;
 +     }
 + 
-+     bb23 (cleanup): {
-+         goto -> bb22;
++     bb23: {
++         switchInt(copy _9) -> [0: bb18, otherwise: bb22];
 +     }
 + 
 +     bb24 (cleanup): {
-+         _17 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
-+         goto -> bb23;
++         drop((_1.1: DropAllocator)) -> [return: bb13, unwind terminate(cleanup)];
 +     }
 + 
 +     bb25 (cleanup): {
-+         switchInt(copy _9) -> [0: bb21, otherwise: bb24];
++         switchInt(copy _9) -> [0: bb13, otherwise: bb24];
++     }
++ 
++     bb26 (cleanup): {
++         _15 = &mut _1;
++         _16 = <Box<HasDrop, DropAllocator> as Drop>::drop(move _15) -> [return: bb25, unwind terminate(cleanup)];
++     }
++ 
++     bb27 (cleanup): {
++         goto -> bb26;
++     }
++ 
++     bb28 (cleanup): {
++         _17 = copy ((_1.0: std::ptr::Unique<HasDrop>).0: std::ptr::NonNull<HasDrop>) as *const HasDrop (Transmute);
++         goto -> bb27;
++     }
++ 
++     bb29 (cleanup): {
++         switchInt(copy _9) -> [0: bb25, otherwise: bb28];
       }
   }
   

--- a/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
+++ b/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
@@ -19,7 +19,7 @@
 +         _5 = const true;
           StorageLive(_3);
           _3 = copy _1;
-          switchInt(move _3) -> [0: bb2, otherwise: bb1];
+          switchInt(move _3) -> [0: bb3, otherwise: bb1];
       }
   
       bb1: {
@@ -27,58 +27,68 @@
 +         _5 = const false;
           _4 = move (*_2);
           _0 = Option::<String>::Some(move _4);
-          StorageDead(_4);
-          goto -> bb3;
+-         drop(_4) -> [return: bb2, unwind: bb6];
++         goto -> bb2;
       }
   
       bb2: {
-          _0 = Option::<String>::None;
-          goto -> bb3;
+          StorageDead(_4);
+          goto -> bb4;
       }
   
       bb3: {
-          StorageDead(_3);
--         drop(_2) -> [return: bb4, unwind continue];
-+         goto -> bb12;
+          _0 = Option::<String>::None;
+          goto -> bb4;
       }
   
       bb4: {
+          StorageDead(_3);
+-         drop(_2) -> [return: bb5, unwind continue];
++         goto -> bb14;
+      }
+  
+      bb5: {
           return;
+      }
+  
+      bb6 (cleanup): {
+-         drop(_2) -> [return: bb7, unwind terminate(cleanup)];
++         goto -> bb7;
+      }
+  
+      bb7 (cleanup): {
+          resume;
 +     }
 + 
-+     bb5 (cleanup): {
-+         resume;
-+     }
-+ 
-+     bb6: {
-+         goto -> bb4;
-+     }
-+ 
-+     bb7: {
-+         _6 = &mut _2;
-+         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb6, unwind: bb5];
-+     }
-+ 
-+     bb8 (cleanup): {
-+         _8 = &mut _2;
-+         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb5, unwind terminate(cleanup)];
++     bb8: {
++         goto -> bb5;
 +     }
 + 
 +     bb9: {
-+         goto -> bb11;
++         _6 = &mut _2;
++         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb8, unwind: bb7];
 +     }
 + 
-+     bb10: {
-+         drop((*_10)) -> [return: bb7, unwind: bb8];
++     bb10 (cleanup): {
++         _8 = &mut _2;
++         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb7, unwind terminate(cleanup)];
 +     }
 + 
 +     bb11: {
-+         switchInt(copy _5) -> [0: bb7, otherwise: bb10];
++         goto -> bb13;
 +     }
 + 
 +     bb12: {
++         drop((*_10)) -> [return: bb9, unwind: bb10];
++     }
++ 
++     bb13: {
++         switchInt(copy _5) -> [0: bb9, otherwise: bb12];
++     }
++ 
++     bb14: {
 +         _10 = copy ((_2.0: std::ptr::Unique<std::string::String>).0: std::ptr::NonNull<std::string::String>) as *const std::string::String (Transmute);
-+         goto -> bb9;
++         goto -> bb11;
       }
   }
   

--- a/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
+++ b/tests/mir-opt/box_partial_move.maybe_move.ElaborateDrops.diff
@@ -19,7 +19,7 @@
 +         _5 = const true;
           StorageLive(_3);
           _3 = copy _1;
-          switchInt(move _3) -> [0: bb3, otherwise: bb1];
+          switchInt(move _3) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
@@ -27,68 +27,58 @@
 +         _5 = const false;
           _4 = move (*_2);
           _0 = Option::<String>::Some(move _4);
--         drop(_4) -> [return: bb2, unwind: bb6];
-+         goto -> bb2;
+          StorageDead(_4);
+          goto -> bb3;
       }
   
       bb2: {
-          StorageDead(_4);
-          goto -> bb4;
+          _0 = Option::<String>::None;
+          goto -> bb3;
       }
   
       bb3: {
-          _0 = Option::<String>::None;
-          goto -> bb4;
+          StorageDead(_3);
+-         drop(_2) -> [return: bb4, unwind continue];
++         goto -> bb12;
       }
   
       bb4: {
-          StorageDead(_3);
--         drop(_2) -> [return: bb5, unwind continue];
-+         goto -> bb14;
-      }
-  
-      bb5: {
           return;
-      }
-  
-      bb6 (cleanup): {
--         drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-+         goto -> bb7;
-      }
-  
-      bb7 (cleanup): {
-          resume;
 +     }
 + 
-+     bb8: {
-+         goto -> bb5;
++     bb5 (cleanup): {
++         resume;
++     }
++ 
++     bb6: {
++         goto -> bb4;
++     }
++ 
++     bb7: {
++         _6 = &mut _2;
++         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb6, unwind: bb5];
++     }
++ 
++     bb8 (cleanup): {
++         _8 = &mut _2;
++         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb5, unwind terminate(cleanup)];
 +     }
 + 
 +     bb9: {
-+         _6 = &mut _2;
-+         _7 = <Box<String> as Drop>::drop(move _6) -> [return: bb8, unwind: bb7];
++         goto -> bb11;
 +     }
 + 
-+     bb10 (cleanup): {
-+         _8 = &mut _2;
-+         _9 = <Box<String> as Drop>::drop(move _8) -> [return: bb7, unwind terminate(cleanup)];
++     bb10: {
++         drop((*_10)) -> [return: bb7, unwind: bb8];
 +     }
 + 
 +     bb11: {
-+         goto -> bb13;
++         switchInt(copy _5) -> [0: bb7, otherwise: bb10];
 +     }
 + 
 +     bb12: {
-+         drop((*_10)) -> [return: bb9, unwind: bb10];
-+     }
-+ 
-+     bb13: {
-+         switchInt(copy _5) -> [0: bb9, otherwise: bb12];
-+     }
-+ 
-+     bb14: {
 +         _10 = copy ((_2.0: std::ptr::Unique<std::string::String>).0: std::ptr::NonNull<std::string::String>) as *const std::string::String (Transmute);
-+         goto -> bb11;
++         goto -> bb9;
       }
   }
   

--- a/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
+++ b/tests/mir-opt/building/async_await.b-{closure#0}.coroutine_resume.0.mir
@@ -105,7 +105,7 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) ->
     bb0: {
         _39 = copy (_1.0: &mut {async fn body of b()});
         _38 = discriminant((*_39));
-        switchInt(move _38) -> [0: bb1, 1: bb29, 3: bb27, 4: bb28, otherwise: bb8];
+        switchInt(move _38) -> [0: bb1, 1: bb27, 3: bb25, 4: bb26, otherwise: bb8];
     }
 
     bb1: {
@@ -206,30 +206,26 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) ->
 
     bb12: {
         nop;
-        goto -> bb13;
-    }
-
-    bb13: {
         StorageDead(_4);
         StorageDead(_3);
         StorageLive(_21);
         StorageLive(_22);
-        _22 = a() -> [return: bb14, unwind unreachable];
+        _22 = a() -> [return: bb13, unwind unreachable];
+    }
+
+    bb13: {
+        _21 = <{async fn body of a()} as IntoFuture>::into_future(move _22) -> [return: bb14, unwind unreachable];
     }
 
     bb14: {
-        _21 = <{async fn body of a()} as IntoFuture>::into_future(move _22) -> [return: bb15, unwind unreachable];
-    }
-
-    bb15: {
         StorageDead(_22);
         PlaceMention(_21);
         nop;
         (((*_39) as variant#4).0: {async fn body of a()}) = move _21;
-        goto -> bb16;
+        goto -> bb15;
     }
 
-    bb16: {
+    bb15: {
         StorageLive(_24);
         StorageLive(_25);
         StorageLive(_26);
@@ -237,34 +233,34 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) ->
         StorageLive(_28);
         _28 = &mut (((*_39) as variant#4).0: {async fn body of a()});
         _27 = &mut (*_28);
-        _26 = Pin::<&mut {async fn body of a()}>::new_unchecked(move _27) -> [return: bb17, unwind unreachable];
+        _26 = Pin::<&mut {async fn body of a()}>::new_unchecked(move _27) -> [return: bb16, unwind unreachable];
     }
 
-    bb17: {
+    bb16: {
         StorageDead(_27);
         StorageLive(_29);
         StorageLive(_30);
         StorageLive(_31);
         _31 = copy _2;
         _30 = move _31;
-        goto -> bb18;
+        goto -> bb17;
+    }
+
+    bb17: {
+        _29 = &mut (*_30);
+        StorageDead(_31);
+        _25 = <{async fn body of a()} as Future>::poll(move _26, move _29) -> [return: bb18, unwind unreachable];
     }
 
     bb18: {
-        _29 = &mut (*_30);
-        StorageDead(_31);
-        _25 = <{async fn body of a()} as Future>::poll(move _26, move _29) -> [return: bb19, unwind unreachable];
-    }
-
-    bb19: {
         StorageDead(_29);
         StorageDead(_26);
         PlaceMention(_25);
         _32 = discriminant(_25);
-        switchInt(move _32) -> [0: bb21, 1: bb20, otherwise: bb8];
+        switchInt(move _32) -> [0: bb20, 1: bb19, otherwise: bb8];
     }
 
-    bb20: {
+    bb19: {
         _24 = const ();
         StorageDead(_30);
         StorageDead(_28);
@@ -281,7 +277,7 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) ->
         return;
     }
 
-    bb21: {
+    bb20: {
         StorageLive(_33);
         _33 = copy ((_25 as Ready).0: ());
         _37 = copy _33;
@@ -290,38 +286,34 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) ->
         StorageDead(_28);
         StorageDead(_25);
         StorageDead(_24);
-        drop((((*_39) as variant#4).0: {async fn body of a()})) -> [return: bb23, unwind unreachable];
+        drop((((*_39) as variant#4).0: {async fn body of a()})) -> [return: bb22, unwind unreachable];
     }
 
-    bb22: {
+    bb21: {
         StorageDead(_36);
         _2 = move _35;
         StorageDead(_35);
         _7 = const ();
-        goto -> bb16;
+        goto -> bb15;
     }
 
-    bb23: {
+    bb22: {
         nop;
+        StorageDead(_21);
         goto -> bb24;
     }
 
-    bb24: {
-        StorageDead(_21);
-        goto -> bb26;
-    }
-
-    bb25: {
+    bb23: {
         _0 = Poll::<()>::Ready(move _37);
         discriminant((*_39)) = 1;
         return;
     }
 
-    bb26: {
-        goto -> bb25;
+    bb24: {
+        goto -> bb23;
     }
 
-    bb27: {
+    bb25: {
         StorageLive(_3);
         StorageLive(_4);
         StorageLive(_19);
@@ -330,15 +322,15 @@ fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) ->
         goto -> bb11;
     }
 
-    bb28: {
+    bb26: {
         StorageLive(_21);
         StorageLive(_35);
         StorageLive(_36);
         _35 = move _2;
-        goto -> bb22;
+        goto -> bb21;
     }
 
-    bb29: {
-        assert(const false, "`async fn` resumed after completion") -> [success: bb29, unwind unreachable];
+    bb27: {
+        assert(const false, "`async fn` resumed after completion") -> [success: bb27, unwind unreachable];
     }
 }

--- a/tests/mir-opt/building/coroutine.main-{closure#0}.StateTransform.after.mir
+++ b/tests/mir-opt/building/coroutine.main-{closure#0}.StateTransform.after.mir
@@ -45,7 +45,7 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
     bb0: {
         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:18:5: 18:18});
         _17 = discriminant((*_18));
-        switchInt(move _17) -> [0: bb1, 1: bb19, 3: bb17, 4: bb18, otherwise: bb20];
+        switchInt(move _17) -> [0: bb1, 1: bb15, 3: bb13, 4: bb14, otherwise: bb16];
     }
 
     bb1: {
@@ -67,10 +67,6 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
     bb3: {
         _4 = (const "first", move _5, move _7);
         StorageDead(_7);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_5);
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _4);
         StorageDead(_3);
@@ -79,16 +75,12 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
         return;
     }
 
-    bb5: {
-        goto -> bb6;
-    }
-
-    bb6: {
+    bb4: {
         StorageDead(_4);
-        drop(_3) -> [return: bb7, unwind unreachable];
+        drop(_3) -> [return: bb5, unwind unreachable];
     }
 
-    bb7: {
+    bb5: {
         StorageDead(_3);
         StorageLive(_8);
         StorageLive(_9);
@@ -99,24 +91,20 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
         StorageLive(_12);
         StorageLive(_13);
         _13 = &(((*_18) as variant#4).0: std::string::String);
-        _12 = <String as Clone>::clone(move _13) -> [return: bb8, unwind unreachable];
+        _12 = <String as Clone>::clone(move _13) -> [return: bb6, unwind unreachable];
     }
 
-    bb8: {
+    bb6: {
         StorageDead(_13);
         StorageLive(_14);
         StorageLive(_15);
-        _15 = Location::<'_>::caller() -> [return: bb9, unwind unreachable];
+        _15 = Location::<'_>::caller() -> [return: bb7, unwind unreachable];
     }
 
-    bb9: {
+    bb7: {
         _14 = &(*_15);
         _9 = (move _10, move _12, move _14);
         StorageDead(_14);
-        goto -> bb10;
-    }
-
-    bb10: {
         StorageDead(_12);
         StorageDead(_10);
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _9);
@@ -128,58 +116,54 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
         return;
     }
 
-    bb11: {
-        goto -> bb12;
-    }
-
-    bb12: {
+    bb8: {
         StorageDead(_9);
-        drop(_8) -> [return: bb13, unwind unreachable];
+        drop(_8) -> [return: bb9, unwind unreachable];
     }
 
-    bb13: {
+    bb9: {
         StorageDead(_15);
         StorageDead(_11);
         StorageDead(_8);
         _16 = const ();
-        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb14, unwind unreachable];
+        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb10, unwind unreachable];
     }
 
-    bb14: {
-        goto -> bb16;
+    bb10: {
+        goto -> bb12;
     }
 
-    bb15: {
+    bb11: {
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Complete(move _16);
         discriminant((*_18)) = 1;
         return;
     }
 
-    bb16: {
-        goto -> bb15;
+    bb12: {
+        goto -> bb11;
     }
 
-    bb17: {
+    bb13: {
         StorageLive(_3);
         StorageLive(_4);
         _3 = move _2;
-        goto -> bb5;
+        goto -> bb4;
     }
 
-    bb18: {
+    bb14: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_11);
         StorageLive(_15);
         _8 = move _2;
-        goto -> bb11;
+        goto -> bb8;
     }
 
-    bb19: {
-        assert(const false, "coroutine resumed after completion") -> [success: bb19, unwind unreachable];
+    bb15: {
+        assert(const false, "coroutine resumed after completion") -> [success: bb15, unwind unreachable];
     }
 
-    bb20: {
+    bb16: {
         unreachable;
     }
 }

--- a/tests/mir-opt/building/coroutine.main-{closure#0}.StateTransform.after.mir
+++ b/tests/mir-opt/building/coroutine.main-{closure#0}.StateTransform.after.mir
@@ -45,7 +45,7 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
     bb0: {
         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:18:5: 18:18});
         _17 = discriminant((*_18));
-        switchInt(move _17) -> [0: bb1, 1: bb15, 3: bb13, 4: bb14, otherwise: bb16];
+        switchInt(move _17) -> [0: bb1, 1: bb13, 3: bb11, 4: bb12, otherwise: bb14];
     }
 
     bb1: {
@@ -77,10 +77,6 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
 
     bb4: {
         StorageDead(_4);
-        drop(_3) -> [return: bb5, unwind unreachable];
-    }
-
-    bb5: {
         StorageDead(_3);
         StorageLive(_8);
         StorageLive(_9);
@@ -91,17 +87,17 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
         StorageLive(_12);
         StorageLive(_13);
         _13 = &(((*_18) as variant#4).0: std::string::String);
-        _12 = <String as Clone>::clone(move _13) -> [return: bb6, unwind unreachable];
+        _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind unreachable];
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_13);
         StorageLive(_14);
         StorageLive(_15);
-        _15 = Location::<'_>::caller() -> [return: bb7, unwind unreachable];
+        _15 = Location::<'_>::caller() -> [return: bb6, unwind unreachable];
     }
 
-    bb7: {
+    bb6: {
         _14 = &(*_15);
         _9 = (move _10, move _12, move _14);
         StorageDead(_14);
@@ -116,54 +112,50 @@ fn main::{closure#0}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:18:5: 18:18}>, _2
         return;
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_9);
-        drop(_8) -> [return: bb9, unwind unreachable];
-    }
-
-    bb9: {
         StorageDead(_15);
         StorageDead(_11);
         StorageDead(_8);
         _16 = const ();
-        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb10, unwind unreachable];
+        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb8, unwind unreachable];
     }
 
-    bb10: {
-        goto -> bb12;
+    bb8: {
+        goto -> bb10;
     }
 
-    bb11: {
+    bb9: {
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Complete(move _16);
         discriminant((*_18)) = 1;
         return;
     }
 
-    bb12: {
-        goto -> bb11;
+    bb10: {
+        goto -> bb9;
     }
 
-    bb13: {
+    bb11: {
         StorageLive(_3);
         StorageLive(_4);
         _3 = move _2;
         goto -> bb4;
     }
 
-    bb14: {
+    bb12: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_11);
         StorageLive(_15);
         _8 = move _2;
-        goto -> bb8;
+        goto -> bb7;
     }
 
-    bb15: {
-        assert(const false, "coroutine resumed after completion") -> [success: bb15, unwind unreachable];
+    bb13: {
+        assert(const false, "coroutine resumed after completion") -> [success: bb13, unwind unreachable];
     }
 
-    bb16: {
+    bb14: {
         unreachable;
     }
 }

--- a/tests/mir-opt/building/coroutine.main-{closure#1}.StateTransform.after.mir
+++ b/tests/mir-opt/building/coroutine.main-{closure#1}.StateTransform.after.mir
@@ -45,7 +45,7 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
     bb0: {
         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:25:5: 25:18});
         _17 = discriminant((*_18));
-        switchInt(move _17) -> [0: bb1, 1: bb19, 3: bb17, 4: bb18, otherwise: bb20];
+        switchInt(move _17) -> [0: bb1, 1: bb15, 3: bb13, 4: bb14, otherwise: bb16];
     }
 
     bb1: {
@@ -67,10 +67,6 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
     bb3: {
         _4 = (const "first", move _5, move _7);
         StorageDead(_7);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_5);
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _4);
         StorageDead(_3);
@@ -79,16 +75,12 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
         return;
     }
 
-    bb5: {
-        goto -> bb6;
-    }
-
-    bb6: {
+    bb4: {
         StorageDead(_4);
-        drop(_3) -> [return: bb7, unwind unreachable];
+        drop(_3) -> [return: bb5, unwind unreachable];
     }
 
-    bb7: {
+    bb5: {
         StorageDead(_3);
         StorageLive(_8);
         StorageLive(_9);
@@ -99,24 +91,20 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
         StorageLive(_12);
         StorageLive(_13);
         _13 = &(((*_18) as variant#4).0: std::string::String);
-        _12 = <String as Clone>::clone(move _13) -> [return: bb8, unwind unreachable];
+        _12 = <String as Clone>::clone(move _13) -> [return: bb6, unwind unreachable];
     }
 
-    bb8: {
+    bb6: {
         StorageDead(_13);
         StorageLive(_14);
         StorageLive(_15);
-        _15 = Location::<'_>::caller() -> [return: bb9, unwind unreachable];
+        _15 = Location::<'_>::caller() -> [return: bb7, unwind unreachable];
     }
 
-    bb9: {
+    bb7: {
         _14 = &(*_15);
         _9 = (move _10, move _12, move _14);
         StorageDead(_14);
-        goto -> bb10;
-    }
-
-    bb10: {
         StorageDead(_12);
         StorageDead(_10);
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Yielded(move _9);
@@ -128,58 +116,54 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
         return;
     }
 
-    bb11: {
-        goto -> bb12;
-    }
-
-    bb12: {
+    bb8: {
         StorageDead(_9);
-        drop(_8) -> [return: bb13, unwind unreachable];
+        drop(_8) -> [return: bb9, unwind unreachable];
     }
 
-    bb13: {
+    bb9: {
         StorageDead(_15);
         StorageDead(_11);
         StorageDead(_8);
         _16 = const ();
-        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb14, unwind unreachable];
+        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb10, unwind unreachable];
     }
 
-    bb14: {
-        goto -> bb16;
+    bb10: {
+        goto -> bb12;
     }
 
-    bb15: {
+    bb11: {
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Complete(move _16);
         discriminant((*_18)) = 1;
         return;
     }
 
-    bb16: {
-        goto -> bb15;
+    bb12: {
+        goto -> bb11;
     }
 
-    bb17: {
+    bb13: {
         StorageLive(_3);
         StorageLive(_4);
         _3 = move _2;
-        goto -> bb5;
+        goto -> bb4;
     }
 
-    bb18: {
+    bb14: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_11);
         StorageLive(_15);
         _8 = move _2;
-        goto -> bb11;
+        goto -> bb8;
     }
 
-    bb19: {
-        assert(const false, "coroutine resumed after completion") -> [success: bb19, unwind unreachable];
+    bb15: {
+        assert(const false, "coroutine resumed after completion") -> [success: bb15, unwind unreachable];
     }
 
-    bb20: {
+    bb16: {
         unreachable;
     }
 }

--- a/tests/mir-opt/building/coroutine.main-{closure#1}.StateTransform.after.mir
+++ b/tests/mir-opt/building/coroutine.main-{closure#1}.StateTransform.after.mir
@@ -45,7 +45,7 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
     bb0: {
         _18 = copy (_1.0: &mut {coroutine@$DIR/coroutine.rs:25:5: 25:18});
         _17 = discriminant((*_18));
-        switchInt(move _17) -> [0: bb1, 1: bb15, 3: bb13, 4: bb14, otherwise: bb16];
+        switchInt(move _17) -> [0: bb1, 1: bb13, 3: bb11, 4: bb12, otherwise: bb14];
     }
 
     bb1: {
@@ -77,10 +77,6 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
 
     bb4: {
         StorageDead(_4);
-        drop(_3) -> [return: bb5, unwind unreachable];
-    }
-
-    bb5: {
         StorageDead(_3);
         StorageLive(_8);
         StorageLive(_9);
@@ -91,17 +87,17 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
         StorageLive(_12);
         StorageLive(_13);
         _13 = &(((*_18) as variant#4).0: std::string::String);
-        _12 = <String as Clone>::clone(move _13) -> [return: bb6, unwind unreachable];
+        _12 = <String as Clone>::clone(move _13) -> [return: bb5, unwind unreachable];
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_13);
         StorageLive(_14);
         StorageLive(_15);
-        _15 = Location::<'_>::caller() -> [return: bb7, unwind unreachable];
+        _15 = Location::<'_>::caller() -> [return: bb6, unwind unreachable];
     }
 
-    bb7: {
+    bb6: {
         _14 = &(*_15);
         _9 = (move _10, move _12, move _14);
         StorageDead(_14);
@@ -116,54 +112,50 @@ fn main::{closure#1}(_1: Pin<&mut {coroutine@$DIR/coroutine.rs:25:5: 25:18}>, _2
         return;
     }
 
-    bb8: {
+    bb7: {
         StorageDead(_9);
-        drop(_8) -> [return: bb9, unwind unreachable];
-    }
-
-    bb9: {
         StorageDead(_15);
         StorageDead(_11);
         StorageDead(_8);
         _16 = const ();
-        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb10, unwind unreachable];
+        drop((((*_18) as variant#4).0: std::string::String)) -> [return: bb8, unwind unreachable];
     }
 
-    bb10: {
-        goto -> bb12;
+    bb8: {
+        goto -> bb10;
     }
 
-    bb11: {
+    bb9: {
         _0 = CoroutineState::<(&str, String, &Location<'_>), ()>::Complete(move _16);
         discriminant((*_18)) = 1;
         return;
     }
 
-    bb12: {
-        goto -> bb11;
+    bb10: {
+        goto -> bb9;
     }
 
-    bb13: {
+    bb11: {
         StorageLive(_3);
         StorageLive(_4);
         _3 = move _2;
         goto -> bb4;
     }
 
-    bb14: {
+    bb12: {
         StorageLive(_8);
         StorageLive(_9);
         StorageLive(_11);
         StorageLive(_15);
         _8 = move _2;
-        goto -> bb8;
+        goto -> bb7;
     }
 
-    bb15: {
-        assert(const false, "coroutine resumed after completion") -> [success: bb15, unwind unreachable];
+    bb13: {
+        assert(const false, "coroutine resumed after completion") -> [success: bb13, unwind unreachable];
     }
 
-    bb16: {
+    bb14: {
         unreachable;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
@@ -16,45 +16,53 @@ fn move_out_by_subslice() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
     }
 
     bb2: {
         _1 = [move _2, move _3];
+        drop(_3) -> [return: bb3, unwind: bb8];
+    }
+
+    bb3: {
         StorageDead(_3);
+        drop(_2) -> [return: bb4, unwind: bb9];
+    }
+
+    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[0..2];
         _0 = const ();
-        drop(_4) -> [return: bb3, unwind: bb5];
+        drop(_4) -> [return: bb5, unwind: bb7];
     }
 
-    bb3: {
+    bb5: {
         StorageDead(_4);
-        drop(_1) -> [return: bb4, unwind: bb7];
+        drop(_1) -> [return: bb6, unwind: bb9];
     }
 
-    bb4: {
+    bb6: {
         StorageDead(_1);
         return;
     }
 
-    bb5 (cleanup): {
-        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
-    bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
     bb7 (cleanup): {
+        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
+    }
+
+    bb8 (cleanup): {
+        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
+    }
+
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
@@ -16,53 +16,45 @@ fn move_out_by_subslice() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
         _1 = [move _2, move _3];
-        drop(_3) -> [return: bb3, unwind: bb8];
-    }
-
-    bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb9];
-    }
-
-    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[0..2];
         _0 = const ();
-        drop(_4) -> [return: bb5, unwind: bb7];
+        drop(_4) -> [return: bb3, unwind: bb5];
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);
-        drop(_1) -> [return: bb6, unwind: bb9];
+        drop(_1) -> [return: bb4, unwind: bb7];
     }
 
-    bb6: {
+    bb4: {
         StorageDead(_1);
         return;
     }
 
+    bb5 (cleanup): {
+        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
@@ -16,53 +16,45 @@ fn move_out_by_subslice() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
         _1 = [move _2, move _3];
-        goto -> bb3;
-    }
-
-    bb3: {
         StorageDead(_3);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[0..2];
         _0 = const ();
-        drop(_4) -> [return: bb5, unwind: bb7];
+        drop(_4) -> [return: bb3, unwind: bb5];
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);
-        drop(_1) -> [return: bb6, unwind: bb9];
+        drop(_1) -> [return: bb4, unwind: bb7];
     }
 
-    bb6: {
+    bb4: {
         StorageDead(_1);
         return;
     }
 
+    bb5 (cleanup): {
+        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_by_subslice.CleanupPostBorrowck.after.mir
@@ -26,12 +26,12 @@ fn move_out_by_subslice() -> () {
 
     bb2: {
         _1 = [move _2, move _3];
-        drop(_3) -> [return: bb3, unwind: bb8];
+        goto -> bb3;
     }
 
     bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb9];
+        goto -> bb4;
     }
 
     bb4: {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
@@ -26,12 +26,12 @@ fn move_out_from_end() -> () {
 
     bb2: {
         _1 = [move _2, move _3];
-        drop(_3) -> [return: bb3, unwind: bb8];
+        goto -> bb3;
     }
 
     bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb9];
+        goto -> bb4;
     }
 
     bb4: {

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
@@ -16,53 +16,45 @@ fn move_out_from_end() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
         _1 = [move _2, move _3];
-        drop(_3) -> [return: bb3, unwind: bb8];
-    }
-
-    bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb9];
-    }
-
-    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[1 of 2];
         _0 = const ();
-        drop(_4) -> [return: bb5, unwind: bb7];
+        drop(_4) -> [return: bb3, unwind: bb5];
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);
-        drop(_1) -> [return: bb6, unwind: bb9];
+        drop(_1) -> [return: bb4, unwind: bb7];
     }
 
-    bb6: {
+    bb4: {
         StorageDead(_1);
         return;
     }
 
+    bb5 (cleanup): {
+        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
@@ -16,53 +16,45 @@ fn move_out_from_end() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
         _1 = [move _2, move _3];
-        goto -> bb3;
-    }
-
-    bb3: {
         StorageDead(_3);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[1 of 2];
         _0 = const ();
-        drop(_4) -> [return: bb5, unwind: bb7];
+        drop(_4) -> [return: bb3, unwind: bb5];
     }
 
-    bb5: {
+    bb3: {
         StorageDead(_4);
-        drop(_1) -> [return: bb6, unwind: bb9];
+        drop(_1) -> [return: bb4, unwind: bb7];
     }
 
-    bb6: {
+    bb4: {
         StorageDead(_1);
         return;
     }
 
+    bb5 (cleanup): {
+        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
     bb7 (cleanup): {
-        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-    }
-
-    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/uniform_array_move_out.move_out_from_end.CleanupPostBorrowck.after.mir
@@ -16,45 +16,53 @@ fn move_out_from_end() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb7];
+        _2 = Box::<i32>::new(const 1_i32) -> [return: bb1, unwind: bb9];
     }
 
     bb1: {
         StorageLive(_3);
-        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb6];
+        _3 = Box::<i32>::new(const 2_i32) -> [return: bb2, unwind: bb8];
     }
 
     bb2: {
         _1 = [move _2, move _3];
+        drop(_3) -> [return: bb3, unwind: bb8];
+    }
+
+    bb3: {
         StorageDead(_3);
+        drop(_2) -> [return: bb4, unwind: bb9];
+    }
+
+    bb4: {
         StorageDead(_2);
         nop;
         PlaceMention(_1);
         StorageLive(_4);
         _4 = move _1[1 of 2];
         _0 = const ();
-        drop(_4) -> [return: bb3, unwind: bb5];
+        drop(_4) -> [return: bb5, unwind: bb7];
     }
 
-    bb3: {
+    bb5: {
         StorageDead(_4);
-        drop(_1) -> [return: bb4, unwind: bb7];
+        drop(_1) -> [return: bb6, unwind: bb9];
     }
 
-    bb4: {
+    bb6: {
         StorageDead(_1);
         return;
     }
 
-    bb5 (cleanup): {
-        drop(_1) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
-    bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
     bb7 (cleanup): {
+        drop(_1) -> [return: bb9, unwind terminate(cleanup)];
+    }
+
+    bb8 (cleanup): {
+        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
+    }
+
+    bb9 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -13,7 +13,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
@@ -26,33 +26,21 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         ((((*_4).1: std::mem::ManuallyDrop<[T; 1024]>).0: std::mem::MaybeDangling<[T; 1024]>).0: [T; 1024]) = [move _5; 1024];
         StorageDead(_5);
         _3 = move _4;
-        goto -> bb2;
+        StorageDead(_4);
+        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _3) -> [return: bb2, unwind: bb3];
     }
 
     bb2: {
-        StorageDead(_4);
-        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _3) -> [return: bb3, unwind: bb5];
-    }
-
-    bb3: {
         StorageDead(_3);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         return;
     }
 
-    bb5 (cleanup): {
-        drop(_3) -> [return: bb6, unwind terminate(cleanup)];
+    bb3 (cleanup): {
+        drop(_3) -> [return: bb4, unwind terminate(cleanup)];
     }
 
-    bb6 (cleanup): {
-        goto -> bb7;
-    }
-
-    bb7 (cleanup): {
+    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -26,7 +26,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         ((((*_4).1: std::mem::ManuallyDrop<[T; 1024]>).0: std::mem::MaybeDangling<[T; 1024]>).0: [T; 1024]) = [move _5; 1024];
         StorageDead(_5);
         _3 = move _4;
-        drop(_4) -> [return: bb2, unwind: bb5];
+        goto -> bb2;
     }
 
     bb2: {
@@ -36,7 +36,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb7];
+        goto -> bb4;
     }
 
     bb4: {
@@ -49,7 +49,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
     }
 
     bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+        goto -> bb7;
     }
 
     bb7 (cleanup): {

--- a/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -13,7 +13,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
@@ -26,33 +26,21 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         ((((*_4).1: std::mem::ManuallyDrop<[T; 1024]>).0: std::mem::MaybeDangling<[T; 1024]>).0: [T; 1024]) = [move _5; 1024];
         StorageDead(_5);
         _3 = move _4;
-        drop(_4) -> [return: bb2, unwind: bb5];
+        StorageDead(_4);
+        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _3) -> [return: bb2, unwind: bb3];
     }
 
     bb2: {
-        StorageDead(_4);
-        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _3) -> [return: bb3, unwind: bb5];
-    }
-
-    bb3: {
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb7];
-    }
-
-    bb4: {
         StorageDead(_2);
         return;
     }
 
-    bb5 (cleanup): {
-        drop(_3) -> [return: bb6, unwind terminate(cleanup)];
+    bb3 (cleanup): {
+        drop(_3) -> [return: bb4, unwind terminate(cleanup)];
     }
 
-    bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
-    bb7 (cleanup): {
+    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -13,7 +13,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb4];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
@@ -26,21 +26,33 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         ((((*_4).1: std::mem::ManuallyDrop<[T; 1024]>).0: std::mem::MaybeDangling<[T; 1024]>).0: [T; 1024]) = [move _5; 1024];
         StorageDead(_5);
         _3 = move _4;
-        StorageDead(_4);
-        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _3) -> [return: bb2, unwind: bb3];
+        drop(_4) -> [return: bb2, unwind: bb5];
     }
 
     bb2: {
+        StorageDead(_4);
+        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _3) -> [return: bb3, unwind: bb5];
+    }
+
+    bb3: {
         StorageDead(_3);
+        drop(_2) -> [return: bb4, unwind: bb7];
+    }
+
+    bb4: {
         StorageDead(_2);
         return;
     }
 
-    bb3 (cleanup): {
-        drop(_3) -> [return: bb4, unwind terminate(cleanup)];
+    bb5 (cleanup): {
+        drop(_3) -> [return: bb6, unwind terminate(cleanup)];
     }
 
-    bb4 (cleanup): {
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
@@ -8,30 +8,26 @@ fn vec_macro() -> Vec<i32> {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<[i32; 8]>::new_uninit() -> [return: bb1, unwind: bb5];
+        _2 = Box::<[i32; 8]>::new_uninit() -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
         ((((*_2).1: std::mem::ManuallyDrop<[i32; 8]>).0: std::mem::MaybeDangling<[i32; 8]>).0: [i32; 8]) = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32, const 6_i32, const 7_i32];
         _1 = move _2;
-        goto -> bb2;
+        StorageDead(_2);
+        _0 = std::boxed::box_assume_init_into_vec_unsafe::<i32, 8>(move _1) -> [return: bb2, unwind: bb3];
     }
 
     bb2: {
-        StorageDead(_2);
-        _0 = std::boxed::box_assume_init_into_vec_unsafe::<i32, 8>(move _1) -> [return: bb3, unwind: bb4];
-    }
-
-    bb3: {
         StorageDead(_1);
         return;
     }
 
-    bb4 (cleanup): {
-        drop(_1) -> [return: bb5, unwind terminate(cleanup)];
+    bb3 (cleanup): {
+        drop(_1) -> [return: bb4, unwind terminate(cleanup)];
     }
 
-    bb5 (cleanup): {
+    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
@@ -8,26 +8,30 @@ fn vec_macro() -> Vec<i32> {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<[i32; 8]>::new_uninit() -> [return: bb1, unwind: bb4];
+        _2 = Box::<[i32; 8]>::new_uninit() -> [return: bb1, unwind: bb5];
     }
 
     bb1: {
         ((((*_2).1: std::mem::ManuallyDrop<[i32; 8]>).0: std::mem::MaybeDangling<[i32; 8]>).0: [i32; 8]) = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32, const 6_i32, const 7_i32];
         _1 = move _2;
-        StorageDead(_2);
-        _0 = std::boxed::box_assume_init_into_vec_unsafe::<i32, 8>(move _1) -> [return: bb2, unwind: bb3];
+        drop(_2) -> [return: bb2, unwind: bb4];
     }
 
     bb2: {
+        StorageDead(_2);
+        _0 = std::boxed::box_assume_init_into_vec_unsafe::<i32, 8>(move _1) -> [return: bb3, unwind: bb4];
+    }
+
+    bb3: {
         StorageDead(_1);
         return;
     }
 
-    bb3 (cleanup): {
-        drop(_1) -> [return: bb4, unwind terminate(cleanup)];
+    bb4 (cleanup): {
+        drop(_1) -> [return: bb5, unwind terminate(cleanup)];
     }
 
-    bb4 (cleanup): {
+    bb5 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
@@ -8,30 +8,26 @@ fn vec_macro() -> Vec<i32> {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = Box::<[i32; 8]>::new_uninit() -> [return: bb1, unwind: bb5];
+        _2 = Box::<[i32; 8]>::new_uninit() -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
         ((((*_2).1: std::mem::ManuallyDrop<[i32; 8]>).0: std::mem::MaybeDangling<[i32; 8]>).0: [i32; 8]) = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32, const 6_i32, const 7_i32];
         _1 = move _2;
-        drop(_2) -> [return: bb2, unwind: bb4];
+        StorageDead(_2);
+        _0 = std::boxed::box_assume_init_into_vec_unsafe::<i32, 8>(move _1) -> [return: bb2, unwind: bb3];
     }
 
     bb2: {
-        StorageDead(_2);
-        _0 = std::boxed::box_assume_init_into_vec_unsafe::<i32, 8>(move _1) -> [return: bb3, unwind: bb4];
-    }
-
-    bb3: {
         StorageDead(_1);
         return;
     }
 
-    bb4 (cleanup): {
-        drop(_1) -> [return: bb5, unwind terminate(cleanup)];
+    bb3 (cleanup): {
+        drop(_1) -> [return: bb4, unwind terminate(cleanup)];
     }
 
-    bb5 (cleanup): {
+    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_box_via_move.vec_macro.CleanupPostBorrowck.after.mir
@@ -14,7 +14,7 @@ fn vec_macro() -> Vec<i32> {
     bb1: {
         ((((*_2).1: std::mem::ManuallyDrop<[i32; 8]>).0: std::mem::MaybeDangling<[i32; 8]>).0: [i32; 8]) = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32, const 6_i32, const 7_i32];
         _1 = move _2;
-        drop(_2) -> [return: bb2, unwind: bb4];
+        goto -> bb2;
     }
 
     bb2: {

--- a/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -20,7 +20,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb5];
     }
 
     bb1: {
@@ -30,7 +30,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageLive(_5);
         _5 = &mut (*_2);
         _4 = &mut (*_5);
-        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb6];
+        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb4];
     }
 
     bb2: {
@@ -48,29 +48,21 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageDead(_6);
         StorageLive(_9);
         _9 = move _2;
-        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _9) -> [return: bb3, unwind: bb5];
+        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _9) -> [return: bb3, unwind: bb4];
     }
 
     bb3: {
         StorageDead(_9);
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb7];
-    }
-
-    bb4: {
         StorageDead(_2);
         return;
     }
 
+    bb4 (cleanup): {
+        drop(_2) -> [return: bb5, unwind terminate(cleanup)];
+    }
+
     bb5 (cleanup): {
-        drop(_9) -> [return: bb6, unwind terminate(cleanup)];
-    }
-
-    bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
-    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -20,7 +20,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb5];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
     }
 
     bb1: {
@@ -30,7 +30,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageLive(_5);
         _5 = &mut (*_2);
         _4 = &mut (*_5);
-        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb4];
+        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb6];
     }
 
     bb2: {
@@ -48,21 +48,29 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageDead(_6);
         StorageLive(_9);
         _9 = move _2;
-        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _9) -> [return: bb3, unwind: bb4];
+        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _9) -> [return: bb3, unwind: bb5];
     }
 
     bb3: {
         StorageDead(_9);
         StorageDead(_3);
+        drop(_2) -> [return: bb4, unwind: bb7];
+    }
+
+    bb4: {
         StorageDead(_2);
         return;
     }
 
-    bb4 (cleanup): {
-        drop(_2) -> [return: bb5, unwind terminate(cleanup)];
+    bb5 (cleanup): {
+        drop(_9) -> [return: bb6, unwind terminate(cleanup)];
     }
 
-    bb5 (cleanup): {
+    bb6 (cleanup): {
+        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
+    }
+
+    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -20,7 +20,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
 
     bb0: {
         StorageLive(_2);
-        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb7];
+        _2 = Box::<[T; 1024]>::new_uninit() -> [return: bb1, unwind: bb5];
     }
 
     bb1: {
@@ -30,7 +30,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageLive(_5);
         _5 = &mut (*_2);
         _4 = &mut (*_5);
-        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb6];
+        _3 = MaybeUninit::<[T; 1024]>::as_mut_ptr(move _4) -> [return: bb2, unwind: bb4];
     }
 
     bb2: {
@@ -48,29 +48,21 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
         StorageDead(_6);
         StorageLive(_9);
         _9 = move _2;
-        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _9) -> [return: bb3, unwind: bb5];
+        _0 = Box::<MaybeUninit<[T; 1024]>>::assume_init(move _9) -> [return: bb3, unwind: bb4];
     }
 
     bb3: {
         StorageDead(_9);
         StorageDead(_3);
-        goto -> bb4;
-    }
-
-    bb4: {
         StorageDead(_2);
         return;
     }
 
+    bb4 (cleanup): {
+        drop(_2) -> [return: bb5, unwind terminate(cleanup)];
+    }
+
     bb5 (cleanup): {
-        goto -> bb6;
-    }
-
-    bb6 (cleanup): {
-        drop(_2) -> [return: bb7, unwind terminate(cleanup)];
-    }
-
-    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
+++ b/tests/mir-opt/building/write_via_move.box_new.CleanupPostBorrowck.after.mir
@@ -54,7 +54,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
     bb3: {
         StorageDead(_9);
         StorageDead(_3);
-        drop(_2) -> [return: bb4, unwind: bb7];
+        goto -> bb4;
     }
 
     bb4: {
@@ -63,7 +63,7 @@ fn box_new(_1: T) -> Box<[T; 1024]> {
     }
 
     bb5 (cleanup): {
-        drop(_9) -> [return: bb6, unwind terminate(cleanup)];
+        goto -> bb6;
     }
 
     bb6 (cleanup): {

--- a/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-abort.mir
+++ b/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-abort.mir
@@ -27,7 +27,7 @@ yields ()
         StorageLive(_5);
         StorageLive(_6);
         _6 = ();
-        _5 = yield(move _6) -> [resume: bb1, drop: bb6];
+        _5 = yield(move _6) -> [resume: bb1, drop: bb5];
     }
 
     bb1: {
@@ -53,31 +53,27 @@ yields ()
         StorageDead(_9);
         _0 = const ();
         StorageDead(_4);
-        goto -> bb4;
+        StorageDead(_3);
+        drop(_1) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        StorageDead(_3);
-        drop(_1) -> [return: bb5, unwind unreachable];
-    }
-
-    bb5: {
         return;
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_6);
         StorageDead(_5);
         StorageDead(_4);
-        drop(_3) -> [return: bb7, unwind unreachable];
+        drop(_3) -> [return: bb6, unwind unreachable];
+    }
+
+    bb6: {
+        StorageDead(_3);
+        drop(_1) -> [return: bb7, unwind unreachable];
     }
 
     bb7: {
-        StorageDead(_3);
-        drop(_1) -> [return: bb8, unwind unreachable];
-    }
-
-    bb8: {
         coroutine_drop;
     }
 }

--- a/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
+++ b/tests/mir-opt/coroutine_storage_dead_unwind.main-{closure#0}.StateTransform.before.panic-unwind.mir
@@ -27,7 +27,7 @@ yields ()
         StorageLive(_5);
         StorageLive(_6);
         _6 = ();
-        _5 = yield(move _6) -> [resume: bb1, drop: bb6];
+        _5 = yield(move _6) -> [resume: bb1, drop: bb5];
     }
 
     bb1: {
@@ -36,7 +36,7 @@ yields ()
         StorageLive(_7);
         StorageLive(_8);
         _8 = move _3;
-        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb10];
+        _7 = take::<Foo>(move _8) -> [return: bb2, unwind: bb9];
     }
 
     bb2: {
@@ -45,7 +45,7 @@ yields ()
         StorageLive(_9);
         StorageLive(_10);
         _10 = move _4;
-        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb9];
+        _9 = take::<Bar>(move _10) -> [return: bb3, unwind: bb8];
     }
 
     bb3: {
@@ -53,66 +53,54 @@ yields ()
         StorageDead(_9);
         _0 = const ();
         StorageDead(_4);
-        goto -> bb4;
+        StorageDead(_3);
+        drop(_1) -> [return: bb4, unwind: bb11];
     }
 
     bb4: {
-        StorageDead(_3);
-        drop(_1) -> [return: bb5, unwind: bb14];
-    }
-
-    bb5: {
         return;
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_6);
         StorageDead(_5);
         StorageDead(_4);
-        drop(_3) -> [return: bb7, unwind: bb15];
+        drop(_3) -> [return: bb6, unwind: bb12];
+    }
+
+    bb6: {
+        StorageDead(_3);
+        drop(_1) -> [return: bb7, unwind: bb11];
     }
 
     bb7: {
-        StorageDead(_3);
-        drop(_1) -> [return: bb8, unwind: bb14];
-    }
-
-    bb8: {
         coroutine_drop;
     }
 
-    bb9 (cleanup): {
+    bb8 (cleanup): {
         StorageDead(_10);
         StorageDead(_9);
-        goto -> bb12;
+        goto -> bb10;
+    }
+
+    bb9 (cleanup): {
+        StorageDead(_8);
+        StorageDead(_7);
+        goto -> bb10;
     }
 
     bb10 (cleanup): {
-        goto -> bb11;
+        StorageDead(_4);
+        StorageDead(_3);
+        drop(_1) -> [return: bb11, unwind terminate(cleanup)];
     }
 
     bb11 (cleanup): {
-        StorageDead(_8);
-        StorageDead(_7);
-        goto -> bb12;
-    }
-
-    bb12 (cleanup): {
-        StorageDead(_4);
-        goto -> bb13;
-    }
-
-    bb13 (cleanup): {
-        StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind terminate(cleanup)];
-    }
-
-    bb14 (cleanup): {
         resume;
     }
 
-    bb15 (cleanup): {
+    bb12 (cleanup): {
         StorageDead(_3);
-        drop(_1) -> [return: bb14, unwind terminate(cleanup)];
+        drop(_1) -> [return: bb11, unwind terminate(cleanup)];
     }
 }

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = f() -> [return: bb1, unwind: bb5];
+          _2 = f() -> [return: bb1, unwind: bb4];
       }
   
       bb1: {
@@ -18,7 +18,7 @@
   
       bb2: {
           StorageDead(_2);
-          drop(_1) -> [return: bb3, unwind: bb5];
+          drop(_1) -> [return: bb3, unwind: bb4];
       }
   
       bb3: {
@@ -28,10 +28,6 @@
       }
   
       bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
-      }
-  
-      bb5 (cleanup): {
           resume;
       }
   }

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-abort.diff
@@ -9,7 +9,7 @@
       bb0: {
           StorageLive(_1);
           StorageLive(_2);
-          _2 = f() -> [return: bb1, unwind: bb4];
+          _2 = f() -> [return: bb1, unwind: bb5];
       }
   
       bb1: {
@@ -18,7 +18,7 @@
   
       bb2: {
           StorageDead(_2);
-          drop(_1) -> [return: bb3, unwind: bb4];
+          drop(_1) -> [return: bb3, unwind: bb5];
       }
   
       bb3: {
@@ -28,6 +28,10 @@
       }
   
       bb4 (cleanup): {
+          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
+      }
+  
+      bb5 (cleanup): {
           resume;
       }
   }

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
@@ -13,7 +13,7 @@
       }
   
       bb1: {
-          _1 = Box::<Box<u32>>::new(move _2) -> [return: bb2, unwind: bb4];
+          _1 = Box::<Box<u32>>::new(move _2) -> [return: bb2, unwind continue];
       }
   
       bb2: {
@@ -25,14 +25,6 @@
           StorageDead(_1);
           _0 = const ();
           return;
-      }
-  
-      bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
-      }
-  
-      bb5 (cleanup): {
-          resume;
       }
   }
   

--- a/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
+++ b/tests/mir-opt/derefer_inline_test.main.Derefer.panic-unwind.diff
@@ -13,7 +13,7 @@
       }
   
       bb1: {
-          _1 = Box::<Box<u32>>::new(move _2) -> [return: bb2, unwind continue];
+          _1 = Box::<Box<u32>>::new(move _2) -> [return: bb2, unwind: bb4];
       }
   
       bb2: {
@@ -25,6 +25,14 @@
           StorageDead(_1);
           _0 = const ();
           return;
+      }
+  
+      bb4 (cleanup): {
+          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
+      }
+  
+      bb5 (cleanup): {
+          resume;
       }
   }
   

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -21,7 +21,7 @@
       bb0: {
           StorageLive(_2);
           _2 = move _1;
--         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2];
+-         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind continue];
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _3 = discriminant(_2);
@@ -29,13 +29,9 @@
       }
   
       bb1: {
--         StorageDead(_2);
--         return;
 +         unreachable;
-      }
-  
--     bb2 (cleanup): {
--         resume;
++     }
++ 
 +     bb2: {
 +         assume(UbChecks);
 +         _4 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
@@ -45,8 +41,8 @@
 +         _0 = move ((_2 as Some).0: T);
 +         StorageDead(_4);
 +         StorageDead(_3);
-+         StorageDead(_2);
-+         return;
+          StorageDead(_2);
+          return;
       }
   }
   

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -21,7 +21,7 @@
       bb0: {
           StorageLive(_2);
           _2 = move _1;
--         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind continue];
+-         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2];
 +         StorageLive(_3);
 +         StorageLive(_4);
 +         _3 = discriminant(_2);
@@ -29,9 +29,13 @@
       }
   
       bb1: {
+-         StorageDead(_2);
+-         return;
 +         unreachable;
-+     }
-+ 
+      }
+  
+-     bb2 (cleanup): {
+-         resume;
 +     bb2: {
 +         assume(UbChecks);
 +         _4 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
@@ -41,8 +45,8 @@
 +         _0 = move ((_2 as Some).0: T);
 +         StorageDead(_4);
 +         StorageDead(_3);
-          StorageDead(_2);
-          return;
++         StorageDead(_2);
++         return;
       }
   }
   

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
@@ -21,7 +21,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = S;
-          _3 = S::id(move _4) -> [return: bb1, unwind: bb3];
+          _3 = S::id(move _4) -> [return: bb1, unwind: bb4];
       }
   
       bb1: {
@@ -40,20 +40,30 @@
       }
   
       bb3 (cleanup): {
--         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-+         goto -> bb6;
+-         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
++         goto -> bb5;
       }
   
       bb4 (cleanup): {
+-         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
++         goto -> bb5;
+      }
+  
+      bb5 (cleanup): {
+-         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb6 (cleanup): {
           resume;
 +     }
 + 
-+     bb5 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
++     bb7 (cleanup): {
++         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +     }
 + 
-+     bb6 (cleanup): {
-+         switchInt(copy _5) -> [0: bb4, otherwise: bb5];
++     bb8 (cleanup): {
++         switchInt(copy _5) -> [0: bb6, otherwise: bb7];
       }
   }
   

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-abort.diff
@@ -21,7 +21,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = S;
-          _3 = S::id(move _4) -> [return: bb1, unwind: bb4];
+          _3 = S::id(move _4) -> [return: bb1, unwind: bb3];
       }
   
       bb1: {
@@ -40,30 +40,20 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
+-         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
++         goto -> bb6;
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
-      }
-  
-      bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb6 (cleanup): {
           resume;
 +     }
 + 
-+     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
++     bb5 (cleanup): {
++         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
 +     }
 + 
-+     bb8 (cleanup): {
-+         switchInt(copy _5) -> [0: bb6, otherwise: bb7];
++     bb6 (cleanup): {
++         switchInt(copy _5) -> [0: bb4, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = S;
-          _3 = S::id(move _4) -> [return: bb1, unwind: bb3];
+          _3 = S::id(move _4) -> [return: bb1, unwind: bb4];
       }
   
       bb1: {
@@ -40,20 +40,30 @@
       }
   
       bb3 (cleanup): {
--         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-+         goto -> bb6;
+-         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
++         goto -> bb5;
       }
   
       bb4 (cleanup): {
+-         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
++         goto -> bb5;
+      }
+  
+      bb5 (cleanup): {
+-         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb6 (cleanup): {
           resume;
 +     }
 + 
-+     bb5 (cleanup): {
-+         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
++     bb7 (cleanup): {
++         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +     }
 + 
-+     bb6 (cleanup): {
-+         switchInt(copy _5) -> [0: bb4, otherwise: bb5];
++     bb8 (cleanup): {
++         switchInt(copy _5) -> [0: bb6, otherwise: bb7];
       }
   }
   

--- a/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.main.ElaborateDrops.panic-unwind.diff
@@ -21,7 +21,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = S;
-          _3 = S::id(move _4) -> [return: bb1, unwind: bb4];
+          _3 = S::id(move _4) -> [return: bb1, unwind: bb3];
       }
   
       bb1: {
@@ -40,30 +40,20 @@
       }
   
       bb3 (cleanup): {
--         drop(_3) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
+-         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
++         goto -> bb6;
       }
   
       bb4 (cleanup): {
--         drop(_4) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb5;
-      }
-  
-      bb5 (cleanup): {
--         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb6 (cleanup): {
           resume;
 +     }
 + 
-+     bb7 (cleanup): {
-+         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
++     bb5 (cleanup): {
++         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
 +     }
 + 
-+     bb8 (cleanup): {
-+         switchInt(copy _5) -> [0: bb6, otherwise: bb7];
++     bb6 (cleanup): {
++         switchInt(copy _5) -> [0: bb4, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
@@ -26,7 +26,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = move _2;
-          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7];
+          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb3];
       }
   
       bb1: {
@@ -35,65 +35,39 @@
           StorageLive(_5);
 +         _6 = const false;
           _5 = move _1;
--         drop(_2) -> [return: bb2, unwind: bb3];
-+         goto -> bb2;
+          _2 = move _5;
+          StorageDead(_5);
+          _0 = const ();
+          drop(_2) -> [return: bb2, unwind: bb4];
       }
   
       bb2: {
-          _2 = move _5;
--         drop(_5) -> [return: bb4, unwind: bb8];
-+         goto -> bb4;
-      }
-  
-      bb3 (cleanup): {
-          _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb4: {
-          StorageDead(_5);
-          _0 = const ();
-          drop(_2) -> [return: bb5, unwind: bb9];
-      }
-  
-      bb5: {
           StorageDead(_2);
--         drop(_1) -> [return: bb6, unwind: bb10];
-+         goto -> bb6;
-      }
-  
-      bb6: {
 +         _6 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
+      bb3 (cleanup): {
+-         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
++         goto -> bb4;
       }
   
-      bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+      bb4 (cleanup): {
+-         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
++         goto -> bb7;
       }
   
-      bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb12;
-      }
-  
-      bb10 (cleanup): {
+      bb5 (cleanup): {
           resume;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
++     bb6 (cleanup): {
++         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
 +     }
 + 
-+     bb12 (cleanup): {
-+         switchInt(copy _6) -> [0: bb10, otherwise: bb11];
++     bb7 (cleanup): {
++         switchInt(copy _6) -> [0: bb5, otherwise: bb6];
       }
   }
   

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-abort.diff
@@ -26,7 +26,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = move _2;
-          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb3];
+          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7];
       }
   
       bb1: {
@@ -35,39 +35,65 @@
           StorageLive(_5);
 +         _6 = const false;
           _5 = move _1;
-          _2 = move _5;
-          StorageDead(_5);
-          _0 = const ();
-          drop(_2) -> [return: bb2, unwind: bb4];
+-         drop(_2) -> [return: bb2, unwind: bb3];
++         goto -> bb2;
       }
   
       bb2: {
+          _2 = move _5;
+-         drop(_5) -> [return: bb4, unwind: bb8];
++         goto -> bb4;
+      }
+  
+      bb3 (cleanup): {
+          _2 = move _5;
+-         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb4: {
+          StorageDead(_5);
+          _0 = const ();
+          drop(_2) -> [return: bb5, unwind: bb9];
+      }
+  
+      bb5: {
           StorageDead(_2);
+-         drop(_1) -> [return: bb6, unwind: bb10];
++         goto -> bb6;
+      }
+  
+      bb6: {
 +         _6 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb3 (cleanup): {
--         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-+         goto -> bb4;
+      bb7 (cleanup): {
+-         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
       }
   
-      bb4 (cleanup): {
--         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb7;
+      bb8 (cleanup): {
+-         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
       }
   
-      bb5 (cleanup): {
+      bb9 (cleanup): {
+-         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb12;
+      }
+  
+      bb10 (cleanup): {
           resume;
 +     }
 + 
-+     bb6 (cleanup): {
-+         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
++     bb11 (cleanup): {
++         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
 +     }
 + 
-+     bb7 (cleanup): {
-+         switchInt(copy _6) -> [0: bb5, otherwise: bb6];
++     bb12 (cleanup): {
++         switchInt(copy _6) -> [0: bb10, otherwise: bb11];
       }
   }
   

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
@@ -26,7 +26,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = move _2;
-          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7];
+          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb3];
       }
   
       bb1: {
@@ -35,65 +35,39 @@
           StorageLive(_5);
 +         _6 = const false;
           _5 = move _1;
--         drop(_2) -> [return: bb2, unwind: bb3];
-+         goto -> bb2;
+          _2 = move _5;
+          StorageDead(_5);
+          _0 = const ();
+          drop(_2) -> [return: bb2, unwind: bb4];
       }
   
       bb2: {
-          _2 = move _5;
--         drop(_5) -> [return: bb4, unwind: bb8];
-+         goto -> bb4;
-      }
-  
-      bb3 (cleanup): {
-          _2 = move _5;
--         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb4: {
-          StorageDead(_5);
-          _0 = const ();
-          drop(_2) -> [return: bb5, unwind: bb9];
-      }
-  
-      bb5: {
           StorageDead(_2);
--         drop(_1) -> [return: bb6, unwind continue];
-+         goto -> bb6;
-      }
-  
-      bb6: {
 +         _6 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb7 (cleanup): {
--         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
+      bb3 (cleanup): {
+-         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
++         goto -> bb4;
       }
   
-      bb8 (cleanup): {
--         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+      bb4 (cleanup): {
+-         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
++         goto -> bb7;
       }
   
-      bb9 (cleanup): {
--         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
-+         goto -> bb12;
-      }
-  
-      bb10 (cleanup): {
+      bb5 (cleanup): {
           resume;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
++     bb6 (cleanup): {
++         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
 +     }
 + 
-+     bb12 (cleanup): {
-+         switchInt(copy _6) -> [0: bb10, otherwise: bb11];
++     bb7 (cleanup): {
++         switchInt(copy _6) -> [0: bb5, otherwise: bb6];
       }
   }
   

--- a/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41110.test.ElaborateDrops.panic-unwind.diff
@@ -26,7 +26,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = move _2;
-          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb3];
+          _3 = std::mem::drop::<S>(move _4) -> [return: bb1, unwind: bb7];
       }
   
       bb1: {
@@ -35,39 +35,65 @@
           StorageLive(_5);
 +         _6 = const false;
           _5 = move _1;
-          _2 = move _5;
-          StorageDead(_5);
-          _0 = const ();
-          drop(_2) -> [return: bb2, unwind: bb4];
+-         drop(_2) -> [return: bb2, unwind: bb3];
++         goto -> bb2;
       }
   
       bb2: {
+          _2 = move _5;
+-         drop(_5) -> [return: bb4, unwind: bb8];
++         goto -> bb4;
+      }
+  
+      bb3 (cleanup): {
+          _2 = move _5;
+-         drop(_5) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb4: {
+          StorageDead(_5);
+          _0 = const ();
+          drop(_2) -> [return: bb5, unwind: bb9];
+      }
+  
+      bb5: {
           StorageDead(_2);
+-         drop(_1) -> [return: bb6, unwind continue];
++         goto -> bb6;
+      }
+  
+      bb6: {
 +         _6 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb3 (cleanup): {
--         drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-+         goto -> bb4;
+      bb7 (cleanup): {
+-         drop(_4) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
       }
   
-      bb4 (cleanup): {
--         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
-+         goto -> bb7;
+      bb8 (cleanup): {
+-         drop(_2) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
       }
   
-      bb5 (cleanup): {
+      bb9 (cleanup): {
+-         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
++         goto -> bb12;
+      }
+  
+      bb10 (cleanup): {
           resume;
 +     }
 + 
-+     bb6 (cleanup): {
-+         drop(_1) -> [return: bb5, unwind terminate(cleanup)];
++     bb11 (cleanup): {
++         drop(_1) -> [return: bb10, unwind terminate(cleanup)];
 +     }
 + 
-+     bb7 (cleanup): {
-+         switchInt(copy _6) -> [0: bb5, otherwise: bb6];
++     bb12 (cleanup): {
++         switchInt(copy _6) -> [0: bb10, otherwise: bb11];
       }
   }
   

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
@@ -25,11 +25,11 @@
 +         _8 = const false;
           StorageLive(_1);
           StorageLive(_2);
-          _2 = cond() -> [return: bb1, unwind: bb8];
+          _2 = cond() -> [return: bb1, unwind: bb11];
       }
   
       bb1: {
-          switchInt(move _2) -> [0: bb5, otherwise: bb2];
+          switchInt(move _2) -> [0: bb8, otherwise: bb2];
       }
   
       bb2: {
@@ -38,92 +38,110 @@
           _4 = K;
           _3 = E::F(move _4);
           StorageDead(_4);
-+         _7 = const true;
-+         _8 = const true;
-          _1 = move _3;
-          StorageDead(_3);
-          PlaceMention(_1);
-          _5 = discriminant(_1);
-          switchInt(move _5) -> [0: bb3, otherwise: bb4];
+-         drop(_1) -> [return: bb3, unwind: bb4];
++         goto -> bb3;
       }
   
       bb3: {
++         _7 = const true;
++         _8 = const true;
+          _1 = move _3;
+-         drop(_3) -> [return: bb5, unwind: bb11];
++         goto -> bb5;
+      }
+  
+      bb4 (cleanup): {
++         _7 = const true;
++         _8 = const true;
+          _1 = move _3;
+-         drop(_3) -> [return: bb11, unwind terminate(cleanup)];
++         goto -> bb11;
+      }
+  
+      bb5: {
+          StorageDead(_3);
+          PlaceMention(_1);
+          _5 = discriminant(_1);
+          switchInt(move _5) -> [0: bb6, otherwise: bb7];
+      }
+  
+      bb6: {
           StorageLive(_6);
           _6 = move ((_1 as F).0: K);
           _0 = const ();
           StorageDead(_6);
-          goto -> bb6;
-      }
-  
-      bb4: {
-          _0 = const ();
-          goto -> bb6;
-      }
-  
-      bb5: {
-          _0 = const ();
-          goto -> bb6;
-      }
-  
-      bb6: {
-          StorageDead(_2);
--         drop(_1) -> [return: bb7, unwind: bb9];
-+         goto -> bb16;
+          goto -> bb9;
       }
   
       bb7: {
+          _0 = const ();
+          goto -> bb9;
+      }
+  
+      bb8: {
+          _0 = const ();
+          goto -> bb9;
+      }
+  
+      bb9: {
+          StorageDead(_2);
+-         drop(_1) -> [return: bb10, unwind: bb12];
++         goto -> bb19;
+      }
+  
+      bb10: {
 +         _7 = const false;
 +         _8 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb8 (cleanup): {
--         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+      bb11 (cleanup): {
+-         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
++         goto -> bb12;
       }
   
-      bb9 (cleanup): {
+      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb10: {
-+         _7 = const false;
-+         goto -> bb7;
-+     }
-+ 
-+     bb11 (cleanup): {
-+         drop(((_1 as F).0: K)) -> [return: bb9, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb12 (cleanup): {
-+         switchInt(copy _7) -> [0: bb9, otherwise: bb11];
-+     }
-+ 
 +     bb13: {
-+         drop(_1) -> [return: bb10, unwind: bb9];
++         _7 = const false;
++         goto -> bb10;
 +     }
 + 
 +     bb14 (cleanup): {
-+         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         drop(((_1 as F).0: K)) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb15: {
-+         _9 = discriminant(_1);
-+         switchInt(move _9) -> [0: bb10, otherwise: bb13];
++     bb15 (cleanup): {
++         switchInt(copy _7) -> [0: bb12, otherwise: bb14];
 +     }
 + 
 +     bb16: {
-+         switchInt(copy _7) -> [0: bb10, otherwise: bb15];
++         drop(_1) -> [return: bb13, unwind: bb12];
 +     }
 + 
 +     bb17 (cleanup): {
-+         _10 = discriminant(_1);
-+         switchInt(move _10) -> [0: bb12, otherwise: bb14];
++         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb18 (cleanup): {
-+         switchInt(copy _7) -> [0: bb9, otherwise: bb17];
++     bb18: {
++         _9 = discriminant(_1);
++         switchInt(move _9) -> [0: bb13, otherwise: bb16];
++     }
++ 
++     bb19: {
++         switchInt(copy _7) -> [0: bb13, otherwise: bb18];
++     }
++ 
++     bb20 (cleanup): {
++         _10 = discriminant(_1);
++         switchInt(move _10) -> [0: bb15, otherwise: bb17];
++     }
++ 
++     bb21 (cleanup): {
++         switchInt(copy _7) -> [0: bb12, otherwise: bb20];
       }
   }
   

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
@@ -25,11 +25,11 @@
 +         _8 = const false;
           StorageLive(_1);
           StorageLive(_2);
-          _2 = cond() -> [return: bb1, unwind: bb11];
+          _2 = cond() -> [return: bb1, unwind: bb8];
       }
   
       bb1: {
-          switchInt(move _2) -> [0: bb8, otherwise: bb2];
+          switchInt(move _2) -> [0: bb5, otherwise: bb2];
       }
   
       bb2: {
@@ -38,110 +38,92 @@
           _4 = K;
           _3 = E::F(move _4);
           StorageDead(_4);
--         drop(_1) -> [return: bb3, unwind: bb4];
-+         goto -> bb3;
-      }
-  
-      bb3: {
 +         _7 = const true;
 +         _8 = const true;
           _1 = move _3;
--         drop(_3) -> [return: bb5, unwind: bb11];
-+         goto -> bb5;
-      }
-  
-      bb4 (cleanup): {
-+         _7 = const true;
-+         _8 = const true;
-          _1 = move _3;
--         drop(_3) -> [return: bb11, unwind terminate(cleanup)];
-+         goto -> bb11;
-      }
-  
-      bb5: {
           StorageDead(_3);
           PlaceMention(_1);
           _5 = discriminant(_1);
-          switchInt(move _5) -> [0: bb6, otherwise: bb7];
+          switchInt(move _5) -> [0: bb3, otherwise: bb4];
       }
   
-      bb6: {
+      bb3: {
           StorageLive(_6);
           _6 = move ((_1 as F).0: K);
           _0 = const ();
           StorageDead(_6);
-          goto -> bb9;
+          goto -> bb6;
+      }
+  
+      bb4: {
+          _0 = const ();
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _0 = const ();
+          goto -> bb6;
+      }
+  
+      bb6: {
+          StorageDead(_2);
+-         drop(_1) -> [return: bb7, unwind: bb9];
++         goto -> bb16;
       }
   
       bb7: {
-          _0 = const ();
-          goto -> bb9;
-      }
-  
-      bb8: {
-          _0 = const ();
-          goto -> bb9;
-      }
-  
-      bb9: {
-          StorageDead(_2);
--         drop(_1) -> [return: bb10, unwind: bb12];
-+         goto -> bb19;
-      }
-  
-      bb10: {
 +         _7 = const false;
 +         _8 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb11 (cleanup): {
--         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-+         goto -> bb12;
+      bb8 (cleanup): {
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
       }
   
-      bb12 (cleanup): {
+      bb9 (cleanup): {
           resume;
 +     }
 + 
-+     bb13: {
++     bb10: {
 +         _7 = const false;
-+         goto -> bb10;
++         goto -> bb7;
++     }
++ 
++     bb11 (cleanup): {
++         drop(((_1 as F).0: K)) -> [return: bb9, unwind terminate(cleanup)];
++     }
++ 
++     bb12 (cleanup): {
++         switchInt(copy _7) -> [0: bb9, otherwise: bb11];
++     }
++ 
++     bb13: {
++         drop(_1) -> [return: bb10, unwind: bb9];
 +     }
 + 
 +     bb14 (cleanup): {
-+         drop(((_1 as F).0: K)) -> [return: bb12, unwind terminate(cleanup)];
++         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb15 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb14];
++     bb15: {
++         _9 = discriminant(_1);
++         switchInt(move _9) -> [0: bb10, otherwise: bb13];
 +     }
 + 
 +     bb16: {
-+         drop(_1) -> [return: bb13, unwind: bb12];
++         switchInt(copy _7) -> [0: bb10, otherwise: bb15];
 +     }
 + 
 +     bb17 (cleanup): {
-+         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb18: {
-+         _9 = discriminant(_1);
-+         switchInt(move _9) -> [0: bb13, otherwise: bb16];
-+     }
-+ 
-+     bb19: {
-+         switchInt(copy _7) -> [0: bb13, otherwise: bb18];
-+     }
-+ 
-+     bb20 (cleanup): {
 +         _10 = discriminant(_1);
-+         switchInt(move _10) -> [0: bb15, otherwise: bb17];
++         switchInt(move _10) -> [0: bb12, otherwise: bb14];
 +     }
 + 
-+     bb21 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb20];
++     bb18 (cleanup): {
++         switchInt(copy _7) -> [0: bb9, otherwise: bb17];
       }
   }
   

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
@@ -25,11 +25,11 @@
 +         _8 = const false;
           StorageLive(_1);
           StorageLive(_2);
-          _2 = cond() -> [return: bb1, unwind: bb8];
+          _2 = cond() -> [return: bb1, unwind: bb11];
       }
   
       bb1: {
-          switchInt(move _2) -> [0: bb5, otherwise: bb2];
+          switchInt(move _2) -> [0: bb8, otherwise: bb2];
       }
   
       bb2: {
@@ -38,92 +38,110 @@
           _4 = K;
           _3 = E::F(move _4);
           StorageDead(_4);
-+         _7 = const true;
-+         _8 = const true;
-          _1 = move _3;
-          StorageDead(_3);
-          PlaceMention(_1);
-          _5 = discriminant(_1);
-          switchInt(move _5) -> [0: bb3, otherwise: bb4];
+-         drop(_1) -> [return: bb3, unwind: bb4];
++         goto -> bb3;
       }
   
       bb3: {
++         _7 = const true;
++         _8 = const true;
+          _1 = move _3;
+-         drop(_3) -> [return: bb5, unwind: bb11];
++         goto -> bb5;
+      }
+  
+      bb4 (cleanup): {
++         _7 = const true;
++         _8 = const true;
+          _1 = move _3;
+-         drop(_3) -> [return: bb11, unwind terminate(cleanup)];
++         goto -> bb11;
+      }
+  
+      bb5: {
+          StorageDead(_3);
+          PlaceMention(_1);
+          _5 = discriminant(_1);
+          switchInt(move _5) -> [0: bb6, otherwise: bb7];
+      }
+  
+      bb6: {
           StorageLive(_6);
           _6 = move ((_1 as F).0: K);
           _0 = const ();
           StorageDead(_6);
-          goto -> bb6;
-      }
-  
-      bb4: {
-          _0 = const ();
-          goto -> bb6;
-      }
-  
-      bb5: {
-          _0 = const ();
-          goto -> bb6;
-      }
-  
-      bb6: {
-          StorageDead(_2);
--         drop(_1) -> [return: bb7, unwind continue];
-+         goto -> bb16;
+          goto -> bb9;
       }
   
       bb7: {
+          _0 = const ();
+          goto -> bb9;
+      }
+  
+      bb8: {
+          _0 = const ();
+          goto -> bb9;
+      }
+  
+      bb9: {
+          StorageDead(_2);
+-         drop(_1) -> [return: bb10, unwind continue];
++         goto -> bb19;
+      }
+  
+      bb10: {
 +         _7 = const false;
 +         _8 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb8 (cleanup): {
--         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+      bb11 (cleanup): {
+-         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
++         goto -> bb12;
       }
   
-      bb9 (cleanup): {
+      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb10: {
-+         _7 = const false;
-+         goto -> bb7;
-+     }
-+ 
-+     bb11 (cleanup): {
-+         drop(((_1 as F).0: K)) -> [return: bb9, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb12 (cleanup): {
-+         switchInt(copy _7) -> [0: bb9, otherwise: bb11];
-+     }
-+ 
 +     bb13: {
-+         drop(_1) -> [return: bb10, unwind: bb9];
++         _7 = const false;
++         goto -> bb10;
 +     }
 + 
 +     bb14 (cleanup): {
-+         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         drop(((_1 as F).0: K)) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb15: {
-+         _9 = discriminant(_1);
-+         switchInt(move _9) -> [0: bb10, otherwise: bb13];
++     bb15 (cleanup): {
++         switchInt(copy _7) -> [0: bb12, otherwise: bb14];
 +     }
 + 
 +     bb16: {
-+         switchInt(copy _7) -> [0: bb10, otherwise: bb15];
++         drop(_1) -> [return: bb13, unwind: bb12];
 +     }
 + 
 +     bb17 (cleanup): {
-+         _10 = discriminant(_1);
-+         switchInt(move _10) -> [0: bb12, otherwise: bb14];
++         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb18 (cleanup): {
-+         switchInt(copy _7) -> [0: bb9, otherwise: bb17];
++     bb18: {
++         _9 = discriminant(_1);
++         switchInt(move _9) -> [0: bb13, otherwise: bb16];
++     }
++ 
++     bb19: {
++         switchInt(copy _7) -> [0: bb13, otherwise: bb18];
++     }
++ 
++     bb20 (cleanup): {
++         _10 = discriminant(_1);
++         switchInt(move _10) -> [0: bb15, otherwise: bb17];
++     }
++ 
++     bb21 (cleanup): {
++         switchInt(copy _7) -> [0: bb12, otherwise: bb20];
       }
   }
   

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
@@ -25,11 +25,11 @@
 +         _8 = const false;
           StorageLive(_1);
           StorageLive(_2);
-          _2 = cond() -> [return: bb1, unwind: bb11];
+          _2 = cond() -> [return: bb1, unwind: bb8];
       }
   
       bb1: {
-          switchInt(move _2) -> [0: bb8, otherwise: bb2];
+          switchInt(move _2) -> [0: bb5, otherwise: bb2];
       }
   
       bb2: {
@@ -38,110 +38,92 @@
           _4 = K;
           _3 = E::F(move _4);
           StorageDead(_4);
--         drop(_1) -> [return: bb3, unwind: bb4];
-+         goto -> bb3;
-      }
-  
-      bb3: {
 +         _7 = const true;
 +         _8 = const true;
           _1 = move _3;
--         drop(_3) -> [return: bb5, unwind: bb11];
-+         goto -> bb5;
-      }
-  
-      bb4 (cleanup): {
-+         _7 = const true;
-+         _8 = const true;
-          _1 = move _3;
--         drop(_3) -> [return: bb11, unwind terminate(cleanup)];
-+         goto -> bb11;
-      }
-  
-      bb5: {
           StorageDead(_3);
           PlaceMention(_1);
           _5 = discriminant(_1);
-          switchInt(move _5) -> [0: bb6, otherwise: bb7];
+          switchInt(move _5) -> [0: bb3, otherwise: bb4];
       }
   
-      bb6: {
+      bb3: {
           StorageLive(_6);
           _6 = move ((_1 as F).0: K);
           _0 = const ();
           StorageDead(_6);
-          goto -> bb9;
+          goto -> bb6;
+      }
+  
+      bb4: {
+          _0 = const ();
+          goto -> bb6;
+      }
+  
+      bb5: {
+          _0 = const ();
+          goto -> bb6;
+      }
+  
+      bb6: {
+          StorageDead(_2);
+-         drop(_1) -> [return: bb7, unwind continue];
++         goto -> bb16;
       }
   
       bb7: {
-          _0 = const ();
-          goto -> bb9;
-      }
-  
-      bb8: {
-          _0 = const ();
-          goto -> bb9;
-      }
-  
-      bb9: {
-          StorageDead(_2);
--         drop(_1) -> [return: bb10, unwind continue];
-+         goto -> bb19;
-      }
-  
-      bb10: {
 +         _7 = const false;
 +         _8 = const false;
           StorageDead(_1);
           return;
       }
   
-      bb11 (cleanup): {
--         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-+         goto -> bb12;
+      bb8 (cleanup): {
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
       }
   
-      bb12 (cleanup): {
+      bb9 (cleanup): {
           resume;
 +     }
 + 
-+     bb13: {
++     bb10: {
 +         _7 = const false;
-+         goto -> bb10;
++         goto -> bb7;
++     }
++ 
++     bb11 (cleanup): {
++         drop(((_1 as F).0: K)) -> [return: bb9, unwind terminate(cleanup)];
++     }
++ 
++     bb12 (cleanup): {
++         switchInt(copy _7) -> [0: bb9, otherwise: bb11];
++     }
++ 
++     bb13: {
++         drop(_1) -> [return: bb10, unwind: bb9];
 +     }
 + 
 +     bb14 (cleanup): {
-+         drop(((_1 as F).0: K)) -> [return: bb12, unwind terminate(cleanup)];
++         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb15 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb14];
++     bb15: {
++         _9 = discriminant(_1);
++         switchInt(move _9) -> [0: bb10, otherwise: bb13];
 +     }
 + 
 +     bb16: {
-+         drop(_1) -> [return: bb13, unwind: bb12];
++         switchInt(copy _7) -> [0: bb10, otherwise: bb15];
 +     }
 + 
 +     bb17 (cleanup): {
-+         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb18: {
-+         _9 = discriminant(_1);
-+         switchInt(move _9) -> [0: bb13, otherwise: bb16];
-+     }
-+ 
-+     bb19: {
-+         switchInt(copy _7) -> [0: bb13, otherwise: bb18];
-+     }
-+ 
-+     bb20 (cleanup): {
 +         _10 = discriminant(_1);
-+         switchInt(move _10) -> [0: bb15, otherwise: bb17];
++         switchInt(move _10) -> [0: bb12, otherwise: bb14];
 +     }
 + 
-+     bb21 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb20];
++     bb18 (cleanup): {
++         switchInt(copy _7) -> [0: bb9, otherwise: bb17];
       }
   }
   

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_1);
         StorageLive(_2);
         StorageLive(_3);
-        _3 = Box::<[u32; 1]>::new_uninit() -> [return: bb1, unwind: bb14];
+        _3 = Box::<[u32; 1]>::new_uninit() -> [return: bb1, unwind: bb12];
     }
 
     bb1: {
@@ -36,7 +36,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_5);
         StorageLive(_6);
         _6 = Option::<u32>::None;
-        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb13];
+        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb11];
     }
 
     bb2: {
@@ -58,7 +58,8 @@ fn test() -> Option<Vec<u32>> {
         ((((*_3).1: std::mem::ManuallyDrop<[u32; 1]>).0: std::mem::MaybeDangling<[u32; 1]>).0: [u32; 1]) = [move _4];
         StorageDead(_4);
         _2 = move _3;
-        goto -> bb7;
+        StorageDead(_3);
+        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb7, unwind: bb10];
     }
 
     bb5: {
@@ -66,54 +67,45 @@ fn test() -> Option<Vec<u32>> {
         _8 = copy ((_5 as Break).0: std::option::Option<std::convert::Infallible>);
         StorageLive(_10);
         _10 = copy _8;
-        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb13];
+        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb11];
     }
 
     bb6: {
         StorageDead(_10);
         StorageDead(_8);
         StorageDead(_4);
-        drop(_3) -> [return: bb10, unwind: bb14];
+        drop(_3) -> [return: bb8, unwind: bb12];
     }
 
     bb7: {
-        StorageDead(_3);
-        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb12];
+        StorageDead(_2);
+        _0 = Option::<Vec<u32>>::Some(move _1);
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb9;
     }
 
     bb8: {
+        StorageDead(_3);
         StorageDead(_2);
-        _0 = Option::<Vec<u32>>::Some(move _1);
+        StorageDead(_1);
+        StorageDead(_5);
         goto -> bb9;
     }
 
     bb9: {
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb11;
-    }
-
-    bb10: {
-        StorageDead(_3);
-        StorageDead(_2);
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb11;
-    }
-
-    bb11: {
         return;
     }
 
+    bb10 (cleanup): {
+        goto -> bb12;
+    }
+
+    bb11 (cleanup): {
+        drop(_3) -> [return: bb12, unwind terminate(cleanup)];
+    }
+
     bb12 (cleanup): {
-        goto -> bb14;
-    }
-
-    bb13 (cleanup): {
-        drop(_3) -> [return: bb14, unwind terminate(cleanup)];
-    }
-
-    bb14 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-abort.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-abort.mir
@@ -28,7 +28,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_1);
         StorageLive(_2);
         StorageLive(_3);
-        _3 = Box::<[u32; 1]>::new_uninit() -> [return: bb1, unwind: bb12];
+        _3 = Box::<[u32; 1]>::new_uninit() -> [return: bb1, unwind: bb14];
     }
 
     bb1: {
@@ -36,7 +36,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_5);
         StorageLive(_6);
         _6 = Option::<u32>::None;
-        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb11];
+        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb13];
     }
 
     bb2: {
@@ -58,8 +58,7 @@ fn test() -> Option<Vec<u32>> {
         ((((*_3).1: std::mem::ManuallyDrop<[u32; 1]>).0: std::mem::MaybeDangling<[u32; 1]>).0: [u32; 1]) = [move _4];
         StorageDead(_4);
         _2 = move _3;
-        StorageDead(_3);
-        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb7, unwind: bb10];
+        goto -> bb7;
     }
 
     bb5: {
@@ -67,45 +66,54 @@ fn test() -> Option<Vec<u32>> {
         _8 = copy ((_5 as Break).0: std::option::Option<std::convert::Infallible>);
         StorageLive(_10);
         _10 = copy _8;
-        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb11];
+        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
         StorageDead(_10);
         StorageDead(_8);
         StorageDead(_4);
-        drop(_3) -> [return: bb8, unwind: bb12];
+        drop(_3) -> [return: bb10, unwind: bb14];
     }
 
     bb7: {
-        StorageDead(_2);
-        _0 = Option::<Vec<u32>>::Some(move _1);
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb9;
+        StorageDead(_3);
+        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb12];
     }
 
     bb8: {
-        StorageDead(_3);
         StorageDead(_2);
-        StorageDead(_1);
-        StorageDead(_5);
+        _0 = Option::<Vec<u32>>::Some(move _1);
         goto -> bb9;
     }
 
     bb9: {
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb11;
+    }
+
+    bb10: {
+        StorageDead(_3);
+        StorageDead(_2);
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb11;
+    }
+
+    bb11: {
         return;
     }
 
-    bb10 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb11 (cleanup): {
-        drop(_3) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
     bb12 (cleanup): {
+        goto -> bb14;
+    }
+
+    bb13 (cleanup): {
+        drop(_3) -> [return: bb14, unwind terminate(cleanup)];
+    }
+
+    bb14 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-unwind.mir
@@ -36,7 +36,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_5);
         StorageLive(_6);
         _6 = Option::<u32>::None;
-        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb13];
+        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb11];
     }
 
     bb2: {
@@ -58,7 +58,8 @@ fn test() -> Option<Vec<u32>> {
         ((((*_3).1: std::mem::ManuallyDrop<[u32; 1]>).0: std::mem::MaybeDangling<[u32; 1]>).0: [u32; 1]) = [move _4];
         StorageDead(_4);
         _2 = move _3;
-        goto -> bb7;
+        StorageDead(_3);
+        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb7, unwind: bb10];
     }
 
     bb5: {
@@ -66,54 +67,45 @@ fn test() -> Option<Vec<u32>> {
         _8 = copy ((_5 as Break).0: std::option::Option<std::convert::Infallible>);
         StorageLive(_10);
         _10 = copy _8;
-        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb13];
+        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb11];
     }
 
     bb6: {
         StorageDead(_10);
         StorageDead(_8);
         StorageDead(_4);
-        drop(_3) -> [return: bb10, unwind: bb14];
+        drop(_3) -> [return: bb8, unwind: bb12];
     }
 
     bb7: {
-        StorageDead(_3);
-        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb12];
+        StorageDead(_2);
+        _0 = Option::<Vec<u32>>::Some(move _1);
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb9;
     }
 
     bb8: {
+        StorageDead(_3);
         StorageDead(_2);
-        _0 = Option::<Vec<u32>>::Some(move _1);
+        StorageDead(_1);
+        StorageDead(_5);
         goto -> bb9;
     }
 
     bb9: {
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb11;
-    }
-
-    bb10: {
-        StorageDead(_3);
-        StorageDead(_2);
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb11;
-    }
-
-    bb11: {
         return;
     }
 
+    bb10 (cleanup): {
+        goto -> bb12;
+    }
+
+    bb11 (cleanup): {
+        drop(_3) -> [return: bb12, unwind terminate(cleanup)];
+    }
+
     bb12 (cleanup): {
-        goto -> bb14;
-    }
-
-    bb13 (cleanup): {
-        drop(_3) -> [return: bb14, unwind terminate(cleanup)];
-    }
-
-    bb14 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/issue_62289.test.ElaborateDrops.after.panic-unwind.mir
@@ -36,7 +36,7 @@ fn test() -> Option<Vec<u32>> {
         StorageLive(_5);
         StorageLive(_6);
         _6 = Option::<u32>::None;
-        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb11];
+        _5 = <Option<u32> as Try>::branch(move _6) -> [return: bb2, unwind: bb13];
     }
 
     bb2: {
@@ -58,8 +58,7 @@ fn test() -> Option<Vec<u32>> {
         ((((*_3).1: std::mem::ManuallyDrop<[u32; 1]>).0: std::mem::MaybeDangling<[u32; 1]>).0: [u32; 1]) = [move _4];
         StorageDead(_4);
         _2 = move _3;
-        StorageDead(_3);
-        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb7, unwind: bb10];
+        goto -> bb7;
     }
 
     bb5: {
@@ -67,45 +66,54 @@ fn test() -> Option<Vec<u32>> {
         _8 = copy ((_5 as Break).0: std::option::Option<std::convert::Infallible>);
         StorageLive(_10);
         _10 = copy _8;
-        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb11];
+        _0 = <Option<Vec<u32>> as FromResidual<Option<Infallible>>>::from_residual(move _10) -> [return: bb6, unwind: bb13];
     }
 
     bb6: {
         StorageDead(_10);
         StorageDead(_8);
         StorageDead(_4);
-        drop(_3) -> [return: bb8, unwind: bb12];
+        drop(_3) -> [return: bb10, unwind: bb14];
     }
 
     bb7: {
-        StorageDead(_2);
-        _0 = Option::<Vec<u32>>::Some(move _1);
-        StorageDead(_1);
-        StorageDead(_5);
-        goto -> bb9;
+        StorageDead(_3);
+        _1 = std::boxed::box_assume_init_into_vec_unsafe::<u32, 1>(move _2) -> [return: bb8, unwind: bb12];
     }
 
     bb8: {
-        StorageDead(_3);
         StorageDead(_2);
-        StorageDead(_1);
-        StorageDead(_5);
+        _0 = Option::<Vec<u32>>::Some(move _1);
         goto -> bb9;
     }
 
     bb9: {
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb11;
+    }
+
+    bb10: {
+        StorageDead(_3);
+        StorageDead(_2);
+        StorageDead(_1);
+        StorageDead(_5);
+        goto -> bb11;
+    }
+
+    bb11: {
         return;
     }
 
-    bb10 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb11 (cleanup): {
-        drop(_3) -> [return: bb12, unwind terminate(cleanup)];
-    }
-
     bb12 (cleanup): {
+        goto -> bb14;
+    }
+
+    bb13 (cleanup): {
+        drop(_3) -> [return: bb14, unwind terminate(cleanup)];
+    }
+
+    bb14 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-abort.diff
@@ -16,10 +16,6 @@
   
       bb1: {
           StorageDead(_2);
-          goto -> bb2;
-      }
-  
-      bb2: {
           return;
       }
   }

--- a/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-abort.diff
+++ b/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-abort.diff
@@ -16,6 +16,10 @@
   
       bb1: {
           StorageDead(_2);
+          goto -> bb2;
+      }
+  
+      bb2: {
           return;
       }
   }

--- a/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-unwind.diff
@@ -16,10 +16,6 @@
   
       bb1: {
           StorageDead(_2);
-          goto -> bb2;
-      }
-  
-      bb2: {
           return;
       }
   }

--- a/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-unwind.diff
+++ b/tests/mir-opt/lower_intrinsics.forget.LowerIntrinsics.panic-unwind.diff
@@ -16,6 +16,10 @@
   
       bb1: {
           StorageDead(_2);
+          goto -> bb2;
+      }
+  
+      bb2: {
           return;
       }
   }

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
@@ -14,7 +14,7 @@ fn main() -> () {
         StorageLive(_4);
         _4 = const "";
         _3 = &(*_4);
-        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind: bb4];
+        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind: bb3];
     }
 
     bb1: {
@@ -31,10 +31,6 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-    }
-
-    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-abort.mir
@@ -14,7 +14,7 @@ fn main() -> () {
         StorageLive(_4);
         _4 = const "";
         _3 = &(*_4);
-        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind: bb3];
+        _2 = <str as ToString>::to_string(move _3) -> [return: bb1, unwind: bb4];
     }
 
     bb1: {
@@ -31,6 +31,10 @@ fn main() -> () {
     }
 
     bb3 (cleanup): {
+        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
+    }
+
+    bb4 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
@@ -19,7 +19,7 @@ fn main() -> () {
 
     bb1: {
         StorageDead(_3);
-        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind continue];
+        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3];
     }
 
     bb2: {
@@ -28,6 +28,14 @@ fn main() -> () {
         StorageDead(_1);
         _0 = const ();
         return;
+    }
+
+    bb3 (cleanup): {
+        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
+    }
+
+    bb4 (cleanup): {
+        resume;
     }
 }
 

--- a/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
+++ b/tests/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.panic-unwind.mir
@@ -19,7 +19,7 @@ fn main() -> () {
 
     bb1: {
         StorageDead(_3);
-        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind: bb3];
+        _1 = std::mem::drop::<String>(move _2) -> [return: bb2, unwind continue];
     }
 
     bb2: {
@@ -28,14 +28,6 @@ fn main() -> () {
         StorageDead(_1);
         _0 = const ();
         return;
-    }
-
-    bb3 (cleanup): {
-        drop(_2) -> [return: bb4, unwind terminate(cleanup)];
-    }
-
-    bb4 (cleanup): {
-        resume;
     }
 }
 

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -24,7 +24,7 @@
   
       bb1: {
           _0 = Option::<String>::None;
-          goto -> bb5;
+          goto -> bb3;
       }
   
       bb2: {
@@ -33,42 +33,38 @@
           StorageLive(_4);
           _4 = move _3;
           _0 = Option::<String>::Some(move _4);
--         drop(_4) -> [return: bb3, unwind: bb7];
-+         goto -> bb3;
+          StorageDead(_4);
+          StorageDead(_3);
+          goto -> bb3;
       }
   
       bb3: {
-          StorageDead(_4);
--         drop(_3) -> [return: bb4, unwind: bb8];
-+         goto -> bb4;
+-         drop(_1) -> [return: bb4, unwind: bb5];
++         goto -> bb12;
       }
   
       bb4: {
-          StorageDead(_3);
-          goto -> bb5;
-      }
-  
-      bb5: {
--         drop(_1) -> [return: bb6, unwind: bb9];
-+         goto -> bb16;
-      }
-  
-      bb6: {
           return;
       }
   
-      bb7 (cleanup): {
--         drop(_3) -> [return: bb8, unwind terminate(cleanup)];
-+         goto -> bb8;
-      }
-  
-      bb8 (cleanup): {
--         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
-      }
-  
-      bb9 (cleanup): {
+      bb5 (cleanup): {
           resume;
++     }
++ 
++     bb6: {
++         goto -> bb4;
++     }
++ 
++     bb7 (cleanup): {
++         goto -> bb5;
++     }
++ 
++     bb8 (cleanup): {
++         goto -> bb5;
++     }
++ 
++     bb9: {
++         goto -> bb6;
 +     }
 + 
 +     bb10: {
@@ -76,33 +72,17 @@
 +     }
 + 
 +     bb11 (cleanup): {
-+         goto -> bb9;
++         goto -> bb5;
 +     }
 + 
-+     bb12 (cleanup): {
-+         goto -> bb9;
-+     }
-+ 
-+     bb13: {
-+         goto -> bb10;
-+     }
-+ 
-+     bb14: {
-+         goto -> bb10;
-+     }
-+ 
-+     bb15 (cleanup): {
-+         goto -> bb9;
-+     }
-+ 
-+     bb16: {
++     bb12: {
 +         _6 = discriminant(_1);
-+         switchInt(move _6) -> [0: bb13, otherwise: bb14];
++         switchInt(move _6) -> [0: bb9, otherwise: bb10];
 +     }
 + 
-+     bb17 (cleanup): {
++     bb13 (cleanup): {
 +         _7 = discriminant(_1);
-+         switchInt(move _7) -> [0: bb11, otherwise: bb15];
++         switchInt(move _7) -> [0: bb7, otherwise: bb11];
       }
   }
   

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -24,7 +24,7 @@
   
       bb1: {
           _0 = Option::<String>::None;
-          goto -> bb3;
+          goto -> bb5;
       }
   
       bb2: {
@@ -33,38 +33,42 @@
           StorageLive(_4);
           _4 = move _3;
           _0 = Option::<String>::Some(move _4);
-          StorageDead(_4);
-          StorageDead(_3);
-          goto -> bb3;
+-         drop(_4) -> [return: bb3, unwind: bb7];
++         goto -> bb3;
       }
   
       bb3: {
--         drop(_1) -> [return: bb4, unwind: bb5];
-+         goto -> bb12;
+          StorageDead(_4);
+-         drop(_3) -> [return: bb4, unwind: bb8];
++         goto -> bb4;
       }
   
       bb4: {
+          StorageDead(_3);
+          goto -> bb5;
+      }
+  
+      bb5: {
+-         drop(_1) -> [return: bb6, unwind: bb9];
++         goto -> bb16;
+      }
+  
+      bb6: {
           return;
       }
   
-      bb5 (cleanup): {
+      bb7 (cleanup): {
+-         drop(_3) -> [return: bb8, unwind terminate(cleanup)];
++         goto -> bb8;
+      }
+  
+      bb8 (cleanup): {
+-         drop(_1) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
+      }
+  
+      bb9 (cleanup): {
           resume;
-+     }
-+ 
-+     bb6: {
-+         goto -> bb4;
-+     }
-+ 
-+     bb7 (cleanup): {
-+         goto -> bb5;
-+     }
-+ 
-+     bb8 (cleanup): {
-+         goto -> bb5;
-+     }
-+ 
-+     bb9: {
-+         goto -> bb6;
 +     }
 + 
 +     bb10: {
@@ -72,17 +76,33 @@
 +     }
 + 
 +     bb11 (cleanup): {
-+         goto -> bb5;
++         goto -> bb9;
 +     }
 + 
-+     bb12: {
++     bb12 (cleanup): {
++         goto -> bb9;
++     }
++ 
++     bb13: {
++         goto -> bb10;
++     }
++ 
++     bb14: {
++         goto -> bb10;
++     }
++ 
++     bb15 (cleanup): {
++         goto -> bb9;
++     }
++ 
++     bb16: {
 +         _6 = discriminant(_1);
-+         switchInt(move _6) -> [0: bb9, otherwise: bb10];
++         switchInt(move _6) -> [0: bb13, otherwise: bb14];
 +     }
 + 
-+     bb13 (cleanup): {
++     bb17 (cleanup): {
 +         _7 = discriminant(_1);
-+         switchInt(move _7) -> [0: bb7, otherwise: bb11];
++         switchInt(move _7) -> [0: bb11, otherwise: bb15];
       }
   }
   

--- a/tests/mir-opt/sroa/structs.dropping.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.dropping.ScalarReplacementOfAggregates.diff
@@ -23,22 +23,22 @@
           StorageDead(_4);
           StorageDead(_3);
           _1 = move (_2.1: Tag);
-          drop(_1) -> [return: bb1, unwind unreachable];
+          drop(_1) -> [return: bb3, unwind unreachable];
       }
   
       bb1: {
-          drop((_2.0: Tag)) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb2: {
           StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
       }
   
+      bb2: {
+          drop((_2.2: Tag)) -> [return: bb1, unwind unreachable];
+      }
+  
       bb3: {
-          drop((_2.2: Tag)) -> [return: bb2, unwind unreachable];
+          drop((_2.0: Tag)) -> [return: bb2, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/sroa/structs.dropping.ScalarReplacementOfAggregates.diff
+++ b/tests/mir-opt/sroa/structs.dropping.ScalarReplacementOfAggregates.diff
@@ -23,22 +23,22 @@
           StorageDead(_4);
           StorageDead(_3);
           _1 = move (_2.1: Tag);
-          drop(_1) -> [return: bb3, unwind unreachable];
+          drop(_1) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
+          drop((_2.0: Tag)) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb2: {
           StorageDead(_2);
           StorageDead(_1);
           _0 = const ();
           return;
       }
   
-      bb2: {
-          drop((_2.2: Tag)) -> [return: bb1, unwind unreachable];
-      }
-  
       bb3: {
-          drop((_2.0: Tag)) -> [return: bb2, unwind unreachable];
+          drop((_2.2: Tag)) -> [return: bb2, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
@@ -27,20 +27,20 @@
       bb0: {
 +         _8 = const false;
           StorageLive(_2);
-          _2 = String::new() -> [return: bb1, unwind: bb12];
+          _2 = String::new() -> [return: bb1, unwind: bb10];
       }
   
       bb1: {
           StorageLive(_3);
           _3 = const 12_i32;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb2, unwind: bb11];
+          _4 = String::new() -> [return: bb2, unwind: bb9];
       }
   
       bb2: {
 +         _8 = const true;
           StorageLive(_5);
-          _5 = String::new() -> [return: bb3, unwind: bb10];
+          _5 = String::new() -> [return: bb3, unwind: bb8];
       }
   
       bb3: {
@@ -48,60 +48,50 @@
           StorageLive(_7);
 +         _8 = const false;
           _7 = move _4;
-          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb8];
+          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb7];
       }
   
       bb4: {
           StorageDead(_7);
           StorageDead(_6);
-          drop(_5) -> [return: bb5, unwind: bb10];
+          drop(_5) -> [return: bb5, unwind: bb8];
       }
   
       bb5: {
           StorageDead(_5);
--         drop(_4) -> [return: bb6, unwind: bb11];
-+         goto -> bb6;
++         _8 = const false;
+          StorageDead(_4);
+          drop(_2) -> [return: bb6, unwind: bb10];
       }
   
       bb6: {
-+         _8 = const false;
-          StorageDead(_4);
-          drop(_2) -> [return: bb7, unwind: bb12];
-      }
-  
-      bb7: {
           StorageDead(_2);
           tailcall g();
       }
   
+      bb7 (cleanup): {
+          drop(_5) -> [return: bb8, unwind terminate(cleanup)];
+      }
+  
       bb8 (cleanup): {
--         drop(_7) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+-         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb12;
       }
   
       bb9 (cleanup): {
-          drop(_5) -> [return: bb10, unwind terminate(cleanup)];
+          drop(_2) -> [return: bb10, unwind terminate(cleanup)];
       }
   
       bb10 (cleanup): {
--         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
-+         goto -> bb14;
-      }
-  
-      bb11 (cleanup): {
-          drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
-      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb13 (cleanup): {
-+         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
++     bb11 (cleanup): {
++         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb14 (cleanup): {
-+         switchInt(copy _8) -> [0: bb11, otherwise: bb13];
++     bb12 (cleanup): {
++         switchInt(copy _8) -> [0: bb9, otherwise: bb11];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
@@ -27,20 +27,20 @@
       bb0: {
 +         _8 = const false;
           StorageLive(_2);
-          _2 = String::new() -> [return: bb1, unwind: bb10];
+          _2 = String::new() -> [return: bb1, unwind: bb12];
       }
   
       bb1: {
           StorageLive(_3);
           _3 = const 12_i32;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb2, unwind: bb9];
+          _4 = String::new() -> [return: bb2, unwind: bb11];
       }
   
       bb2: {
 +         _8 = const true;
           StorageLive(_5);
-          _5 = String::new() -> [return: bb3, unwind: bb8];
+          _5 = String::new() -> [return: bb3, unwind: bb10];
       }
   
       bb3: {
@@ -48,50 +48,60 @@
           StorageLive(_7);
 +         _8 = const false;
           _7 = move _4;
-          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb7];
+          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb8];
       }
   
       bb4: {
           StorageDead(_7);
           StorageDead(_6);
-          drop(_5) -> [return: bb5, unwind: bb8];
+          drop(_5) -> [return: bb5, unwind: bb10];
       }
   
       bb5: {
           StorageDead(_5);
-+         _8 = const false;
-          StorageDead(_4);
-          drop(_2) -> [return: bb6, unwind: bb10];
+-         drop(_4) -> [return: bb6, unwind: bb11];
++         goto -> bb6;
       }
   
       bb6: {
++         _8 = const false;
+          StorageDead(_4);
+          drop(_2) -> [return: bb7, unwind: bb12];
+      }
+  
+      bb7: {
           StorageDead(_2);
           tailcall g();
       }
   
-      bb7 (cleanup): {
-          drop(_5) -> [return: bb8, unwind terminate(cleanup)];
-      }
-  
       bb8 (cleanup): {
--         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb12;
+-         drop(_7) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
       }
   
       bb9 (cleanup): {
-          drop(_2) -> [return: bb10, unwind terminate(cleanup)];
+          drop(_5) -> [return: bb10, unwind terminate(cleanup)];
       }
   
       bb10 (cleanup): {
+-         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
++         goto -> bb14;
+      }
+  
+      bb11 (cleanup): {
+          drop(_2) -> [return: bb12, unwind terminate(cleanup)];
+      }
+  
+      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
++     bb13 (cleanup): {
++         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
 +     }
 + 
-+     bb12 (cleanup): {
-+         switchInt(copy _8) -> [0: bb9, otherwise: bb11];
++     bb14 (cleanup): {
++         switchInt(copy _8) -> [0: bb11, otherwise: bb13];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
@@ -34,13 +34,13 @@
           StorageLive(_3);
           _3 = const 12_i32;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb2, unwind: bb9];
+          _4 = String::new() -> [return: bb2, unwind: bb11];
       }
   
       bb2: {
 +         _8 = const true;
           StorageLive(_5);
-          _5 = String::new() -> [return: bb3, unwind: bb8];
+          _5 = String::new() -> [return: bb3, unwind: bb10];
       }
   
       bb3: {
@@ -48,51 +48,61 @@
           StorageLive(_7);
 +         _8 = const false;
           _7 = move _4;
-          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb7];
+          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb8];
       }
   
       bb4: {
           StorageDead(_7);
           StorageDead(_6);
-          drop(_5) -> [return: bb5, unwind: bb8];
+          drop(_5) -> [return: bb5, unwind: bb10];
       }
   
       bb5: {
           StorageDead(_5);
-+         _8 = const false;
-          StorageDead(_4);
--         drop(_2) -> [return: bb6, unwind continue];
-+         drop(_2) -> [return: bb6, unwind: bb10];
+-         drop(_4) -> [return: bb6, unwind: bb11];
++         goto -> bb6;
       }
   
       bb6: {
++         _8 = const false;
+          StorageDead(_4);
+-         drop(_2) -> [return: bb7, unwind continue];
++         drop(_2) -> [return: bb7, unwind: bb12];
+      }
+  
+      bb7: {
           StorageDead(_2);
           tailcall g();
       }
   
-      bb7 (cleanup): {
-          drop(_5) -> [return: bb8, unwind terminate(cleanup)];
-      }
-  
       bb8 (cleanup): {
--         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb12;
+-         drop(_7) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb9;
       }
   
       bb9 (cleanup): {
-          drop(_2) -> [return: bb10, unwind terminate(cleanup)];
+          drop(_5) -> [return: bb10, unwind terminate(cleanup)];
       }
   
       bb10 (cleanup): {
+-         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
++         goto -> bb14;
+      }
+  
+      bb11 (cleanup): {
+          drop(_2) -> [return: bb12, unwind terminate(cleanup)];
+      }
+  
+      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb11 (cleanup): {
-+         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
++     bb13 (cleanup): {
++         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
 +     }
 + 
-+     bb12 (cleanup): {
-+         switchInt(copy _8) -> [0: bb9, otherwise: bb11];
++     bb14 (cleanup): {
++         switchInt(copy _8) -> [0: bb11, otherwise: bb13];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
@@ -34,13 +34,13 @@
           StorageLive(_3);
           _3 = const 12_i32;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb2, unwind: bb11];
+          _4 = String::new() -> [return: bb2, unwind: bb9];
       }
   
       bb2: {
 +         _8 = const true;
           StorageLive(_5);
-          _5 = String::new() -> [return: bb3, unwind: bb10];
+          _5 = String::new() -> [return: bb3, unwind: bb8];
       }
   
       bb3: {
@@ -48,61 +48,51 @@
           StorageLive(_7);
 +         _8 = const false;
           _7 = move _4;
-          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb8];
+          _6 = std::mem::drop::<String>(move _7) -> [return: bb4, unwind: bb7];
       }
   
       bb4: {
           StorageDead(_7);
           StorageDead(_6);
-          drop(_5) -> [return: bb5, unwind: bb10];
+          drop(_5) -> [return: bb5, unwind: bb8];
       }
   
       bb5: {
           StorageDead(_5);
--         drop(_4) -> [return: bb6, unwind: bb11];
-+         goto -> bb6;
++         _8 = const false;
+          StorageDead(_4);
+-         drop(_2) -> [return: bb6, unwind continue];
++         drop(_2) -> [return: bb6, unwind: bb10];
       }
   
       bb6: {
-+         _8 = const false;
-          StorageDead(_4);
--         drop(_2) -> [return: bb7, unwind continue];
-+         drop(_2) -> [return: bb7, unwind: bb12];
-      }
-  
-      bb7: {
           StorageDead(_2);
           tailcall g();
       }
   
+      bb7 (cleanup): {
+          drop(_5) -> [return: bb8, unwind terminate(cleanup)];
+      }
+  
       bb8 (cleanup): {
--         drop(_7) -> [return: bb9, unwind terminate(cleanup)];
-+         goto -> bb9;
+-         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
++         goto -> bb12;
       }
   
       bb9 (cleanup): {
-          drop(_5) -> [return: bb10, unwind terminate(cleanup)];
+          drop(_2) -> [return: bb10, unwind terminate(cleanup)];
       }
   
       bb10 (cleanup): {
--         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
-+         goto -> bb14;
-      }
-  
-      bb11 (cleanup): {
-          drop(_2) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
-      bb12 (cleanup): {
           resume;
 +     }
 + 
-+     bb13 (cleanup): {
-+         drop(_4) -> [return: bb11, unwind terminate(cleanup)];
++     bb11 (cleanup): {
++         drop(_4) -> [return: bb9, unwind terminate(cleanup)];
 +     }
 + 
-+     bb14 (cleanup): {
-+         switchInt(copy _8) -> [0: bb11, otherwise: bb13];
++     bb12 (cleanup): {
++         switchInt(copy _8) -> [0: bb9, otherwise: bb11];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
@@ -31,20 +31,20 @@
       bb0: {
 +         _12 = const false;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb1, unwind: bb23];
+          _4 = String::new() -> [return: bb1, unwind: bb27];
       }
   
       bb1: {
           StorageLive(_5);
           _5 = const 12_i32;
           StorageLive(_6);
-          _6 = String::new() -> [return: bb2, unwind: bb22];
+          _6 = String::new() -> [return: bb2, unwind: bb26];
       }
   
       bb2: {
 +         _12 = const true;
           StorageLive(_7);
-          _7 = String::new() -> [return: bb3, unwind: bb21];
+          _7 = String::new() -> [return: bb3, unwind: bb25];
       }
   
       bb3: {
@@ -52,112 +52,132 @@
           StorageLive(_9);
 +         _12 = const false;
           _9 = move _6;
-          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb20];
+          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb23];
       }
   
       bb4: {
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
-          _10 = String::new() -> [return: bb5, unwind: bb20];
+          _10 = String::new() -> [return: bb5, unwind: bb24];
       }
   
       bb5: {
           StorageLive(_11);
-          _11 = String::new() -> [return: bb6, unwind: bb19];
+          _11 = String::new() -> [return: bb6, unwind: bb22];
       }
   
       bb6: {
-          drop(_7) -> [return: bb7, unwind: bb17];
+          drop(_7) -> [return: bb7, unwind: bb20];
       }
   
       bb7: {
           StorageDead(_7);
-+         _12 = const false;
-          StorageDead(_6);
-          drop(_4) -> [return: bb8, unwind: bb15];
+-         drop(_6) -> [return: bb8, unwind: bb18];
++         goto -> bb8;
       }
   
       bb8: {
-          StorageDead(_4);
-          drop(_2) -> [return: bb9, unwind: bb13];
++         _12 = const false;
+          StorageDead(_6);
+          drop(_4) -> [return: bb9, unwind: bb16];
       }
   
       bb9: {
-          drop(_1) -> [return: bb10, unwind: bb11];
+          StorageDead(_4);
+          drop(_2) -> [return: bb10, unwind: bb14];
       }
   
       bb10: {
+          drop(_1) -> [return: bb11, unwind: bb12];
+      }
+  
+      bb11: {
           tailcall g_with_arg(move _10, move _11);
       }
   
-      bb11 (cleanup): {
-          drop(_10) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
       bb12 (cleanup): {
-          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb13, unwind terminate(cleanup)];
       }
   
       bb13 (cleanup): {
-          drop(_10) -> [return: bb14, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
       }
   
       bb14 (cleanup): {
-          drop(_11) -> [return: bb24, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb15, unwind terminate(cleanup)];
       }
   
       bb15 (cleanup): {
-          drop(_10) -> [return: bb16, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb16 (cleanup): {
-          drop(_11) -> [return: bb23, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb17, unwind terminate(cleanup)];
       }
   
       bb17 (cleanup): {
-          drop(_10) -> [return: bb18, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
       }
   
       bb18 (cleanup): {
-          drop(_11) -> [return: bb21, unwind terminate(cleanup)];
+-         drop(_10) -> [return: bb19, unwind terminate(cleanup)];
++         goto -> bb19;
       }
   
       bb19 (cleanup): {
-          drop(_10) -> [return: bb20, unwind terminate(cleanup)];
+-         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
++         goto -> bb26;
       }
   
       bb20 (cleanup): {
-          drop(_7) -> [return: bb21, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb21, unwind terminate(cleanup)];
       }
   
       bb21 (cleanup): {
--         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
-+         goto -> bb27;
+          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {
-          drop(_4) -> [return: bb23, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb23 (cleanup): {
-          drop(_2) -> [return: bb24, unwind terminate(cleanup)];
+-         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
++         goto -> bb24;
       }
   
       bb24 (cleanup): {
-          drop(_1) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_7) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb25 (cleanup): {
+-         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
++         goto -> bb31;
+      }
+  
+      bb26 (cleanup): {
+          drop(_4) -> [return: bb27, unwind terminate(cleanup)];
+      }
+  
+      bb27 (cleanup): {
+          drop(_2) -> [return: bb28, unwind terminate(cleanup)];
+      }
+  
+      bb28 (cleanup): {
+          drop(_1) -> [return: bb29, unwind terminate(cleanup)];
+      }
+  
+      bb29 (cleanup): {
           resume;
 +     }
 + 
-+     bb26 (cleanup): {
-+         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
++     bb30 (cleanup): {
++         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
 +     }
 + 
-+     bb27 (cleanup): {
-+         switchInt(copy _12) -> [0: bb22, otherwise: bb26];
++     bb31 (cleanup): {
++         switchInt(copy _12) -> [0: bb26, otherwise: bb30];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
@@ -31,20 +31,20 @@
       bb0: {
 +         _12 = const false;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb1, unwind: bb27];
+          _4 = String::new() -> [return: bb1, unwind: bb23];
       }
   
       bb1: {
           StorageLive(_5);
           _5 = const 12_i32;
           StorageLive(_6);
-          _6 = String::new() -> [return: bb2, unwind: bb26];
+          _6 = String::new() -> [return: bb2, unwind: bb22];
       }
   
       bb2: {
 +         _12 = const true;
           StorageLive(_7);
-          _7 = String::new() -> [return: bb3, unwind: bb25];
+          _7 = String::new() -> [return: bb3, unwind: bb21];
       }
   
       bb3: {
@@ -52,132 +52,112 @@
           StorageLive(_9);
 +         _12 = const false;
           _9 = move _6;
-          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb23];
+          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb20];
       }
   
       bb4: {
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
-          _10 = String::new() -> [return: bb5, unwind: bb24];
+          _10 = String::new() -> [return: bb5, unwind: bb20];
       }
   
       bb5: {
           StorageLive(_11);
-          _11 = String::new() -> [return: bb6, unwind: bb22];
+          _11 = String::new() -> [return: bb6, unwind: bb19];
       }
   
       bb6: {
-          drop(_7) -> [return: bb7, unwind: bb20];
+          drop(_7) -> [return: bb7, unwind: bb17];
       }
   
       bb7: {
           StorageDead(_7);
--         drop(_6) -> [return: bb8, unwind: bb18];
-+         goto -> bb8;
++         _12 = const false;
+          StorageDead(_6);
+          drop(_4) -> [return: bb8, unwind: bb15];
       }
   
       bb8: {
-+         _12 = const false;
-          StorageDead(_6);
-          drop(_4) -> [return: bb9, unwind: bb16];
+          StorageDead(_4);
+          drop(_2) -> [return: bb9, unwind: bb13];
       }
   
       bb9: {
-          StorageDead(_4);
-          drop(_2) -> [return: bb10, unwind: bb14];
+          drop(_1) -> [return: bb10, unwind: bb11];
       }
   
       bb10: {
-          drop(_1) -> [return: bb11, unwind: bb12];
-      }
-  
-      bb11: {
           tailcall g_with_arg(move _10, move _11);
       }
   
+      bb11 (cleanup): {
+          drop(_10) -> [return: bb12, unwind terminate(cleanup)];
+      }
+  
       bb12 (cleanup): {
-          drop(_10) -> [return: bb13, unwind terminate(cleanup)];
-      }
-  
-      bb13 (cleanup): {
-          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
-      }
-  
-      bb14 (cleanup): {
-          drop(_10) -> [return: bb15, unwind terminate(cleanup)];
-      }
-  
-      bb15 (cleanup): {
-          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
-      }
-  
-      bb16 (cleanup): {
-          drop(_10) -> [return: bb17, unwind terminate(cleanup)];
-      }
-  
-      bb17 (cleanup): {
-          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
-      }
-  
-      bb18 (cleanup): {
--         drop(_10) -> [return: bb19, unwind terminate(cleanup)];
-+         goto -> bb19;
-      }
-  
-      bb19 (cleanup): {
--         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb26;
-      }
-  
-      bb20 (cleanup): {
-          drop(_10) -> [return: bb21, unwind terminate(cleanup)];
-      }
-  
-      bb21 (cleanup): {
           drop(_11) -> [return: bb25, unwind terminate(cleanup)];
       }
   
+      bb13 (cleanup): {
+          drop(_10) -> [return: bb14, unwind terminate(cleanup)];
+      }
+  
+      bb14 (cleanup): {
+          drop(_11) -> [return: bb24, unwind terminate(cleanup)];
+      }
+  
+      bb15 (cleanup): {
+          drop(_10) -> [return: bb16, unwind terminate(cleanup)];
+      }
+  
+      bb16 (cleanup): {
+          drop(_11) -> [return: bb23, unwind terminate(cleanup)];
+      }
+  
+      bb17 (cleanup): {
+          drop(_10) -> [return: bb18, unwind terminate(cleanup)];
+      }
+  
+      bb18 (cleanup): {
+          drop(_11) -> [return: bb21, unwind terminate(cleanup)];
+      }
+  
+      bb19 (cleanup): {
+          drop(_10) -> [return: bb20, unwind terminate(cleanup)];
+      }
+  
+      bb20 (cleanup): {
+          drop(_7) -> [return: bb21, unwind terminate(cleanup)];
+      }
+  
+      bb21 (cleanup): {
+-         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
++         goto -> bb27;
+      }
+  
       bb22 (cleanup): {
-          drop(_10) -> [return: bb24, unwind terminate(cleanup)];
+          drop(_4) -> [return: bb23, unwind terminate(cleanup)];
       }
   
       bb23 (cleanup): {
--         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
-+         goto -> bb24;
+          drop(_2) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb24 (cleanup): {
-          drop(_7) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_1) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb25 (cleanup): {
--         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb31;
-      }
-  
-      bb26 (cleanup): {
-          drop(_4) -> [return: bb27, unwind terminate(cleanup)];
-      }
-  
-      bb27 (cleanup): {
-          drop(_2) -> [return: bb28, unwind terminate(cleanup)];
-      }
-  
-      bb28 (cleanup): {
-          drop(_1) -> [return: bb29, unwind terminate(cleanup)];
-      }
-  
-      bb29 (cleanup): {
           resume;
 +     }
 + 
-+     bb30 (cleanup): {
-+         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
++     bb26 (cleanup): {
++         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
 +     }
 + 
-+     bb31 (cleanup): {
-+         switchInt(copy _12) -> [0: bb26, otherwise: bb30];
++     bb27 (cleanup): {
++         switchInt(copy _12) -> [0: bb22, otherwise: bb26];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
@@ -31,20 +31,20 @@
       bb0: {
 +         _12 = const false;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb1, unwind: bb23];
+          _4 = String::new() -> [return: bb1, unwind: bb27];
       }
   
       bb1: {
           StorageLive(_5);
           _5 = const 12_i32;
           StorageLive(_6);
-          _6 = String::new() -> [return: bb2, unwind: bb22];
+          _6 = String::new() -> [return: bb2, unwind: bb26];
       }
   
       bb2: {
 +         _12 = const true;
           StorageLive(_7);
-          _7 = String::new() -> [return: bb3, unwind: bb21];
+          _7 = String::new() -> [return: bb3, unwind: bb25];
       }
   
       bb3: {
@@ -52,112 +52,132 @@
           StorageLive(_9);
 +         _12 = const false;
           _9 = move _6;
-          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb20];
+          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb23];
       }
   
       bb4: {
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
-          _10 = String::new() -> [return: bb5, unwind: bb20];
+          _10 = String::new() -> [return: bb5, unwind: bb24];
       }
   
       bb5: {
           StorageLive(_11);
-          _11 = String::new() -> [return: bb6, unwind: bb19];
+          _11 = String::new() -> [return: bb6, unwind: bb22];
       }
   
       bb6: {
-          drop(_7) -> [return: bb7, unwind: bb17];
+          drop(_7) -> [return: bb7, unwind: bb20];
       }
   
       bb7: {
           StorageDead(_7);
-+         _12 = const false;
-          StorageDead(_6);
-          drop(_4) -> [return: bb8, unwind: bb15];
+-         drop(_6) -> [return: bb8, unwind: bb18];
++         goto -> bb8;
       }
   
       bb8: {
-          StorageDead(_4);
-          drop(_2) -> [return: bb9, unwind: bb13];
++         _12 = const false;
+          StorageDead(_6);
+          drop(_4) -> [return: bb9, unwind: bb16];
       }
   
       bb9: {
-          drop(_1) -> [return: bb10, unwind: bb11];
+          StorageDead(_4);
+          drop(_2) -> [return: bb10, unwind: bb14];
       }
   
       bb10: {
+          drop(_1) -> [return: bb11, unwind: bb12];
+      }
+  
+      bb11: {
           tailcall g_with_arg(move _10, move _11);
       }
   
-      bb11 (cleanup): {
-          drop(_10) -> [return: bb12, unwind terminate(cleanup)];
-      }
-  
       bb12 (cleanup): {
-          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb13, unwind terminate(cleanup)];
       }
   
       bb13 (cleanup): {
-          drop(_10) -> [return: bb14, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
       }
   
       bb14 (cleanup): {
-          drop(_11) -> [return: bb24, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb15, unwind terminate(cleanup)];
       }
   
       bb15 (cleanup): {
-          drop(_10) -> [return: bb16, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
       }
   
       bb16 (cleanup): {
-          drop(_11) -> [return: bb23, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb17, unwind terminate(cleanup)];
       }
   
       bb17 (cleanup): {
-          drop(_10) -> [return: bb18, unwind terminate(cleanup)];
+          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
       }
   
       bb18 (cleanup): {
-          drop(_11) -> [return: bb21, unwind terminate(cleanup)];
+-         drop(_10) -> [return: bb19, unwind terminate(cleanup)];
++         goto -> bb19;
       }
   
       bb19 (cleanup): {
-          drop(_10) -> [return: bb20, unwind terminate(cleanup)];
+-         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
++         goto -> bb26;
       }
   
       bb20 (cleanup): {
-          drop(_7) -> [return: bb21, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb21, unwind terminate(cleanup)];
       }
   
       bb21 (cleanup): {
--         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
-+         goto -> bb27;
+          drop(_11) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb22 (cleanup): {
-          drop(_4) -> [return: bb23, unwind terminate(cleanup)];
+          drop(_10) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb23 (cleanup): {
-          drop(_2) -> [return: bb24, unwind terminate(cleanup)];
+-         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
++         goto -> bb24;
       }
   
       bb24 (cleanup): {
-          drop(_1) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_7) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb25 (cleanup): {
+-         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
++         goto -> bb31;
+      }
+  
+      bb26 (cleanup): {
+          drop(_4) -> [return: bb27, unwind terminate(cleanup)];
+      }
+  
+      bb27 (cleanup): {
+          drop(_2) -> [return: bb28, unwind terminate(cleanup)];
+      }
+  
+      bb28 (cleanup): {
+          drop(_1) -> [return: bb29, unwind terminate(cleanup)];
+      }
+  
+      bb29 (cleanup): {
           resume;
 +     }
 + 
-+     bb26 (cleanup): {
-+         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
++     bb30 (cleanup): {
++         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
 +     }
 + 
-+     bb27 (cleanup): {
-+         switchInt(copy _12) -> [0: bb22, otherwise: bb26];
++     bb31 (cleanup): {
++         switchInt(copy _12) -> [0: bb26, otherwise: bb30];
       }
   }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
@@ -31,20 +31,20 @@
       bb0: {
 +         _12 = const false;
           StorageLive(_4);
-          _4 = String::new() -> [return: bb1, unwind: bb27];
+          _4 = String::new() -> [return: bb1, unwind: bb23];
       }
   
       bb1: {
           StorageLive(_5);
           _5 = const 12_i32;
           StorageLive(_6);
-          _6 = String::new() -> [return: bb2, unwind: bb26];
+          _6 = String::new() -> [return: bb2, unwind: bb22];
       }
   
       bb2: {
 +         _12 = const true;
           StorageLive(_7);
-          _7 = String::new() -> [return: bb3, unwind: bb25];
+          _7 = String::new() -> [return: bb3, unwind: bb21];
       }
   
       bb3: {
@@ -52,132 +52,112 @@
           StorageLive(_9);
 +         _12 = const false;
           _9 = move _6;
-          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb23];
+          _8 = std::mem::drop::<String>(move _9) -> [return: bb4, unwind: bb20];
       }
   
       bb4: {
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
-          _10 = String::new() -> [return: bb5, unwind: bb24];
+          _10 = String::new() -> [return: bb5, unwind: bb20];
       }
   
       bb5: {
           StorageLive(_11);
-          _11 = String::new() -> [return: bb6, unwind: bb22];
+          _11 = String::new() -> [return: bb6, unwind: bb19];
       }
   
       bb6: {
-          drop(_7) -> [return: bb7, unwind: bb20];
+          drop(_7) -> [return: bb7, unwind: bb17];
       }
   
       bb7: {
           StorageDead(_7);
--         drop(_6) -> [return: bb8, unwind: bb18];
-+         goto -> bb8;
++         _12 = const false;
+          StorageDead(_6);
+          drop(_4) -> [return: bb8, unwind: bb15];
       }
   
       bb8: {
-+         _12 = const false;
-          StorageDead(_6);
-          drop(_4) -> [return: bb9, unwind: bb16];
+          StorageDead(_4);
+          drop(_2) -> [return: bb9, unwind: bb13];
       }
   
       bb9: {
-          StorageDead(_4);
-          drop(_2) -> [return: bb10, unwind: bb14];
+          drop(_1) -> [return: bb10, unwind: bb11];
       }
   
       bb10: {
-          drop(_1) -> [return: bb11, unwind: bb12];
-      }
-  
-      bb11: {
           tailcall g_with_arg(move _10, move _11);
       }
   
+      bb11 (cleanup): {
+          drop(_10) -> [return: bb12, unwind terminate(cleanup)];
+      }
+  
       bb12 (cleanup): {
-          drop(_10) -> [return: bb13, unwind terminate(cleanup)];
-      }
-  
-      bb13 (cleanup): {
-          drop(_11) -> [return: bb29, unwind terminate(cleanup)];
-      }
-  
-      bb14 (cleanup): {
-          drop(_10) -> [return: bb15, unwind terminate(cleanup)];
-      }
-  
-      bb15 (cleanup): {
-          drop(_11) -> [return: bb28, unwind terminate(cleanup)];
-      }
-  
-      bb16 (cleanup): {
-          drop(_10) -> [return: bb17, unwind terminate(cleanup)];
-      }
-  
-      bb17 (cleanup): {
-          drop(_11) -> [return: bb27, unwind terminate(cleanup)];
-      }
-  
-      bb18 (cleanup): {
--         drop(_10) -> [return: bb19, unwind terminate(cleanup)];
-+         goto -> bb19;
-      }
-  
-      bb19 (cleanup): {
--         drop(_11) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb26;
-      }
-  
-      bb20 (cleanup): {
-          drop(_10) -> [return: bb21, unwind terminate(cleanup)];
-      }
-  
-      bb21 (cleanup): {
           drop(_11) -> [return: bb25, unwind terminate(cleanup)];
       }
   
+      bb13 (cleanup): {
+          drop(_10) -> [return: bb14, unwind terminate(cleanup)];
+      }
+  
+      bb14 (cleanup): {
+          drop(_11) -> [return: bb24, unwind terminate(cleanup)];
+      }
+  
+      bb15 (cleanup): {
+          drop(_10) -> [return: bb16, unwind terminate(cleanup)];
+      }
+  
+      bb16 (cleanup): {
+          drop(_11) -> [return: bb23, unwind terminate(cleanup)];
+      }
+  
+      bb17 (cleanup): {
+          drop(_10) -> [return: bb18, unwind terminate(cleanup)];
+      }
+  
+      bb18 (cleanup): {
+          drop(_11) -> [return: bb21, unwind terminate(cleanup)];
+      }
+  
+      bb19 (cleanup): {
+          drop(_10) -> [return: bb20, unwind terminate(cleanup)];
+      }
+  
+      bb20 (cleanup): {
+          drop(_7) -> [return: bb21, unwind terminate(cleanup)];
+      }
+  
+      bb21 (cleanup): {
+-         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
++         goto -> bb27;
+      }
+  
       bb22 (cleanup): {
-          drop(_10) -> [return: bb24, unwind terminate(cleanup)];
+          drop(_4) -> [return: bb23, unwind terminate(cleanup)];
       }
   
       bb23 (cleanup): {
--         drop(_9) -> [return: bb24, unwind terminate(cleanup)];
-+         goto -> bb24;
+          drop(_2) -> [return: bb24, unwind terminate(cleanup)];
       }
   
       bb24 (cleanup): {
-          drop(_7) -> [return: bb25, unwind terminate(cleanup)];
+          drop(_1) -> [return: bb25, unwind terminate(cleanup)];
       }
   
       bb25 (cleanup): {
--         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
-+         goto -> bb31;
-      }
-  
-      bb26 (cleanup): {
-          drop(_4) -> [return: bb27, unwind terminate(cleanup)];
-      }
-  
-      bb27 (cleanup): {
-          drop(_2) -> [return: bb28, unwind terminate(cleanup)];
-      }
-  
-      bb28 (cleanup): {
-          drop(_1) -> [return: bb29, unwind terminate(cleanup)];
-      }
-  
-      bb29 (cleanup): {
           resume;
 +     }
 + 
-+     bb30 (cleanup): {
-+         drop(_6) -> [return: bb26, unwind terminate(cleanup)];
++     bb26 (cleanup): {
++         drop(_6) -> [return: bb22, unwind terminate(cleanup)];
 +     }
 + 
-+     bb31 (cleanup): {
-+         switchInt(copy _12) -> [0: bb26, otherwise: bb30];
++     bb27 (cleanup): {
++         switchInt(copy _12) -> [0: bb22, otherwise: bb26];
       }
   }
   

--- a/tests/ui/coroutine/minimal_reproducer.rs
+++ b/tests/ui/coroutine/minimal_reproducer.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes, negative_impls)]
+
+use std::ops::Coroutine;
+
+struct Guard;
+impl !Send for Guard {}
+impl Drop for Guard {
+    fn drop(&mut self) {}
+}
+
+fn lock() -> Guard {
+    Guard
+}
+
+fn bar() -> impl Coroutine {
+    #[coroutine]
+    static || {
+        let mut guard = lock();
+        loop {
+            drop(guard);
+            yield;
+            guard = lock();
+        }
+    }
+}
+
+fn main() {
+    fn require_send<T: Send>(_: T) {}
+    require_send(bar());
+}

--- a/tests/ui/coroutine/mutex_guard_await.rs
+++ b/tests/ui/coroutine/mutex_guard_await.rs
@@ -1,0 +1,26 @@
+//@ check-pass
+//@ edition: 2024
+
+use std::sync::Mutex;
+
+struct Fut;
+impl std::future::Future for Fut {
+    type Output = ();
+    fn poll(self: std::pin::Pin<&mut Self>, _cx: &mut std::task::Context<'_>) -> std::task::Poll<()> {
+        std::task::Poll::Ready(())
+    }
+}
+
+async fn bar(mutex: &Mutex<()>) {
+    let mut guard = mutex.lock();
+    loop {
+        drop(guard);
+        Fut.await;
+        guard = mutex.lock();
+    }
+}
+
+fn main() {
+    fn require_send<T: Send>(_: T) {}
+    require_send(bar(&Mutex::new(())));
+}

--- a/tests/ui/drop/drop-order-comparisons.e2021.fixed
+++ b/tests/ui/drop/drop-order-comparisons.e2021.fixed
@@ -102,8 +102,6 @@ fn t_tailexpr_tuples() {
         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
         //[e2021]~^ WARN relative drop order changing in Rust 2024
         //[e2021]~| WARN this changes meaning in Rust 2024
-        //[e2021]~| WARN relative drop order changing in Rust 2024
-        //[e2021]~| WARN this changes meaning in Rust 2024
     }, e.mark(1), e.ok(4));
     e.assert(6);
 }

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -27,22 +27,22 @@ LL | |     }, e.mark(3), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#3` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_v` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,10 +62,12 @@ warning: relative drop order changing in Rust 2024
 LL |       _ = ({
    |  _________-
 LL | |         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
-   | |                                             ^^^^^^^
-   | |                                             |
-   | |                                             this value will be stored in a temporary; let us call it `#2`
-   | |                                             up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
+   | |                   -------                   ^^^^^^^
+   | |                   |                         |
+   | |                   |                         this value will be stored in a temporary; let us call it `#2`
+   | |                   |                         up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
+   | |                   this value will be stored in a temporary; let us call it `#3`
+   | |                   up until Edition 2021 `#3` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(1), e.ok(4));
    | |                          -
@@ -75,12 +77,17 @@ LL | |     }, e.mark(1), e.ok(4));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
+   |
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: `#3` invokes this custom destructor
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,39 +96,7 @@ LL | impl<'b> Drop for LogDrop<'b> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:102:19
-   |
-LL |       _ = ({
-   |  _________-
-LL | |         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
-   | |                   ^^^^^^^
-   | |                   |
-   | |                   this value will be stored in a temporary; let us call it `#2`
-   | |                   up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
-...  |
-LL | |     }, e.mark(1), e.ok(4));
-   | |                          -
-   | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
-   | |__________________________this value will be stored in a temporary; let us call it `#1`
-   |                            `#1` will be dropped later as of Edition 2024
-   |
-note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
-   |
-LL | impl<'b> Drop for LogDrop<'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
-   |
-LL | impl<'b> Drop for LogDrop<'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
-   = warning: this changes meaning in Rust 2024
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
-
-warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:223:24
+  --> $DIR/drop-order-comparisons.rs:221:24
    |
 LL |       _ = ({
    |  _________-
@@ -139,12 +114,12 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,7 +128,7 @@ LL | impl<'b> Drop for LogDrop<'b> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 warning: relative drop order changing in Rust 2024
-  --> $DIR/drop-order-comparisons.rs:249:24
+  --> $DIR/drop-order-comparisons.rs:247:24
    |
 LL |       _ = ({
    |  _________-
@@ -171,12 +146,12 @@ LL | |     }, e.mark(2), e.ok(3));
    |                            `#1` will be dropped later as of Edition 2024
    |
 note: `#2` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,7 +160,7 @@ LL | impl<'b> Drop for LogDrop<'b> {
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:125:13
+  --> $DIR/drop-order-comparisons.rs:123:13
    |
 LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |             ^^^^^^^^^^^^-------^^^^^^^^^
@@ -193,12 +168,12 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:129:5
+  --> $DIR/drop-order-comparisons.rs:127:5
    |
 LL |     }, e.mark(2), e.ok(3));
    |     ^
@@ -215,7 +190,7 @@ LL ~     } _ => {}}, e.mark(2), e.ok(3));
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:147:13
+  --> $DIR/drop-order-comparisons.rs:145:13
    |
 LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |             ^^^^^^^^^^^^--------^^^^^^^^^
@@ -223,12 +198,12 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:147:44
+  --> $DIR/drop-order-comparisons.rs:145:44
    |
 LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
    |                                            ^
@@ -244,7 +219,7 @@ LL ~     }}, e.mark(2), e.ok(3));
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:249:12
+  --> $DIR/drop-order-comparisons.rs:247:12
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -252,12 +227,12 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:249:43
+  --> $DIR/drop-order-comparisons.rs:247:43
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                                           ^
@@ -273,7 +248,7 @@ LL ~         }}
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:320:12
+  --> $DIR/drop-order-comparisons.rs:318:12
    |
 LL |         if let true = e.err(9).is_ok() {} else {
    |            ^^^^^^^^^^^--------^^^^^^^^
@@ -281,12 +256,12 @@ LL |         if let true = e.err(9).is_ok() {} else {
    |                       this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:320:41
+  --> $DIR/drop-order-comparisons.rs:318:41
    |
 LL |         if let true = e.err(9).is_ok() {} else {
    |                                         ^
@@ -302,7 +277,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:323:12
+  --> $DIR/drop-order-comparisons.rs:321:12
    |
 LL |         if let Ok(_v) = e.err(8) {} else {
    |            ^^^^^^^^^^^^^--------
@@ -310,12 +285,12 @@ LL |         if let Ok(_v) = e.err(8) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:323:35
+  --> $DIR/drop-order-comparisons.rs:321:35
    |
 LL |         if let Ok(_v) = e.err(8) {} else {
    |                                   ^
@@ -331,7 +306,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:326:12
+  --> $DIR/drop-order-comparisons.rs:324:12
    |
 LL |         if let Ok(_) = e.err(7) {} else {
    |            ^^^^^^^^^^^^--------
@@ -339,12 +314,12 @@ LL |         if let Ok(_) = e.err(7) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:326:34
+  --> $DIR/drop-order-comparisons.rs:324:34
    |
 LL |         if let Ok(_) = e.err(7) {} else {
    |                                  ^
@@ -360,7 +335,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:329:12
+  --> $DIR/drop-order-comparisons.rs:327:12
    |
 LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -368,12 +343,12 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:329:43
+  --> $DIR/drop-order-comparisons.rs:327:43
    |
 LL |         if let Ok(_) = e.err(6).as_ref() {} else {
    |                                           ^
@@ -389,7 +364,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:333:12
+  --> $DIR/drop-order-comparisons.rs:331:12
    |
 LL |         if let Ok(_v) = e.err(5) {} else {
    |            ^^^^^^^^^^^^^--------
@@ -397,12 +372,12 @@ LL |         if let Ok(_v) = e.err(5) {} else {
    |                         this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:333:35
+  --> $DIR/drop-order-comparisons.rs:331:35
    |
 LL |         if let Ok(_v) = e.err(5) {} else {
    |                                   ^
@@ -418,7 +393,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:336:12
+  --> $DIR/drop-order-comparisons.rs:334:12
    |
 LL |         if let Ok(_) = e.err(4) {} else {
    |            ^^^^^^^^^^^^--------
@@ -426,12 +401,12 @@ LL |         if let Ok(_) = e.err(4) {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:336:34
+  --> $DIR/drop-order-comparisons.rs:334:34
    |
 LL |         if let Ok(_) = e.err(4) {} else {
    |                                  ^
@@ -447,7 +422,7 @@ LL ~         }}}}}}}}};
    |
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/drop-order-comparisons.rs:372:12
+  --> $DIR/drop-order-comparisons.rs:370:12
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |            ^^^^^^^^^^^^--------^^^^^^^^^
@@ -455,12 +430,12 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
 note: value invokes this custom destructor
-  --> $DIR/drop-order-comparisons.rs:503:1
+  --> $DIR/drop-order-comparisons.rs:501:1
    |
 LL | impl<'b> Drop for LogDrop<'b> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
-  --> $DIR/drop-order-comparisons.rs:372:43
+  --> $DIR/drop-order-comparisons.rs:370:43
    |
 LL |         if let Ok(_) = e.err(4).as_ref() {} else {
    |                                           ^
@@ -475,5 +450,5 @@ LL |             e.mark(3);
 LL ~         }}}}}}}}};
    |
 
-warning: 15 warnings emitted
+warning: 14 warnings emitted
 

--- a/tests/ui/drop/drop-order-comparisons.rs
+++ b/tests/ui/drop/drop-order-comparisons.rs
@@ -102,8 +102,6 @@ fn t_tailexpr_tuples() {
         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
         //[e2021]~^ WARN relative drop order changing in Rust 2024
         //[e2021]~| WARN this changes meaning in Rust 2024
-        //[e2021]~| WARN relative drop order changing in Rust 2024
-        //[e2021]~| WARN this changes meaning in Rust 2024
     }, e.mark(1), e.ok(4));
     e.assert(6);
 }

--- a/tests/ui/mir/issue-80949.rs
+++ b/tests/ui/mir/issue-80949.rs
@@ -1,4 +1,4 @@
-//@ build-pass
+//@ check-fail
 
 trait Trait { type Item; }
 
@@ -30,5 +30,6 @@ fn main() {
     let storage = vec![()];
     may_panic(());
     let storage_ref = &storage;
+    //~^ ERROR `storage` does not live long enough
     diff(dyn_trait, storage_ref);
 }

--- a/tests/ui/nll/ice-106874.rs
+++ b/tests/ui/nll/ice-106874.rs
@@ -14,8 +14,6 @@ pub fn func<V, F: Fn(&mut V)>(f: F) -> A<impl X> {
     //~| ERROR implementation of `FnOnce` is not general enough
     //~| ERROR implementation of `Fn` is not general enough
     //~| ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR higher-ranked subtype error
-    //~| ERROR higher-ranked subtype error
 }
 
 trait X {}

--- a/tests/ui/nll/ice-106874.stderr
+++ b/tests/ui/nll/ice-106874.stderr
@@ -17,20 +17,6 @@ LL |     A(B(C::new(D::new(move |st| f(st)))))
    = note: ...but it actually implements `FnOnce<(&'1 mut V,)>`, for some specific lifetime `'1`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: higher-ranked subtype error
-  --> $DIR/ice-106874.rs:8:5
-   |
-LL |     A(B(C::new(D::new(move |st| f(st)))))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: higher-ranked subtype error
-  --> $DIR/ice-106874.rs:8:5
-   |
-LL |     A(B(C::new(D::new(move |st| f(st)))))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: implementation of `FnOnce` is not general enough
   --> $DIR/ice-106874.rs:8:7
    |
@@ -89,5 +75,5 @@ LL |     A(B(C::new(D::new(move |st| f(st)))))
    = note: ...but it actually implements `Fn<(&'2 mut V,)>`, for some specific lifetime `'2`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155022)*
<!-- homu-ignore:end -->

This change is meant to fix rust-lang/rust#151942. Putting this up to see the perf effects of running it on every MIR body; then I'll work out a strategy to merge it.

Related issues to triage:

- [x] rust-lang/rust#151942
- [x] rust-lang/rust#69663 
- [ ] rust-lang/rust#104883
- [ ] rust-lang/rust#57478
- [ ] rust-lang/rust#87309
- [x] rust-lang/rust#63768: This PR fixes at least part of the issue.
- [ ] rust-lang/rust#57017

---

Coroutine traits like Send and Sync are computed based on the `mir_coroutine_witnesses` query to get the types saved in the coroutine. This query runs the regular coroutine analysis pass on mir_promoted to compute which locals are saved across suspension points.

At this stage of MIR, drop terminators exist along every exit path of the function, even when a local has already been moved from. Those extra drop terminators causes locals (like `guard` in the case below) to appear live over suspension points, even when they have just been dropped.

```rust
async fn bar(mutex: &Mutex<()>) {
    let mut guard = mutex.lock().unwrap();
    loop {
        drop(guard);
        foo().await;
        guard = mutex.lock().unwrap();
    }
}
```

See [this gist](https://gist.github.com/tmandry/9758c1a24a198f2f9163d335e1666a57) for MIR of a simplified version of this function.

Later MIR passes like drop_elaboration and remove_unneeded_drops remove the redundant drop terminators, but they depend on type info to check needs_drop on a place's type. Since `mir_coroutine_witnesses` query is run inside typeck, we cannot depend on this without introducing cycles.

Instead, we implement a simple pass that removes drop terminators for definitely-uninitialized places. It avoids the need for type info by skipping the check for whether types have destructors.

r? @ghost