### PR TITLE
Use special DefIds for aliases

### DIFF
--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -9,7 +9,7 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_span::{DUMMY_SP, Span, Symbol};
-use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
+use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::{CollectAndApply, Interner, TypeFoldable, search_graph};
 
 use crate::dep_graph::{DepKind, DepNodeIndex};
@@ -40,6 +40,11 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type AdtId = DefId;
     type ImplId = DefId;
     type UnevaluatedConstId = DefId;
+    type ProjectionTyId = DefId;
+    type ProjectionId = DefId;
+    type OpaqueId = DefId;
+    type FreeAliasId = DefId;
+    type ImplTyAliasId = DefId;
     type Span = Span;
 
     type GenericArgs = ty::GenericArgsRef<'tcx>;
@@ -290,7 +295,11 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.mk_type_list_from_iter(args)
     }
 
-    fn parent(self, def_id: DefId) -> DefId {
+    fn projection_parent(self, def_id: Self::ProjectionId) -> Self::TraitId {
+        self.parent(def_id)
+    }
+
+    fn impl_ty_alias_parent(self, def_id: Self::ImplTyAliasId) -> Self::ImplId {
         self.parent(def_id)
     }
 
@@ -436,7 +445,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         !self.codegen_fn_attrs(def_id).target_features.is_empty()
     }
 
-    fn require_lang_item(self, lang_item: SolverLangItem) -> DefId {
+    fn require_projection_lang_item(self, lang_item: SolverProjectionLangItem) -> DefId {
         self.require_lang_item(solver_lang_item_to_lang_item(lang_item), DUMMY_SP)
     }
 
@@ -448,7 +457,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.require_lang_item(solver_adt_lang_item_to_lang_item(lang_item), DUMMY_SP)
     }
 
-    fn is_lang_item(self, def_id: DefId, lang_item: SolverLangItem) -> bool {
+    fn is_projection_lang_item(self, def_id: DefId, lang_item: SolverProjectionLangItem) -> bool {
         self.is_lang_item(def_id, solver_lang_item_to_lang_item(lang_item))
     }
 
@@ -468,7 +477,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.is_sizedness_trait(def_id)
     }
 
-    fn as_lang_item(self, def_id: DefId) -> Option<SolverLangItem> {
+    fn as_projection_lang_item(self, def_id: DefId) -> Option<SolverProjectionLangItem> {
         lang_item_to_solver_lang_item(self.lang_items().from_def_id(def_id)?)
     }
 
@@ -747,7 +756,7 @@ macro_rules! bidirectional_lang_item_map {
 }
 
 bidirectional_lang_item_map! {
-    SolverLangItem, fn lang_item_to_solver_lang_item, fn solver_lang_item_to_lang_item;
+    SolverProjectionLangItem, fn lang_item_to_solver_lang_item, fn solver_lang_item_to_lang_item;
 
 // tidy-alphabetical-start
     AsyncFnKindUpvars,

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -77,10 +77,10 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
     fn fetch_eligible_assoc_item(
         &self,
         goal_trait_ref: ty::TraitRef<Self::Interner>,
-        trait_assoc_def_id: <Self::Interner as Interner>::DefId,
+        trait_assoc_def_id: <Self::Interner as Interner>::ProjectionId,
         impl_def_id: <Self::Interner as Interner>::ImplId,
     ) -> Result<
-        Option<<Self::Interner as Interner>::DefId>,
+        Option<<Self::Interner as Interner>::ImplTyAliasId>,
         <Self::Interner as Interner>::ErrorGuaranteed,
     >;
 

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -4,7 +4,7 @@
 use derive_where::derive_where;
 use rustc_type_ir::data_structures::HashMap;
 use rustc_type_ir::inherent::*;
-use rustc_type_ir::lang_items::{SolverLangItem, SolverTraitLangItem};
+use rustc_type_ir::lang_items::{SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::solve::inspect::ProbeKind;
 use rustc_type_ir::{
@@ -102,7 +102,7 @@ where
             // We can resolve the `impl Trait` to its concrete type,
             // which enforces a DAG between the functions requiring
             // the auto trait bounds in question.
-            Ok(ty::Binder::dummy(vec![cx.type_of(def_id).instantiate(cx, args)]))
+            Ok(ty::Binder::dummy(vec![cx.type_of(def_id.into()).instantiate(cx, args)]))
         }
     }
 }
@@ -535,7 +535,8 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_async_callable<I: 
                 );
             }
 
-            let future_output_def_id = cx.require_lang_item(SolverLangItem::FutureOutput);
+            let future_output_def_id =
+                cx.require_projection_lang_item(SolverProjectionLangItem::FutureOutput);
             let future_output_ty = Ty::new_projection(cx, future_output_def_id, [sig.output()]);
             Ok((
                 bound_sig.rebind(AsyncCallableRelevantTypes {
@@ -590,7 +591,8 @@ fn fn_item_to_async_callable<I: Interner>(
     let nested = vec![
         bound_sig.rebind(ty::TraitRef::new(cx, future_trait_def_id, [sig.output()])).upcast(cx),
     ];
-    let future_output_def_id = cx.require_lang_item(SolverLangItem::FutureOutput);
+    let future_output_def_id =
+        cx.require_projection_lang_item(SolverProjectionLangItem::FutureOutput);
     let future_output_ty = Ty::new_projection(cx, future_output_def_id, [sig.output()]);
     Ok((
         bound_sig.rebind(AsyncCallableRelevantTypes {
@@ -636,7 +638,8 @@ fn coroutine_closure_to_ambiguous_coroutine<I: Interner>(
     args: ty::CoroutineClosureArgs<I>,
     sig: ty::CoroutineClosureSignature<I>,
 ) -> I::Ty {
-    let upvars_projection_def_id = cx.require_lang_item(SolverLangItem::AsyncFnKindUpvars);
+    let upvars_projection_def_id =
+        cx.require_projection_lang_item(SolverProjectionLangItem::AsyncFnKindUpvars);
     let tupled_upvars_ty = Ty::new_projection(
         cx,
         upvars_projection_def_id,
@@ -907,7 +910,10 @@ where
             // show up in the bounds, but just ones that come from substituting
             // `Self` with the dyn type.
             let proj = proj.with_self_ty(cx, trait_ref.self_ty());
-            replace_projection_with.entry(proj.def_id()).or_default().push(bound.rebind(proj));
+            replace_projection_with
+                .entry(proj.def_id().into())
+                .or_default()
+                .push(bound.rebind(proj));
         }
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1124,9 +1124,9 @@ where
     pub(super) fn fetch_eligible_assoc_item(
         &self,
         goal_trait_ref: ty::TraitRef<I>,
-        trait_assoc_def_id: I::DefId,
+        trait_assoc_def_id: I::ProjectionId,
         impl_def_id: I::ImplId,
-    ) -> Result<Option<I::DefId>, I::ErrorGuaranteed> {
+    ) -> Result<Option<I::ImplTyAliasId>, I::ErrorGuaranteed> {
         self.delegate.fetch_eligible_assoc_item(goal_trait_ref, trait_assoc_def_id, impl_def_id)
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -365,7 +365,7 @@ where
         }
     }
 
-    fn opaque_type_is_rigid(&self, def_id: I::DefId) -> bool {
+    fn opaque_type_is_rigid(&self, def_id: I::OpaqueId) -> bool {
         match self.typing_mode() {
             // Opaques are never rigid outside of analysis mode.
             TypingMode::Coherence | TypingMode::PostAnalysis => false,

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/inherent.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/inherent.rs
@@ -22,14 +22,14 @@ where
         let cx = self.cx();
         let inherent = goal.predicate.alias;
 
-        let impl_def_id = cx.parent(inherent.def_id);
-        let impl_args = self.fresh_args_for_item(impl_def_id);
+        let impl_def_id = cx.impl_ty_alias_parent(inherent.def_id.try_into().unwrap());
+        let impl_args = self.fresh_args_for_item(impl_def_id.into());
 
         // Equate impl header and add impl where clauses
         self.eq(
             goal.param_env,
             inherent.self_ty(),
-            cx.type_of(impl_def_id).instantiate(cx, impl_args),
+            cx.type_of(impl_def_id.into()).instantiate(cx, impl_args),
         )?;
 
         // Equate IAT with the RHS of the project goal

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -5,7 +5,7 @@ mod opaque_types;
 
 use rustc_type_ir::fast_reject::DeepRejectCtxt;
 use rustc_type_ir::inherent::*;
-use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
+use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::{self as ty, FieldInfo, Interner, NormalizesTo, PredicateKind, Upcast as _};
 use tracing::instrument;
@@ -273,7 +273,7 @@ where
 
             let target_item_def_id = match ecx.fetch_eligible_assoc_item(
                 goal_trait_ref,
-                goal.predicate.def_id(),
+                goal.predicate.def_id().try_into().unwrap(),
                 impl_def_id,
             ) {
                 Ok(Some(target_item_def_id)) => target_item_def_id,
@@ -350,7 +350,7 @@ where
                 }
             }
 
-            let target_container_def_id = cx.parent(target_item_def_id);
+            let target_container_def_id = cx.impl_ty_alias_parent(target_item_def_id);
 
             // Getting the right args here is complex, e.g. given:
             // - a goal `<Vec<u32> as Trait<i32>>::Assoc<u64>`
@@ -367,10 +367,10 @@ where
                 impl_def_id,
                 impl_args,
                 impl_trait_ref,
-                target_container_def_id,
+                target_container_def_id.into(),
             )?;
 
-            if !cx.check_args_compatible(target_item_def_id, target_args) {
+            if !cx.check_args_compatible(target_item_def_id.into(), target_args) {
                 return error_response(
                     ecx,
                     cx.delay_bug("associated item has mismatched arguments"),
@@ -380,10 +380,10 @@ where
             // Finally we construct the actual value of the associated type.
             let term = match goal.predicate.alias.kind(cx) {
                 ty::AliasTermKind::ProjectionTy => {
-                    cx.type_of(target_item_def_id).map_bound(|ty| ty.into())
+                    cx.type_of(target_item_def_id.into()).map_bound(|ty| ty.into())
                 }
                 ty::AliasTermKind::ProjectionConst => {
-                    cx.const_of_item(target_item_def_id).map_bound(|ct| ct.into())
+                    cx.const_of_item(target_item_def_id.into()).map_bound(|ct| ct.into())
                 }
                 kind => panic!("expected projection, found {kind:?}"),
             };
@@ -486,6 +486,7 @@ where
         goal_kind: ty::ClosureKind,
     ) -> Result<Candidate<I>, NoSolution> {
         let cx = ecx.cx();
+        let def_id = goal.predicate.def_id().try_into().unwrap();
 
         let env_region = match goal_kind {
             ty::ClosureKind::Fn | ty::ClosureKind::FnMut => goal.predicate.alias.args.region_at(2),
@@ -513,41 +514,42 @@ where
             [output_coroutine_ty],
         );
 
-        let (projection_term, term) =
-            if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CallOnceFuture) {
-                (
-                    ty::AliasTerm::new(
-                        cx,
-                        goal.predicate.def_id(),
-                        [goal.predicate.self_ty(), tupled_inputs_ty],
-                    ),
-                    output_coroutine_ty.into(),
-                )
-            } else if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CallRefFuture) {
-                (
-                    ty::AliasTerm::new(
-                        cx,
-                        goal.predicate.def_id(),
-                        [
-                            I::GenericArg::from(goal.predicate.self_ty()),
-                            tupled_inputs_ty.into(),
-                            env_region.into(),
-                        ],
-                    ),
-                    output_coroutine_ty.into(),
-                )
-            } else if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::AsyncFnOnceOutput) {
-                (
-                    ty::AliasTerm::new(
-                        cx,
-                        goal.predicate.def_id(),
-                        [goal.predicate.self_ty(), tupled_inputs_ty],
-                    ),
-                    coroutine_return_ty.into(),
-                )
-            } else {
-                panic!("no such associated type in `AsyncFn*`: {:?}", goal.predicate.def_id())
-            };
+        let (projection_term, term) = if cx
+            .is_projection_lang_item(def_id, SolverProjectionLangItem::CallOnceFuture)
+        {
+            (
+                ty::AliasTerm::new(
+                    cx,
+                    goal.predicate.def_id(),
+                    [goal.predicate.self_ty(), tupled_inputs_ty],
+                ),
+                output_coroutine_ty.into(),
+            )
+        } else if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::CallRefFuture) {
+            (
+                ty::AliasTerm::new(
+                    cx,
+                    goal.predicate.def_id(),
+                    [
+                        I::GenericArg::from(goal.predicate.self_ty()),
+                        tupled_inputs_ty.into(),
+                        env_region.into(),
+                    ],
+                ),
+                output_coroutine_ty.into(),
+            )
+        } else if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::AsyncFnOnceOutput) {
+            (
+                ty::AliasTerm::new(
+                    cx,
+                    goal.predicate.def_id(),
+                    [goal.predicate.self_ty(), tupled_inputs_ty],
+                ),
+                coroutine_return_ty.into(),
+            )
+        } else {
+            panic!("no such associated type in `AsyncFn*`: {:?}", goal.predicate.def_id())
+        };
         let pred = ty::ProjectionPredicate { projection_term, term }.upcast(cx);
 
         Self::probe_and_consider_implied_clause(
@@ -621,8 +623,8 @@ where
         goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolution> {
         let cx = ecx.cx();
-        let metadata_def_id = cx.require_lang_item(SolverLangItem::Metadata);
-        assert_eq!(metadata_def_id, goal.predicate.def_id());
+        let metadata_def_id = cx.require_projection_lang_item(SolverProjectionLangItem::Metadata);
+        assert_eq!(Into::<I::DefId>::into(metadata_def_id), goal.predicate.def_id());
         let metadata_ty = match goal.predicate.self_ty().kind() {
             ty::Bool
             | ty::Char
@@ -648,8 +650,9 @@ where
             ty::Str | ty::Slice(_) => Ty::new_usize(cx),
 
             ty::Dynamic(_, _) => {
-                let dyn_metadata = cx.require_lang_item(SolverLangItem::DynMetadata);
-                cx.type_of(dyn_metadata)
+                let dyn_metadata =
+                    cx.require_projection_lang_item(SolverProjectionLangItem::DynMetadata);
+                cx.type_of(dyn_metadata.into())
                     .instantiate(cx, &[I::GenericArg::from(goal.predicate.self_ty())])
             }
 
@@ -836,10 +839,12 @@ where
         }
 
         let coroutine = args.as_coroutine();
+        let def_id = goal.predicate.def_id().try_into().unwrap();
 
-        let term = if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CoroutineReturn) {
+        let term = if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::CoroutineReturn)
+        {
             coroutine.return_ty().into()
-        } else if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CoroutineYield) {
+        } else if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::CoroutineYield) {
             coroutine.yield_ty().into()
         } else {
             panic!("unexpected associated item `{:?}` for `{self_ty:?}`", goal.predicate.def_id())
@@ -963,9 +968,10 @@ where
         else {
             return Err(NoSolution);
         };
-        let ty = match ecx.cx().as_lang_item(goal.predicate.def_id()) {
-            Some(SolverLangItem::FieldBase) => base,
-            Some(SolverLangItem::FieldType) => ty,
+        let ty = match ecx.cx().as_projection_lang_item(goal.predicate.def_id().try_into().unwrap())
+        {
+            Some(SolverProjectionLangItem::FieldBase) => base,
+            Some(SolverProjectionLangItem::FieldType) => ty,
             _ => panic!("unexpected associated type {:?} in `Field`", goal.predicate),
         };
         ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -234,7 +234,7 @@ where
             goal.predicate.self_ty().kind()
         {
             debug_assert!(ecx.opaque_type_is_rigid(def_id));
-            for item_bound in cx.item_self_bounds(def_id).skip_binder() {
+            for item_bound in cx.item_self_bounds(def_id.into()).skip_binder() {
                 if item_bound
                     .as_trait_clause()
                     .is_some_and(|b| b.def_id() == goal.predicate.def_id())

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -54,7 +54,11 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_alias(interner: I, alias_ty: ty::AliasTy<I>) -> Self;
 
-    fn new_projection_from_args(interner: I, def_id: I::DefId, args: I::GenericArgs) -> Self {
+    fn new_projection_from_args(
+        interner: I,
+        def_id: I::ProjectionTyId,
+        args: I::GenericArgs,
+    ) -> Self {
         Self::new_alias(
             interner,
             ty::AliasTy::new_from_args(interner, ty::AliasTyKind::Projection { def_id }, args),
@@ -63,7 +67,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_projection(
         interner: I,
-        def_id: I::DefId,
+        def_id: I::ProjectionTyId,
         args: impl IntoIterator<Item: Into<I::GenericArg>>,
     ) -> Self {
         Self::new_alias(

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -9,7 +9,7 @@ use rustc_index::bit_set::DenseBitSet;
 use crate::fold::TypeFoldable;
 use crate::inherent::*;
 use crate::ir_print::IrPrint;
-use crate::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
+use crate::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use crate::relate::Relate;
 use crate::solve::{CanonicalInput, Certainty, ExternalConstraintsData, QueryResult, inspect};
 use crate::visit::{Flags, TypeVisitable};
@@ -54,6 +54,11 @@ pub trait Interner:
     type AdtId: SpecificDefId<Self>;
     type ImplId: SpecificDefId<Self>;
     type UnevaluatedConstId: SpecificDefId<Self>;
+    type ProjectionTyId: SpecificDefId<Self> + Into<Self::ProjectionId>;
+    type ProjectionId: SpecificDefId<Self>;
+    type OpaqueId: SpecificDefId<Self>;
+    type FreeAliasId: SpecificDefId<Self>;
+    type ImplTyAliasId: SpecificDefId<Self>;
     type Span: Span<Self>;
 
     type GenericArgs: GenericArgs<Self>;
@@ -218,7 +223,7 @@ pub trait Interner:
 
     fn trait_ref_and_own_args_for_alias(
         self,
-        def_id: Self::DefId,
+        def_id: Self::ProjectionId,
         args: Self::GenericArgs,
     ) -> (ty::TraitRef<Self>, Self::GenericArgsSlice);
 
@@ -242,7 +247,9 @@ pub trait Interner:
         I: Iterator<Item = T>,
         T: CollectAndApply<Self::Ty, Self::Tys>;
 
-    fn parent(self, def_id: Self::DefId) -> Self::DefId;
+    fn projection_parent(self, def_id: Self::ProjectionId) -> Self::TraitId;
+
+    fn impl_ty_alias_parent(self, def_id: Self::ImplTyAliasId) -> Self::ImplId;
 
     fn recursion_limit(self) -> usize;
 
@@ -324,13 +331,20 @@ pub trait Interner:
 
     fn has_target_features(self, def_id: Self::FunctionId) -> bool;
 
-    fn require_lang_item(self, lang_item: SolverLangItem) -> Self::DefId;
+    fn require_projection_lang_item(
+        self,
+        lang_item: SolverProjectionLangItem,
+    ) -> Self::ProjectionTyId;
 
     fn require_trait_lang_item(self, lang_item: SolverTraitLangItem) -> Self::TraitId;
 
     fn require_adt_lang_item(self, lang_item: SolverAdtLangItem) -> Self::AdtId;
 
-    fn is_lang_item(self, def_id: Self::DefId, lang_item: SolverLangItem) -> bool;
+    fn is_projection_lang_item(
+        self,
+        def_id: Self::ProjectionTyId,
+        lang_item: SolverProjectionLangItem,
+    ) -> bool;
 
     fn is_trait_lang_item(self, def_id: Self::TraitId, lang_item: SolverTraitLangItem) -> bool;
 
@@ -340,7 +354,10 @@ pub trait Interner:
 
     fn is_sizedness_trait(self, def_id: Self::TraitId) -> bool;
 
-    fn as_lang_item(self, def_id: Self::DefId) -> Option<SolverLangItem>;
+    fn as_projection_lang_item(
+        self,
+        def_id: Self::ProjectionTyId,
+    ) -> Option<SolverProjectionLangItem>;
 
     fn as_trait_lang_item(self, def_id: Self::TraitId) -> Option<SolverTraitLangItem>;
 
@@ -359,7 +376,7 @@ pub trait Interner:
     );
     fn for_each_blanket_impl(self, trait_def_id: Self::TraitId, f: impl FnMut(Self::ImplId));
 
-    fn has_item_definition(self, def_id: Self::DefId) -> bool;
+    fn has_item_definition(self, def_id: Self::ImplTyAliasId) -> bool;
 
     fn impl_specializes(self, impl_def_id: Self::ImplId, victim_def_id: Self::ImplId) -> bool;
 

--- a/compiler/rustc_type_ir/src/lang_items.rs
+++ b/compiler/rustc_type_ir/src/lang_items.rs
@@ -1,6 +1,6 @@
 /// Lang items used by the new trait solver. This can be mapped to whatever internal
 /// representation of `LangItem`s used in the underlying compiler implementation.
-pub enum SolverLangItem {
+pub enum SolverProjectionLangItem {
     // tidy-alphabetical-start
     AsyncFnKindUpvars,
     AsyncFnOnceOutput,

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -414,7 +414,7 @@ impl<I: Interner> ty::Binder<I, ExistentialTraitRef<I>> {
     derive(Decodable_NoContext, Encodable_NoContext, HashStable_NoContext)
 )]
 pub struct ExistentialProjection<I: Interner> {
-    pub def_id: I::DefId,
+    pub def_id: I::ProjectionId,
     pub args: I::GenericArgs,
     pub term: I::Term,
 
@@ -429,17 +429,17 @@ impl<I: Interner> Eq for ExistentialProjection<I> {}
 impl<I: Interner> ExistentialProjection<I> {
     pub fn new_from_args(
         interner: I,
-        def_id: I::DefId,
+        def_id: I::ProjectionId,
         args: I::GenericArgs,
         term: I::Term,
     ) -> ExistentialProjection<I> {
-        interner.debug_assert_existential_args_compatible(def_id, args);
+        interner.debug_assert_existential_args_compatible(def_id.into(), args);
         Self { def_id, args, term, use_existential_projection_new_instead: () }
     }
 
     pub fn new(
         interner: I,
-        def_id: I::DefId,
+        def_id: I::ProjectionId,
         args: impl IntoIterator<Item: Into<I::GenericArg>>,
         term: I::Term,
     ) -> ExistentialProjection<I> {
@@ -453,10 +453,10 @@ impl<I: Interner> ExistentialProjection<I> {
     /// then this function would return an `exists T. T: Iterator` existential trait
     /// reference.
     pub fn trait_ref(&self, interner: I) -> ExistentialTraitRef<I> {
-        let def_id = interner.parent(self.def_id);
-        let args_count = interner.generics_of(def_id).count() - 1;
+        let def_id = interner.projection_parent(self.def_id);
+        let args_count = interner.generics_of(def_id.into()).count() - 1;
         let args = interner.mk_args(&self.args.as_slice()[..args_count]);
-        ExistentialTraitRef::new_from_args(interner, def_id.try_into().unwrap(), args)
+        ExistentialTraitRef::new_from_args(interner, def_id, args)
     }
 
     pub fn with_self_ty(&self, interner: I, self_ty: I::Ty) -> ProjectionPredicate<I> {
@@ -466,7 +466,7 @@ impl<I: Interner> ExistentialProjection<I> {
         ProjectionPredicate {
             projection_term: AliasTerm::new(
                 interner,
-                self.def_id,
+                self.def_id.into(),
                 [self_ty.into()].iter().chain(self.args.iter()),
             ),
             term: self.term,
@@ -478,7 +478,7 @@ impl<I: Interner> ExistentialProjection<I> {
         projection_predicate.projection_term.args.type_at(0);
 
         Self {
-            def_id: projection_predicate.projection_term.def_id,
+            def_id: projection_predicate.def_id(),
             args: interner.mk_args(&projection_predicate.projection_term.args.as_slice()[1..]),
             term: projection_predicate.term,
             use_existential_projection_new_instead: (),
@@ -491,7 +491,7 @@ impl<I: Interner> ty::Binder<I, ExistentialProjection<I>> {
         self.map_bound(|p| p.with_self_ty(cx, self_ty))
     }
 
-    pub fn item_def_id(&self) -> I::DefId {
+    pub fn item_def_id(&self) -> I::ProjectionId {
         self.skip_binder().def_id
     }
 }
@@ -625,10 +625,16 @@ impl<I: Interner> AliasTerm<I> {
 
     pub fn expect_ty(self, interner: I) -> ty::AliasTy<I> {
         let kind = match self.kind(interner) {
-            AliasTermKind::ProjectionTy => AliasTyKind::Projection { def_id: self.def_id },
-            AliasTermKind::InherentTy => AliasTyKind::Inherent { def_id: self.def_id },
-            AliasTermKind::OpaqueTy => AliasTyKind::Opaque { def_id: self.def_id },
-            AliasTermKind::FreeTy => AliasTyKind::Free { def_id: self.def_id },
+            AliasTermKind::ProjectionTy => {
+                AliasTyKind::Projection { def_id: self.def_id.try_into().unwrap() }
+            }
+            AliasTermKind::InherentTy => {
+                AliasTyKind::Inherent { def_id: self.def_id.try_into().unwrap() }
+            }
+            AliasTermKind::OpaqueTy => {
+                AliasTyKind::Opaque { def_id: self.def_id.try_into().unwrap() }
+            }
+            AliasTermKind::FreeTy => AliasTyKind::Free { def_id: self.def_id.try_into().unwrap() },
             AliasTermKind::InherentConst
             | AliasTermKind::FreeConst
             | AliasTermKind::UnevaluatedConst
@@ -656,10 +662,12 @@ impl<I: Interner> AliasTerm<I> {
                 .into();
             }
 
-            AliasTermKind::ProjectionTy => ty::Projection { def_id: self.def_id },
-            AliasTermKind::InherentTy => ty::Inherent { def_id: self.def_id },
-            AliasTermKind::OpaqueTy => ty::Opaque { def_id: self.def_id },
-            AliasTermKind::FreeTy => ty::Free { def_id: self.def_id },
+            AliasTermKind::ProjectionTy => {
+                ty::Projection { def_id: self.def_id.try_into().unwrap() }
+            }
+            AliasTermKind::InherentTy => ty::Inherent { def_id: self.def_id.try_into().unwrap() },
+            AliasTermKind::OpaqueTy => ty::Opaque { def_id: self.def_id.try_into().unwrap() },
+            AliasTermKind::FreeTy => ty::Free { def_id: self.def_id.try_into().unwrap() },
         };
 
         Ty::new_alias(interner, ty::AliasTy::new_from_args(interner, alias_ty_kind, self.args))
@@ -681,15 +689,23 @@ impl<I: Interner> AliasTerm<I> {
         )
     }
 
+    fn projection_def_id(self, interner: I) -> Option<I::ProjectionId> {
+        if matches!(
+            self.kind(interner),
+            AliasTermKind::ProjectionTy | AliasTermKind::ProjectionConst
+        ) {
+            Some(self.def_id.try_into().unwrap())
+        } else {
+            None
+        }
+    }
+
+    fn expect_projection_def_id(self, interner: I) -> I::ProjectionId {
+        self.projection_def_id(interner).expect("expected a projection")
+    }
+
     pub fn trait_def_id(self, interner: I) -> I::TraitId {
-        assert!(
-            matches!(
-                self.kind(interner),
-                AliasTermKind::ProjectionTy | AliasTermKind::ProjectionConst
-            ),
-            "expected a projection"
-        );
-        interner.parent(self.def_id).try_into().unwrap()
+        interner.projection_parent(self.expect_projection_def_id(interner))
     }
 
     /// Extracts the underlying trait reference and own args from this projection.
@@ -697,7 +713,8 @@ impl<I: Interner> AliasTerm<I> {
     /// then this function would return a `T: StreamingIterator` trait reference and
     /// `['a]` as the own args.
     pub fn trait_ref_and_own_args(self, interner: I) -> (TraitRef<I>, I::GenericArgsSlice) {
-        interner.trait_ref_and_own_args_for_alias(self.def_id, self.args)
+        interner
+            .trait_ref_and_own_args_for_alias(self.expect_projection_def_id(interner), self.args)
     }
 
     /// Extracts the underlying trait reference from this projection.
@@ -797,8 +814,8 @@ impl<I: Interner> ProjectionPredicate<I> {
         self.projection_term.trait_def_id(interner)
     }
 
-    pub fn def_id(self) -> I::DefId {
-        self.projection_term.def_id
+    pub fn def_id(self) -> I::ProjectionId {
+        self.projection_term.def_id.try_into().unwrap()
     }
 }
 

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -270,7 +270,10 @@ impl<I: Interner> Relate<I> for ty::ExistentialProjection<I> {
         b: ty::ExistentialProjection<I>,
     ) -> RelateResult<I, ty::ExistentialProjection<I>> {
         if a.def_id != b.def_id {
-            Err(TypeError::ProjectionMismatched(ExpectedFound::new(a.def_id, b.def_id)))
+            Err(TypeError::ProjectionMismatched(ExpectedFound::new(
+                a.def_id.into(),
+                b.def_id.into(),
+            )))
         } else {
             let term = relation.relate_with_variance(
                 ty::Invariant,

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -37,12 +37,12 @@ pub enum AliasTyKind<I: Interner> {
     /// Note that the `def_id` is not the `DefId` of the `TraitRef` containing this
     /// associated type, which is in `interner.associated_item(def_id).container`,
     /// aka. `interner.parent(def_id)`.
-    Projection { def_id: I::DefId },
+    Projection { def_id: I::ProjectionTyId },
 
     /// An associated type in an inherent `impl`
     ///
     /// The `def_id` is the `DefId` of the `ImplItem` for the associated type.
-    Inherent { def_id: I::DefId },
+    Inherent { def_id: I::ImplTyAliasId },
 
     /// An opaque type (usually from `impl Trait` in type aliases or function return types)
     ///
@@ -53,13 +53,13 @@ pub enum AliasTyKind<I: Interner> {
     ///
     /// During codegen, `interner.type_of(def_id)` can be used to get the type of the
     /// underlying type if the type is an opaque.
-    Opaque { def_id: I::DefId },
+    Opaque { def_id: I::OpaqueId },
 
     /// A type alias that actually checks its trait bounds.
     ///
     /// Currently only used if the type alias references opaque types.
     /// Can always be normalized away.
-    Free { def_id: I::DefId },
+    Free { def_id: I::FreeAliasId },
 }
 
 impl<I: Interner> AliasTyKind<I> {
@@ -77,12 +77,12 @@ impl<I: Interner> AliasTyKind<I> {
     }
 
     pub fn def_id(self) -> I::DefId {
-        let (AliasTyKind::Projection { def_id }
-        | AliasTyKind::Inherent { def_id }
-        | AliasTyKind::Opaque { def_id }
-        | AliasTyKind::Free { def_id }) = self;
-
-        def_id
+        match self {
+            AliasTyKind::Projection { def_id } => def_id.into(),
+            AliasTyKind::Inherent { def_id } => def_id.into(),
+            AliasTyKind::Opaque { def_id } => def_id.into(),
+            AliasTyKind::Free { def_id } => def_id.into(),
+        }
     }
 }
 
@@ -507,10 +507,10 @@ impl<I: Interner> AliasTy<I> {
         )
     }
 
-    pub fn trait_def_id(self, interner: I) -> I::DefId {
+    pub fn trait_def_id(self, interner: I) -> I::TraitId {
         let AliasTyKind::Projection { def_id } = self.kind else { panic!("expected a projection") };
 
-        interner.parent(def_id)
+        interner.projection_parent(def_id.into())
     }
 
     /// Extracts the underlying trait reference and own args from this projection.
@@ -521,7 +521,7 @@ impl<I: Interner> AliasTy<I> {
     pub fn trait_ref_and_own_args(self, interner: I) -> (ty::TraitRef<I>, I::GenericArgsSlice) {
         let AliasTyKind::Projection { def_id } = self.kind else { panic!("expected a projection") };
 
-        interner.trait_ref_and_own_args_for_alias(def_id, self.args)
+        interner.trait_ref_and_own_args_for_alias(def_id.into(), self.args)
     }
 
     /// Extracts the underlying trait reference from this projection.


### PR DESCRIPTION
Like we do for other things for better experience in rust-analyzer.

It's possible now that the `AliasTyKind` contains the DefId. It does require a few unwraps since `AliasTermKind` still does not contain the DefId and some things only include a DefId with no kind, but IMO it's still better.

r? types

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
