### PR TITLE
delegation: fix unelided lifetime ICE, refactoring of GenericArgPosition

### DIFF
--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::{
 use rustc_span::{ErrorGuaranteed, Span, kw};
 
 use crate::collect::ItemCtxt;
-use crate::hir_ty_lowering::{GenericArgPosition, HirTyLowerer};
+use crate::hir_ty_lowering::HirTyLowerer;
 
 type RemapTable = FxHashMap<u32, u32>;
 
@@ -581,14 +581,7 @@ fn get_delegation_user_specified_args<'tcx>(
         let self_ty = get_delegation_self_ty(tcx, delegation_id);
 
         lowerer
-            .lower_generic_args_of_path(
-                segment.ident.span,
-                def_id,
-                &[],
-                segment,
-                self_ty,
-                GenericArgPosition::Type,
-            )
+            .lower_generic_args_of_path(segment.ident.span, def_id, &[], segment, self_ty)
             .0
             .as_slice()
     });
@@ -610,14 +603,7 @@ fn get_delegation_user_specified_args<'tcx>(
             };
 
             let args = lowerer
-                .lower_generic_args_of_path(
-                    segment.ident.span,
-                    def_id,
-                    parent_args,
-                    segment,
-                    None,
-                    GenericArgPosition::Value,
-                )
+                .lower_generic_args_of_path(segment.ident.span, def_id, parent_args, segment, None)
                 .0;
 
             &args[parent_args.len()..]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -385,17 +385,14 @@ pub fn lower_generic_args<'tcx: 'a, 'a>(
 
 /// Checks that the correct number of generic arguments have been provided.
 /// Used specifically for function calls.
-pub fn check_generic_arg_count_for_call(
+pub fn check_generic_arg_count_for_value_path(
     cx: &dyn HirTyLowerer<'_>,
     def_id: DefId,
     generics: &ty::Generics,
     seg: &hir::PathSegment<'_>,
     is_method_call: IsMethodCall,
 ) -> GenericArgCountResult {
-    let gen_pos = match is_method_call {
-        IsMethodCall::Yes => GenericArgPosition::MethodCall,
-        IsMethodCall::No => GenericArgPosition::Value,
-    };
+    let gen_pos = GenericArgPosition::Value(is_method_call);
     check_generic_arg_count(cx, def_id, seg, generics, gen_pos, generics.has_own_self())
 }
 
@@ -649,7 +646,7 @@ pub(crate) fn prohibit_explicit_late_bound_lifetimes(
         let note = "the late bound lifetime parameter is introduced here";
         let span = args.args[0].span();
 
-        if position == GenericArgPosition::Value
+        if position == GenericArgPosition::Value(IsMethodCall::No)
             && args.num_lifetime_params() != param_counts.lifetimes
         {
             struct_span_code_err!(cx.dcx(), span, E0794, "{}", msg)

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -318,7 +318,7 @@ pub enum ExplicitLateBound {
     No,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum IsMethodCall {
     Yes,
     No,
@@ -329,8 +329,7 @@ pub enum IsMethodCall {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) enum GenericArgPosition {
     Type,
-    Value, // e.g., functions
-    MethodCall,
+    Value(IsMethodCall),
 }
 
 /// Whether to allow duplicate associated iten constraints in a trait ref, e.g.
@@ -561,14 +560,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         def_id: DefId,
         item_segment: &hir::PathSegment<'tcx>,
     ) -> GenericArgsRef<'tcx> {
-        let (args, _) = self.lower_generic_args_of_path(
-            span,
-            def_id,
-            &[],
-            item_segment,
-            None,
-            GenericArgPosition::Type,
-        );
+        let (args, _) = self.lower_generic_args_of_path(span, def_id, &[], item_segment, None);
         if let Some(c) = item_segment.args().constraints.first() {
             prohibit_assoc_item_constraint(self, c, Some((def_id, item_segment, span)));
         }
@@ -617,7 +609,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         parent_args: &[ty::GenericArg<'tcx>],
         segment: &hir::PathSegment<'tcx>,
         self_ty: Option<Ty<'tcx>>,
-        pos: GenericArgPosition,
     ) -> (GenericArgsRef<'tcx>, GenericArgCountResult) {
         // If the type is parameterized by this region, then replace this
         // region with the current anon region binding (in other words,
@@ -640,8 +631,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             assert!(self_ty.is_none());
         }
 
-        let arg_count =
-            check_generic_arg_count(self, def_id, segment, generics, pos, self_ty.is_some());
+        let arg_count = check_generic_arg_count(
+            self,
+            def_id,
+            segment,
+            generics,
+            GenericArgPosition::Type,
+            self_ty.is_some(),
+        );
 
         // Skip processing if type has no generic parameters.
         // Traits always have `Self` as a generic parameter, which means they will not return early
@@ -826,14 +823,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         item_segment: &hir::PathSegment<'tcx>,
         parent_args: GenericArgsRef<'tcx>,
     ) -> GenericArgsRef<'tcx> {
-        let (args, _) = self.lower_generic_args_of_path(
-            span,
-            item_def_id,
-            parent_args,
-            item_segment,
-            None,
-            GenericArgPosition::Type,
-        );
+        let (args, _) =
+            self.lower_generic_args_of_path(span, item_def_id, parent_args, item_segment, None);
         if let Some(c) = item_segment.args().constraints.first() {
             prohibit_assoc_item_constraint(self, c, Some((item_def_id, item_segment, span)));
         }
@@ -945,7 +936,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             &[],
             segment,
             Some(self_ty),
-            GenericArgPosition::Type,
         );
 
         let constraints = segment.args().constraints;
@@ -1121,14 +1111,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     ) -> ty::TraitRef<'tcx> {
         self.report_internal_fn_trait(span, trait_def_id, trait_segment, is_impl);
 
-        let (generic_args, _) = self.lower_generic_args_of_path(
-            span,
-            trait_def_id,
-            &[],
-            trait_segment,
-            Some(self_ty),
-            GenericArgPosition::Type,
-        );
+        let (generic_args, _) =
+            self.lower_generic_args_of_path(span, trait_def_id, &[], trait_segment, Some(self_ty));
         if let Some(c) = trait_segment.args().constraints.first() {
             prohibit_assoc_item_constraint(self, c, Some((trait_def_id, trait_segment, span)));
         }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -13,7 +13,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::{self as hir, AmbigArg, ExprKind, GenericArg, HirId, Node, QPath, intravisit};
 use rustc_hir_analysis::hir_ty_lowering::errors::GenericsArgsErrExtend;
 use rustc_hir_analysis::hir_ty_lowering::generics::{
-    check_generic_arg_count_for_call, lower_generic_args,
+    check_generic_arg_count_for_value_path, lower_generic_args,
 };
 use rustc_hir_analysis::hir_ty_lowering::{
     ExplicitLateBound, GenericArgCountMismatch, GenericArgCountResult, GenericArgsLowerer,
@@ -1098,8 +1098,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // parameter internally, but we don't allow users to specify the
             // parameter's value explicitly, so we have to do some error-
             // checking here.
-            let arg_count =
-                check_generic_arg_count_for_call(self, def_id, generics, seg, IsMethodCall::No);
+            let arg_count = check_generic_arg_count_for_value_path(
+                self,
+                def_id,
+                generics,
+                seg,
+                IsMethodCall::No,
+            );
 
             if let ExplicitLateBound::Yes = arg_count.explicit_late_bound {
                 explicit_late_bound = ExplicitLateBound::Yes;

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -5,7 +5,7 @@ use rustc_hir as hir;
 use rustc_hir::GenericArg;
 use rustc_hir::def_id::DefId;
 use rustc_hir_analysis::hir_ty_lowering::generics::{
-    check_generic_arg_count_for_call, lower_generic_args,
+    check_generic_arg_count_for_value_path, lower_generic_args,
 };
 use rustc_hir_analysis::hir_ty_lowering::{
     GenericArgsLowerer, HirTyLowerer, IsMethodCall, RegionInferReason,
@@ -403,7 +403,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         // variables.
         let generics = self.tcx.generics_of(pick.item.def_id);
 
-        let arg_count_correct = check_generic_arg_count_for_call(
+        let arg_count_correct = check_generic_arg_count_for_value_path(
             self.fcx,
             pick.item.def_id,
             generics,

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -36,6 +36,7 @@ mod test_1 {
         //~| ERROR can't use generic parameters from outer item
         //~| ERROR can't use generic parameters from outer item
         //~| ERROR: unresolved item provided when a constant was expected
+        //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
     }
 }
 
@@ -47,6 +48,7 @@ mod test_2 {
 
     reuse foo::<String, String> as bar2;
     //~^ ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
+    //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
 
     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
     //~^ ERROR: use of undeclared lifetime name `'asdasd`
@@ -58,10 +60,12 @@ mod test_2 {
 
     reuse foo::<1, 2, _, 4, 5, _> as bar5;
     //~^ ERROR: function takes 3 generic arguments but 6 generic arguments were supplied
+    //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
 
     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
     //~^ ERROR: cannot find type `asd` in this scope
     //~| ERROR: function takes 3 generic arguments but 5 generic arguments were supplied
+    //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
 
     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
     //~^ ERROR: use of undeclared lifetime name `'a`
@@ -70,6 +74,7 @@ mod test_2 {
 
     reuse foo::<{}, {}, {}> as bar8;
     //~^ ERROR: constant provided when a type was expected
+    //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
 }
 
 mod test_3 {
@@ -107,12 +112,14 @@ mod test_3 {
     //~| ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR: trait takes 2 generic arguments but 3 generic arguments were supplied
     //~| ERROR: method takes 2 generic arguments but 6 generic arguments were supplied
+    //~| ERROR: method takes 1 lifetime argument but 0 lifetime arguments were supplied
 
     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
     //~^ ERROR: missing lifetime specifiers [E0106]
     //~| ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR: trait takes 2 generic arguments but 5 generic arguments were supplied
     //~| ERROR: method takes 2 generic arguments but 5 generic arguments were supplied
+    //~| ERROR: method takes 1 lifetime argument but 0 lifetime arguments were supplied
 }
 
 fn main() {}

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -38,7 +38,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0261]: use of undeclared lifetime name `'asdasd`
-  --> $DIR/generics-gen-args-errors.rs:51:29
+  --> $DIR/generics-gen-args-errors.rs:53:29
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |                             ^^^^^^^ undeclared lifetime
@@ -49,7 +49,7 @@ LL |     reuse foo'asdasd, ::<'static, _, 'asdasd, 'static, 'static, 'static, _>
    |              ++++++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generics-gen-args-errors.rs:66:50
+  --> $DIR/generics-gen-args-errors.rs:70:50
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                                                  ^^ undeclared lifetime
@@ -60,7 +60,7 @@ LL |     reuse foo'a, ::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |              +++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/generics-gen-args-errors.rs:111:19
+  --> $DIR/generics-gen-args-errors.rs:117:19
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                   ^^^^^ expected 3 lifetime parameters
@@ -114,64 +114,512 @@ LL |     fn check<A, B, C, asd>() {
    |                     +++++
 
 error[E0425]: cannot find type `asdasd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:55:39
+  --> $DIR/generics-gen-args-errors.rs:57:39
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |                                       ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:62:22
+  --> $DIR/generics-gen-args-errors.rs:65:22
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |                      ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:66:27
+  --> $DIR/generics-gen-args-errors.rs:70:27
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                           ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:80:19
+  --> $DIR/generics-gen-args-errors.rs:85:19
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                   ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:80:24
+  --> $DIR/generics-gen-args-errors.rs:85:24
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                        ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:80:29
+  --> $DIR/generics-gen-args-errors.rs:85:29
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                             ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:80:34
+  --> $DIR/generics-gen-args-errors.rs:85:34
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                  ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:80:39
+  --> $DIR/generics-gen-args-errors.rs:85:39
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                       ^^^ not found in this scope
 
 error[E0425]: cannot find type `asdasa` in this scope
-  --> $DIR/generics-gen-args-errors.rs:80:44
+  --> $DIR/generics-gen-args-errors.rs:85:44
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `DDDD` in this scope
-  --> $DIR/generics-gen-args-errors.rs:105:34
+  --> $DIR/generics-gen-args-errors.rs:110:34
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                  ^^^^ not found in this scope
+
+error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:34:15
+   |
+LL |         reuse foo::<A, B, C> as xd;
+   |               ^^^ expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:7:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime arguments
+   |
+LL |         reuse foo::<'a, 'b, A, B, C> as xd;
+   |                     +++++++
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/generics-gen-args-errors.rs:46:11
+   |
+LL |     reuse foo::<> as bar1;
+   |           ^^^ not allowed in type signatures
+
+error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:49:11
+   |
+LL |     reuse foo::<String, String> as bar2;
+   |           ^^^ expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime arguments
+   |
+LL |     reuse foo::<'a, 'b, String, String> as bar2;
+   |                 +++++++
+
+error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:49:11
+   |
+LL |     reuse foo::<String, String> as bar2;
+   |           ^^^   ------  ------ supplied 2 generic arguments
+   |           |
+   |           expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+help: add missing generic argument
+   |
+LL |     reuse foo::<String, String, N> as bar2;
+   |                               +++
+
+error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:53:11
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |           ^^^                      --------------------------- help: remove the lifetime arguments
+   |           |
+   |           expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+
+error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:53:11
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |           ^^^ expected 3 generic arguments             -------  - supplied 2 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+help: add missing generic argument
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _, N> as bar3;
+   |                                                                  +++
+
+error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:57:11
+   |
+LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
+   |           ^^^   ------ supplied 1 lifetime argument
+   |           |
+   |           expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime argument
+   |
+LL |     reuse foo::<String, 'static, 'static, 123, asdasd> as bar4;
+   |                       +++++++++
+
+error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:61:11
+   |
+LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
+   |           ^^^ expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime arguments
+   |
+LL |     reuse foo::<'a, 'b, 1, 2, _, 4, 5, _> as bar5;
+   |                 +++++++
+
+error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:61:11
+   |
+LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
+   |           ^^^          --------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+
+error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:65:11
+   |
+LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
+   |           ^^^ expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime arguments
+   |
+LL |     reuse foo::<'a, 'b, 1, 2,asd,String, { let x = 0; }> as bar6;
+   |                 +++++++
+
+error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:65:11
+   |
+LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
+   |           ^^^           ----------------------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `T`, `U`, `N`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^                 -         -         --------------
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/generics-gen-args-errors.rs:70:17
+   |
+LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+   |                 ^^^^^^^^
+
+error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:75:11
+   |
+LL |     reuse foo::<{}, {}, {}> as bar8;
+   |           ^^^ expected 2 lifetime arguments
+   |
+note: function defined here, with 2 lifetime parameters: `'a`, `'b`
+  --> $DIR/generics-gen-args-errors.rs:44:8
+   |
+LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
+   |        ^^^ --      --
+help: add missing lifetime arguments
+   |
+LL |     reuse foo::<'a, 'b, {}, {}, {}> as bar8;
+   |                 +++++++
+
+error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:85:11
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |           ^^^^^ expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<'b, 'c, 'a, asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |                   +++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:85:11
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |           ^^^^^           ----------------------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:95:11
+   |
+LL |     reuse Trait::<'static, 'static>::foo as bar2;
+   |           ^^^^^   -------  ------- supplied 2 lifetime arguments
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime argument
+   |
+LL |     reuse Trait::<'static, 'static, 'static>::foo as bar2;
+   |                                   +++++++++
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/generics-gen-args-errors.rs:95:11
+   |
+LL |     reuse Trait::<'static, 'static>::foo as bar2;
+   |           ^^^^^ not allowed in type signatures
+
+error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:98:11
+   |
+LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
+   |           ^^^^^ expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<'b, 'c, 'a, 1, 2, 3, 4, 5>::foo as bar3;
+   |                   +++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:98:11
+   |
+LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
+   |           ^^^^^       --------- help: remove the unnecessary generic arguments
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:102:11
+   |
+LL |     reuse Trait::<1, 2, true>::foo as bar4;
+   |           ^^^^^ expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<'b, 'c, 'a, 1, 2, true>::foo as bar4;
+   |                   +++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:102:11
+   |
+LL |     reuse Trait::<1, 2, true>::foo as bar4;
+   |           ^^^^^       ------ help: remove the unnecessary generic argument
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:106:11
+   |
+LL |     reuse Trait::<'static>::foo as bar5;
+   |           ^^^^^   ------- supplied 1 lifetime argument
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<'static, 'static, 'static>::foo as bar5;
+   |                          ++++++++++++++++++
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/generics-gen-args-errors.rs:106:11
+   |
+LL |     reuse Trait::<'static>::foo as bar5;
+   |           ^^^^^ not allowed in type signatures
+
+error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:110:11
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |           ^^^^^   - supplied 1 lifetime argument
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<1, 'static, 'static, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                    ++++++++++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:110:11
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |           ^^^^^       --------------- help: remove the unnecessary generic argument
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:110:41
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                                         ^^^ expected 1 lifetime argument
+   |
+note: method defined here, with 1 lifetime parameter: `'d`
+  --> $DIR/generics-gen-args-errors.rs:82:12
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |            ^^^ --
+help: add missing lifetime argument
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<'d, 1, 2, 3, 4, 5, 6> as bar6;
+   |                                               +++
+
+error[E0107]: method takes 2 generic arguments but 6 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:110:41
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                                         ^^^       ------------ help: remove the unnecessary generic arguments
+   |                                         |
+   |                                         expected 2 generic arguments
+   |
+note: method defined here, with 2 generic parameters: `U`, `M`
+  --> $DIR/generics-gen-args-errors.rs:82:12
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |            ^^^         -  -------------
+
+error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/generics-gen-args-errors.rs:117:11
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |           ^^^^^   ----- supplied 1 lifetime argument
+   |           |
+   |           expected 3 lifetime arguments
+   |
+note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^ --  --  --
+help: add missing lifetime arguments
+   |
+LL |     reuse Trait::<Trait, 'static, 'static, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                        ++++++++++++++++++
+
+error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:117:11
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |           ^^^^^               --- help: remove the unnecessary generic argument
+   |           |
+   |           expected 2 generic arguments
+   |
+note: trait defined here, with 2 generic parameters: `T`, `N`
+  --> $DIR/generics-gen-args-errors.rs:81:11
+   |
+LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
+   |           ^^^^^             -  --------------
+
+error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:117:59
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                                                           ^^^ expected 1 lifetime argument
+   |
+note: method defined here, with 1 lifetime parameter: `'d`
+  --> $DIR/generics-gen-args-errors.rs:82:12
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |            ^^^ --
+help: add missing lifetime argument
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<'d, 1, 2, 3, _, 6> as bar7;
+   |                                                                 +++
+
+error[E0107]: method takes 2 generic arguments but 5 generic arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:117:59
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                                                           ^^^       --------- help: remove the unnecessary generic arguments
+   |                                                           |
+   |                                                           expected 2 generic arguments
+   |
+note: method defined here, with 2 generic parameters: `U`, `M`
+  --> $DIR/generics-gen-args-errors.rs:82:12
+   |
+LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
+   |            ^^^         -  -------------
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/generics-gen-args-errors.rs:34:27
@@ -184,347 +632,11 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |         reuse foo::<A, B, { C }> as xd;
    |                           +   +
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:45:11
-   |
-LL |     reuse foo::<> as bar1;
-   |           ^^^ not allowed in type signatures
-
-error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:48:11
-   |
-LL |     reuse foo::<String, String> as bar2;
-   |           ^^^   ------  ------ supplied 2 generic arguments
-   |           |
-   |           expected 3 generic arguments
-   |
-note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
-   |
-LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
-   |        ^^^                 -         -         --------------
-help: add missing generic argument
-   |
-LL |     reuse foo::<String, String, N> as bar2;
-   |                               +++
-
-error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:51:11
-   |
-LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
-   |           ^^^                      --------------------------- help: remove the lifetime arguments
-   |           |
-   |           expected 2 lifetime arguments
-   |
-note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
-   |
-LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
-   |        ^^^ --      --
-
-error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:51:11
-   |
-LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
-   |           ^^^ expected 3 generic arguments             -------  - supplied 2 generic arguments
-   |
-note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
-   |
-LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
-   |        ^^^                 -         -         --------------
-help: add missing generic argument
-   |
-LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _, N> as bar3;
-   |                                                                  +++
-
-error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:55:11
-   |
-LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
-   |           ^^^   ------ supplied 1 lifetime argument
-   |           |
-   |           expected 2 lifetime arguments
-   |
-note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
-   |
-LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
-   |        ^^^ --      --
-help: add missing lifetime argument
-   |
-LL |     reuse foo::<String, 'static, 'static, 123, asdasd> as bar4;
-   |                       +++++++++
-
-error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:59:11
-   |
-LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
-   |           ^^^          --------- help: remove the unnecessary generic arguments
-   |           |
-   |           expected 3 generic arguments
-   |
-note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
-   |
-LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
-   |        ^^^                 -         -         --------------
-
-error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:62:11
-   |
-LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
-   |           ^^^           ----------------------- help: remove the unnecessary generic arguments
-   |           |
-   |           expected 3 generic arguments
-   |
-note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
-   |
-LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
-   |        ^^^                 -         -         --------------
-
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:66:17
-   |
-LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
-   |                 ^^^^^^^^
-
-error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:71:17
+  --> $DIR/generics-gen-args-errors.rs:75:17
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |                 ^^
-
-error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:80:11
-   |
-LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
-   |           ^^^^^ expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL |     reuse Trait::<'b, 'c, 'a, asd, asd, asd, asd, asd, asdasa>::foo as bar1;
-   |                   +++++++++++
-
-error[E0107]: trait takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:80:11
-   |
-LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
-   |           ^^^^^           ----------------------- help: remove the unnecessary generic arguments
-   |           |
-   |           expected 2 generic arguments
-   |
-note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^             -  --------------
-
-error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:90:11
-   |
-LL |     reuse Trait::<'static, 'static>::foo as bar2;
-   |           ^^^^^   -------  ------- supplied 2 lifetime arguments
-   |           |
-   |           expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime argument
-   |
-LL |     reuse Trait::<'static, 'static, 'static>::foo as bar2;
-   |                                   +++++++++
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:90:11
-   |
-LL |     reuse Trait::<'static, 'static>::foo as bar2;
-   |           ^^^^^ not allowed in type signatures
-
-error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:93:11
-   |
-LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
-   |           ^^^^^ expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL |     reuse Trait::<'b, 'c, 'a, 1, 2, 3, 4, 5>::foo as bar3;
-   |                   +++++++++++
-
-error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:93:11
-   |
-LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
-   |           ^^^^^       --------- help: remove the unnecessary generic arguments
-   |           |
-   |           expected 2 generic arguments
-   |
-note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^             -  --------------
-
-error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:97:11
-   |
-LL |     reuse Trait::<1, 2, true>::foo as bar4;
-   |           ^^^^^ expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL |     reuse Trait::<'b, 'c, 'a, 1, 2, true>::foo as bar4;
-   |                   +++++++++++
-
-error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:97:11
-   |
-LL |     reuse Trait::<1, 2, true>::foo as bar4;
-   |           ^^^^^       ------ help: remove the unnecessary generic argument
-   |           |
-   |           expected 2 generic arguments
-   |
-note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^             -  --------------
-
-error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:101:11
-   |
-LL |     reuse Trait::<'static>::foo as bar5;
-   |           ^^^^^   ------- supplied 1 lifetime argument
-   |           |
-   |           expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL |     reuse Trait::<'static, 'static, 'static>::foo as bar5;
-   |                          ++++++++++++++++++
-
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:101:11
-   |
-LL |     reuse Trait::<'static>::foo as bar5;
-   |           ^^^^^ not allowed in type signatures
-
-error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:105:11
-   |
-LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
-   |           ^^^^^   - supplied 1 lifetime argument
-   |           |
-   |           expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL |     reuse Trait::<1, 'static, 'static, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
-   |                    ++++++++++++++++++
-
-error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:105:11
-   |
-LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
-   |           ^^^^^       --------------- help: remove the unnecessary generic argument
-   |           |
-   |           expected 2 generic arguments
-   |
-note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^             -  --------------
-
-error[E0107]: method takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:105:41
-   |
-LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
-   |                                         ^^^       ------------ help: remove the unnecessary generic arguments
-   |                                         |
-   |                                         expected 2 generic arguments
-   |
-note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:77:12
-   |
-LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
-   |            ^^^         -  -------------
-
-error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:111:11
-   |
-LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
-   |           ^^^^^   ----- supplied 1 lifetime argument
-   |           |
-   |           expected 3 lifetime arguments
-   |
-note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^ --  --  --
-help: add missing lifetime arguments
-   |
-LL |     reuse Trait::<Trait, 'static, 'static, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
-   |                        ++++++++++++++++++
-
-error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:111:11
-   |
-LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
-   |           ^^^^^               --- help: remove the unnecessary generic argument
-   |           |
-   |           expected 2 generic arguments
-   |
-note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:76:11
-   |
-LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
-   |           ^^^^^             -  --------------
-
-error[E0107]: method takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:111:59
-   |
-LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
-   |                                                           ^^^       --------- help: remove the unnecessary generic arguments
-   |                                                           |
-   |                                                           expected 2 generic arguments
-   |
-note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:77:12
-   |
-LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
-   |            ^^^         -  -------------
 
 error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
   --> $DIR/generics-gen-args-errors.rs:11:9
@@ -585,7 +697,7 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL |         bar::<asd, asd, { asd }>();
    |                         +     +
 
-error: aborting due to 51 previous errors
+error: aborting due to 58 previous errors
 
 Some errors have detailed explanations: E0106, E0107, E0121, E0261, E0401, E0423, E0425, E0747.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/delegation/generics/mapping/free-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-free-pass.rs
@@ -2,7 +2,6 @@
 
 #![feature(fn_delegation)]
 #![allow(incomplete_features)]
-#![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/free-to-trait-pass.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-trait-pass.rs
@@ -2,7 +2,6 @@
 
 #![feature(fn_delegation)]
 #![allow(incomplete_features)]
-#![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-free-pass.rs
@@ -2,7 +2,6 @@
 
 #![feature(fn_delegation)]
 #![allow(incomplete_features)]
-#![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/trait-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/trait-to-free-pass.rs
@@ -2,7 +2,6 @@
 
 #![feature(fn_delegation)]
 #![allow(incomplete_features)]
-#![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/unelided-lifetime-ice-154178.rs
+++ b/tests/ui/delegation/generics/unelided-lifetime-ice-154178.rs
@@ -1,0 +1,12 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
+#![feature(fn_delegation)]
+
+fn foo<'b: 'b, const N: usize>() {}
+
+trait Trait {
+    reuse foo::<1>;
+    //~^ ERROR: function takes 1 lifetime argument but 0 lifetime arguments were supplied
+}
+
+fn main() {}

--- a/tests/ui/delegation/generics/unelided-lifetime-ice-154178.stderr
+++ b/tests/ui/delegation/generics/unelided-lifetime-ice-154178.stderr
@@ -1,0 +1,19 @@
+error[E0107]: function takes 1 lifetime argument but 0 lifetime arguments were supplied
+  --> $DIR/unelided-lifetime-ice-154178.rs:8:11
+   |
+LL |     reuse foo::<1>;
+   |           ^^^ expected 1 lifetime argument
+   |
+note: function defined here, with 1 lifetime parameter: `'b`
+  --> $DIR/unelided-lifetime-ice-154178.rs:5:4
+   |
+LL | fn foo<'b: 'b, const N: usize>() {}
+   |    ^^^ --
+help: add missing lifetime argument
+   |
+LL |     reuse foo::<'b, 1>;
+   |                 +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155031)*
<!-- homu-ignore:end -->

This PR does two things:
- First it restores `lower_generic_args_of_path` as it was before rust-lang/rust#151864, as it turns out we should use `GenericArgPosition::Type` for generic args lowering for signature inheritance, as it will not cause lifetime inference and then ICEs during child args lowering,
- Next it refactors `GenericArgPosition` enum replacing `Value` and `MethodCall` with `Call(IsMethodCall)`, as the only place where we created `Value` or `MethodCall` variants was in `check_generic_arg_count_for_call`, where it was a match over `is_method_call`. Not sure it is needed, but seems cleaner to me.

Fixes rust-lang/rust#154178, part of rust-lang/rust#118212.

r? @petrochenkov