### PR TITLE
[beta] Revert performing basic const checks in typeck on stable

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -921,6 +921,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         callee_did: DefId,
         callee_args: GenericArgsRef<'tcx>,
     ) {
+        // FIXME(const_trait_impl): We should be enforcing these effects unconditionally.
+        // This can be done as soon as we convert the standard library back to
+        // using const traits, since if we were to enforce these conditions now,
+        // we'd fail on basically every builtin trait call (i.e. `1 + 2`).
+        if !self.tcx.features().const_trait_impl() {
+            return;
+        }
+
         // If we have `rustc_do_not_const_check`, do not check `[const]` bounds.
         if self.has_rustc_attrs && find_attr!(self.tcx, self.body_id, RustcDoNotConstCheck) {
             return;

--- a/tests/crashes/137187.rs
+++ b/tests/crashes/137187.rs
@@ -1,13 +1,10 @@
 //@ known-bug: #137187
-#![feature(const_trait_impl, const_ops)]
-
 use std::ops::Add;
+
 const trait A where
-    *const Self: const Add,
+    *const Self: Add,
 {
     fn b(c: *const Self) -> <*const Self as Add>::Output {
         c + c
     }
 }
-
-fn main() {}

--- a/tests/ui/coercion/coerce-loop-issue-122561.rs
+++ b/tests/ui/coercion/coerce-loop-issue-122561.rs
@@ -42,8 +42,6 @@ fn for_single_line() -> bool { for i in 0.. { return false; } }
 //    that it's readable
 fn for_in_arg(a: &[(); for x in 0..2 {}]) -> bool {
     //~^ ERROR mismatched types
-    //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
-    //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
     true
 }
 
@@ -88,8 +86,6 @@ fn loop_() -> bool {
 const C: i32 = {
     for i in 0.. {
     //~^ ERROR mismatched types
-    //~| ERROR `std::ops::RangeFrom<{integer}>: const Iterator` is not satisfied
-    //~| ERROR `std::ops::RangeFrom<{integer}>: const Iterator` is not satisfied
     }
 };
 
@@ -97,8 +93,6 @@ fn main() {
     let _ = [10; {
         for i in 0..5 {
         //~^ ERROR mismatched types
-        //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
-        //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
         }
     }];
 
@@ -111,6 +105,4 @@ fn main() {
 
     let _ = |a: &[(); for x in 0..2 {}]| {};
     //~^ ERROR mismatched types
-    //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
-    //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
 }

--- a/tests/ui/coercion/coerce-loop-issue-122561.stderr
+++ b/tests/ui/coercion/coerce-loop-issue-122561.stderr
@@ -1,5 +1,5 @@
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/coerce-loop-issue-122561.rs:51:5
+  --> $DIR/coerce-loop-issue-122561.rs:49:5
    |
 LL |     while true {
    |     ^^^^^^^^^^ help: use `loop`
@@ -7,29 +7,10 @@ LL |     while true {
    = note: `#[warn(while_true)]` on by default
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/coerce-loop-issue-122561.rs:75:5
+  --> $DIR/coerce-loop-issue-122561.rs:73:5
    |
 LL |     while true {
    |     ^^^^^^^^^^ help: use `loop`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:43:33
-   |
-LL | fn for_in_arg(a: &[(); for x in 0..2 {}]) -> bool {
-   |                                 ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:43:33
-   |
-LL | fn for_in_arg(a: &[(); for x in 0..2 {}]) -> bool {
-   |                                 ^^^^
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
 
 error[E0308]: mismatched types
   --> $DIR/coerce-loop-issue-122561.rs:43:24
@@ -131,7 +112,7 @@ LL | fn for_single_line() -> bool { for i in 0.. { return false; } /* `bool` val
    |                                                               ++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:51:5
+  --> $DIR/coerce-loop-issue-122561.rs:49:5
    |
 LL |   fn while_inifinite() -> bool {
    |                           ---- expected `bool` because of return type
@@ -150,7 +131,7 @@ LL +     /* `bool` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:60:5
+  --> $DIR/coerce-loop-issue-122561.rs:58:5
    |
 LL |   fn while_finite() -> bool {
    |                        ---- expected `bool` because of return type
@@ -170,7 +151,7 @@ LL +     /* `bool` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:68:5
+  --> $DIR/coerce-loop-issue-122561.rs:66:5
    |
 LL |   fn while_zero_times() -> bool {
    |                            ---- expected `bool` because of return type
@@ -188,7 +169,7 @@ LL +     /* `bool` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:75:5
+  --> $DIR/coerce-loop-issue-122561.rs:73:5
    |
 LL |   fn while_never_type() -> ! {
    |                            - expected `!` because of return type
@@ -206,30 +187,11 @@ LL ~     }
 LL +     /* `loop {}` or `panic!("...")` */
    |
 
-error[E0277]: the trait bound `std::ops::RangeFrom<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:89:14
-   |
-LL |     for i in 0.. {
-   |              ^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::RangeFrom<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::RangeFrom<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:89:14
-   |
-LL |     for i in 0.. {
-   |              ^^^
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:89:5
+  --> $DIR/coerce-loop-issue-122561.rs:87:5
    |
 LL | /     for i in 0.. {
-...  |
+LL | |
 LL | |     }
    | |_____^ expected `i32`, found `()`
    |
@@ -240,30 +202,11 @@ LL ~     }
 LL +     /* `i32` value */
    |
 
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:98:18
-   |
-LL |         for i in 0..5 {
-   |                  ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:98:18
-   |
-LL |         for i in 0..5 {
-   |                  ^^^^
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:98:9
+  --> $DIR/coerce-loop-issue-122561.rs:94:9
    |
 LL | /         for i in 0..5 {
-...  |
+LL | |
 LL | |         }
    | |_________^ expected `usize`, found `()`
    |
@@ -275,7 +218,7 @@ LL +         /* `usize` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:106:9
+  --> $DIR/coerce-loop-issue-122561.rs:100:9
    |
 LL | /         while false {
 LL | |
@@ -289,27 +232,8 @@ LL ~         }
 LL +         /* `usize` value */
    |
 
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:112:32
-   |
-LL |     let _ = |a: &[(); for x in 0..2 {}]| {};
-   |                                ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/coerce-loop-issue-122561.rs:112:32
-   |
-LL |     let _ = |a: &[(); for x in 0..2 {}]| {};
-   |                                ^^^^
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:112:23
+  --> $DIR/coerce-loop-issue-122561.rs:106:23
    |
 LL |     let _ = |a: &[(); for x in 0..2 {}]| {};
    |                       ^^^^^^^^^^^^^^^^ expected `usize`, found `()`
@@ -320,7 +244,6 @@ help: consider returning a value here
 LL |     let _ = |a: &[(); for x in 0..2 {} /* `usize` value */]| {};
    |                                        +++++++++++++++++++
 
-error: aborting due to 22 previous errors; 2 warnings emitted
+error: aborting due to 14 previous errors; 2 warnings emitted
 
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/const-eval/const_raw_ptr_ops.stable.stderr
+++ b/tests/ui/consts/const-eval/const_raw_ptr_ops.stable.stderr
@@ -1,23 +1,18 @@
-error[E0277]: pointers cannot be reliably compared during const eval
+error: pointers cannot be reliably compared during const eval
   --> $DIR/const_raw_ptr_ops.rs:7:26
    |
 LL | const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 };
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: trait `PartialEq` is implemented but not `const`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
 
-error[E0277]: pointers cannot be reliably compared during const eval
+error: pointers cannot be reliably compared during const eval
   --> $DIR/const_raw_ptr_ops.rs:9:27
    |
 LL | const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: trait `PartialEq` is implemented but not `const`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/consts/const-fn-error.rs
+++ b/tests/ui/consts/const-fn-error.rs
@@ -3,8 +3,8 @@ const X : usize = 2;
 const fn f(x: usize) -> usize {
     let mut sum = 0;
     for i in 0..x {
-        //~^ ERROR `std::ops::Range<usize>: [const] Iterator` is not satisfied
-        //~| ERROR `std::ops::Range<usize>: [const] Iterator` is not satisfied
+        //~^ ERROR cannot use `for`
+        //~| ERROR cannot use `for`
         sum += i;
     }
     sum

--- a/tests/ui/consts/const-fn-error.stderr
+++ b/tests/ui/consts/const-fn-error.stderr
@@ -1,22 +1,20 @@
-error[E0277]: the trait bound `std::ops::Range<usize>: [const] Iterator` is not satisfied
-  --> $DIR/const-fn-error.rs:5:14
-   |
-LL |     for i in 0..x {
-   |              ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<usize>` to implement `[const] IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<usize>: [const] Iterator` is not satisfied
+error[E0015]: cannot use `for` loop on `std::ops::Range<usize>` in constant functions
   --> $DIR/const-fn-error.rs:5:14
    |
 LL |     for i in 0..x {
    |              ^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+
+error[E0015]: cannot use `for` loop on `std::ops::Range<usize>` in constant functions
+  --> $DIR/const-fn-error.rs:5:14
+   |
+LL |     for i in 0..x {
+   |              ^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/consts/const-for-feature-gate.rs
+++ b/tests/ui/consts/const-for-feature-gate.rs
@@ -2,8 +2,8 @@
 
 const _: () = {
     for _ in 0..5 {}
-    //~^ ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
-    //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
+    //~^ ERROR cannot use `for`
+    //~| ERROR cannot use `for`
 };
 
 fn main() {}

--- a/tests/ui/consts/const-for-feature-gate.stderr
+++ b/tests/ui/consts/const-for-feature-gate.stderr
@@ -1,22 +1,20 @@
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/const-for-feature-gate.rs:4:14
-   |
-LL |     for _ in 0..5 {}
-   |              ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
   --> $DIR/const-for-feature-gate.rs:4:14
    |
 LL |     for _ in 0..5 {}
    |              ^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
+  --> $DIR/const-for-feature-gate.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/consts/const-for.rs
+++ b/tests/ui/consts/const-for.rs
@@ -2,8 +2,8 @@
 
 const _: () = {
     for _ in 0..5 {}
-    //~^ ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
-    //~| ERROR `std::ops::Range<{integer}>: const Iterator` is not satisfied
+    //~^ ERROR cannot use `for`
+    //~| ERROR cannot use `for`
 };
 
 fn main() {}

--- a/tests/ui/consts/const-for.stderr
+++ b/tests/ui/consts/const-for.stderr
@@ -1,22 +1,20 @@
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/const-for.rs:4:14
-   |
-LL |     for _ in 0..5 {}
-   |              ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
   --> $DIR/const-for.rs:4:14
    |
 LL |     for _ in 0..5 {}
    |              ^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
+  --> $DIR/const-for.rs:4:14
+   |
+LL |     for _ in 0..5 {}
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/consts/control-flow/loop.rs
+++ b/tests/ui/consts/control-flow/loop.rs
@@ -51,14 +51,14 @@ const _: i32 = {
     let mut x = 0;
 
     for i in 0..4 {
-        //~^ ERROR: `std::ops::Range<{integer}>: const Iterator` is not satisfied
-        //~| ERROR: `std::ops::Range<{integer}>: const Iterator` is not satisfied
+        //~^ ERROR: cannot use `for`
+        //~| ERROR: cannot use `for`
         x += i;
     }
 
     for i in 0..4 {
-        //~^ ERROR: `std::ops::Range<{integer}>: const Iterator` is not satisfied
-        //~| ERROR: `std::ops::Range<{integer}>: const Iterator` is not satisfied
+        //~^ ERROR: cannot use `for`
+        //~| ERROR: cannot use `for`
         x += i;
     }
 

--- a/tests/ui/consts/control-flow/loop.stderr
+++ b/tests/ui/consts/control-flow/loop.stderr
@@ -1,41 +1,37 @@
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/loop.rs:53:14
-   |
-LL |     for i in 0..4 {
-   |              ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
   --> $DIR/loop.rs:53:14
    |
 LL |     for i in 0..4 {
    |              ^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/loop.rs:59:14
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
+  --> $DIR/loop.rs:53:14
    |
 LL |     for i in 0..4 {
-   |              ^^^^ required by a bound introduced by this call
+   |              ^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
   --> $DIR/loop.rs:59:14
    |
 LL |     for i in 0..4 {
    |              ^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error[E0015]: cannot use `for` loop on `std::ops::Range<i32>` in constants
+  --> $DIR/loop.rs:59:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/consts/different-fn-ptr-binders-during-ctfe.stable.stderr
+++ b/tests/ui/consts/different-fn-ptr-binders-during-ctfe.stable.stderr
@@ -1,13 +1,10 @@
-error[E0277]: pointers cannot be reliably compared during const eval
+error: pointers cannot be reliably compared during const eval
   --> $DIR/different-fn-ptr-binders-during-ctfe.rs:5:5
    |
 LL |     x == y
    |     ^^^^^^
    |
-note: trait `PartialEq` is implemented but not `const`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/consts/issue-25826.stderr
+++ b/tests/ui/consts/issue-25826.stderr
@@ -1,13 +1,10 @@
-error[E0277]: pointers cannot be reliably compared during const eval
+error: pointers cannot be reliably compared during const eval
   --> $DIR/issue-25826.rs:3:30
    |
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: trait `PartialOrd` is implemented but not `const`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/consts/min_const_fn/cmp_fn_pointers.stderr
+++ b/tests/ui/consts/min_const_fn/cmp_fn_pointers.stderr
@@ -1,13 +1,10 @@
-error[E0277]: pointers cannot be reliably compared during const eval
+error: pointers cannot be reliably compared during const eval
   --> $DIR/cmp_fn_pointers.rs:2:14
    |
 LL |     unsafe { x == y }
    |              ^^^^^^
    |
-note: trait `PartialEq` is implemented but not `const`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/feature-gates/feature-gate-diagnostic-on-const.rs
+++ b/tests/ui/feature-gates/feature-gate-diagnostic-on-const.rs
@@ -10,7 +10,7 @@ use diagnostic_on_const::Foo;
 
 const fn foo() {
     Foo == Foo;
-    //~^ ERROR: the trait bound `Foo: [const] PartialEq` is not satisfied
+    //~^ ERROR: cannot call non-const operator in constant functions
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-diagnostic-on-const.stderr
+++ b/tests/ui/feature-gates/feature-gate-diagnostic-on-const.stderr
@@ -1,15 +1,16 @@
-error[E0277]: the trait bound `Foo: [const] PartialEq` is not satisfied
+error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/feature-gate-diagnostic-on-const.rs:12:5
    |
 LL |     Foo == Foo;
    |     ^^^^^^^^^^
    |
-note: trait `PartialEq` is implemented but not `const`
+note: impl defined here, but it is not `const`
   --> $DIR/auxiliary/diagnostic-on-const.rs:4:1
    |
 LL | impl PartialEq for Foo {
    | ^^^^^^^^^^^^^^^^^^^^^^
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/issues/issue-25901.rs
+++ b/tests/ui/issues/issue-25901.rs
@@ -2,13 +2,16 @@ struct A;
 struct B;
 
 static S: &'static B = &A;
-//~^ ERROR the trait bound `A: const Deref` is not satisfied
+//~^ ERROR cannot perform non-const deref coercion on `A` in statics
 
 use std::ops::Deref;
 
 impl Deref for A {
     type Target = B;
-    fn deref(&self)->&B { static B_: B = B; &B_ }
+    fn deref(&self) -> &B {
+        static B_: B = B;
+        &B_
+    }
 }
 
-fn main(){}
+fn main() {}

--- a/tests/ui/issues/issue-25901.stderr
+++ b/tests/ui/issues/issue-25901.stderr
@@ -1,14 +1,23 @@
-error[E0277]: the trait bound `A: const Deref` is not satisfied
+error[E0015]: cannot perform non-const deref coercion on `A` in statics
   --> $DIR/issue-25901.rs:4:24
    |
 LL | static S: &'static B = &A;
    |                        ^^
    |
-help: make the `impl` of trait `Deref` `const`
+   = note: attempting to deref into `B`
+note: deref defined here
+  --> $DIR/issue-25901.rs:10:5
    |
-LL | impl const Deref for A {
-   |      +++++
+LL |     type Target = B;
+   |     ^^^^^^^^^^^
+note: impl defined here, but it is not `const`
+  --> $DIR/issue-25901.rs:9:1
+   |
+LL | impl Deref for A {
+   | ^^^^^^^^^^^^^^^^
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
+   = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/mismatched_types/for-loop-in-vec-type-mismatchrs-50585.rs
+++ b/tests/ui/mismatched_types/for-loop-in-vec-type-mismatchrs-50585.rs
@@ -2,6 +2,4 @@
 fn main() {
     |y: Vec<[(); for x in 0..2 {}]>| {};
     //~^ ERROR mismatched types
-    //~| ERROR  `std::ops::Range<{integer}>: const Iterator` is not satisfied
-    //~| ERROR  `std::ops::Range<{integer}>: const Iterator` is not satisfied
 }

--- a/tests/ui/mismatched_types/for-loop-in-vec-type-mismatchrs-50585.stderr
+++ b/tests/ui/mismatched_types/for-loop-in-vec-type-mismatchrs-50585.stderr
@@ -1,22 +1,3 @@
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/for-loop-in-vec-type-mismatchrs-50585.rs:3:27
-   |
-LL |     |y: Vec<[(); for x in 0..2 {}]>| {};
-   |                           ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/for-loop-in-vec-type-mismatchrs-50585.rs:3:27
-   |
-LL |     |y: Vec<[(); for x in 0..2 {}]>| {};
-   |                           ^^^^
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-
 error[E0308]: mismatched types
   --> $DIR/for-loop-in-vec-type-mismatchrs-50585.rs:3:18
    |
@@ -29,7 +10,6 @@ help: consider returning a value here
 LL |     |y: Vec<[(); for x in 0..2 {} /* `usize` value */]>| {};
    |                                   +++++++++++++++++++
 
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/never_type/issue-52443.rs
+++ b/tests/ui/never_type/issue-52443.rs
@@ -7,6 +7,6 @@ fn main() {
     //~^ WARN denote infinite loops with
 
     [(); { for _ in 0usize.. {}; 0}];
-    //~^ ERROR `std::ops::RangeFrom<usize>: const Iterator` is not satisfied
-    //~| ERROR `std::ops::RangeFrom<usize>: const Iterator` is not satisfied
+    //~^ ERROR cannot use `for` loop on `std::ops::RangeFrom<usize>` in constants
+    //~| ERROR cannot use `for` loop on `std::ops::RangeFrom<usize>` in constants
 }

--- a/tests/ui/never_type/issue-52443.stderr
+++ b/tests/ui/never_type/issue-52443.stderr
@@ -31,26 +31,24 @@ help: give the `break` a value of the expected type
 LL |     [(); loop { break 42 }];
    |                       ++
 
-error[E0277]: the trait bound `std::ops::RangeFrom<usize>: const Iterator` is not satisfied
-  --> $DIR/issue-52443.rs:9:21
-   |
-LL |     [(); { for _ in 0usize.. {}; 0}];
-   |                     ^^^^^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::RangeFrom<usize>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::RangeFrom<usize>: const Iterator` is not satisfied
+error[E0015]: cannot use `for` loop on `std::ops::RangeFrom<usize>` in constants
   --> $DIR/issue-52443.rs:9:21
    |
 LL |     [(); { for _ in 0usize.. {}; 0}];
    |                     ^^^^^^^^
    |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error[E0015]: cannot use `for` loop on `std::ops::RangeFrom<usize>` in constants
+  --> $DIR/issue-52443.rs:9:21
+   |
+LL |     [(); { for _ in 0usize.. {}; 0}];
+   |                     ^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 4 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0277, E0308.
-For more information about an error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0015, E0308.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/self/arbitrary-self-from-method-substs-ice.rs
+++ b/tests/ui/self/arbitrary-self-from-method-substs-ice.rs
@@ -9,8 +9,9 @@ struct Foo(u32);
 impl Foo {
     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
         //~^ ERROR invalid generic `self` parameter type
+        //~| ERROR destructor of `R` cannot be evaluated at compile-time
         self.0
-        //~^ ERROR the trait bound `R: [const] Deref` is not satisfied
+        //~^ ERROR cannot perform non-const deref coercion on `R` in constant functions
     }
 }
 

--- a/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
@@ -1,8 +1,20 @@
-error[E0277]: the trait bound `R: [const] Deref` is not satisfied
-  --> $DIR/arbitrary-self-from-method-substs-ice.rs:12:9
+error[E0015]: cannot perform non-const deref coercion on `R` in constant functions
+  --> $DIR/arbitrary-self-from-method-substs-ice.rs:13:9
    |
 LL |         self.0
-   |         ^^^^
+   |         ^^^^^^
+   |
+   = note: attempting to deref into `Foo`
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+
+error[E0493]: destructor of `R` cannot be evaluated at compile-time
+  --> $DIR/arbitrary-self-from-method-substs-ice.rs:10:43
+   |
+LL |     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
+   |                                           ^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL |     }
+   |     - value is dropped here
 
 error[E0801]: invalid generic `self` parameter type: `R`
   --> $DIR/arbitrary-self-from-method-substs-ice.rs:10:49
@@ -13,7 +25,7 @@ LL |     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    = note: type of `self` must not be a method generic parameter type
    = help: use a concrete type such as `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0277, E0801.
-For more information about an error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0015, E0493, E0801.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.rs
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.rs
@@ -10,6 +10,6 @@ impl Default for A {
 
 #[derive_const(Default)]
 pub struct S(A);
-//~^ ERROR: `A: [const] Default` is not satisfied
+//~^ ERROR: cannot call non-const associated function
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `A: [const] Default` is not satisfied
+error[E0015]: cannot call non-const associated function `<A as Default>::default` in constant functions
   --> $DIR/derive-const-non-const-type.rs:12:14
    |
 LL | #[derive_const(Default)]
@@ -6,11 +6,8 @@ LL | #[derive_const(Default)]
 LL | pub struct S(A);
    |              ^
    |
-help: make the `impl` of trait `Default` `const`
-   |
-LL | impl const Default for A {
-   |      +++++
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0015`.

--- a/tests/ui/traits/const-traits/cross-crate.rs
+++ b/tests/ui/traits/const-traits/cross-crate.rs
@@ -17,9 +17,10 @@ fn non_const_context() {
 const fn const_context() {
     #[cfg(any(stocknc, gatednc))]
     NonConst.func();
-    //[stocknc,gatednc]~^ ERROR: the trait bound
+    //[stocknc]~^ ERROR: cannot call
+    //[gatednc]~^^ ERROR: the trait bound
     Const.func();
-    //[stock]~^ ERROR: cannot call
+    //[stock,stocknc]~^ ERROR: cannot call
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/cross-crate.stock.stderr
+++ b/tests/ui/traits/const-traits/cross-crate.stock.stderr
@@ -1,5 +1,5 @@
 error[E0658]: cannot call conditionally-const method `<cross_crate::Const as cross_crate::MyTrait>::func` in constant functions
-  --> $DIR/cross-crate.rs:21:11
+  --> $DIR/cross-crate.rs:22:11
    |
 LL |     Const.func();
    |           ^^^^^^

--- a/tests/ui/traits/const-traits/cross-crate.stocknc.stderr
+++ b/tests/ui/traits/const-traits/cross-crate.stocknc.stderr
@@ -1,15 +1,23 @@
-error[E0277]: the trait bound `cross_crate::NonConst: [const] cross_crate::MyTrait` is not satisfied
+error[E0015]: cannot call non-const method `<cross_crate::NonConst as cross_crate::MyTrait>::func` in constant functions
   --> $DIR/cross-crate.rs:19:14
    |
 LL |     NonConst.func();
-   |              ^^^^
+   |              ^^^^^^
    |
-note: trait `MyTrait` is implemented but not `const`
-  --> $DIR/auxiliary/cross-crate.rs:11:1
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+
+error[E0658]: cannot call conditionally-const method `<cross_crate::Const as cross_crate::MyTrait>::func` in constant functions
+  --> $DIR/cross-crate.rs:22:11
    |
-LL | impl MyTrait for NonConst {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     Const.func();
+   |           ^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = note: see issue #143874 <https://github.com/rust-lang/rust/issues/143874> for more information
+   = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/traits/const-traits/gate.rs
+++ b/tests/ui/traits/const-traits/gate.rs
@@ -3,7 +3,6 @@
 fn main() {
     (const || {})();
     //~^ ERROR: const closures are experimental
-    //~| ERROR: the trait bound `{closure@$DIR/gate.rs:4:6: 4:14}: [const] Fn()` is not satisfied
 }
 
 macro_rules! e {

--- a/tests/ui/traits/const-traits/gate.stderr
+++ b/tests/ui/traits/const-traits/gate.stderr
@@ -9,7 +9,7 @@ LL |     (const || {})();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: const closures are experimental
-  --> $DIR/gate.rs:13:5
+  --> $DIR/gate.rs:12:5
    |
 LL | e!((const || {}));
    |     ^^^^^
@@ -18,13 +18,6 @@ LL | e!((const || {}));
    = help: add `#![feature(const_closures)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0277]: the trait bound `{closure@$DIR/gate.rs:4:6: 4:14}: [const] Fn()` is not satisfied
-  --> $DIR/gate.rs:4:5
-   |
-LL |     (const || {})();
-   |     ^^^^^^^^^^^^^^^
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0277, E0658.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nyn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nyn.stderr
@@ -83,13 +83,15 @@ help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `co
 LL | #[cfg(any(yyn, ynn, nyn, nnn))] const trait Bar: [const] Foo {}
    |                                 +++++
 
-error[E0277]: the trait bound `T: [const] Foo` is not satisfied
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-3.rs:38:7
    |
 LL |     x.a();
-   |       ^
+   |       ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 9 previous errors
 
-Some errors have detailed explanations: E0277, E0658.
-For more information about an error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0015, E0658.
+For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/traits/const-traits/super-traits-fail-3.rs
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.rs
@@ -36,8 +36,8 @@ const fn foo<T: [const] Bar>(x: &T) {
     //[yyn,ynn,nyn,nnn]~| ERROR: `[const]` can only be applied to `const` traits
     //[nyy,nyn,nny,nnn]~^^^ ERROR: const trait impls are experimental
     x.a();
-    //[yyn,nyn]~^ ERROR: the trait bound `T: [const] Foo` is not satisfied
-    //[ynn,yny,nny,nnn]~^^ ERROR: cannot call non-const method `<T as Foo>::a` in constant functions
+    //[yyn]~^ ERROR: the trait bound `T: [const] Foo` is not satisfied
+    //[ynn,yny,nny,nnn,nyn]~^^ ERROR: cannot call non-const method `<T as Foo>::a` in constant functions
     //[nyy]~^^^ ERROR: cannot call conditionally-const method `<T as Foo>::a` in constant functions
 }
 

--- a/tests/ui/typeck/for-in-const-eval.rs
+++ b/tests/ui/typeck/for-in-const-eval.rs
@@ -2,6 +2,4 @@
 fn main() {
     Vec::<[(); 1 + for x in 0..1 {}]>::new();
     //~^ ERROR cannot add
-    //~| ERROR const Iterator` is not satisfied
-    //~| ERROR const Iterator` is not satisfied
 }

--- a/tests/ui/typeck/for-in-const-eval.stderr
+++ b/tests/ui/typeck/for-in-const-eval.stderr
@@ -1,22 +1,3 @@
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/for-in-const-eval.rs:3:29
-   |
-LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
-   |                             ^^^^ required by a bound introduced by this call
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-   = note: required for `std::ops::Range<{integer}>` to implement `const IntoIterator`
-
-error[E0277]: the trait bound `std::ops::Range<{integer}>: const Iterator` is not satisfied
-  --> $DIR/for-in-const-eval.rs:3:29
-   |
-LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
-   |                             ^^^^
-   |
-note: trait `Iterator` is implemented but not `const`
-  --> $SRC_DIR/core/src/iter/range.rs:LL:COL
-
 error[E0277]: cannot add `()` to `{integer}`
   --> $DIR/for-in-const-eval.rs:3:18
    |
@@ -35,6 +16,6 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
              `&f64` implements `Add`
            and 56 others
 
-error: aborting due to 3 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
beta backport of https://github.com/rust-lang/rust/pull/154930

approval in [#t-compiler/backports > #154930: beta-nominated @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports/topic/.23154930.3A.20beta-nominated/near/583931681)

the nightly PR hasn't landed yet, but it will, and this is a trivial revert that only affects diagnostics