### PR TITLE
Fix code block whitespace handling in Markdown

### DIFF
--- a/compiler/rustc_errors/src/markdown/parse.rs
+++ b/compiler/rustc_errors/src/markdown/parse.rs
@@ -220,7 +220,7 @@ fn parse_codeblock(buf: &[u8]) -> Parsed<'_> {
     let mut found = None;
     for idx in (0..working.len()).filter(|idx| working[*idx..].starts_with(&end_pat)) {
         let (eol_txt, rest) = parse_to_newline(&working[(idx + end_pat.len())..]);
-        if !eol_txt.iter().any(u8::is_ascii_whitespace) {
+        if eol_txt.iter().all(u8::is_ascii_whitespace) {
             found = Some((&working[..idx], rest));
             break;
         }

--- a/compiler/rustc_errors/src/markdown/tests/parse.rs
+++ b/compiler/rustc_errors/src/markdown/tests/parse.rs
@@ -367,7 +367,7 @@ fn test_snake_case() {
 
 #[test]
 fn test_codeblock_trailing_whitespace() {
-    let buf = "```rust\ncode\n```	\nrest";
+    let buf = "```rust\ncode\n```    \nrest";
     let (t, r) = parse_codeblock(buf.as_bytes());
     assert_eq!(t, MdTree::CodeBlock { txt: "code", lang: Some("rust") });
     assert_eq!(r, b"\nrest");

--- a/compiler/rustc_errors/src/markdown/tests/parse.rs
+++ b/compiler/rustc_errors/src/markdown/tests/parse.rs
@@ -364,3 +364,16 @@ fn test_snake_case() {
     let res = entrypoint(SNAKE_CASE);
     assert_eq!(res, expected);
 }
+
+#[test]
+fn test_codeblock_trailing_whitespace() {
+    let buf = "```rust\ncode\n```	\nrest";
+    let (t, r) = parse_codeblock(buf.as_bytes());
+    assert_eq!(t, MdTree::CodeBlock { txt: "code", lang: Some("rust") });
+    assert_eq!(r, b"\nrest");
+
+    let buf = "```rust\ncode\n```abc\nrest";
+    let (t, r) = parse_codeblock(buf.as_bytes());
+    assert_eq!(t, MdTree::CodeBlock { txt: "code\n```abc\nrest", lang: Some("rust") });
+    assert_eq!(r, b"");
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

### Fix Markdown code block closing whitespace handling

Previously, the parser incorrectly accepted closing backticks followed by extra text and rejected lines where only spaces appeared after closing backticks. This did not match expected Markdown behavior.

Now, the parser correctly ends a code block only when line after the code ends with spaces or nothing. Lines where extra text appears after the closing backticks are treated as part of the code block.

Includes tests for both correct and incorrect cases.

### Related issue

This PR addresses the Outreachy issue: [Markdown whitespace bug in Rust Compiler](https://github.com/rustfoundation/interop-initiative/issues/53)
