### PR TITLE
UI automation

### DIFF
--- a/tests/ui/deref/derefmut-closure-drop-order.rs
+++ b/tests/ui/deref/derefmut-closure-drop-order.rs
@@ -1,3 +1,5 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/16774
+
 //@ run-pass
 #![feature(box_patterns)]
 

--- a/tests/ui/lifetimes/missing-lifetime-in-return.rs
+++ b/tests/ui/lifetimes/missing-lifetime-in-return.rs
@@ -1,3 +1,5 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/3154
+
 struct Thing<'a, Q:'a> {
     x: &'a Q
 }

--- a/tests/ui/lifetimes/missing-lifetime-in-return.stderr
+++ b/tests/ui/lifetimes/missing-lifetime-in-return.stderr
@@ -1,5 +1,5 @@
 error[E0621]: explicit lifetime required in the type of `x`
-  --> $DIR/issue-3154.rs:6:5
+  --> $DIR/missing-lifetime-in-return.rs:8:5
    |
 LL |     Thing { x: x }
    |     ^^^^^^^^^^^^^^ lifetime `'a` required


### PR DESCRIPTION
# To move issue-3154 and issue-16774 to functional subdirectories:

I have moved 2 tests from tests/ui/issues to their appropriate directories using "test-manager" tool.
## Changes:

- Moved tests/ui/issues/issue-3154.rs to tests/ui/borrowck/missing-lifetime-in-return.rs

- Moved tests/ui/issues/issue-16774.rs to tests/ui/deref/derefmut-closure-drop-order.rs
These moves where performed using the test-manager automation tool.
