### PR TITLE
Fixed  split_maybe_args to split on default shell IFS (space, tab, ne…

### DIFF
--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -90,10 +90,74 @@ pub fn cmd<S: AsRef<OsStr>>(program: S) -> Command {
 }
 
 fn split_maybe_args(s: &str) -> Vec<OsString> {
-    // FIXME(132599): implement proper env var/shell argument splitting.
-    s.split(' ')
-        .filter_map(|s| {
-            if s.chars().all(|c| c.is_whitespace()) { None } else { Some(OsString::from(s)) }
-        })
+    // Split on default shell IFS (space, tab, newline).
+    s.split(|c: char| matches!(c, ' ' | '\t' | '\n'))
+        .filter(|s| !s.is_empty())
+        .map(OsString::from)
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(s: &str) -> OsString {
+        OsString::from(s)
+    }
+
+    // --- Tests that PASS on the current (buggy) code ---
+
+    #[test]
+    fn split_on_space() {
+        assert_eq!(
+            split_maybe_args("valgrind --tool=memcheck"),
+            vec![os("valgrind"), os("--tool=memcheck")]
+        );
+    }
+
+    #[test]
+    fn single_arg_no_whitespace() {
+        assert_eq!(split_maybe_args("valgrind"), vec![os("valgrind")]);
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(split_maybe_args(""), Vec::<OsString>::new());
+    }
+
+    // --- Tests that FAIL on the current (buggy) code ---
+    // They prove the bug: split_maybe_args only splits on space,
+    // but shells split on IFS which defaults to space, tab, and newline.
+
+    #[test]
+    fn split_on_tab() {
+        assert_eq!(
+            split_maybe_args("valgrind\t--tool=memcheck"),
+            vec![os("valgrind"), os("--tool=memcheck")]
+        );
+    }
+
+    #[test]
+    fn split_on_newline() {
+        assert_eq!(
+            split_maybe_args("valgrind\n--tool=memcheck"),
+            vec![os("valgrind"), os("--tool=memcheck")]
+        );
+    }
+
+    #[test]
+    fn multiple_ifs_separators() {
+        assert_eq!(
+            split_maybe_args("a  b\t\tc\n\nd"),
+            vec![os("a"), os("b"), os("c"), os("d")]
+        );
+    }
+
+    #[test]
+    fn leading_and_trailing_whitespace() {
+        assert_eq!(
+            split_maybe_args("  valgrind\t"),
+            vec![os("valgrind")]
+        );
+    }
 }

--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -147,17 +147,11 @@ mod tests {
 
     #[test]
     fn multiple_ifs_separators() {
-        assert_eq!(
-            split_maybe_args("a  b\t\tc\n\nd"),
-            vec![os("a"), os("b"), os("c"), os("d")]
-        );
+        assert_eq!(split_maybe_args("a  b\t\tc\n\nd"), vec![os("a"), os("b"), os("c"), os("d")]);
     }
 
     #[test]
     fn leading_and_trailing_whitespace() {
-        assert_eq!(
-            split_maybe_args("  valgrind\t"),
-            vec![os("valgrind")]
-        );
+        assert_eq!(split_maybe_args("  valgrind\t"), vec![os("valgrind")]);
     }
 }

--- a/src/tools/run-make-support/src/run/mod.rs
+++ b/src/tools/run-make-support/src/run/mod.rs
@@ -89,7 +89,7 @@ pub fn cmd<S: AsRef<OsStr>>(program: S) -> Command {
     command
 }
 
-fn split_maybe_args(s: &str) -> Vec<OsString> {
+pub(crate) fn split_maybe_args(s: &str) -> Vec<OsString> {
     // Split on default shell IFS (space, tab, newline).
     s.split(|c: char| matches!(c, ' ' | '\t' | '\n'))
         .filter(|s| !s.is_empty())
@@ -98,60 +98,4 @@ fn split_maybe_args(s: &str) -> Vec<OsString> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn os(s: &str) -> OsString {
-        OsString::from(s)
-    }
-
-    // --- Tests that PASS on the current (buggy) code ---
-
-    #[test]
-    fn split_on_space() {
-        assert_eq!(
-            split_maybe_args("valgrind --tool=memcheck"),
-            vec![os("valgrind"), os("--tool=memcheck")]
-        );
-    }
-
-    #[test]
-    fn single_arg_no_whitespace() {
-        assert_eq!(split_maybe_args("valgrind"), vec![os("valgrind")]);
-    }
-
-    #[test]
-    fn empty_string() {
-        assert_eq!(split_maybe_args(""), Vec::<OsString>::new());
-    }
-
-    // --- Tests that FAIL on the current (buggy) code ---
-    // They prove the bug: split_maybe_args only splits on space,
-    // but shells split on IFS which defaults to space, tab, and newline.
-
-    #[test]
-    fn split_on_tab() {
-        assert_eq!(
-            split_maybe_args("valgrind\t--tool=memcheck"),
-            vec![os("valgrind"), os("--tool=memcheck")]
-        );
-    }
-
-    #[test]
-    fn split_on_newline() {
-        assert_eq!(
-            split_maybe_args("valgrind\n--tool=memcheck"),
-            vec![os("valgrind"), os("--tool=memcheck")]
-        );
-    }
-
-    #[test]
-    fn multiple_ifs_separators() {
-        assert_eq!(split_maybe_args("a  b\t\tc\n\nd"), vec![os("a"), os("b"), os("c"), os("d")]);
-    }
-
-    #[test]
-    fn leading_and_trailing_whitespace() {
-        assert_eq!(split_maybe_args("  valgrind\t"), vec![os("valgrind")]);
-    }
-}
+mod tests;

--- a/src/tools/run-make-support/src/run/tests.rs
+++ b/src/tools/run-make-support/src/run/tests.rs
@@ -1,0 +1,51 @@
+use std::ffi::OsString;
+
+use super::split_maybe_args;
+
+fn os(s: &str) -> OsString {
+    OsString::from(s)
+}
+
+#[test]
+fn split_on_space() {
+    assert_eq!(
+        split_maybe_args("valgrind --tool=memcheck"),
+        vec![os("valgrind"), os("--tool=memcheck")]
+    );
+}
+
+#[test]
+fn single_arg_no_whitespace() {
+    assert_eq!(split_maybe_args("valgrind"), vec![os("valgrind")]);
+}
+
+#[test]
+fn empty_string() {
+    assert_eq!(split_maybe_args(""), Vec::<OsString>::new());
+}
+
+#[test]
+fn split_on_tab() {
+    assert_eq!(
+        split_maybe_args("valgrind\t--tool=memcheck"),
+        vec![os("valgrind"), os("--tool=memcheck")]
+    );
+}
+
+#[test]
+fn split_on_newline() {
+    assert_eq!(
+        split_maybe_args("valgrind\n--tool=memcheck"),
+        vec![os("valgrind"), os("--tool=memcheck")]
+    );
+}
+
+#[test]
+fn multiple_ifs_separators() {
+    assert_eq!(split_maybe_args("a  b\t\tc\n\nd"), vec![os("a"), os("b"), os("c"), os("d")]);
+}
+
+#[test]
+fn leading_and_trailing_whitespace() {
+    assert_eq!(split_maybe_args("  valgrind\t"), vec![os("valgrind")]);
+}


### PR DESCRIPTION
This PR fixes the `split_maybe_args` function in `run-make-support` to correctly split
on default shell IFS characters (space, tab, newline), instead of only splitting
on spaces.

Relates to [implement shell whitespace splitting correctly](https://github.com/rust-lang/rust/blob/ad4b9354009cb6bd5a9ff1b5f5a63a13ec98ebc9/src/tools/run-make-support/src/run.rs#L96)





