### PR TITLE
Fix ICE in `span_extend_prev_while` with multibyte characters

### DIFF
--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -743,7 +743,7 @@ impl SourceMap {
             let n = s[..start]
                 .char_indices()
                 .rfind(|&(_, c)| !f(c))
-                .map_or(start, |(i, _)| start - i - 1);
+                .map_or(start, |(i, c)| start - i - c.len_utf8());
             Ok(span.with_lo(span.lo() - BytePos(n as u32)))
         })
     }

--- a/tests/ui/span/span-extend-prev-while-multibyte.rs
+++ b/tests/ui/span/span-extend-prev-while-multibyte.rs
@@ -1,0 +1,10 @@
+//@ build-pass
+// Regression test for https://github.com/rust-lang/rust/issues/155037
+#![feature(associated_type_defaults)]
+
+trait Trait {
+    type 否 where = ();
+    //~^ WARNING where clause not allowed here
+}
+
+fn main() {}

--- a/tests/ui/span/span-extend-prev-while-multibyte.stderr
+++ b/tests/ui/span/span-extend-prev-while-multibyte.stderr
@@ -1,0 +1,16 @@
+warning: where clause not allowed here
+  --> $DIR/span-extend-prev-while-multibyte.rs:6:12
+   |
+LL |     type 否 where = ();
+   |             ^^^^^
+   |
+   = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+   = note: `#[warn(deprecated_where_clause_location)]` on by default
+help: move it to the end of the type declaration
+   |
+LL -     type 否 where = ();
+LL +     type 否 = () where;
+   |
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/155037

The function assumed that the character found by `rfind` was always one byte wide, using a hardcoded `1` instead of `c.len_utf8()`. When a multibyte character appeared immediately before the span, this caused the resulting span to point into the middle of a UTF-8 sequence, triggering an assertion failure in `bytepos_to_file_charpos`.