### PR TITLE
Allow manual Unpin impls for local extern types

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -162,7 +162,8 @@ fn visit_implementation_of_unpin(checker: &Checker<'_>) -> Result<(), ErrorGuara
                     adt_name: tcx.item_name(adt.did()),
                 }));
             }
-            ty::Adt(_, _) => {}
+            // `extern type`s do not have Rust-visible fields that `#[pin_v2]` could project.
+            ty::Adt(_, _) | ty::Foreign(_) => {}
             _ => {
                 return Err(tcx.dcx().span_delayed_bug(span, "impl of `Unpin` for a non-adt type"));
             }

--- a/tests/ui/pin-ergonomics/impl-unpin-foreign.rs
+++ b/tests/ui/pin-ergonomics/impl-unpin-foreign.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+#![feature(extern_types, pin_ergonomics)]
+#![allow(incomplete_features)]
+
+unsafe extern "C" {
+    type ExternType;
+}
+
+impl Unpin for ExternType {}
+
+fn main() {}


### PR DESCRIPTION
This allows explicit `Unpin` impls for local `extern type`s under `pin_ergonomics`.

`#[pin_v2]` only applies to ADTs with Rust-visible fields, so local foreign types do not need the structurally pinned rejection path. Before this change, that path hit a delayed bug and ICEd on code like `impl Unpin for ExternType {}`.

Fixes rust-lang/rust#155053.
