### PR TITLE
Avoid mir_const_qualif ICE for invalid const trait methods

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -437,7 +437,7 @@ fn mir_promoted(
 
     let const_qualifs = match tcx.def_kind(def) {
         DefKind::Fn | DefKind::AssocFn | DefKind::Closure
-            if tcx.constness(def) == hir::Constness::Const =>
+            if tcx.hir_body_const_context(def).is_some() =>
         {
             tcx.mir_const_qualif(def)
         }

--- a/tests/ui/traits/const-traits/issue-153891.rs
+++ b/tests/ui/traits/const-traits/issue-153891.rs
@@ -1,0 +1,11 @@
+// Regression test for issue #153891.
+#![feature(const_closures)]
+
+trait Tr {
+    const fn test() {
+        //~^ ERROR functions in traits cannot be declared const
+        (const || {})()
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/issue-153891.stderr
+++ b/tests/ui/traits/const-traits/issue-153891.stderr
@@ -1,0 +1,12 @@
+error[E0379]: functions in traits cannot be declared const
+  --> $DIR/issue-153891.rs:5:5
+   |
+LL |     const fn test() {
+   |     ^^^^^-
+   |     |
+   |     functions in traits cannot be const
+   |     help: remove the `const`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0379`.


### PR DESCRIPTION
This switches MIR const-qualification gating to use the body's actual const context instead of raw item constness for functions, associated functions, and closures.

That avoids calling `mir_const_qualif` for closures nested inside invalid `const fn` trait methods, which previously ICEd after emitting E0379. Added a regression test.

Fixes rust-lang/rust#153891.
