### PR TITLE
Deny `#[global_allocator]` + `#[thread_local]`

### DIFF
--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -158,6 +158,13 @@ pub(crate) struct AllocMustStatics {
     pub(crate) span: Span,
 }
 
+#[derive(Diagnostic)]
+#[diag("allocators cannot be `#[thread_local]`")]
+pub(crate) struct AllocCannotThreadLocal {
+    #[primary_span]
+    pub(crate) span: Span,
+}
+
 pub(crate) use autodiff::*;
 
 mod autodiff {

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -163,6 +163,9 @@ pub(crate) struct AllocMustStatics {
 pub(crate) struct AllocCannotThreadLocal {
     #[primary_span]
     pub(crate) span: Span,
+    #[label("marked `#[thread_local]` here")]
+    #[suggestion("remove this attribute", code = "", applicability = "maybe-incorrect")]
+    pub(crate) attr: Span,
 }
 
 pub(crate) use autodiff::*;

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -39,11 +39,8 @@ pub(crate) fn expand(
     };
 
     // Forbid `#[thread_local]` attributes on the item
-    if let Some(attr) = item.attrs.iter().find(|x| { x.has_name(sym::thread_local) }) {
-        ecx.dcx().emit_err(errors::AllocCannotThreadLocal {
-            span: item.span,
-            attr: attr.span
-        });
+    if let Some(attr) = item.attrs.iter().find(|x| x.has_name(sym::thread_local)) {
+        ecx.dcx().emit_err(errors::AllocCannotThreadLocal { span: item.span, attr: attr.span });
         return vec![orig_item];
     }
 

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -39,8 +39,11 @@ pub(crate) fn expand(
     };
 
     // Forbid `#[thread_local]` attributes on the item
-    if let Some(_) = item.attrs.iter().find(|x| { x.has_name(sym::thread_local) }) {
-        ecx.dcx().emit_err(errors::AllocCannotThreadLocal { span: item.span_with_attributes() });
+    if let Some(attr) = item.attrs.iter().find(|x| { x.has_name(sym::thread_local) }) {
+        ecx.dcx().emit_err(errors::AllocCannotThreadLocal {
+            span: item.span,
+            attr: attr.span
+        });
         return vec![orig_item];
     }
 

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -38,6 +38,12 @@ pub(crate) fn expand(
         return vec![orig_item];
     };
 
+    // Forbid `#[thread_local]` attributes on the item
+    if let Some(_) = item.attrs.iter().find(|x| { x.has_name(sym::thread_local) }) {
+        ecx.dcx().emit_err(errors::AllocCannotThreadLocal { span: item.span_with_attributes() });
+        return vec![orig_item];
+    }
+
     // Generate a bunch of new items using the AllocFnFactory
     let span = ecx.with_def_site_ctxt(item.span);
     let f = AllocFnFactory { span, ty_span, global: ident, cx: ecx };

--- a/tests/ui/allocator/no-thread-local.rs
+++ b/tests/ui/allocator/no-thread-local.rs
@@ -1,0 +1,10 @@
+#![feature(thread_local)]
+
+use std::alloc::System;
+
+#[global_allocator]
+#[thread_local]
+//~^ ERROR: allocators cannot be `#[thread_local]`
+static A: System = System;
+
+fn main() {}

--- a/tests/ui/allocator/no-thread-local.rs
+++ b/tests/ui/allocator/no-thread-local.rs
@@ -4,7 +4,7 @@ use std::alloc::System;
 
 #[global_allocator]
 #[thread_local]
-//~^ ERROR: allocators cannot be `#[thread_local]`
 static A: System = System;
+//~^ ERROR: allocators cannot be `#[thread_local]`
 
 fn main() {}

--- a/tests/ui/allocator/no-thread-local.stderr
+++ b/tests/ui/allocator/no-thread-local.stderr
@@ -1,10 +1,13 @@
 error: allocators cannot be `#[thread_local]`
-  --> $DIR/no-thread-local.rs:6:1
+  --> $DIR/no-thread-local.rs:7:1
    |
-LL | / #[thread_local]
-LL | |
-LL | | static A: System = System;
-   | |__________________________^
+LL | #[thread_local]
+   | ---------------
+   | |
+   | marked `#[thread_local]` here
+   | help: remove this attribute
+LL | static A: System = System;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/allocator/no-thread-local.stderr
+++ b/tests/ui/allocator/no-thread-local.stderr
@@ -1,0 +1,10 @@
+error: allocators cannot be `#[thread_local]`
+  --> $DIR/no-thread-local.rs:6:1
+   |
+LL | / #[thread_local]
+LL | |
+LL | | static A: System = System;
+   | |__________________________^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This forbids using `#[thread_local]` on `static` items that are also `#[global_allocator]`s.

Fixes rust-lang/rust#85517.