### PR TITLE
Set the Fuchsia ABI to the documented minimum

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_fuchsia.rs
@@ -6,7 +6,7 @@ pub(crate) fn target() -> Target {
     let mut base = base::fuchsia::opts();
     base.code_model = Some(CodeModel::Medium);
     base.cpu = "generic-rv64".into();
-    base.features = "+m,+a,+f,+d,+c,+zicsr,+zifencei".into();
+    base.features = "+m,+a,+f,+d,+c,+v,+zicsr,+zifencei".into();
     base.llvm_abiname = LlvmAbi::Lp64d;
     base.max_atomic_width = Some(64);
     base.stack_probes = StackProbeType::Inline;


### PR DESCRIPTION
Fuchsia only supports the RVA22 + vector as its minimum ABI for RISC-V.

See: [fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0234_riscv_abi_rva22+v](https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0234_riscv_abi_rva22+v)[fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0234_riscv_abi_rva22+v](https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0234_riscv_abi_rva22+v)

