### PR TITLE
Reject dangling attributes in where clauses

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1305,6 +1305,14 @@ pub(crate) struct ExpectedStatementAfterOuterAttr {
 }
 
 #[derive(Diagnostic)]
+#[diag("attribute without where predicates")]
+pub(crate) struct AttrWithoutWherePredicates {
+    #[primary_span]
+    #[label("attributes are only permitted when preceding predicates")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("found a documentation comment that doesn't document anything", code = E0585)]
 #[help("doc comments must come before what they document, if a comment was intended use `//`")]
 pub(crate) struct DocCommentDoesNotDocumentAnything {

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -473,6 +473,17 @@ impl<'a> Parser<'a> {
                         }
                     }
                 } else {
+                    if let [.., last] = &attrs[..] {
+                        if last.is_doc_comment() {
+                            this.dcx().emit_err(errors::DocCommentDoesNotDocumentAnything {
+                                span: last.span,
+                                missing_comma: None,
+                            });
+                        } else {
+                            this.dcx()
+                                .emit_err(errors::AttrWithoutWherePredicates { span: last.span });
+                        }
+                    }
                     None
                 };
                 let predicate = kind.map(|kind| ast::WherePredicate {

--- a/tests/ui/parser/where-clause-attrs-without-predicate.rs
+++ b/tests/ui/parser/where-clause-attrs-without-predicate.rs
@@ -1,0 +1,21 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/155073>
+
+#![crate_type = "lib"]
+#![feature(where_clause_attrs)]
+
+fn f<T>()
+where
+    T: Copy,
+    #[cfg(true)]
+    #[cfg(false)]
+    //~^ ERROR attribute without where predicates
+{
+}
+
+fn g<T>()
+where
+    T: Copy,
+    /// dangling
+    //~^ ERROR found a documentation comment that doesn't document anything
+{
+}

--- a/tests/ui/parser/where-clause-attrs-without-predicate.stderr
+++ b/tests/ui/parser/where-clause-attrs-without-predicate.stderr
@@ -1,0 +1,17 @@
+error: attribute without where predicates
+  --> $DIR/where-clause-attrs-without-predicate.rs:10:5
+   |
+LL |     #[cfg(false)]
+   |     ^^^^^^^^^^^^^ attributes are only permitted when preceding predicates
+
+error[E0585]: found a documentation comment that doesn't document anything
+  --> $DIR/where-clause-attrs-without-predicate.rs:18:5
+   |
+LL |     /// dangling
+   |     ^^^^^^^^^^^^
+   |
+   = help: doc comments must come before what they document, if a comment was intended use `//`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0585`.


### PR DESCRIPTION
Report `attribute without where predicates` for trailing outer attributes in where clauses.

Closes rust-lang/rust#155073 .

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
