### PR TITLE
Simplify `try_load_from_disk_fn`.

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -99,9 +99,11 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
 
     pub will_cache_on_disk_for_key_fn: fn(key: C::Key) -> bool,
 
+    /// Function pointer that tries to load a query value from disk.
+    ///
+    /// This should only be called after a successful check of `will_cache_on_disk_for_key_fn`.
     pub try_load_from_disk_fn: fn(
         tcx: TyCtxt<'tcx>,
-        key: C::Key,
         prev_index: SerializedDepNodeIndex,
         index: DepNodeIndex,
     ) -> Option<C::Value>,

--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -102,11 +102,8 @@ pub struct QueryVTable<'tcx, C: QueryCache> {
     /// Function pointer that tries to load a query value from disk.
     ///
     /// This should only be called after a successful check of `will_cache_on_disk_for_key_fn`.
-    pub try_load_from_disk_fn: fn(
-        tcx: TyCtxt<'tcx>,
-        prev_index: SerializedDepNodeIndex,
-        index: DepNodeIndex,
-    ) -> Option<C::Value>,
+    pub try_load_from_disk_fn:
+        fn(tcx: TyCtxt<'tcx>, prev_index: SerializedDepNodeIndex) -> Option<C::Value>,
 
     /// Function pointer that hashes this query's result values.
     ///

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -478,7 +478,10 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
 
     // First try to load the result from the on-disk cache. Some things are never cached on disk.
     let try_value = if (query.will_cache_on_disk_for_key_fn)(key) {
-        (query.try_load_from_disk_fn)(tcx, prev_index, dep_node_index)
+        let prof_timer = tcx.prof.incr_cache_loading();
+        let value = (query.try_load_from_disk_fn)(tcx, prev_index);
+        prof_timer.finish_with_query_invocation_id(dep_node_index.into());
+        value
     } else {
         None
     };

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -477,15 +477,16 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
     debug_assert!(dep_graph_data.is_index_green(prev_index));
 
     // First try to load the result from the on-disk cache. Some things are never cached on disk.
-    let value;
-    let verify;
-    match (query.try_load_from_disk_fn)(tcx, key, prev_index, dep_node_index) {
-        Some(loaded_value) => {
+    let try_value = if (query.will_cache_on_disk_for_key_fn)(key) {
+        (query.try_load_from_disk_fn)(tcx, prev_index, dep_node_index)
+    } else {
+        None
+    };
+    let (value, verify) = match try_value {
+        Some(value) => {
             if std::intrinsics::unlikely(tcx.sess.opts.unstable_opts.query_dep_graph) {
                 dep_graph_data.mark_debug_loaded_from_disk(*dep_node)
             }
-
-            value = loaded_value;
 
             let prev_fingerprint = dep_graph_data.prev_value_fingerprint_of(prev_index);
             // If `-Zincremental-verify-ich` is specified, re-hash results from
@@ -495,17 +496,19 @@ fn load_from_disk_or_invoke_provider_green<'tcx, C: QueryCache>(
             // from disk. Re-hashing results is fairly expensive, so we can't
             // currently afford to verify every hash. This subset should still
             // give us some coverage of potential bugs.
-            verify = prev_fingerprint.split().1.as_u64().is_multiple_of(32)
+            let verify = prev_fingerprint.split().1.as_u64().is_multiple_of(32)
                 || tcx.sess.opts.unstable_opts.incremental_verify_ich;
+
+            (value, verify)
         }
         None => {
             // We could not load a result from the on-disk cache, so recompute. The dep-graph for
             // this computation is already in-place, so we can just call the query provider.
             let prof_timer = tcx.prof.query_provider();
-            value = tcx.dep_graph.with_ignore(|| (query.invoke_provider_fn)(tcx, key));
+            let value = tcx.dep_graph.with_ignore(|| (query.invoke_provider_fn)(tcx, key));
             prof_timer.finish_with_query_invocation_id(dep_node_index.into());
 
-            verify = true;
+            (value, true)
         }
     };
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -5,7 +5,7 @@ use rustc_hir::limit::Limit;
 use rustc_middle::bug;
 #[expect(unused_imports, reason = "used by doc comments")]
 use rustc_middle::dep_graph::DepKindVTable;
-use rustc_middle::dep_graph::{DepNode, DepNodeIndex, DepNodeKey, SerializedDepNodeIndex};
+use rustc_middle::dep_graph::{DepNode, DepNodeKey, SerializedDepNodeIndex};
 use rustc_middle::query::erase::{Erasable, Erased};
 use rustc_middle::query::on_disk_cache::{CacheDecoder, CacheEncoder};
 use rustc_middle::query::{QueryCache, QueryJobId, QueryMode, QueryVTable, erase};
@@ -184,23 +184,14 @@ pub(crate) fn loadable_from_disk<'tcx>(tcx: TyCtxt<'tcx>, id: SerializedDepNodeI
 pub(crate) fn try_load_from_disk<'tcx, V>(
     tcx: TyCtxt<'tcx>,
     prev_index: SerializedDepNodeIndex,
-    index: DepNodeIndex,
 ) -> Option<V>
 where
     V: for<'a> Decodable<CacheDecoder<'a, 'tcx>>,
 {
     let on_disk_cache = tcx.query_system.on_disk_cache.as_ref()?;
 
-    let prof_timer = tcx.prof.incr_cache_loading();
-
     // The call to `with_query_deserialization` enforces that no new `DepNodes`
     // are created during deserialization. See the docs of that method for more
     // details.
-    let value = tcx
-        .dep_graph
-        .with_query_deserialization(|| on_disk_cache.try_load_query_value(tcx, prev_index));
-
-    prof_timer.finish_with_query_invocation_id(index.into());
-
-    value
+    tcx.dep_graph.with_query_deserialization(|| on_disk_cache.try_load_query_value(tcx, prev_index))
 }

--- a/compiler/rustc_query_impl/src/query_impl.rs
+++ b/compiler/rustc_query_impl/src/query_impl.rs
@@ -160,17 +160,17 @@ macro_rules! define_queries {
                             $crate::query_impl::$name::will_cache_on_disk_for_key,
 
                         #[cfg($cache_on_disk)]
-                        try_load_from_disk_fn: |tcx, prev_index, index| {
+                        try_load_from_disk_fn: |tcx, prev_index| {
                             use rustc_middle::queries::$name::{ProvidedValue, provided_to_erased};
 
                             let loaded_value: ProvidedValue<'tcx> =
-                                $crate::plumbing::try_load_from_disk(tcx, prev_index, index)?;
+                                $crate::plumbing::try_load_from_disk(tcx, prev_index)?;
 
                             // Arena-alloc the value if appropriate, and erase it.
                             Some(provided_to_erased(tcx, loaded_value))
                         },
                         #[cfg(not($cache_on_disk))]
-                        try_load_from_disk_fn: |_tcx, _prev_index, _index| None,
+                        try_load_from_disk_fn: |_tcx, _prev_index| None,
 
                         #[cfg($handle_cycle_error)]
                         handle_cycle_error_fn: |tcx, key, cycle, err| {

--- a/compiler/rustc_query_impl/src/query_impl.rs
+++ b/compiler/rustc_query_impl/src/query_impl.rs
@@ -160,13 +160,8 @@ macro_rules! define_queries {
                             $crate::query_impl::$name::will_cache_on_disk_for_key,
 
                         #[cfg($cache_on_disk)]
-                        try_load_from_disk_fn: |tcx, key, prev_index, index| {
+                        try_load_from_disk_fn: |tcx, prev_index, index| {
                             use rustc_middle::queries::$name::{ProvidedValue, provided_to_erased};
-
-                            // Check the cache-on-disk condition for this key.
-                            if !$crate::query_impl::$name::will_cache_on_disk_for_key(key) {
-                                return None;
-                            }
 
                             let loaded_value: ProvidedValue<'tcx> =
                                 $crate::plumbing::try_load_from_disk(tcx, prev_index, index)?;
@@ -175,7 +170,7 @@ macro_rules! define_queries {
                             Some(provided_to_erased(tcx, loaded_value))
                         },
                         #[cfg(not($cache_on_disk))]
-                        try_load_from_disk_fn: |_tcx, _key, _prev_index, _index| None,
+                        try_load_from_disk_fn: |_tcx, _prev_index, _index| None,
 
                         #[cfg($handle_cycle_error)]
                         handle_cycle_error_fn: |tcx, key, cycle, err| {


### PR DESCRIPTION
`try_load_from_disk_fn` has a single call site. We can move some of the stuff within it to its single call site, which simplifies it, and also results in all of the query profiling code ending up in the same module. Details in individual commits.

r? @Zalathar