### PR TITLE
Initial functions to start on transmute v2

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -32,6 +32,7 @@
 
 use crate::alloc::Layout;
 use crate::clone::TrivialClone;
+use crate::cmp::Ordering;
 use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
@@ -1086,6 +1087,102 @@ pub const unsafe fn transmute_copy<Src, Dst>(src: &Src) -> Dst {
         // The caller must guarantee that the actual transmutation is safe.
         unsafe { ptr::read(src as *const Src as *const Dst) }
     }
+}
+
+/// Like [`transmute`], but only initializes the "common prefix" of the first
+/// `min(size_of::<Src>(), size_of::<Dst>())` bytes of the destination from the
+/// corresponding bytes of the source.
+///
+/// This is equivalent to a "union cast" through a `union` with `#[repr(C)]`.
+///
+/// That means some size mismatches are not UB, like `[T; 2]` to `[T; 1]`.
+/// Increasing size is usually UB from being insufficiently initialized -- like
+/// `u8` to `u32` -- but isn't always.  For example, going from `u8` to
+/// `#[repr(C, align(4))] AlignedU8(u8);` is sound.
+///
+/// Prefer normal `transmute` where possible, for the extra checking, since
+/// both do exactly the same thing at runtime, if they both compile.
+///
+/// # Safety
+///
+/// If `size_of::<Src>() >= size_of::<Dst>()`, the first `size_of::<Dst>()` bytes
+/// of `src` must be be *valid* when interpreted as a `Dst`.  (In this case, the
+/// preconditions are the same as for `transmute_copy(&ManuallyDrop::new(src))`.)
+///
+/// If `size_of::<Src>() <= size_of::<Dst>()`, the bytes of `src` padded with
+/// uninitialized bytes afterwards up to a total size of `size_of::<Dst>()`
+/// must be *valid* when interpreted as a `Dst`.
+///
+/// In both cases, any safety preconditions of the `Dst` type must also be upheld.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(transmute_prefix)]
+/// use std::mem::transmute_prefix;
+///
+/// assert_eq!(unsafe { transmute_prefix::<[i32; 4], [i32; 2]>([1, 2, 3, 4]) }, [1, 2]);
+///
+/// let expected = if cfg!(target_endian = "little") { 0x34 } else { 0x12 };
+/// assert_eq!(unsafe { transmute_prefix::<u16, u8>(0x1234) }, expected);
+///
+/// // Would be UB because the destination is incompletely initialized.
+/// // transmute_prefix::<u8, u16>(123)
+///
+/// // OK because the destination is allowed to be partially initialized.
+/// let _: std::mem::MaybeUninit<u16> = unsafe { transmute_prefix(123_u8) };
+/// ```
+#[unstable(feature = "transmute_prefix", issue = "155079")]
+pub const unsafe fn transmute_prefix<Src, Dst>(src: Src) -> Dst {
+    #[repr(C)]
+    union Transmute<A, B> {
+        a: ManuallyDrop<A>,
+        b: ManuallyDrop<B>,
+    }
+
+    match const { Ord::cmp(&Src::SIZE, &Dst::SIZE) } {
+        // SAFETY: When Dst is bigger, the union is the size of Dst
+        Ordering::Less => unsafe {
+            let a = transmute_neo(src);
+            intrinsics::transmute_unchecked(Transmute::<Src, Dst> { a })
+        },
+        // SAFETY: When they're the same size, we can use the MIR primitive
+        Ordering::Equal => unsafe { intrinsics::transmute_unchecked::<Src, Dst>(src) },
+        // SAFETY: When Src is bigger, the union is the size of Src
+        Ordering::Greater => unsafe {
+            let u: Transmute<Src, Dst> = intrinsics::transmute_unchecked(src);
+            transmute_neo(u.b)
+        },
+    }
+}
+
+/// New version of `transmute`, exposed under this name so it can be iterated upon
+/// without risking breakage to uses of "real" transmute.
+///
+/// It will not be stabilized under this name.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(transmute_neo)]
+/// use std::mem::transmute_neo;
+///
+/// assert_eq!(unsafe { transmute_neo::<f32, u32>(0.0) }, 0);
+/// ```
+///
+/// ```compile_fail,E0080
+/// #![feature(transmute_neo)]
+/// use std::mem::transmute_neo;
+///
+/// unsafe { transmute_neo::<u32, u16>(123) };
+/// ```
+#[unstable(feature = "transmute_neo", issue = "155079")]
+pub const unsafe fn transmute_neo<Src, Dst>(src: Src) -> Dst {
+    const { assert!(Src::SIZE == Dst::SIZE) };
+
+    // SAFETY: the const-assert just checked that they're the same size,
+    // and any other safety invariants need to be upheld by the caller.
+    unsafe { intrinsics::transmute_unchecked(src) }
 }
 
 /// Opaque type representing the discriminant of an enum.

--- a/tests/mir-opt/pre-codegen/transmutes.forget_at_home.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transmutes.forget_at_home.PreCodegen.after.mir
@@ -1,0 +1,20 @@
+// MIR for `forget_at_home` after PreCodegen
+
+fn forget_at_home(_1: String) -> () {
+    debug x => _1;
+    let mut _0: ();
+    scope 1 (inlined transmute_prefix::<String, ()>) {
+        scope 2 {
+        }
+        scope 3 {
+            scope 4 (inlined transmute_neo::<ManuallyDrop<()>, ()>) {
+            }
+        }
+        scope 5 (inlined transmute_neo::<String, ManuallyDrop<String>>) {
+        }
+    }
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/transmutes.neo_to_cast.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transmutes.neo_to_cast.PreCodegen.after.mir
@@ -1,0 +1,13 @@
+// MIR for `neo_to_cast` after PreCodegen
+
+fn neo_to_cast(_1: f32) -> i32 {
+    debug x => _1;
+    let mut _0: i32;
+    scope 1 (inlined transmute_neo::<f32, i32>) {
+    }
+
+    bb0: {
+        _0 = copy _1 as i32 (Transmute);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/transmutes.pad_for_alignment.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transmutes.pad_for_alignment.PreCodegen.after.mir
@@ -1,0 +1,29 @@
+// MIR for `pad_for_alignment` after PreCodegen
+
+fn pad_for_alignment(_1: u32) -> Align64<u32> {
+    debug x => _1;
+    let mut _0: Align64<u32>;
+    scope 1 (inlined transmute_prefix::<u32, Align64<u32>>) {
+        let _2: std::mem::ManuallyDrop<u32>;
+        let mut _3: std::mem::transmute_prefix::Transmute<u32, Align64<u32>>;
+        scope 2 {
+        }
+        scope 3 {
+            scope 4 (inlined transmute_neo::<ManuallyDrop<Align64<u32>>, Align64<u32>>) {
+            }
+        }
+        scope 5 (inlined transmute_neo::<u32, ManuallyDrop<u32>>) {
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = copy _1 as std::mem::ManuallyDrop<u32> (Transmute);
+        StorageLive(_3);
+        _3 = transmute_prefix::Transmute::<u32, Align64<u32>> { a: copy _2 };
+        _0 = move _3 as Align64<u32> (Transmute);
+        StorageDead(_3);
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/transmutes.prefix_of_array.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transmutes.prefix_of_array.PreCodegen.after.mir
@@ -1,0 +1,29 @@
+// MIR for `prefix_of_array` after PreCodegen
+
+fn prefix_of_array(_1: [u32; 4]) -> [u32; 2] {
+    debug x => _1;
+    let mut _0: [u32; 2];
+    scope 1 (inlined transmute_prefix::<[u32; 4], [u32; 2]>) {
+        let _2: std::mem::transmute_prefix::Transmute<[u32; 4], [u32; 2]>;
+        let mut _3: std::mem::ManuallyDrop<[u32; 2]>;
+        scope 2 {
+        }
+        scope 3 {
+            scope 4 (inlined transmute_neo::<ManuallyDrop<[u32; 2]>, [u32; 2]>) {
+            }
+        }
+        scope 5 (inlined transmute_neo::<[u32; 4], ManuallyDrop<[u32; 4]>>) {
+        }
+    }
+
+    bb0: {
+        StorageLive(_2);
+        _2 = copy _1 as std::mem::transmute_prefix::Transmute<[u32; 4], [u32; 2]> (Transmute);
+        StorageLive(_3);
+        _3 = move (_2.1: std::mem::ManuallyDrop<[u32; 2]>);
+        _0 = copy _3 as [u32; 2] (Transmute);
+        StorageDead(_3);
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/transmutes.prefix_to_cast.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/transmutes.prefix_to_cast.PreCodegen.after.mir
@@ -1,0 +1,21 @@
+// MIR for `prefix_to_cast` after PreCodegen
+
+fn prefix_to_cast(_1: f32) -> i32 {
+    debug x => _1;
+    let mut _0: i32;
+    scope 1 (inlined transmute_prefix::<f32, i32>) {
+        scope 2 {
+        }
+        scope 3 {
+            scope 4 (inlined transmute_neo::<ManuallyDrop<i32>, i32>) {
+            }
+        }
+        scope 5 (inlined transmute_neo::<f32, ManuallyDrop<f32>>) {
+        }
+    }
+
+    bb0: {
+        _0 = copy _1 as i32 (Transmute);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/transmutes.rs
+++ b/tests/mir-opt/pre-codegen/transmutes.rs
@@ -1,0 +1,50 @@
+//@ compile-flags: -O -Zmir-opt-level=2
+
+#![crate_type = "lib"]
+#![feature(transmute_neo)]
+#![feature(transmute_prefix)]
+
+use std::mem::{transmute_neo, transmute_prefix};
+
+// EMIT_MIR transmutes.neo_to_cast.PreCodegen.after.mir
+pub fn neo_to_cast(x: f32) -> i32 {
+    // CHECK-LABEL: fn neo_to_cast
+    // CHECK: _0 = copy _1 as i32 (Transmute);
+    unsafe { transmute_neo(x) }
+}
+
+// EMIT_MIR transmutes.prefix_to_cast.PreCodegen.after.mir
+pub fn prefix_to_cast(x: f32) -> i32 {
+    // CHECK-LABEL: fn prefix_to_cast
+    // CHECK: _0 = copy _1 as i32 (Transmute);
+    unsafe { transmute_prefix(x) }
+}
+
+// EMIT_MIR transmutes.prefix_of_array.PreCodegen.after.mir
+pub fn prefix_of_array(x: [u32; 4]) -> [u32; 2] {
+    // CHECK-LABEL: fn prefix_of_array
+    // CHECK: _2 = copy _1 as {{.+}}::Transmute<[u32; 4], [u32; 2]> (Transmute);
+    // CHECK: _3 = move (_2.1: {{.+}}::ManuallyDrop<[u32; 2]>);
+    // CHECK: _0 = copy _3 as [u32; 2] (Transmute);
+    unsafe { transmute_prefix(x) }
+}
+
+#[repr(C, align(64))]
+struct Align64<T>(T);
+
+// EMIT_MIR transmutes.pad_for_alignment.PreCodegen.after.mir
+pub fn pad_for_alignment(x: u32) -> Align64<u32> {
+    // CHECK-LABEL: fn pad_for_alignment
+    // CHECK: _2 = copy _1 as {{.+}}::ManuallyDrop<u32> (Transmute);
+    // CHECK: _3 = {{.+}}::Transmute::<u32, Align64<u32>> { a: copy _2 };
+    // CHECK: _0 = move _3 as Align64<u32> (Transmute);
+    unsafe { transmute_prefix(x) }
+}
+
+// EMIT_MIR transmutes.forget_at_home.PreCodegen.after.mir
+pub fn forget_at_home(x: String) {
+    // CHECK-LABEL: fn forget_at_home
+    // CHECK: bb0:
+    // CHECK-NEXT: return;
+    unsafe { transmute_prefix(x) }
+}


### PR DESCRIPTION
For context, see https://github.com/rust-lang/rfcs/pull/3844 and https://github.com/rust-lang/libs-team/issues/772

*Experimental* still, tracked under https://github.com/rust-lang/rust/issues/155079

This is just library functions.  A future PR will do compiler changes for things like lints.