### PR TITLE
changed the information provided by (mut x) to mut x (Fix 155030)

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -4022,23 +4022,74 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if let Some(decl) = local_decl
             && decl.can_be_made_mutable()
         {
-            let is_for_loop = matches!(
-                            decl.local_info(),
-                            LocalInfo::User(BindingForm::Var(VarBindingForm {
-                                opt_match_place: Some((_, match_span)),
-                                ..
-                            })) if matches!(match_span.desugaring_kind(), Some(DesugaringKind::ForLoop))
-            );
-            let message = if is_for_loop
+            let mut is_for_loop = false;
+            let mut is_ref_pattern = false;
+            if let LocalInfo::User(BindingForm::Var(VarBindingForm {
+                opt_match_place: Some((_, match_span)),
+                ..
+            })) = *decl.local_info()
+            {
+                if matches!(match_span.desugaring_kind(), Some(DesugaringKind::ForLoop)) {
+                    is_for_loop = true;
+
+                    if let Some(body) = self.infcx.tcx.hir_maybe_body_owned_by(self.mir_def_id()) {
+                        struct RefPatternFinder<'tcx> {
+                            tcx: TyCtxt<'tcx>,
+                            binding_span: Span,
+                            is_ref_pattern: bool,
+                        }
+
+                        impl<'tcx> Visitor<'tcx> for RefPatternFinder<'tcx> {
+                            type NestedFilter = OnlyBodies;
+
+                            fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+                                self.tcx
+                            }
+
+                            fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+                                if !self.is_ref_pattern
+                                    && let hir::PatKind::Binding(_, _, ident, _) = pat.kind
+                                    && ident.span == self.binding_span
+                                {
+                                    self.is_ref_pattern =
+                                        self.tcx.hir_parent_iter(pat.hir_id).any(|(_, node)| {
+                                            matches!(
+                                                node,
+                                                hir::Node::Pat(hir::Pat {
+                                                    kind: hir::PatKind::Ref(..),
+                                                    ..
+                                                })
+                                            )
+                                        });
+                                }
+                                hir::intravisit::walk_pat(self, pat);
+                            }
+                        }
+
+                        let mut finder = RefPatternFinder {
+                            tcx: self.infcx.tcx,
+                            binding_span: decl.source_info.span,
+                            is_ref_pattern: false,
+                        };
+
+                        finder.visit_body(body);
+                        is_ref_pattern = finder.is_ref_pattern;
+                    }
+                }
+            }
+
+            let (span, message) = if is_for_loop
+                && is_ref_pattern
                 && let Ok(binding_name) =
                     self.infcx.tcx.sess.source_map().span_to_snippet(decl.source_info.span)
             {
-                format!("(mut {}) ", binding_name)
+                (decl.source_info.span, format!("(mut {})", binding_name))
             } else {
-                "mut ".to_string()
+                (decl.source_info.span.shrink_to_lo(), "mut ".to_string())
             };
+
             err.span_suggestion_verbose(
-                decl.source_info.span.shrink_to_lo(),
+                span,
                 "consider making this binding mutable",
                 message,
                 Applicability::MachineApplicable,

--- a/tests/ui/borrowck/borrowck_for_loop_pattern_assignment.rs
+++ b/tests/ui/borrowck/borrowck_for_loop_pattern_assignment.rs
@@ -1,0 +1,9 @@
+//! regression test for <https://github.com/rust-lang/rust/issues/155030>
+
+fn main() {
+    let nums: [u32; 3] = [1, 2, 3];
+    for num in nums {
+        num *= 2; //~ ERROR cannot assign twice to immutable variable `num`
+        println!("{num}");
+    }
+}

--- a/tests/ui/borrowck/borrowck_for_loop_pattern_assignment.stderr
+++ b/tests/ui/borrowck/borrowck_for_loop_pattern_assignment.stderr
@@ -1,16 +1,15 @@
 error[E0384]: cannot assign twice to immutable variable `num`
-  --> $DIR/borrowck-for-loop-deref-pattern-assignment.rs:7:9
+  --> $DIR/borrowck_for_loop_pattern_assignment.rs:6:9
    |
-LL |     for &num in nums {
-   |          --- first assignment to `num`
+LL |     for num in nums {
+   |         --- first assignment to `num`
 LL |         num *= 2;
    |         ^^^^^^^^ cannot assign twice to immutable variable
    |
 help: consider making this binding mutable
    |
-LL -     for &num in nums {
-LL +     for &(mut num) in nums {
-   |
+LL |     for mut num in nums {
+   |         +++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
When trying to change a value without using mut in a for loop, the recommendation for this change is incorrect, so I am correcting it.

resolve: rust-lang/rust#155030 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
