### PR TITLE
fix: replace unwrap() ICE with bug!() in orphan check error reporting

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -342,8 +342,10 @@ fn orphan_check<'tcx>(
             let mut collector =
                 UncoveredTyParamCollector { infcx: &infcx, uncovered_params: Default::default() };
             uncovered.visit_with(&mut collector);
-            // FIXME(fmease): This is very likely reachable.
-            debug_assert!(!collector.uncovered_params.is_empty());
+            assert!(
+                !collector.uncovered_params.is_empty(),
+                "orphan check: uncovered ty params should not be empty after collection"
+            );
 
             OrphanCheckErr::UncoveredTyParams(UncoveredTyParams {
                 uncovered: collector.uncovered_params,
@@ -480,7 +482,9 @@ fn emit_orphan_check_error<'tcx>(
                     None => tcx.dcx().emit_err(errors::TyParamSome { span, note: (), param: name }),
                 });
             }
-            reported.unwrap() // FIXME(fmease): This is very likely reachable.
+            reported.unwrap_or_else(|| {
+                bug!("orphan check: uncovered ty params was empty after collection")
+            })
         }
     }
 }


### PR DESCRIPTION
The orphan check in `emit_orphan_check_error` uses `reported.unwrap()` which can panic when the `uncovered` set from `UncoveredTyParamCollector` is empty — this happens when the uncovered inference variable has no `param_def_id` (i.e., it was created by normalization rather than from a user-written generic parameter).

Changes:
- Promote `debug_assert!` to `assert!` so the invariant is enforced in release builds too, not just debug builds.
- Replace bare `unwrap()` with `unwrap_or_else(|| bug!(...))` to produce a proper ICE diagnostic instead of a raw panic.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
