### PR TITLE
Ensure Send/Sync impl for std::process::CommandArgs

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1296,6 +1296,12 @@ impl<'a> ExactSizeIterator for CommandArgs<'a> {
     }
 }
 
+const fn assert_send<T: core::marker::Send>() {}
+const fn assert_sync<T: core::marker::Sync>() {}
+
+const _: () = assert_send::<CommandArgs<'static>>();
+const _: () = assert_sync::<CommandArgs<'static>>();
+
 /// An iterator over the command environment variables.
 ///
 /// This struct is created by

--- a/library/std/src/sys/process/unix/common/cstring_array.rs
+++ b/library/std/src/sys/process/unix/common/cstring_array.rs
@@ -91,6 +91,11 @@ pub struct CStringIter<'a> {
     iter: crate::slice::Iter<'a, *const c_char>,
 }
 
+// SAFETY: `CStringIter` is basically just a `slice::Iter<&'a CStr>`
+unsafe impl Send for CStringIter<'_> {}
+// SAFETY: `CStringIter` is basically just a `slice::Iter<&'a CStr>`
+unsafe impl Sync for CStringIter<'_> {}
+
 impl<'a> Iterator for CStringIter<'a> {
     type Item = &'a CStr;
     fn next(&mut self) -> Option<&'a CStr> {


### PR DESCRIPTION
This also adds static assertions to ensure this continues to hold across all targets. I think today this was just missing on cfg(unix) targets, but haven't checked too thoroughly. I think all tier 2+ targets continue to compile with the assertions (but we'll see what CI says).

cc https://github.com/rust-lang/rust/issues/154517