### PR TITLE
borrowck: clarify an E0502 label for &self.field vs mutable self

### DIFF
--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -195,6 +195,7 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         old_span: Span,
         noun_old: &str,
         kind_old: &str,
+        old_place_desc_for_label: Option<&str>,
         msg_old: &str,
         old_load_end_span: Option<Span>,
     ) -> Diag<'infcx> {
@@ -215,7 +216,14 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         if msg_new.is_empty() {
             // If `msg_new` is empty, then this isn't a borrow of a union field.
             err.span_label(span, format!("{kind_new} borrow occurs here"));
-            err.span_label(old_span, format!("{kind_old} borrow occurs here"));
+            if let Some(old_place_desc_for_label) = old_place_desc_for_label {
+                err.span_label(
+                    old_span,
+                    format!("{kind_old} borrow of {old_place_desc_for_label} occurs here"),
+                );
+            } else {
+                err.span_label(old_span, format!("{kind_old} borrow occurs here"));
+            }
         } else {
             // If `msg_new` isn't empty, then this a borrow of a union field.
             err.span_label(

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1766,6 +1766,22 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
 
         let explanation = self.explain_why_borrow_contains_point(location, issued_borrow, None);
         let second_borrow_desc = if explanation.is_explained() { "second " } else { "" };
+        let old_place_desc_for_label = if msg_place.is_empty()
+            && place != issued_borrow.borrowed_place
+            && place.local == issued_borrow.borrowed_place.local
+            && self.local_name(place.local) == Some(kw::SelfLower)
+            && place.as_ref().is_prefix_of(issued_borrow.borrowed_place.as_ref())
+            && issued_borrow
+                .borrowed_place
+                .projection
+                .iter()
+                .skip(place.projection.len())
+                .any(|elem| !matches!(elem, ProjectionElem::Deref))
+        {
+            Some(self.describe_any_place(issued_borrow.borrowed_place.as_ref()))
+        } else {
+            None
+        };
 
         // FIXME: supply non-"" `opt_via` when appropriate
         let first_borrow_desc;
@@ -1783,6 +1799,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     issued_span,
                     "it",
                     "mutable",
+                    old_place_desc_for_label.as_deref(),
                     &msg_borrow,
                     None,
                 );
@@ -1808,6 +1825,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     issued_span,
                     "it",
                     "immutable",
+                    old_place_desc_for_label.as_deref(),
                     &msg_borrow,
                     None,
                 );
@@ -1910,6 +1928,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         issued_span,
                         "it",
                         "immutable",
+                        old_place_desc_for_label.as_deref(),
                         &msg_borrow,
                         None,
                     )

--- a/tests/ui/borrowck/field-borrow-mut-self-issue-154275.rs
+++ b/tests/ui/borrowck/field-borrow-mut-self-issue-154275.rs
@@ -1,0 +1,15 @@
+struct S {
+    a: i32,
+}
+
+impl S {
+    fn helper(&mut self) {}
+
+    fn f(&mut self) {
+        let a = &self.a;
+        self.helper(); //~ ERROR cannot borrow `*self` as mutable because it is also borrowed as immutable
+        a;
+    }
+}
+
+fn main() {}

--- a/tests/ui/borrowck/field-borrow-mut-self-issue-154275.stderr
+++ b/tests/ui/borrowck/field-borrow-mut-self-issue-154275.stderr
@@ -1,0 +1,13 @@
+error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
+  --> $DIR/field-borrow-mut-self-issue-154275.rs:10:9
+   |
+LL |         let a = &self.a;
+   |                 ------- immutable borrow of `self.a` occurs here
+LL |         self.helper();
+   |         ^^^^^^^^^^^^^ mutable borrow occurs here
+LL |         a;
+   |         - immutable borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/tests/ui/borrowck/two-phase-surprise-no-conflict.stderr
+++ b/tests/ui/borrowck/two-phase-surprise-no-conflict.stderr
@@ -15,7 +15,7 @@ error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as im
 LL |                 self.hash_expr(&self.cx_mut.body(eid).value);
    |                 ^^^^^---------^^-----------^^^^^^^^^^^^^^^^^
    |                 |    |          |
-   |                 |    |          immutable borrow occurs here
+   |                 |    |          immutable borrow of `*self.cx_mut` occurs here
    |                 |    immutable borrow later used by call
    |                 mutable borrow occurs here
 


### PR DESCRIPTION
Small diagnostics-only fix for rust-lang/rust#154275.

This keeps the overall E0502 wording as-is and just makes the earlier label more specific in the &self.field / later mutable self case.