### PR TITLE
compiletest: inject LLVM_PROFILE_FILE when COMPILETEST_LLVM_PROFILE_DIR is set

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1344,6 +1344,14 @@ impl<'test> TestCx<'test> {
 
         rustc.envs(self.props.rustc_env.clone());
         self.props.unset_rustc_env.iter().fold(&mut rustc, Command::env_remove);
+
+        // Inject LLVM_PROFILE_FILE when coverage collection is requested.
+        // Set COMPILETEST_LLVM_PROFILE_DIR to a directory path to collect profraw files
+        // from every rustc invocation during testing.
+        if let Ok(profile_dir) = std::env::var("COMPILETEST_LLVM_PROFILE_DIR") {
+            rustc.env("LLVM_PROFILE_FILE", format!("{}/rustc-%p.profraw", profile_dir));
+        }
+
         self.compose_and_run(
             rustc,
             self.config.host_compile_lib_path.as_path(),


### PR DESCRIPTION
When `COMPILETEST_LLVM_PROFILE_DIR` is set, compiletest now forward `LLVM_PROFILE_FILE` to each `rustc` invocation so it writes a per-process `.profraw` file to that directory. The `%p` in the filename ensures concurrent rustc processes don't collide.

This is fully opt-in — normal test runs are unaffected.
Useful for collecting compiler coverage data across the full test suite.
r? @jackh726 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
