### PR TITLE
Suggest similar targets on unrecognized `--target`

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3718,7 +3718,25 @@ impl Target {
                     return load_file(&p, unstable_options);
                 }
 
-                Err(format!("could not find specification for target {target_tuple:?}"))
+                let mut msg = format!("could not find specification for target {target_tuple:?}");
+                // Suggest the closest built-in target using edit distance
+                let max_dist = target_tuple.len() / 3;
+                let mut best: Option<(&str, usize)> = None;
+                for candidate in TARGETS {
+                    if let Some(dist) = rustc_span::edit_distance::edit_distance_with_substrings(
+                        target_tuple,
+                        candidate,
+                        max_dist,
+                    ) {
+                        if best.is_none() || dist < best.unwrap().1 {
+                            best = Some((candidate, dist));
+                        }
+                    }
+                }
+                if let Some((suggestion, _)) = best {
+                    msg.push_str(&format!(". Did you mean `{suggestion}`?"));
+                }
+                Err(msg)
             }
             TargetTuple::TargetJson { ref contents, .. } if !unstable_options => {
                 Err("custom targets are unstable and require `-Zunstable-options`".to_string())

--- a/tests/ui/errors/wrong-target-spec.rs
+++ b/tests/ui/errors/wrong-target-spec.rs
@@ -8,4 +8,4 @@
 
 fn main() {}
 
-//~? ERROR error loading target specification: could not find specification for target "x86_64_unknown-linux-musl"
+//~? ERROR error loading target specification: could not find specification for target "x86_64_unknown-linux-musl". Did you mean `x86_64-unknown-linux-musl`?

--- a/tests/ui/errors/wrong-target-spec.stderr
+++ b/tests/ui/errors/wrong-target-spec.stderr
@@ -1,4 +1,4 @@
-error: error loading target specification: could not find specification for target "x86_64_unknown-linux-musl"
+error: error loading target specification: could not find specification for target "x86_64_unknown-linux-musl". Did you mean `x86_64-unknown-linux-musl`?
   |
   = help: run `rustc --print target-list` for a list of built-in targets
 


### PR DESCRIPTION
When an unrecognized target is passed to `--target`, use `edit_distance_with_substrings` to find the closest built-in target and suggest it in the error message.

Before:
  error: could not find specification for target "riscv64-unknown-linux-gnu"

After:
  error: could not find specification for target "riscv64-unknown-linux-gnu".
         Did you mean `riscv64gc-unknown-linux-gnu`?

This helps with common mistakes like typos, missing components (e.g. `x86_64-linux-gnu` -> `x86_64-unknown-linux-gnu`), or swapped characters. No suggestion is shown when the input is too far from any known target.

Fixes rust-lang/rust#155085

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
