### PR TITLE
Use a linting node closer the parsing of `#[cfg_attr]`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -2,7 +2,7 @@ use std::convert::identity;
 
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::DelimSpan;
-use rustc_ast::{AttrItem, Attribute, CRATE_NODE_ID, LitKind, ast, token};
+use rustc_ast::{AttrItem, Attribute, LitKind, ast, token};
 use rustc_errors::{Applicability, PResult, msg};
 use rustc_feature::{
     AttrSuggestionStyle, AttributeTemplate, Features, GatedCfg, find_gated_cfg, template,
@@ -324,12 +324,13 @@ pub fn parse_cfg_attr(
     cfg_attr: &Attribute,
     sess: &Session,
     features: Option<&Features>,
+    lint_node_id: ast::NodeId,
 ) -> Option<(CfgEntry, Vec<(AttrItem, Span)>)> {
     match cfg_attr.get_normal_item().args.unparsed_ref().unwrap() {
         ast::AttrArgs::Delimited(ast::DelimArgs { dspan, delim, tokens }) if !tokens.is_empty() => {
             check_cfg_attr_bad_delim(&sess.psess, *dspan, *delim);
             match parse_in(&sess.psess, tokens.clone(), "`cfg_attr` input", |p| {
-                parse_cfg_attr_internal(p, sess, features, cfg_attr)
+                parse_cfg_attr_internal(p, sess, features, lint_node_id, cfg_attr)
             }) {
                 Ok(r) => return Some(r),
                 Err(e) => {
@@ -390,6 +391,7 @@ fn parse_cfg_attr_internal<'a>(
     parser: &mut Parser<'a>,
     sess: &'a Session,
     features: Option<&Features>,
+    lint_node_id: ast::NodeId,
     attribute: &Attribute,
 ) -> PResult<'a, (CfgEntry, Vec<(ast::AttrItem, Span)>)> {
     // Parse cfg predicate
@@ -410,7 +412,7 @@ fn parse_cfg_attr_internal<'a>(
         Some(attribute.get_normal_item().unsafety),
         ParsedDescription::Attribute,
         pred_span,
-        CRATE_NODE_ID,
+        lint_node_id,
         Target::Crate,
         features,
         ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -283,9 +283,12 @@ impl<'a> StripUnconfigured<'a> {
         trace_attr.replace_args(AttrItemKind::Parsed(EarlyParsedAttribute::CfgAttrTrace));
         let trace_attr = attr_into_trace(trace_attr, sym::cfg_attr_trace);
 
-        let Some((cfg_predicate, expanded_attrs)) =
-            rustc_attr_parsing::parse_cfg_attr(cfg_attr, &self.sess, self.features)
-        else {
+        let Some((cfg_predicate, expanded_attrs)) = rustc_attr_parsing::parse_cfg_attr(
+            cfg_attr,
+            &self.sess,
+            self.features,
+            self.lint_node_id,
+        ) else {
             return vec![trace_attr];
         };
 

--- a/tests/ui/check-cfg/allow-mod-level.rs
+++ b/tests/ui/check-cfg/allow-mod-level.rs
@@ -1,0 +1,16 @@
+// This test check that a module-level `#![allow(unexpected_cfgs)]` works
+//
+// Related to https://github.com/rust-lang/rust/issues/155118
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --check-cfg=cfg()
+
+mod my_mod {
+    #![allow(unexpected_cfgs)]
+
+    #[cfg_attr(asan, sanitize(address = "off"))]
+    static MY_ITEM: () = ();
+}
+
+fn main() {}


### PR DESCRIPTION
The parsing of `#[cfg_attr]` unconditionally used the crate-root as a linting node to attach lints, but the `unexpected_cfgs` lint can fire when parsing the attribute and users expect to be able to allow it at places other than the crate-root.

Let's instead use the linting node id, which is unfortunately always the parent but that's better than the crate-root when you are in a sub-module.

The parsing of `#[cfg]` and other already use the expansion linting node id, so no change required there.

Related to https://github.com/rust-lang/rust/issues/155118

<!-- homu-ignore:start -->
r? @JonathanBrouwer
cc @jschwe 
<!-- homu-ignore:end -->
