### PR TITLE
Suggest similar target names on unrecognized `--target`

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1615,6 +1615,19 @@ pub fn build_target_config(
             let mut err =
                 early_dcx.early_struct_fatal(format!("error loading target specification: {e}"));
             err.help("run `rustc --print target-list` for a list of built-in targets");
+            let typed = target.tuple();
+            let limit = typed.len() / 3 + 1;
+            if let Some(suggestion) = rustc_target::spec::TARGETS
+                .iter()
+                .filter_map(|&t| {
+                    rustc_span::edit_distance::edit_distance_with_substrings(typed, t, limit)
+                        .map(|d| (d, t))
+                })
+                .min_by_key(|(d, _)| *d)
+                .map(|(_, t)| t)
+            {
+                err.help(format!("did you mean `{suggestion}`?"));
+            }
             err.emit()
         }
     }

--- a/tests/ui/errors/unknown-target-suggestion.rs
+++ b/tests/ui/errors/unknown-target-suggestion.rs
@@ -1,0 +1,11 @@
+// Checks that an unknown --target also suggests a similar known target.
+// See https://github.com/rust-lang/rust/issues/155085
+
+// ignore-tidy-target-specific-tests
+//@ compile-flags: --target x86_64-linux-gnu
+
+fn main() {}
+
+//~? ERROR error loading target specification: could not find specification for target "x86_64-linux-gnu"
+//~? HELP run `rustc --print target-list` for a list of built-in targets
+//~? HELP did you mean `x86_64-unknown-linux-gnu`

--- a/tests/ui/errors/unknown-target-suggestion.stderr
+++ b/tests/ui/errors/unknown-target-suggestion.stderr
@@ -1,0 +1,5 @@
+error: error loading target specification: could not find specification for target "x86_64-linux-gnu"
+  |
+  = help: run `rustc --print target-list` for a list of built-in targets
+  = help: did you mean `x86_64-unknown-linux-gnu`?
+

--- a/tests/ui/errors/wrong-target-spec.stderr
+++ b/tests/ui/errors/wrong-target-spec.stderr
@@ -1,4 +1,5 @@
 error: error loading target specification: could not find specification for target "x86_64_unknown-linux-musl"
   |
   = help: run `rustc --print target-list` for a list of built-in targets
+  = help: did you mean `x86_64-unknown-linux-musl`?
 


### PR DESCRIPTION
When an unrecognized `--target` is passed check the list of available targets and suggest the closest matching built-in target as a help message.

### Before

```
    error: error loading target specification: could not find specification for target "x86_64-linux-gnu"
      = help: run `rustc --print target-list` for a list of built-in targets
```

### After

```
    error: error loading target specification: could not find specification for target "x86_64-linux-gnu"
      = help: run `rustc --print target-list` for a list of built-in targets
      = help: did you mean `x86_64-unknown-linux-gnu`?
```

Regarding the expected test case in https://github.com/rust-lang/rust/issues/155085#issuecomment-4222050023 the `edit_distance_with_substrings` was used over `edit_distance` because in the case of `x86_64-linux-gnu` the `edit_distance` would return `x86_64-linux-android` instead of `x86_64-unknown-linux-gnu`


Fixes rust-lang/rust#155085 
