### PR TITLE
Replace custom trim_ascii_start with the standard library method

### DIFF
--- a/compiler/rustc_errors/src/markdown/parse.rs
+++ b/compiler/rustc_errors/src/markdown/parse.rs
@@ -252,7 +252,7 @@ fn parse_heading(buf: &[u8]) -> ParseResult<'_> {
 fn parse_unordered_li(buf: &[u8]) -> Parsed<'_> {
     let (txt, rest) = get_indented_section(&buf[2..]);
     let ctx = Context { .. };
-    let stream = parse_recursive(trim_ascii_start(txt), ctx);
+    let stream = parse_recursive(txt.trim_ascii_start(), ctx);
     (MdTree::UnorderedListItem(stream), rest)
 }
 
@@ -261,7 +261,7 @@ fn parse_ordered_li(buf: &[u8]) -> Parsed<'_> {
     let (num, pos) = ord_list_start(buf).unwrap(); // success tested in caller
     let (txt, rest) = get_indented_section(&buf[pos..]);
     let ctx = Context { .. };
-    let stream = parse_recursive(trim_ascii_start(txt), ctx);
+    let stream = parse_recursive(txt.trim_ascii_start(), ctx);
     (MdTree::OrderedListItem(num, stream), rest)
 }
 
@@ -576,12 +576,6 @@ fn trim_extra_ws(mut txt: &str) -> &str {
         .unwrap_or(txt.len())
         .saturating_sub(1);
     &txt[..txt.len() - end_ws]
-}
-
-/// If there is more than one whitespace char at start, trim the extras
-fn trim_ascii_start(buf: &[u8]) -> &[u8] {
-    let count = buf.iter().take_while(|ch| ch.is_ascii_whitespace()).count();
-    &buf[count..]
 }
 
 #[cfg(test)]

--- a/compiler/rustc_errors/src/markdown/tests/parse.rs
+++ b/compiler/rustc_errors/src/markdown/tests/parse.rs
@@ -377,3 +377,24 @@ fn test_codeblock_trailing_whitespace() {
     assert_eq!(t, MdTree::CodeBlock { txt: "code\n```abc\nrest", lang: Some("rust") });
     assert_eq!(r, b"");
 }
+
+#[test]
+fn test_list_item_leading_whitespace() {
+    // extra spaces after marker
+    let buf = "-   hello";
+    let (t, r) = parse_unordered_li(buf.as_bytes());
+    assert_eq!(t, MdTree::UnorderedListItem(vec![MdTree::PlainText("hello")].into()));
+    assert_eq!(r, b"");
+
+    // tab after the marker space
+    let buf = "- \thello";
+    let (t, r) = parse_unordered_li(buf.as_bytes());
+    assert_eq!(t, MdTree::UnorderedListItem(vec![MdTree::PlainText("hello")].into()));
+    assert_eq!(r, b"");
+
+    // ordered list
+    let buf = "1.   hello";
+    let (t, r) = parse_ordered_li(buf.as_bytes());
+    assert_eq!(t, MdTree::OrderedListItem(1, vec![MdTree::PlainText("hello")].into()));
+    assert_eq!(r, b"");
+}


### PR DESCRIPTION
The markdown parser in `rustc_errors` has a local `trim_ascii_start` function that strips leading ASCII whitespace from a byte slice. The standard library has had `<[u8]>::trim_ascii_start()` since Rust 1.80, which does the same thing.

This PR removes the custom function and calls the stdlib method directly in `parse_unordered_li` and `parse_ordered_li`. No behaviour change.

I also added a test covering the list item leading-whitespace trimming behaviour, including a tab case.

Fixes rustfoundation/interop-initiative#53