### PR TITLE
Enable split_debuginfo=packed/unpacked for RISC-V

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_gnu.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-
-use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SplitDebuginfo, Target, TargetMetadata, TargetOptions, base,
-};
+use crate::spec::{Arch, CodeModel, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -22,7 +18,6 @@ pub(crate) fn target() -> Target {
             features: "+m,+a,+f,+d,+c,+zicsr,+zifencei".into(),
             llvm_abiname: LlvmAbi::Ilp32d,
             max_atomic_width: Some(32),
-            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_musl.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-
-use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SplitDebuginfo, Target, TargetMetadata, TargetOptions, base,
-};
+use crate::spec::{Arch, CodeModel, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -22,7 +18,6 @@ pub(crate) fn target() -> Target {
             features: "+m,+a,+f,+d,+c,+zicsr,+zifencei".into(),
             llvm_abiname: LlvmAbi::Ilp32d,
             max_atomic_width: Some(32),
-            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_musl::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64_linux_android.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64_linux_android.rs
@@ -1,8 +1,5 @@
-use std::borrow::Cow;
-
 use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SanitizerSet, SplitDebuginfo, Target, TargetMetadata, TargetOptions,
-    base,
+    Arch, CodeModel, LlvmAbi, SanitizerSet, Target, TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -24,7 +21,6 @@ pub(crate) fn target() -> Target {
             llvm_abiname: LlvmAbi::Lp64d,
             supported_sanitizers: SanitizerSet::ADDRESS,
             max_atomic_width: Some(64),
-            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::android::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_linux_gnu.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-
-use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SplitDebuginfo, Target, TargetMetadata, TargetOptions, base,
-};
+use crate::spec::{Arch, CodeModel, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -22,7 +18,6 @@ pub(crate) fn target() -> Target {
             features: "+rva23u64".into(),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
-            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_gnu.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-
-use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SplitDebuginfo, Target, TargetMetadata, TargetOptions, base,
-};
+use crate::spec::{Arch, CodeModel, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -22,7 +18,6 @@ pub(crate) fn target() -> Target {
             features: "+m,+a,+f,+d,+c,+zicsr,+zifencei".into(),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
-            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_musl.rs
@@ -1,8 +1,4 @@
-use std::borrow::Cow;
-
-use crate::spec::{
-    Arch, CodeModel, LlvmAbi, SplitDebuginfo, Target, TargetMetadata, TargetOptions, base,
-};
+use crate::spec::{Arch, CodeModel, LlvmAbi, Target, TargetMetadata, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -22,7 +18,6 @@ pub(crate) fn target() -> Target {
             features: "+m,+a,+f,+d,+c,+zicsr,+zifencei".into(),
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
-            supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
             ..base::linux_musl::opts()
         },
     }

--- a/tests/run-make/split-debuginfo/rmake.rs
+++ b/tests/run-make/split-debuginfo/rmake.rs
@@ -44,13 +44,6 @@
 // NOTE: this is a host test
 //@ ignore-cross-compile
 
-// NOTE: this seems to be a host test, and testing on host `riscv64-gc-unknown-linux-gnu` reveals
-// that this test is failing because of [MC: "error: A dwo section may not contain relocations" when
-// building with fission + RISCV64 #56642](https://github.com/llvm/llvm-project/issues/56642). This
-// test is ignored for now to unblock efforts to bring riscv64 targets to be exercised in CI, cf.
-// [Enable riscv64gc-gnu testing #126641](https://github.com/rust-lang/rust/pull/126641).
-//@ ignore-riscv64 (https://github.com/llvm/llvm-project/issues/56642)
-
 // FIXME(#135531): the `Makefile` version practically didn't test `-C split-debuginfo` on Windows
 // at all, and lumped windows-msvc and windows-gnu together at that.
 //@ ignore-windows-gnu

--- a/tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs
+++ b/tests/ui/debuginfo/debuginfo-emit-llvm-ir-and-split-debuginfo.rs
@@ -1,6 +1,5 @@
 //@ build-pass
 //@ only-linux
-//@ ignore-riscv64 On this platform `-Csplit-debuginfo=unpacked` is unstable, see #120518
 //
 //@ compile-flags: -g --emit=llvm-ir -Csplit-debuginfo=unpacked
 //


### PR DESCRIPTION
The packed/unpacked options are disabled for this target in rust-lang/rust#120518.
Now they are implemented in LLVM 22.1: https://github.com/llvm/llvm-project/issues/56642#issuecomment-4223447929.

Note that I am not sure about the minimum supported LLVM version for rustc.
This PR could wait for some time if the minimum supported LLVM version is below 22.1 on nightly/1.96.0.

## Tests done

- [x] `build/host/stage1/bin/rustc --edition=2024 src/main.rs --crate-type bin  -C debuginfo=2 -C split-debuginfo=packed --target riscv64gc-unknown-linux-gnu -C linker=riscv64-linux-gnu-gcc`
- [x] `build/host/stage1/bin/rustc --edition=2024 src/main.rs --crate-type bin  -C debuginfo=2 -C split-debuginfo=unpacked --target riscv64gc-unknown-linux-gnu -C linker=riscv64-linux-gnu-gcc`

<details> 

<summary>run `./x test` on riscv64 linux to confirm the re-enabled tests pass. The only failure is #148748</summary>

```
failures:

---- [ui] tests/ui/explicit-tail-calls/become-indirect-return.rs stdout ----

error: test compilation failed although it shouldn't!
status: exit status: 101
command: env -u RUSTC_LOG_COLOR RUSTC_ICE="0" RUST_BACKTRACE="short" "/home/kxxt/rust/build/riscv64gc-unknown-linux-gnu/stage1/bin/rustc" "/home/kxxt/rust/tests/ui/explicit-tail-calls/become-indirect-return.rs" "-Zthreads=1" "-Zsimulate-remapped-rust-src-base=/rustc/FAKE_PREFIX" "-Ztranslate-remapped-path-to-local-path=no" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/kxxt/.cargo" "-Z" "ignore-directory-in-diagnostics-source-blocks=/home/kxxt/rust/vendor" "--sysroot" "/home/kxxt/rust/build/riscv64gc-unknown-linux-gnu/stage1" "--target=riscv64gc-unknown-linux-gnu" "--check-cfg" "cfg(test,FALSE)" "-O" "--error-format" "json" "--json" "future-incompat" "-Ccodegen-units=1" "-Zui-testing" "-Zdeduplicate-diagnostics=no" "-Zwrite-long-types-to-disk=no" "-Cstrip=debuginfo" "-C" "prefer-dynamic" "-o" "/home/kxxt/rust/build/riscv64gc-unknown-linux-gnu/test/ui/explicit-tail-calls/become-indirect-return/a" "-A" "internal_features" "-A" "unused_parens" "-A" "unused_braces" "-Crpath" "-Cdebuginfo=0" "-Lnative=/home/kxxt/rust/build/riscv64gc-unknown-linux-gnu/native/rust-test-helpers"
stdout: none
--- stderr -------------------------------
rustc-LLVM ERROR: failed to perform tail call elimination on a call site marked musttail
------------------------------------------

---- [ui] tests/ui/explicit-tail-calls/become-indirect-return.rs stdout end ----

failures:
    [ui] tests/ui/explicit-tail-calls/become-indirect-return.rs

test result: FAILED. 19741 passed; 1 failed; 404 ignored; 0 measured; 0 filtered out; finished in 541.49s

Some tests failed in compiletest suite=ui mode=ui host=riscv64gc-unknown-linux-gnu target=riscv64gc-unknown-linux-gnu
Build completed unsuccessfully in 0:11:53
```

</details>

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
