### PR TITLE
add regression test for OpenOptionsExt downstream compat

### DIFF
--- a/tests/ui/std/open-options-ext-compat.rs
+++ b/tests/ui/std/open-options-ext-compat.rs
@@ -1,0 +1,20 @@
+//@ only-windows
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/153486
+// Ensures that `OpenOptionsExt` remains implementable by downstream crates
+// without requiring changes when new methods are added to the standard library.
+
+use std::os::windows::fs::OpenOptionsExt;
+
+struct MockOptions;
+
+impl OpenOptionsExt for MockOptions {
+    fn access_mode(&mut self, _: u32) -> &mut Self { self }
+    fn share_mode(&mut self, _: u32) -> &mut Self { self }
+    fn custom_flags(&mut self, _: u32) -> &mut Self { self }
+    fn attributes(&mut self, _: u32) -> &mut Self { self }
+    fn security_qos_flags(&mut self, _: u32) -> &mut Self { self }
+}
+
+fn main() {}


### PR DESCRIPTION
Following up on rust-lang/rust#153491, which added a warning comment there, but no automated guardrail to prevent another breaking change like rust-lang/rust#149718

This adds a simple windows-only ui test that manually implements `OpenOptionsExt`. That way, if someone accidentally adds another required method to the trait, we catch it before it reaches stable and breaks downstream crates like Tokio again.

Closes rust-lang/rust#153486