### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -2,7 +2,7 @@ use std::convert::identity;
 
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::DelimSpan;
-use rustc_ast::{AttrItem, Attribute, CRATE_NODE_ID, LitKind, ast, token};
+use rustc_ast::{AttrItem, Attribute, LitKind, ast, token};
 use rustc_errors::{Applicability, PResult, msg};
 use rustc_feature::{
     AttrSuggestionStyle, AttributeTemplate, Features, GatedCfg, find_gated_cfg, template,
@@ -324,12 +324,13 @@ pub fn parse_cfg_attr(
     cfg_attr: &Attribute,
     sess: &Session,
     features: Option<&Features>,
+    lint_node_id: ast::NodeId,
 ) -> Option<(CfgEntry, Vec<(AttrItem, Span)>)> {
     match cfg_attr.get_normal_item().args.unparsed_ref().unwrap() {
         ast::AttrArgs::Delimited(ast::DelimArgs { dspan, delim, tokens }) if !tokens.is_empty() => {
             check_cfg_attr_bad_delim(&sess.psess, *dspan, *delim);
             match parse_in(&sess.psess, tokens.clone(), "`cfg_attr` input", |p| {
-                parse_cfg_attr_internal(p, sess, features, cfg_attr)
+                parse_cfg_attr_internal(p, sess, features, lint_node_id, cfg_attr)
             }) {
                 Ok(r) => return Some(r),
                 Err(e) => {
@@ -390,6 +391,7 @@ fn parse_cfg_attr_internal<'a>(
     parser: &mut Parser<'a>,
     sess: &'a Session,
     features: Option<&Features>,
+    lint_node_id: ast::NodeId,
     attribute: &Attribute,
 ) -> PResult<'a, (CfgEntry, Vec<(ast::AttrItem, Span)>)> {
     // Parse cfg predicate
@@ -410,7 +412,7 @@ fn parse_cfg_attr_internal<'a>(
         Some(attribute.get_normal_item().unsafety),
         ParsedDescription::Attribute,
         pred_span,
-        CRATE_NODE_ID,
+        lint_node_id,
         Target::Crate,
         features,
         ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -78,7 +78,7 @@ pub fn parse_cfg<S: Stage>(
             }
         }
 
-        adcx.expected_single_argument(list.span);
+        adcx.expected_single_argument(list.span, list.len());
         return None;
     };
     parse_cfg_entry(cx, single).ok()
@@ -93,7 +93,7 @@ pub fn parse_cfg_entry<S: Stage>(
             ArgParser::List(list) => match meta.path().word_sym() {
                 Some(sym::not) => {
                     let Some(single) = list.single() else {
-                        return Err(cx.adcx().expected_single_argument(list.span));
+                        return Err(cx.adcx().expected_single_argument(list.span, list.len()));
                     };
                     CfgEntry::Not(Box::new(parse_cfg_entry(cx, single)?), list.span)
                 }

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -30,7 +30,7 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
         };
 
         let Some(single) = list.single() else {
-            cx.adcx().expected_single_argument(list.span);
+            cx.adcx().expected_single_argument(list.span, list.len());
             return None;
         };
 
@@ -91,7 +91,7 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
         };
 
         let Some(arg) = args.single() else {
-            cx.adcx().expected_single_argument(args.span);
+            cx.adcx().expected_single_argument(args.span, args.len());
             return None;
         };
 
@@ -394,7 +394,7 @@ impl<S: Stage> AttributeParser<S> for UsedParser {
                 ArgParser::NoArgs => UsedBy::Default,
                 ArgParser::List(list) => {
                     let Some(l) = list.single() else {
-                        cx.adcx().expected_single_argument(list.span);
+                        cx.adcx().expected_single_argument(list.span, list.len());
                         return;
                     };
 

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -737,7 +737,7 @@ impl<S: Stage> SingleAttributeParser<S> for PatchableFunctionEntryParser {
         let mut entry = None;
 
         if meta_item_list.len() == 0 {
-            cx.adcx().expected_list(meta_item_list.span, args);
+            cx.adcx().expected_at_least_one_argument(meta_item_list.span);
             return None;
         }
 

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -23,16 +23,7 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["size", "speed", "none"]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
-        let Some(list) = args.list() else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_list(attr_span, args);
-            return None;
-        };
-
-        let Some(single) = list.single() else {
-            cx.adcx().expected_single_argument(list.span, list.len());
-            return None;
-        };
+        let single = cx.single_element_list(args, cx.attr_span)?;
 
         let res = match single.meta_item().and_then(|i| i.path().word().map(|i| i.name)) {
             Some(sym::size) => OptimizeAttr::Size,
@@ -84,22 +75,13 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::off, sym::on]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
-        let Some(args) = args.list() else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_specific_argument_and_list(attr_span, &[sym::on, sym::off]);
-            return None;
-        };
-
-        let Some(arg) = args.single() else {
-            cx.adcx().expected_single_argument(args.span, args.len());
-            return None;
-        };
+        let arg = cx.single_element_list(args, cx.attr_span)?;
 
         let mut fail_incorrect_argument =
             |span| cx.adcx().expected_specific_argument(span, &[sym::on, sym::off]);
 
         let Some(arg) = arg.meta_item() else {
-            fail_incorrect_argument(args.span);
+            fail_incorrect_argument(arg.span());
             return None;
         };
 

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -26,7 +26,7 @@ impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
             return None;
         };
         let Some(single) = l.single() else {
-            cx.adcx().expected_single_argument(l.span);
+            cx.adcx().expected_single_argument(l.span, l.len());
             return None;
         };
         let Some(mi) = single.meta_item() else {

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -20,15 +20,7 @@ impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
         cx: &mut AcceptContext<'_, '_, S>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
-        let Some(l) = args.list() else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_list(attr_span, args);
-            return None;
-        };
-        let Some(single) = l.single() else {
-            cx.adcx().expected_single_argument(l.span, l.len());
-            return None;
-        };
+        let single = cx.single_element_list(args, cx.attr_span)?;
         let Some(mi) = single.meta_item() else {
             cx.adcx().expected_name_value(single.span(), None);
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -38,7 +38,7 @@ impl<S: Stage> SingleAttributeParser<S> for InlineParser {
             ArgParser::NoArgs => Some(AttributeKind::Inline(InlineAttr::Hint, cx.attr_span)),
             ArgParser::List(list) => {
                 let Some(l) = list.single() else {
-                    cx.adcx().expected_single_argument(list.span);
+                    cx.adcx().expected_single_argument(list.span, list.len());
                     return None;
                 };
 
@@ -80,7 +80,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcForceInlineParser {
             ArgParser::NoArgs => None,
             ArgParser::List(list) => {
                 let Some(l) = list.single() else {
-                    cx.adcx().expected_single_argument(list.span);
+                    cx.adcx().expected_single_argument(list.span, list.len());
                     return None;
                 };
 

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -20,11 +20,7 @@ impl<S: Stage> SingleAttributeParser<S> for InstructionSetParser {
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         const POSSIBLE_SYMBOLS: &[Symbol] = &[sym::arm_a32, sym::arm_t32];
         const POSSIBLE_ARM_SYMBOLS: &[Symbol] = &[sym::a32, sym::t32];
-        let Some(maybe_meta_item) = args.list().and_then(MetaItemListParser::single) else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_specific_argument(attr_span, POSSIBLE_SYMBOLS);
-            return None;
-        };
+        let maybe_meta_item = cx.single_element_list(args, cx.attr_span)?;
 
         let Some(meta_item) = maybe_meta_item.meta_item() else {
             cx.adcx().expected_specific_argument(maybe_meta_item.span(), POSSIBLE_SYMBOLS);

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -393,7 +393,7 @@ impl LinkParser {
             return true;
         };
         let Some(link_cfg) = link_cfg.single() else {
-            cx.adcx().expected_single_argument(item.span());
+            cx.adcx().expected_single_argument(item.span(), link_cfg.len());
             return true;
         };
         if !features.link_cfg() {

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -388,12 +388,7 @@ impl LinkParser {
             cx.adcx().duplicate_key(item.span(), sym::cfg);
             return true;
         }
-        let Some(link_cfg) = item.args().list() else {
-            cx.adcx().expected_list(item.span(), item.args());
-            return true;
-        };
-        let Some(link_cfg) = link_cfg.single() else {
-            cx.adcx().expected_single_argument(item.span(), link_cfg.len());
+        let Some(link_cfg) = cx.single_element_list(item.args(), item.span()) else {
             return true;
         };
         if !features.link_cfg() {

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -181,7 +181,7 @@ impl<S: Stage> SingleAttributeParser<S> for CollapseDebugInfoParser {
             return None;
         };
         let Some(single) = list.single() else {
-            cx.adcx().expected_single_argument(list.span);
+            cx.adcx().expected_single_argument(list.span, list.len());
             return None;
         };
         let Some(mi) = single.meta_item() else {

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -175,15 +175,7 @@ impl<S: Stage> SingleAttributeParser<S> for CollapseDebugInfoParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
-        let Some(list) = args.list() else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_list(attr_span, args);
-            return None;
-        };
-        let Some(single) = list.single() else {
-            cx.adcx().expected_single_argument(list.span, list.len());
-            return None;
-        };
+        let single = cx.single_element_list(args, cx.attr_span)?;
         let Some(mi) = single.meta_item() else {
             cx.adcx().expected_not_literal(single.span());
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -82,7 +82,7 @@ fn extract_value<S: Stage>(
     }
 
     let Some(val) = arg.name_value() else {
-        cx.adcx().expected_single_argument(arg.span().unwrap_or(span));
+        cx.adcx().expected_single_argument(arg.span().unwrap_or(span), 2);
         *failed = true;
         return;
     };

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -82,7 +82,7 @@ fn extract_value<S: Stage>(
     }
 
     let Some(val) = arg.name_value() else {
-        cx.adcx().expected_single_argument(arg.span().unwrap_or(span), 2);
+        cx.adcx().expected_name_value(span, Some(key));
         *failed = true;
         return;
     };

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -297,7 +297,7 @@ impl RustcAlignParser {
             }
             ArgParser::List(list) => {
                 let Some(align) = list.single() else {
-                    cx.adcx().expected_single_argument(list.span);
+                    cx.adcx().expected_single_argument(list.span, list.len());
                     return;
                 };
 

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -197,7 +197,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLintOptDenyFieldAccessParser {
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(arg) = args.list().and_then(MetaItemListParser::single) else {
             let attr_span = cx.attr_span;
-            cx.adcx().expected_single_argument(attr_span);
+            cx.adcx().expected_single_argument(attr_span, 2);
             return None;
         };
 
@@ -382,7 +382,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDeprecatedSafe2024Parser {
         };
 
         let Some(single) = args.single() else {
-            cx.adcx().expected_single_argument(args.span);
+            cx.adcx().expected_single_argument(args.span, args.len());
             return None;
         };
 
@@ -1022,7 +1022,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcIfThisChangedParser {
             ArgParser::List(list) => {
                 let Some(item) = list.single() else {
                     let attr_span = cx.attr_span;
-                    cx.adcx().expected_single_argument(attr_span);
+                    cx.adcx().expected_single_argument(attr_span, list.len());
                     return None;
                 };
                 let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {
@@ -1084,7 +1084,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcThenThisWouldNeedParser {
         }
         let Some(item) = args.list().and_then(|l| l.single()) else {
             let inner_span = cx.inner_span;
-            cx.adcx().expected_single_argument(inner_span);
+            cx.adcx().expected_single_argument(inner_span, 2);
             return None;
         };
         let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -195,11 +195,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLintOptDenyFieldAccessParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Field)]);
     const TEMPLATE: AttributeTemplate = template!(Word);
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
-        let Some(arg) = args.list().and_then(MetaItemListParser::single) else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_single_argument(attr_span, 2);
-            return None;
-        };
+        let arg = cx.single_element_list(args, cx.attr_span)?;
 
         let MetaItemOrLitParser::Lit(MetaItemLit { kind: LitKind::Str(lint_message, _), .. }) = arg
         else {
@@ -375,19 +371,10 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDeprecatedSafe2024Parser {
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"audit_that = "...""#]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
-        let Some(args) = args.list() else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_list(attr_span, args);
-            return None;
-        };
-
-        let Some(single) = args.single() else {
-            cx.adcx().expected_single_argument(args.span, args.len());
-            return None;
-        };
+        let single = cx.single_element_list(args, cx.attr_span)?;
 
         let Some(arg) = single.meta_item() else {
-            cx.adcx().expected_name_value(args.span, None);
+            cx.adcx().expected_name_value(single.span(), None);
             return None;
         };
 
@@ -1082,11 +1069,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcThenThisWouldNeedParser {
         if !cx.cx.sess.opts.unstable_opts.query_dep_graph {
             cx.emit_err(AttributeRequiresOpt { span: cx.attr_span, opt: "-Z query-dep-graph" });
         }
-        let Some(item) = args.list().and_then(|l| l.single()) else {
-            let inner_span = cx.inner_span;
-            cx.adcx().expected_single_argument(inner_span, 2);
-            return None;
-        };
+        let item = cx.single_element_list(args, cx.attr_span)?;
         let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {
             cx.adcx().expected_identifier(item.span());
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -72,7 +72,7 @@ impl<S: Stage> SingleAttributeParser<S> for ShouldPanicParser {
                 }
                 ArgParser::List(list) => {
                     let Some(single) = list.single() else {
-                        cx.adcx().expected_single_argument(list.span);
+                        cx.adcx().expected_single_argument(list.span, list.len());
                         return None;
                     };
                     let Some(single) = single.meta_item() else {
@@ -150,7 +150,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAbiParser {
 
         let Some(arg) = args.single() else {
             let attr_span = cx.attr_span;
-            cx.adcx().expected_single_argument(attr_span);
+            cx.adcx().expected_single_argument(attr_span, args.len());
             return None;
         };
 
@@ -215,7 +215,7 @@ impl<S: Stage> SingleAttributeParser<S> for TestRunnerParser {
         };
 
         let Some(single) = list.single() else {
-            cx.adcx().expected_single_argument(list.span);
+            cx.adcx().expected_single_argument(list.span, list.len());
             return None;
         };
 

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -208,16 +208,7 @@ impl<S: Stage> SingleAttributeParser<S> for TestRunnerParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["path"]);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
-        let Some(list) = args.list() else {
-            let attr_span = cx.attr_span;
-            cx.adcx().expected_list(attr_span, args);
-            return None;
-        };
-
-        let Some(single) = list.single() else {
-            cx.adcx().expected_single_argument(list.span, list.len());
-            return None;
-        };
+        let single = cx.single_element_list(args, cx.attr_span)?;
 
         let Some(meta) = single.meta_item() else {
             cx.adcx().expected_not_literal(single.span());

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -41,15 +41,7 @@ pub(crate) fn parse_single_integer<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     args: &ArgParser,
 ) -> Option<u128> {
-    let Some(list) = args.list() else {
-        let attr_span = cx.attr_span;
-        cx.adcx().expected_list(attr_span, args);
-        return None;
-    };
-    let Some(single) = list.single() else {
-        cx.adcx().expected_single_argument(list.span, list.len());
-        return None;
-    };
+    let single = cx.single_element_list(args, cx.attr_span)?;
     let Some(lit) = single.lit() else {
         cx.adcx().expected_integer_literal(single.span());
         return None;

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -47,7 +47,7 @@ pub(crate) fn parse_single_integer<S: Stage>(
         return None;
     };
     let Some(single) = list.single() else {
-        cx.adcx().expected_single_argument(list.span);
+        cx.adcx().expected_single_argument(list.span, list.len());
         return None;
     };
     let Some(lit) = single.lit() else {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -751,8 +751,22 @@ where
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedNotLiteral)
     }
 
-    pub(crate) fn expected_single_argument(&mut self, span: Span) -> ErrorGuaranteed {
-        self.emit_parse_error(span, AttributeParseErrorReason::ExpectedSingleArgument)
+    /// Signals that we expected exactly one argument and that we got either zero or two or more.
+    /// The `provided_arguments` argument allows distinguishing between "expected an argument here"
+    /// (when zero arguments are provided) and "expect a single argument here" (when two or more
+    /// arguments are provided).
+    pub(crate) fn expected_single_argument(
+        &mut self,
+        span: Span,
+        provided_arguments: usize,
+    ) -> ErrorGuaranteed {
+        let reason = if provided_arguments == 0 {
+            AttributeParseErrorReason::ExpectedArgument
+        } else {
+            AttributeParseErrorReason::ExpectedSingleArgument
+        };
+
+        self.emit_parse_error(span, reason)
     }
 
     pub(crate) fn expected_at_least_one_argument(&mut self, span: Span) -> ErrorGuaranteed {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -60,7 +60,7 @@ use crate::attributes::test_attrs::*;
 use crate::attributes::traits::*;
 use crate::attributes::transparency::*;
 use crate::attributes::{AttributeParser as _, Combine, Single, WithoutArgs};
-use crate::parser::{ArgParser, RefPathParser};
+use crate::parser::{ArgParser, MetaItemOrLitParser, RefPathParser};
 use crate::session_diagnostics::{
     AttributeParseError, AttributeParseErrorReason, AttributeParseErrorSuggestions,
     ParsedDescription,
@@ -502,6 +502,36 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
     pub(crate) fn adcx(&mut self) -> AttributeDiagnosticContext<'_, 'f, 'sess, S> {
         AttributeDiagnosticContext { ctx: self, custom_suggestions: Vec::new() }
     }
+
+    /// Asserts that this MetaItem is a list that contains a single element. Emits an error and
+    /// returns `None` if it is not the case.
+    ///
+    /// Some examples:
+    ///
+    /// - In `#[allow(warnings)]`, `warnings` is returned
+    /// - In `#[cfg_attr(docsrs, doc = "foo")]`, `None` is returned, "expected a single argument
+    ///   here" is emitted.
+    /// - In `#[cfg()]`, `None` is returned, "expected an argument here" is emitted.
+    ///
+    /// The provided span is used as a fallback for diagnostic generation in case `arg` does not
+    /// contain any. It should be the span of the node that contains `arg`.
+    pub(crate) fn single_element_list<'arg>(
+        &mut self,
+        arg: &'arg ArgParser,
+        span: Span,
+    ) -> Option<&'arg MetaItemOrLitParser> {
+        let ArgParser::List(l) = arg else {
+            self.adcx().expected_list(span, arg);
+            return None;
+        };
+
+        let Some(single) = l.single() else {
+            self.adcx().expected_single_argument(l.span, l.len());
+            return None;
+        };
+
+        Some(single)
+    }
 }
 
 impl<'f, 'sess, S: Stage> Deref for AcceptContext<'f, 'sess, S> {
@@ -689,6 +719,8 @@ where
         )
     }
 
+    /// The provided span is used as a fallback in case `args` does not contain any. It should be
+    /// the span of the node that contains `args`.
     pub(crate) fn expected_list(&mut self, span: Span, args: &ArgParser) -> ErrorGuaranteed {
         let span = match args {
             ArgParser::NoArgs => span,
@@ -745,7 +777,7 @@ where
         self.emit_parse_error(span, AttributeParseErrorReason::DuplicateKey(key))
     }
 
-    /// An error that should be emitted when a [`MetaItemOrLitParser`](crate::parser::MetaItemOrLitParser)
+    /// An error that should be emitted when a [`MetaItemOrLitParser`]
     /// was expected *not* to be a literal, but instead a meta item.
     pub(crate) fn expected_not_literal(&mut self, span: Span) -> ErrorGuaranteed {
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedNotLiteral)

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -557,6 +557,7 @@ pub(crate) enum AttributeParseErrorReason<'a> {
         upper_bound: isize,
     },
     ExpectedAtLeastOneArgument,
+    ExpectedArgument,
     ExpectedSingleArgument,
     ExpectedList,
     ExpectedListOrNoArgs,
@@ -775,6 +776,10 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
             }
             AttributeParseErrorReason::ExpectedSingleArgument => {
                 diag.span_label(self.span, "expected a single argument here");
+                diag.code(E0805);
+            }
+            AttributeParseErrorReason::ExpectedArgument => {
+                diag.span_label(self.span, "expected an argument here");
                 diag.code(E0805);
             }
             AttributeParseErrorReason::ExpectedAtLeastOneArgument => {

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -283,9 +283,12 @@ impl<'a> StripUnconfigured<'a> {
         trace_attr.replace_args(AttrItemKind::Parsed(EarlyParsedAttribute::CfgAttrTrace));
         let trace_attr = attr_into_trace(trace_attr, sym::cfg_attr_trace);
 
-        let Some((cfg_predicate, expanded_attrs)) =
-            rustc_attr_parsing::parse_cfg_attr(cfg_attr, &self.sess, self.features)
-        else {
+        let Some((cfg_predicate, expanded_attrs)) = rustc_attr_parsing::parse_cfg_attr(
+            cfg_attr,
+            &self.sess,
+            self.features,
+            self.lint_node_id,
+        ) else {
             return vec![trace_attr];
         };
 

--- a/tests/rustdoc-ui/doc-cfg.stderr
+++ b/tests/rustdoc-ui/doc-cfg.stderr
@@ -4,7 +4,7 @@ error[E0805]: malformed `doc` attribute input
 LL | #[doc(cfg(), cfg(foo, bar))]
    | ^^^^^^^^^--^^^^^^^^^^^^^^^^^
    |          |
-   |          expected a single argument here
+   |          expected an argument here
    |
 help: if the function should be disabled, use `#[cfg(false)]`
    |
@@ -36,7 +36,7 @@ error[E0805]: malformed `doc` attribute input
 LL | #[doc(cfg())]
    | ^^^^^^^^^--^^
    |          |
-   |          expected a single argument here
+   |          expected an argument here
    |
 help: if the function should be disabled, use `#[cfg(false)]`
    |

--- a/tests/ui/attributes/inline/invalid-inline.stderr
+++ b/tests/ui/attributes/inline/invalid-inline.stderr
@@ -25,7 +25,7 @@ error[E0805]: malformed `inline` attribute input
 LL | #[inline()]
    | ^^^^^^^^--^
    |         |
-   |         expected a single argument here
+   |         expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -314,7 +314,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/malformed-attrs.rs:92:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -353,7 +353,7 @@ error[E0539]: malformed `instruction_set` attribute input
 LL | #[instruction_set]
    | ^^^^^^^^^^^^^^^^^^
    | |
-   | valid arguments are `arm::a32` or `arm::t32`
+   | expected this to be a list
    | help: must be of the form: `#[instruction_set(set)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -242,7 +242,7 @@ error[E0805]: malformed `used` attribute input
 LL | #[used()]
    | ^^^^^^--^
    |       |
-   |       expected a single argument here
+   |       expected an argument here
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/cfg/suggest-any-or-all.stderr
+++ b/tests/ui/cfg/suggest-any-or-all.stderr
@@ -24,7 +24,7 @@ error[E0805]: malformed `cfg` attribute input
 LL | #[cfg()]
    | ^^^^^--^
    |      |
-   |      expected a single argument here
+   |      expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: if the struct should be disabled, use `#[cfg(false)]`

--- a/tests/ui/check-cfg/allow-mod-level.rs
+++ b/tests/ui/check-cfg/allow-mod-level.rs
@@ -1,0 +1,16 @@
+// This test check that a module-level `#![allow(unexpected_cfgs)]` works
+//
+// Related to https://github.com/rust-lang/rust/issues/155118
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --check-cfg=cfg()
+
+mod my_mod {
+    #![allow(unexpected_cfgs)]
+
+    #[cfg_attr(asan, sanitize(address = "off"))]
+    static MY_ITEM: () = ();
+}
+
+fn main() {}

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.rs
@@ -12,7 +12,7 @@ struct S2;
 
 #[cfg()]
 //~^ ERROR malformed `cfg` attribute
-//~| NOTE expected a single argument here
+//~| NOTE expected an argument here
 //~| NOTE for more information, visit
 struct S3;
 

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -26,7 +26,7 @@ error[E0805]: malformed `cfg` attribute input
 LL | #[cfg()]
    | ^^^^^--^
    |      |
-   |      expected a single argument here
+   |      expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: if the struct should be disabled, use `#[cfg(false)]`

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -123,7 +123,7 @@ error[E0805]: malformed `inline` attribute input
 LL | #[cfg_attr(true, inline())]
    |                  ^^^^^^--
    |                        |
-   |                        expected a single argument here
+   |                        expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -2,7 +2,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/bad-attr-ice.rs:11:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -12,7 +12,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/bad-attr-ice.rs:11:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -26,7 +26,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/bad-syntax.rs:17:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -39,7 +39,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/bad-syntax.rs:20:1
    |
 LL | #[coverage = true]
-   | ^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -56,7 +56,7 @@ error[E0805]: malformed `coverage` attribute input
 LL | #[coverage()]
    | ^^^^^^^^^^--^
    |           |
-   |           expected a single argument here
+   |           expected an argument here
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -2,7 +2,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:12:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -17,7 +19,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:17:5
    |
 LL |     #![coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^^-------^
+   |                 |
+   |                 expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -32,7 +36,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:21:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -55,7 +61,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:26:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -70,7 +78,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:29:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^-------^
+   |                |
+   |                expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -93,7 +103,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:35:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -116,7 +128,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:39:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^-------^
+   |                |
+   |                expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -139,7 +153,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:44:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^-------^
+   |                |
+   |                expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -162,7 +178,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:50:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -177,7 +195,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:53:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^-------^
+   |                |
+   |                expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -200,7 +220,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:58:5
    |
 LL |     #[coverage = "off"]
-   |     ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^-------^
+   |                |
+   |                expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -223,7 +245,9 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/name-value.rs:64:1
    |
 LL | #[coverage = "off"]
-   | ^^^^^^^^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^-------^
+   |            |
+   |            expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -2,7 +2,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:12:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -15,7 +15,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:17:5
    |
 LL |     #![coverage]
-   |     ^^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -28,7 +28,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:21:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -49,7 +49,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:26:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -62,7 +62,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:29:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -83,7 +83,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:35:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -104,7 +104,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:39:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -125,7 +125,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:44:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -146,7 +146,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:50:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -159,7 +159,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:53:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -180,7 +180,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:58:5
    |
 LL |     #[coverage]
-   |     ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   |     ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |
@@ -201,7 +201,7 @@ error[E0539]: malformed `coverage` attribute input
   --> $DIR/word-only.rs:64:1
    |
 LL | #[coverage]
-   | ^^^^^^^^^^^ this attribute is only valid with either `on` or `off` as an argument
+   | ^^^^^^^^^^^ expected this to be a list
    |
 help: try changing it to one of the following valid forms of the attribute
    |

--- a/tests/ui/error-codes/E0540.stderr
+++ b/tests/ui/error-codes/E0540.stderr
@@ -4,7 +4,7 @@ error[E0805]: malformed `inline` attribute input
 LL | #[inline()]
    | ^^^^^^^^--^
    |         |
-   |         expected a single argument here
+   |         expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
 help: try changing it to one of the following valid forms of the attribute

--- a/tests/ui/link-native-libs/issue-43926.stderr
+++ b/tests/ui/link-native-libs/issue-43926.stderr
@@ -4,7 +4,7 @@ error[E0805]: malformed `link` attribute input
 LL | #[link(name = "foo", cfg())]
    | ^^^^^^^^^^^^^^^^^^^^^-----^^
    |                      |
-   |                      expected a single argument here
+   |                      expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/link-native-libs/issue-43926.stderr
+++ b/tests/ui/link-native-libs/issue-43926.stderr
@@ -2,9 +2,9 @@ error[E0805]: malformed `link` attribute input
   --> $DIR/issue-43926.rs:1:1
    |
 LL | #[link(name = "foo", cfg())]
-   | ^^^^^^^^^^^^^^^^^^^^^-----^^
-   |                      |
-   |                      expected an argument here
+   | ^^^^^^^^^^^^^^^^^^^^^^^^--^^
+   |                         |
+   |                         expected an argument here
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.rs
@@ -2,12 +2,12 @@
 extern "C" {
     #[link_ordinal()]
     //~^ ERROR malformed `link_ordinal` attribute input
-    //~| NOTE  expected a single argument
+    //~| NOTE expected an argument here
     //~| NOTE for more information, visit
     fn foo();
     #[link_ordinal()]
     //~^ ERROR malformed `link_ordinal` attribute input
-    //~| NOTE  expected a single argument
+    //~| NOTE expected an argument here
     //~| NOTE for more information, visit
     static mut imported_variable: i32;
 }

--- a/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/link-ordinal-missing-argument.stderr
@@ -4,7 +4,7 @@ error[E0805]: malformed `link_ordinal` attribute input
 LL |     #[link_ordinal()]
    |     ^^^^^^^^^^^^^^--^
    |     |             |
-   |     |             expected a single argument here
+   |     |             expected an argument here
    |     help: must be of the form: `#[link_ordinal(ordinal)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>
@@ -15,7 +15,7 @@ error[E0805]: malformed `link_ordinal` attribute input
 LL |     #[link_ordinal()]
    |     ^^^^^^^^^^^^^^--^
    |     |             |
-   |     |             expected a single argument here
+   |     |             expected an argument here
    |     help: must be of the form: `#[link_ordinal(ordinal)]`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute>

--- a/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
+++ b/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
@@ -40,7 +40,7 @@ error[E0539]: malformed `patchable_function_entry` attribute input
 LL | #[patchable_function_entry()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^--^
    | |                         |
-   | |                         expected this to be a list
+   | |                         expected at least 1 argument here
    | help: must be of the form: `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
 
 error[E0538]: malformed `patchable_function_entry` attribute input

--- a/tests/ui/span/E0805.stderr
+++ b/tests/ui/span/E0805.stderr
@@ -4,7 +4,7 @@ error[E0805]: malformed `cfg` macro input
 LL |     if cfg!(not()) { }
    |        ^^^^^^^^--^
    |        |       |
-   |        |       expected a single argument here
+   |        |       expected an argument here
    |        help: must be of the form: `cfg!(predicate)`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154827 (distinguish "expected a single argument" and "expected an argument" on attribute parsing)
 - rust-lang/rust#155120 (Use a linting node closer the parsing of `#[cfg_attr]`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154827,155120)
<!-- homu-ignore:end -->

