### PR TITLE
Fix ICE when using attributes on delegation items

### DIFF
--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -1335,7 +1335,7 @@ impl<'tcx> ItemCollector<'tcx> {
             let delayed_kinds =
                 krate.delayed_ids.iter().copied().map(|id| (id, krate.owners[id].expect_delayed()));
 
-            // FIXME(fn_delegation): need to add delayed lints, eiis
+            // FIXME(fn_delegation): need to add eiis
             for (def_id, kind) in delayed_kinds {
                 let owner_id = OwnerId { def_id };
 
@@ -1350,6 +1350,9 @@ impl<'tcx> ItemCollector<'tcx> {
                 };
 
                 collector.body_owners.push(def_id);
+                // Delegation items are skipped by the HIR walk (see `visit_if_delayed`),
+                // so we have to account for their delayed lints manually.
+                collector.delayed_lint_items.push(owner_id);
             }
         }
 

--- a/tests/ui/delegation/ice-issue-155127.rs
+++ b/tests/ui/delegation/ice-issue-155127.rs
@@ -1,0 +1,17 @@
+// https://github.com/rust-lang/rust/issues/155127
+
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+struct S;
+
+fn foo() {}
+
+impl S {
+    #[deprecated]
+    //~^ ERROR `#[deprecated]` attribute cannot be used on delegations
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    reuse foo;
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-issue-155127.stderr
+++ b/tests/ui/delegation/ice-issue-155127.stderr
@@ -1,0 +1,12 @@
+error: `#[deprecated]` attribute cannot be used on delegations
+  --> $DIR/ice-issue-155127.rs:11:5
+   |
+LL |     #[deprecated]
+   |     ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
+   = note: `#[deny(useless_deprecated)]` on by default
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Delegation items are skipped by `hir_walk_toplevel_module` (via
`visit_if_delayed`), so they were never added to `delayed_lint_items`.
This caused a debug assertion failure in `emit_ast_lowering_delayed_lints`
when an attribute like `#[deprecated]` generated a delayed lint on the item.

The FIXME in `ItemCollector::new` already noted this gap.

Fixes rust-lang/rust#155127

