### PR TITLE
replace <name> @ ty::AliasTy matches with just using args: <name>_args

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/opaque_types.rs
@@ -219,12 +219,12 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for FindOpaqueRegion<'_, 'tcx> {
     fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
         // If we find an opaque in a local ty, then for each of its captured regions,
         // try to find a path between that captured regions and our borrow region...
-        if let ty::Alias(opaque @ ty::AliasTy { kind: ty::Opaque { def_id }, .. }) = *ty.kind()
+        if let ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) = *ty.kind()
             && let hir::OpaqueTyOrigin::FnReturn { parent, in_trait_or_impl: None } =
                 self.tcx.opaque_ty_origin(def_id)
         {
             let variances = self.tcx.variances_of(def_id);
-            for (idx, (arg, variance)) in std::iter::zip(opaque.args, variances).enumerate() {
+            for (idx, (arg, variance)) in std::iter::zip(args, variances).enumerate() {
                 // Skip uncaptured args.
                 if *variance == ty::Bivariant {
                     continue;
@@ -276,12 +276,12 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for CheckExplicitRegionMentionAndCollectGen
 
     fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
         match *ty.kind() {
-            ty::Alias(opaque @ ty::AliasTy { kind: ty::Opaque { def_id }, .. }) => {
+            ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => {
                 if self.seen_opaques.insert(def_id) {
                     for (bound, _) in self
                         .tcx
                         .explicit_item_bounds(def_id)
-                        .iter_instantiated_copied(self.tcx, opaque.args)
+                        .iter_instantiated_copied(self.tcx, args)
                     {
                         bound.visit_with(self)?;
                     }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -523,8 +523,8 @@ fn sanity_check_found_hidden_type<'tcx>(
         // Nothing was actually constrained.
         return Ok(());
     }
-    if let &ty::Alias(alias @ ty::AliasTy { kind: ty::Opaque { def_id }, .. }) = ty.ty.kind() {
-        if def_id == key.def_id.to_def_id() && alias.args == key.args {
+    if let &ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) = ty.ty.kind() {
+        if def_id == key.def_id.to_def_id() && args == key.args {
             // Nothing was actually constrained, this is an opaque usage that was
             // only discovered to be opaque after inference vars resolved.
             return Ok(());

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -820,24 +820,25 @@ where
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        if let &ty::Alias(proj @ ty::AliasTy { kind: ty::Projection { def_id }, .. }) = ty.kind()
+        if let &ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args: proj_args, .. }) =
+            ty.kind()
             && self.cx().is_impl_trait_in_trait(def_id)
         {
             if let Some((ty, _)) = self.types.get(&def_id) {
                 return *ty;
             }
             //FIXME(RPITIT): Deny nested RPITIT in args too
-            if proj.args.has_escaping_bound_vars() {
+            if proj_args.has_escaping_bound_vars() {
                 bug!("FIXME(RPITIT): error here");
             }
             // Replace with infer var
             let infer_ty = self.ocx.infcx.next_ty_var(self.span);
-            self.types.insert(def_id, (infer_ty, proj.args));
+            self.types.insert(def_id, (infer_ty, proj_args));
             // Recurse into bounds
             for (pred, pred_span) in self
                 .cx()
                 .explicit_item_bounds(def_id)
-                .iter_instantiated_copied(self.cx(), proj.args)
+                .iter_instantiated_copied(self.cx(), proj_args)
             {
                 let pred = pred.fold_with(self);
                 let pred = self.ocx.normalize(
@@ -2707,8 +2708,8 @@ fn param_env_with_gat_bounds<'tcx>(
         let bound_vars = tcx.mk_bound_variable_kinds(&bound_vars);
 
         match normalize_impl_ty.kind() {
-            &ty::Alias(proj @ ty::AliasTy { kind: ty::Projection { def_id }, .. })
-                if def_id == trait_ty.def_id && proj.args == rebased_args =>
+            &ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
+                if def_id == trait_ty.def_id && args == rebased_args =>
             {
                 // Don't include this predicate if the projected type is
                 // exactly the same as the projection. This can occur in

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs
@@ -308,9 +308,9 @@ fn report_mismatched_rpitit_signature<'tcx>(
     let mut return_ty = trait_m_sig.output().fold_with(&mut super::RemapLateParam { tcx, mapping });
 
     if tcx.asyncness(impl_m_def_id).is_async() && tcx.asyncness(trait_m_def_id).is_async() {
-        let &ty::Alias(
-            future_ty @ ty::AliasTy { kind: ty::Projection { def_id: future_ty_def_id }, .. },
-        ) = return_ty.kind()
+        let &ty::Alias(ty::AliasTy {
+            kind: ty::Projection { def_id: future_ty_def_id }, args, ..
+        }) = return_ty.kind()
         else {
             span_bug!(
                 tcx.def_span(trait_m_def_id),
@@ -319,7 +319,7 @@ fn report_mismatched_rpitit_signature<'tcx>(
         };
         let Some(future_output_ty) = tcx
             .explicit_item_bounds(future_ty_def_id)
-            .iter_instantiated_copied(tcx, future_ty.args)
+            .iter_instantiated_copied(tcx, args)
             .find_map(|(clause, _)| match clause.kind().no_bound_vars()? {
                 ty::ClauseKind::Projection(proj) => proj.term.as_type(),
                 _ => None,

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -773,10 +773,10 @@ impl<'tcx> GATArgsCollector<'tcx> {
 impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for GATArgsCollector<'tcx> {
     fn visit_ty(&mut self, t: Ty<'tcx>) {
         match t.kind() {
-            &ty::Alias(p @ ty::AliasTy { kind: ty::Projection { def_id }, .. })
+            &ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
                 if def_id == self.gat =>
             {
-                for (idx, arg) in p.args.iter().enumerate() {
+                for (idx, arg) in args.iter().enumerate() {
                     match arg.kind() {
                         GenericArgKind::Lifetime(lt) if !lt.is_bound() => {
                             self.regions.insert((lt, idx));

--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -549,17 +549,16 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTyToOpaque<'tcx> {
     }
 
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        if let &ty::Alias(
-            projection_ty @ ty::AliasTy {
-                kind: ty::Projection { def_id: projection_ty_def_id },
-                ..
-            },
-        ) = ty.kind()
+        if let &ty::Alias(ty::AliasTy {
+            kind: ty::Projection { def_id: projection_ty_def_id },
+            args,
+            ..
+        }) = ty.kind()
             && let Some(ty::ImplTraitInTraitData::Trait { fn_def_id, .. }) =
                 self.tcx.opt_rpitit_info(projection_ty_def_id)
             && fn_def_id == self.fn_def_id
         {
-            self.tcx.type_of(projection_ty_def_id).instantiate(self.tcx, projection_ty.args)
+            self.tcx.type_of(projection_ty_def_id).instantiate(self.tcx, args)
         } else {
             ty.super_fold_with(self)
         }

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -513,13 +513,13 @@ pub(super) fn explicit_predicates_of<'tcx>(
             //     identity args of the trait.
             // * It must be an associated type for this trait (*not* a
             //   supertrait).
-            if let &ty::Alias(
-                projection @ ty::AliasTy {
-                    kind: ty::Projection { def_id: projection_def_id }, ..
-                },
-            ) = ty.kind()
+            if let &ty::Alias(ty::AliasTy {
+                kind: ty::Projection { def_id: projection_def_id },
+                args,
+                ..
+            }) = ty.kind()
             {
-                projection.args == trait_identity_args
+                args == trait_identity_args
                     // FIXME(return_type_notation): This check should be more robust
                     && !tcx.is_impl_trait_in_trait(projection_def_id)
                     && tcx.parent(projection_def_id) == def_id.to_def_id()

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -242,13 +242,12 @@ where
             return;
         }
 
-        if let ty::Alias(opaque_ty @ ty::AliasTy { kind: ty::Projection { def_id }, .. }) =
-            *t.kind()
+        if let ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args, .. }) = *t.kind()
             && self.tcx.is_impl_trait_in_trait(def_id)
         {
             // visit the opaque of the RPITIT
-            self.tcx.type_of(def_id).instantiate(self.tcx, opaque_ty.args).visit_with(self)
-        } else if let ty::Alias(opaque_ty @ ty::AliasTy { kind: ty::Opaque { def_id}, .. }) = *t.kind()
+            self.tcx.type_of(def_id).instantiate(self.tcx, args).visit_with(self)
+        } else if let ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args: opaque_ty_args, .. }) = *t.kind()
             && let Some(opaque_def_id) = def_id.as_local()
             // Don't recurse infinitely on an opaque
             && self.seen.insert(opaque_def_id)
@@ -280,7 +279,7 @@ where
                             continue;
                         }
 
-                        let arg = opaque_ty.args[param.index as usize];
+                        let arg = opaque_ty_args[param.index as usize];
                         // We need to turn all `ty::Param`/`ConstKind::Param` and
                         // `ReEarlyParam`/`ReBound` into def ids.
                         captured.insert(extract_def_id_from_arg(self.tcx, generics, arg));
@@ -413,7 +412,7 @@ where
             // in this lint as well. Interestingly, one place that I expect this lint to fire
             // is for `impl for<'a> Bound<Out = impl Other>`, since `impl Other` will begin
             // to capture `'a` in e2024 (even though late-bound vars in opaques are not allowed).
-            for clause in self.tcx.item_bounds(def_id).iter_instantiated(self.tcx, opaque_ty.args) {
+            for clause in self.tcx.item_bounds(def_id).iter_instantiated(self.tcx, opaque_ty_args) {
                 clause.visit_with(self)
             }
         }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -126,12 +126,12 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
     #[inline]
     pub fn reveal_opaque_ty(&self, ty: Ty<'tcx>) -> RevealedTy<'tcx> {
         fn reveal_inner<'tcx>(cx: &RustcPatCtxt<'_, 'tcx>, ty: Ty<'tcx>) -> RevealedTy<'tcx> {
-            let ty::Alias(alias_ty @ ty::AliasTy { kind: ty::Opaque { .. }, .. }) = *ty.kind()
+            let ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) = *ty.kind()
             else {
                 bug!()
             };
-            if let Some(local_def_id) = alias_ty.kind.def_id().as_local() {
-                let key = ty::OpaqueTypeKey { def_id: local_def_id, args: alias_ty.args };
+            if let Some(local_def_id) = def_id.as_local() {
+                let key = ty::OpaqueTypeKey { def_id: local_def_id, args };
                 if let Some(ty) = cx.reveal_opaque_key(key) {
                     return RevealedTy(ty);
                 }

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -210,13 +210,13 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for OpaqueTypeCollector<'tcx> {
             }
             // Skips type aliases, as they are meant to be transparent.
             // FIXME(type_alias_impl_trait): can we require mentioning nested type aliases explicitly?
-            ty::Alias(alias_ty @ ty::AliasTy { kind: ty::Free { def_id }, .. })
+            ty::Alias(ty::AliasTy { kind: ty::Free { def_id }, args, .. })
                 if let Some(def_id) = def_id.as_local() =>
             {
                 if !self.seen.insert(def_id) {
                     return;
                 }
-                self.tcx.type_of(def_id).instantiate(self.tcx, alias_ty.args).visit_with(self);
+                self.tcx.type_of(def_id).instantiate(self.tcx, args).visit_with(self);
             }
             ty::Alias(
                 alias_ty @ ty::AliasTy { kind: ty::Projection { def_id: alias_def_id }, .. },


### PR DESCRIPTION
ref rust-lang/rust#154941

replace `<name> @ ty::AliasTy` matches with just using `args: <name>_args`


I updated all occurrences where <name> @ ty::AliasTy became unnecessary after the change. In cases where both forms are still used, no changes were made.

r? @WaffleLapkin 