### PR TITLE
Ensure Send/Sync is not implemented for std::env::Vars{,Os}

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -101,6 +101,12 @@ pub struct VarsOs {
     inner: env_imp::Env,
 }
 
+#[stable(feature = "env_vars_unimpl_send_sync", since = "CURRENT_RUSTC_VERSION")]
+impl !Send for VarsOs {}
+
+#[stable(feature = "env_vars_unimpl_send_sync", since = "CURRENT_RUSTC_VERSION")]
+impl !Sync for VarsOs {}
+
 /// Returns an iterator of (variable, value) pairs of strings, for all the
 /// environment variables of the current process.
 ///

--- a/library/std/src/sys/env/common.rs
+++ b/library/std/src/sys/env/common.rs
@@ -17,9 +17,6 @@ impl fmt::Debug for Env {
     }
 }
 
-impl !Send for Env {}
-impl !Sync for Env {}
-
 impl Iterator for Env {
     type Item = (OsString, OsString);
     fn next(&mut self) -> Option<(OsString, OsString)> {


### PR DESCRIPTION
On some platforms, it looks like these are not currently Send/Sync. We have a negative impl in env/common.rs. This is a breaking change on a bunch of targets, but it makes it less likely that someone unintentionally/accidentally depends on this. This is a potentially partial list but should be fairly complete. These are all platforms where these previously were [unsupported](https://github.com/rust-lang/rust/blob/main/library/std/src/sys/env/unsupported.rs), so this is relatively unlikely to actually break them.

aarch64-unknown-none, aarch64-unknown-none-softfloat, armv7a-none-eabi, armv7a-none-eabihf, armv7r-none-eabi, armv7r-none-eabihf, armv8r-none-eabihf, loongarch64-unknown-none,
loongarch64-unknown-none-softfloat, nvptx64-nvidia-cuda, riscv32i-unknown-none-elf, riscv32im-unknown-none-elf, riscv32imac-unknown-none-elf, riscv32imafc-unknown-none-elf, riscv32imc-unknown-none-elf, riscv64gc-unknown-none-elf, riscv64imac-unknown-none-elf, s390x-unknown-none-softfloat, thumbv6m-none-eabi, thumbv7a-none-eabi, thumbv7a-none-eabihf, thumbv7em-none-eabi, thumbv7em-none-eabihf, thumbv7m-none-eabi, thumbv7r-none-eabi, thumbv7r-none-eabihf, thumbv8m.base-none-eabi, thumbv8m.main-none-eabi, thumbv8m.main-none-eabihf, thumbv8r-none-eabihf, wasm32-unknown-unknown, wasm32v1-none, x86_64-unknown-none

cc https://github.com/rust-lang/rust/issues/154517