### PR TITLE
Fix min-specialization ICE from ignored region resolution failure

### DIFF
--- a/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check/min_specialization.rs
@@ -190,7 +190,7 @@ fn get_impl_args(
     }
 
     let assumed_wf_types = ocx.assumed_wf_types_and_report_errors(param_env, impl1_def_id)?;
-    let _ = ocx.resolve_regions_and_report_errors(impl1_def_id, param_env, assumed_wf_types);
+    ocx.resolve_regions_and_report_errors(impl1_def_id, param_env, assumed_wf_types)?;
     let Ok(impl2_args) = infcx.fully_resolve(impl2_args) else {
         let span = tcx.def_span(impl1_def_id);
         let guar = tcx.dcx().emit_err(GenericArgsOnOverriddenImpl { span });

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
@@ -1,0 +1,26 @@
+//@ compile-flags: -Znext-solver=globally
+// Regression test for https://github.com/rust-lang/rust/issues/151327
+
+#![feature(min_specialization)]
+
+trait Foo {
+    type Item;
+}
+
+trait Baz {}
+
+impl<'a, T> Foo for &'a T //~ ERROR not all trait items implemented, missing: `Item`
+//~| ERROR the trait bound `&'a T: Foo` is not satisfied
+where
+    Self::Item: 'a, //~ ERROR the trait bound `&'a T: Foo` is not satisfied
+{
+}
+
+impl<'a, T> Foo for &T //~ ERROR not all trait items implemented, missing: `Item`
+//~| ERROR cannot normalize `<&_ as Foo>::Item: '_`
+where
+    Self::Item: Baz,
+{
+}
+
+fn main() {}

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
@@ -1,0 +1,69 @@
+error[E0046]: not all trait items implemented, missing: `Item`
+  --> $DIR/next-solver-region-resolution.rs:12:1
+   |
+LL |       type Item;
+   |       --------- `Item` from trait
+...
+LL | / impl<'a, T> Foo for &'a T
+LL | |
+LL | | where
+LL | |     Self::Item: 'a,
+   | |___________________^ missing `Item` in implementation
+
+error[E0277]: the trait bound `&'a T: Foo` is not satisfied
+  --> $DIR/next-solver-region-resolution.rs:12:21
+   |
+LL | impl<'a, T> Foo for &'a T
+   |                     ^^^^^ the trait `Foo` is not implemented for `&'a T`
+   |
+help: the trait `Foo` is not implemented for `&'a _`
+      but it is implemented for `&_`
+  --> $DIR/next-solver-region-resolution.rs:12:1
+   |
+LL | / impl<'a, T> Foo for &'a T
+LL | |
+LL | | where
+LL | |     Self::Item: 'a,
+   | |___________________^
+
+error[E0277]: the trait bound `&'a T: Foo` is not satisfied
+  --> $DIR/next-solver-region-resolution.rs:15:17
+   |
+LL |     Self::Item: 'a,
+   |                 ^^ the trait `Foo` is not implemented for `&'a T`
+   |
+help: the trait `Foo` is not implemented for `&'a _`
+      but it is implemented for `&_`
+  --> $DIR/next-solver-region-resolution.rs:12:1
+   |
+LL | / impl<'a, T> Foo for &'a T
+LL | |
+LL | | where
+LL | |     Self::Item: 'a,
+   | |___________________^
+
+error[E0046]: not all trait items implemented, missing: `Item`
+  --> $DIR/next-solver-region-resolution.rs:19:1
+   |
+LL |       type Item;
+   |       --------- `Item` from trait
+...
+LL | / impl<'a, T> Foo for &T
+LL | |
+LL | | where
+LL | |     Self::Item: Baz,
+   | |____________________^ missing `Item` in implementation
+
+error: cannot normalize `<&_ as Foo>::Item: '_`
+  --> $DIR/next-solver-region-resolution.rs:19:1
+   |
+LL | / impl<'a, T> Foo for &T
+LL | |
+LL | | where
+LL | |     Self::Item: Baz,
+   | |____________________^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0046, E0277.
+For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#151327


`min_specialization::get_impl_args` resolved regions and then immediately called `fully_resolve`, but it ignored failures from `resolve_regions_and_report_errors`.

Propagate the region-resolution error instead of ignoring it. That matches the pattern used in:

https://github.com/rust-lang/rust/blob/40a3ed1e1407ebbe892ce1a74128482ea1dadf7a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs#L706

https://github.com/rust-lang/rust/blob/40a3ed1e1407ebbe892ce1a74128482ea1dadf7a/compiler/rustc_hir_analysis/src/coherence/builtin.rs#L421