### PR TITLE
Use Vec::push_mut when adding a chunk to arenas

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -287,10 +287,9 @@ impl<T> TypedArena<T> {
             // Also ensure that this chunk can fit `additional`.
             new_cap = cmp::max(additional, new_cap);
 
-            let mut chunk = ArenaChunk::<T>::new(new_cap);
+            let chunk = chunks.push_mut(ArenaChunk::<T>::new(new_cap));
             self.ptr.set(chunk.start());
             self.end.set(chunk.end());
-            chunks.push(chunk);
         }
     }
 
@@ -419,7 +418,7 @@ impl DroplessArena {
             // Also ensure that this chunk can fit `additional`.
             new_cap = cmp::max(additional, new_cap);
 
-            let mut chunk = ArenaChunk::new(align_up(new_cap, PAGE));
+            let chunk = chunks.push_mut(ArenaChunk::new(align_up(new_cap, PAGE)));
             self.start.set(chunk.start());
 
             // Align the end to DROPLESS_ALIGNMENT.
@@ -430,8 +429,6 @@ impl DroplessArena {
             debug_assert!(chunk.start().addr() <= end);
 
             self.end.set(chunk.end().with_addr(end));
-
-            chunks.push(chunk);
         }
     }
 

--- a/library/proc_macro/src/bridge/arena.rs
+++ b/library/proc_macro/src/bridge/arena.rs
@@ -58,11 +58,10 @@ impl Arena {
         // Also ensure that this chunk can fit `additional`.
         new_cap = cmp::max(additional, new_cap);
 
-        let mut chunk = Box::new_uninit_slice(new_cap);
+        let chunk = chunks.push_mut(Box::new_uninit_slice(new_cap));
         let Range { start, end } = chunk.as_mut_ptr_range();
         self.start.set(start);
         self.end.set(end);
-        chunks.push(chunk);
     }
 
     /// Allocates a byte slice with specified size from the current memory


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/155148, which may or may not be worth fixing on its own merits, but I think `Vec::push_mut` also makes the code nicer.