### PR TITLE
jsondoclint: simplify code using idiomatic Rust

### DIFF
--- a/src/tools/jsondoclint/src/item_kind.rs
+++ b/src/tools/jsondoclint/src/item_kind.rs
@@ -77,11 +77,7 @@ impl Kind {
     }
 
     pub fn can_appear_in_glob_import(self) -> bool {
-        match self {
-            Kind::Module => true,
-            Kind::Enum => true,
-            _ => false,
-        }
+        matches!(self, Kind::Module | Kind::Enum)
     }
 
     pub fn can_appear_in_trait(self) -> bool {

--- a/src/tools/jsondoclint/src/main.rs
+++ b/src/tools/jsondoclint/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
                     [sel] => eprintln!(
                         "{} not in index or paths, but referred to at '{}'",
                         err.id.0,
-                        json_find::to_jsonpath(&sel)
+                        json_find::to_jsonpath(sel)
                     ),
                     [sel, ..] => {
                         if verbose {
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
                             eprintln!(
                                 "{} not in index or paths, but referred to at '{}' and {} more",
                                 err.id.0,
-                                json_find::to_jsonpath(&sel),
+                                json_find::to_jsonpath(sel),
                                 sels.len() - 1,
                             )
                         }

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -20,10 +20,10 @@ const LOCAL_CRATE_ID: u32 = 0;
 /// It is made of several parts.
 ///
 /// - `check_*`: These take a type from [`rustdoc_json_types`], and check that
-///              it is well formed. This involves calling `check_*` functions on
-///              fields of that item, and `add_*` functions on [`Id`]s.
+///   it is well formed. This involves calling `check_*` functions on
+///   fields of that item, and `add_*` functions on [`Id`]s.
 /// - `add_*`: These add an [`Id`] to the worklist, after validating it to check if
-///            the `Id` is a kind expected in this situation.
+///   the `Id` is a kind expected in this situation.
 #[derive(Debug)]
 pub struct Validator<'a> {
     pub(crate) errs: Vec<Error>,
@@ -262,17 +262,17 @@ impl<'a> Validator<'a> {
             Type::Generic(_) => {}
             Type::Primitive(_) => {}
             Type::Pat { type_, __pat_unstable_do_not_use: _ } => self.check_type(type_),
-            Type::FunctionPointer(fp) => self.check_function_pointer(&**fp),
+            Type::FunctionPointer(fp) => self.check_function_pointer(fp),
             Type::Tuple(tys) => tys.iter().for_each(|ty| self.check_type(ty)),
-            Type::Slice(inner) => self.check_type(&**inner),
-            Type::Array { type_, len: _ } => self.check_type(&**type_),
+            Type::Slice(inner) => self.check_type(inner),
+            Type::Array { type_, len: _ } => self.check_type(type_),
             Type::ImplTrait(bounds) => bounds.iter().for_each(|b| self.check_generic_bound(b)),
             Type::Infer => {}
-            Type::RawPointer { is_mutable: _, type_ } => self.check_type(&**type_),
-            Type::BorrowedRef { lifetime: _, is_mutable: _, type_ } => self.check_type(&**type_),
+            Type::RawPointer { is_mutable: _, type_ } => self.check_type(type_),
+            Type::BorrowedRef { lifetime: _, is_mutable: _, type_ } => self.check_type(type_),
             Type::QualifiedPath { name: _, args, self_type, trait_ } => {
-                self.check_opt_generic_args(&args);
-                self.check_type(&**self_type);
+                self.check_opt_generic_args(args);
+                self.check_type(self_type);
                 if let Some(trait_) = trait_ {
                     self.check_path(trait_, PathKind::Trait);
                 }
@@ -404,7 +404,7 @@ impl<'a> Validator<'a> {
         // which encodes rustc implementation details.
         if item_info.crate_id == LOCAL_CRATE_ID && !self.krate.index.contains_key(id) {
             self.errs.push(Error {
-                id: id.clone(),
+                id: *id,
                 kind: ErrorKind::Custom(
                     "Id for local item in `paths` but not in `index`".to_owned(),
                 ),
@@ -483,16 +483,14 @@ impl<'a> Validator<'a> {
     }
 
     fn fail(&mut self, id: &Id, kind: ErrorKind) {
-        self.errs.push(Error { id: id.clone(), kind });
+        self.errs.push(Error { id: *id, kind });
     }
 
     fn kind_of(&mut self, id: &Id) -> Option<Kind> {
         if let Some(item) = self.krate.index.get(id) {
             Some(Kind::from_item(item))
-        } else if let Some(summary) = self.krate.paths.get(id) {
-            Some(Kind::from_summary(summary))
         } else {
-            None
+            self.krate.paths.get(id).map(Kind::from_summary)
         }
     }
 }

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -78,7 +78,7 @@ fn errors_on_local_in_paths_and_not_index() {
                     span: None,
                     visibility: Visibility::Public,
                     docs: None,
-                    links: FxHashMap::from_iter([(("prim@i32".to_owned(), Id(2)))]),
+                    links: FxHashMap::from_iter([("prim@i32".to_owned(), Id(2))]),
                     attrs: Vec::new(),
                     deprecation: None,
                     inner: ItemEnum::Module(Module {


### PR DESCRIPTION
Simplify `jsondoclint` with small idiomatic Rust cleanups. No behavior changes.

- Use `matches!()` macro instead of `match` in `item_kind.rs`
- Remove unnecessary derefs and simplify Option mapping in `validator.rs`
- Replace `clone()` on Copy type with `*id`
- Fix doc comment indentation
- Remove redundant tuple parens in `tests.rs`
- Remove needless borrow and closure in `main.rs`

Verified:
- `cargo clippy -p jsondoclint --tests --quiet` → no warnings
- `cargo test -p jsondoclint --quiet` → all 5 tests pass

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->