### PR TITLE
Make the expansion of guard metavars begin guard non-terminals

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3464,11 +3464,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn eat_metavar_guard(&mut self) -> Option<Box<Guard>> {
-        self.eat_metavar_seq_with_matcher(
-            |mv_kind| matches!(mv_kind, MetaVarKind::Guard),
-            |this| this.parse_match_arm_guard(),
-        )
-        .flatten()
+        self.eat_metavar_seq(MetaVarKind::Guard, |this| this.parse_match_arm_guard()).flatten()
     }
 
     fn parse_match_arm_guard(&mut self) -> PResult<'a, Option<Box<Guard>>> {

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -105,7 +105,10 @@ impl<'a> Parser<'a> {
                 token::Lifetime(..) | token::NtLifetime(..) => true,
                 _ => false,
             },
-            NonterminalKind::Guard => token.is_keyword(kw::If),
+            NonterminalKind::Guard => match token.kind {
+                token::OpenInvisible(InvisibleOrigin::MetaVar(MetaVarKind::Guard)) => true,
+                _ => token.is_keyword(kw::If),
+            },
             NonterminalKind::TT | NonterminalKind::Item | NonterminalKind::Stmt => {
                 token.kind.close_delim().is_none()
             }

--- a/tests/ui/macros/macro-guard-matcher.rs
+++ b/tests/ui/macros/macro-guard-matcher.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     macro_rules! m {
-        ($x:guard) => {};
+        ($g:guard) => {};
     }
 
     // Accepts
@@ -14,4 +14,12 @@ fn main() {
 
     // Rejects
     m!(let Some(x) = Some(1)); //~ERROR no rules expected keyword `let`
+
+    macro_rules! m_m {
+        ($g:guard) => { m!($g); };
+    }
+
+    // Accepted since `m` recognizes that the sequence produced by the expansion of
+    // metavar `$g` "begins" (i.e., is) a guard since it's of kind `guard`.
+    m_m!(if true);
 }

--- a/tests/ui/macros/macro-guard-matcher.stderr
+++ b/tests/ui/macros/macro-guard-matcher.stderr
@@ -7,10 +7,10 @@ LL |     macro_rules! m {
 LL |     m!(let Some(x) = Some(1));
    |        ^^^ no rules expected this token in macro call
    |
-note: while trying to match meta-variable `$x:guard`
+note: while trying to match meta-variable `$g:guard`
   --> $DIR/macro-guard-matcher.rs:5:10
    |
-LL |         ($x:guard) => {};
+LL |         ($g:guard) => {};
    |          ^^^^^^^^
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
While investigating something unrelated, I noticed a bug in the impl of unstable feature `macro_guard_matcher` (tracking issue: rust-lang/rust#153104). Namely, the following doesn't compile:

```rs
#![feature(macro_guard_matcher)]

macro_rules! a { ($guard:guard) => { b!($guard); }; }
macro_rules! b { ($guard:guard) => {}; }
a!(if true);
```

```
error: no rules expected `guard` metavariable
 --> src/lib.rs:3:41
  |
3 | macro_rules! a { ($guard:guard) => { b!($guard); }; }
  |                                         ^^^^^^ no rules expected this token in macro call
4 | macro_rules! b { ($guard:guard) => {}; }
  | -------------- when calling this macro
5 | a!(if true);
  | ----------- in this macro invocation
  |
note: while trying to match meta-variable `$guard:guard`
 --> src/lib.rs:4:19
  |
4 | macro_rules! b { ($guard:guard) => {}; }
  |                   ^^^^^^^^^^^^
  = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
```

---

While I'm still skeptical of `guard` fragment specifiers in general (although I can't quite pinpoint why), I figured I should fix this issue.