### PR TITLE
std: fix HashMap RNG docs wording

### DIFF
--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -20,7 +20,7 @@ use crate::ops::Index;
 /// reasonable best-effort is made to generate this seed from a high quality,
 /// secure source of randomness provided by the host without blocking the
 /// program. Because of this, the randomness of the seed depends on the output
-/// quality of the system's random number coroutine when the seed is created.
+/// quality of the system's random number generator when the seed is created.
 /// In particular, seeds generated when the system's entropy pool is abnormally
 /// low such as during system boot may be of a lower quality.
 ///


### PR DESCRIPTION
Fixes a wording typo in the top-level HashMap docs.

Changed "random number coroutine" to "random number generator" in the seed entropy paragraph.

This section is security-relevant, and "generator" is the correct term in RNG context.

Testing:
- Not run locally (docs-only text change).
