### PR TITLE
simd_reduce_min/max: remove float support

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -2313,65 +2313,8 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         self.vector_extremum(a, b, ExtremumOperation::Min)
     }
 
-    #[cfg(feature = "master")]
-    pub fn vector_reduce_fmin(&mut self, src: RValue<'gcc>) -> RValue<'gcc> {
-        let vector_type = src.get_type().unqualified().dyncast_vector().expect("vector type");
-        let element_count = vector_type.get_num_units();
-        let mut acc = self
-            .context
-            .new_vector_access(self.location, src, self.context.new_rvalue_zero(self.int_type))
-            .to_rvalue();
-        for i in 1..element_count {
-            let elem = self
-                .context
-                .new_vector_access(
-                    self.location,
-                    src,
-                    self.context.new_rvalue_from_int(self.int_type, i as _),
-                )
-                .to_rvalue();
-            let cmp = self.context.new_comparison(self.location, ComparisonOp::LessThan, acc, elem);
-            acc = self.select(cmp, acc, elem);
-        }
-        acc
-    }
-
-    #[cfg(not(feature = "master"))]
-    pub fn vector_reduce_fmin(&mut self, _src: RValue<'gcc>) -> RValue<'gcc> {
-        unimplemented!();
-    }
-
     pub fn vector_maximum_number_nsz(&mut self, a: RValue<'gcc>, b: RValue<'gcc>) -> RValue<'gcc> {
         self.vector_extremum(a, b, ExtremumOperation::Max)
-    }
-
-    #[cfg(feature = "master")]
-    pub fn vector_reduce_fmax(&mut self, src: RValue<'gcc>) -> RValue<'gcc> {
-        let vector_type = src.get_type().unqualified().dyncast_vector().expect("vector type");
-        let element_count = vector_type.get_num_units();
-        let mut acc = self
-            .context
-            .new_vector_access(self.location, src, self.context.new_rvalue_zero(self.int_type))
-            .to_rvalue();
-        for i in 1..element_count {
-            let elem = self
-                .context
-                .new_vector_access(
-                    self.location,
-                    src,
-                    self.context.new_rvalue_from_int(self.int_type, i as _),
-                )
-                .to_rvalue();
-            let cmp =
-                self.context.new_comparison(self.location, ComparisonOp::GreaterThan, acc, elem);
-            acc = self.select(cmp, acc, elem);
-        }
-        acc
-    }
-
-    #[cfg(not(feature = "master"))]
-    pub fn vector_reduce_fmax(&mut self, _src: RValue<'gcc>) -> RValue<'gcc> {
-        unimplemented!();
     }
 
     pub fn vector_select(

--- a/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
@@ -1422,7 +1422,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     );
 
     macro_rules! minmax_red {
-        ($name:ident: $int_red:ident, $float_red:ident) => {
+        ($name:ident: $int_red:ident) => {
             if name == sym::$name {
                 require!(
                     ret_ty == in_elem,
@@ -1430,7 +1430,6 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                 );
                 return match *in_elem.kind() {
                     ty::Int(_) | ty::Uint(_) => Ok(bx.$int_red(args[0].immediate())),
-                    ty::Float(_) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                         span,
                         name,
@@ -1444,8 +1443,8 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         };
     }
 
-    minmax_red!(simd_reduce_min: vector_reduce_min, vector_reduce_fmin);
-    minmax_red!(simd_reduce_max: vector_reduce_max, vector_reduce_fmax);
+    minmax_red!(simd_reduce_min: vector_reduce_min);
+    minmax_red!(simd_reduce_max: vector_reduce_max);
 
     macro_rules! bitwise_red {
         ($name:ident : $op:expr, $boolean:expr) => {

--- a/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
@@ -1416,7 +1416,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     );
 
     macro_rules! minmax_red {
-        ($name:ident: $int_red:ident, $float_red:ident) => {
+        ($name:ident: $int_red:ident) => {
             if name == sym::$name {
                 require!(
                     ret_ty == in_elem,
@@ -1424,7 +1424,6 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                 );
                 return match *in_elem.kind() {
                     ty::Int(_) | ty::Uint(_) => Ok(bx.$int_red(args[0].immediate())),
-                    ty::Float(_) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                         span,
                         name,
@@ -1438,8 +1437,8 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         };
     }
 
-    minmax_red!(simd_reduce_min: vector_reduce_min, vector_reduce_fmin);
-    minmax_red!(simd_reduce_max: vector_reduce_max, vector_reduce_fmax);
+    minmax_red!(simd_reduce_min: vector_reduce_min);
+    minmax_red!(simd_reduce_max: vector_reduce_max);
 
     macro_rules! bitwise_red {
         ($name:ident : $op:expr, $boolean:expr) => {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1668,12 +1668,6 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
     pub(crate) fn vector_reduce_xor(&mut self, src: &'ll Value) -> &'ll Value {
         self.call_intrinsic("llvm.vector.reduce.xor", &[self.val_ty(src)], &[src])
     }
-    pub(crate) fn vector_reduce_fmin(&mut self, src: &'ll Value) -> &'ll Value {
-        self.call_intrinsic("llvm.vector.reduce.fmin", &[self.val_ty(src)], &[src])
-    }
-    pub(crate) fn vector_reduce_fmax(&mut self, src: &'ll Value) -> &'ll Value {
-        self.call_intrinsic("llvm.vector.reduce.fmax", &[self.val_ty(src)], &[src])
-    }
     pub(crate) fn vector_reduce_min(&mut self, src: &'ll Value, is_signed: bool) -> &'ll Value {
         self.call_intrinsic(
             if is_signed { "llvm.vector.reduce.smin" } else { "llvm.vector.reduce.umin" },

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -2599,7 +2599,7 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
     );
 
     macro_rules! minmax_red {
-        ($name:ident: $int_red:ident, $float_red:ident) => {
+        ($name:ident: $int_red:ident) => {
             if name == sym::$name {
                 require!(
                     ret_ty == in_elem,
@@ -2608,7 +2608,6 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
                 return match in_elem.kind() {
                     ty::Int(_i) => Ok(bx.$int_red(args[0].immediate(), true)),
                     ty::Uint(_u) => Ok(bx.$int_red(args[0].immediate(), false)),
-                    ty::Float(_f) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                         span,
                         name,
@@ -2622,8 +2621,9 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
         };
     }
 
-    minmax_red!(simd_reduce_min: vector_reduce_min, vector_reduce_fmin);
-    minmax_red!(simd_reduce_max: vector_reduce_max, vector_reduce_fmax);
+    // Currently no support for float due to <https://github.com/llvm/llvm-project/issues/185827>.
+    minmax_red!(simd_reduce_min: vector_reduce_min);
+    minmax_red!(simd_reduce_max: vector_reduce_max);
 
     macro_rules! bitwise_red {
         ($name:ident : $red:ident, $boolean:expr) => {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -2922,7 +2922,7 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
     );
 
     macro_rules! minmax_red {
-        ($name:ident: $int_red:ident, $float_red:ident) => {
+        ($name:ident: $int_red:ident) => {
             if name == sym::$name {
                 require!(
                     ret_ty == in_elem,
@@ -2931,7 +2931,6 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
                 return match in_elem.kind() {
                     ty::Int(_i) => Ok(bx.$int_red(args[0].immediate(), true)),
                     ty::Uint(_u) => Ok(bx.$int_red(args[0].immediate(), false)),
-                    ty::Float(_f) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                         span,
                         name,
@@ -2945,8 +2944,9 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
         };
     }
 
-    minmax_red!(simd_reduce_min: vector_reduce_min, vector_reduce_fmin);
-    minmax_red!(simd_reduce_max: vector_reduce_max, vector_reduce_fmax);
+    // Currently no support for float due to <https://github.com/llvm/llvm-project/issues/185827>.
+    minmax_red!(simd_reduce_min: vector_reduce_min);
+    minmax_red!(simd_reduce_max: vector_reduce_max);
 
     macro_rules! bitwise_red {
         ($name:ident : $red:ident, $boolean:expr) => {

--- a/library/core/src/intrinsics/simd/mod.rs
+++ b/library/core/src/intrinsics/simd/mod.rs
@@ -520,7 +520,7 @@ pub unsafe fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
 
 /// Checks if all mask values are true.
 ///
-/// `T` must be a vector of integer primitive types.
+/// `T` must be a vector of integers.
 ///
 /// # Safety
 /// `x` must contain only `0` or `!0`.
@@ -530,7 +530,7 @@ pub const unsafe fn simd_reduce_all<T>(x: T) -> bool;
 
 /// Checks if any mask value is true.
 ///
-/// `T` must be a vector of integer primitive types.
+/// `T` must be a vector of integers.
 ///
 /// # Safety
 /// `x` must contain only `0` or `!0`.
@@ -540,29 +540,25 @@ pub const unsafe fn simd_reduce_any<T>(x: T) -> bool;
 
 /// Returns the maximum element of a vector.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
-///
-/// For floating-point values, uses IEEE-754 `maxNum`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_reduce_max<T, U>(x: T) -> U;
 
 /// Returns the minimum element of a vector.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
-///
-/// For floating-point values, uses IEEE-754 `minNum`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_reduce_min<T, U>(x: T) -> U;
 
 /// Logical "and"s all elements together.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
@@ -571,7 +567,7 @@ pub const unsafe fn simd_reduce_and<T, U>(x: T) -> U;
 
 /// Logical "ors" all elements together.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
@@ -580,7 +576,7 @@ pub const unsafe fn simd_reduce_or<T, U>(x: T) -> U;
 
 /// Logical "exclusive ors" all elements together.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]

--- a/tests/ui/simd/intrinsic/generic-reduction-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction-pass.rs
@@ -109,10 +109,11 @@ const fn ordered() {
         let r: f32 = simd_reduce_mul_ordered(x, 2.);
         assert_eq!(r, -48_f32);
 
-        let r: f32 = simd_reduce_min(x);
-        assert_eq!(r, -2_f32);
-        let r: f32 = simd_reduce_max(x);
-        assert_eq!(r, 4_f32);
+        // FIXME: re-enable when the intrinsic works on floats again.
+        // let r: f32 = simd_reduce_min(x);
+        // assert_eq!(r, -2_f32);
+        // let r: f32 = simd_reduce_max(x);
+        // assert_eq!(r, 4_f32);
     }
 
     unsafe {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155189)*
<!-- homu-ignore:end -->

LLVM currently doesn't have an intrinsic with the right semantics here (see https://github.com/llvm/llvm-project/issues/185827). The only remaining user of this intrinsic with float types is portable-simd and it's easier to implement a fallback there than here, so I opted for making the intrinsic int-only. I kept around the float support in cranelift and Miri because there it already has the desired semantics (matching scalar min/max).

Fixes https://github.com/rust-lang/rust/issues/153395
~~Blocked on https://github.com/rust-lang/portable-simd/pull/515~~