### PR TITLE
Fix `Path::strip_prefix` for verbatim path roots without trailing separator

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -941,7 +941,7 @@ impl<'a> Iterator for Components<'a> {
                         self.path = &self.path[1..];
                         return Some(Component::RootDir);
                     } else if HAS_PREFIXES && let Some(p) = self.prefix {
-                        if p.has_implicit_root() && !p.is_verbatim() {
+                        if p.has_implicit_root() {
                             return Some(Component::RootDir);
                         }
                     } else if self.include_cur_dir() {
@@ -992,7 +992,7 @@ impl<'a> DoubleEndedIterator for Components<'a> {
                         self.path = &self.path[..self.path.len() - 1];
                         return Some(Component::RootDir);
                     } else if HAS_PREFIXES && let Some(p) = self.prefix {
-                        if p.has_implicit_root() && !p.is_verbatim() {
+                        if p.has_implicit_root() {
                             return Some(Component::RootDir);
                         }
                     } else if self.include_cur_dir() {

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -890,7 +890,7 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\?\\bar",
-    iter: ["\\\\?\\bar"],
+    iter: ["\\\\?\\bar", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -901,7 +901,7 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\?\\",
-    iter: ["\\\\?\\"],
+    iter: ["\\\\?\\", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -923,7 +923,7 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\?\\UNC\\server",
-    iter: ["\\\\?\\UNC\\server"],
+    iter: ["\\\\?\\UNC\\server", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -934,7 +934,7 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\?\\UNC\\",
-    iter: ["\\\\?\\UNC\\"],
+    iter: ["\\\\?\\UNC\\", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -967,7 +967,7 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\?\\C:",
-    iter: ["\\\\?\\C:"],
+    iter: ["\\\\?\\C:", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -1258,7 +1258,7 @@ pub fn test_decompositions_cygwin() {
     );
 
     t!("\\\\?\\bar",
-    iter: ["\\\\?\\bar"],
+    iter: ["\\\\?\\bar", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -1269,7 +1269,7 @@ pub fn test_decompositions_cygwin() {
     );
 
     t!("\\\\?\\",
-    iter: ["\\\\?\\"],
+    iter: ["\\\\?\\", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -1324,7 +1324,7 @@ pub fn test_decompositions_cygwin() {
     );
 
     t!("\\\\?\\UNC\\server",
-    iter: ["\\\\?\\UNC\\server"],
+    iter: ["\\\\?\\UNC\\server", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -1335,7 +1335,7 @@ pub fn test_decompositions_cygwin() {
     );
 
     t!("\\\\?\\UNC\\",
-    iter: ["\\\\?\\UNC\\"],
+    iter: ["\\\\?\\UNC\\", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -1390,7 +1390,7 @@ pub fn test_decompositions_cygwin() {
     );
 
     t!("\\\\?\\C:",
-    iter: ["\\\\?\\C:"],
+    iter: ["\\\\?\\C:", "\\"],
     has_root: true,
     is_absolute: true,
     parent: None,
@@ -2218,6 +2218,29 @@ pub fn test_compare() {
         starts_with: false,
         ends_with: false,
         relative_from: None
+        );
+
+        // issue #155183: strip_prefix for VerbatimUNC share roots
+        tc!(r"\\?\UNC\server\share\dir1\dir2", r"\\?\UNC\server\share",
+        eq: false,
+        starts_with: true,
+        ends_with: false,
+        relative_from: Some(r"dir1\dir2")
+        );
+
+        tc!(r"\\?\UNC\server\share\dir1\dir2", r"\\?\UNC\server\share\dir1",
+        eq: false,
+        starts_with: true,
+        ends_with: false,
+        relative_from: Some("dir2")
+        );
+
+        // VerbatimDisk without trailing separator
+        tc!(r"\\?\C:\dir1\dir2", r"\\?\C:",
+        eq: false,
+        starts_with: true,
+        ends_with: false,
+        relative_from: Some(r"dir1\dir2")
         );
     }
 }


### PR DESCRIPTION
Fixes rust-lang/rust#155183

`Path::strip_prefix` was returning a path with a leading separator when the base was a verbatim prefix root without a trailing separator (e.g., `\\?\UNC\server\share`).

```rust
let path = Path::new(r"\\?\UNC\server\share\dir1\dir2");
let base = Path::new(r"\\?\UNC\server\share");
// Before: path.strip_prefix(base) => "\dir1\dir2" (wrong)
// After:  path.strip_prefix(base) => "dir1\dir2"  (correct)
```

The `Components` iterator was not emitting an implicit `RootDir` component for verbatim prefixes (`VerbatimUNC`, `VerbatimDisk`, `Verbatim`) when no physical root separator was present. Non-verbatim counterparts (e.g., `UNC`) correctly emitted it via `has_implicit_root()`, but the `!p.is_verbatim()` guard blocked it.

The fix removes the `!p.is_verbatim()` guard in both the forward and backward `Components` iterators, making verbatim prefixes consistent with their non-verbatim equivalents:
- `\\server\share` already yielded `[Prefix, RootDir]`
- `\\?\UNC\server\share` now also yields `[Prefix, RootDir]` (previously just `[Prefix]`)

r? libs