### PR TITLE
Add regression test for #135287

### DIFF
--- a/tests/incremental/adt-sized-constraint-on-enum.rs
+++ b/tests/incremental/adt-sized-constraint-on-enum.rs
@@ -1,0 +1,67 @@
+// Regression test for https://github.com/rust-lang/rust/issues/135287.
+// Changing a struct to an enum with incremental compilation previously caused
+// an ICE: `adt_sized_constraint called on non-struct type`.
+
+//@ revisions: cfail1 cfail2
+//@ edition: 2021
+//@ check-pass
+
+#![allow(dead_code)]
+
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[cfg(cfail1)]
+struct SourceDocument {}
+
+#[cfg(cfail2)]
+enum SourceDocument {}
+
+trait Loader {
+    type Value;
+    fn load(&self) -> impl Future<Output = Self::Value>;
+}
+
+struct SourceDocumentLoader;
+impl Loader for SourceDocumentLoader {
+    type Value = SourceDocument;
+    async fn load(&self) -> Self::Value {
+        todo!()
+    }
+}
+
+struct ManualSend<T>(T);
+unsafe impl<T: Send> Send for ManualSend<T> {}
+
+struct PendingButCovariant<T>(PhantomData<T>);
+impl<T> Future for PendingButCovariant<T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+struct DataLoader<T>(T);
+impl<T> DataLoader<T> {
+    async fn load_one(&self) -> ManualSend<T::Value>
+    where
+        T: Loader,
+    {
+        PendingButCovariant(PhantomData).await
+    }
+}
+
+trait ContainerType {
+    fn resolve_field(&self) -> impl Future<Output = ()> + Send;
+}
+impl ContainerType for () {
+    async fn resolve_field(&self) {
+        let loader = DataLoader(SourceDocumentLoader);
+        loader.load_one().await;
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#135287

The ICE (`adt_sized_constraint called on non-struct type`) triggered when changing a struct to an enum under incremental compilation. It was fixed indirectly by the removal of the `adt_sized_constraint` query in rust-lang/rust#122493, but no regression test was added.

This adds one using the [minimized reproducer](https://github.com/rust-lang/rust/issues/135287#issuecomment-2726103994) from the issue.

r? incremental