### PR TITLE
Check arguments of attributes where no arguments are expected

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -91,7 +91,7 @@ fn parse_unstable<S: Stage>(
 
     for param in list.mixed() {
         let param_span = param.span();
-        if let Some(ident) = param.meta_item().and_then(|i| i.path().word()) {
+        if let Some(ident) = param.meta_item_no_args().and_then(|i| i.path().word()) {
             res.push(ident.name);
         } else {
             cx.emit_err(session_diagnostics::ExpectsFeatures {

--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -91,7 +91,7 @@ fn parse_unstable(
 
     for param in list.mixed() {
         let param_span = param.span();
-        if let Some(ident) = param.meta_item().and_then(|i| i.path().word()) {
+        if let Some(ident) = param.meta_item_no_args().and_then(|i| i.path().word()) {
             res.push(ident.name);
         } else {
             cx.emit_err(session_diagnostics::ExpectsFeatures {

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -375,7 +375,7 @@ impl<S: Stage> AttributeParser<S> for UsedParser {
                         return;
                     };
 
-                    match l.meta_item().and_then(|i| i.path().word_sym()) {
+                    match l.meta_item_no_args().and_then(|i| i.path().word_sym()) {
                         Some(sym::compiler) => {
                             if !cx.features().used_with_arg() {
                                 feature_err(

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -25,7 +25,7 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.single_element_list(args, cx.attr_span)?;
 
-        let res = match single.meta_item().and_then(|i| i.path().word().map(|i| i.name)) {
+        let res = match single.meta_item_no_args().and_then(|i| i.path().word().map(|i| i.name)) {
             Some(sym::size) => OptimizeAttr::Size,
             Some(sym::speed) => OptimizeAttr::Speed,
             Some(sym::none) => OptimizeAttr::DoNotOptimize,

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -80,7 +80,7 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
         let mut fail_incorrect_argument =
             |span| cx.adcx().expected_specific_argument(span, &[sym::on, sym::off]);
 
-        let Some(arg) = arg.meta_item() else {
+        let Some(arg) = arg.meta_item_no_args() else {
             fail_incorrect_argument(arg.span());
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -26,7 +26,7 @@ impl SingleAttributeParser for OptimizeParser {
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
 
-        let res = match single.meta_item().and_then(|i| i.path().word().map(|i| i.name)) {
+        let res = match single.meta_item_no_args().and_then(|i| i.path().word().map(|i| i.name)) {
             Some(sym::size) => OptimizeAttr::Size,
             Some(sym::speed) => OptimizeAttr::Speed,
             Some(sym::none) => OptimizeAttr::DoNotOptimize,

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -373,7 +373,7 @@ impl AttributeParser for UsedParser {
                         return;
                     };
 
-                    match l.meta_item().and_then(|i| i.path().word_sym()) {
+                    match l.meta_item_no_args().and_then(|i| i.path().word_sym()) {
                         Some(sym::compiler) => {
                             if !cx.features().used_with_arg() {
                                 feature_err(

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -80,7 +80,7 @@ impl SingleAttributeParser for CoverageParser {
         let mut fail_incorrect_argument =
             |span| cx.adcx().expected_specific_argument(span, &[sym::on, sym::off]);
 
-        let Some(arg) = arg.meta_item() else {
+        let Some(arg) = arg.meta_item_no_args() else {
             fail_incorrect_argument(arg.span());
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -18,6 +18,7 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
         |this, cx, args| {
             if !cx.features().diagnostic_on_const() {
                 // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+                args.ignore_args();
                 return;
             }
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -17,6 +17,7 @@ impl AttributeParser for OnConstParser {
         |this, cx, args| {
             if !cx.features().diagnostic_on_const() {
                 // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+                args.ignore_args();
                 return;
             }
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -25,6 +25,7 @@ impl OnMoveParser {
     ) {
         if !cx.features().diagnostic_on_move() {
             // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+            args.ignore_args();
             return;
         }
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -20,6 +20,7 @@ impl OnMoveParser {
     fn parse<'sess>(&mut self, cx: &mut AcceptContext<'_, 'sess>, args: &ArgParser, mode: Mode) {
         if !cx.features().diagnostic_on_move() {
             // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+            args.ignore_args();
             return;
         }
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -19,6 +19,7 @@ impl OnUnknownParser {
     ) {
         if !cx.features().diagnostic_on_unknown() {
             // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+            args.ignore_args();
             return;
         }
         let span = cx.attr_span;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -18,6 +18,7 @@ impl OnUnknownParser {
             && !features.diagnostic_on_unknown()
         {
             // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
+            args.ignore_args();
             return;
         }
         let span = cx.attr_span;

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -204,6 +204,8 @@ impl DocParser {
 
                 // FIXME: convert list into a Vec of `AttributeKind` because current code is awful.
                 for attr in list.mixed() {
+                    // Arguments of `attr` are checked via the span, so can be safely ignored
+                    attr.ignore_args();
                     self.attribute.test_attrs.push(attr.span());
                 }
             }

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -190,6 +190,8 @@ impl DocParser {
 
                 // FIXME: convert list into a Vec of `AttributeKind` because current code is awful.
                 for attr in list.mixed() {
+                    // Arguments of `attr` are checked via the span, so can be safely ignored
+                    attr.ignore_args();
                     self.attribute.test_attrs.push(attr.span());
                 }
             }

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -14,7 +14,8 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDummyParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
 
-    fn convert(_: &mut AcceptContext<'_, '_, S>, _: &ArgParser) -> Option<AttributeKind> {
+    fn convert(_: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+        args.ignore_args();
         Some(AttributeKind::RustcDummy)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -14,7 +14,8 @@ impl SingleAttributeParser for RustcDummyParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
 
-    fn convert(_: &mut AcceptContext<'_, '_>, _: &ArgParser) -> Option<AttributeKind> {
+    fn convert(_: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
+        args.ignore_args();
         Some(AttributeKind::RustcDummy)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -42,7 +42,7 @@ impl<S: Stage> SingleAttributeParser<S> for InlineParser {
                     return None;
                 };
 
-                match l.meta_item().and_then(|i| i.path().word_sym()) {
+                match l.meta_item_no_args().and_then(|i| i.path().word_sym()) {
                     Some(sym::always) => {
                         Some(AttributeKind::Inline(InlineAttr::Always, cx.attr_span))
                     }

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -39,7 +39,7 @@ impl SingleAttributeParser for InlineParser {
             ArgParser::List(list) => {
                 let l = cx.expect_single(list)?;
 
-                match l.meta_item().and_then(|i| i.path().word_sym()) {
+                match l.meta_item_no_args().and_then(|i| i.path().word_sym()) {
                     Some(sym::always) => {
                         Some(AttributeKind::Inline(InlineAttr::Always, cx.attr_span))
                     }

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -22,7 +22,7 @@ impl<S: Stage> SingleAttributeParser<S> for InstructionSetParser {
         const POSSIBLE_ARM_SYMBOLS: &[Symbol] = &[sym::a32, sym::t32];
         let maybe_meta_item = cx.single_element_list(args, cx.attr_span)?;
 
-        let Some(meta_item) = maybe_meta_item.meta_item() else {
+        let Some(meta_item) = maybe_meta_item.meta_item_no_args() else {
             cx.adcx().expected_specific_argument(maybe_meta_item.span(), POSSIBLE_SYMBOLS);
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -21,7 +21,7 @@ impl SingleAttributeParser for InstructionSetParser {
         const POSSIBLE_ARM_SYMBOLS: &[Symbol] = &[sym::a32, sym::t32];
         let maybe_meta_item = cx.expect_single_element_list(args, cx.attr_span)?;
 
-        let Some(meta_item) = maybe_meta_item.meta_item() else {
+        let Some(meta_item) = maybe_meta_item.meta_item_no_args() else {
             cx.adcx().expected_specific_argument(maybe_meta_item.span(), POSSIBLE_SYMBOLS);
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -146,7 +146,7 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
                     cx.adcx().warn_ill_formed_attribute_input(INVALID_MACRO_EXPORT_ARGUMENTS);
                     return None;
                 };
-                match l.meta_item().and_then(|i| i.path().word_sym()) {
+                match l.meta_item_no_args().and_then(|i| i.path().word_sym()) {
                     Some(sym::local_inner_macros) => true,
                     _ => {
                         cx.adcx().warn_ill_formed_attribute_input(INVALID_MACRO_EXPORT_ARGUMENTS);

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -145,7 +145,7 @@ impl SingleAttributeParser for MacroExportParser {
                     cx.adcx().warn_ill_formed_attribute_input(INVALID_MACRO_EXPORT_ARGUMENTS);
                     return None;
                 };
-                match l.meta_item().and_then(|i| i.path().word_sym()) {
+                match l.meta_item_no_args().and_then(|i| i.path().word_sym()) {
                     Some(sym::local_inner_macros) => true,
                     _ => {
                         cx.adcx().warn_ill_formed_attribute_input(INVALID_MACRO_EXPORT_ARGUMENTS);

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -110,7 +110,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcDumpLayoutParser {
 
         let mut result = Vec::new();
         for item in items.mixed() {
-            let Some(arg) = item.meta_item() else {
+            let Some(arg) = item.meta_item_no_args() else {
                 cx.adcx().expected_not_literal(item.span());
                 continue;
             };

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -98,7 +98,7 @@ impl CombineAttributeParser for RustcDumpLayoutParser {
 
         let mut result = Vec::new();
         for item in items.mixed() {
-            let Some(arg) = item.meta_item() else {
+            let Some(arg) = item.meta_item_no_args() else {
                 cx.adcx().expected_not_literal(item.span());
                 continue;
             };

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -945,7 +945,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcIfThisChangedParser {
                     cx.adcx().expected_single_argument(attr_span, list.len());
                     return None;
                 };
-                let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {
+                let Some(ident) = item.meta_item_no_args().and_then(|item| item.ident()) else {
                     cx.adcx().expected_identifier(item.span());
                     return None;
                 };
@@ -1003,7 +1003,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcThenThisWouldNeedParser {
             cx.emit_err(AttributeRequiresOpt { span: cx.attr_span, opt: "-Z query-dep-graph" });
         }
         let item = cx.single_element_list(args, cx.attr_span)?;
-        let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {
+        let Some(ident) = item.meta_item_no_args().and_then(|item| item.ident()) else {
             cx.adcx().expected_identifier(item.span());
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -49,7 +49,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcMustImplementOneOfParser {
 
         let mut errored = false;
         for argument in inputs {
-            let Some(meta) = argument.meta_item() else {
+            let Some(meta) = argument.meta_item_no_args() else {
                 cx.adcx().expected_identifier(argument.span());
                 return None;
             };

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -43,7 +43,7 @@ impl SingleAttributeParser for RustcMustImplementOneOfParser {
 
         let mut errored = false;
         for argument in inputs {
-            let Some(meta) = argument.meta_item() else {
+            let Some(meta) = argument.meta_item_no_args() else {
                 cx.adcx().expected_identifier(argument.span());
                 return None;
             };

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -820,7 +820,7 @@ impl SingleAttributeParser for RustcIfThisChangedParser {
             ArgParser::NoArgs => Some(AttributeKind::RustcIfThisChanged(cx.attr_span, None)),
             ArgParser::List(list) => {
                 let item = cx.expect_single(list)?;
-                let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {
+                let Some(ident) = item.meta_item_no_args().and_then(|item| item.ident()) else {
                     cx.adcx().expected_identifier(item.span());
                     return None;
                 };
@@ -878,7 +878,7 @@ impl CombineAttributeParser for RustcThenThisWouldNeedParser {
             cx.emit_err(AttributeRequiresOpt { span: cx.attr_span, opt: "-Z query-dep-graph" });
         }
         let item = cx.expect_single_element_list(args, cx.attr_span)?;
-        let Some(ident) = item.meta_item().and_then(|item| item.ident()) else {
+        let Some(ident) = item.meta_item_no_args().and_then(|item| item.ident()) else {
             cx.adcx().expected_identifier(item.span());
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -157,7 +157,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAbiParser {
         let mut fail_incorrect_argument =
             |span| cx.adcx().expected_specific_argument(span, &[sym::assert_eq, sym::debug]);
 
-        let Some(arg) = arg.meta_item() else {
+        let Some(arg) = arg.meta_item_no_args() else {
             fail_incorrect_argument(args.span);
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -210,7 +210,7 @@ impl<S: Stage> SingleAttributeParser<S> for TestRunnerParser {
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.single_element_list(args, cx.attr_span)?;
 
-        let Some(meta) = single.meta_item() else {
+        let Some(meta) = single.meta_item_no_args() else {
             cx.adcx().expected_not_literal(single.span());
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -123,7 +123,7 @@ impl SingleAttributeParser for RustcAbiParser {
         let mut fail_incorrect_argument =
             |span| cx.adcx().expected_specific_argument(span, &[sym::assert_eq, sym::debug]);
 
-        let Some(arg) = arg.meta_item() else {
+        let Some(arg) = arg.meta_item_no_args() else {
             fail_incorrect_argument(args.span);
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -173,7 +173,7 @@ impl SingleAttributeParser for TestRunnerParser {
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
 
-        let Some(meta) = single.meta_item() else {
+        let Some(meta) = single.meta_item_no_args() else {
             cx.adcx().expected_not_literal(single.span());
             return None;
         };

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -465,6 +465,8 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
         kind: AttributeLintKind,
         span: M,
     ) {
+        #[cfg(debug_assertions)]
+        self.has_lint_been_emitted.store(true, std::sync::atomic::Ordering::Relaxed);
         if !matches!(
             self.stage.should_emit(),
             ShouldEmit::ErrorsAndLints { .. } | ShouldEmit::EarlyFatal { also_emit_lints: true }
@@ -568,6 +570,11 @@ pub struct SharedContext<'p, 'sess, S: Stage> {
     /// The second argument of the closure is a [`NodeId`] if `S` is `Early` and a [`HirId`] if `S`
     /// is `Late` and is the ID of the syntactical component this attribute was applied to.
     pub(crate) emit_lint: &'p mut dyn FnMut(LintId, MultiSpan, AttributeLintKind),
+
+    /// This atomic bool keeps track of whether any lint has been emitted.
+    /// This is used for the arguments-used check.
+    #[cfg(debug_assertions)]
+    pub(crate) has_lint_been_emitted: std::sync::atomic::AtomicBool,
 }
 
 /// Context given to every attribute parser during finalization.

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -4,6 +4,8 @@ use std::collections::btree_map::Entry;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::LazyLock;
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rustc_ast::{AttrStyle, MetaItemLit, Safety};
 use rustc_data_structures::sync::{DynSend, DynSync};
@@ -405,6 +407,8 @@ impl<'f, 'sess: 'f> SharedContext<'f, 'sess> {
         kind: EmitAttribute,
         span: impl Into<MultiSpan>,
     ) {
+        #[cfg(debug_assertions)]
+        self.has_lint_been_emitted.store(true, Ordering::Relaxed);
         if !matches!(
             self.should_emit,
             ShouldEmit::ErrorsAndLints { .. } | ShouldEmit::EarlyFatal { also_emit_lints: true }
@@ -744,6 +748,11 @@ pub struct SharedContext<'p, 'sess> {
     pub(crate) target: rustc_hir::Target,
 
     pub(crate) emit_lint: &'p mut dyn FnMut(LintId, MultiSpan, EmitAttribute),
+
+    /// This atomic bool keeps track of whether any lint has been emitted.
+    /// This is used for the arguments-used check.
+    #[cfg(debug_assertions)]
+    pub(crate) has_lint_been_emitted: AtomicBool,
 }
 
 /// Context given to every attribute parser during finalization.

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -207,6 +207,8 @@ impl<'sess> AttributeParser<'sess, Early> {
                 target_span,
                 target,
                 emit_lint: &mut emit_lint,
+                #[cfg(debug_assertions)]
+                has_lint_been_emitted: std::sync::atomic::AtomicBool::new(false),
             },
             attr_span,
             inner_span,
@@ -372,6 +374,8 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                                 target_span,
                                 target,
                                 emit_lint: &mut emit_lint,
+                                #[cfg(debug_assertions)]
+                                has_lint_been_emitted: std::sync::atomic::AtomicBool::new(false),
                             },
                             attr_span,
                             inner_span: lower_span(n.item.span()),
@@ -384,6 +388,14 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                         (accept.accept_fn)(&mut cx, &args);
                         finalizers.push(&accept.finalizer);
 
+                        #[cfg(debug_assertions)]
+                        if !cx
+                            .shared
+                            .has_lint_been_emitted
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                        {
+                            cx.shared.cx.check_args_used(&attr, &args)
+                        }
                         if !matches!(cx.stage.should_emit(), ShouldEmit::Nothing) {
                             Self::check_target(&accept.allowed_targets, target, &mut cx);
                         }
@@ -423,7 +435,14 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         early_parsed_state.finalize_early_parsed_attributes(&mut attributes);
         for f in &finalizers {
             if let Some(attr) = f(&mut FinalizeContext {
-                shared: SharedContext { cx: self, target_span, target, emit_lint: &mut emit_lint },
+                shared: SharedContext {
+                    cx: self,
+                    target_span,
+                    target,
+                    emit_lint: &mut emit_lint,
+                    #[cfg(debug_assertions)]
+                    has_lint_been_emitted: std::sync::atomic::AtomicBool::new(false),
+                },
                 all_attrs: &attr_paths,
             }) {
                 attributes.push(Attribute::Parsed(attr));
@@ -437,6 +456,26 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         }
 
         attributes
+    }
+
+    #[cfg(debug_assertions)]
+    /// Checks whether all `ArgParser`s were observed by an attribute parser at least once
+    /// This check exists because otherwise it is too easy to accidentally ignore the arguments of an attribute
+    fn check_args_used(&self, attr: &ast::Attribute, args: &ArgParser) {
+        if let ArgParser::List(items) = args {
+            for item in items.mixed() {
+                if let crate::parser::MetaItemOrLitParser::MetaItemParser(item) = item {
+                    if !item.are_args_checked() {
+                        self.dcx().span_delayed_bug(
+                            item.span(),
+                            "attribute args were not properly checked",
+                        );
+                        return;
+                    }
+                    self.check_args_used(attr, item.args());
+                }
+            }
+        }
     }
 
     /// Returns whether there is a parser for an attribute with this name

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -1,4 +1,6 @@
 use std::convert::identity;
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rustc_ast as ast;
 use rustc_ast::token::DocFragmentKind;
@@ -228,6 +230,8 @@ impl<'sess> AttributeParser<'sess> {
                 target_span,
                 target,
                 emit_lint: &mut emit_lint,
+                #[cfg(debug_assertions)]
+                has_lint_been_emitted: AtomicBool::new(false),
             },
             attr_span,
             inner_span,
@@ -394,6 +398,8 @@ impl<'sess> AttributeParser<'sess> {
                                 target_span,
                                 target,
                                 emit_lint: &mut emit_lint,
+                                #[cfg(debug_assertions)]
+                                has_lint_been_emitted: AtomicBool::new(false),
                             },
                             attr_span,
                             inner_span: lower_span(n.item.span()),
@@ -408,6 +414,10 @@ impl<'sess> AttributeParser<'sess> {
                         finalizers.push(accept.finalizer);
 
                         Self::check_target(&accept.allowed_targets, &mut cx);
+                        #[cfg(debug_assertions)]
+                        if !cx.shared.has_lint_been_emitted.load(Ordering::Relaxed) {
+                            cx.shared.cx.check_args_used(&attr, &args)
+                        }
                     } else {
                         let attr = AttrItem {
                             path: attr_path.clone(),
@@ -441,7 +451,14 @@ impl<'sess> AttributeParser<'sess> {
         early_parsed_state.finalize_early_parsed_attributes(&mut attributes);
         for f in &finalizers {
             if let Some(attr) = f(&mut FinalizeContext {
-                shared: SharedContext { cx: self, target_span, target, emit_lint: &mut emit_lint },
+                shared: SharedContext {
+                    cx: self,
+                    target_span,
+                    target,
+                    emit_lint: &mut emit_lint,
+                    #[cfg(debug_assertions)]
+                    has_lint_been_emitted: AtomicBool::new(false),
+                },
                 all_attrs: &attr_paths,
             }) {
                 attributes.push(Attribute::Parsed(attr));
@@ -453,6 +470,26 @@ impl<'sess> AttributeParser<'sess> {
         }
 
         attributes
+    }
+
+    #[cfg(debug_assertions)]
+    /// Checks whether all `ArgParser`s were observed by an attribute parser at least once
+    /// This check exists because otherwise it is too easy to accidentally ignore the arguments of an attribute
+    fn check_args_used(&self, attr: &ast::Attribute, args: &ArgParser) {
+        if let ArgParser::List(items) = args {
+            for item in items.mixed() {
+                if let crate::parser::MetaItemOrLitParser::MetaItemParser(item) = item {
+                    if !item.are_args_checked() {
+                        self.dcx().span_delayed_bug(
+                            item.span(),
+                            "attribute args were not properly checked",
+                        );
+                        return;
+                    }
+                    self.check_args_used(attr, item.args());
+                }
+            }
+        }
     }
 
     /// Returns whether there is a parser for an attribute with this name

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -5,7 +5,7 @@
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display};
-use std::sync::atomic::AtomicBool;
+
 use rustc_ast::token::{self, Delimiter, MetaVarKind};
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{
@@ -209,6 +209,19 @@ impl ArgParser {
             Self::NameValue(args) => Err(args.args_span()),
         }
     }
+
+    /// Explicitly ignore the arguments, disarming the arguments-used check
+    pub fn ignore_args(&self) {
+        #[cfg(debug_assertions)]
+        match self {
+            ArgParser::List(list) => {
+                for item in list.mixed() {
+                    item.ignore_args();
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Inside lists, values could be either literals, or more deeply nested meta items.
@@ -253,6 +266,26 @@ impl MetaItemOrLitParser {
             MetaItemOrLitParser::Lit(_) => None,
         }
     }
+
+    /// Returns some if this `MetaItemOrLitParser` is a `MetaItem` with no arguments
+    pub fn meta_item_no_args(&self) -> Option<&MetaItemParser> {
+        let meta_item = self.meta_item()?;
+        match meta_item.args().no_args() {
+            Ok(_) => Some(meta_item),
+            Err(_) => None,
+        }
+    }
+
+    /// Explicitly ignore the arguments, disarming the arguments-used check
+    pub fn ignore_args(&self) {
+        #[cfg(debug_assertions)]
+        match self {
+            MetaItemOrLitParser::MetaItemParser(meta_item) => {
+                meta_item.ignore_args();
+            }
+            MetaItemOrLitParser::Lit(_) => {}
+        }
+    }
 }
 
 /// Utility that deconstructs a MetaItem into usable parts.
@@ -271,6 +304,11 @@ impl MetaItemOrLitParser {
 pub struct MetaItemParser {
     path: OwnedPathParser,
     args: ArgParser,
+
+    /// Whether the `args` of this meta item have been looked at.
+    /// This is tracked because if the arguments of a `MetaItemParser` are ignored, this is probably a mistake
+    #[cfg(debug_assertions)]
+    args_checked: std::sync::atomic::AtomicBool,
 }
 
 impl Debug for MetaItemParser {
@@ -307,6 +345,8 @@ impl MetaItemParser {
 
     /// Gets just the args parser, without caring about the path.
     pub fn args(&self) -> &ArgParser {
+        #[cfg(debug_assertions)]
+        self.args_checked.store(true, std::sync::atomic::Ordering::Relaxed);
         &self.args
     }
 
@@ -318,6 +358,17 @@ impl MetaItemParser {
     ///   and not a word and should instead be parsed using [`path`](Self::path)
     pub fn word_is(&self, sym: Symbol) -> Option<&ArgParser> {
         self.path().word_is(sym).then(|| self.args())
+    }
+
+    /// Explicitly ignore the arguments, disarming the arguments-used check
+    pub fn ignore_args(&self) {
+        #[cfg(debug_assertions)]
+        self.args().ignore_args();
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn are_args_checked(&self) -> bool {
+        self.args_checked.load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -529,7 +580,12 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
             ArgParser::NoArgs
         };
 
-        Ok(MetaItemParser { path: PathParser(path), args })
+        Ok(MetaItemParser {
+            path: PathParser(path),
+            args,
+            #[cfg(debug_assertions)]
+            args_checked: std::sync::atomic::AtomicBool::new(false),
+        })
     }
 
     fn parse_meta_item_inner(&mut self) -> PResult<'sess, MetaItemOrLitParser> {

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -5,7 +5,7 @@
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display};
-
+use std::sync::atomic::AtomicBool;
 use rustc_ast::token::{self, Delimiter, MetaVarKind};
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{
@@ -87,7 +87,7 @@ impl<P: Borrow<Path>> Display for PathParser<P> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[must_use]
 pub enum ArgParser {
     NoArgs,
@@ -215,7 +215,7 @@ impl ArgParser {
 /// This enum represents that.
 ///
 /// Choose which one you want using the provided methods.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum MetaItemOrLitParser {
     MetaItemParser(MetaItemParser),
     Lit(MetaItemLit),
@@ -268,7 +268,6 @@ impl MetaItemOrLitParser {
 ///   `= value` part
 ///
 /// The syntax of MetaItems can be found at <https://doc.rust-lang.org/reference/attributes.html>
-#[derive(Clone)]
 pub struct MetaItemParser {
     path: OwnedPathParser,
     args: ArgParser,
@@ -655,7 +654,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MetaItemListParser {
     sub_parsers: ThinVec<MetaItemOrLitParser>,
     pub span: Span,

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -5,7 +5,7 @@
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display};
-
+use std::sync::atomic::AtomicBool;
 use rustc_ast::token::{self, Delimiter, MetaVarKind};
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{
@@ -87,7 +87,7 @@ impl<P: Borrow<Path>> Display for PathParser<P> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[must_use]
 pub enum ArgParser {
     NoArgs,
@@ -215,7 +215,7 @@ impl ArgParser {
 /// This enum represents that.
 ///
 /// Choose which one you want using the provided methods.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum MetaItemOrLitParser {
     MetaItemParser(MetaItemParser),
     Lit(MetaItemLit),
@@ -270,7 +270,6 @@ impl MetaItemOrLitParser {
 ///   `= value` part
 ///
 /// The syntax of MetaItems can be found at <https://doc.rust-lang.org/reference/attributes.html>
-#[derive(Clone)]
 pub struct MetaItemParser {
     path: OwnedPathParser,
     args: ArgParser,
@@ -670,7 +669,7 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MetaItemListParser {
     sub_parsers: ThinVec<MetaItemOrLitParser>,
     pub span: Span,

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -5,7 +5,9 @@
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display};
-use std::sync::atomic::AtomicBool;
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use rustc_ast::token::{self, Delimiter, MetaVarKind};
 use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::{
@@ -209,6 +211,19 @@ impl ArgParser {
             Self::NameValue(args) => Err(args.args_span()),
         }
     }
+
+    /// Explicitly ignore the arguments, disarming the arguments-used check
+    pub fn ignore_args(&self) {
+        #[cfg(debug_assertions)]
+        match self {
+            ArgParser::List(list) => {
+                for item in list.mixed() {
+                    item.ignore_args();
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Inside lists, values could be either literals, or more deeply nested meta items.
@@ -253,6 +268,26 @@ impl MetaItemOrLitParser {
             MetaItemOrLitParser::Lit(_) => None,
         }
     }
+
+    /// Returns some if this `MetaItemOrLitParser` is a `MetaItem` with no arguments
+    pub fn meta_item_no_args(&self) -> Option<&MetaItemParser> {
+        let meta_item = self.meta_item()?;
+        match meta_item.args().as_no_args() {
+            Ok(_) => Some(meta_item),
+            Err(_) => None,
+        }
+    }
+
+    /// Explicitly ignore the arguments, disarming the arguments-used check
+    pub fn ignore_args(&self) {
+        #[cfg(debug_assertions)]
+        match self {
+            MetaItemOrLitParser::MetaItemParser(meta_item) => {
+                meta_item.ignore_args();
+            }
+            MetaItemOrLitParser::Lit(_) => {}
+        }
+    }
 }
 
 // FIXME(scrabsha): once #155696 is merged, update this and mention the higher-level APIs.
@@ -273,6 +308,11 @@ impl MetaItemOrLitParser {
 pub struct MetaItemParser {
     path: OwnedPathParser,
     args: ArgParser,
+
+    /// Whether the `args` of this meta item have been looked at.
+    /// This is tracked because if the arguments of a `MetaItemParser` are ignored, this is probably a mistake
+    #[cfg(debug_assertions)]
+    args_checked: AtomicBool,
 }
 
 impl Debug for MetaItemParser {
@@ -309,6 +349,8 @@ impl MetaItemParser {
 
     /// Gets just the args parser, without caring about the path.
     pub fn args(&self) -> &ArgParser {
+        #[cfg(debug_assertions)]
+        self.args_checked.store(true, Ordering::Relaxed);
         &self.args
     }
 
@@ -320,6 +362,16 @@ impl MetaItemParser {
     ///   and not a word and should instead be parsed using [`path`](Self::path)
     pub fn word_is(&self, sym: Symbol) -> Option<&ArgParser> {
         self.path().word_is(sym).then(|| self.args())
+    }
+
+    /// Explicitly ignore the arguments, disarming the arguments-used check
+    pub fn ignore_args(&self) {
+        self.args().ignore_args();
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn are_args_checked(&self) -> bool {
+        self.args_checked.load(Ordering::Relaxed)
     }
 }
 
@@ -544,7 +596,12 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
             ArgParser::NoArgs
         };
 
-        Ok(MetaItemParser { path: PathParser(path), args })
+        Ok(MetaItemParser {
+            path: PathParser(path),
+            args,
+            #[cfg(debug_assertions)]
+            args_checked: AtomicBool::new(false),
+        })
     }
 
     fn parse_meta_item_inner(&mut self) -> PResult<'sess, MetaItemOrLitParser> {

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -9,3 +9,13 @@
 fn main() {
 
 }
+
+#[macro_export(local_inner_macros = 5)]
+//~^ ERROR valid forms for the attribute are
+//~| WARN previously accepted
+#[macro_export(local_inner_macros(x, y, z))]
+//~^ ERROR valid forms for the attribute are
+//~| WARN previously accepted
+macro_rules! m {
+    () => {};
+}

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -52,3 +52,11 @@ static H: u64 = 5;
 trait T {
 
 }
+
+#[rustc_dump_layout(debug = 5)]
+//~^ ERROR malformed
+#[rustc_dump_layout(debug(x, y, z))]
+//~^ ERROR malformed
+enum E {
+
+}

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -2,6 +2,10 @@
 //~^ ERROR malformed
 #[inline(always(x, y, z))]
 //~^ ERROR malformed
+#[instruction_set(arm::a32 = 5)]
+//~^ ERROR malformed
+#[instruction_set(arm::a32(x, y, z))]
+//~^ ERROR malformed
 fn main() {
 
 }

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -19,6 +19,10 @@
 //~^ ERROR malformed
 #[coverage(off(x, y, z))]
 //~^ ERROR malformed
+#[rustc_abi(debug = 5)]
+//~^ ERROR malformed
+#[rustc_abi(debug(x, y, z))]
+//~^ ERROR malformed
 fn main() {
 
 }

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,0 +1,7 @@
+#[inline(always = 5)]
+//~^ ERROR malformed
+#[inline(always(x, y, z))]
+//~^ ERROR malformed
+fn main() {
+
+}

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,7 +1,13 @@
 #![feature(rustc_attrs)]
 #![feature(optimize_attribute)]
 #![feature(coverage_attribute)]
+#![feature(custom_test_frameworks)]
 #![allow(unused_attributes)]
+
+#![test_runner(x = 5)]
+//~^ ERROR malformed
+#![test_runner(x(x,y,z))]
+//~^ ERROR malformed
 
 #[inline(always = 5)]
 //~^ ERROR malformed

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -38,3 +38,9 @@ macro_rules! m {
 #[rustc_allow_const_fn_unstable(x(x, y, z))]
 //~^ ERROR `rustc_allow_const_fn_unstable` expects feature names
 const fn g() {}
+
+#[used(always = 5)]
+//~^ ERROR malformed
+#[used(always(x, y, z))]
+//~^ ERROR malformed
+static H: u64 = 5;

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,4 +1,6 @@
 #![feature(rustc_attrs)]
+#![feature(optimize_attribute)]
+#![allow(unused_attributes)]
 
 #[inline(always = 5)]
 //~^ ERROR malformed
@@ -7,6 +9,10 @@
 #[instruction_set(arm::a32 = 5)]
 //~^ ERROR malformed
 #[instruction_set(arm::a32(x, y, z))]
+//~^ ERROR malformed
+#[optimize(size = 5)]
+//~^ ERROR malformed
+#[optimize(size(x, y, z))]
 //~^ ERROR malformed
 fn main() {
 

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_attrs)]
 #![feature(optimize_attribute)]
+#![feature(coverage_attribute)]
 #![allow(unused_attributes)]
 
 #[inline(always = 5)]
@@ -13,6 +14,10 @@
 #[optimize(size = 5)]
 //~^ ERROR malformed
 #[optimize(size(x, y, z))]
+//~^ ERROR malformed
+#[coverage(off = 5)]
+//~^ ERROR malformed
+#[coverage(off(x, y, z))]
 //~^ ERROR malformed
 fn main() {
 

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -44,3 +44,11 @@ const fn g() {}
 #[used(always(x, y, z))]
 //~^ ERROR malformed
 static H: u64 = 5;
+
+#[rustc_must_implement_one_of(eq = 5, neq)]
+//~^ ERROR malformed
+#[rustc_must_implement_one_of(eq(x, y, z), neq)]
+//~^ ERROR malformed
+trait T {
+
+}

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 #[inline(always = 5)]
 //~^ ERROR malformed
 #[inline(always(x, y, z))]
@@ -19,3 +21,9 @@ fn main() {
 macro_rules! m {
     () => {};
 }
+
+#[rustc_allow_const_fn_unstable(x = 5)]
+//~^ ERROR `rustc_allow_const_fn_unstable` expects feature names
+#[rustc_allow_const_fn_unstable(x(x, y, z))]
+//~^ ERROR `rustc_allow_const_fn_unstable` expects feature names
+const fn g() {}

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_attrs)]
 #![feature(optimize_attribute)]
+#![feature(coverage_attribute)]
 #![allow(unused_attributes)]
 
 #[inline(always = 5)]
@@ -15,6 +16,10 @@
 #[optimize(size(x, y, z))]
 //~^ ERROR malformed
 //~| ERROR multiple `optimize` attributes
+#[coverage(off = 5)]
+//~^ ERROR malformed
+#[coverage(off(x, y, z))]
+//~^ ERROR malformed
 fn main() {
 
 }

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -1,4 +1,6 @@
 #![feature(rustc_attrs)]
+#![feature(optimize_attribute)]
+#![allow(unused_attributes)]
 
 #[inline(always = 5)]
 //~^ ERROR malformed
@@ -8,6 +10,11 @@
 //~^ ERROR malformed
 #[instruction_set(arm::a32(x, y, z))]
 //~^ ERROR malformed
+#[optimize(size = 5)]
+//~^ ERROR malformed
+#[optimize(size(x, y, z))]
+//~^ ERROR malformed
+//~| ERROR multiple `optimize` attributes
 fn main() {
 
 }

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -20,6 +20,10 @@
 //~^ ERROR malformed
 #[coverage(off(x, y, z))]
 //~^ ERROR malformed
+#[rustc_abi(debug = 5)]
+//~^ ERROR malformed
+#[rustc_abi(debug(x, y, z))]
+//~^ ERROR malformed
 fn main() {
 
 }

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -45,3 +45,11 @@ const fn g() {}
 #[used(always(x, y, z))]
 //~^ ERROR malformed
 static H: u64 = 5;
+
+#[rustc_must_implement_one_of(eq = 5, neq)]
+//~^ ERROR malformed
+#[rustc_must_implement_one_of(eq(x, y, z), neq)]
+//~^ ERROR malformed
+trait T {
+
+}

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -39,3 +39,9 @@ macro_rules! m {
 #[rustc_allow_const_fn_unstable(x(x, y, z))]
 //~^ ERROR `rustc_allow_const_fn_unstable` expects feature names
 const fn g() {}
+
+#[used(always = 5)]
+//~^ ERROR malformed
+#[used(always(x, y, z))]
+//~^ ERROR malformed
+static H: u64 = 5;

--- a/tests/ui/attributes/args-checked.rs
+++ b/tests/ui/attributes/args-checked.rs
@@ -53,3 +53,11 @@ static H: u64 = 5;
 trait T {
 
 }
+
+#[rustc_dump_layout(debug = 5)]
+//~^ ERROR malformed
+#[rustc_dump_layout(debug(x, y, z))]
+//~^ ERROR malformed
+enum E {
+
+}

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -148,6 +148,46 @@ error: `rustc_allow_const_fn_unstable` expects feature names
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
+error[E0539]: malformed `used` attribute input
+  --> $DIR/args-checked.rs:42:1
+   |
+LL | #[used(always = 5)]
+   | ^^^^^^^----------^^
+   |        |
+   |        valid arguments are `compiler` or `linker`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[used(always = 5)]
+LL + #[used(compiler)]
+   |
+LL - #[used(always = 5)]
+LL + #[used(linker)]
+   |
+LL - #[used(always = 5)]
+LL + #[used]
+   |
+
+error[E0539]: malformed `used` attribute input
+  --> $DIR/args-checked.rs:44:1
+   |
+LL | #[used(always(x, y, z))]
+   | ^^^^^^^---------------^^
+   |        |
+   |        valid arguments are `compiler` or `linker`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[used(always(x, y, z))]
+LL + #[used(compiler)]
+   |
+LL - #[used(always(x, y, z))]
+LL + #[used(linker)]
+   |
+LL - #[used(always(x, y, z))]
+LL + #[used]
+   |
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:26:1
    |
@@ -167,7 +207,7 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:1:1
+  --> $DIR/args-checked.rs:3:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +20,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:3:1
+  --> $DIR/args-checked.rs:5:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +41,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:5:1
+  --> $DIR/args-checked.rs:7:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -52,7 +52,7 @@ LL | #[instruction_set(arm::a32 = 5)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:9:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -62,8 +62,20 @@ LL | #[instruction_set(arm::a32(x, y, z))]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
+error: `rustc_allow_const_fn_unstable` expects feature names
+  --> $DIR/args-checked.rs:25:33
+   |
+LL | #[rustc_allow_const_fn_unstable(x = 5)]
+   |                                 ^^^^^
+
+error: `rustc_allow_const_fn_unstable` expects feature names
+  --> $DIR/args-checked.rs:27:33
+   |
+LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
+   |                                 ^^^^^^^^^^
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:15:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -73,7 +85,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:18:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,12 +93,12 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:15:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +109,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:18:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,23 @@
+error[E0565]: malformed `test_runner` attribute input
+  --> $DIR/args-checked.rs:7:1
+   |
+LL | #![test_runner(x = 5)]
+   | ^^^^^^^^^^^^^^^-----^^
+   | |              |
+   | |              didn't expect a literal here
+   | help: must be of the form: `#![test_runner(path)]`
+
+error[E0565]: malformed `test_runner` attribute input
+  --> $DIR/args-checked.rs:9:1
+   |
+LL | #![test_runner(x(x,y,z))]
+   | ^^^^^^^^^^^^^^^--------^^
+   | |              |
+   | |              didn't expect a literal here
+   | help: must be of the form: `#![test_runner(path)]`
+
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:6:1
+  --> $DIR/args-checked.rs:12:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +38,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:8:1
+  --> $DIR/args-checked.rs:14:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +59,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:10:1
+  --> $DIR/args-checked.rs:16:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -52,7 +70,7 @@ LL | #[instruction_set(arm::a32 = 5)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:12:1
+  --> $DIR/args-checked.rs:18:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -63,7 +81,7 @@ LL | #[instruction_set(arm::a32(x, y, z))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:14:1
+  --> $DIR/args-checked.rs:20:1
    |
 LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^--------^^
@@ -83,7 +101,7 @@ LL + #[optimize(speed)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:22:1
    |
 LL | #[optimize(size(x, y, z))]
    | ^^^^^^^^^^^-------------^^
@@ -103,7 +121,7 @@ LL + #[optimize(speed)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/args-checked.rs:18:1
+  --> $DIR/args-checked.rs:24:1
    |
 LL | #[coverage(off = 5)]
    | ^^^^^^^^^^^-------^^
@@ -120,7 +138,7 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/args-checked.rs:20:1
+  --> $DIR/args-checked.rs:26:1
    |
 LL | #[coverage(off(x, y, z))]
    | ^^^^^^^^^^^------------^^
@@ -137,7 +155,7 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/args-checked.rs:22:1
+  --> $DIR/args-checked.rs:28:1
    |
 LL | #[rustc_abi(debug = 5)]
    | ^^^^^^^^^^^-----------^
@@ -154,7 +172,7 @@ LL + #[rustc_abi(debug)]
    |
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/args-checked.rs:24:1
+  --> $DIR/args-checked.rs:30:1
    |
 LL | #[rustc_abi(debug(x, y, z))]
    | ^^^^^^^^^^^----------------^
@@ -171,19 +189,19 @@ LL + #[rustc_abi(debug)]
    |
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:40:33
+  --> $DIR/args-checked.rs:46:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:42:33
+  --> $DIR/args-checked.rs:48:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:46:1
+  --> $DIR/args-checked.rs:52:1
    |
 LL | #[used(always = 5)]
    | ^^^^^^^----------^^
@@ -203,7 +221,7 @@ LL + #[used]
    |
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:48:1
+  --> $DIR/args-checked.rs:54:1
    |
 LL | #[used(always(x, y, z))]
    | ^^^^^^^---------------^^
@@ -223,7 +241,7 @@ LL + #[used]
    |
 
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:52:1
+  --> $DIR/args-checked.rs:58:1
    |
 LL | #[rustc_must_implement_one_of(eq = 5, neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
@@ -232,7 +250,7 @@ LL | #[rustc_must_implement_one_of(eq = 5, neq)]
    | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
 
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:54:1
+  --> $DIR/args-checked.rs:60:1
    |
 LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
@@ -241,7 +259,7 @@ LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:60:1
+  --> $DIR/args-checked.rs:66:1
    |
 LL | #[rustc_dump_layout(debug = 5)]
    | ^^^^^^^^^^^^^^^^^^^^---------^^
@@ -249,7 +267,7 @@ LL | #[rustc_dump_layout(debug = 5)]
    |                     didn't expect a literal here
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:62:1
+  --> $DIR/args-checked.rs:68:1
    |
 LL | #[rustc_dump_layout(debug(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^--------------^^
@@ -257,7 +275,7 @@ LL | #[rustc_dump_layout(debug(x, y, z))]
    |                     didn't expect a literal here
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:30:1
+  --> $DIR/args-checked.rs:36:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -267,7 +285,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:33:1
+  --> $DIR/args-checked.rs:39:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -275,13 +293,13 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 20 previous errors
+error: aborting due to 22 previous errors
 
 Some errors have detailed explanations: E0539, E0565.
 For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:30:1
+  --> $DIR/args-checked.rs:36:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -292,7 +310,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:33:1
+  --> $DIR/args-checked.rs:39:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -136,20 +136,54 @@ LL - #[coverage(off(x, y, z))]
 LL + #[coverage(on)]
    |
 
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/args-checked.rs:22:1
+   |
+LL | #[rustc_abi(debug = 5)]
+   | ^^^^^^^^^^^-----------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi(debug = 5)]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi(debug = 5)]
+LL + #[rustc_abi(debug)]
+   |
+
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/args-checked.rs:24:1
+   |
+LL | #[rustc_abi(debug(x, y, z))]
+   | ^^^^^^^^^^^----------------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi(debug(x, y, z))]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi(debug(x, y, z))]
+LL + #[rustc_abi(debug)]
+   |
+
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:36:33
+  --> $DIR/args-checked.rs:40:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:38:33
+  --> $DIR/args-checked.rs:42:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:42:1
+  --> $DIR/args-checked.rs:46:1
    |
 LL | #[used(always = 5)]
    | ^^^^^^^----------^^
@@ -169,7 +203,7 @@ LL + #[used]
    |
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:44:1
+  --> $DIR/args-checked.rs:48:1
    |
 LL | #[used(always(x, y, z))]
    | ^^^^^^^---------------^^
@@ -189,7 +223,7 @@ LL + #[used]
    |
 
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:48:1
+  --> $DIR/args-checked.rs:52:1
    |
 LL | #[rustc_must_implement_one_of(eq = 5, neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
@@ -198,7 +232,7 @@ LL | #[rustc_must_implement_one_of(eq = 5, neq)]
    | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
 
 error[E0539]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:50:1
+  --> $DIR/args-checked.rs:54:1
    |
 LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
@@ -207,7 +241,7 @@ LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:56:1
+  --> $DIR/args-checked.rs:60:1
    |
 LL | #[rustc_dump_layout(debug = 5)]
    | ^^^^^^^^^^^^^^^^^^^^---------^^
@@ -215,7 +249,7 @@ LL | #[rustc_dump_layout(debug = 5)]
    |                     didn't expect a literal here
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:58:1
+  --> $DIR/args-checked.rs:62:1
    |
 LL | #[rustc_dump_layout(debug(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^--------------^^
@@ -223,7 +257,7 @@ LL | #[rustc_dump_layout(debug(x, y, z))]
    |                     didn't expect a literal here
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:26:1
+  --> $DIR/args-checked.rs:30:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +267,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:29:1
+  --> $DIR/args-checked.rs:33:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,13 +275,13 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 18 previous errors
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0539, E0565.
 For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:26:1
+  --> $DIR/args-checked.rs:30:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -258,7 +292,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:29:1
+  --> $DIR/args-checked.rs:33:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -40,6 +40,28 @@ LL - #[inline(always(x, y, z))]
 LL + #[inline]
    |
 
-error: aborting due to 2 previous errors
+error[E0539]: malformed `instruction_set` attribute input
+  --> $DIR/args-checked.rs:5:1
+   |
+LL | #[instruction_set(arm::a32 = 5)]
+   | ^^^^^^^^^^^^^^^^^^------------^^
+   | |                 |
+   | |                 valid arguments are `arm::a32` or `arm::t32`
+   | help: must be of the form: `#[instruction_set(set)]`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+
+error[E0539]: malformed `instruction_set` attribute input
+  --> $DIR/args-checked.rs:7:1
+   |
+LL | #[instruction_set(arm::a32(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^-----------------^^
+   | |                 |
+   | |                 valid arguments are `arm::a32` or `arm::t32`
+   | help: must be of the form: `#[instruction_set(set)]`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,0 +1,45 @@
+error[E0539]: malformed `inline` attribute input
+  --> $DIR/args-checked.rs:1:1
+   |
+LL | #[inline(always = 5)]
+   | ^^^^^^^^^----------^^
+   |          |
+   |          valid arguments are `always` or `never`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[inline(always = 5)]
+LL + #[inline(always)]
+   |
+LL - #[inline(always = 5)]
+LL + #[inline(never)]
+   |
+LL - #[inline(always = 5)]
+LL + #[inline]
+   |
+
+error[E0539]: malformed `inline` attribute input
+  --> $DIR/args-checked.rs:3:1
+   |
+LL | #[inline(always(x, y, z))]
+   | ^^^^^^^^^---------------^^
+   |          |
+   |          valid arguments are `always` or `never`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute>
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[inline(always(x, y, z))]
+LL + #[inline(always)]
+   |
+LL - #[inline(always(x, y, z))]
+LL + #[inline(never)]
+   |
+LL - #[inline(always(x, y, z))]
+LL + #[inline]
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -62,6 +62,47 @@ LL | #[instruction_set(arm::a32(x, y, z))]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
-error: aborting due to 4 previous errors
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[macro_export(local_inner_macros = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:16:1
+   |
+LL | #[macro_export(local_inner_macros(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
+Future incompatibility report: Future breakage diagnostic:
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[macro_export(local_inner_macros = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:16:1
+   |
+LL | #[macro_export(local_inner_macros(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -206,6 +206,22 @@ LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | |                             expected a valid identifier here
    | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
 
+error[E0565]: malformed `rustc_dump_layout` attribute input
+  --> $DIR/args-checked.rs:56:1
+   |
+LL | #[rustc_dump_layout(debug = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^---------^^
+   |                     |
+   |                     didn't expect a literal here
+
+error[E0565]: malformed `rustc_dump_layout` attribute input
+  --> $DIR/args-checked.rs:58:1
+   |
+LL | #[rustc_dump_layout(debug(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^--------------^^
+   |                     |
+   |                     didn't expect a literal here
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:26:1
    |
@@ -225,9 +241,10 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 16 previous errors
+error: aborting due to 18 previous errors
 
-For more information about this error, try `rustc --explain E0539`.
+Some errors have detailed explanations: E0539, E0565.
+For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:26:1

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -188,6 +188,24 @@ LL - #[used(always(x, y, z))]
 LL + #[used]
    |
 
+error[E0539]: malformed `rustc_must_implement_one_of` attribute input
+  --> $DIR/args-checked.rs:48:1
+   |
+LL | #[rustc_must_implement_one_of(eq = 5, neq)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
+   | |                             |
+   | |                             expected a valid identifier here
+   | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
+
+error[E0539]: malformed `rustc_must_implement_one_of` attribute input
+  --> $DIR/args-checked.rs:50:1
+   |
+LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
+   | |                             |
+   | |                             expected a valid identifier here
+   | help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:26:1
    |
@@ -207,7 +225,7 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 14 previous errors
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:3:1
+  --> $DIR/args-checked.rs:5:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +20,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:5:1
+  --> $DIR/args-checked.rs:7:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +41,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:9:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -52,7 +52,7 @@ LL | #[instruction_set(arm::a32 = 5)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:9:1
+  --> $DIR/args-checked.rs:11:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -62,20 +62,60 @@ LL | #[instruction_set(arm::a32(x, y, z))]
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
+error[E0539]: malformed `optimize` attribute input
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[optimize(size = 5)]
+   | ^^^^^^^^^^^--------^^
+   |            |
+   |            valid arguments are `size`, `speed` or `none`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[optimize(size = 5)]
+LL + #[optimize(none)]
+   |
+LL - #[optimize(size = 5)]
+LL + #[optimize(size)]
+   |
+LL - #[optimize(size = 5)]
+LL + #[optimize(speed)]
+   |
+
+error[E0539]: malformed `optimize` attribute input
+  --> $DIR/args-checked.rs:15:1
+   |
+LL | #[optimize(size(x, y, z))]
+   | ^^^^^^^^^^^-------------^^
+   |            |
+   |            valid arguments are `size`, `speed` or `none`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[optimize(size(x, y, z))]
+LL + #[optimize(none)]
+   |
+LL - #[optimize(size(x, y, z))]
+LL + #[optimize(size)]
+   |
+LL - #[optimize(size(x, y, z))]
+LL + #[optimize(speed)]
+   |
+
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:25:33
+  --> $DIR/args-checked.rs:31:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:27:33
+  --> $DIR/args-checked.rs:33:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:21:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +125,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:18:1
+  --> $DIR/args-checked.rs:24:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,12 +133,12 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:21:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +149,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:18:1
+  --> $DIR/args-checked.rs:24:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:5:1
+  --> $DIR/args-checked.rs:6:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +20,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:8:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +41,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:9:1
+  --> $DIR/args-checked.rs:10:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -52,7 +52,7 @@ LL | #[instruction_set(arm::a32 = 5)]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:11:1
+  --> $DIR/args-checked.rs:12:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -63,7 +63,7 @@ LL | #[instruction_set(arm::a32(x, y, z))]
    = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:14:1
    |
 LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^--------^^
@@ -83,7 +83,7 @@ LL + #[optimize(speed)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:16:1
    |
 LL | #[optimize(size(x, y, z))]
    | ^^^^^^^^^^^-------------^^
@@ -102,20 +102,54 @@ LL - #[optimize(size(x, y, z))]
 LL + #[optimize(speed)]
    |
 
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/args-checked.rs:18:1
+   |
+LL | #[coverage(off = 5)]
+   | ^^^^^^^^^^^-------^^
+   |            |
+   |            valid arguments are `on` or `off`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off = 5)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off = 5)]
+LL + #[coverage(on)]
+   |
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/args-checked.rs:20:1
+   |
+LL | #[coverage(off(x, y, z))]
+   | ^^^^^^^^^^^------------^^
+   |            |
+   |            valid arguments are `on` or `off`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off(x, y, z))]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off(x, y, z))]
+LL + #[coverage(on)]
+   |
+
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:31:33
+  --> $DIR/args-checked.rs:36:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:33:33
+  --> $DIR/args-checked.rs:38:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:21:1
+  --> $DIR/args-checked.rs:26:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -125,7 +159,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:24:1
+  --> $DIR/args-checked.rs:29:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -133,12 +167,12 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:21:1
+  --> $DIR/args-checked.rs:26:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +183,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:24:1
+  --> $DIR/args-checked.rs:29:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -236,6 +236,22 @@ LL - #[rustc_must_implement_one_of(eq(x, y, z), neq)]
 LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
+error[E0565]: malformed `rustc_dump_layout` attribute input
+  --> $DIR/args-checked.rs:57:1
+   |
+LL | #[rustc_dump_layout(debug = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^---------^^
+   |                     |
+   |                     didn't expect a literal here
+
+error[E0565]: malformed `rustc_dump_layout` attribute input
+  --> $DIR/args-checked.rs:59:1
+   |
+LL | #[rustc_dump_layout(debug(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^--------------^^
+   |                     |
+   |                     didn't expect a literal here
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:27:1
    |
@@ -255,9 +271,10 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 17 previous errors
+error: aborting due to 19 previous errors
 
-For more information about this error, try `rustc --explain E0539`.
+Some errors have detailed explanations: E0539, E0565.
+For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:27:1

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:5:1
+  --> $DIR/args-checked.rs:6:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +20,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:8:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +41,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:9:1
+  --> $DIR/args-checked.rs:10:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -56,7 +56,7 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:11:1
+  --> $DIR/args-checked.rs:12:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -71,7 +71,7 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:14:1
    |
 LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^--------^^
@@ -91,7 +91,7 @@ LL + #[optimize(speed)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:16:1
    |
 LL | #[optimize(size(x, y, z))]
    | ^^^^^^^^^^^-------------^^
@@ -111,31 +111,65 @@ LL + #[optimize(speed)]
    |
 
 error: multiple `optimize` attributes
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:16:1
    |
 LL | #[optimize(size(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:14:1
    |
 LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^
 
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/args-checked.rs:19:1
+   |
+LL | #[coverage(off = 5)]
+   | ^^^^^^^^^^^-------^^
+   |            |
+   |            valid arguments are `on` or `off`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off = 5)]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off = 5)]
+LL + #[coverage(on)]
+   |
+
+error[E0539]: malformed `coverage` attribute input
+  --> $DIR/args-checked.rs:21:1
+   |
+LL | #[coverage(off(x, y, z))]
+   | ^^^^^^^^^^^------------^^
+   |            |
+   |            valid arguments are `on` or `off`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[coverage(off(x, y, z))]
+LL + #[coverage(off)]
+   |
+LL - #[coverage(off(x, y, z))]
+LL + #[coverage(on)]
+   |
+
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:32:33
+  --> $DIR/args-checked.rs:37:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:34:33
+  --> $DIR/args-checked.rs:39:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:22:1
+  --> $DIR/args-checked.rs:27:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -145,7 +179,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:25:1
+  --> $DIR/args-checked.rs:30:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -153,12 +187,12 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:22:1
+  --> $DIR/args-checked.rs:27:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +203,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:25:1
+  --> $DIR/args-checked.rs:30:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,33 @@
+error[E0565]: malformed `test_runner` attribute input
+  --> $DIR/args-checked.rs:7:1
+   |
+LL | #![test_runner(x = 5)]
+   | ^^^^^^^^^^^^^^^-----^^
+   |                |
+   |                didn't expect a literal here
+   |
+help: must be of the form
+   |
+LL - #![test_runner(x = 5)]
+LL + #![test_runner(path)]
+   |
+
+error[E0565]: malformed `test_runner` attribute input
+  --> $DIR/args-checked.rs:9:1
+   |
+LL | #![test_runner(x(x,y,z))]
+   | ^^^^^^^^^^^^^^^--------^^
+   |                |
+   |                didn't expect a literal here
+   |
+help: must be of the form
+   |
+LL - #![test_runner(x(x,y,z))]
+LL + #![test_runner(path)]
+   |
+
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:6:1
+  --> $DIR/args-checked.rs:12:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +48,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:8:1
+  --> $DIR/args-checked.rs:14:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +69,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:10:1
+  --> $DIR/args-checked.rs:16:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -56,7 +84,7 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:12:1
+  --> $DIR/args-checked.rs:18:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -71,7 +99,7 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:14:1
+  --> $DIR/args-checked.rs:20:1
    |
 LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^--------^^
@@ -91,7 +119,7 @@ LL + #[optimize(speed)]
    |
 
 error[E0539]: malformed `optimize` attribute input
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:22:1
    |
 LL | #[optimize(size(x, y, z))]
    | ^^^^^^^^^^^-------------^^
@@ -111,19 +139,19 @@ LL + #[optimize(speed)]
    |
 
 error: multiple `optimize` attributes
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:22:1
    |
 LL | #[optimize(size(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/args-checked.rs:14:1
+  --> $DIR/args-checked.rs:20:1
    |
 LL | #[optimize(size = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/args-checked.rs:19:1
+  --> $DIR/args-checked.rs:25:1
    |
 LL | #[coverage(off = 5)]
    | ^^^^^^^^^^^-------^^
@@ -140,7 +168,7 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/args-checked.rs:21:1
+  --> $DIR/args-checked.rs:27:1
    |
 LL | #[coverage(off(x, y, z))]
    | ^^^^^^^^^^^------------^^
@@ -157,7 +185,7 @@ LL + #[coverage(on)]
    |
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/args-checked.rs:23:1
+  --> $DIR/args-checked.rs:29:1
    |
 LL | #[rustc_abi(debug = 5)]
    | ^^^^^^^^^^^-----------^
@@ -174,7 +202,7 @@ LL + #[rustc_abi(debug)]
    |
 
 error[E0539]: malformed `rustc_abi` attribute input
-  --> $DIR/args-checked.rs:25:1
+  --> $DIR/args-checked.rs:31:1
    |
 LL | #[rustc_abi(debug(x, y, z))]
    | ^^^^^^^^^^^----------------^
@@ -191,19 +219,19 @@ LL + #[rustc_abi(debug)]
    |
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:41:33
+  --> $DIR/args-checked.rs:47:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:43:33
+  --> $DIR/args-checked.rs:49:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:47:1
+  --> $DIR/args-checked.rs:53:1
    |
 LL | #[used(always = 5)]
    | ^^^^^^^----------^^
@@ -223,7 +251,7 @@ LL + #[used]
    |
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:49:1
+  --> $DIR/args-checked.rs:55:1
    |
 LL | #[used(always(x, y, z))]
    | ^^^^^^^---------------^^
@@ -243,7 +271,7 @@ LL + #[used]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:53:1
+  --> $DIR/args-checked.rs:59:1
    |
 LL | #[rustc_must_implement_one_of(eq = 5, neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
@@ -257,7 +285,7 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:55:1
+  --> $DIR/args-checked.rs:61:1
    |
 LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
@@ -271,7 +299,7 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:61:1
+  --> $DIR/args-checked.rs:67:1
    |
 LL | #[rustc_dump_layout(debug = 5)]
    | ^^^^^^^^^^^^^^^^^^^^---------^^
@@ -279,7 +307,7 @@ LL | #[rustc_dump_layout(debug = 5)]
    |                     didn't expect a literal here
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:63:1
+  --> $DIR/args-checked.rs:69:1
    |
 LL | #[rustc_dump_layout(debug(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^--------------^^
@@ -287,7 +315,7 @@ LL | #[rustc_dump_layout(debug(x, y, z))]
    |                     didn't expect a literal here
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:31:1
+  --> $DIR/args-checked.rs:37:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -297,7 +325,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:34:1
+  --> $DIR/args-checked.rs:40:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -305,13 +333,13 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 21 previous errors
+error: aborting due to 23 previous errors
 
 Some errors have detailed explanations: E0539, E0565.
 For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:31:1
+  --> $DIR/args-checked.rs:37:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -322,7 +350,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:34:1
+  --> $DIR/args-checked.rs:40:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:3:1
+  --> $DIR/args-checked.rs:5:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +20,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:5:1
+  --> $DIR/args-checked.rs:7:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +41,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:9:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -56,7 +56,7 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:9:1
+  --> $DIR/args-checked.rs:11:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -70,20 +70,72 @@ LL - #[instruction_set(arm::a32(x, y, z))]
 LL + #[instruction_set(set)]
    |
 
+error[E0539]: malformed `optimize` attribute input
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[optimize(size = 5)]
+   | ^^^^^^^^^^^--------^^
+   |            |
+   |            valid arguments are `size`, `speed` or `none`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[optimize(size = 5)]
+LL + #[optimize(none)]
+   |
+LL - #[optimize(size = 5)]
+LL + #[optimize(size)]
+   |
+LL - #[optimize(size = 5)]
+LL + #[optimize(speed)]
+   |
+
+error[E0539]: malformed `optimize` attribute input
+  --> $DIR/args-checked.rs:15:1
+   |
+LL | #[optimize(size(x, y, z))]
+   | ^^^^^^^^^^^-------------^^
+   |            |
+   |            valid arguments are `size`, `speed` or `none`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[optimize(size(x, y, z))]
+LL + #[optimize(none)]
+   |
+LL - #[optimize(size(x, y, z))]
+LL + #[optimize(size)]
+   |
+LL - #[optimize(size(x, y, z))]
+LL + #[optimize(speed)]
+   |
+
+error: multiple `optimize` attributes
+  --> $DIR/args-checked.rs:15:1
+   |
+LL | #[optimize(size(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[optimize(size = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:25:33
+  --> $DIR/args-checked.rs:32:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:27:33
+  --> $DIR/args-checked.rs:34:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:22:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +145,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:18:1
+  --> $DIR/args-checked.rs:25:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -101,12 +153,12 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 8 previous errors
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:15:1
+  --> $DIR/args-checked.rs:22:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -117,7 +169,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:18:1
+  --> $DIR/args-checked.rs:25:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -40,6 +40,36 @@ LL - #[inline(always(x, y, z))]
 LL + #[inline]
    |
 
-error: aborting due to 2 previous errors
+error[E0539]: malformed `instruction_set` attribute input
+  --> $DIR/args-checked.rs:5:1
+   |
+LL | #[instruction_set(arm::a32 = 5)]
+   | ^^^^^^^^^^^^^^^^^^------------^^
+   |                   |
+   |                   valid arguments are `arm::a32` or `arm::t32`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+help: must be of the form
+   |
+LL - #[instruction_set(arm::a32 = 5)]
+LL + #[instruction_set(set)]
+   |
+
+error[E0539]: malformed `instruction_set` attribute input
+  --> $DIR/args-checked.rs:7:1
+   |
+LL | #[instruction_set(arm::a32(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^-----------------^^
+   |                   |
+   |                   valid arguments are `arm::a32` or `arm::t32`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute>
+help: must be of the form
+   |
+LL - #[instruction_set(arm::a32(x, y, z))]
+LL + #[instruction_set(set)]
+   |
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -208,6 +208,34 @@ LL - #[used(always(x, y, z))]
 LL + #[used]
    |
 
+error[E0565]: malformed `rustc_must_implement_one_of` attribute input
+  --> $DIR/args-checked.rs:49:1
+   |
+LL | #[rustc_must_implement_one_of(eq = 5, neq)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
+   |                               |
+   |                               expected a valid identifier here
+   |
+help: must be of the form
+   |
+LL - #[rustc_must_implement_one_of(eq = 5, neq)]
+LL + #[rustc_must_implement_one_of(function1, function2, ...)]
+   |
+
+error[E0565]: malformed `rustc_must_implement_one_of` attribute input
+  --> $DIR/args-checked.rs:51:1
+   |
+LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
+   |                               |
+   |                               expected a valid identifier here
+   |
+help: must be of the form
+   |
+LL - #[rustc_must_implement_one_of(eq(x, y, z), neq)]
+LL + #[rustc_must_implement_one_of(function1, function2, ...)]
+   |
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:27:1
    |
@@ -227,7 +255,7 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 15 previous errors
+error: aborting due to 17 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -156,20 +156,54 @@ LL - #[coverage(off(x, y, z))]
 LL + #[coverage(on)]
    |
 
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/args-checked.rs:23:1
+   |
+LL | #[rustc_abi(debug = 5)]
+   | ^^^^^^^^^^^-----------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi(debug = 5)]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi(debug = 5)]
+LL + #[rustc_abi(debug)]
+   |
+
+error[E0539]: malformed `rustc_abi` attribute input
+  --> $DIR/args-checked.rs:25:1
+   |
+LL | #[rustc_abi(debug(x, y, z))]
+   | ^^^^^^^^^^^----------------^
+   |            |
+   |            valid arguments are `assert_eq` or `debug`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[rustc_abi(debug(x, y, z))]
+LL + #[rustc_abi(assert_eq)]
+   |
+LL - #[rustc_abi(debug(x, y, z))]
+LL + #[rustc_abi(debug)]
+   |
+
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:37:33
+  --> $DIR/args-checked.rs:41:33
    |
 LL | #[rustc_allow_const_fn_unstable(x = 5)]
    |                                 ^^^^^
 
 error: `rustc_allow_const_fn_unstable` expects feature names
-  --> $DIR/args-checked.rs:39:33
+  --> $DIR/args-checked.rs:43:33
    |
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:43:1
+  --> $DIR/args-checked.rs:47:1
    |
 LL | #[used(always = 5)]
    | ^^^^^^^----------^^
@@ -189,7 +223,7 @@ LL + #[used]
    |
 
 error[E0539]: malformed `used` attribute input
-  --> $DIR/args-checked.rs:45:1
+  --> $DIR/args-checked.rs:49:1
    |
 LL | #[used(always(x, y, z))]
    | ^^^^^^^---------------^^
@@ -209,7 +243,7 @@ LL + #[used]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:49:1
+  --> $DIR/args-checked.rs:53:1
    |
 LL | #[rustc_must_implement_one_of(eq = 5, neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------^^^^^^^
@@ -223,7 +257,7 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0565]: malformed `rustc_must_implement_one_of` attribute input
-  --> $DIR/args-checked.rs:51:1
+  --> $DIR/args-checked.rs:55:1
    |
 LL | #[rustc_must_implement_one_of(eq(x, y, z), neq)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^
@@ -237,7 +271,7 @@ LL + #[rustc_must_implement_one_of(function1, function2, ...)]
    |
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:57:1
+  --> $DIR/args-checked.rs:61:1
    |
 LL | #[rustc_dump_layout(debug = 5)]
    | ^^^^^^^^^^^^^^^^^^^^---------^^
@@ -245,7 +279,7 @@ LL | #[rustc_dump_layout(debug = 5)]
    |                     didn't expect a literal here
 
 error[E0565]: malformed `rustc_dump_layout` attribute input
-  --> $DIR/args-checked.rs:59:1
+  --> $DIR/args-checked.rs:63:1
    |
 LL | #[rustc_dump_layout(debug(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^--------------^^
@@ -253,7 +287,7 @@ LL | #[rustc_dump_layout(debug(x, y, z))]
    |                     didn't expect a literal here
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:27:1
+  --> $DIR/args-checked.rs:31:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,7 +297,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:30:1
+  --> $DIR/args-checked.rs:34:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,13 +305,13 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 19 previous errors
+error: aborting due to 21 previous errors
 
 Some errors have detailed explanations: E0539, E0565.
 For more information about an error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:27:1
+  --> $DIR/args-checked.rs:31:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -288,7 +322,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:30:1
+  --> $DIR/args-checked.rs:34:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:1:1
+  --> $DIR/args-checked.rs:3:1
    |
 LL | #[inline(always = 5)]
    | ^^^^^^^^^----------^^
@@ -20,7 +20,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `inline` attribute input
-  --> $DIR/args-checked.rs:3:1
+  --> $DIR/args-checked.rs:5:1
    |
 LL | #[inline(always(x, y, z))]
    | ^^^^^^^^^---------------^^
@@ -41,7 +41,7 @@ LL + #[inline]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:5:1
+  --> $DIR/args-checked.rs:7:1
    |
 LL | #[instruction_set(arm::a32 = 5)]
    | ^^^^^^^^^^^^^^^^^^------------^^
@@ -56,7 +56,7 @@ LL + #[instruction_set(set)]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/args-checked.rs:7:1
+  --> $DIR/args-checked.rs:9:1
    |
 LL | #[instruction_set(arm::a32(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^-----------------^^
@@ -70,8 +70,20 @@ LL - #[instruction_set(arm::a32(x, y, z))]
 LL + #[instruction_set(set)]
    |
 
+error: `rustc_allow_const_fn_unstable` expects feature names
+  --> $DIR/args-checked.rs:25:33
+   |
+LL | #[rustc_allow_const_fn_unstable(x = 5)]
+   |                                 ^^^^^
+
+error: `rustc_allow_const_fn_unstable` expects feature names
+  --> $DIR/args-checked.rs:27:33
+   |
+LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
+   |                                 ^^^^^^^^^^
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:15:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -81,7 +93,7 @@ LL | #[macro_export(local_inner_macros = 5)]
    = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
 
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:18:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,12 +101,12 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:13:1
+  --> $DIR/args-checked.rs:15:1
    |
 LL | #[macro_export(local_inner_macros = 5)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +117,7 @@ LL | #[macro_export(local_inner_macros = 5)]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
-  --> $DIR/args-checked.rs:16:1
+  --> $DIR/args-checked.rs:18:1
    |
 LL | #[macro_export(local_inner_macros(x, y, z))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -168,6 +168,46 @@ error: `rustc_allow_const_fn_unstable` expects feature names
 LL | #[rustc_allow_const_fn_unstable(x(x, y, z))]
    |                                 ^^^^^^^^^^
 
+error[E0539]: malformed `used` attribute input
+  --> $DIR/args-checked.rs:43:1
+   |
+LL | #[used(always = 5)]
+   | ^^^^^^^----------^^
+   |        |
+   |        valid arguments are `compiler` or `linker`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[used(always = 5)]
+LL + #[used(compiler)]
+   |
+LL - #[used(always = 5)]
+LL + #[used(linker)]
+   |
+LL - #[used(always = 5)]
+LL + #[used]
+   |
+
+error[E0539]: malformed `used` attribute input
+  --> $DIR/args-checked.rs:45:1
+   |
+LL | #[used(always(x, y, z))]
+   | ^^^^^^^---------------^^
+   |        |
+   |        valid arguments are `compiler` or `linker`
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[used(always(x, y, z))]
+LL + #[used(compiler)]
+   |
+LL - #[used(always(x, y, z))]
+LL + #[used(linker)]
+   |
+LL - #[used(always(x, y, z))]
+LL + #[used]
+   |
+
 error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
   --> $DIR/args-checked.rs:27:1
    |
@@ -187,7 +227,7 @@ LL | #[macro_export(local_inner_macros(x, y, z))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
 Future incompatibility report: Future breakage diagnostic:

--- a/tests/ui/attributes/args-checked.stderr
+++ b/tests/ui/attributes/args-checked.stderr
@@ -70,6 +70,47 @@ LL - #[instruction_set(arm::a32(x, y, z))]
 LL + #[instruction_set(set)]
    |
 
-error: aborting due to 4 previous errors
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[macro_export(local_inner_macros = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
+
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:16:1
+   |
+LL | #[macro_export(local_inner_macros(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0539`.
+Future incompatibility report: Future breakage diagnostic:
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:13:1
+   |
+LL | #[macro_export(local_inner_macros = 5)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
+
+Future breakage diagnostic:
+error: valid forms for the attribute are `#[macro_export(local_inner_macros)]` and `#[macro_export]`
+  --> $DIR/args-checked.rs:16:1
+   |
+LL | #[macro_export(local_inner_macros(x, y, z))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
+   = note: `#[deny(invalid_macro_export_arguments)]` (part of `#[deny(future_incompatible)]`) on by default
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155193)*
<!-- homu-ignore:end -->

This PR does the following:
- Add a debug assertion to `rustc_attr_parsing`, to ensure we never forget to check the arguments of a meta item again
- Removes the unused `#[derive(Clone)]` from `ArgParser` as that would break this debug assertion
- **[BREAKING]** Properly check that `#[inline(always(...))]` gets no arguments
- **[BREAKING]** Properly check that `#[instruction_set(arm::a32(...))]` gets no arguments
- **[BREAKING]** Properly check that `#[macro_export(local_inner_macros(...))]` gets no arguments.
  Fixes https://github.com/rust-lang/rust/issues/154977
- **[BREAKING]** Properly check that `#[used(compiler(...))]` gets no arguments.
- Properly check that `#[optimize(size(...))]` gets no arguments.
- Properly check that `#[coverage(on(...))]` gets no arguments.
- Properly check that `#[rustc_dump_layout(debug(...))]` gets no arguments.
- Properly check that `#[rustc_abi(debug(...))]` gets no arguments.
- Properly check that `#![test_runner(arg(...))]` gets no arguments.
- Properly check that `#[rustc_must_implement_one_of(arg(...))]` gets no arguments.
- Properly check that `#[allow_internal_unstable(arg(...))]` gets no arguments.
- Properly check that `#[unstable_feature_bound(arg(...))]` gets no arguments.
- Properly check that `#[rustc_allow_const_fn_unstable(arg(...))]` gets no arguments.
- Properly check that `#[rustc_if_this_changed(arg(...))]` gets no arguments.
- Properly check that `#[rustc_then_this_would_need(arg(...))]` gets no arguments.

r? @jdonszelmann 