### PR TITLE
tidy: handle `#[cfg_attr(bootstrap, doc = "...")]` in `compiler/` comments

### DIFF
--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -602,11 +602,34 @@ pub fn check(path: &Path, tidy_ctx: TidyCtx) {
                     err(DOUBLE_SPACE_AFTER_DOT)
                 }
 
-                if trimmed.contains("//") {
+                // Heuristics for matching unbalanced backticks by trying to find comments and
+                // comment blocks. Technically, this can have false negatives (or false positives),
+                // but as a heuristic this is fine.
+                let likely_comment = |trimmed: &str| {
+                    // Line comments, doc comments
+                    trimmed.contains("//")
+                        // Also account for `#[cfg_attr(bootstrap, doc = "")]` cases.
+                        || (trimmed.contains("cfg_attr") && trimmed.contains("doc"))
+                };
+
+                if likely_comment(trimmed) {
                     let (start_line, mut backtick_count) = comment_block.unwrap_or((i + 1, 0));
                     let line_backticks = trimmed.chars().filter(|ch| *ch == '`').count();
-                    let comment_text = trimmed.split("//").nth(1).unwrap();
-                    // This check ensures that we don't lint for code that has `//` in a string literal
+
+                    // Try to split `//`-like comments or `#[cfg_attr(bootstrap), doc = ""]`-like
+                    // doc attributes. Fuzzy, but probably good enough.
+                    let comment_text = match trimmed.split("//").nth(1) {
+                        Some(text) => text,
+                        None => {
+                            // Fallback to try look for RHS of doc attr bits.
+                            let (_doc, rest) =
+                                trimmed.split_once("doc").expect("failed to find `doc` attribute");
+                            rest
+                        }
+                    };
+
+                    // If backticks on a given comment line is not balanced, add to backtick count.
+                    // This is to account for wrapped backticks and code blocks.
                     if line_backticks % 2 == 1 {
                         backtick_count += comment_text.chars().filter(|ch| *ch == '`').count();
                     }


### PR DESCRIPTION
For the unbalanced backtick check that Waffle ran into in https://github.com/rust-lang/rust/pull/154887.

This PR cherry-picks Waffle's tidy patch in that PR (and adds some explaining comments) even though I'd say this is somewhat hacky[^1]. But since the original tidy check implementation is already based on heuristics and so are likewise fuzzy, this is probably fine in practice for most cases.

[^1]: There can be false positives/negatives like having both fragments `cfg_attr` and `doc` inside a string literal, but I would expect that to be very very niche, so it's "good enough".

(I wanted to write a regression test, but this check needs some restructuring to make it more easy to test that I don't want to bundle in this PR.)

r? wafflelapkin (or bootstrap/compiler)