### PR TITLE
Deduplication: Extract a shared helper function to remove duplicate associated const binding lowering

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -541,19 +541,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             hir::AssocItemConstraintKind::Equality { term } => {
                 let term = match term {
                     hir::Term::Ty(ty) => self.lower_ty(ty).into(),
-                    hir::Term::Const(ct) => {
-                        let ty = projection_term.map_bound(|alias| {
-                            tcx.type_of(alias.def_id).instantiate(tcx, alias.args).skip_norm_wip()
-                        });
-                        let ty = check_assoc_const_binding_type(
-                            self,
+                    hir::Term::Const(ct) => self
+                        .lower_assoc_const_binding_rhs(
+                            ct,
                             constraint.ident,
-                            ty,
                             constraint.hir_id,
-                        );
-
-                        self.lower_const_arg(ct, ty).into()
-                    }
+                            projection_term,
+                        )
+                        .into(),
                 };
 
                 // Find any late-bound regions declared in `ty` that are not
@@ -852,6 +847,23 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // and it's no coincidence why.
         let shifted_output = tcx.shift_bound_var_indices(num_bound_vars, output);
         Ok(ty::EarlyBinder::bind(shifted_output).instantiate(tcx, args).skip_norm_wip())
+    }
+
+    /// Derives the expected type of an associated const,
+    /// validates it, and lowers the RHS const arg against that type
+    pub(crate) fn lower_assoc_const_binding_rhs(
+        &self,
+        ct: &'tcx hir::ConstArg<'tcx>,
+        assoc_ident: Ident,
+        constraint_hir_id: hir::HirId,
+        projection_term: ty::Binder<'tcx, ty::AliasTerm<'tcx>>,
+    ) -> ty::Const<'tcx> {
+        let tcx = self.tcx();
+        let ty = projection_term.map_bound(|alias| {
+            tcx.type_of(alias.def_id).instantiate(tcx, alias.args).skip_norm_wip()
+        });
+        let ty = check_assoc_const_binding_type(self, assoc_ident, ty, constraint_hir_id);
+        self.lower_const_arg(ct, ty)
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1371,8 +1371,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                                             )
                                         });
 
-                                        // FIXME(mgca): code duplication with other places we lower
-                                        // the rhs' of associated const bindings
                                         self.lower_assoc_const_binding_rhs(
                                             ct,
                                             constraint.ident,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1373,19 +1373,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
                                         // FIXME(mgca): code duplication with other places we lower
                                         // the rhs' of associated const bindings
-                                        let ty = projection_term.map_bound(|alias| {
-                                            tcx.type_of(alias.def_id)
-                                                .instantiate(tcx, alias.args)
-                                                .skip_norm_wip()
-                                        });
-                                        let ty = bounds::check_assoc_const_binding_type(
-                                            self,
+                                        self.lower_assoc_const_binding_rhs(
+                                            ct,
                                             constraint.ident,
-                                            ty,
                                             constraint.hir_id,
-                                        );
-
-                                        self.lower_const_arg(ct, ty).into()
+                                            projection_term,
+                                        )
+                                        .into()
                                     }
                                 };
                                 if term.references_error() {


### PR DESCRIPTION
This PR aims to deduplicate the code the responsible for lowering the RHS of associated const bindings (found at `bounds.rs` and `mod.rs`) by creating a helper function `lower_assoc_const_binding_rhs`.

Related: rust-lang/rust#150621