### PR TITLE
add llvm writable attribute conditionally

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -527,6 +527,21 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNoMirInlineParser {
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoMirInline;
 }
 
+pub(crate) struct RustcNoWritableParser;
+
+impl<S: Stage> NoArgsAttributeParser<S> for RustcNoWritableParser {
+    const PATH: &[Symbol] = &[sym::rustc_no_writable];
+    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
+        Allow(Target::Fn),
+        Allow(Target::Closure),
+        Allow(Target::Method(MethodKind::Inherent)),
+        Allow(Target::Method(MethodKind::TraitImpl)),
+        Allow(Target::Method(MethodKind::Trait { body: true })),
+    ]);
+    const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoWritable;
+}
+
 pub(crate) struct RustcLintQueryInstabilityParser;
 
 impl<S: Stage> NoArgsAttributeParser<S> for RustcLintQueryInstabilityParser {

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -314,6 +314,7 @@ attribute_parsers!(
         Single<WithoutArgs<RustcNoImplicitAutorefsParser>>,
         Single<WithoutArgs<RustcNoImplicitBoundsParser>>,
         Single<WithoutArgs<RustcNoMirInlineParser>>,
+        Single<WithoutArgs<RustcNoWritableParser>>,
         Single<WithoutArgs<RustcNonConstTraitMethodParser>>,
         Single<WithoutArgs<RustcNonnullOptimizationGuaranteedParser>>,
         Single<WithoutArgs<RustcNounwindParser>>,

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -38,11 +38,12 @@ trait ArgAttributesExt {
 const ABI_AFFECTING_ATTRIBUTES: [(ArgAttribute, llvm::AttributeKind); 1] =
     [(ArgAttribute::InReg, llvm::AttributeKind::InReg)];
 
-const OPTIMIZATION_ATTRIBUTES: [(ArgAttribute, llvm::AttributeKind); 4] = [
+const OPTIMIZATION_ATTRIBUTES: [(ArgAttribute, llvm::AttributeKind); 5] = [
     (ArgAttribute::NoAlias, llvm::AttributeKind::NoAlias),
     (ArgAttribute::NonNull, llvm::AttributeKind::NonNull),
     (ArgAttribute::ReadOnly, llvm::AttributeKind::ReadOnly),
     (ArgAttribute::NoUndef, llvm::AttributeKind::NoUndef),
+    (ArgAttribute::Writable, llvm::AttributeKind::Writable),
 ];
 
 const CAPTURES_ATTRIBUTES: [(ArgAttribute, llvm::AttributeKind); 3] = [

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -955,6 +955,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_must_match_exhaustively,
         "enums with `#[rustc_must_match_exhaustively]` must be matched on with a match block that mentions all variants explicitly"
     ),
+    rustc_attr!(
+        rustc_no_writable,
+        "`#[rustc_no_writable]` stops the compiler from considering mutable reference arguments of this function as implicitly writable"
+    ),
 
     // ==========================================================================
     // Internal attributes, Testing:

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1508,6 +1508,9 @@ pub enum AttributeKind {
     /// Represents `#[rustc_no_mir_inline]`
     RustcNoMirInline,
 
+    /// Represents `#[rustc_no_writable]`
+    RustcNoWritable,
+
     /// Represents `#[rustc_non_const_trait_method]`.
     RustcNonConstTraitMethod,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -163,6 +163,7 @@ impl AttributeKind {
             RustcNoImplicitAutorefs => Yes,
             RustcNoImplicitBounds => No,
             RustcNoMirInline => Yes,
+            RustcNoWritable => Yes,
             RustcNonConstTraitMethod => No, // should be reported via other queries like `constness`
             RustcNonnullOptimizationGuaranteed => Yes,
             RustcNounwind => No,

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -817,6 +817,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(lint_llvm_ir, true);
     tracked!(llvm_module_flag, vec![("bar".to_string(), 123, "max".to_string())]);
     tracked!(llvm_plugins, vec![String::from("plugin_name")]);
+    tracked!(llvm_writable, true);
     tracked!(location_detail, LocationDetail { file: true, line: false, column: false });
     tracked!(maximal_hir_to_mir_coverage, true);
     tracked!(merge_functions, Some(MergeFunctions::Disabled));

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -350,6 +350,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::RustcNoImplicitAutorefs
                     | AttributeKind::RustcNoImplicitBounds
                     | AttributeKind::RustcNoMirInline
+                    | AttributeKind::RustcNoWritable
                     | AttributeKind::RustcNonConstTraitMethod
                     | AttributeKind::RustcNonnullOptimizationGuaranteed
                     | AttributeKind::RustcNounwind

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2530,6 +2530,8 @@ options! {
         "a list LLVM plugins to enable (space separated)"),
     llvm_time_trace: bool = (false, parse_bool, [UNTRACKED],
         "generate JSON tracing data file from LLVM data (default: no)"),
+    llvm_writable: bool = (false, parse_bool, [TRACKED],
+        "emit the LLVM writable attribute for mutable reference arguments (default: no)"),
     location_detail: LocationDetail = (LocationDetail::all(), parse_location_detail, [TRACKED],
         "what location details should be tracked when using caller_location, either \
         `none`, or a comma separated list of location details, for which \

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1769,6 +1769,7 @@ symbols! {
         rustc_no_implicit_autorefs,
         rustc_no_implicit_bounds,
         rustc_no_mir_inline,
+        rustc_no_writable,
         rustc_non_const_trait_method,
         rustc_nonnull_optimization_guaranteed,
         rustc_nounwind,

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -110,9 +110,9 @@ mod attr_impl {
 
     // The subset of llvm::Attribute needed for arguments, packed into a bitfield.
     #[derive(Clone, Copy, Default, Hash, PartialEq, Eq, HashStable_Generic)]
-    pub struct ArgAttribute(u8);
+    pub struct ArgAttribute(u16);
     bitflags::bitflags! {
-        impl ArgAttribute: u8 {
+        impl ArgAttribute: u16 {
             const CapturesNone     = 0b111;
             const CapturesAddress  = 0b110;
             const CapturesReadOnly = 0b100;
@@ -121,6 +121,7 @@ mod attr_impl {
             const ReadOnly = 1 << 5;
             const InReg    = 1 << 6;
             const NoUndef  = 1 << 7;
+            const Writable = 1 << 8;
         }
     }
     rustc_data_structures::external_bitflags_debug! { ArgAttribute }

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -2,8 +2,8 @@ use std::{assert_matches, iter};
 
 use rustc_abi::Primitive::Pointer;
 use rustc_abi::{Align, BackendRepr, ExternAbi, PointerKind, Scalar, Size};
-use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
+use rustc_hir::{self as hir, find_attr};
 use rustc_middle::bug;
 use rustc_middle::middle::deduced_param_attrs::DeducedParamAttrs;
 use rustc_middle::query::Providers;
@@ -355,6 +355,7 @@ fn arg_attrs_for_rust_scalar<'tcx>(
     offset: Size,
     is_return: bool,
     drop_target_pointee: Option<Ty<'tcx>>,
+    determined_fn_def_id: Option<DefId>,
 ) -> ArgAttributes {
     let mut attrs = ArgAttributes::new();
 
@@ -430,6 +431,21 @@ fn arg_attrs_for_rust_scalar<'tcx>(
             // (see <https://github.com/rust-lang/unsafe-code-guidelines/issues/385#issuecomment-1368055745>).
             if no_alias && !is_return {
                 attrs.set(ArgAttribute::NoAlias);
+            }
+
+            // Set writable if no_alias is set, it's a mutable reference and the feature is enabled.
+            if tcx.sess.opts.unstable_opts.llvm_writable
+                && matches!(kind, PointerKind::MutableRef { unpin: true })
+                && !is_return
+            {
+                let rustc_no_writable = match determined_fn_def_id {
+                    Some(def_id) => find_attr!(tcx, def_id, RustcNoWritable),
+                    None => true, // If no def_id exists, we make the conservative choice and disable the feature.
+                };
+
+                if !rustc_no_writable {
+                    attrs.set(ArgAttribute::Writable);
+                }
             }
 
             if matches!(kind, PointerKind::SharedRef { frozen: true }) && !is_return {
@@ -624,6 +640,7 @@ fn fn_abi_new_uncached<'tcx>(
                 // Only set `drop_target_pointee` for the data part of a wide pointer.
                 // See `arg_attrs_for_rust_scalar` docs for more information.
                 drop_target_pointee.filter(|_| offset == Size::ZERO),
+                determined_fn_def_id,
             )
         }))
     };

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -754,6 +754,7 @@ impl<T> [T] {
     #[rustc_as_ptr]
     #[inline(always)]
     #[must_use]
+    #[rustc_no_writable]
     pub const fn as_mut_ptr(&mut self) -> *mut T {
         self as *mut [T] as *mut T
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -589,6 +589,7 @@ impl str {
     #[rustc_as_ptr]
     #[must_use]
     #[inline(always)]
+    #[rustc_no_writable]
     pub const fn as_mut_ptr(&mut self) -> *mut u8 {
         self as *mut str as *mut u8
     }

--- a/src/doc/unstable-book/src/compiler-flags/llvm-writable.md
+++ b/src/doc/unstable-book/src/compiler-flags/llvm-writable.md
@@ -1,0 +1,11 @@
+# `llvm-writable`
+
+---
+
+Setting this flag will allow the compiler to insert the [writable](https://llvm.org/docs/LangRef.html#writable) LLVM flag.
+This allows for more optimizations but also introduces more Undefined Behaviour.
+To be more precise, mutable reference function arguments are now considered to be always writable, which means the compiler may insert writes to those references even if the original code contained no such writes.
+The attribute `#[rustc_no_writable]` can be used to disable the optimization on a per-function basis.
+
+The [Miri](https://github.com/rust-lang/miri) tool can be used to detect some problematic cases.
+However, note that when using Tree Borrows, you must set `-Zmiri-tree-borrows-implicit-writes` to ensure that the UB arising from these implicit writes is detected.

--- a/tests/codegen-llvm/llvm-writable.rs
+++ b/tests/codegen-llvm/llvm-writable.rs
@@ -1,0 +1,30 @@
+//! The tests here test that the `-Zllvm-writable` flag and
+//! the `#[rustc_no_writable]` attribute have the desired effect.
+//@ compile-flags: -Copt-level=3 -C no-prepopulate-passes -Zllvm-writable
+#![crate_type = "lib"]
+#![feature(rustc_attrs, unsafe_pinned)]
+
+// CHECK: @mutable_borrow(ptr noalias noundef writable align 4 dereferenceable(4) %_1)
+#[no_mangle]
+pub fn mutable_borrow(_: &mut i32) {}
+
+// CHECK: @mutable_unsafe_borrow(ptr noalias noundef writable align 2 dereferenceable(2) %_1)
+#[no_mangle]
+pub fn mutable_unsafe_borrow(_: &mut std::cell::UnsafeCell<i16>) {}
+
+// CHECK: @option_borrow_mut(ptr noalias noundef writable align 4 dereferenceable_or_null(4) %_1)
+#[no_mangle]
+pub fn option_borrow_mut(_: Option<&mut i32>) {}
+
+// CHECK: @box_moved(ptr noalias noundef nonnull align 4 %0)
+#[no_mangle]
+pub fn box_moved(_: Box<i32>) {}
+
+// CHECK: @unsafe_pinned_borrow_mut(ptr noundef nonnull align 4 %_1)
+#[no_mangle]
+pub fn unsafe_pinned_borrow_mut(_: &mut std::pin::UnsafePinned<i32>) {}
+
+// CHECK: @mutable_borrow_no_writable(ptr noalias noundef align 4 dereferenceable(4) %_1)
+#[no_mangle]
+#[rustc_no_writable]
+pub fn mutable_borrow_no_writable(_: &mut i32) {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155207)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This PR tries to address https://github.com/rust-lang/unsafe-code-guidelines/issues/584#issue-3440604811. It is part of a bachelor thesis supervised by @JoJoDeveloping and @RalfJung, for more information, see: [Project_Description.pdf](https://github.com/user-attachments/files/26537277/Project_Description.pdf).
If the new `-Zllvm-writable` flag is set, the [llvm writable attribute](https://llvm.org/docs/LangRef.html#writable) is inserted for all mutable borrows. This can be conditionally turned off on a per-function basis using the `#[rustc_no_writable]` attribute. The new Undefined Behaviour introduced by this can detected by Miri, which is implemented here: https://github.com/rust-lang/miri/pull/4947.

Two library functions already received the `#[rustc_no_writable]` attribute, as they are known to cause problems under the Tree Borrows aliasing model with implicit writes enabled.