### PR TITLE
Post-attribute ports cleanup pt. 1 (again)

### DIFF
--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -9,7 +9,7 @@ use rustc_ast::{
     self as ast, AttrArgs, Attribute, DelimArgs, MetaItem, MetaItemInner, MetaItemKind, Safety,
 };
 use rustc_errors::{Applicability, PResult};
-use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
+use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute, template};
 use rustc_hir::AttrPath;
 use rustc_hir::lints::AttributeLintKind;
 use rustc_parse::parse_in;
@@ -30,15 +30,22 @@ pub fn check_attr(psess: &ParseSess, attr: &Attribute) {
 
     // Check input tokens for built-in and key-value attributes.
     match builtin_attr_info {
-        // `rustc_dummy` doesn't have any restrictions specific to built-in attributes.
-        Some(BuiltinAttribute { name, template, .. }) => {
+        Some(BuiltinAttribute { name, .. }) => {
             if AttributeParser::<Late>::is_parsed_attribute(slice::from_ref(&name)) {
                 return;
             }
             match parse_meta(psess, attr) {
                 // Don't check safety again, we just did that
                 Ok(meta) => {
-                    check_builtin_meta_item(psess, &meta, attr.style, *name, *template, false)
+                    // FIXME The only unparsed builtin attributes that are left are the lint attributes, so we can hardcode the template here
+                    let lint_attrs = [sym::forbid, sym::allow, sym::warn, sym::deny, sym::expect];
+                    assert!(lint_attrs.contains(name));
+
+                    let template = template!(
+                        List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
+                        "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
+                    );
+                    check_builtin_meta_item(psess, &meta, attr.style, *name, template, false)
                 }
                 Err(err) => {
                     err.emit();

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -8,7 +8,7 @@ use rustc_ast::tokenstream::DelimSpan;
 use rustc_ast::{
     self as ast, AttrArgs, Attribute, DelimArgs, MetaItem, MetaItemInner, MetaItemKind, Safety,
 };
-use rustc_errors::{Applicability, FatalError, PResult};
+use rustc_errors::{Applicability, PResult};
 use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
 use rustc_hir::AttrPath;
 use rustc_hir::lints::AttributeLintKind;
@@ -169,7 +169,7 @@ pub fn check_builtin_meta_item(
     }
 }
 
-fn emit_malformed_attribute(
+pub fn emit_malformed_attribute(
     psess: &ParseSess,
     style: ast::AttrStyle,
     span: Span,
@@ -230,16 +230,4 @@ fn emit_malformed_attribute(
         }
         err.emit();
     }
-}
-
-pub fn emit_fatal_malformed_builtin_attribute(
-    psess: &ParseSess,
-    attr: &Attribute,
-    name: Symbol,
-) -> ! {
-    let template = BUILTIN_ATTRIBUTE_MAP.get(&name).expect("builtin attr defined").template;
-    emit_malformed_attribute(psess, attr.style, attr.span, name, template);
-    // This is fatal, otherwise it will likely cause a cascade of other errors
-    // (and an error here is expected to be very rare).
-    FatalError.raise()
 }

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -2,12 +2,14 @@ use std::iter::once;
 use std::path::{self, Path, PathBuf};
 
 use rustc_ast::{AttrVec, Attribute, Inline, Item, ModSpans};
-use rustc_attr_parsing::validate_attr;
+use rustc_attr_parsing::validate_attr::emit_malformed_attribute;
 use rustc_errors::{Diag, ErrorGuaranteed};
+use rustc_feature::template;
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::{exp, new_parser_from_file, unwrap_or_emit_fatal};
 use rustc_session::Session;
 use rustc_session::parse::ParseSess;
+use rustc_span::fatal_error::FatalError;
 use rustc_span::{Ident, Span, sym};
 use thin_vec::ThinVec;
 
@@ -184,6 +186,7 @@ pub(crate) fn mod_file_path_from_attr(
     attrs: &[Attribute],
     dir_path: &Path,
 ) -> Option<PathBuf> {
+    // FIXME(154781) use a parsed attribute here
     // Extract path string from first `#[path = "path_string"]` attribute.
     let first_path = attrs.iter().find(|at| at.has_name(sym::path))?;
     let Some(path_sym) = first_path.value_str() else {
@@ -195,7 +198,17 @@ pub(crate) fn mod_file_path_from_attr(
         // Usually bad forms are checked during semantic analysis via
         // `TyCtxt::check_mod_attrs`), but by the time that runs the macro
         // is expanded, and it doesn't give an error.
-        validate_attr::emit_fatal_malformed_builtin_attribute(&sess.psess, first_path, sym::path);
+        emit_malformed_attribute(
+            &sess.psess,
+            first_path.style,
+            first_path.span,
+            sym::path,
+            template!(
+                NameValueStr: "file",
+                "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
+            ),
+        );
+        FatalError.raise()
     };
 
     let path_str = path_sym.as_str();

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -2,7 +2,6 @@
 
 use std::sync::LazyLock;
 
-use AttributeDuplicates::*;
 use AttributeGate::*;
 use AttributeType::*;
 use rustc_data_structures::fx::FxHashMap;
@@ -182,57 +181,6 @@ impl AttributeTemplate {
     }
 }
 
-/// How to handle multiple duplicate attributes on the same item.
-#[derive(Clone, Copy, Default)]
-pub enum AttributeDuplicates {
-    /// Duplicates of this attribute are allowed.
-    ///
-    /// This should only be used with attributes where duplicates have semantic
-    /// meaning, or some kind of "additive" behavior. For example, `#[warn(..)]`
-    /// can be specified multiple times, and it combines all the entries. Or use
-    /// this if there is validation done elsewhere.
-    #[default]
-    DuplicatesOk,
-    /// Duplicates after the first attribute will be an unused_attribute warning.
-    ///
-    /// This is usually used for "word" attributes, where they are used as a
-    /// boolean marker, like `#[used]`. It is not necessarily wrong that there
-    /// are duplicates, but the others should probably be removed.
-    WarnFollowing,
-    /// Same as `WarnFollowing`, but only issues warnings for word-style attributes.
-    ///
-    /// This is only for special cases, for example multiple `#[macro_use]` can
-    /// be warned, but multiple `#[macro_use(...)]` should not because the list
-    /// form has different meaning from the word form.
-    WarnFollowingWordOnly,
-    /// Duplicates after the first attribute will be an error.
-    ///
-    /// This should be used where duplicates would be ignored, but carry extra
-    /// meaning that could cause confusion. For example, `#[stable(since="1.0")]
-    /// #[stable(since="2.0")]`, which version should be used for `stable`?
-    ErrorFollowing,
-    /// Duplicates preceding the last instance of the attribute will be an error.
-    ///
-    /// This is the same as `ErrorFollowing`, except the last attribute is the
-    /// one that is "used". This is typically used in cases like codegen
-    /// attributes which usually only honor the last attribute.
-    ErrorPreceding,
-    /// Duplicates after the first attribute will be an unused_attribute warning
-    /// with a note that this will be an error in the future.
-    ///
-    /// This should be used for attributes that should be `ErrorFollowing`, but
-    /// because older versions of rustc silently accepted (and ignored) the
-    /// attributes, this is used to transition.
-    FutureWarnFollowing,
-    /// Duplicates preceding the last instance of the attribute will be a
-    /// warning, with a note that this will be an error in the future.
-    ///
-    /// This is the same as `FutureWarnFollowing`, except the last attribute is
-    /// the one that is "used". Ideally these can eventually migrate to
-    /// `ErrorPreceding`.
-    FutureWarnPreceding,
-}
-
 /// A convenience macro for constructing attribute templates.
 /// E.g., `template!(Word, List: "description")` means that the attribute
 /// supports forms `#[attr]` and `#[attr(description)]`.
@@ -269,7 +217,7 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
@@ -277,10 +225,9 @@ macro_rules! ungated {
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
             template: $tpl,
             gate: Ungated,
-            duplicates: $duplicates,
         }
     };
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
@@ -288,10 +235,9 @@ macro_rules! ungated {
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Ungated,
-            duplicates: $duplicates,
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
@@ -299,20 +245,18 @@ macro_rules! ungated {
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Ungated,
-            duplicates: $duplicates,
         }
     };
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
-            duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$gate,
                 message: $message,
@@ -321,14 +265,13 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
-            duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$attr,
                 message: $message,
@@ -337,14 +280,13 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
-            duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$gate,
                 message: $message,
@@ -353,14 +295,13 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
-            duplicates: $duplicates,
             gate: Gated {
                 feature: sym::$attr,
                 message: $message,
@@ -372,12 +313,11 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $typ:expr, $tpl:expr, $duplicate:expr, $encode_cross_crate:expr $(,)?) => {
+    (TEST, $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         rustc_attr!(
             $attr,
             $typ,
             $tpl,
-            $duplicate,
             $encode_cross_crate,
             concat!(
                 "the `#[",
@@ -386,14 +326,13 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $duplicates:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
             type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
-            duplicates: $duplicates,
             gate: Gated {
                 feature: sym::rustc_attrs,
                 message: "use of an internal attribute",
@@ -425,7 +364,6 @@ pub struct BuiltinAttribute {
     pub type_: AttributeType,
     pub safety: AttributeSafety,
     pub template: AttributeTemplate,
-    pub duplicates: AttributeDuplicates,
     pub gate: AttributeGate,
 }
 
@@ -443,7 +381,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["predicate"],
             "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute"
         ),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         cfg_attr, Normal,
@@ -451,7 +389,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["predicate, attr1, attr2, ..."],
             "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
         ),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
 
     // Testing:
@@ -462,7 +400,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
         ),
-        WarnFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         should_panic, Normal,
@@ -472,7 +410,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
         ),
-        FutureWarnFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
 
     // Macros:
@@ -482,7 +420,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             Word,
             "https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute"
         ),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         macro_use, Normal,
@@ -491,9 +429,9 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["name1, name2, ..."],
             "https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute"
         ),
-        WarnFollowingWordOnly, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
-    ungated!(macro_escape, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
+    ungated!(macro_escape, Normal, template!(Word), EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
     ungated!(
         macro_export, Normal,
         template!(
@@ -501,14 +439,14 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["local_inner_macros"],
             "https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope"
         ),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         proc_macro, Normal,
         template!(
             Word,
             "https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros"),
-        ErrorFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         proc_macro_derive, Normal,
@@ -516,12 +454,12 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
             "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
         ),
-        ErrorFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         proc_macro_attribute, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros"),
-        ErrorFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
 
     // Lints:
@@ -531,7 +469,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         allow, Normal,
@@ -539,7 +477,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         expect, Normal,
@@ -547,7 +485,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         forbid, Normal,
@@ -555,7 +493,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         deny, Normal,
@@ -563,7 +501,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         must_use, Normal,
@@ -572,10 +510,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
         ),
-        FutureWarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     gated!(
-        must_not_suspend, Normal, template!(Word, NameValueStr: "reason"), WarnFollowing,
+        must_not_suspend, Normal, template!(Word, NameValueStr: "reason"),
         EncodeCrossCrate::Yes, experimental!(must_not_suspend)
     ),
     ungated!(
@@ -586,7 +524,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"
         ),
-        ErrorFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
 
     // Crate properties:
@@ -596,7 +534,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "name",
             "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-crate_name-attribute"
         ),
-        FutureWarnFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         crate_type, CrateLevel,
@@ -604,7 +542,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: ["bin", "lib", "dylib", "cdylib", "rlib", "staticlib", "sdylib", "proc-macro"],
             "https://doc.rust-lang.org/reference/linkage.html"
         ),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
 
     // ABI, linking, symbols, and FFI
@@ -617,17 +555,17 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             r#"name = "...", import_name_type = "decorated|noprefix|undecorated""#,
             r#"name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated""#,
         ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute"),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         link_name, Normal,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"),
-        FutureWarnPreceding, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         no_link, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         repr, Normal,
@@ -635,44 +573,44 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["C", "Rust", "transparent", "align(...)", "packed(...)", "<integer type>"],
             "https://doc.rust-lang.org/reference/type-layout.html#representations"
         ),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, Normal, template!(List: &["alignment"]), DuplicatesOk, EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, Normal, template!(List: &["alignment"]), DuplicatesOk, EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, Normal, template!(List: &["alignment"]), EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, Normal, template!(List: &["alignment"]), EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
     ungated!(
         unsafe(Edition2024) export_name, Normal,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute"),
-        FutureWarnPreceding, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         unsafe(Edition2024) link_section, Normal,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"),
-        FutureWarnPreceding, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         unsafe(Edition2024) no_mangle, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         used, Normal,
         template!(Word, List: &["compiler", "linker"], "https://doc.rust-lang.org/reference/abi.html#the-used-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         link_ordinal, Normal,
         template!(List: &["ordinal"], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"),
-        ErrorPreceding, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         unsafe naked, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-naked-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
-        rustc_pass_indirectly_in_non_rustic_abis, Normal, template!(Word), ErrorFollowing,
+        rustc_pass_indirectly_in_non_rustic_abis, Normal, template!(Word),
         EncodeCrossCrate::No,
         "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
@@ -681,15 +619,15 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(
         recursion_limit, CrateLevel,
         template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute"),
-        FutureWarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         type_length_limit, CrateLevel,
         template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-type_length_limit-attribute"),
-        FutureWarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     gated!(
-        move_size_limit, CrateLevel, template!(NameValueStr: "N"), ErrorFollowing,
+        move_size_limit, CrateLevel, template!(NameValueStr: "N"),
         EncodeCrossCrate::No, large_assignments, experimental!(move_size_limit)
     ),
 
@@ -697,41 +635,41 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(
         no_main, CrateLevel,
         template!(Word, "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-no_main-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
 
     // Modules, prelude, and resolution:
     ungated!(
         path, Normal,
         template!(NameValueStr: "file", "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"),
-        FutureWarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         no_std, CrateLevel,
         template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         no_implicit_prelude, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         non_exhaustive, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
 
     // Runtime
     ungated!(
         windows_subsystem, CrateLevel,
         template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute"),
-        FutureWarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!( // RFC 2070
         panic_handler, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/panic.html#the-panic_handler-attribute"),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
 
     // Code generation:
@@ -742,44 +680,44 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["always", "never"],
             "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
         ),
-        FutureWarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         cold, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-cold-attribute"),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         no_builtins, CrateLevel,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-no_builtins-attribute"),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         target_feature, Normal,
         template!(List: &[r#"enable = "name""#], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         track_caller, Normal,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute"),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         instruction_set, Normal,
         template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute"),
-        ErrorPreceding, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     gated!(
         unsafe force_target_feature, Normal, template!(List: &[r#"enable = "name""#]),
-        DuplicatesOk, EncodeCrossCrate::No, effective_target_features, experimental!(force_target_feature)
+        EncodeCrossCrate::No, effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
-        sanitize, Normal, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]), ErrorPreceding,
+        sanitize, Normal, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]),
         EncodeCrossCrate::No, sanitize, experimental!(sanitize),
     ),
     gated!(
         coverage, Normal, template!(OneOf: &[sym::off, sym::on]),
-        ErrorPreceding, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         coverage_attribute, experimental!(coverage)
     ),
 
@@ -790,7 +728,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "string",
             "https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html"
         ),
-        DuplicatesOk, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
 
     // Debugging
@@ -800,7 +738,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &[r#"natvis_file = "...", gdb_script_file = "...""#],
             "https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute"
         ),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     ungated!(
         collapse_debuginfo, Normal,
@@ -808,7 +746,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["no", "external", "yes"],
             "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
         ),
-        ErrorFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
 
     // ==========================================================================
@@ -817,70 +755,70 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, Normal, template!(Word), WarnFollowing,
+        export_stable, Normal, template!(Word),
         EncodeCrossCrate::No, experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, CrateLevel, template!(List: &["path"]), ErrorFollowing,
+        test_runner, CrateLevel, template!(List: &["path"]),
         EncodeCrossCrate::Yes, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
-        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"), ErrorFollowing,
+        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"),
         EncodeCrossCrate::No, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        marker, Normal, template!(Word), EncodeCrossCrate::No,
         marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        thread_local, Normal, template!(Word), EncodeCrossCrate::No,
         "`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
-        no_core, CrateLevel, template!(Word), WarnFollowing,
+        no_core, CrateLevel, template!(Word),
         EncodeCrossCrate::No, experimental!(no_core)
     ),
     // RFC 2412
     gated!(
-        optimize, Normal, template!(List: &["none", "size", "speed"]), ErrorPreceding,
+        optimize, Normal, template!(List: &["none", "size", "speed"]),
         EncodeCrossCrate::No, optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, Normal, template!(Word), WarnFollowing,
+        unsafe ffi_pure, Normal, template!(Word),
         EncodeCrossCrate::No, experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, Normal, template!(Word), WarnFollowing,
+        unsafe ffi_const, Normal, template!(Word),
         EncodeCrossCrate::No, experimental!(ffi_const)
     ),
     gated!(
-        register_tool, CrateLevel, template!(List: &["tool1, tool2, ..."]), DuplicatesOk,
+        register_tool, CrateLevel, template!(List: &["tool1, tool2, ..."]),
         EncodeCrossCrate::No, experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
-        cfi_encoding, Normal, template!(NameValueStr: "encoding"), ErrorPreceding,
+        cfi_encoding, Normal, template!(NameValueStr: "encoding"),
         EncodeCrossCrate::Yes, experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, Normal, template!(Word), ErrorFollowing,
+        coroutine, Normal, template!(Word),
         EncodeCrossCrate::No, coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
-        patchable_function_entry, Normal, template!(List: &["prefix_nops = m, entry_nops = n"]), ErrorPreceding,
+        patchable_function_entry, Normal, template!(List: &["prefix_nops = m, entry_nops = n"]),
         EncodeCrossCrate::Yes, experimental!(patchable_function_entry)
     ),
 
@@ -889,11 +827,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, Normal, template!(Word), ErrorFollowing,
+        const_continue, Normal, template!(Word),
         EncodeCrossCrate::No, loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, Normal, template!(Word), ErrorFollowing,
+        loop_match, Normal, template!(Word),
         EncodeCrossCrate::No, loop_match, experimental!(loop_match)
     ),
 
@@ -902,7 +840,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, Normal, template!(Word), ErrorFollowing,
+        pin_v2, Normal, template!(Word),
         EncodeCrossCrate::Yes, pin_ergonomics, experimental!(pin_v2),
     ),
 
@@ -912,21 +850,21 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     ungated!(
         feature, CrateLevel,
-        template!(List: &["name1, name2, ..."]), DuplicatesOk, EncodeCrossCrate::No,
+        template!(List: &["name1, name2, ..."]), EncodeCrossCrate::No,
     ),
     // DuplicatesOk since it has its own validation
     ungated!(
         stable, Normal,
-        template!(List: &[r#"feature = "name", since = "version""#]), DuplicatesOk, EncodeCrossCrate::No,
+        template!(List: &[r#"feature = "name", since = "version""#]), EncodeCrossCrate::No,
     ),
     ungated!(
         unstable, Normal,
-        template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]), DuplicatesOk,
+        template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
         EncodeCrossCrate::Yes
     ),
     ungated!(
         unstable_feature_bound, Normal, template!(Word, List: &["feat1, feat2, ..."]),
-        DuplicatesOk, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
     ungated!(
         unstable_removed, CrateLevel,
@@ -935,45 +873,45 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(
         rustc_const_unstable, Normal, template!(List: &[r#"feature = "name""#]),
-        DuplicatesOk, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     ungated!(
         rustc_const_stable, Normal,
-        template!(List: &[r#"feature = "name""#]), DuplicatesOk, EncodeCrossCrate::No,
+        template!(List: &[r#"feature = "name""#]), EncodeCrossCrate::No,
     ),
     ungated!(
         rustc_default_body_unstable, Normal,
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     gated!(
         allow_internal_unstable, Normal, template!(Word, List: &["feat1, feat2, ..."]),
-        DuplicatesOk, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, Normal, template!(Word), WarnFollowing,
+        allow_internal_unsafe, Normal, template!(Word),
         EncodeCrossCrate::No, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
         rustc_eii_foreign_item, Normal, template!(Word),
-        ErrorFollowing, EncodeCrossCrate::Yes, eii_internals,
+        EncodeCrossCrate::Yes, eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
         rustc_allowed_through_unstable_modules, Normal, template!(NameValueStr: "deprecation message"),
-        WarnFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
         rustc_deprecated_safe_2024, Normal, template!(List: &[r#"audit_that = "...""#]),
-        ErrorFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
         "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
         rustc_pub_transparent, Normal, template!(Word),
-        ErrorFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
 
@@ -982,9 +920,9 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes, experimental!(fundamental)),
+    gated!(fundamental, Normal, template!(Word), EncodeCrossCrate::Yes, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, template!(Word), WarnFollowing,
+        may_dangle, Normal, template!(Word),
         EncodeCrossCrate::No, dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
@@ -999,7 +937,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             r#"fallback = "never""#,
             r#"fallback = "no""#,
         ]),
-        ErrorFollowing,
         EncodeCrossCrate::No,
         "`rustc_never_type_options` is used to experiment with never type fallback and work on \
          never type stabilization"
@@ -1010,53 +947,48 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_allocator, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_allocator, Normal, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_nounwind, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_nounwind, Normal, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_reallocator, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_reallocator, Normal, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_deallocator, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_deallocator, Normal, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_allocator_zeroed, Normal, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed_variant, Normal, template!(NameValueStr: "function"), ErrorPreceding,
+        rustc_allocator_zeroed_variant, Normal, template!(NameValueStr: "function"),
         EncodeCrossCrate::Yes,
     ),
     gated!(
-        default_lib_allocator, Normal, template!(Word), WarnFollowing,
+        default_lib_allocator, Normal, template!(Word),
         EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        needs_allocator, Normal, template!(Word), WarnFollowing,
+        needs_allocator, Normal, template!(Word),
         EncodeCrossCrate::No, allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        panic_runtime, CrateLevel, template!(Word), WarnFollowing,
+        panic_runtime, CrateLevel, template!(Word),
         EncodeCrossCrate::No, experimental!(panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, CrateLevel, template!(Word), WarnFollowing,
+        needs_panic_runtime, CrateLevel, template!(Word),
         EncodeCrossCrate::No, experimental!(needs_panic_runtime)
     ),
     gated!(
-        compiler_builtins, CrateLevel, template!(Word), WarnFollowing,
+        compiler_builtins, CrateLevel, template!(Word),
         EncodeCrossCrate::No,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
-        profiler_runtime, CrateLevel, template!(Word), WarnFollowing,
+        profiler_runtime, CrateLevel, template!(Word),
         EncodeCrossCrate::No,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
@@ -1078,20 +1010,17 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             "weak",
             "weak_odr",
         ], "https://doc.rust-lang.org/reference/linkage.html"),
-        ErrorPreceding, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
     rustc_attr!(
-        rustc_std_internal_symbol, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_std_internal_symbol, Normal, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_objc_class, Normal, template!(NameValueStr: "ClassName"), ErrorPreceding,
-        EncodeCrossCrate::No,
+        rustc_objc_class, Normal, template!(NameValueStr: "ClassName"), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_objc_selector, Normal, template!(NameValueStr: "methodName"), ErrorPreceding,
-        EncodeCrossCrate::No,
+        rustc_objc_selector, Normal, template!(NameValueStr: "methodName"), EncodeCrossCrate::No,
     ),
 
     // ==========================================================================
@@ -1100,39 +1029,36 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_builtin_macro, Normal,
-        template!(Word, List: &["name", "name, /*opt*/ attributes(name1, name2, ...)"]), ErrorFollowing,
+        template!(Word, List: &["name", "name, /*opt*/ attributes(name1, name2, ...)"]),
         EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
-        rustc_proc_macro_decls, Normal, template!(Word), WarnFollowing,
+        rustc_proc_macro_decls, Normal, template!(Word),
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_macro_transparency, Normal,
-        template!(NameValueStr: ["transparent", "semiopaque", "opaque"]), ErrorFollowing,
+        template!(NameValueStr: ["transparent", "semiopaque", "opaque"]),
         EncodeCrossCrate::Yes, "used internally for testing macro hygiene",
     ),
     rustc_attr!(
         rustc_autodiff, Normal,
-        template!(Word, List: &[r#""...""#]), DuplicatesOk,
+        template!(Word, List: &[r#""...""#]),
         EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
         rustc_offload_kernel, Normal,
-        template!(Word), DuplicatesOk,
-        EncodeCrossCrate::Yes,
+        template!(Word), EncodeCrossCrate::Yes,
     ),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
     ungated!(
-        cfg_trace, Normal, template!(Word /* irrelevant */), DuplicatesOk,
-        EncodeCrossCrate::Yes
+        cfg_trace, Normal, template!(Word /* irrelevant */), EncodeCrossCrate::Yes
     ),
     ungated!(
-        cfg_attr_trace, Normal, template!(Word /* irrelevant */), DuplicatesOk,
-        EncodeCrossCrate::No
+        cfg_attr_trace, Normal, template!(Word /* irrelevant */), EncodeCrossCrate::No
     ),
 
     // ==========================================================================
@@ -1145,48 +1071,48 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#],
             NameValueStr: "message"
         ),
-        ErrorFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
         "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
         rustc_confusables, Normal,
         template!(List: &[r#""name1", "name2", ..."#]),
-        ErrorFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
         rustc_conversion_suggestion, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
         rustc_trivial_field_reads, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_query_instability, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_untracked_query_information, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_ty, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_deny_field_access, Normal, template!(List: &["message"]),
-        WarnFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
     ),
 
     // ==========================================================================
@@ -1194,31 +1120,31 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_promotable, Normal, template!(Word), WarnFollowing,
+        rustc_promotable, Normal, template!(Word),
         EncodeCrossCrate::No, ),
     rustc_attr!(
-        rustc_legacy_const_generics, Normal, template!(List: &["N"]), ErrorFollowing,
+        rustc_legacy_const_generics, Normal, template!(List: &["N"]),
         EncodeCrossCrate::Yes,
     ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
-        rustc_do_not_const_check, Normal, template!(Word), WarnFollowing,
+        rustc_do_not_const_check, Normal, template!(Word),
         EncodeCrossCrate::Yes, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
         rustc_const_stable_indirect, Normal,
         template!(Word),
-        WarnFollowing,
+       
         EncodeCrossCrate::No,
         "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_intrinsic_const_stable_indirect, Normal,
-        template!(Word), WarnFollowing, EncodeCrossCrate::No,  "this is an internal implementation detail",
+        template!(Word), EncodeCrossCrate::No,  "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_allow_const_fn_unstable, Normal,
-        template!(Word, List: &["feat1, feat2, ..."]), DuplicatesOk, EncodeCrossCrate::No,
+        template!(Word, List: &["feat1, feat2, ..."]), EncodeCrossCrate::No,
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
@@ -1227,25 +1153,25 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_layout_scalar_valid_range_start, Normal, template!(List: &["value"]), ErrorFollowing,
+        rustc_layout_scalar_valid_range_start, Normal, template!(List: &["value"]),
         EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_layout_scalar_valid_range_end, Normal, template!(List: &["value"]), ErrorFollowing,
+        rustc_layout_scalar_valid_range_end, Normal, template!(List: &["value"]),
         EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_simd_monomorphize_lane_limit, Normal, template!(NameValueStr: "N"), ErrorFollowing,
+        rustc_simd_monomorphize_lane_limit, Normal, template!(NameValueStr: "N"),
         EncodeCrossCrate::Yes,
         "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
-        rustc_nonnull_optimization_guaranteed, Normal, template!(Word), WarnFollowing,
+        rustc_nonnull_optimization_guaranteed, Normal, template!(Word),
         EncodeCrossCrate::Yes,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
@@ -1257,54 +1183,54 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, Normal, template!(NameValueStr: "name"), DuplicatesOk, EncodeCrossCrate::No, lang_items,
+        lang, Normal, template!(NameValueStr: "name"), EncodeCrossCrate::No, lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
-        rustc_as_ptr, Normal, template!(Word), ErrorFollowing,
+        rustc_as_ptr, Normal, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
-        rustc_should_not_be_called_on_const_items, Normal, template!(Word), ErrorFollowing,
+        rustc_should_not_be_called_on_const_items, Normal, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
-        rustc_pass_by_value, Normal, template!(Word), ErrorFollowing,
+        rustc_pass_by_value, Normal, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
-        rustc_never_returns_null_ptr, Normal, template!(Word), ErrorFollowing,
+        rustc_never_returns_null_ptr, Normal, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, AttributeType::Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::Yes,
+        rustc_no_implicit_autorefs, AttributeType::Normal, template!(Word), EncodeCrossCrate::Yes,
         "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, AttributeType::CrateLevel, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
+        rustc_coherence_is_core, AttributeType::CrateLevel, template!(Word), EncodeCrossCrate::No,
         "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, AttributeType::Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_coinductive, AttributeType::Normal, template!(Word), EncodeCrossCrate::No,
         "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, AttributeType::Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
+        rustc_allow_incoherent_impl, AttributeType::Normal, template!(Word), EncodeCrossCrate::No,
         "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, AttributeType::CrateLevel, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
+        rustc_preserve_ub_checks, AttributeType::CrateLevel, template!(Word), EncodeCrossCrate::No,
         "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
         AttributeType::Normal,
         template!(Word),
-        ErrorFollowing,
+       
         EncodeCrossCrate::No,
         "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
@@ -1312,20 +1238,20 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_dyn_incompatible_trait,
         AttributeType::Normal,
         template!(Word),
-        ErrorFollowing,
+       
         EncodeCrossCrate::No,
         "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
         rustc_has_incoherent_inherent_impls, AttributeType::Normal, template!(Word),
-        ErrorFollowing, EncodeCrossCrate::Yes,
+        EncodeCrossCrate::Yes,
         "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
         rustc_non_const_trait_method, AttributeType::Normal, template!(Word),
-        ErrorFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
     ),
@@ -1337,7 +1263,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         type_: Normal,
         safety: AttributeSafety::Normal,
         template: template!(NameValueStr: "name"),
-        duplicates: ErrorFollowing,
         gate: Gated {
             feature: sym::rustc_attrs,
             message: "use of an internal attribute",
@@ -1348,45 +1273,45 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, Normal, template!(Word), WarnFollowing,
+        prelude_import, Normal, template!(Word),
         EncodeCrossCrate::No, "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_paren_sugar, Normal, template!(Word), EncodeCrossCrate::No,
         unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_inherit_overflow_checks, Normal, template!(Word), EncodeCrossCrate::No,
         "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
         rustc_reservation_impl, Normal,
-        template!(NameValueStr: "reservation message"), ErrorFollowing, EncodeCrossCrate::Yes,
+        template!(NameValueStr: "reservation message"), EncodeCrossCrate::Yes,
         "the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
-        rustc_test_marker, Normal, template!(NameValueStr: "name"), WarnFollowing,
+        rustc_test_marker, Normal, template!(NameValueStr: "name"),
         EncodeCrossCrate::No, "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
         rustc_unsafe_specialization_marker, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
         rustc_specialization_trait, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::No,
+        rustc_main, Normal, template!(Word), EncodeCrossCrate::No,
         "the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
-        rustc_skip_during_method_dispatch, Normal, template!(List: &["array, boxed_slice"]), ErrorFollowing,
+        rustc_skip_during_method_dispatch, Normal, template!(List: &["array, boxed_slice"]),
         EncodeCrossCrate::No,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
@@ -1394,34 +1319,34 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     rustc_attr!(
         rustc_must_implement_one_of, Normal, template!(List: &["function1, function2, ..."]),
-        ErrorFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
-        rustc_doc_primitive, Normal, template!(NameValueStr: "primitive name"), ErrorFollowing,
+        rustc_doc_primitive, Normal, template!(NameValueStr: "primitive name"),
         EncodeCrossCrate::Yes, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::Yes, intrinsics,
+        rustc_intrinsic, Normal, template!(Word), EncodeCrossCrate::Yes, intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_no_mir_inline, Normal, template!(Word), EncodeCrossCrate::Yes,
         "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, Normal, template!(Word, NameValueStr: "reason"), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_force_inline, Normal, template!(Word, NameValueStr: "reason"), EncodeCrossCrate::Yes,
         "`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, Normal, template!(List: &["count"]), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_scalable_vector, Normal, template!(List: &["count"]), EncodeCrossCrate::Yes,
         "`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
     rustc_attr!(
-        rustc_must_match_exhaustively, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes,
+        rustc_must_match_exhaustively, Normal, template!(Word), EncodeCrossCrate::Yes,
         "enums with `#[rustc_must_match_exhaustively]` must be matched on with a match block that mentions all variants explicitly"
     ),
 
@@ -1429,134 +1354,134 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, Normal, template!(Word), WarnFollowing, EncodeCrossCrate::Yes),
+    rustc_attr!(TEST, rustc_effective_visibility, Normal, template!(Word), EncodeCrossCrate::Yes),
     rustc_attr!(
         TEST, rustc_dump_inferred_outlives, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_capture_analysis, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_insignificant_dtor, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_no_implicit_bounds, CrateLevel, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_strict_coherence, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_dump_variances, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_variances_of_opaques, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_hidden_type_of_opaques, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_layout, Normal, template!(List: &["field1, field2, ..."]),
-        WarnFollowing, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_abi, Normal, template!(List: &["field1, field2, ..."]),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_regions, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_delayed_bug_from_inside_query, Normal,
         template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
-    ),
-    rustc_attr!(
-        TEST, rustc_dump_user_args, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
-    ),
-    rustc_attr!(
-        TEST, rustc_evaluate_where_clauses, Normal, template!(Word), WarnFollowing,
-        EncodeCrossCrate::Yes
-    ),
-    rustc_attr!(
-        TEST, rustc_if_this_changed, Normal, template!(Word, List: &["DepNode"]), DuplicatesOk,
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_then_this_would_need, Normal, template!(List: &["DepNode"]), DuplicatesOk,
+        TEST, rustc_dump_user_args, Normal, template!(Word),
+        EncodeCrossCrate::No
+    ),
+    rustc_attr!(
+        TEST, rustc_evaluate_where_clauses, Normal, template!(Word),
+        EncodeCrossCrate::Yes
+    ),
+    rustc_attr!(
+        TEST, rustc_if_this_changed, Normal, template!(Word, List: &["DepNode"]),
+        EncodeCrossCrate::No
+    ),
+    rustc_attr!(
+        TEST, rustc_then_this_would_need, Normal, template!(List: &["DepNode"]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_clean, Normal,
         template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_partition_reused, Normal,
-        template!(List: &[r#"cfg = "...", module = "...""#]), DuplicatesOk, EncodeCrossCrate::No
+        template!(List: &[r#"cfg = "...", module = "...""#]), EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_partition_codegened, Normal,
-        template!(List: &[r#"cfg = "...", module = "...""#]), DuplicatesOk, EncodeCrossCrate::No
+        template!(List: &[r#"cfg = "...", module = "...""#]), EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_expected_cgu_reuse, Normal,
-        template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]), DuplicatesOk,
+        template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_symbol_name, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_def_path, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_mir, Normal, template!(List: &["arg1, arg2, ..."]),
-        DuplicatesOk, EncodeCrossCrate::Yes
+        EncodeCrossCrate::Yes
     ),
     gated!(
         custom_mir, Normal, template!(List: &[r#"dialect = "...", phase = "...""#]),
-        ErrorFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
         "the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
         TEST, rustc_dump_item_bounds, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_predicates, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_def_parents, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_object_lifetime_defaults, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_vtable, Normal, template!(Word),
-        WarnFollowing, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dummy, Normal, template!(Word /* doesn't matter*/),
-        DuplicatesOk, EncodeCrossCrate::No
+        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, pattern_complexity_limit, CrateLevel, template!(NameValueStr: "N"),
-        ErrorFollowing, EncodeCrossCrate::No,
+        EncodeCrossCrate::No,
     ),
 ];
 
@@ -1572,14 +1497,6 @@ pub fn encode_cross_crate(name: Symbol) -> bool {
     } else {
         true
     }
-}
-
-pub fn is_valid_for_get_attr(name: Symbol) -> bool {
-    BUILTIN_ATTRIBUTE_MAP.get(&name).is_some_and(|attr| match attr.duplicates {
-        WarnFollowing | ErrorFollowing | ErrorPreceding | FutureWarnFollowing
-        | FutureWarnPreceding => true,
-        DuplicatesOk | WarnFollowingWordOnly => false,
-    })
 }
 
 pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>> =

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -5,7 +5,6 @@ use std::sync::LazyLock;
 use AttributeGate::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::AttrStyle;
-use rustc_hir::attrs::EncodeCrossCrate;
 use rustc_span::edition::Edition;
 use rustc_span::{Symbol, sym};
 
@@ -206,28 +205,25 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident, $tpl:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
             template: $tpl,
             gate: Ungated,
         }
     };
-    (unsafe $attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe $attr:ident, $tpl:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Ungated,
         }
     };
-    ($attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    ($attr:ident, $tpl:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Ungated,
@@ -236,10 +232,9 @@ macro_rules! ungated {
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $tpl:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Gated {
@@ -250,10 +245,9 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $tpl:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Gated {
@@ -264,10 +258,9 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $tpl:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Gated {
@@ -278,10 +271,9 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    ($attr:ident, $tpl:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Gated {
@@ -295,11 +287,10 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    (TEST, $attr:ident, $tpl:expr $(,)?) => {
         rustc_attr!(
             $attr,
             $tpl,
-            $encode_cross_crate,
             concat!(
                 "the `#[",
                 stringify!($attr),
@@ -307,10 +298,9 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $tpl:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $tpl:expr, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
-            encode_cross_crate: $encode_cross_crate,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Gated {
@@ -336,11 +326,6 @@ macro_rules! experimental {
 
 pub struct BuiltinAttribute {
     pub name: Symbol,
-    /// Whether this attribute is encode cross crate.
-    ///
-    /// If so, it is encoded in the crate metadata.
-    /// Otherwise, it can only be used in the local crate.
-    pub encode_cross_crate: EncodeCrossCrate,
     pub safety: AttributeSafety,
     pub template: AttributeTemplate,
     pub gate: AttributeGate,
@@ -360,7 +345,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["predicate"],
             "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute"
         ),
-        EncodeCrossCrate::No
     ),
     ungated!(
         cfg_attr,
@@ -368,7 +352,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["predicate, attr1, attr2, ..."],
             "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
         ),
-        EncodeCrossCrate::No
     ),
 
     // Testing:
@@ -379,7 +362,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
         ),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         should_panic,
@@ -389,7 +371,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
         ),
-        EncodeCrossCrate::No,
     ),
 
     // Macros:
@@ -399,7 +380,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             Word,
             "https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute"
         ),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         macro_use,
@@ -408,9 +388,8 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["name1, name2, ..."],
             "https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute"
         ),
-        EncodeCrossCrate::No,
     ),
-    ungated!(macro_escape, template!(Word), EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
+    ungated!(macro_escape, template!(Word),), // Deprecated synonym for `macro_use`.
     ungated!(
         macro_export,
         template!(
@@ -418,14 +397,12 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["local_inner_macros"],
             "https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope"
         ),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         proc_macro,
         template!(
             Word,
             "https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         proc_macro_derive,
@@ -433,12 +410,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
             "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
         ),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         proc_macro_attribute,
         template!(Word, "https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros"),
-        EncodeCrossCrate::No
     ),
 
     // Lints:
@@ -448,7 +423,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         allow,
@@ -456,7 +430,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         expect,
@@ -464,7 +437,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         forbid,
@@ -472,7 +444,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        EncodeCrossCrate::No
     ),
     ungated!(
         deny,
@@ -480,7 +451,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
         ),
-        EncodeCrossCrate::No
     ),
     ungated!(
         must_use,
@@ -489,11 +459,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
         ),
-        EncodeCrossCrate::Yes
     ),
     gated!(
         must_not_suspend, template!(Word, NameValueStr: "reason"),
-        EncodeCrossCrate::Yes, experimental!(must_not_suspend)
+        experimental!(must_not_suspend)
     ),
     ungated!(
         deprecated,
@@ -503,7 +472,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "reason",
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"
         ),
-        EncodeCrossCrate::Yes
     ),
 
     // Crate properties:
@@ -513,7 +481,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "name",
             "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-crate_name-attribute"
         ),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         crate_type,
@@ -521,7 +488,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: ["bin", "lib", "dylib", "cdylib", "rlib", "staticlib", "sdylib", "proc-macro"],
             "https://doc.rust-lang.org/reference/linkage.html"
         ),
-        EncodeCrossCrate::No,
     ),
 
     // ABI, linking, symbols, and FFI
@@ -534,17 +500,14 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             r#"name = "...", import_name_type = "decorated|noprefix|undecorated""#,
             r#"name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated""#,
         ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute"),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         link_name,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         no_link,
         template!(Word, "https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         repr,
@@ -552,45 +515,37 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["C", "Rust", "transparent", "align(...)", "packed(...)", "<integer type>"],
             "https://doc.rust-lang.org/reference/type-layout.html#representations"
         ),
-        EncodeCrossCrate::No
     ),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, template!(List: &["alignment"]), EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, template!(List: &["alignment"]), EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, template!(List: &["alignment"]), fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, template!(List: &["alignment"]), static_align, experimental!(rustc_align_static)),
     ungated!(
         unsafe(Edition2024) export_name,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         unsafe(Edition2024) link_section,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         unsafe(Edition2024) no_mangle,
         template!(Word, "https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         used,
         template!(Word, List: &["compiler", "linker"], "https://doc.rust-lang.org/reference/abi.html#the-used-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         link_ordinal,
         template!(List: &["ordinal"], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         unsafe naked,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-naked-attribute"),
-        EncodeCrossCrate::No
     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
         rustc_pass_indirectly_in_non_rustic_abis, template!(Word),
-        EncodeCrossCrate::No,
         "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
 
@@ -598,57 +553,48 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(
         recursion_limit,
         template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         type_length_limit,
         template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-type_length_limit-attribute"),
-        EncodeCrossCrate::No
     ),
     gated!(
         move_size_limit, template!(NameValueStr: "N"),
-        EncodeCrossCrate::No, large_assignments, experimental!(move_size_limit)
+        large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
     ungated!(
         no_main,
         template!(Word, "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-no_main-attribute"),
-        EncodeCrossCrate::No
     ),
 
     // Modules, prelude, and resolution:
     ungated!(
         path,
         template!(NameValueStr: "file", "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         no_std,
         template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         no_implicit_prelude,
         template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         non_exhaustive,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
-        EncodeCrossCrate::Yes
     ),
 
     // Runtime
     ungated!(
         windows_subsystem,
         template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!( // RFC 2070
         panic_handler,
         template!(Word, "https://doc.rust-lang.org/reference/panic.html#the-panic_handler-attribute"),
-        EncodeCrossCrate::Yes
     ),
 
     // Code generation:
@@ -659,44 +605,37 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["always", "never"],
             "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
         ),
-        EncodeCrossCrate::No
     ),
     ungated!(
         cold,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-cold-attribute"),
-        EncodeCrossCrate::No
     ),
     ungated!(
         no_builtins,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-no_builtins-attribute"),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         target_feature,
         template!(List: &[r#"enable = "name""#], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         track_caller,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute"),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         instruction_set,
         template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute"),
-        EncodeCrossCrate::No
     ),
     gated!(
         unsafe force_target_feature, template!(List: &[r#"enable = "name""#]),
-        EncodeCrossCrate::No, effective_target_features, experimental!(force_target_feature)
+        effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
         sanitize, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]),
-        EncodeCrossCrate::No, sanitize, experimental!(sanitize),
+        sanitize, experimental!(sanitize),
     ),
     gated!(
         coverage, template!(OneOf: &[sym::off, sym::on]),
-        EncodeCrossCrate::No,
         coverage_attribute, experimental!(coverage)
     ),
 
@@ -707,7 +646,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             NameValueStr: "string",
             "https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html"
         ),
-        EncodeCrossCrate::Yes
     ),
 
     // Debugging
@@ -717,7 +655,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &[r#"natvis_file = "...", gdb_script_file = "...""#],
             "https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute"
         ),
-        EncodeCrossCrate::No
     ),
     ungated!(
         collapse_debuginfo,
@@ -725,7 +662,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &["no", "external", "yes"],
             "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
         ),
-        EncodeCrossCrate::Yes
     ),
 
     // ==========================================================================
@@ -735,70 +671,70 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Linking:
     gated!(
         export_stable, template!(Word),
-        EncodeCrossCrate::No, experimental!(export_stable)
+        experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
         test_runner, template!(List: &["path"]),
-        EncodeCrossCrate::Yes, custom_test_frameworks,
+        custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
         reexport_test_harness_main, template!(NameValueStr: "name"),
-        EncodeCrossCrate::No, custom_test_frameworks,
+        custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, template!(Word), EncodeCrossCrate::No,
+        marker, template!(Word),
         marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, template!(Word), EncodeCrossCrate::No,
+        thread_local, template!(Word),
         "`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
         no_core, template!(Word),
-        EncodeCrossCrate::No, experimental!(no_core)
+        experimental!(no_core)
     ),
     // RFC 2412
     gated!(
         optimize, template!(List: &["none", "size", "speed"]),
-        EncodeCrossCrate::No, optimize_attribute, experimental!(optimize)
+        optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
         unsafe ffi_pure, template!(Word),
-        EncodeCrossCrate::No, experimental!(ffi_pure)
+        experimental!(ffi_pure)
     ),
     gated!(
         unsafe ffi_const, template!(Word),
-        EncodeCrossCrate::No, experimental!(ffi_const)
+        experimental!(ffi_const)
     ),
     gated!(
         register_tool, template!(List: &["tool1, tool2, ..."]),
-        EncodeCrossCrate::No, experimental!(register_tool),
+        experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
         cfi_encoding, template!(NameValueStr: "encoding"),
-        EncodeCrossCrate::Yes, experimental!(cfi_encoding)
+        experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
         coroutine, template!(Word),
-        EncodeCrossCrate::No, coroutines, experimental!(coroutine)
+        coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
         patchable_function_entry, template!(List: &["prefix_nops = m, entry_nops = n"]),
-        EncodeCrossCrate::Yes, experimental!(patchable_function_entry)
+        experimental!(patchable_function_entry)
     ),
 
     // The `#[loop_match]` and `#[const_continue]` attributes are part of the
@@ -807,11 +743,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
         const_continue, template!(Word),
-        EncodeCrossCrate::No, loop_match, experimental!(const_continue)
+        loop_match, experimental!(const_continue)
     ),
     gated!(
         loop_match, template!(Word),
-        EncodeCrossCrate::No, loop_match, experimental!(loop_match)
+        loop_match, experimental!(loop_match)
     ),
 
     // The `#[pin_v2]` attribute is part of the `pin_ergonomics` experiment
@@ -820,7 +756,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
         pin_v2, template!(Word),
-        EncodeCrossCrate::Yes, pin_ergonomics, experimental!(pin_v2),
+        pin_ergonomics, experimental!(pin_v2),
     ),
 
     // ==========================================================================
@@ -829,21 +765,19 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     ungated!(
         feature,
-        template!(List: &["name1, name2, ..."]), EncodeCrossCrate::No,
+        template!(List: &["name1, name2, ..."]),
     ),
     // DuplicatesOk since it has its own validation
     ungated!(
         stable,
-        template!(List: &[r#"feature = "name", since = "version""#]), EncodeCrossCrate::No,
+        template!(List: &[r#"feature = "name", since = "version""#]),
     ),
     ungated!(
         unstable,
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         unstable_feature_bound, template!(Word, List: &["feat1, feat2, ..."]),
-        EncodeCrossCrate::No,
     ),
     ungated!(
         unstable_removed, CrateLevel,
@@ -852,45 +786,39 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(
         rustc_const_unstable, template!(List: &[r#"feature = "name""#]),
-        EncodeCrossCrate::Yes
     ),
     ungated!(
         rustc_const_stable,
-        template!(List: &[r#"feature = "name""#]), EncodeCrossCrate::No,
+        template!(List: &[r#"feature = "name""#]),
     ),
     ungated!(
         rustc_default_body_unstable,
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
-        EncodeCrossCrate::No
     ),
     gated!(
         allow_internal_unstable, template!(Word, List: &["feat1, feat2, ..."]),
-        EncodeCrossCrate::Yes,
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
         allow_internal_unsafe, template!(Word),
-        EncodeCrossCrate::No, "allow_internal_unsafe side-steps the unsafe_code lint",
+        "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
         rustc_eii_foreign_item, template!(Word),
-        EncodeCrossCrate::Yes, eii_internals,
+        eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
         rustc_allowed_through_unstable_modules, template!(NameValueStr: "deprecation message"),
-        EncodeCrossCrate::No,
         "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
         rustc_deprecated_safe_2024, template!(List: &[r#"audit_that = "...""#]),
-        EncodeCrossCrate::Yes,
         "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
         rustc_pub_transparent, template!(Word),
-        EncodeCrossCrate::Yes,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
 
@@ -899,10 +827,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, template!(Word), EncodeCrossCrate::Yes, experimental!(fundamental)),
+    gated!(fundamental, template!(Word), experimental!(fundamental)),
     gated!(
         may_dangle, template!(Word),
-        EncodeCrossCrate::No, dropck_eyepatch,
+        dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
 
@@ -915,7 +843,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             r#"fallback = "never""#,
             r#"fallback = "no""#,
         ]),
-        EncodeCrossCrate::No,
         "`rustc_never_type_options` is used to experiment with never type fallback and work on \
          never type stabilization"
     ),
@@ -925,49 +852,46 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_allocator, template!(Word), EncodeCrossCrate::No,
+        rustc_allocator, template!(Word),
     ),
     rustc_attr!(
-        rustc_nounwind, template!(Word), EncodeCrossCrate::No,
+        rustc_nounwind, template!(Word),
     ),
     rustc_attr!(
-        rustc_reallocator, template!(Word), EncodeCrossCrate::No,
+        rustc_reallocator, template!(Word),
     ),
     rustc_attr!(
-        rustc_deallocator, template!(Word), EncodeCrossCrate::No,
+        rustc_deallocator, template!(Word),
     ),
     rustc_attr!(
-        rustc_allocator_zeroed, template!(Word), EncodeCrossCrate::No,
+        rustc_allocator_zeroed, template!(Word),
     ),
     rustc_attr!(
         rustc_allocator_zeroed_variant, template!(NameValueStr: "function"),
-        EncodeCrossCrate::Yes,
     ),
     gated!(
         default_lib_allocator, template!(Word),
-        EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),
+        allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
         needs_allocator, template!(Word),
-        EncodeCrossCrate::No, allocator_internals, experimental!(needs_allocator),
+        allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
         panic_runtime, template!(Word),
-        EncodeCrossCrate::No, experimental!(panic_runtime)
+        experimental!(panic_runtime)
     ),
     gated!(
         needs_panic_runtime, template!(Word),
-        EncodeCrossCrate::No, experimental!(needs_panic_runtime)
+        experimental!(needs_panic_runtime)
     ),
     gated!(
         compiler_builtins, template!(Word),
-        EncodeCrossCrate::No,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
         profiler_runtime, template!(Word),
-        EncodeCrossCrate::No,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
     ),
@@ -988,17 +912,16 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             "weak",
             "weak_odr",
         ], "https://doc.rust-lang.org/reference/linkage.html"),
-        EncodeCrossCrate::No,
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
     rustc_attr!(
-        rustc_std_internal_symbol, template!(Word), EncodeCrossCrate::No,
+        rustc_std_internal_symbol, template!(Word),
     ),
     rustc_attr!(
-        rustc_objc_class, template!(NameValueStr: "ClassName"), EncodeCrossCrate::No,
+        rustc_objc_class, template!(NameValueStr: "ClassName"),
     ),
     rustc_attr!(
-        rustc_objc_selector, template!(NameValueStr: "methodName"), EncodeCrossCrate::No,
+        rustc_objc_selector, template!(NameValueStr: "methodName"),
     ),
 
     // ==========================================================================
@@ -1008,36 +931,31 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(
         rustc_builtin_macro,
         template!(Word, List: &["name", "name, /*opt*/ attributes(name1, name2, ...)"]),
-        EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
         rustc_proc_macro_decls, template!(Word),
-        EncodeCrossCrate::No,
     ),
     rustc_attr!(
         rustc_macro_transparency,
         template!(NameValueStr: ["transparent", "semiopaque", "opaque"]),
-        EncodeCrossCrate::Yes, "used internally for testing macro hygiene",
+        "used internally for testing macro hygiene",
     ),
     rustc_attr!(
         rustc_autodiff,
         template!(Word, List: &[r#""...""#]),
-        EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
         rustc_offload_kernel,
-        template!(Word), EncodeCrossCrate::Yes,
+        template!(Word),
     ),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
     ungated!(
-        cfg_trace, template!(Word /* irrelevant */), EncodeCrossCrate::Yes
-    ),
+        cfg_trace, template!(Word /* irrelevant */),    ),
     ungated!(
-        cfg_attr_trace, template!(Word /* irrelevant */), EncodeCrossCrate::No
-    ),
+        cfg_attr_trace, template!(Word /* irrelevant */),    ),
 
     // ==========================================================================
     // Internal attributes, Diagnostics related:
@@ -1049,48 +967,40 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#],
             NameValueStr: "message"
         ),
-        EncodeCrossCrate::Yes,
         "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
         rustc_confusables,
         template!(List: &[r#""name1", "name2", ..."#]),
-        EncodeCrossCrate::Yes,
     ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
         rustc_conversion_suggestion, template!(Word),
-        EncodeCrossCrate::Yes,
     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
         rustc_trivial_field_reads, template!(Word),
-        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_query_instability, template!(Word),
-        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
         rustc_lint_untracked_query_information, template!(Word),
-        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_ty, template!(Word),
-        EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
         rustc_lint_opt_deny_field_access, template!(List: &["message"]),
-        EncodeCrossCrate::Yes,
     ),
 
     // ==========================================================================
@@ -1099,30 +1009,27 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_promotable, template!(Word),
-        EncodeCrossCrate::No, ),
+    ),
     rustc_attr!(
         rustc_legacy_const_generics, template!(List: &["N"]),
-        EncodeCrossCrate::Yes,
     ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
         rustc_do_not_const_check, template!(Word),
-        EncodeCrossCrate::Yes, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
+        "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
         rustc_const_stable_indirect,
         template!(Word),
-       
-        EncodeCrossCrate::No,
         "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_intrinsic_const_stable_indirect,
-        template!(Word), EncodeCrossCrate::No,  "this is an internal implementation detail",
+        template!(Word),  "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_allow_const_fn_unstable,
-        template!(Word, List: &["feat1, feat2, ..."]), EncodeCrossCrate::No,
+        template!(Word, List: &["feat1, feat2, ..."]),
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
@@ -1132,25 +1039,21 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_layout_scalar_valid_range_start, template!(List: &["value"]),
-        EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
         rustc_layout_scalar_valid_range_end, template!(List: &["value"]),
-        EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
         rustc_simd_monomorphize_lane_limit, template!(NameValueStr: "N"),
-        EncodeCrossCrate::Yes,
         "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
         rustc_nonnull_optimization_guaranteed, template!(Word),
-        EncodeCrossCrate::Yes,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; \
@@ -1161,79 +1064,69 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, template!(NameValueStr: "name"), EncodeCrossCrate::No, lang_items,
+        lang, template!(NameValueStr: "name"), lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
         rustc_as_ptr, template!(Word),
-        EncodeCrossCrate::Yes,
         "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
         rustc_should_not_be_called_on_const_items, template!(Word),
-        EncodeCrossCrate::Yes,
         "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
         rustc_pass_by_value, template!(Word),
-        EncodeCrossCrate::Yes,
         "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
         rustc_never_returns_null_ptr, template!(Word),
-        EncodeCrossCrate::Yes,
         "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, template!(Word), EncodeCrossCrate::Yes,
+        rustc_no_implicit_autorefs, template!(Word),
         "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, template!(Word), EncodeCrossCrate::No,
+        rustc_coherence_is_core, template!(Word),
         "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, template!(Word), EncodeCrossCrate::No,
+        rustc_coinductive, template!(Word),
         "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, template!(Word), EncodeCrossCrate::No,
+        rustc_allow_incoherent_impl, template!(Word),
         "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, template!(Word), EncodeCrossCrate::No,
+        rustc_preserve_ub_checks, template!(Word),
         "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
         template!(Word),
-        EncodeCrossCrate::No,
         "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
     rustc_attr!(
         rustc_dyn_incompatible_trait,
         template!(Word),
-        EncodeCrossCrate::No,
         "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
         rustc_has_incoherent_inherent_impls, template!(Word),
-        EncodeCrossCrate::Yes,
         "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
         rustc_non_const_trait_method, template!(Word),
-        EncodeCrossCrate::No,
         "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
     ),
 
     BuiltinAttribute {
         name: sym::rustc_diagnostic_item,
-        // FIXME: This can be `true` once we always use `tcx.is_diagnostic_item`.
-        encode_cross_crate: EncodeCrossCrate::Yes,
         safety: AttributeSafety::Normal,
         template: template!(NameValueStr: "name"),
         gate: Gated {
@@ -1247,79 +1140,75 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     gated!(
         // Used in resolve:
         prelude_import, template!(Word),
-        EncodeCrossCrate::No, "`#[prelude_import]` is for use by rustc only",
+        "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, template!(Word), EncodeCrossCrate::No,
+        rustc_paren_sugar, template!(Word),
         unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, template!(Word), EncodeCrossCrate::No,
+        rustc_inherit_overflow_checks, template!(Word),
         "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
         rustc_reservation_impl,
-        template!(NameValueStr: "reservation message"), EncodeCrossCrate::Yes,
+        template!(NameValueStr: "reservation message"),
         "the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
         rustc_test_marker, template!(NameValueStr: "name"),
-        EncodeCrossCrate::No, "the `#[rustc_test_marker]` attribute is used internally to track tests",
+        "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
         rustc_unsafe_specialization_marker, template!(Word),
-        EncodeCrossCrate::No,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
         rustc_specialization_trait, template!(Word),
-        EncodeCrossCrate::No,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, template!(Word), EncodeCrossCrate::No,
+        rustc_main, template!(Word),
         "the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
         rustc_skip_during_method_dispatch, template!(List: &["array, boxed_slice"]),
-        EncodeCrossCrate::No,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
     rustc_attr!(
         rustc_must_implement_one_of, template!(List: &["function1, function2, ..."]),
-        EncodeCrossCrate::No,
         "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
         rustc_doc_primitive, template!(NameValueStr: "primitive name"),
-        EncodeCrossCrate::Yes, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
+        "the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, template!(Word), EncodeCrossCrate::Yes, intrinsics,
+        rustc_intrinsic, template!(Word), intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, template!(Word), EncodeCrossCrate::Yes,
+        rustc_no_mir_inline, template!(Word),
         "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, template!(Word, NameValueStr: "reason"), EncodeCrossCrate::Yes,
+        rustc_force_inline, template!(Word, NameValueStr: "reason"),
         "`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, template!(List: &["count"]), EncodeCrossCrate::Yes,
+        rustc_scalable_vector, template!(List: &["count"]),
         "`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
     rustc_attr!(
-        rustc_must_match_exhaustively, template!(Word), EncodeCrossCrate::Yes,
+        rustc_must_match_exhaustively, template!(Word),
         "enums with `#[rustc_must_match_exhaustively]` must be matched on with a match block that mentions all variants explicitly"
     ),
 
@@ -1327,149 +1216,108 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, template!(Word), EncodeCrossCrate::Yes),
+    rustc_attr!(TEST, rustc_effective_visibility, template!(Word)),
     rustc_attr!(
         TEST, rustc_dump_inferred_outlives, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_capture_analysis, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_insignificant_dtor, template!(Word),
-        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_no_implicit_bounds, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_strict_coherence, template!(Word),
-        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_dump_variances, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_variances_of_opaques, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_hidden_type_of_opaques, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_layout, template!(List: &["field1, field2, ..."]),
-        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_abi, template!(List: &["field1, field2, ..."]),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_regions, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_delayed_bug_from_inside_query,
         template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_user_args, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_evaluate_where_clauses, template!(Word),
-        EncodeCrossCrate::Yes
     ),
     rustc_attr!(
         TEST, rustc_if_this_changed, template!(Word, List: &["DepNode"]),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_then_this_would_need, template!(List: &["DepNode"]),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_clean,
         template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_partition_reused,
-        template!(List: &[r#"cfg = "...", module = "...""#]), EncodeCrossCrate::No
-    ),
+        template!(List: &[r#"cfg = "...", module = "...""#]),    ),
     rustc_attr!(
         TEST, rustc_partition_codegened,
-        template!(List: &[r#"cfg = "...", module = "...""#]), EncodeCrossCrate::No
-    ),
+        template!(List: &[r#"cfg = "...", module = "...""#]),    ),
     rustc_attr!(
         TEST, rustc_expected_cgu_reuse,
         template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_symbol_name, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_def_path, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_mir, template!(List: &["arg1, arg2, ..."]),
-        EncodeCrossCrate::Yes
     ),
     gated!(
         custom_mir, template!(List: &[r#"dialect = "...", phase = "...""#]),
-        EncodeCrossCrate::No,
         "the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
         TEST, rustc_dump_item_bounds, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_predicates, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_def_parents, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_object_lifetime_defaults, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dump_vtable, template!(Word),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, rustc_dummy, template!(Word /* doesn't matter*/),
-        EncodeCrossCrate::No
     ),
     rustc_attr!(
         TEST, pattern_complexity_limit, template!(NameValueStr: "N"),
-        EncodeCrossCrate::No,
     ),
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {
     BUILTIN_ATTRIBUTE_MAP.get(&name).is_some()
-}
-
-/// Whether this builtin attribute is encoded cross crate.
-/// This means it can be used cross crate.
-pub fn encode_cross_crate(name: Symbol) -> bool {
-    if let Some(attr) = BUILTIN_ATTRIBUTE_MAP.get(&name) {
-        attr.encode_cross_crate == EncodeCrossCrate::Yes
-    } else {
-        true
-    }
 }
 
 pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>> =
@@ -1482,13 +1330,3 @@ pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>>
         }
         map
     });
-
-pub fn is_stable_diagnostic_attribute(sym: Symbol, features: &Features) -> bool {
-    match sym {
-        sym::on_unimplemented | sym::do_not_recommend => true,
-        sym::on_const => features.diagnostic_on_const(),
-        sym::on_move => features.diagnostic_on_move(),
-        sym::on_unknown => features.diagnostic_on_unknown(),
-        _ => false,
-    }
-}

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -3,7 +3,6 @@
 use std::sync::LazyLock;
 
 use AttributeGate::*;
-use AttributeType::*;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::AttrStyle;
 use rustc_hir::attrs::EncodeCrossCrate;
@@ -72,16 +71,6 @@ pub fn find_gated_cfg(pred: impl Fn(Symbol) -> bool) -> Option<&'static GatedCfg
 // If you change this, please modify `src/doc/unstable-book` as well. You must
 // move that documentation into the relevant place in the other docs, and
 // remove the chapter on the flag.
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-pub enum AttributeType {
-    /// Normal, builtin attribute that is consumed
-    /// by the compiler before the unused_attribute check
-    Normal,
-
-    /// Builtin attribute that is only allowed at the crate level
-    CrateLevel,
-}
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AttributeSafety {
@@ -217,31 +206,28 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
             template: $tpl,
             gate: Ungated,
         }
     };
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    (unsafe $attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Ungated,
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    ($attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Ungated,
@@ -250,11 +236,10 @@ macro_rules! ungated {
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Gated {
@@ -265,11 +250,10 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
             template: $tpl,
             gate: Gated {
@@ -280,11 +264,10 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $tpl:expr, $encode_cross_crate:expr, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Gated {
@@ -295,11 +278,10 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
+    ($attr:ident, $tpl:expr, $encode_cross_crate:expr, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Gated {
@@ -313,10 +295,9 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
+    (TEST, $attr:ident, $tpl:expr, $encode_cross_crate:expr $(,)?) => {
         rustc_attr!(
             $attr,
-            $typ,
             $tpl,
             $encode_cross_crate,
             concat!(
@@ -326,11 +307,10 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $typ:expr, $tpl:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident, $tpl:expr, $encode_cross_crate:expr, $($notes:expr),* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             encode_cross_crate: $encode_cross_crate,
-            type_: $typ,
             safety: AttributeSafety::Normal,
             template: $tpl,
             gate: Gated {
@@ -361,7 +341,6 @@ pub struct BuiltinAttribute {
     /// If so, it is encoded in the crate metadata.
     /// Otherwise, it can only be used in the local crate.
     pub encode_cross_crate: EncodeCrossCrate,
-    pub type_: AttributeType,
     pub safety: AttributeSafety,
     pub template: AttributeTemplate,
     pub gate: AttributeGate,
@@ -376,7 +355,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Conditional compilation:
     ungated!(
-        cfg, Normal,
+        cfg,
         template!(
             List: &["predicate"],
             "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute"
@@ -384,7 +363,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No
     ),
     ungated!(
-        cfg_attr, Normal,
+        cfg_attr,
         template!(
             List: &["predicate, attr1, attr2, ..."],
             "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
@@ -394,7 +373,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Testing:
     ungated!(
-        ignore, Normal,
+        ignore,
         template!(
             Word,
             NameValueStr: "reason",
@@ -403,7 +382,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        should_panic, Normal,
+        should_panic,
         template!(
             Word,
             List: &[r#"expected = "reason""#],
@@ -415,7 +394,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Macros:
     ungated!(
-        automatically_derived, Normal,
+        automatically_derived,
         template!(
             Word,
             "https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute"
@@ -423,7 +402,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        macro_use, Normal,
+        macro_use,
         template!(
             Word,
             List: &["name1, name2, ..."],
@@ -431,9 +410,9 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         ),
         EncodeCrossCrate::No,
     ),
-    ungated!(macro_escape, Normal, template!(Word), EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
+    ungated!(macro_escape, template!(Word), EncodeCrossCrate::No), // Deprecated synonym for `macro_use`.
     ungated!(
-        macro_export, Normal,
+        macro_export,
         template!(
             Word,
             List: &["local_inner_macros"],
@@ -442,14 +421,14 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        proc_macro, Normal,
+        proc_macro,
         template!(
             Word,
             "https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        proc_macro_derive, Normal,
+        proc_macro_derive,
         template!(
             List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
             "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
@@ -457,14 +436,14 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        proc_macro_attribute, Normal,
+        proc_macro_attribute,
         template!(Word, "https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros"),
         EncodeCrossCrate::No
     ),
 
     // Lints:
     ungated!(
-        warn, Normal,
+        warn,
         template!(
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
@@ -472,7 +451,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        allow, Normal,
+        allow,
         template!(
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
@@ -480,7 +459,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        expect, Normal,
+        expect,
         template!(
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
@@ -488,7 +467,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        forbid, Normal,
+        forbid,
         template!(
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
@@ -496,7 +475,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No
     ),
     ungated!(
-        deny, Normal,
+        deny,
         template!(
             List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
             "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
@@ -504,7 +483,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No
     ),
     ungated!(
-        must_use, Normal,
+        must_use,
         template!(
             Word,
             NameValueStr: "reason",
@@ -513,11 +492,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes
     ),
     gated!(
-        must_not_suspend, Normal, template!(Word, NameValueStr: "reason"),
+        must_not_suspend, template!(Word, NameValueStr: "reason"),
         EncodeCrossCrate::Yes, experimental!(must_not_suspend)
     ),
     ungated!(
-        deprecated, Normal,
+        deprecated,
         template!(
             Word,
             List: &[r#"/*opt*/ since = "version", /*opt*/ note = "reason""#],
@@ -529,7 +508,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Crate properties:
     ungated!(
-        crate_name, CrateLevel,
+        crate_name,
         template!(
             NameValueStr: "name",
             "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-crate_name-attribute"
@@ -537,7 +516,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        crate_type, CrateLevel,
+        crate_type,
         template!(
             NameValueStr: ["bin", "lib", "dylib", "cdylib", "rlib", "staticlib", "sdylib", "proc-macro"],
             "https://doc.rust-lang.org/reference/linkage.html"
@@ -547,7 +526,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // ABI, linking, symbols, and FFI
     ungated!(
-        link, Normal,
+        link,
         template!(List: &[
             r#"name = "...""#,
             r#"name = "...", kind = "dylib|static|...""#,
@@ -558,17 +537,17 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No,
     ),
     ungated!(
-        link_name, Normal,
+        link_name,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"),
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        no_link, Normal,
+        no_link,
         template!(Word, "https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        repr, Normal,
+        repr,
         template!(
             List: &["C", "Rust", "transparent", "align(...)", "packed(...)", "<integer type>"],
             "https://doc.rust-lang.org/reference/type-layout.html#representations"
@@ -576,105 +555,105 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No
     ),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, Normal, template!(List: &["alignment"]), EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, Normal, template!(List: &["alignment"]), EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, template!(List: &["alignment"]), EncodeCrossCrate::No, fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, template!(List: &["alignment"]), EncodeCrossCrate::No, static_align, experimental!(rustc_align_static)),
     ungated!(
-        unsafe(Edition2024) export_name, Normal,
+        unsafe(Edition2024) export_name,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        unsafe(Edition2024) link_section, Normal,
+        unsafe(Edition2024) link_section,
         template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        unsafe(Edition2024) no_mangle, Normal,
+        unsafe(Edition2024) no_mangle,
         template!(Word, "https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        used, Normal,
+        used,
         template!(Word, List: &["compiler", "linker"], "https://doc.rust-lang.org/reference/abi.html#the-used-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        link_ordinal, Normal,
+        link_ordinal,
         template!(List: &["ordinal"], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"),
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        unsafe naked, Normal,
+        unsafe naked,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-naked-attribute"),
         EncodeCrossCrate::No
     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
-        rustc_pass_indirectly_in_non_rustic_abis, Normal, template!(Word),
+        rustc_pass_indirectly_in_non_rustic_abis, template!(Word),
         EncodeCrossCrate::No,
         "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
 
     // Limits:
     ungated!(
-        recursion_limit, CrateLevel,
+        recursion_limit,
         template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        type_length_limit, CrateLevel,
+        type_length_limit,
         template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-type_length_limit-attribute"),
         EncodeCrossCrate::No
     ),
     gated!(
-        move_size_limit, CrateLevel, template!(NameValueStr: "N"),
+        move_size_limit, template!(NameValueStr: "N"),
         EncodeCrossCrate::No, large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
     ungated!(
-        no_main, CrateLevel,
+        no_main,
         template!(Word, "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-no_main-attribute"),
         EncodeCrossCrate::No
     ),
 
     // Modules, prelude, and resolution:
     ungated!(
-        path, Normal,
+        path,
         template!(NameValueStr: "file", "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        no_std, CrateLevel,
+        no_std,
         template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        no_implicit_prelude, Normal,
+        no_implicit_prelude,
         template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        non_exhaustive, Normal,
+        non_exhaustive,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
         EncodeCrossCrate::Yes
     ),
 
     // Runtime
     ungated!(
-        windows_subsystem, CrateLevel,
+        windows_subsystem,
         template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!( // RFC 2070
-        panic_handler, Normal,
+        panic_handler,
         template!(Word, "https://doc.rust-lang.org/reference/panic.html#the-panic_handler-attribute"),
         EncodeCrossCrate::Yes
     ),
 
     // Code generation:
     ungated!(
-        inline, Normal,
+        inline,
         template!(
             Word,
             List: &["always", "never"],
@@ -683,46 +662,46 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No
     ),
     ungated!(
-        cold, Normal,
+        cold,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-cold-attribute"),
         EncodeCrossCrate::No
     ),
     ungated!(
-        no_builtins, CrateLevel,
+        no_builtins,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-no_builtins-attribute"),
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        target_feature, Normal,
+        target_feature,
         template!(List: &[r#"enable = "name""#], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
         EncodeCrossCrate::No,
     ),
     ungated!(
-        track_caller, Normal,
+        track_caller,
         template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute"),
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        instruction_set, Normal,
+        instruction_set,
         template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute"),
         EncodeCrossCrate::No
     ),
     gated!(
-        unsafe force_target_feature, Normal, template!(List: &[r#"enable = "name""#]),
+        unsafe force_target_feature, template!(List: &[r#"enable = "name""#]),
         EncodeCrossCrate::No, effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
-        sanitize, Normal, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]),
+        sanitize, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]),
         EncodeCrossCrate::No, sanitize, experimental!(sanitize),
     ),
     gated!(
-        coverage, Normal, template!(OneOf: &[sym::off, sym::on]),
+        coverage, template!(OneOf: &[sym::off, sym::on]),
         EncodeCrossCrate::No,
         coverage_attribute, experimental!(coverage)
     ),
 
     ungated!(
-        doc, Normal,
+        doc,
         template!(
             List: &["hidden", "inline"],
             NameValueStr: "string",
@@ -733,7 +712,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Debugging
     ungated!(
-        debugger_visualizer, Normal,
+        debugger_visualizer,
         template!(
             List: &[r#"natvis_file = "...", gdb_script_file = "...""#],
             "https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute"
@@ -741,7 +720,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::No
     ),
     ungated!(
-        collapse_debuginfo, Normal,
+        collapse_debuginfo,
         template!(
             List: &["no", "external", "yes"],
             "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
@@ -755,70 +734,70 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, Normal, template!(Word),
+        export_stable, template!(Word),
         EncodeCrossCrate::No, experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, CrateLevel, template!(List: &["path"]),
+        test_runner, template!(List: &["path"]),
         EncodeCrossCrate::Yes, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
-        reexport_test_harness_main, CrateLevel, template!(NameValueStr: "name"),
+        reexport_test_harness_main, template!(NameValueStr: "name"),
         EncodeCrossCrate::No, custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, Normal, template!(Word), EncodeCrossCrate::No,
+        marker, template!(Word), EncodeCrossCrate::No,
         marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, Normal, template!(Word), EncodeCrossCrate::No,
+        thread_local, template!(Word), EncodeCrossCrate::No,
         "`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
-        no_core, CrateLevel, template!(Word),
+        no_core, template!(Word),
         EncodeCrossCrate::No, experimental!(no_core)
     ),
     // RFC 2412
     gated!(
-        optimize, Normal, template!(List: &["none", "size", "speed"]),
+        optimize, template!(List: &["none", "size", "speed"]),
         EncodeCrossCrate::No, optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, Normal, template!(Word),
+        unsafe ffi_pure, template!(Word),
         EncodeCrossCrate::No, experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, Normal, template!(Word),
+        unsafe ffi_const, template!(Word),
         EncodeCrossCrate::No, experimental!(ffi_const)
     ),
     gated!(
-        register_tool, CrateLevel, template!(List: &["tool1, tool2, ..."]),
+        register_tool, template!(List: &["tool1, tool2, ..."]),
         EncodeCrossCrate::No, experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
-        cfi_encoding, Normal, template!(NameValueStr: "encoding"),
+        cfi_encoding, template!(NameValueStr: "encoding"),
         EncodeCrossCrate::Yes, experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, Normal, template!(Word),
+        coroutine, template!(Word),
         EncodeCrossCrate::No, coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
-        patchable_function_entry, Normal, template!(List: &["prefix_nops = m, entry_nops = n"]),
+        patchable_function_entry, template!(List: &["prefix_nops = m, entry_nops = n"]),
         EncodeCrossCrate::Yes, experimental!(patchable_function_entry)
     ),
 
@@ -827,11 +806,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, Normal, template!(Word),
+        const_continue, template!(Word),
         EncodeCrossCrate::No, loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, Normal, template!(Word),
+        loop_match, template!(Word),
         EncodeCrossCrate::No, loop_match, experimental!(loop_match)
     ),
 
@@ -840,7 +819,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, Normal, template!(Word),
+        pin_v2, template!(Word),
         EncodeCrossCrate::Yes, pin_ergonomics, experimental!(pin_v2),
     ),
 
@@ -849,21 +828,21 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     ungated!(
-        feature, CrateLevel,
+        feature,
         template!(List: &["name1, name2, ..."]), EncodeCrossCrate::No,
     ),
     // DuplicatesOk since it has its own validation
     ungated!(
-        stable, Normal,
+        stable,
         template!(List: &[r#"feature = "name", since = "version""#]), EncodeCrossCrate::No,
     ),
     ungated!(
-        unstable, Normal,
+        unstable,
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        unstable_feature_bound, Normal, template!(Word, List: &["feat1, feat2, ..."]),
+        unstable_feature_bound, template!(Word, List: &["feat1, feat2, ..."]),
         EncodeCrossCrate::No,
     ),
     ungated!(
@@ -872,45 +851,45 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         DuplicatesOk, EncodeCrossCrate::Yes
     ),
     ungated!(
-        rustc_const_unstable, Normal, template!(List: &[r#"feature = "name""#]),
+        rustc_const_unstable, template!(List: &[r#"feature = "name""#]),
         EncodeCrossCrate::Yes
     ),
     ungated!(
-        rustc_const_stable, Normal,
+        rustc_const_stable,
         template!(List: &[r#"feature = "name""#]), EncodeCrossCrate::No,
     ),
     ungated!(
-        rustc_default_body_unstable, Normal,
+        rustc_default_body_unstable,
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
         EncodeCrossCrate::No
     ),
     gated!(
-        allow_internal_unstable, Normal, template!(Word, List: &["feat1, feat2, ..."]),
+        allow_internal_unstable, template!(Word, List: &["feat1, feat2, ..."]),
         EncodeCrossCrate::Yes,
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, Normal, template!(Word),
+        allow_internal_unsafe, template!(Word),
         EncodeCrossCrate::No, "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
-        rustc_eii_foreign_item, Normal, template!(Word),
+        rustc_eii_foreign_item, template!(Word),
         EncodeCrossCrate::Yes, eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
-        rustc_allowed_through_unstable_modules, Normal, template!(NameValueStr: "deprecation message"),
+        rustc_allowed_through_unstable_modules, template!(NameValueStr: "deprecation message"),
         EncodeCrossCrate::No,
         "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
-        rustc_deprecated_safe_2024, Normal, template!(List: &[r#"audit_that = "...""#]),
+        rustc_deprecated_safe_2024, template!(List: &[r#"audit_that = "...""#]),
         EncodeCrossCrate::Yes,
         "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
-        rustc_pub_transparent, Normal, template!(Word),
+        rustc_pub_transparent, template!(Word),
         EncodeCrossCrate::Yes,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
@@ -920,16 +899,15 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, Normal, template!(Word), EncodeCrossCrate::Yes, experimental!(fundamental)),
+    gated!(fundamental, template!(Word), EncodeCrossCrate::Yes, experimental!(fundamental)),
     gated!(
-        may_dangle, Normal, template!(Word),
+        may_dangle, template!(Word),
         EncodeCrossCrate::No, dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
 
     rustc_attr!(
         rustc_never_type_options,
-        Normal,
         template!(List: &[
             "",
             r#"fallback = "unit""#,
@@ -947,48 +925,48 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_allocator, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_allocator, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_nounwind, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_nounwind, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_reallocator, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_reallocator, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_deallocator, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_deallocator, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_allocator_zeroed, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed_variant, Normal, template!(NameValueStr: "function"),
+        rustc_allocator_zeroed_variant, template!(NameValueStr: "function"),
         EncodeCrossCrate::Yes,
     ),
     gated!(
-        default_lib_allocator, Normal, template!(Word),
+        default_lib_allocator, template!(Word),
         EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        needs_allocator, Normal, template!(Word),
+        needs_allocator, template!(Word),
         EncodeCrossCrate::No, allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        panic_runtime, CrateLevel, template!(Word),
+        panic_runtime, template!(Word),
         EncodeCrossCrate::No, experimental!(panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, CrateLevel, template!(Word),
+        needs_panic_runtime, template!(Word),
         EncodeCrossCrate::No, experimental!(needs_panic_runtime)
     ),
     gated!(
-        compiler_builtins, CrateLevel, template!(Word),
+        compiler_builtins, template!(Word),
         EncodeCrossCrate::No,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
-        profiler_runtime, CrateLevel, template!(Word),
+        profiler_runtime, template!(Word),
         EncodeCrossCrate::No,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
@@ -999,7 +977,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     gated!(
-        linkage, Normal, template!(NameValueStr: [
+        linkage, template!(NameValueStr: [
             "available_externally",
             "common",
             "extern_weak",
@@ -1014,13 +992,13 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
     rustc_attr!(
-        rustc_std_internal_symbol, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_std_internal_symbol, template!(Word), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_objc_class, Normal, template!(NameValueStr: "ClassName"), EncodeCrossCrate::No,
+        rustc_objc_class, template!(NameValueStr: "ClassName"), EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_objc_selector, Normal, template!(NameValueStr: "methodName"), EncodeCrossCrate::No,
+        rustc_objc_selector, template!(NameValueStr: "methodName"), EncodeCrossCrate::No,
     ),
 
     // ==========================================================================
@@ -1028,26 +1006,26 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_builtin_macro, Normal,
+        rustc_builtin_macro,
         template!(Word, List: &["name", "name, /*opt*/ attributes(name1, name2, ...)"]),
         EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
-        rustc_proc_macro_decls, Normal, template!(Word),
+        rustc_proc_macro_decls, template!(Word),
         EncodeCrossCrate::No,
     ),
     rustc_attr!(
-        rustc_macro_transparency, Normal,
+        rustc_macro_transparency,
         template!(NameValueStr: ["transparent", "semiopaque", "opaque"]),
         EncodeCrossCrate::Yes, "used internally for testing macro hygiene",
     ),
     rustc_attr!(
-        rustc_autodiff, Normal,
+        rustc_autodiff,
         template!(Word, List: &[r#""...""#]),
         EncodeCrossCrate::Yes,
     ),
     rustc_attr!(
-        rustc_offload_kernel, Normal,
+        rustc_offload_kernel,
         template!(Word), EncodeCrossCrate::Yes,
     ),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
@@ -1055,10 +1033,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
     ungated!(
-        cfg_trace, Normal, template!(Word /* irrelevant */), EncodeCrossCrate::Yes
+        cfg_trace, template!(Word /* irrelevant */), EncodeCrossCrate::Yes
     ),
     ungated!(
-        cfg_attr_trace, Normal, template!(Word /* irrelevant */), EncodeCrossCrate::No
+        cfg_attr_trace, template!(Word /* irrelevant */), EncodeCrossCrate::No
     ),
 
     // ==========================================================================
@@ -1066,7 +1044,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_on_unimplemented, Normal,
+        rustc_on_unimplemented,
         template!(
             List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#],
             NameValueStr: "message"
@@ -1075,43 +1053,43 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
-        rustc_confusables, Normal,
+        rustc_confusables,
         template!(List: &[r#""name1", "name2", ..."#]),
         EncodeCrossCrate::Yes,
     ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
-        rustc_conversion_suggestion, Normal, template!(Word),
+        rustc_conversion_suggestion, template!(Word),
         EncodeCrossCrate::Yes,
     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
-        rustc_trivial_field_reads, Normal, template!(Word),
+        rustc_trivial_field_reads, template!(Word),
         EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
-        rustc_lint_query_instability, Normal, template!(Word),
+        rustc_lint_query_instability, template!(Word),
         EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
-        rustc_lint_untracked_query_information, Normal, template!(Word),
+        rustc_lint_untracked_query_information, template!(Word),
         EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
-        rustc_lint_opt_ty, Normal, template!(Word),
+        rustc_lint_opt_ty, template!(Word),
         EncodeCrossCrate::Yes,
     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
-        rustc_lint_opt_deny_field_access, Normal, template!(List: &["message"]),
+        rustc_lint_opt_deny_field_access, template!(List: &["message"]),
         EncodeCrossCrate::Yes,
     ),
 
@@ -1120,30 +1098,30 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_promotable, Normal, template!(Word),
+        rustc_promotable, template!(Word),
         EncodeCrossCrate::No, ),
     rustc_attr!(
-        rustc_legacy_const_generics, Normal, template!(List: &["N"]),
+        rustc_legacy_const_generics, template!(List: &["N"]),
         EncodeCrossCrate::Yes,
     ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
-        rustc_do_not_const_check, Normal, template!(Word),
+        rustc_do_not_const_check, template!(Word),
         EncodeCrossCrate::Yes, "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
-        rustc_const_stable_indirect, Normal,
+        rustc_const_stable_indirect,
         template!(Word),
        
         EncodeCrossCrate::No,
         "this is an internal implementation detail",
     ),
     rustc_attr!(
-        rustc_intrinsic_const_stable_indirect, Normal,
+        rustc_intrinsic_const_stable_indirect,
         template!(Word), EncodeCrossCrate::No,  "this is an internal implementation detail",
     ),
     rustc_attr!(
-        rustc_allow_const_fn_unstable, Normal,
+        rustc_allow_const_fn_unstable,
         template!(Word, List: &["feat1, feat2, ..."]), EncodeCrossCrate::No,
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
@@ -1153,25 +1131,25 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_layout_scalar_valid_range_start, Normal, template!(List: &["value"]),
+        rustc_layout_scalar_valid_range_start, template!(List: &["value"]),
         EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_layout_scalar_valid_range_end, Normal, template!(List: &["value"]),
+        rustc_layout_scalar_valid_range_end, template!(List: &["value"]),
         EncodeCrossCrate::Yes,
         "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_simd_monomorphize_lane_limit, Normal, template!(NameValueStr: "N"),
+        rustc_simd_monomorphize_lane_limit, template!(NameValueStr: "N"),
         EncodeCrossCrate::Yes,
         "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
-        rustc_nonnull_optimization_guaranteed, Normal, template!(Word),
+        rustc_nonnull_optimization_guaranteed, template!(Word),
         EncodeCrossCrate::Yes,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
@@ -1183,74 +1161,70 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, Normal, template!(NameValueStr: "name"), EncodeCrossCrate::No, lang_items,
+        lang, template!(NameValueStr: "name"), EncodeCrossCrate::No, lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
-        rustc_as_ptr, Normal, template!(Word),
+        rustc_as_ptr, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
-        rustc_should_not_be_called_on_const_items, Normal, template!(Word),
+        rustc_should_not_be_called_on_const_items, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
-        rustc_pass_by_value, Normal, template!(Word),
+        rustc_pass_by_value, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
-        rustc_never_returns_null_ptr, Normal, template!(Word),
+        rustc_never_returns_null_ptr, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, AttributeType::Normal, template!(Word), EncodeCrossCrate::Yes,
+        rustc_no_implicit_autorefs, template!(Word), EncodeCrossCrate::Yes,
         "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, AttributeType::CrateLevel, template!(Word), EncodeCrossCrate::No,
+        rustc_coherence_is_core, template!(Word), EncodeCrossCrate::No,
         "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, AttributeType::Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_coinductive, template!(Word), EncodeCrossCrate::No,
         "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, AttributeType::Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_allow_incoherent_impl, template!(Word), EncodeCrossCrate::No,
         "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, AttributeType::CrateLevel, template!(Word), EncodeCrossCrate::No,
+        rustc_preserve_ub_checks, template!(Word), EncodeCrossCrate::No,
         "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
-        AttributeType::Normal,
         template!(Word),
-       
         EncodeCrossCrate::No,
         "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
     rustc_attr!(
         rustc_dyn_incompatible_trait,
-        AttributeType::Normal,
         template!(Word),
-       
         EncodeCrossCrate::No,
         "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
-        rustc_has_incoherent_inherent_impls, AttributeType::Normal, template!(Word),
+        rustc_has_incoherent_inherent_impls, template!(Word),
         EncodeCrossCrate::Yes,
         "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
-        rustc_non_const_trait_method, AttributeType::Normal, template!(Word),
+        rustc_non_const_trait_method, template!(Word),
         EncodeCrossCrate::No,
         "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
@@ -1260,7 +1234,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         name: sym::rustc_diagnostic_item,
         // FIXME: This can be `true` once we always use `tcx.is_diagnostic_item`.
         encode_cross_crate: EncodeCrossCrate::Yes,
-        type_: Normal,
         safety: AttributeSafety::Normal,
         template: template!(NameValueStr: "name"),
         gate: Gated {
@@ -1273,80 +1246,80 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, Normal, template!(Word),
+        prelude_import, template!(Word),
         EncodeCrossCrate::No, "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_paren_sugar, template!(Word), EncodeCrossCrate::No,
         unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_inherit_overflow_checks, template!(Word), EncodeCrossCrate::No,
         "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
-        rustc_reservation_impl, Normal,
+        rustc_reservation_impl,
         template!(NameValueStr: "reservation message"), EncodeCrossCrate::Yes,
         "the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
-        rustc_test_marker, Normal, template!(NameValueStr: "name"),
+        rustc_test_marker, template!(NameValueStr: "name"),
         EncodeCrossCrate::No, "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
-        rustc_unsafe_specialization_marker, Normal, template!(Word),
+        rustc_unsafe_specialization_marker, template!(Word),
         EncodeCrossCrate::No,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_specialization_trait, Normal, template!(Word),
+        rustc_specialization_trait, template!(Word),
         EncodeCrossCrate::No,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, Normal, template!(Word), EncodeCrossCrate::No,
+        rustc_main, template!(Word), EncodeCrossCrate::No,
         "the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
-        rustc_skip_during_method_dispatch, Normal, template!(List: &["array, boxed_slice"]),
+        rustc_skip_during_method_dispatch, template!(List: &["array, boxed_slice"]),
         EncodeCrossCrate::No,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
     rustc_attr!(
-        rustc_must_implement_one_of, Normal, template!(List: &["function1, function2, ..."]),
+        rustc_must_implement_one_of, template!(List: &["function1, function2, ..."]),
         EncodeCrossCrate::No,
         "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
-        rustc_doc_primitive, Normal, template!(NameValueStr: "primitive name"),
+        rustc_doc_primitive, template!(NameValueStr: "primitive name"),
         EncodeCrossCrate::Yes, "the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, Normal, template!(Word), EncodeCrossCrate::Yes, intrinsics,
+        rustc_intrinsic, template!(Word), EncodeCrossCrate::Yes, intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, Normal, template!(Word), EncodeCrossCrate::Yes,
+        rustc_no_mir_inline, template!(Word), EncodeCrossCrate::Yes,
         "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, Normal, template!(Word, NameValueStr: "reason"), EncodeCrossCrate::Yes,
+        rustc_force_inline, template!(Word, NameValueStr: "reason"), EncodeCrossCrate::Yes,
         "`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, Normal, template!(List: &["count"]), EncodeCrossCrate::Yes,
+        rustc_scalable_vector, template!(List: &["count"]), EncodeCrossCrate::Yes,
         "`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
     rustc_attr!(
-        rustc_must_match_exhaustively, Normal, template!(Word), EncodeCrossCrate::Yes,
+        rustc_must_match_exhaustively, template!(Word), EncodeCrossCrate::Yes,
         "enums with `#[rustc_must_match_exhaustively]` must be matched on with a match block that mentions all variants explicitly"
     ),
 
@@ -1354,133 +1327,133 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, Normal, template!(Word), EncodeCrossCrate::Yes),
+    rustc_attr!(TEST, rustc_effective_visibility, template!(Word), EncodeCrossCrate::Yes),
     rustc_attr!(
-        TEST, rustc_dump_inferred_outlives, Normal, template!(Word),
+        TEST, rustc_dump_inferred_outlives, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_capture_analysis, Normal, template!(Word),
+        TEST, rustc_capture_analysis, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_insignificant_dtor, Normal, template!(Word),
+        TEST, rustc_insignificant_dtor, template!(Word),
         EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_no_implicit_bounds, CrateLevel, template!(Word),
+        TEST, rustc_no_implicit_bounds, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_strict_coherence, Normal, template!(Word),
+        TEST, rustc_strict_coherence, template!(Word),
         EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_dump_variances, Normal, template!(Word),
+        TEST, rustc_dump_variances, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_variances_of_opaques, Normal, template!(Word),
+        TEST, rustc_dump_variances_of_opaques, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_hidden_type_of_opaques, Normal, template!(Word),
+        TEST, rustc_dump_hidden_type_of_opaques, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_layout, Normal, template!(List: &["field1, field2, ..."]),
+        TEST, rustc_dump_layout, template!(List: &["field1, field2, ..."]),
         EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_abi, Normal, template!(List: &["field1, field2, ..."]),
+        TEST, rustc_abi, template!(List: &["field1, field2, ..."]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_regions, Normal, template!(Word),
+        TEST, rustc_regions, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_delayed_bug_from_inside_query, Normal,
+        TEST, rustc_delayed_bug_from_inside_query,
         template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_user_args, Normal, template!(Word),
+        TEST, rustc_dump_user_args, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_evaluate_where_clauses, Normal, template!(Word),
+        TEST, rustc_evaluate_where_clauses, template!(Word),
         EncodeCrossCrate::Yes
     ),
     rustc_attr!(
-        TEST, rustc_if_this_changed, Normal, template!(Word, List: &["DepNode"]),
+        TEST, rustc_if_this_changed, template!(Word, List: &["DepNode"]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_then_this_would_need, Normal, template!(List: &["DepNode"]),
+        TEST, rustc_then_this_would_need, template!(List: &["DepNode"]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_clean, Normal,
+        TEST, rustc_clean,
         template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_partition_reused, Normal,
+        TEST, rustc_partition_reused,
         template!(List: &[r#"cfg = "...", module = "...""#]), EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_partition_codegened, Normal,
+        TEST, rustc_partition_codegened,
         template!(List: &[r#"cfg = "...", module = "...""#]), EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_expected_cgu_reuse, Normal,
+        TEST, rustc_expected_cgu_reuse,
         template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_symbol_name, Normal, template!(Word),
+        TEST, rustc_dump_symbol_name, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_def_path, Normal, template!(Word),
+        TEST, rustc_dump_def_path, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_mir, Normal, template!(List: &["arg1, arg2, ..."]),
+        TEST, rustc_mir, template!(List: &["arg1, arg2, ..."]),
         EncodeCrossCrate::Yes
     ),
     gated!(
-        custom_mir, Normal, template!(List: &[r#"dialect = "...", phase = "...""#]),
+        custom_mir, template!(List: &[r#"dialect = "...", phase = "...""#]),
         EncodeCrossCrate::No,
         "the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
-        TEST, rustc_dump_item_bounds, Normal, template!(Word),
+        TEST, rustc_dump_item_bounds, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_predicates, Normal, template!(Word),
+        TEST, rustc_dump_predicates, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_def_parents, Normal, template!(Word),
+        TEST, rustc_dump_def_parents, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_object_lifetime_defaults, Normal, template!(Word),
+        TEST, rustc_dump_object_lifetime_defaults, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dump_vtable, Normal, template!(Word),
+        TEST, rustc_dump_vtable, template!(Word),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_dummy, Normal, template!(Word /* doesn't matter*/),
+        TEST, rustc_dummy, template!(Word /* doesn't matter*/),
         EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, pattern_complexity_limit, CrateLevel, template!(NameValueStr: "N"),
+        TEST, pattern_complexity_limit, template!(NameValueStr: "N"),
         EncodeCrossCrate::No,
     ),
 ];

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -205,38 +205,30 @@ macro_rules! template {
 }
 
 macro_rules! ungated {
-    (unsafe($edition:ident) $attr:ident, $tpl:expr $(,)?) => {
+    (unsafe($edition:ident) $attr:ident $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Unsafe { unsafe_since: Some(Edition::$edition) },
-            template: $tpl,
             gate: Ungated,
         }
     };
-    (unsafe $attr:ident, $tpl:expr $(,)?) => {
+    (unsafe $attr:ident $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            template: $tpl,
             gate: Ungated,
         }
     };
-    ($attr:ident, $tpl:expr $(,)?) => {
-        BuiltinAttribute {
-            name: sym::$attr,
-            safety: AttributeSafety::Normal,
-            template: $tpl,
-            gate: Ungated,
-        }
+    ($attr:ident $(,)?) => {
+        BuiltinAttribute { name: sym::$attr, safety: AttributeSafety::Normal, gate: Ungated }
     };
 }
 
 macro_rules! gated {
-    (unsafe $attr:ident, $tpl:expr, $gate:ident, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            template: $tpl,
             gate: Gated {
                 feature: sym::$gate,
                 message: $message,
@@ -245,11 +237,10 @@ macro_rules! gated {
             },
         }
     };
-    (unsafe $attr:ident, $tpl:expr, $message:expr $(,)?) => {
+    (unsafe $attr:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Unsafe { unsafe_since: None },
-            template: $tpl,
             gate: Gated {
                 feature: sym::$attr,
                 message: $message,
@@ -258,11 +249,10 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $tpl:expr, $gate:ident, $message:expr $(,)?) => {
+    ($attr:ident, $gate:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             gate: Gated {
                 feature: sym::$gate,
                 message: $message,
@@ -271,11 +261,10 @@ macro_rules! gated {
             },
         }
     };
-    ($attr:ident, $tpl:expr, $message:expr $(,)?) => {
+    ($attr:ident, $message:expr $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             gate: Gated {
                 feature: sym::$attr,
                 message: $message,
@@ -287,10 +276,9 @@ macro_rules! gated {
 }
 
 macro_rules! rustc_attr {
-    (TEST, $attr:ident, $tpl:expr $(,)?) => {
+    (TEST, $attr:ident $(,)?) => {
         rustc_attr!(
             $attr,
-            $tpl,
             concat!(
                 "the `#[",
                 stringify!($attr),
@@ -298,11 +286,10 @@ macro_rules! rustc_attr {
             ),
         )
     };
-    ($attr:ident, $tpl:expr, $($notes:expr),* $(,)?) => {
+    ($attr:ident $(, $notes:expr)* $(,)?) => {
         BuiltinAttribute {
             name: sym::$attr,
             safety: AttributeSafety::Normal,
-            template: $tpl,
             gate: Gated {
                 feature: sym::rustc_attrs,
                 message: "use of an internal attribute",
@@ -327,7 +314,6 @@ macro_rules! experimental {
 pub struct BuiltinAttribute {
     pub name: Symbol,
     pub safety: AttributeSafety,
-    pub template: AttributeTemplate,
     pub gate: AttributeGate,
 }
 
@@ -339,329 +325,152 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     // Conditional compilation:
-    ungated!(
-        cfg,
-        template!(
-            List: &["predicate"],
-            "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute"
-        ),
-    ),
-    ungated!(
-        cfg_attr,
-        template!(
-            List: &["predicate, attr1, attr2, ..."],
-            "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
-        ),
-    ),
+    ungated!(cfg),
+    ungated!(cfg_attr),
 
     // Testing:
-    ungated!(
-        ignore,
-        template!(
-            Word,
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
-        ),
-    ),
-    ungated!(
-        should_panic,
-        template!(
-            Word,
-            List: &[r#"expected = "reason""#],
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
-        ),
-    ),
+    ungated!(ignore),
+    ungated!(should_panic),
 
     // Macros:
-    ungated!(
-        automatically_derived,
-        template!(
-            Word,
-            "https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute"
-        ),
-    ),
-    ungated!(
-        macro_use,
-        template!(
-            Word,
-            List: &["name1, name2, ..."],
-            "https://doc.rust-lang.org/reference/macros-by-example.html#the-macro_use-attribute"
-        ),
-    ),
-    ungated!(macro_escape, template!(Word),), // Deprecated synonym for `macro_use`.
-    ungated!(
-        macro_export,
-        template!(
-            Word,
-            List: &["local_inner_macros"],
-            "https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope"
-        ),
-    ),
-    ungated!(
-        proc_macro,
-        template!(
-            Word,
-            "https://doc.rust-lang.org/reference/procedural-macros.html#function-like-procedural-macros"),
-    ),
-    ungated!(
-        proc_macro_derive,
-        template!(
-            List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
-            "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
-        ),
-    ),
-    ungated!(
-        proc_macro_attribute,
-        template!(Word, "https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros"),
-    ),
+    ungated!(automatically_derived),
+    ungated!(macro_use),
+    ungated!(macro_escape), // Deprecated synonym for `macro_use`.
+    ungated!(macro_export),
+    ungated!(proc_macro),
+    ungated!(proc_macro_derive),
+    ungated!(proc_macro_attribute),
 
     // Lints:
-    ungated!(
-        warn,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
-    ),
-    ungated!(
-        allow,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
-    ),
-    ungated!(
-        expect,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
-    ),
-    ungated!(
-        forbid,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
-    ),
-    ungated!(
-        deny,
-        template!(
-            List: &["lint1", "lint1, lint2, ...", r#"lint1, lint2, lint3, reason = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes"
-        ),
-    ),
-    ungated!(
-        must_use,
-        template!(
-            Word,
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
-        ),
-    ),
+    ungated!(warn),
+    ungated!(allow),
+    ungated!(expect),
+    ungated!(forbid),
+    ungated!(deny),
+    ungated!(must_use),
     gated!(
-        must_not_suspend, template!(Word, NameValueStr: "reason"),
+        must_not_suspend,
         experimental!(must_not_suspend)
     ),
-    ungated!(
-        deprecated,
-        template!(
-            Word,
-            List: &[r#"/*opt*/ since = "version", /*opt*/ note = "reason""#],
-            NameValueStr: "reason",
-            "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute"
-        ),
-    ),
+    ungated!(deprecated),
 
     // Crate properties:
-    ungated!(
-        crate_name,
-        template!(
-            NameValueStr: "name",
-            "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-crate_name-attribute"
-        ),
-    ),
-    ungated!(
-        crate_type,
-        template!(
-            NameValueStr: ["bin", "lib", "dylib", "cdylib", "rlib", "staticlib", "sdylib", "proc-macro"],
-            "https://doc.rust-lang.org/reference/linkage.html"
-        ),
-    ),
+    ungated!(crate_name),
+    ungated!(crate_type),
 
     // ABI, linking, symbols, and FFI
-    ungated!(
-        link,
-        template!(List: &[
-            r#"name = "...""#,
-            r#"name = "...", kind = "dylib|static|...""#,
-            r#"name = "...", wasm_import_module = "...""#,
-            r#"name = "...", import_name_type = "decorated|noprefix|undecorated""#,
-            r#"name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated""#,
-        ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute"),
-    ),
-    ungated!(
-        link_name,
-        template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"),
-    ),
-    ungated!(
-        no_link,
-        template!(Word, "https://doc.rust-lang.org/reference/items/extern-crates.html#the-no_link-attribute"),
-    ),
-    ungated!(
-        repr,
-        template!(
-            List: &["C", "Rust", "transparent", "align(...)", "packed(...)", "<integer type>"],
-            "https://doc.rust-lang.org/reference/type-layout.html#representations"
-        ),
-    ),
+    ungated!(link),
+    ungated!(link_name),
+    ungated!(no_link),
+    ungated!(repr),
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, template!(List: &["alignment"]), fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, template!(List: &["alignment"]), static_align, experimental!(rustc_align_static)),
+    gated!(rustc_align, fn_align, experimental!(rustc_align)),
+    gated!(rustc_align_static, static_align, experimental!(rustc_align_static)),
     ungated!(
         unsafe(Edition2024) export_name,
-        template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-export_name-attribute"),
     ),
     ungated!(
         unsafe(Edition2024) link_section,
-        template!(NameValueStr: "name", "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"),
     ),
     ungated!(
         unsafe(Edition2024) no_mangle,
-        template!(Word, "https://doc.rust-lang.org/reference/abi.html#the-no_mangle-attribute"),
     ),
     ungated!(
         used,
-        template!(Word, List: &["compiler", "linker"], "https://doc.rust-lang.org/reference/abi.html#the-used-attribute"),
     ),
     ungated!(
         link_ordinal,
-        template!(List: &["ordinal"], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"),
     ),
     ungated!(
         unsafe naked,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-naked-attribute"),
     ),
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
     rustc_attr!(
-        rustc_pass_indirectly_in_non_rustic_abis, template!(Word),
+        rustc_pass_indirectly_in_non_rustic_abis,
         "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"
     ),
 
     // Limits:
     ungated!(
         recursion_limit,
-        template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute"),
     ),
     ungated!(
         type_length_limit,
-        template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-type_length_limit-attribute"),
     ),
     gated!(
-        move_size_limit, template!(NameValueStr: "N"),
+        move_size_limit,
         large_assignments, experimental!(move_size_limit)
     ),
 
     // Entry point:
     ungated!(
         no_main,
-        template!(Word, "https://doc.rust-lang.org/reference/crates-and-source-files.html#the-no_main-attribute"),
     ),
 
     // Modules, prelude, and resolution:
     ungated!(
         path,
-        template!(NameValueStr: "file", "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"),
     ),
     ungated!(
         no_std,
-        template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_std-attribute"),
     ),
     ungated!(
         no_implicit_prelude,
-        template!(Word, "https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute"),
     ),
     ungated!(
         non_exhaustive,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute"),
     ),
 
     // Runtime
     ungated!(
         windows_subsystem,
-        template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute"),
     ),
     ungated!( // RFC 2070
         panic_handler,
-        template!(Word, "https://doc.rust-lang.org/reference/panic.html#the-panic_handler-attribute"),
     ),
 
     // Code generation:
     ungated!(
         inline,
-        template!(
-            Word,
-            List: &["always", "never"],
-            "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
-        ),
     ),
     ungated!(
         cold,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-cold-attribute"),
     ),
     ungated!(
         no_builtins,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-no_builtins-attribute"),
     ),
     ungated!(
         target_feature,
-        template!(List: &[r#"enable = "name""#], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-target_feature-attribute"),
     ),
     ungated!(
         track_caller,
-        template!(Word, "https://doc.rust-lang.org/reference/attributes/codegen.html#the-track_caller-attribute"),
     ),
     ungated!(
         instruction_set,
-        template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute"),
     ),
     gated!(
-        unsafe force_target_feature, template!(List: &[r#"enable = "name""#]),
+        unsafe force_target_feature,
         effective_target_features, experimental!(force_target_feature)
     ),
     gated!(
-        sanitize, template!(List: &[r#"address = "on|off""#, r#"kernel_address = "on|off""#, r#"cfi = "on|off""#, r#"hwaddress = "on|off""#, r#"kernel_hwaddress = "on|off""#, r#"kcfi = "on|off""#, r#"memory = "on|off""#, r#"memtag = "on|off""#, r#"shadow_call_stack = "on|off""#, r#"thread = "on|off""#]),
+        sanitize,
         sanitize, experimental!(sanitize),
     ),
     gated!(
-        coverage, template!(OneOf: &[sym::off, sym::on]),
+        coverage,
         coverage_attribute, experimental!(coverage)
     ),
 
     ungated!(
         doc,
-        template!(
-            List: &["hidden", "inline"],
-            NameValueStr: "string",
-            "https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html"
-        ),
     ),
 
     // Debugging
     ungated!(
         debugger_visualizer,
-        template!(
-            List: &[r#"natvis_file = "...", gdb_script_file = "...""#],
-            "https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute"
-        ),
     ),
     ungated!(
         collapse_debuginfo,
-        template!(
-            List: &["no", "external", "yes"],
-            "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
-        ),
     ),
 
     // ==========================================================================
@@ -670,70 +479,70 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Linking:
     gated!(
-        export_stable, template!(Word),
+        export_stable,
         experimental!(export_stable)
     ),
 
     // Testing:
     gated!(
-        test_runner, template!(List: &["path"]),
+        test_runner,
         custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     gated!(
-        reexport_test_harness_main, template!(NameValueStr: "name"),
+        reexport_test_harness_main,
         custom_test_frameworks,
         "custom test frameworks are an unstable feature",
     ),
 
     // RFC #1268
     gated!(
-        marker, template!(Word),
+        marker,
         marker_trait_attr, experimental!(marker)
     ),
     gated!(
-        thread_local, template!(Word),
+        thread_local,
         "`#[thread_local]` is an experimental feature, and does not currently handle destructors",
     ),
     gated!(
-        no_core, template!(Word),
+        no_core,
         experimental!(no_core)
     ),
     // RFC 2412
     gated!(
-        optimize, template!(List: &["none", "size", "speed"]),
+        optimize,
         optimize_attribute, experimental!(optimize)
     ),
 
     gated!(
-        unsafe ffi_pure, template!(Word),
+        unsafe ffi_pure,
         experimental!(ffi_pure)
     ),
     gated!(
-        unsafe ffi_const, template!(Word),
+        unsafe ffi_const,
         experimental!(ffi_const)
     ),
     gated!(
-        register_tool, template!(List: &["tool1, tool2, ..."]),
+        register_tool,
         experimental!(register_tool),
     ),
     // `#[cfi_encoding = ""]`
     gated!(
-        cfi_encoding, template!(NameValueStr: "encoding"),
+        cfi_encoding,
         experimental!(cfi_encoding)
     ),
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
     gated!(
-        coroutine, template!(Word),
+        coroutine,
         coroutines, experimental!(coroutine)
     ),
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
     gated!(
-        patchable_function_entry, template!(List: &["prefix_nops = m, entry_nops = n"]),
+        patchable_function_entry,
         experimental!(patchable_function_entry)
     ),
 
@@ -742,11 +551,11 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(
-        const_continue, template!(Word),
+        const_continue,
         loop_match, experimental!(const_continue)
     ),
     gated!(
-        loop_match, template!(Word),
+        loop_match,
         loop_match, experimental!(loop_match)
     ),
 
@@ -755,7 +564,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/130494
     gated!(
-        pin_v2, template!(Word),
+        pin_v2,
         pin_ergonomics, experimental!(pin_v2),
     ),
 
@@ -765,60 +574,43 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     ungated!(
         feature,
-        template!(List: &["name1, name2, ..."]),
     ),
     // DuplicatesOk since it has its own validation
     ungated!(
         stable,
-        template!(List: &[r#"feature = "name", since = "version""#]),
     ),
     ungated!(
         unstable,
-        template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
     ),
-    ungated!(
-        unstable_feature_bound, template!(Word, List: &["feat1, feat2, ..."]),
-    ),
-    ungated!(
-        unstable_removed, CrateLevel,
-        template!(List: &[r#"feature = "name", reason = "...", link = "...", since = "version""#]),
-        DuplicatesOk, EncodeCrossCrate::Yes
-    ),
-    ungated!(
-        rustc_const_unstable, template!(List: &[r#"feature = "name""#]),
-    ),
-    ungated!(
-        rustc_const_stable,
-        template!(List: &[r#"feature = "name""#]),
-    ),
-    ungated!(
-        rustc_default_body_unstable,
-        template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
-    ),
+    ungated!(unstable_feature_bound),
+    ungated!(unstable_removed),
+    ungated!(rustc_const_unstable),
+    ungated!(rustc_const_stable),
+    ungated!(rustc_default_body_unstable),
     gated!(
-        allow_internal_unstable, template!(Word, List: &["feat1, feat2, ..."]),
+        allow_internal_unstable,
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
-        allow_internal_unsafe, template!(Word),
+        allow_internal_unsafe,
         "allow_internal_unsafe side-steps the unsafe_code lint",
     ),
     gated!(
-        rustc_eii_foreign_item, template!(Word),
+        rustc_eii_foreign_item,
         eii_internals,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
     rustc_attr!(
-        rustc_allowed_through_unstable_modules, template!(NameValueStr: "deprecation message"),
+        rustc_allowed_through_unstable_modules,
         "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
         through unstable paths"
     ),
     rustc_attr!(
-        rustc_deprecated_safe_2024, template!(List: &[r#"audit_that = "...""#]),
+        rustc_deprecated_safe_2024,
         "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
     ),
     rustc_attr!(
-        rustc_pub_transparent, template!(Word),
+        rustc_pub_transparent,
         "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
     ),
 
@@ -827,22 +619,15 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, template!(Word), experimental!(fundamental)),
+    gated!(fundamental, experimental!(fundamental)),
     gated!(
-        may_dangle, template!(Word),
+        may_dangle,
         dropck_eyepatch,
         "`may_dangle` has unstable semantics and may be removed in the future",
     ),
 
     rustc_attr!(
         rustc_never_type_options,
-        template!(List: &[
-            "",
-            r#"fallback = "unit""#,
-            r#"fallback = "niko""#,
-            r#"fallback = "never""#,
-            r#"fallback = "no""#,
-        ]),
         "`rustc_never_type_options` is used to experiment with never type fallback and work on \
          never type stabilization"
     ),
@@ -852,46 +637,46 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_allocator, template!(Word),
+        rustc_allocator,
     ),
     rustc_attr!(
-        rustc_nounwind, template!(Word),
+        rustc_nounwind,
     ),
     rustc_attr!(
-        rustc_reallocator, template!(Word),
+        rustc_reallocator,
     ),
     rustc_attr!(
-        rustc_deallocator, template!(Word),
+        rustc_deallocator,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed, template!(Word),
+        rustc_allocator_zeroed,
     ),
     rustc_attr!(
-        rustc_allocator_zeroed_variant, template!(NameValueStr: "function"),
+        rustc_allocator_zeroed_variant,
     ),
     gated!(
-        default_lib_allocator, template!(Word),
+        default_lib_allocator,
         allocator_internals, experimental!(default_lib_allocator),
     ),
     gated!(
-        needs_allocator, template!(Word),
+        needs_allocator,
         allocator_internals, experimental!(needs_allocator),
     ),
     gated!(
-        panic_runtime, template!(Word),
+        panic_runtime,
         experimental!(panic_runtime)
     ),
     gated!(
-        needs_panic_runtime, template!(Word),
+        needs_panic_runtime,
         experimental!(needs_panic_runtime)
     ),
     gated!(
-        compiler_builtins, template!(Word),
+        compiler_builtins,
         "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
         which contains compiler-rt intrinsics and will never be stable",
     ),
     gated!(
-        profiler_runtime, template!(Word),
+        profiler_runtime,
         "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
         which contains the profiler runtime and will never be stable",
     ),
@@ -901,61 +686,31 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     gated!(
-        linkage, template!(NameValueStr: [
-            "available_externally",
-            "common",
-            "extern_weak",
-            "external",
-            "internal",
-            "linkonce",
-            "linkonce_odr",
-            "weak",
-            "weak_odr",
-        ], "https://doc.rust-lang.org/reference/linkage.html"),
+        linkage,
         "the `linkage` attribute is experimental and not portable across platforms",
     ),
-    rustc_attr!(
-        rustc_std_internal_symbol, template!(Word),
-    ),
-    rustc_attr!(
-        rustc_objc_class, template!(NameValueStr: "ClassName"),
-    ),
-    rustc_attr!(
-        rustc_objc_selector, template!(NameValueStr: "methodName"),
-    ),
+    rustc_attr!(rustc_std_internal_symbol),
+    rustc_attr!(rustc_objc_class),
+    rustc_attr!(rustc_objc_selector),
 
     // ==========================================================================
     // Internal attributes, Macro related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_builtin_macro,
-        template!(Word, List: &["name", "name, /*opt*/ attributes(name1, name2, ...)"]),
-    ),
-    rustc_attr!(
-        rustc_proc_macro_decls, template!(Word),
-    ),
+    rustc_attr!(rustc_builtin_macro),
+    rustc_attr!(rustc_proc_macro_decls),
     rustc_attr!(
         rustc_macro_transparency,
-        template!(NameValueStr: ["transparent", "semiopaque", "opaque"]),
         "used internally for testing macro hygiene",
     ),
-    rustc_attr!(
-        rustc_autodiff,
-        template!(Word, List: &[r#""...""#]),
-    ),
-    rustc_attr!(
-        rustc_offload_kernel,
-        template!(Word),
-    ),
+    rustc_attr!(rustc_autodiff),
+    rustc_attr!(rustc_offload_kernel),
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
-    ungated!(
-        cfg_trace, template!(Word /* irrelevant */),    ),
-    ungated!(
-        cfg_attr_trace, template!(Word /* irrelevant */),    ),
+    ungated!(cfg_trace),
+    ungated!(cfg_attr_trace),
 
     // ==========================================================================
     // Internal attributes, Diagnostics related:
@@ -963,44 +718,39 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     rustc_attr!(
         rustc_on_unimplemented,
-        template!(
-            List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#],
-            NameValueStr: "message"
-        ),
         "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
     ),
     rustc_attr!(
         rustc_confusables,
-        template!(List: &[r#""name1", "name2", ..."#]),
     ),
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
     rustc_attr!(
-        rustc_conversion_suggestion, template!(Word),
+        rustc_conversion_suggestion,
     ),
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
     rustc_attr!(
-        rustc_trivial_field_reads, template!(Word),
+        rustc_trivial_field_reads,
     ),
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
-        rustc_lint_query_instability, template!(Word),
+        rustc_lint_query_instability,
     ),
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
     rustc_attr!(
-        rustc_lint_untracked_query_information, template!(Word),
+        rustc_lint_untracked_query_information,
     ),
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
     rustc_attr!(
-        rustc_lint_opt_ty, template!(Word),
+        rustc_lint_opt_ty,
     ),
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
     rustc_attr!(
-        rustc_lint_opt_deny_field_access, template!(List: &["message"]),
+        rustc_lint_opt_deny_field_access,
     ),
 
     // ==========================================================================
@@ -1008,28 +758,26 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_promotable, template!(Word),
+        rustc_promotable,
     ),
     rustc_attr!(
-        rustc_legacy_const_generics, template!(List: &["N"]),
+        rustc_legacy_const_generics,
     ),
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
     rustc_attr!(
-        rustc_do_not_const_check, template!(Word),
+        rustc_do_not_const_check,
         "`#[rustc_do_not_const_check]` skips const-check for this function's body",
     ),
     rustc_attr!(
         rustc_const_stable_indirect,
-        template!(Word),
         "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_intrinsic_const_stable_indirect,
-        template!(Word),  "this is an internal implementation detail",
+         "this is an internal implementation detail",
     ),
     rustc_attr!(
         rustc_allow_const_fn_unstable,
-        template!(Word, List: &["feat1, feat2, ..."]),
         "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
     ),
 
@@ -1038,22 +786,22 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // ==========================================================================
 
     rustc_attr!(
-        rustc_layout_scalar_valid_range_start, template!(List: &["value"]),
+        rustc_layout_scalar_valid_range_start,
         "the `#[rustc_layout_scalar_valid_range_start]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_layout_scalar_valid_range_end, template!(List: &["value"]),
+        rustc_layout_scalar_valid_range_end,
         "the `#[rustc_layout_scalar_valid_range_end]` attribute is just used to enable \
         niche optimizations in the standard library",
     ),
     rustc_attr!(
-        rustc_simd_monomorphize_lane_limit, template!(NameValueStr: "N"),
+        rustc_simd_monomorphize_lane_limit,
         "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
         for better error messages",
     ),
     rustc_attr!(
-        rustc_nonnull_optimization_guaranteed, template!(Word),
+        rustc_nonnull_optimization_guaranteed,
         "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
         guaranteed niche optimizations in the standard library",
         "the compiler does not even check whether the type indeed is being non-null-optimized; \
@@ -1064,63 +812,61 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Misc:
     // ==========================================================================
     gated!(
-        lang, template!(NameValueStr: "name"), lang_items,
+        lang, lang_items,
         "lang items are subject to change",
     ),
     rustc_attr!(
-        rustc_as_ptr, template!(Word),
+        rustc_as_ptr,
         "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
     ),
     rustc_attr!(
-        rustc_should_not_be_called_on_const_items, template!(Word),
+        rustc_should_not_be_called_on_const_items,
         "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
     ),
     rustc_attr!(
-        rustc_pass_by_value, template!(Word),
+        rustc_pass_by_value,
         "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
     ),
     rustc_attr!(
-        rustc_never_returns_null_ptr, template!(Word),
+        rustc_never_returns_null_ptr,
         "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
     ),
     rustc_attr!(
-        rustc_no_implicit_autorefs, template!(Word),
+        rustc_no_implicit_autorefs,
         "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
     ),
     rustc_attr!(
-        rustc_coherence_is_core, template!(Word),
+        rustc_coherence_is_core,
         "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
     ),
     rustc_attr!(
-        rustc_coinductive, template!(Word),
+        rustc_coinductive,
         "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
     ),
     rustc_attr!(
-        rustc_allow_incoherent_impl, template!(Word),
+        rustc_allow_incoherent_impl,
         "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
     ),
     rustc_attr!(
-        rustc_preserve_ub_checks, template!(Word),
+        rustc_preserve_ub_checks,
         "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
     ),
     rustc_attr!(
         rustc_deny_explicit_impl,
-        template!(Word),
         "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
     ),
     rustc_attr!(
         rustc_dyn_incompatible_trait,
-        template!(Word),
         "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
         even if it otherwise satisfies the requirements to be dyn-compatible."
     ),
     rustc_attr!(
-        rustc_has_incoherent_inherent_impls, template!(Word),
+        rustc_has_incoherent_inherent_impls,
         "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
          the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
     ),
     rustc_attr!(
-        rustc_non_const_trait_method, template!(Word),
+        rustc_non_const_trait_method,
         "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
         as non-const to allow large traits an easier transition to const"
     ),
@@ -1128,7 +874,6 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     BuiltinAttribute {
         name: sym::rustc_diagnostic_item,
         safety: AttributeSafety::Normal,
-        template: template!(NameValueStr: "name"),
         gate: Gated {
             feature: sym::rustc_attrs,
             message: "use of an internal attribute",
@@ -1139,76 +884,75 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     },
     gated!(
         // Used in resolve:
-        prelude_import, template!(Word),
+        prelude_import,
         "`#[prelude_import]` is for use by rustc only",
     ),
     gated!(
-        rustc_paren_sugar, template!(Word),
+        rustc_paren_sugar,
         unboxed_closures, "unboxed_closures are still evolving",
     ),
     rustc_attr!(
-        rustc_inherit_overflow_checks, template!(Word),
+        rustc_inherit_overflow_checks,
         "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
         overflow checking behavior of several functions in the standard library that are inlined \
         across crates",
     ),
     rustc_attr!(
         rustc_reservation_impl,
-        template!(NameValueStr: "reservation message"),
         "the `#[rustc_reservation_impl]` attribute is internally used \
         for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
     ),
     rustc_attr!(
-        rustc_test_marker, template!(NameValueStr: "name"),
+        rustc_test_marker,
         "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
     rustc_attr!(
-        rustc_unsafe_specialization_marker, template!(Word),
+        rustc_unsafe_specialization_marker,
         "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_specialization_trait, template!(Word),
+        rustc_specialization_trait,
         "the `#[rustc_specialization_trait]` attribute is used to check specializations"
     ),
     rustc_attr!(
-        rustc_main, template!(Word),
+        rustc_main,
         "the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
-        rustc_skip_during_method_dispatch, template!(List: &["array, boxed_slice"]),
+        rustc_skip_during_method_dispatch,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
         from method dispatch when the receiver is of the following type, for compatibility in \
         editions < 2021 (array) or editions < 2024 (boxed_slice)"
     ),
     rustc_attr!(
-        rustc_must_implement_one_of, template!(List: &["function1, function2, ..."]),
+        rustc_must_implement_one_of,
         "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
         definition of a trait. Its syntax and semantics are highly experimental and will be \
         subject to change before stabilization",
     ),
     rustc_attr!(
-        rustc_doc_primitive, template!(NameValueStr: "primitive name"),
+        rustc_doc_primitive,
         "the `#[rustc_doc_primitive]` attribute is used by the standard library \
         to provide a way to generate documentation for primitive types",
     ),
     gated!(
-        rustc_intrinsic, template!(Word), intrinsics,
+        rustc_intrinsic, intrinsics,
         "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
     ),
     rustc_attr!(
-        rustc_no_mir_inline, template!(Word),
+        rustc_no_mir_inline,
         "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
     ),
     rustc_attr!(
-        rustc_force_inline, template!(Word, NameValueStr: "reason"),
+        rustc_force_inline,
         "`#[rustc_force_inline]` forces a free function to be inlined"
     ),
     rustc_attr!(
-        rustc_scalable_vector, template!(List: &["count"]),
+        rustc_scalable_vector,
         "`#[rustc_scalable_vector]` defines a scalable vector type"
     ),
     rustc_attr!(
-        rustc_must_match_exhaustively, template!(Word),
+        rustc_must_match_exhaustively,
         "enums with `#[rustc_must_match_exhaustively]` must be matched on with a match block that mentions all variants explicitly"
     ),
 
@@ -1216,103 +960,99 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility, template!(Word)),
+    rustc_attr!(TEST, rustc_effective_visibility),
     rustc_attr!(
-        TEST, rustc_dump_inferred_outlives, template!(Word),
+        TEST, rustc_dump_inferred_outlives,
     ),
     rustc_attr!(
-        TEST, rustc_capture_analysis, template!(Word),
+        TEST, rustc_capture_analysis,
     ),
     rustc_attr!(
-        TEST, rustc_insignificant_dtor, template!(Word),
+        TEST, rustc_insignificant_dtor,
     ),
     rustc_attr!(
-        TEST, rustc_no_implicit_bounds, template!(Word),
+        TEST, rustc_no_implicit_bounds,
     ),
     rustc_attr!(
-        TEST, rustc_strict_coherence, template!(Word),
+        TEST, rustc_strict_coherence,
     ),
     rustc_attr!(
-        TEST, rustc_dump_variances, template!(Word),
+        TEST, rustc_dump_variances,
     ),
     rustc_attr!(
-        TEST, rustc_dump_variances_of_opaques, template!(Word),
+        TEST, rustc_dump_variances_of_opaques,
     ),
     rustc_attr!(
-        TEST, rustc_dump_hidden_type_of_opaques, template!(Word),
+        TEST, rustc_dump_hidden_type_of_opaques,
     ),
     rustc_attr!(
-        TEST, rustc_dump_layout, template!(List: &["field1, field2, ..."]),
+        TEST, rustc_dump_layout,
     ),
     rustc_attr!(
-        TEST, rustc_abi, template!(List: &["field1, field2, ..."]),
+        TEST, rustc_abi,
     ),
     rustc_attr!(
-        TEST, rustc_regions, template!(Word),
+        TEST, rustc_regions,
     ),
     rustc_attr!(
         TEST, rustc_delayed_bug_from_inside_query,
-        template!(Word),
     ),
     rustc_attr!(
-        TEST, rustc_dump_user_args, template!(Word),
+        TEST, rustc_dump_user_args,
     ),
     rustc_attr!(
-        TEST, rustc_evaluate_where_clauses, template!(Word),
+        TEST, rustc_evaluate_where_clauses,
     ),
     rustc_attr!(
-        TEST, rustc_if_this_changed, template!(Word, List: &["DepNode"]),
+        TEST, rustc_if_this_changed,
     ),
     rustc_attr!(
-        TEST, rustc_then_this_would_need, template!(List: &["DepNode"]),
+        TEST, rustc_then_this_would_need,
     ),
     rustc_attr!(
         TEST, rustc_clean,
-        template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]),
     ),
     rustc_attr!(
         TEST, rustc_partition_reused,
-        template!(List: &[r#"cfg = "...", module = "...""#]),    ),
+    ),
     rustc_attr!(
         TEST, rustc_partition_codegened,
-        template!(List: &[r#"cfg = "...", module = "...""#]),    ),
+    ),
     rustc_attr!(
         TEST, rustc_expected_cgu_reuse,
-        template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]),
     ),
     rustc_attr!(
-        TEST, rustc_dump_symbol_name, template!(Word),
+        TEST, rustc_dump_symbol_name,
     ),
     rustc_attr!(
-        TEST, rustc_dump_def_path, template!(Word),
+        TEST, rustc_dump_def_path,
     ),
     rustc_attr!(
-        TEST, rustc_mir, template!(List: &["arg1, arg2, ..."]),
+        TEST, rustc_mir,
     ),
     gated!(
-        custom_mir, template!(List: &[r#"dialect = "...", phase = "...""#]),
-        "the `#[custom_mir]` attribute is just used for the Rust test suite",
+        custom_mir, "the `#[custom_mir]` attribute is just used for the Rust test suite",
     ),
     rustc_attr!(
-        TEST, rustc_dump_item_bounds, template!(Word),
+        TEST, rustc_dump_item_bounds,
     ),
     rustc_attr!(
-        TEST, rustc_dump_predicates, template!(Word),
+        TEST, rustc_dump_predicates,
     ),
     rustc_attr!(
-        TEST, rustc_dump_def_parents, template!(Word),
+        TEST, rustc_dump_def_parents,
     ),
     rustc_attr!(
-        TEST, rustc_dump_object_lifetime_defaults, template!(Word),
+        TEST, rustc_dump_object_lifetime_defaults,
     ),
     rustc_attr!(
-        TEST, rustc_dump_vtable, template!(Word),
+        TEST, rustc_dump_vtable,
     ),
     rustc_attr!(
-        TEST, rustc_dummy, template!(Word /* doesn't matter*/),
+        TEST, rustc_dummy,
     ),
     rustc_attr!(
-        TEST, pattern_complexity_limit, template!(NameValueStr: "N"),
+        TEST, pattern_complexity_limit,
     ),
 ];
 

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -130,8 +130,7 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
     AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, BUILTIN_ATTRIBUTE_MAP,
-    BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, encode_cross_crate, find_gated_cfg,
-    is_builtin_attr_name, is_stable_diagnostic_attribute,
+    BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg, is_builtin_attr_name,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -129,10 +129,9 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
-    AttrSuggestionStyle, AttributeDuplicates, AttributeGate, AttributeSafety, AttributeTemplate,
-    AttributeType, BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg,
-    encode_cross_crate, find_gated_cfg, is_builtin_attr_name, is_stable_diagnostic_attribute,
-    is_valid_for_get_attr,
+    AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, AttributeType,
+    BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, encode_cross_crate,
+    find_gated_cfg, is_builtin_attr_name, is_stable_diagnostic_attribute,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -129,9 +129,9 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
-    AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, AttributeType,
-    BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, encode_cross_crate,
-    find_gated_cfg, is_builtin_attr_name, is_stable_diagnostic_attribute,
+    AttrSuggestionStyle, AttributeGate, AttributeSafety, AttributeTemplate, BUILTIN_ATTRIBUTE_MAP,
+    BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, encode_cross_crate, find_gated_cfg,
+    is_builtin_attr_name, is_stable_diagnostic_attribute,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -10,7 +10,6 @@ use rustc_data_structures::memmap::{Mmap, MmapMut};
 use rustc_data_structures::sync::{par_for_each_in, par_join};
 use rustc_data_structures::temp_dir::MaybeTempDir;
 use rustc_data_structures::thousands::usize_with_underscores;
-use rustc_feature::Features;
 use rustc_hir as hir;
 use rustc_hir::attrs::{AttributeKind, EncodeCrossCrate};
 use rustc_hir::def_id::{CRATE_DEF_ID, CRATE_DEF_INDEX, LOCAL_CRATE, LocalDefId, LocalDefIdSet};
@@ -842,10 +841,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     }
 }
 
-struct AnalyzeAttrState<'a> {
+struct AnalyzeAttrState {
     is_exported: bool,
     is_doc_hidden: bool,
-    features: &'a Features,
 }
 
 /// Returns whether an attribute needs to be recorded in metadata, that is, if it's usable and
@@ -858,16 +856,17 @@ struct AnalyzeAttrState<'a> {
 /// visibility: this is a piece of data that can be computed once per defid, and not once per
 /// attribute. Some attributes would only be usable downstream if they are public.
 #[inline]
-fn analyze_attr(attr: &hir::Attribute, state: &mut AnalyzeAttrState<'_>) -> bool {
+fn analyze_attr(attr: &hir::Attribute, state: &mut AnalyzeAttrState) -> bool {
     let mut should_encode = false;
     if let hir::Attribute::Parsed(p) = attr
         && p.encode_cross_crate() == EncodeCrossCrate::No
     {
         // Attributes not marked encode-cross-crate don't need to be encoded for downstream crates.
     } else if let Some(name) = attr.name()
-        && !rustc_feature::encode_cross_crate(name)
+        && [sym::warn, sym::allow, sym::expect, sym::forbid, sym::deny].contains(&name)
     {
-        // Attributes not marked encode-cross-crate don't need to be encoded for downstream crates.
+        // Lint attributes don't need to be encoded for downstream crates.
+        // FIXME remove this when #152369 is re-merged
     } else if let hir::Attribute::Parsed(AttributeKind::DocComment { .. }) = attr {
         // We keep all doc comments reachable to rustdoc because they might be "imported" into
         // downstream crates if they use `#[doc(inline)]` to copy an item's documentation into
@@ -880,8 +879,6 @@ fn analyze_attr(attr: &hir::Attribute, state: &mut AnalyzeAttrState<'_>) -> bool
         if d.hidden.is_some() {
             state.is_doc_hidden = true;
         }
-    } else if let &[sym::diagnostic, seg] = &*attr.path() {
-        should_encode = rustc_feature::is_stable_diagnostic_attribute(seg, state.features);
     } else {
         should_encode = true;
     }
@@ -1397,7 +1394,6 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let mut state = AnalyzeAttrState {
             is_exported: tcx.effective_visibilities(()).is_exported(def_id),
             is_doc_hidden: false,
-            features: &tcx.features(),
         };
         let attr_iter = tcx
             .hir_attrs(tcx.local_def_id_to_hir_id(def_id))

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1736,29 +1736,6 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    #[deprecated = "Though there are valid usecases for this method, especially when your attribute is not a parsed attribute, usually you want to call rustc_hir::find_attr! instead."]
-    pub fn get_attr(self, did: impl Into<DefId>, attr: Symbol) -> Option<&'tcx hir::Attribute> {
-        if cfg!(debug_assertions) && !rustc_feature::is_valid_for_get_attr(attr) {
-            let did: DefId = did.into();
-            bug!("get_attr: unexpected called with DefId `{:?}`, attr `{:?}`", did, attr);
-        } else {
-            #[allow(deprecated)]
-            self.get_attrs(did, attr).next()
-        }
-    }
-
-    /// Determines whether an item is annotated with an attribute.
-    #[deprecated = "Though there are valid usecases for this method, especially when your attribute is not a parsed attribute, usually you want to call rustc_hir::find_attr! instead."]
-    pub fn has_attr(self, did: impl Into<DefId>, attr: Symbol) -> bool {
-        #[allow(deprecated)]
-        self.get_attrs(did, attr).next().is_some()
-    }
-
-    /// Determines whether an item is annotated with a multi-segment attribute
-    pub fn has_attrs_with_path(self, did: impl Into<DefId>, attrs: &[Symbol]) -> bool {
-        self.get_attrs_by_path(did.into(), attrs).next().is_some()
-    }
-
     /// Returns `true` if this is an `auto trait`.
     pub fn trait_is_auto(self, trait_def_id: DefId) -> bool {
         self.trait_def(trait_def_id).has_auto_impl

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -6,17 +6,15 @@
 //! item.
 
 use std::cell::Cell;
-use std::collections::hash_map::Entry;
 use std::slice;
 
 use rustc_abi::ExternAbi;
 use rustc_ast::{AttrStyle, MetaItemKind, ast};
 use rustc_attr_parsing::{AttributeParser, Late};
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
-use rustc_feature::{AttributeDuplicates, AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
+use rustc_feature::{AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_hir::attrs::{
     AttributeKind, DocAttribute, DocInline, EiiDecl, EiiImpl, EiiImplResolution, InlineAttr,
@@ -145,7 +143,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         target: Target,
         item: Option<ItemLike<'_>>,
     ) {
-        let mut seen = FxHashMap::default();
         let attrs = self.tcx.hir_attrs(hir_id);
         for attr in attrs {
             let mut style = None;
@@ -468,20 +465,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         }
                     }
                 }
-            }
-
-            if let Attribute::Unparsed(unparsed_attr) = attr
-                && let Some(BuiltinAttribute { duplicates, .. }) =
-                    attr.name().and_then(|name| BUILTIN_ATTRIBUTE_MAP.get(&name))
-            {
-                check_duplicates(
-                    self.tcx,
-                    unparsed_attr.span,
-                    attr,
-                    hir_id,
-                    *duplicates,
-                    &mut seen,
-                );
             }
 
             self.check_unused_attribute(hir_id, attr, style)
@@ -2039,67 +2022,6 @@ fn check_mod_attrs(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
 
 pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers { check_mod_attrs, ..*providers };
-}
-
-// FIXME(jdonszelmann): remove, check during parsing
-fn check_duplicates(
-    tcx: TyCtxt<'_>,
-    attr_span: Span,
-    attr: &Attribute,
-    hir_id: HirId,
-    duplicates: AttributeDuplicates,
-    seen: &mut FxHashMap<Symbol, Span>,
-) {
-    use AttributeDuplicates::*;
-    if matches!(duplicates, WarnFollowingWordOnly) && !attr.is_word() {
-        return;
-    }
-    let attr_name = attr.name().unwrap();
-    match duplicates {
-        DuplicatesOk => {}
-        WarnFollowing | FutureWarnFollowing | WarnFollowingWordOnly | FutureWarnPreceding => {
-            match seen.entry(attr_name) {
-                Entry::Occupied(mut entry) => {
-                    let (this, other) = if matches!(duplicates, FutureWarnPreceding) {
-                        let to_remove = entry.insert(attr_span);
-                        (to_remove, attr_span)
-                    } else {
-                        (attr_span, *entry.get())
-                    };
-                    tcx.emit_node_span_lint(
-                        UNUSED_ATTRIBUTES,
-                        hir_id,
-                        this,
-                        errors::UnusedDuplicate {
-                            this,
-                            other,
-                            warning: matches!(
-                                duplicates,
-                                FutureWarnFollowing | FutureWarnPreceding
-                            ),
-                        },
-                    );
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(attr_span);
-                }
-            }
-        }
-        ErrorFollowing | ErrorPreceding => match seen.entry(attr_name) {
-            Entry::Occupied(mut entry) => {
-                let (this, other) = if matches!(duplicates, ErrorPreceding) {
-                    let to_remove = entry.insert(attr_span);
-                    (to_remove, attr_span)
-                } else {
-                    (attr_span, *entry.get())
-                };
-                tcx.dcx().emit_err(errors::UnusedMultiple { this, other, name: attr_name });
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(attr_span);
-            }
-        },
-    }
 }
 
 fn doc_fake_variadic_is_allowed_self_ty(self_ty: &hir::Ty<'_>) -> bool {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -14,7 +14,7 @@ use rustc_attr_parsing::{AttributeParser, Late};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
-use rustc_feature::{AttributeType, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute};
+use rustc_feature::BUILTIN_ATTRIBUTE_MAP;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_hir::attrs::{
     AttributeKind, DocAttribute, DocInline, EiiDecl, EiiImpl, EiiImplResolution, InlineAttr,
@@ -418,51 +418,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                             }
                         }
                         [] => unreachable!(),
-                    }
-                }
-            }
-
-            if hir_id != CRATE_HIR_ID {
-                match attr {
-                    Attribute::Parsed(_) => { /* Already validated. */ }
-                    Attribute::Unparsed(attr) => {
-                        // FIXME(jdonszelmann): remove once all crate-level attrs are parsed and caught by
-                        // the above
-                        if let Some(BuiltinAttribute { type_: AttributeType::CrateLevel, .. }) =
-                            attr.path
-                                .segments
-                                .first()
-                                .and_then(|name| BUILTIN_ATTRIBUTE_MAP.get(&name))
-                        {
-                            match attr.style {
-                                ast::AttrStyle::Outer => {
-                                    let attr_span = attr.span;
-                                    let bang_position = self
-                                        .tcx
-                                        .sess
-                                        .source_map()
-                                        .span_until_char(attr_span, '[')
-                                        .shrink_to_hi();
-
-                                    self.tcx.emit_node_span_lint(
-                                        UNUSED_ATTRIBUTES,
-                                        hir_id,
-                                        attr.span,
-                                        errors::OuterCrateLevelAttr {
-                                            suggestion: errors::OuterCrateLevelAttrSuggestion {
-                                                bang_position,
-                                            },
-                                        },
-                                    )
-                                }
-                                ast::AttrStyle::Inner => self.tcx.emit_node_span_lint(
-                                    UNUSED_ATTRIBUTES,
-                                    hir_id,
-                                    attr.span,
-                                    errors::InnerCrateLevelAttr,
-                                ),
-                            }
-                        }
                     }
                 }
             }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -329,30 +329,6 @@ pub(crate) struct InvalidMayDangle {
 }
 
 #[derive(Diagnostic)]
-#[diag("unused attribute")]
-pub(crate) struct UnusedDuplicate {
-    #[suggestion("remove this attribute", code = "", applicability = "machine-applicable")]
-    pub this: Span,
-    #[note("attribute also specified here")]
-    pub other: Span,
-    #[warning(
-        "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"
-    )]
-    pub warning: bool,
-}
-
-#[derive(Diagnostic)]
-#[diag("multiple `{$name}` attributes")]
-pub(crate) struct UnusedMultiple {
-    #[primary_span]
-    #[suggestion("remove this attribute", code = "", applicability = "machine-applicable")]
-    pub this: Span,
-    #[note("attribute also specified here")]
-    pub other: Span,
-    pub name: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag("this `#[deprecated]` annotation has no effect")]
 pub(crate) struct DeprecatedAnnotationHasNoEffect {
     #[suggestion(

--- a/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
+++ b/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
@@ -145,7 +145,7 @@ impl<'tcx> LateLintPass<'tcx> for CognitiveComplexity {
         def_id: LocalDefId,
     ) {
         #[allow(deprecated)]
-        if !cx.tcx.has_attr(def_id, sym::test) {
+        if !cx.tcx.get_attrs(def_id, sym::test).next().is_some() {
             let expr = if kind.asyncness().is_async() {
                 match get_async_fn_body(cx.tcx, body) {
                     Some(b) => b,

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -2400,8 +2400,7 @@ pub fn is_hir_ty_cfg_dependant(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> bool {
     if let TyKind::Path(QPath::Resolved(_, path)) = ty.kind
         && let Res::Def(_, def_id) = path.res
     {
-        #[allow(deprecated)]
-        return cx.tcx.has_attr(def_id, sym::cfg) || cx.tcx.has_attr(def_id, sym::cfg_attr);
+        return find_attr!(cx.tcx, def_id, CfgTrace(..) | CfgAttrTrace);
     }
     false
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155209)*
<!-- homu-ignore:end -->

This is a re-implementation of most (but not all) of https://github.com/rust-lang/rust/pull/154808

The code is the same as in that PR, other than a few changes, I'll leave comments where I changed things.
I did re-implement most of the commits rather than cherry-picking, so it's probably good to check the entire diff regardless

r? @jdonszelmann 