### PR TITLE
Clean up `AttributeLintKind` and refactor diagnostic attribute linting

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -150,18 +150,14 @@ fn parse_directive_items<'p, S: Stage>(
         let span = item.span();
 
         macro malformed() {{
-            if matches!(mode, Mode::RustcOnUnimplemented) {
-                cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
-            } else {
-                cx.emit_lint(
-                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MalFormedDiagnosticAttribute {
-                        attribute: mode.as_str(),
-                        span,
-                    },
+            cx.emit_lint(
+                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                AttributeLintKind::MalFormedDiagnosticAttribute {
+                attribute: mode.as_str(),
                     span,
-                );
-            }
+                },
+                span,
+            );
             continue;
         }}
 
@@ -175,19 +171,15 @@ fn parse_directive_items<'p, S: Stage>(
         }}
 
         macro duplicate($name: ident, $($first_span:tt)*) {{
-            if matches!(mode, Mode::RustcOnUnimplemented) {
-                cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
-            } else {
-                cx.emit_lint(
-                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::IgnoredDiagnosticOption {
-                        first_span: $($first_span)*,
-                        later_span: span,
-                        option_name: $name,
-                    },
-                    span,
-                );
-            }
+            cx.emit_lint(
+                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                AttributeLintKind::IgnoredDiagnosticOption {
+                    first_span: $($first_span)*,
+                    later_span: span,
+                    option_name: $name,
+                },
+                span,
+            );
         }}
 
         let item: &MetaItemParser = or_malformed!(item.meta_item()?);
@@ -564,15 +556,6 @@ pub(crate) enum InvalidOnClause {
         span: Span,
         invalid_flag: Symbol,
     },
-}
-
-#[derive(Diagnostic)]
-#[diag("this attribute must have a value", code = E0232)]
-#[note("e.g. `#[rustc_on_unimplemented(message=\"foo\")]`")]
-pub(crate) struct NoValueInOnUnimplemented {
-    #[primary_span]
-    #[label("expected value here")]
-    pub span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -40,6 +40,18 @@ pub(crate) enum Mode {
     DiagnosticOnUnknown,
 }
 
+impl Mode {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::RustcOnUnimplemented => "rustc_on_unimplemented",
+            Self::DiagnosticOnUnimplemented => "diagnostic::on_unimplemented",
+            Self::DiagnosticOnConst => "diagnostic::on_const",
+            Self::DiagnosticOnMove => "diagnostic::on_move",
+            Self::DiagnosticOnUnknown => "diagnostic::on_unknown",
+        }
+    }
+}
+
 fn merge_directives<S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     first: &mut Option<(Span, Directive)>,
@@ -100,38 +112,17 @@ fn parse_directive_items<'p, S: Stage>(
         let span = item.span();
 
         macro malformed() {{
-            match mode {
-                Mode::RustcOnUnimplemented => {
-                    cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
-                }
-                Mode::DiagnosticOnUnimplemented => {
-                    cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MalformedOnUnimplementedAttr { span },
+            if matches!(mode, Mode::RustcOnUnimplemented) {
+                cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
+            } else {
+                cx.emit_lint(
+                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                    AttributeLintKind::MalFormedDiagnosticAttribute {
+                        attribute: mode.as_str(),
                         span,
-                    );
-                }
-                Mode::DiagnosticOnConst => {
-                    cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MalformedOnConstAttr { span },
-                        span,
-                    );
-                }
-                Mode::DiagnosticOnMove => {
-                    cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MalformedOnMoveAttr { span },
-                        span,
-                    );
-                }
-                Mode::DiagnosticOnUnknown => {
-                    cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MalformedOnUnknownAttr { span },
-                        span,
-                    );
-                }
+                    },
+                    span,
+                );
             }
             continue;
         }}
@@ -146,12 +137,10 @@ fn parse_directive_items<'p, S: Stage>(
         }}
 
         macro duplicate($name: ident, $($first_span:tt)*) {{
-            match mode {
-                Mode::RustcOnUnimplemented => {
-                    cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
-                }
-                Mode::DiagnosticOnUnimplemented |Mode::DiagnosticOnConst | Mode::DiagnosticOnMove | Mode::DiagnosticOnUnknown => {
-                    cx.emit_lint(
+            if matches!(mode, Mode::RustcOnUnimplemented) {
+                cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
+            }else{
+                cx.emit_lint(
                         MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                         AttributeLintKind::IgnoredDiagnosticOption {
                             first_span: $($first_span)*,
@@ -160,7 +149,6 @@ fn parse_directive_items<'p, S: Stage>(
                         },
                         span,
                     );
-                }
             }
         }}
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -177,16 +177,16 @@ fn parse_directive_items<'p, S: Stage>(
         macro duplicate($name: ident, $($first_span:tt)*) {{
             if matches!(mode, Mode::RustcOnUnimplemented) {
                 cx.emit_err(NoValueInOnUnimplemented { span: item.span() });
-            }else{
+            } else {
                 cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::IgnoredDiagnosticOption {
-                            first_span: $($first_span)*,
-                            later_span: span,
-                            option_name: $name,
-                        },
-                        span,
-                    );
+                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                    AttributeLintKind::IgnoredDiagnosticOption {
+                        first_span: $($first_span)*,
+                        later_span: span,
+                        option_name: $name,
+                    },
+                    span,
+                );
             }
         }}
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -50,6 +50,33 @@ impl Mode {
             Self::DiagnosticOnUnknown => "diagnostic::on_unknown",
         }
     }
+
+    fn expected_options(&self) -> &'static str {
+        const DEFAULT: &str =
+            "at least one of the `message`, `note` and `label` options are expected";
+        match self {
+            Self::RustcOnUnimplemented => {
+                "see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>"
+            }
+            Self::DiagnosticOnUnimplemented => DEFAULT,
+            Self::DiagnosticOnConst => DEFAULT,
+            Self::DiagnosticOnMove => DEFAULT,
+            Self::DiagnosticOnUnknown => DEFAULT,
+        }
+    }
+
+    fn allowed_options(&self) -> &'static str {
+        const DEFAULT: &str = "only `message`, `note` and `label` are allowed as options";
+        match self {
+            Self::RustcOnUnimplemented => {
+                "see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>"
+            }
+            Self::DiagnosticOnUnimplemented => DEFAULT,
+            Self::DiagnosticOnConst => DEFAULT,
+            Self::DiagnosticOnMove => DEFAULT,
+            Self::DiagnosticOnUnknown => DEFAULT,
+        }
+    }
 }
 
 fn merge_directives<S: Stage>(
@@ -118,6 +145,7 @@ fn parse_list<'p, S: Stage>(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 AttributeLintKind::MissingOptionsForDiagnosticAttribute {
                     attribute: mode.as_str(),
+                    options: mode.expected_options(),
                 },
                 span,
             );
@@ -125,7 +153,11 @@ fn parse_list<'p, S: Stage>(
         ArgParser::NameValue(_) => {
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                AttributeLintKind::MalFormedDiagnosticAttribute { attribute: mode.as_str(), span },
+                AttributeLintKind::MalFormedDiagnosticAttribute {
+                    attribute: mode.as_str(),
+                    options: mode.allowed_options(),
+                    span,
+                },
                 span,
             );
         }
@@ -153,7 +185,8 @@ fn parse_directive_items<'p, S: Stage>(
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 AttributeLintKind::MalFormedDiagnosticAttribute {
-                attribute: mode.as_str(),
+                    attribute: mode.as_str(),
+                    options: mode.allowed_options(),
                     span,
                 },
                 span,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -95,6 +95,44 @@ fn merge<T, S: Stage>(
     }
 }
 
+fn parse_list<'p, S: Stage>(
+    cx: &mut AcceptContext<'_, '_, S>,
+    args: &'p ArgParser,
+    mode: Mode,
+) -> Option<&'p MetaItemListParser> {
+    let span = cx.attr_span;
+    match args {
+        ArgParser::List(items) if items.len() != 0 => return Some(items),
+        ArgParser::List(list) => {
+            // We're dealing with `#[diagnostic::attr()]`.
+            // This can be because that is what the user typed, but that's also what we'd see
+            // if the user used non-metaitem syntax. See `ArgParser::from_attr_args`.
+            cx.emit_lint(
+                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                AttributeLintKind::NonMetaItemDiagnosticAttribute,
+                list.span,
+            );
+        }
+        ArgParser::NoArgs => {
+            cx.emit_lint(
+                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                AttributeLintKind::MissingOptionsForDiagnosticAttribute {
+                    attribute: mode.as_str(),
+                },
+                span,
+            );
+        }
+        ArgParser::NameValue(_) => {
+            cx.emit_lint(
+                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+                AttributeLintKind::MalFormedDiagnosticAttribute { attribute: mode.as_str(), span },
+                span,
+            );
+        }
+    }
+    None
+}
+
 fn parse_directive_items<'p, S: Stage>(
     cx: &mut AcceptContext<'_, '_, S>,
     mode: Mode,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -29,7 +29,9 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
                 ArgParser::NoArgs | ArgParser::List(_) => {
                     cx.emit_lint(
                         MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MissingOptionsForOnConst,
+                        AttributeLintKind::MissingOptionsForDiagnosticAttribute {
+                            attribute: mode.as_str(),
+                        },
                         span,
                     );
                     return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -22,6 +22,7 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
 
             let span = cx.attr_span;
             this.span = Some(span);
+            let mode = Mode::DiagnosticOnConst;
 
             let items = match args {
                 ArgParser::List(items) if items.len() != 0 => items,
@@ -36,16 +37,17 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
                 ArgParser::NameValue(_) => {
                     cx.emit_lint(
                         MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MalformedOnConstAttr { span },
+                        AttributeLintKind::MalFormedDiagnosticAttribute {
+                            attribute: mode.as_str(),
+                            span,
+                        },
                         span,
                     );
                     return;
                 }
             };
 
-            let Some(directive) =
-                parse_directive_items(cx, Mode::DiagnosticOnConst, items.mixed(), true)
-            else {
+            let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) else {
                 return;
             };
             merge_directives(cx, &mut this.directive, (span, directive));

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -1,6 +1,4 @@
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_hir::lints::AttributeLintKind;
-use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
@@ -24,30 +22,7 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
             this.span = Some(span);
             let mode = Mode::DiagnosticOnConst;
 
-            let items = match args {
-                ArgParser::List(items) if items.len() != 0 => items,
-                ArgParser::NoArgs | ArgParser::List(_) => {
-                    cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MissingOptionsForDiagnosticAttribute {
-                            attribute: mode.as_str(),
-                        },
-                        span,
-                    );
-                    return;
-                }
-                ArgParser::NameValue(_) => {
-                    cx.emit_lint(
-                        MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                        AttributeLintKind::MalFormedDiagnosticAttribute {
-                            attribute: mode.as_str(),
-                            span,
-                        },
-                        span,
-                    );
-                    return;
-                }
-            };
+            let Some(items) = parse_list(cx, args, mode) else { return };
 
             let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) else {
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -1,7 +1,5 @@
 use rustc_feature::template;
 use rustc_hir::attrs::AttributeKind;
-use rustc_hir::lints::AttributeLintKind;
-use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::sym;
 
 use crate::attributes::diagnostic::*;
@@ -29,27 +27,10 @@ impl OnMoveParser {
 
         let span = cx.attr_span;
         self.span = Some(span);
-        let Some(list) = args.list() else {
-            cx.emit_lint(
-                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                AttributeLintKind::MissingOptionsForDiagnosticAttribute {
-                    attribute: mode.as_str(),
-                },
-                span,
-            );
-            return;
-        };
 
-        if list.is_empty() {
-            cx.emit_lint(
-                MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                AttributeLintKind::OnMoveMalformedAttrExpectedLiteralOrDelimiter,
-                list.span,
-            );
-            return;
-        }
+        let Some(items) = parse_list(cx, args, mode) else { return };
 
-        if let Some(directive) = parse_directive_items(cx, mode, list.mixed(), true) {
+        if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
             merge_directives(cx, &mut self.directive, (span, directive));
         }
     }

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -32,7 +32,9 @@ impl OnMoveParser {
         let Some(list) = args.list() else {
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                AttributeLintKind::MissingOptionsForOnMove,
+                AttributeLintKind::MissingOptionsForDiagnosticAttribute {
+                    attribute: mode.as_str(),
+                },
                 span,
             );
             return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -34,7 +34,9 @@ impl OnUnimplementedParser {
             ArgParser::NoArgs | ArgParser::List(_) => {
                 cx.emit_lint(
                     MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MissingOptionsForOnUnimplemented,
+                    AttributeLintKind::MissingOptionsForDiagnosticAttribute {
+                        attribute: mode.as_str(),
+                    },
                     span,
                 );
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -42,7 +42,10 @@ impl OnUnimplementedParser {
             ArgParser::NameValue(_) => {
                 cx.emit_lint(
                     MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MalformedOnUnimplementedAttr { span },
+                    AttributeLintKind::MalFormedDiagnosticAttribute {
+                        attribute: mode.as_str(),
+                        span,
+                    },
                     span,
                 );
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -1,6 +1,4 @@
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_hir::lints::AttributeLintKind;
-use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
@@ -29,30 +27,7 @@ impl OnUnimplementedParser {
             return;
         }
 
-        let items = match args {
-            ArgParser::List(items) if items.len() != 0 => items,
-            ArgParser::NoArgs | ArgParser::List(_) => {
-                cx.emit_lint(
-                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MissingOptionsForDiagnosticAttribute {
-                        attribute: mode.as_str(),
-                    },
-                    span,
-                );
-                return;
-            }
-            ArgParser::NameValue(_) => {
-                cx.emit_lint(
-                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MalFormedDiagnosticAttribute {
-                        attribute: mode.as_str(),
-                        span,
-                    },
-                    span,
-                );
-                return;
-            }
-        };
+        let Some(items) = parse_list(cx, args, mode) else { return };
 
         if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
             merge_directives(cx, &mut self.directive, (span, directive));

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -36,7 +36,10 @@ impl OnUnknownParser {
             ArgParser::NameValue(_) => {
                 cx.emit_lint(
                     MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MalformedOnUnknownAttr { span },
+                    AttributeLintKind::MalFormedDiagnosticAttribute {
+                        attribute: mode.as_str(),
+                        span,
+                    },
                     span,
                 );
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -28,7 +28,9 @@ impl OnUnknownParser {
             ArgParser::NoArgs | ArgParser::List(_) => {
                 cx.emit_lint(
                     MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MissingOptionsForOnUnknown,
+                    AttributeLintKind::MissingOptionsForDiagnosticAttribute {
+                        attribute: mode.as_str(),
+                    },
                     span,
                 );
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -1,5 +1,4 @@
 use rustc_hir::attrs::diagnostic::Directive;
-use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
@@ -23,30 +22,7 @@ impl OnUnknownParser {
         let span = cx.attr_span;
         self.span = Some(span);
 
-        let items = match args {
-            ArgParser::List(items) if !items.is_empty() => items,
-            ArgParser::NoArgs | ArgParser::List(_) => {
-                cx.emit_lint(
-                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MissingOptionsForDiagnosticAttribute {
-                        attribute: mode.as_str(),
-                    },
-                    span,
-                );
-                return;
-            }
-            ArgParser::NameValue(_) => {
-                cx.emit_lint(
-                    MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                    AttributeLintKind::MalFormedDiagnosticAttribute {
-                        attribute: mode.as_str(),
-                        span,
-                    },
-                    span,
-                );
-                return;
-            }
-        };
+        let Some(items) = parse_list(cx, args, mode) else { return };
 
         if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
             merge_directives(cx, &mut self.directive, (span, directive));

--- a/compiler/rustc_error_codes/src/error_codes/E0232.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0232.md
@@ -1,19 +1,14 @@
 The `#[rustc_on_unimplemented]` attribute lets you specify a custom error
 message for when a particular trait isn't implemented on a type placed in a
-position that needs that trait. For example, when the following code is
-compiled:
+position that needs that trait. The attribute will let you filter on
+various types, with `on`:
 
 ```compile_fail,E0232
 #![feature(rustc_attrs)]
 #![allow(internal_features)]
 
-#[rustc_on_unimplemented(lorem="")] // error!
+#[rustc_on_unimplemented(on(blah, message = "foo"))] // error!
 trait BadAnnotation {}
 ```
-
-there will be an error about `bool` not implementing `Index<u8>`, followed by a
-note saying "the type `bool` cannot be indexed by `u8`".
-
-For this to work, some note must be specified. An empty attribute will not do
-anything, please remove the attribute or add some helpful note for users of the
-trait.
+For this to work a cfg-like predicate must be supplied. A malformed filter
+will not do anything.

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -176,8 +176,9 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             &AttributeLintKind::ExpectedNoArgs => lints::ExpectedNoArgs.into_diag(dcx, level),
 
             &AttributeLintKind::ExpectedNameValue => lints::ExpectedNameValue.into_diag(dcx, level),
-            &AttributeLintKind::MalFormedDiagnosticAttribute { attribute, span } => {
-                lints::MalFormedDiagnosticAttributeLint { attribute, span }.into_diag(dcx, level)
+            &AttributeLintKind::MalFormedDiagnosticAttribute { attribute, options, span } => {
+                lints::MalFormedDiagnosticAttributeLint { attribute, options, span }
+                    .into_diag(dcx, level)
             }
 
             AttributeLintKind::MalformedDiagnosticFormat { warning } => match warning {
@@ -198,8 +199,9 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
                 lints::IgnoredDiagnosticOption { option_name, first_span, later_span }
                     .into_diag(dcx, level)
             }
-            &AttributeLintKind::MissingOptionsForDiagnosticAttribute { attribute } => {
-                lints::MissingOptionsForDiagnosticAttribute { attribute }.into_diag(dcx, level)
+            &AttributeLintKind::MissingOptionsForDiagnosticAttribute { attribute, options } => {
+                lints::MissingOptionsForDiagnosticAttribute { attribute, options }
+                    .into_diag(dcx, level)
             }
             &AttributeLintKind::NonMetaItemDiagnosticAttribute => {
                 lints::NonMetaItemDiagnosticAttribute.into_diag(dcx, level)

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -204,8 +204,8 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             &AttributeLintKind::OnMoveMalformedFormatLiterals { name } => {
                 lints::OnMoveMalformedFormatLiterals { name }.into_diag(dcx, level)
             }
-            &AttributeLintKind::OnMoveMalformedAttrExpectedLiteralOrDelimiter => {
-                lints::OnMoveMalformedAttrExpectedLiteralOrDelimiter.into_diag(dcx, level)
+            &AttributeLintKind::NonMetaItemDiagnosticAttribute => {
+                lints::NonMetaItemDiagnosticAttribute.into_diag(dcx, level)
             }
         }
     }

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -201,9 +201,6 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             &AttributeLintKind::MissingOptionsForDiagnosticAttribute { attribute } => {
                 lints::MissingOptionsForDiagnosticAttribute { attribute }.into_diag(dcx, level)
             }
-            &AttributeLintKind::OnMoveMalformedFormatLiterals { name } => {
-                lints::OnMoveMalformedFormatLiterals { name }.into_diag(dcx, level)
-            }
             &AttributeLintKind::NonMetaItemDiagnosticAttribute => {
                 lints::NonMetaItemDiagnosticAttribute.into_diag(dcx, level)
             }

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -176,15 +176,10 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             &AttributeLintKind::ExpectedNoArgs => lints::ExpectedNoArgs.into_diag(dcx, level),
 
             &AttributeLintKind::ExpectedNameValue => lints::ExpectedNameValue.into_diag(dcx, level),
-            &AttributeLintKind::MalformedOnUnimplementedAttr { span } => {
-                lints::MalformedOnUnimplementedAttrLint { span }.into_diag(dcx, level)
+            &AttributeLintKind::MalFormedDiagnosticAttribute { attribute, span } => {
+                lints::MalFormedDiagnosticAttributeLint { attribute, span }.into_diag(dcx, level)
             }
-            &AttributeLintKind::MalformedOnUnknownAttr { span } => {
-                lints::MalformedOnUnknownAttrLint { span }.into_diag(dcx, level)
-            }
-            &AttributeLintKind::MalformedOnConstAttr { span } => {
-                lints::MalformedOnConstAttrLint { span }.into_diag(dcx, level)
-            }
+
             AttributeLintKind::MalformedDiagnosticFormat { warning } => match warning {
                 FormatWarning::PositionalArgument { .. } => {
                     lints::DisallowedPositionalArgument.into_diag(dcx, level)
@@ -208,9 +203,6 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             }
             &AttributeLintKind::MissingOptionsForOnConst => {
                 lints::MissingOptionsForOnConstAttr.into_diag(dcx, level)
-            }
-            &AttributeLintKind::MalformedOnMoveAttr { span } => {
-                lints::MalformedOnMoveAttrLint { span }.into_diag(dcx, level)
             }
             &AttributeLintKind::OnMoveMalformedFormatLiterals { name } => {
                 lints::OnMoveMalformedFormatLiterals { name }.into_diag(dcx, level)

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -198,23 +198,14 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
                 lints::IgnoredDiagnosticOption { option_name, first_span, later_span }
                     .into_diag(dcx, level)
             }
-            &AttributeLintKind::MissingOptionsForOnUnimplemented => {
-                lints::MissingOptionsForOnUnimplementedAttr.into_diag(dcx, level)
-            }
-            &AttributeLintKind::MissingOptionsForOnConst => {
-                lints::MissingOptionsForOnConstAttr.into_diag(dcx, level)
+            &AttributeLintKind::MissingOptionsForDiagnosticAttribute { attribute } => {
+                lints::MissingOptionsForDiagnosticAttribute { attribute }.into_diag(dcx, level)
             }
             &AttributeLintKind::OnMoveMalformedFormatLiterals { name } => {
                 lints::OnMoveMalformedFormatLiterals { name }.into_diag(dcx, level)
             }
             &AttributeLintKind::OnMoveMalformedAttrExpectedLiteralOrDelimiter => {
                 lints::OnMoveMalformedAttrExpectedLiteralOrDelimiter.into_diag(dcx, level)
-            }
-            &AttributeLintKind::MissingOptionsForOnMove => {
-                lints::MissingOptionsForOnMoveAttr.into_diag(dcx, level)
-            }
-            &AttributeLintKind::MissingOptionsForOnUnknown => {
-                lints::MissingOptionsForOnUnknownAttr.into_diag(dcx, level)
             }
         }
     }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3585,9 +3585,10 @@ pub(crate) struct IgnoredDiagnosticOption {
 
 #[derive(Diagnostic)]
 #[diag("missing options for `{$attribute}` attribute")]
-#[help("at least one of the `message`, `note` and `label` options are expected")]
+#[help("{$options}")]
 pub(crate) struct MissingOptionsForDiagnosticAttribute {
     pub attribute: &'static str,
+    pub options: &'static str,
 }
 
 #[derive(Diagnostic)]
@@ -3604,9 +3605,10 @@ pub(crate) struct NonMetaItemDiagnosticAttribute;
 
 #[derive(Diagnostic)]
 #[diag("malformed `{$attribute}` attribute")]
-#[help("only `message`, `note` and `label` are allowed as options")]
+#[help("{$options}")]
 pub(crate) struct MalFormedDiagnosticAttributeLint {
     pub attribute: &'static str,
+    pub options: &'static str,
     #[label("invalid option found here")]
     pub span: Span,
 }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3604,43 +3604,9 @@ pub(crate) struct MissingOptionsForOnConstAttr;
 pub(crate) struct MissingOptionsForOnMoveAttr;
 
 #[derive(Diagnostic)]
-#[diag("malformed `on_unimplemented` attribute")]
-#[help("only `message`, `note` and `label` are allowed as options")]
-pub(crate) struct MalformedOnUnimplementedAttrLint {
-    #[label("invalid option found here")]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag("malformed `on_unknown` attribute")]
-#[help("only `message`, `note` and `label` are allowed as options")]
-pub(crate) struct MalformedOnUnknownAttrLint {
-    #[label("invalid option found here")]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag("malformed `on_const` attribute")]
-#[help("only `message`, `note` and `label` are allowed as options")]
-pub(crate) struct MalformedOnConstAttrLint {
-    #[label("invalid option found here")]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("`Eq::assert_receiver_is_total_eq` should never be implemented by hand")]
 #[note("this method was used to add checks to the `Eq` derive macro")]
 pub(crate) struct EqInternalMethodImplemented;
-
-#[derive(Diagnostic)]
-#[diag("unknown or malformed `on_move` attribute")]
-#[help(
-    "only `message`, `note` and `label` are allowed as options. Their values must be string literals"
-)]
-pub(crate) struct MalformedOnMoveAttrLint {
-    #[label("invalid option found here")]
-    pub span: Span,
-}
 
 #[derive(Diagnostic)]
 #[diag("unknown parameter `{$name}`")]
@@ -3655,3 +3621,12 @@ pub(crate) struct OnMoveMalformedFormatLiterals {
     "only literals are allowed as values for the `message`, `note` and `label` options. These options must be separated by a comma"
 )]
 pub(crate) struct OnMoveMalformedAttrExpectedLiteralOrDelimiter;
+
+#[derive(Diagnostic)]
+#[diag("malformed `{$attribute}` attribute")]
+#[help("only `message`, `note` and `label` are allowed as options")]
+pub(crate) struct MalFormedDiagnosticAttributeLint {
+    pub attribute: &'static str,
+    #[label("invalid option found here")]
+    pub span: Span,
+}

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3584,24 +3584,11 @@ pub(crate) struct IgnoredDiagnosticOption {
 }
 
 #[derive(Diagnostic)]
-#[diag("missing options for `on_unimplemented` attribute")]
+#[diag("missing options for `{$attribute}` attribute")]
 #[help("at least one of the `message`, `note` and `label` options are expected")]
-pub(crate) struct MissingOptionsForOnUnimplementedAttr;
-
-#[derive(Diagnostic)]
-#[diag("missing options for `on_unknown` attribute")]
-#[help("at least one of the `message`, `note` and `label` options are expected")]
-pub(crate) struct MissingOptionsForOnUnknownAttr;
-
-#[derive(Diagnostic)]
-#[diag("missing options for `on_const` attribute")]
-#[help("at least one of the `message`, `note` and `label` options are expected")]
-pub(crate) struct MissingOptionsForOnConstAttr;
-
-#[derive(Diagnostic)]
-#[diag("missing options for `on_move` attribute")]
-#[help("at least one of the `message`, `note` and `label` options are expected")]
-pub(crate) struct MissingOptionsForOnMoveAttr;
+pub(crate) struct MissingOptionsForDiagnosticAttribute {
+    pub attribute: &'static str,
+}
 
 #[derive(Diagnostic)]
 #[diag("`Eq::assert_receiver_is_total_eq` should never be implemented by hand")]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3607,7 +3607,7 @@ pub(crate) struct OnMoveMalformedFormatLiterals {
 #[help(
     "only literals are allowed as values for the `message`, `note` and `label` options. These options must be separated by a comma"
 )]
-pub(crate) struct OnMoveMalformedAttrExpectedLiteralOrDelimiter;
+pub(crate) struct NonMetaItemDiagnosticAttribute;
 
 #[derive(Diagnostic)]
 #[diag("malformed `{$attribute}` attribute")]

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3596,13 +3596,6 @@ pub(crate) struct MissingOptionsForDiagnosticAttribute {
 pub(crate) struct EqInternalMethodImplemented;
 
 #[derive(Diagnostic)]
-#[diag("unknown parameter `{$name}`")]
-#[help("expect `Self` as format argument")]
-pub(crate) struct OnMoveMalformedFormatLiterals {
-    pub name: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag("expected a literal or missing delimiter")]
 #[help(
     "only literals are allowed as values for the `message`, `note` and `label` options. These options must be separated by a comma"

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -733,16 +733,8 @@ pub enum AttributeLintKind {
     MalformedDoc,
     ExpectedNoArgs,
     ExpectedNameValue,
-    MalformedOnUnimplementedAttr {
-        span: Span,
-    },
-    MalformedOnUnknownAttr {
-        span: Span,
-    },
-    MalformedOnConstAttr {
-        span: Span,
-    },
-    MalformedOnMoveAttr {
+    MalFormedDiagnosticAttribute {
+        attribute: &'static str,
         span: Span,
     },
     MalformedDiagnosticFormat {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -750,10 +750,9 @@ pub enum AttributeLintKind {
         first_span: Span,
         later_span: Span,
     },
-    MissingOptionsForOnUnimplemented,
-    MissingOptionsForOnConst,
-    MissingOptionsForOnUnknown,
-    MissingOptionsForOnMove,
+    MissingOptionsForDiagnosticAttribute {
+        attribute: &'static str,
+    },
     OnMoveMalformedFormatLiterals {
         name: Symbol,
     },

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -756,7 +756,7 @@ pub enum AttributeLintKind {
     OnMoveMalformedFormatLiterals {
         name: Symbol,
     },
-    OnMoveMalformedAttrExpectedLiteralOrDelimiter,
+    NonMetaItemDiagnosticAttribute,
 }
 
 #[derive(Debug, Clone, HashStable_Generic)]

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -735,6 +735,7 @@ pub enum AttributeLintKind {
     ExpectedNameValue,
     MalFormedDiagnosticAttribute {
         attribute: &'static str,
+        options: &'static str,
         span: Span,
     },
     MalformedDiagnosticFormat {
@@ -752,6 +753,7 @@ pub enum AttributeLintKind {
     },
     MissingOptionsForDiagnosticAttribute {
         attribute: &'static str,
+        options: &'static str,
     },
     NonMetaItemDiagnosticAttribute,
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -753,9 +753,6 @@ pub enum AttributeLintKind {
     MissingOptionsForDiagnosticAttribute {
         attribute: &'static str,
     },
-    OnMoveMalformedFormatLiterals {
-        name: Symbol,
-    },
     NonMetaItemDiagnosticAttribute,
 }
 

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -140,7 +140,7 @@ pub fn test3() {}
 struct Test;
 
 #[diagnostic::on_unimplemented]
-//~^ WARN missing options for `on_unimplemented` attribute
+//~^ WARN missing options for `diagnostic::on_unimplemented` attribute
 #[diagnostic::on_unimplemented = 1]
 //~^ WARN malformed
 trait Hey {

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -802,7 +802,7 @@ LL | #[diagnostic::on_unimplemented]
    = help: at least one of the `message`, `note` and `label` options are expected
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/malformed-attrs.rs:144:1
    |
 LL | #[diagnostic::on_unimplemented = 1]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -793,7 +793,7 @@ LL | #[no_implicit_prelude = 23]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = help: `#[no_implicit_prelude]` can be applied to crates and modules
 
-warning: missing options for `on_unimplemented` attribute
+warning: missing options for `diagnostic::on_unimplemented` attribute
   --> $DIR/malformed-attrs.rs:142:1
    |
 LL | #[diagnostic::on_unimplemented]

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.rs
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.rs
@@ -1,7 +1,7 @@
 #![feature(diagnostic_on_move)]
 
 #[diagnostic::on_move = "foo"]
-//~^WARN missing options for `diagnostic::on_move` attribute [malformed_diagnostic_attributes]
+//~^WARN malformed `diagnostic::on_move` attribute [malformed_diagnostic_attributes]
 struct Foo;
 
 fn takes_foo(_: Foo) {}

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.rs
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.rs
@@ -1,7 +1,7 @@
 #![feature(diagnostic_on_move)]
 
 #[diagnostic::on_move = "foo"]
-//~^WARN missing options for `on_move` attribute [malformed_diagnostic_attributes]
+//~^WARN missing options for `diagnostic::on_move` attribute [malformed_diagnostic_attributes]
 struct Foo;
 
 fn takes_foo(_: Foo) {}

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.stderr
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.stderr
@@ -1,4 +1,4 @@
-warning: missing options for `on_move` attribute
+warning: missing options for `diagnostic::on_move` attribute
   --> $DIR/report_warning_on_invalid_meta_item_syntax.rs:3:1
    |
 LL | #[diagnostic::on_move = "foo"]

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.stderr
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_invalid_meta_item_syntax.stderr
@@ -1,10 +1,10 @@
-warning: missing options for `diagnostic::on_move` attribute
+warning: malformed `diagnostic::on_move` attribute
   --> $DIR/report_warning_on_invalid_meta_item_syntax.rs:3:1
    |
 LL | #[diagnostic::on_move = "foo"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
    |
-   = help: at least one of the `message`, `note` and `label` options are expected
+   = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0382]: use of moved value: `foo`

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_missing_options.rs
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_missing_options.rs
@@ -1,7 +1,7 @@
 #![feature(diagnostic_on_move)]
 
 #[diagnostic::on_move]
-//~^WARN missing options for `on_move` attribute [malformed_diagnostic_attributes]
+//~^WARN missing options for `diagnostic::on_move` attribute [malformed_diagnostic_attributes]
 struct Foo;
 
 fn takes_foo(_: Foo) {}

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_missing_options.stderr
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_missing_options.stderr
@@ -1,4 +1,4 @@
-warning: missing options for `on_move` attribute
+warning: missing options for `diagnostic::on_move` attribute
   --> $DIR/report_warning_on_missing_options.rs:3:1
    |
 LL | #[diagnostic::on_move]

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_unknown_options.rs
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_unknown_options.rs
@@ -4,8 +4,8 @@
     message = "Foo",
     label = "Bar",
     baz="Baz"
-    //~^WARN unknown or malformed `on_move` attribute
-    //~|HELP only `message`, `note` and `label` are allowed as options. Their values must be string literals
+    //~^WARN malformed `diagnostic::on_move` attribute
+    //~|HELP only `message`, `note` and `label` are allowed as options
 )]
 struct Foo;
 

--- a/tests/ui/diagnostic_namespace/on_move/report_warning_on_unknown_options.stderr
+++ b/tests/ui/diagnostic_namespace/on_move/report_warning_on_unknown_options.stderr
@@ -1,10 +1,10 @@
-warning: unknown or malformed `on_move` attribute
+warning: malformed `diagnostic::on_move` attribute
   --> $DIR/report_warning_on_unknown_options.rs:6:5
    |
 LL |     baz="Baz"
    |     ^^^^^^^^^ invalid option found here
    |
-   = help: only `message`, `note` and `label` are allowed as options. Their values must be string literals
+   = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0382]: Foo

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.rs
@@ -4,19 +4,19 @@
 //@ reference: attributes.diagnostic.on_unimplemented.invalid-formats
 #[diagnostic::on_unimplemented(
     on(Self = "&str"),
-    //~^WARN malformed `on_unimplemented` attribute
+    //~^WARN malformed `diagnostic::on_unimplemented` attribute
     message = "trait has `{Self}` and `{T}` as params",
     label = "trait has `{Self}` and `{T}` as params",
     note  = "trait has `{Self}` and `{T}` as params",
     parent_label = "in this scope",
-    //~^WARN malformed `on_unimplemented` attribute
+    //~^WARN malformed `diagnostic::on_unimplemented` attribute
     append_const_msg
-    //~^WARN malformed `on_unimplemented` attribute
+    //~^WARN malformed `diagnostic::on_unimplemented` attribute
 )]
 trait Foo<T> {}
 
 #[diagnostic::on_unimplemented = "Message"]
-//~^WARN malformed `on_unimplemented` attribute
+//~^WARN malformed `diagnostic::on_unimplemented` attribute
 trait Bar {}
 
 #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
@@ -119,7 +119,7 @@ LL |     label = "{float}{_Self}{crate_local}{Trait}{ItemContext}{This}"
    |
    = help: expect either a generic argument name or `{Self}` as format argument
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:6:5
    |
 LL |     on(Self = "&str"),
@@ -128,7 +128,7 @@ LL |     on(Self = "&str"),
    = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:11:5
    |
 LL |     parent_label = "in this scope",
@@ -136,7 +136,7 @@ LL |     parent_label = "in this scope",
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:13:5
    |
 LL |     append_const_msg
@@ -144,7 +144,7 @@ LL |     append_const_msg
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:18:1
    |
 LL | #[diagnostic::on_unimplemented = "Message"]

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.rs
@@ -25,7 +25,7 @@ trait _Self {}
 trait Doom {}
 
 #[diagnostic::on_unimplemented]
-//~^WARN missing options for `on_unimplemented` attribute
+//~^WARN missing options for `diagnostic::on_unimplemented` attribute
 trait Whatever {}
 
 #[diagnostic::on_unimplemented(message = "{DoesNotExist}")]

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.rs
@@ -1,7 +1,7 @@
 //@ reference: attributes.diagnostic.on_unimplemented.syntax
 //@ reference: attributes.diagnostic.on_unimplemented.unknown-keys
 #[diagnostic::on_unimplemented(unsupported = "foo")]
-//~^WARN malformed `on_unimplemented` attribute
+//~^WARN malformed `diagnostic::on_unimplemented` attribute
 trait Foo {}
 
 #[diagnostic::on_unimplemented(message = "Baz")]
@@ -9,19 +9,19 @@ trait Foo {}
 struct Bar {}
 
 #[diagnostic::on_unimplemented(message = "Boom", unsupported = "Bar")]
-//~^WARN malformed `on_unimplemented` attribute
+//~^WARN malformed `diagnostic::on_unimplemented` attribute
 trait Baz {}
 
 #[diagnostic::on_unimplemented(message = "Boom", on(Self = "i32", message = "whatever"))]
-//~^WARN malformed `on_unimplemented` attribute
+//~^WARN malformed `diagnostic::on_unimplemented` attribute
 trait Boom {}
 
 #[diagnostic::on_unimplemented(message = "Boom", on(_Self = "i32", message = "whatever"))]
-//~^WARN malformed `on_unimplemented` attribute
+//~^WARN malformed `diagnostic::on_unimplemented` attribute
 trait _Self {}
 
 #[diagnostic::on_unimplemented = "boom"]
-//~^WARN malformed `on_unimplemented` attribute
+//~^WARN malformed `diagnostic::on_unimplemented` attribute
 trait Doom {}
 
 #[diagnostic::on_unimplemented]

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -15,7 +15,7 @@ LL | #[diagnostic::on_unimplemented(message = "{DoesNotExist}")]
    = help: expect either a generic argument name or `{Self}` as format argument
    = note: `#[warn(malformed_diagnostic_format_literals)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:3:32
    |
 LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
@@ -24,7 +24,7 @@ LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
    = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:11:50
    |
 LL | #[diagnostic::on_unimplemented(message = "Boom", unsupported = "Bar")]
@@ -32,7 +32,7 @@ LL | #[diagnostic::on_unimplemented(message = "Boom", unsupported = "Bar")]
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:15:50
    |
 LL | #[diagnostic::on_unimplemented(message = "Boom", on(Self = "i32", message = "whatever"))]
@@ -40,7 +40,7 @@ LL | #[diagnostic::on_unimplemented(message = "Boom", on(Self = "i32", message =
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:19:50
    |
 LL | #[diagnostic::on_unimplemented(message = "Boom", on(_Self = "i32", message = "whatever"))]
@@ -48,7 +48,7 @@ LL | #[diagnostic::on_unimplemented(message = "Boom", on(_Self = "i32", message 
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: malformed `on_unimplemented` attribute
+warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:23:1
    |
 LL | #[diagnostic::on_unimplemented = "boom"]

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -56,7 +56,7 @@ LL | #[diagnostic::on_unimplemented = "boom"]
    |
    = help: only `message`, `note` and `label` are allowed as options
 
-warning: missing options for `on_unimplemented` attribute
+warning: missing options for `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:27:1
    |
 LL | #[diagnostic::on_unimplemented]

--- a/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 #[diagnostic::on_unknown(foo = "bar", message = "foo")]
-//~^WARN malformed `on_unknown` attribute
+//~^WARN malformed `diagnostic::on_unknown` attribute
 use std::str::Bytes;
 
 #[diagnostic::on_unknown(label = "foo", label = "bar")]

--- a/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.rs
@@ -1,6 +1,6 @@
 #![feature(diagnostic_on_unknown)]
 #[diagnostic::on_unknown]
-//~^WARN missing options for `on_unknown` attribute
+//~^WARN missing options for `diagnostic::on_unknown` attribute
 use std::str::FromStr;
 
 #[diagnostic::on_unknown(foo = "bar", message = "foo")]

--- a/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.stderr
@@ -15,7 +15,7 @@ LL | #[diagnostic::on_unknown]
    = help: at least one of the `message`, `note` and `label` options are expected
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
-warning: malformed `on_unknown` attribute
+warning: malformed `diagnostic::on_unknown` attribute
   --> $DIR/malformed_attribute.rs:6:26
    |
 LL | #[diagnostic::on_unknown(foo = "bar", message = "foo")]

--- a/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.stderr
@@ -6,7 +6,7 @@ LL | use std::str::NotExisting;
    |
    = note: unresolved import `std::str::NotExisting`
 
-warning: missing options for `on_unknown` attribute
+warning: missing options for `diagnostic::on_unknown` attribute
   --> $DIR/malformed_attribute.rs:2:1
    |
 LL | #[diagnostic::on_unknown]

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -13,7 +13,7 @@ trait MyFromIterator<A> {
 }
 
 #[rustc_on_unimplemented]
-//~^ WARN missing options for `on_unimplemented` attribute
+//~^ WARN missing options for `rustc_on_unimplemented` attribute
 //~| NOTE part of
 trait NoContent {}
 

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -27,21 +27,19 @@ trait ParameterNotPresent<A, B> {}
 trait NoPositionalArgs<A, B> {}
 
 #[rustc_on_unimplemented(lorem = "")]
-//~^ ERROR this attribute must have a value
-//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
-//~^^^ NOTE expected value here
+//~^WARN malformed `rustc_on_unimplemented` attribute
+//~|NOTE invalid option found here
 trait EmptyMessage {}
 
 #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
-//~^ ERROR this attribute must have a value
-//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
-//~^^^ NOTE expected value here
+//~^WARN malformed `rustc_on_unimplemented` attribute
+//~|NOTE invalid option found here
 trait Invalid {}
 
 #[rustc_on_unimplemented(message = "x", message = "y")]
-//~^ ERROR this attribute must have a value
-//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
-//~^^^ NOTE expected value here
+//~^WARN `message` is ignored due to previous definition of `message`
+//~|NOTE `message` is first declared here
+//~|NOTE `message` is later redundantly declared here
 trait DuplicateMessage {}
 
 #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
@@ -55,21 +53,18 @@ trait OnInWrongPosition {}
 trait EmptyOn {}
 
 #[rustc_on_unimplemented(on = "x", message = "y")]
-//~^ ERROR this attribute must have a value
-//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
-//~^^^ NOTE expected value here
+//~^WARN malformed `rustc_on_unimplemented` attribute
+//~|NOTE invalid option found here
 trait ExpectedPredicateInOn {}
 
 #[rustc_on_unimplemented(on(Self = "y"), message = "y")]
-//~^ ERROR this attribute must have a value
-//~| NOTE expected value here
-//~| NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^WARN malformed `rustc_on_unimplemented` attribute
+//~|NOTE invalid option found here
 trait OnWithoutDirectives {}
 
 #[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
-//~^ ERROR this attribute must have a value
-//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
-//~^^^ NOTE expected value here
+//~^WARN malformed `rustc_on_unimplemented` attribute
+//~|NOTE invalid option found here
 trait NestedOn {}
 
 #[rustc_on_unimplemented(on("y", message = "y"))]

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -126,7 +126,7 @@ warning: there is no parameter `abc` on trait `InvalidName2`
 LL | #[rustc_on_unimplemented(on(abc = "y", message = "y"))]
    |                             ^^^^^^^^^
 
-warning: missing options for `on_unimplemented` attribute
+warning: missing options for `rustc_on_unimplemented` attribute
   --> $DIR/bad-annotation.rs:15:1
    |
 LL | #[rustc_on_unimplemented]

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -84,7 +84,7 @@ warning: missing options for `rustc_on_unimplemented` attribute
 LL | #[rustc_on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: at least one of the `message`, `note` and `label` options are expected
+   = help: see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: positional format arguments are not allowed here
@@ -101,7 +101,7 @@ warning: malformed `rustc_on_unimplemented` attribute
 LL | #[rustc_on_unimplemented(lorem = "")]
    |                          ^^^^^^^^^^ invalid option found here
    |
-   = help: only `message`, `note` and `label` are allowed as options
+   = help: see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>
 
 warning: malformed `rustc_on_unimplemented` attribute
   --> $DIR/bad-annotation.rs:34:26
@@ -109,7 +109,7 @@ warning: malformed `rustc_on_unimplemented` attribute
 LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    |                          ^^^^^^^^^^^^^^^^^^^ invalid option found here
    |
-   = help: only `message`, `note` and `label` are allowed as options
+   = help: see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>
 
 warning: `message` is ignored due to previous definition of `message`
   --> $DIR/bad-annotation.rs:39:41
@@ -125,7 +125,7 @@ warning: malformed `rustc_on_unimplemented` attribute
 LL | #[rustc_on_unimplemented(on = "x", message = "y")]
    |                          ^^^^^^^^ invalid option found here
    |
-   = help: only `message`, `note` and `label` are allowed as options
+   = help: see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>
 
 warning: malformed `rustc_on_unimplemented` attribute
   --> $DIR/bad-annotation.rs:60:26
@@ -133,7 +133,7 @@ warning: malformed `rustc_on_unimplemented` attribute
 LL | #[rustc_on_unimplemented(on(Self = "y"), message = "y")]
    |                          ^^^^^^^^^^^^^^ invalid option found here
    |
-   = help: only `message`, `note` and `label` are allowed as options
+   = help: see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>
 
 warning: malformed `rustc_on_unimplemented` attribute
   --> $DIR/bad-annotation.rs:65:46
@@ -141,7 +141,7 @@ warning: malformed `rustc_on_unimplemented` attribute
 LL | #[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
    |
-   = help: only `message`, `note` and `label` are allowed as options
+   = help: see <https://rustc-dev-guide.rust-lang.org/diagnostics.html#rustc_on_unimplemented>
 
 error: aborting due to 10 previous errors; 11 warnings emitted
 

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -1,107 +1,59 @@
-error[E0232]: this attribute must have a value
-  --> $DIR/bad-annotation.rs:29:26
-   |
-LL | #[rustc_on_unimplemented(lorem = "")]
-   |                          ^^^^^^^^^^ expected value here
-   |
-   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
-
-error[E0232]: this attribute must have a value
-  --> $DIR/bad-annotation.rs:35:26
-   |
-LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
-   |                          ^^^^^^^^^^^^^^^^^^^ expected value here
-   |
-   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
-
-error[E0232]: this attribute must have a value
-  --> $DIR/bad-annotation.rs:41:41
-   |
-LL | #[rustc_on_unimplemented(message = "x", message = "y")]
-   |                                         ^^^^^^^^^^^^^ expected value here
-   |
-   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
-
 error[E0232]: invalid flag in `on`-clause
-  --> $DIR/bad-annotation.rs:47:44
+  --> $DIR/bad-annotation.rs:45:44
    |
 LL | #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
    |                                            ^^^^^^^^^ expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `desugared`
 
 error[E0232]: empty `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:52:26
+  --> $DIR/bad-annotation.rs:50:26
    |
 LL | #[rustc_on_unimplemented(on(), message = "y")]
    |                          ^^^^ empty `on`-clause here
 
-error[E0232]: this attribute must have a value
-  --> $DIR/bad-annotation.rs:57:26
-   |
-LL | #[rustc_on_unimplemented(on = "x", message = "y")]
-   |                          ^^^^^^^^ expected value here
-   |
-   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
-
-error[E0232]: this attribute must have a value
-  --> $DIR/bad-annotation.rs:63:26
-   |
-LL | #[rustc_on_unimplemented(on(Self = "y"), message = "y")]
-   |                          ^^^^^^^^^^^^^^ expected value here
-   |
-   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
-
-error[E0232]: this attribute must have a value
-  --> $DIR/bad-annotation.rs:69:46
-   |
-LL | #[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
-   |
-   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
-
 error[E0232]: literals inside `on`-clauses are not supported
-  --> $DIR/bad-annotation.rs:75:29
+  --> $DIR/bad-annotation.rs:70:29
    |
 LL | #[rustc_on_unimplemented(on("y", message = "y"))]
    |                             ^^^ unexpected literal here
 
 error[E0232]: literals inside `on`-clauses are not supported
-  --> $DIR/bad-annotation.rs:80:29
+  --> $DIR/bad-annotation.rs:75:29
    |
 LL | #[rustc_on_unimplemented(on(42, message = "y"))]
    |                             ^^ unexpected literal here
 
 error[E0232]: expected a single predicate in `not(..)`
-  --> $DIR/bad-annotation.rs:85:32
+  --> $DIR/bad-annotation.rs:80:32
    |
 LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
    |                                ^^^^^^ unexpected quantity of predicates here
 
 error[E0232]: expected a single predicate in `not(..)`
-  --> $DIR/bad-annotation.rs:90:32
+  --> $DIR/bad-annotation.rs:85:32
    |
 LL | #[rustc_on_unimplemented(on(not(), message = "y"))]
    |                                ^^ unexpected quantity of predicates here
 
 error[E0232]: expected an identifier inside this `on`-clause
-  --> $DIR/bad-annotation.rs:95:29
+  --> $DIR/bad-annotation.rs:90:29
    |
 LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
    |                             ^^^^^^^^^^^ expected an identifier here, not `thing::What`
 
 error[E0232]: expected an identifier inside this `on`-clause
-  --> $DIR/bad-annotation.rs:100:29
+  --> $DIR/bad-annotation.rs:95:29
    |
 LL | #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
    |                             ^^^^^^^^^^^ expected an identifier here, not `thing::What`
 
 error[E0232]: this predicate is invalid
-  --> $DIR/bad-annotation.rs:105:29
+  --> $DIR/bad-annotation.rs:100:29
    |
 LL | #[rustc_on_unimplemented(on(aaaaaaaaaaaaaa(a, b), message = "y"))]
    |                             ^^^^^^^^^^^^^^ expected one of `any`, `all` or `not` here, not `aaaaaaaaaaaaaa`
 
 error[E0232]: invalid flag in `on`-clause
-  --> $DIR/bad-annotation.rs:110:29
+  --> $DIR/bad-annotation.rs:105:29
    |
 LL | #[rustc_on_unimplemented(on(something, message = "y"))]
    |                             ^^^^^^^^^ expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `something`
@@ -115,13 +67,13 @@ LL | #[rustc_on_unimplemented(label = "Unimplemented error on `{Self}` with para
    = note: `#[warn(malformed_diagnostic_format_literals)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: there is no parameter `_Self` on trait `InvalidName`
-  --> $DIR/bad-annotation.rs:115:29
+  --> $DIR/bad-annotation.rs:110:29
    |
 LL | #[rustc_on_unimplemented(on(_Self = "y", message = "y"))]
    |                             ^^^^^^^^^^^
 
 warning: there is no parameter `abc` on trait `InvalidName2`
-  --> $DIR/bad-annotation.rs:119:29
+  --> $DIR/bad-annotation.rs:114:29
    |
 LL | #[rustc_on_unimplemented(on(abc = "y", message = "y"))]
    |                             ^^^^^^^^^
@@ -143,6 +95,54 @@ LL | #[rustc_on_unimplemented(label = "Unimplemented error on `{Self}` with para
    |
    = help: only named format arguments with the name of one of the generic types are allowed in this context
 
-error: aborting due to 16 previous errors; 5 warnings emitted
+warning: malformed `rustc_on_unimplemented` attribute
+  --> $DIR/bad-annotation.rs:29:26
+   |
+LL | #[rustc_on_unimplemented(lorem = "")]
+   |                          ^^^^^^^^^^ invalid option found here
+   |
+   = help: only `message`, `note` and `label` are allowed as options
+
+warning: malformed `rustc_on_unimplemented` attribute
+  --> $DIR/bad-annotation.rs:34:26
+   |
+LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
+   |                          ^^^^^^^^^^^^^^^^^^^ invalid option found here
+   |
+   = help: only `message`, `note` and `label` are allowed as options
+
+warning: `message` is ignored due to previous definition of `message`
+  --> $DIR/bad-annotation.rs:39:41
+   |
+LL | #[rustc_on_unimplemented(message = "x", message = "y")]
+   |                          -------------  ^^^^^^^^^^^^^ `message` is later redundantly declared here
+   |                          |
+   |                          `message` is first declared here
+
+warning: malformed `rustc_on_unimplemented` attribute
+  --> $DIR/bad-annotation.rs:55:26
+   |
+LL | #[rustc_on_unimplemented(on = "x", message = "y")]
+   |                          ^^^^^^^^ invalid option found here
+   |
+   = help: only `message`, `note` and `label` are allowed as options
+
+warning: malformed `rustc_on_unimplemented` attribute
+  --> $DIR/bad-annotation.rs:60:26
+   |
+LL | #[rustc_on_unimplemented(on(Self = "y"), message = "y")]
+   |                          ^^^^^^^^^^^^^^ invalid option found here
+   |
+   = help: only `message`, `note` and `label` are allowed as options
+
+warning: malformed `rustc_on_unimplemented` attribute
+  --> $DIR/bad-annotation.rs:65:46
+   |
+LL | #[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
+   |
+   = help: only `message`, `note` and `label` are allowed as options
+
+error: aborting due to 10 previous errors; 11 warnings emitted
 
 For more information about this error, try `rustc --explain E0232`.


### PR DESCRIPTION
There was a fair amount of duplication here, and thanks to the proliferation of new diagnostic attributes these days, it was threatening to grow bigger.


