### PR TITLE
cg_clif: Don't show verbose run-make cmd output for passing tests

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/test_rustc_tests.sh
@@ -198,5 +198,5 @@ index 073116933bd..c3e4578204d 100644
 EOF
 
 echo "[TEST] rustc test suite"
-./x.py test --stage 0 --test-args=--no-capture tests/{codegen-units,run-make,run-make-cargo,ui,incremental}
+./x.py test --stage 0 --no-capture --verbose-run-make-subprocess-output=false tests/{codegen-units,run-make,run-make-cargo,ui,incremental}
 popd


### PR DESCRIPTION
Uses `--verbose-run-make-subprocess-output=false` added in rust-lang/rust#154587 to suppress verbose cmd dump for passing `run-make` tests.

Closes rust-lang/rust#154069.