### PR TITLE
Check diagnostic output in incremental `cpass` and `rpass` revisions

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -995,6 +995,7 @@ impl<'test> TestCx<'test> {
                     AllowUnused::No
                 }
             }
+            TestMode::Incremental => AllowUnused::Yes,
             _ => AllowUnused::No,
         };
 

--- a/src/tools/compiletest/src/runtest/incremental.rs
+++ b/src/tools/compiletest/src/runtest/incremental.rs
@@ -1,4 +1,4 @@
-use super::{FailMode, TestCx, WillExecute};
+use super::{FailMode, ProcRes, TestCx, WillExecute};
 use crate::errors;
 
 impl TestCx<'_> {
@@ -93,16 +93,20 @@ impl TestCx<'_> {
         self.check_if_test_should_compile(Some(FailMode::Build), pm, &proc_res);
         self.check_no_compiler_crash(&proc_res, self.props.should_ice);
 
-        let output_to_check = self.get_output(&proc_res);
-        self.check_expected_errors(&proc_res);
-        self.check_all_error_patterns(&output_to_check, &proc_res);
+        self.check_compiler_output_for_incr(&proc_res);
+
         if self.props.should_ice {
             match proc_res.status.code() {
                 Some(101) => (),
                 _ => self.fatal("expected ICE"),
             }
         }
+    }
 
-        self.check_forbid_output(&output_to_check, &proc_res);
+    fn check_compiler_output_for_incr(&self, proc_res: &ProcRes) {
+        let output_to_check = self.get_output(proc_res);
+        self.check_expected_errors(&proc_res);
+        self.check_all_error_patterns(&output_to_check, proc_res);
+        self.check_forbid_output(&output_to_check, proc_res);
     }
 }

--- a/src/tools/compiletest/src/runtest/incremental.rs
+++ b/src/tools/compiletest/src/runtest/incremental.rs
@@ -1,5 +1,4 @@
 use super::{FailMode, ProcRes, TestCx, WillExecute};
-use crate::errors;
 
 impl TestCx<'_> {
     pub(super) fn run_incremental_test(&self) {
@@ -57,10 +56,7 @@ impl TestCx<'_> {
             self.fatal_proc_rec("compilation failed!", &proc_res);
         }
 
-        // FIXME(#41968): Move this check to tidy?
-        if !errors::load_errors(&self.testpaths.file, self.revision).is_empty() {
-            self.fatal("build-pass tests with expected warnings should be moved to ui/");
-        }
+        self.check_compiler_output_for_incr(&proc_res);
     }
 
     fn run_rpass_test(&self) {
@@ -72,10 +68,7 @@ impl TestCx<'_> {
             self.fatal_proc_rec("compilation failed!", &proc_res);
         }
 
-        // FIXME(#41968): Move this check to tidy?
-        if !errors::load_errors(&self.testpaths.file, self.revision).is_empty() {
-            self.fatal("run-pass tests with expected warnings should be moved to ui/");
-        }
+        self.check_compiler_output_for_incr(&proc_res);
 
         if let WillExecute::Disabled = should_run {
             return;

--- a/tests/incremental/const-generics/change-const-param-gat.rs
+++ b/tests/incremental/const-generics/change-const-param-gat.rs
@@ -1,7 +1,6 @@
 //@ revisions: rpass1 rpass2 rpass3
 //@ compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
-#![feature(generic_associated_types)]
 
 // This test unsures that with_opt_const_param returns the
 // def_id of the N param in the Foo::Assoc GAT.

--- a/tests/incremental/krate_reassign_34991/main.rs
+++ b/tests/incremental/krate_reassign_34991/main.rs
@@ -8,13 +8,13 @@
 extern crate a;
 
 #[cfg(rpass1)]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: a::X = 22;
     x as u32
 }
 
 #[cfg(rpass2)]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     22
 }
 

--- a/tests/incremental/rlib_cross_crate/b.rs
+++ b/tests/incremental/rlib_cross_crate/b.rs
@@ -15,14 +15,14 @@ extern crate a;
 
 #[rustc_clean(except="typeck_root,optimized_mir", cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: a::X = 22;
     x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: a::Y = 'c';
 }
 

--- a/tests/incremental/split_debuginfo_mode.rs
+++ b/tests/incremental/split_debuginfo_mode.rs
@@ -5,6 +5,7 @@
 // ignore-tidy-linelength
 //@ only-x86_64-unknown-linux-gnu
 //@ revisions:rpass1 rpass2 rpass3 rpass4
+//@ ignore-backends: gcc
 
 //@ [rpass1]compile-flags: -Zquery-dep-graph -Csplit-debuginfo=unpacked -Zsplit-dwarf-kind=single -Zsplit-dwarf-inlining=on
 //@ [rpass2]compile-flags: -Zquery-dep-graph -Csplit-debuginfo=packed -Zsplit-dwarf-kind=single -Zsplit-dwarf-inlining=on

--- a/tests/incremental/static_cycle/b.rs
+++ b/tests/incremental/static_cycle/b.rs
@@ -3,8 +3,8 @@
 
 #![cfg_attr(rpass2, warn(dead_code))]
 
-pub static mut BAA: *const i8 = unsafe { &BOO as *const _ as *const i8 };
+pub static mut BAA: *const i8 = unsafe { &raw const BOO as *const i8 };
 
-pub static mut BOO: *const i8 = unsafe { &BAA as *const _ as *const i8 };
+pub static mut BOO: *const i8 = unsafe { &raw const BAA as *const i8 };
 
 fn main() {}

--- a/tests/incremental/struct_add_field.rs
+++ b/tests/incremental/struct_add_field.rs
@@ -23,17 +23,17 @@ pub struct Y {
 }
 
 #[rustc_clean(except="fn_sig,typeck_root", cfg="rpass2")]
-pub fn use_X(x: X) -> u32 {
+pub fn use_x(x: X) -> u32 {
     x.x as u32
 }
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
-pub fn use_EmbedX(embed: EmbedX) -> u32 {
+pub fn use_embed_x(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }
 

--- a/tests/incremental/struct_change_field_name.rs
+++ b/tests/incremental/struct_change_field_name.rs
@@ -27,7 +27,7 @@ pub struct Y {
 }
 
 #[rustc_clean(except="typeck_root", cfg="cfail2")]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: X = X { x: 22 };
     //[cfail2]~^ ERROR struct `X` has no field named `x`
     x.x as u32
@@ -35,13 +35,13 @@ pub fn use_X() -> u32 {
 }
 
 #[rustc_clean(except="typeck_root", cfg="cfail2")]
-pub fn use_EmbedX(embed: EmbedX) -> u32 {
+pub fn use_embed_x(embed: EmbedX) -> u32 {
     embed.x.x as u32
     //[cfail2]~^ ERROR no field `x` on type `X`
 }
 
 #[rustc_clean(cfg="cfail2")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }
 

--- a/tests/incremental/struct_change_field_type.rs
+++ b/tests/incremental/struct_change_field_type.rs
@@ -26,19 +26,19 @@ pub struct Y {
 }
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
-pub fn use_EmbedX(x: EmbedX) -> u32 {
+pub fn use_embed_x(x: EmbedX) -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }
 

--- a/tests/incremental/struct_change_field_type_cross_crate/b.rs
+++ b/tests/incremental/struct_change_field_type_cross_crate/b.rs
@@ -10,18 +10,18 @@ extern crate a;
 use a::*;
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
-pub fn use_EmbedX(embed: EmbedX) -> u32 {
+pub fn use_embed_x(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }
 

--- a/tests/incremental/struct_change_nothing.rs
+++ b/tests/incremental/struct_change_nothing.rs
@@ -26,19 +26,19 @@ pub struct Y {
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_EmbedX(x: EmbedX) -> u32 {
+pub fn use_embed_x(x: EmbedX) -> u32 {
     let x: X = X { x: 22 };
     x.x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }
 

--- a/tests/incremental/struct_remove_field.rs
+++ b/tests/incremental/struct_remove_field.rs
@@ -27,17 +27,17 @@ pub struct Y {
 }
 
 #[rustc_clean(except="typeck_root,fn_sig", cfg="rpass2")]
-pub fn use_X(x: X) -> u32 {
+pub fn use_x(x: X) -> u32 {
     x.x as u32
 }
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
-pub fn use_EmbedX(embed: EmbedX) -> u32 {
+pub fn use_embed_x(embed: EmbedX) -> u32 {
     embed.x.x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }
 

--- a/tests/incremental/type_alias_cross_crate/b.rs
+++ b/tests/incremental/type_alias_cross_crate/b.rs
@@ -9,14 +9,14 @@ extern crate a;
 
 #[rustc_clean(except="typeck_root", cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
-pub fn use_X() -> u32 {
+pub fn use_x() -> u32 {
     let x: a::X = 22;
     x as u32
 }
 
 #[rustc_clean(cfg="rpass2")]
 #[rustc_clean(cfg="rpass3")]
-pub fn use_Y() {
+pub fn use_y() {
     let x: a::Y = 'c';
 }
 


### PR DESCRIPTION
This allows compiler warnings to be annotated in `cpass` and `rpass` revisions, and verifies that no unexpected warnings occur.

---

My underlying motivation is that I want to be able to reduce or eliminate the confusing combination of `cfail` revisions with `//@ build-pass` directives, and replace them with a more straightforward `cpass` revision that also checks diagnostic output. That migration is not part of this PR.