### PR TITLE
Remove redundant suffixes from `Try` (`TryType`, `TryTrait`)

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -609,7 +609,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
 
             // `::std::ops::Try::from_output($tail_expr)`
             block.expr = Some(this.wrap_in_try_constructor(
-                hir::LangItem::TryTraitFromOutput,
+                hir::LangItem::TryFromOutput,
                 try_span,
                 tail_expr,
                 ok_wrapped_span,
@@ -1972,7 +1972,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
     ///     ControlFlow::Break(residual) =>
     ///         #[allow(unreachable_code)]
     ///         // If there is an enclosing `try {...}`:
-    ///         break 'catch_target Residual::into_try_type(residual),
+    ///         break 'catch_target Residual::into_try(residual),
     ///         // Otherwise:
     ///         return Try::from_residual(residual),
     /// }
@@ -1997,7 +1997,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
 
             self.expr_call_lang_item_fn(
                 unstable_span,
-                hir::LangItem::TryTraitBranch,
+                hir::LangItem::TryBranch,
                 arena_vec![self; sub_expr],
             )
         };
@@ -2024,13 +2024,13 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
 
             let (constructor_item, target_id) = match self.try_block_scope {
                 TryBlockScope::Function => {
-                    (hir::LangItem::TryTraitFromResidual, Err(hir::LoopIdError::OutsideLoopScope))
+                    (hir::LangItem::TryFromResidual, Err(hir::LoopIdError::OutsideLoopScope))
                 }
                 TryBlockScope::Homogeneous(block_id) => {
-                    (hir::LangItem::ResidualIntoTryType, Ok(block_id))
+                    (hir::LangItem::ResidualIntoTry, Ok(block_id))
                 }
                 TryBlockScope::Heterogeneous(block_id) => {
-                    (hir::LangItem::TryTraitFromResidual, Ok(block_id))
+                    (hir::LangItem::TryFromResidual, Ok(block_id))
                 }
             };
             let from_residual_expr = self.wrap_in_try_constructor(
@@ -2088,7 +2088,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
         );
 
         let from_yeet_expr = self.wrap_in_try_constructor(
-            hir::LangItem::TryTraitFromYeet,
+            hir::LangItem::TryFromYeet,
             unstable_span,
             yeeted_expr,
             yeeted_span,

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -356,11 +356,11 @@ language_item_table! {
     SliceLen,                sym::slice_len_fn,        slice_len_fn,               Target::Method(MethodKind::Inherent), GenericRequirement::None;
 
     // Language items from AST lowering
-    TryTraitFromResidual,    sym::from_residual,       from_residual_fn,           Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
-    TryTraitFromOutput,      sym::from_output,         from_output_fn,             Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
-    TryTraitBranch,          sym::branch,              branch_fn,                  Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
-    TryTraitFromYeet,        sym::from_yeet,           from_yeet_fn,               Target::Fn,             GenericRequirement::None;
-    ResidualIntoTryType,     sym::into_try_type,       into_try_type_fn,           Target::Fn,             GenericRequirement::None;
+    TryFromResidual,    sym::from_residual,       from_residual_fn,           Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
+    TryFromOutput,      sym::from_output,         from_output_fn,             Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
+    TryBranch,          sym::branch,              branch_fn,                  Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
+    TryFromYeet,        sym::from_yeet,           from_yeet_fn,               Target::Fn,             GenericRequirement::None;
+    ResidualIntoTry,    sym::into_try,            into_try_fn,                Target::Fn,             GenericRequirement::None;
 
     CoercePointeeValidated, sym::coerce_pointee_validated, coerce_pointee_validated_trait, Target::Trait,     GenericRequirement::Exact(0);
 

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -576,9 +576,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 {
                     Some(ObligationCauseCode::ForLoopIterator)
                 }
-                LangItem::TryFromOutput
-                    if expr.span.is_desugaring(DesugaringKind::TryBlock) =>
-                {
+                LangItem::TryFromOutput if expr.span.is_desugaring(DesugaringKind::TryBlock) => {
                     // FIXME it's a try block, not a question mark
                     Some(ObligationCauseCode::QuestionMark)
                 }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -576,13 +576,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 {
                     Some(ObligationCauseCode::ForLoopIterator)
                 }
-                LangItem::TryTraitFromOutput
+                LangItem::TryFromOutput
                     if expr.span.is_desugaring(DesugaringKind::TryBlock) =>
                 {
                     // FIXME it's a try block, not a question mark
                     Some(ObligationCauseCode::QuestionMark)
                 }
-                LangItem::TryTraitBranch | LangItem::TryTraitFromResidual
+                LangItem::TryBranch | LangItem::TryFromResidual
                     if expr.span.is_desugaring(DesugaringKind::QuestionMark) =>
                 {
                     Some(ObligationCauseCode::QuestionMark)

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -961,7 +961,10 @@ impl<'tcx, T> ops::Try for InterpResult<'tcx, T> {
 }
 
 impl<'tcx, T> ops::Residual<T> for InterpResult<'tcx, convert::Infallible> {
+    #[cfg(bootstrap)]
     type TryType = InterpResult<'tcx, T>;
+    #[cfg(not(bootstrap))]
+    type Try = InterpResult<'tcx, T>;
 }
 
 impl<'tcx, T> ops::FromResidual for InterpResult<'tcx, T> {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1105,7 +1105,7 @@ symbols! {
         into_async_iter_into_iter,
         into_future,
         into_iter,
-        into_try_type,
+        into_try,
         intra_doc_pointers,
         intrinsics,
         irrefutable_let_patterns,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/call_kind.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/call_kind.rs
@@ -134,14 +134,14 @@ pub fn call_kind<'tcx>(
     {
         Some((CallDesugaringKind::ForLoopNext, method_args.type_at(0)))
     } else if fn_call_span.desugaring_kind() == Some(DesugaringKind::QuestionMark) {
-        if tcx.is_lang_item(method_did, LangItem::TryTraitBranch) {
+        if tcx.is_lang_item(method_did, LangItem::TryBranch) {
             Some((CallDesugaringKind::QuestionBranch, method_args.type_at(0)))
-        } else if tcx.is_lang_item(method_did, LangItem::TryTraitFromResidual) {
+        } else if tcx.is_lang_item(method_did, LangItem::TryFromResidual) {
             Some((CallDesugaringKind::QuestionFromResidual, method_args.type_at(0)))
         } else {
             None
         }
-    } else if tcx.is_lang_item(method_did, LangItem::TryTraitFromOutput)
+    } else if tcx.is_lang_item(method_did, LangItem::TryFromOutput)
         && fn_call_span.desugaring_kind() == Some(DesugaringKind::TryBlock)
     {
         Some((CallDesugaringKind::TryBlockFromOutput, method_args.type_at(0)))

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -476,7 +476,7 @@ impl<T> Box<T> {
     pub fn try_map<R>(
         this: Self,
         f: impl FnOnce(T) -> R,
-    ) -> <R::Residual as Residual<Box<R::Output>>>::TryType
+    ) -> <R::Residual as Residual<Box<R::Output>>>::Try
     where
         R: Try,
         R::Residual: Residual<Box<R::Output>>,

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -713,7 +713,7 @@ impl<T> Rc<T> {
     pub fn try_map<R>(
         this: Self,
         f: impl FnOnce(&T) -> R,
-    ) -> <R::Residual as Residual<Rc<R::Output>>>::TryType
+    ) -> <R::Residual as Residual<Rc<R::Output>>>::Try
     where
         R: Try,
         R::Residual: Residual<Rc<R::Output>>,
@@ -4265,7 +4265,7 @@ impl<T> UniqueRc<T> {
     pub fn try_map<R>(
         this: Self,
         f: impl FnOnce(T) -> R,
-    ) -> <R::Residual as Residual<UniqueRc<R::Output>>>::TryType
+    ) -> <R::Residual as Residual<UniqueRc<R::Output>>>::Try
     where
         R: Try,
         R::Residual: Residual<UniqueRc<R::Output>>,

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -723,7 +723,7 @@ impl<T> Arc<T> {
     pub fn try_map<R>(
         this: Self,
         f: impl FnOnce(&T) -> R,
-    ) -> <R::Residual as Residual<Arc<R::Output>>>::TryType
+    ) -> <R::Residual as Residual<Arc<R::Output>>>::Try
     where
         R: Try,
         R::Residual: Residual<Arc<R::Output>>,
@@ -4691,7 +4691,7 @@ impl<T> UniqueArc<T, Global> {
     pub fn try_map<R>(
         this: Self,
         f: impl FnOnce(T) -> R,
-    ) -> <R::Residual as Residual<UniqueArc<R::Output>>>::TryType
+    ) -> <R::Residual as Residual<UniqueArc<R::Output>>>::Try
     where
         R: Try,
         R::Residual: Residual<UniqueArc<R::Output>>,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3060,7 +3060,7 @@ pub const trait Iterator {
         #[inline]
         fn check<I, V, R>(
             mut f: impl FnMut(&I) -> V,
-        ) -> impl FnMut((), I) -> ControlFlow<R::TryType>
+        ) -> impl FnMut((), I) -> ControlFlow<R::Try>
         where
             V: Try<Output = bool, Residual = R>,
             R: Residual<Option<I>>,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3058,9 +3058,7 @@ pub const trait Iterator {
         R: Try<Output = bool, Residual: Residual<Option<Self::Item>>>,
     {
         #[inline]
-        fn check<I, V, R>(
-            mut f: impl FnMut(&I) -> V,
-        ) -> impl FnMut((), I) -> ControlFlow<R::Try>
+        fn check<I, V, R>(mut f: impl FnMut(&I) -> V) -> impl FnMut((), I) -> ControlFlow<R::Try>
         where
             V: Try<Output = bool, Residual = R>,
             R: Residual<Option<I>>,

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -136,7 +136,7 @@ impl<B, C> const ops::FromResidual<ControlFlow<B, convert::Infallible>> for Cont
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try_residual", issue = "91285")]
 impl<B, C> const ops::Residual<C> for ControlFlow<B, convert::Infallible> {
-    type TryType = ControlFlow<B, C>;
+    type Try = ControlFlow<B, C>;
 }
 
 impl<B, C> ControlFlow<B, C> {

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -358,14 +358,14 @@ where
 /// For example,
 /// `Result<T, E>: Try<Output = T, Residual = Result<Infallible, E>>`,
 /// and in the other direction,
-/// `<Result<Infallible, E> as Residual<T>>::TryType = Result<T, E>`.
+/// `<Result<Infallible, E> as Residual<T>>::Try = Result<T, E>`.
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try_residual", issue = "91285")]
 pub const trait Residual<O>: Sized {
     /// The "return" type of this meta-function.
     #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
     // FIXME: ought to be implied
-    type TryType: [const] Try<Output = O, Residual = Self>;
+    type Try: [const] Try<Output = O, Residual = Self>;
 }
 
 /// Used in `try {}` blocks so the type produced in the `?` desugaring
@@ -377,17 +377,17 @@ pub const trait Residual<O>: Sized {
 // needs to be `pub` to avoid `private type` errors
 #[expect(unreachable_pub)]
 #[inline] // FIXME: force would be nice, but fails -- see #148915
-#[lang = "into_try_type"]
-pub const fn residual_into_try_type<R: [const] Residual<O>, O>(
+#[lang = "into_try"]
+pub const fn residual_into_try<R: [const] Residual<O>, O>(
     r: R,
-) -> <R as Residual<O>>::TryType {
+) -> <R as Residual<O>>::Try {
     FromResidual::from_residual(r)
 }
 
 #[unstable(feature = "pub_crate_should_not_need_unstable_attr", issue = "none")]
 #[allow(type_alias_bounds)]
 pub(crate) type ChangeOutputType<T: Try<Residual: Residual<V>>, V> =
-    <T::Residual as Residual<V>>::TryType;
+    <T::Residual as Residual<V>>::Try;
 
 /// An adapter for implementing non-try methods via the `Try` implementation.
 ///
@@ -463,7 +463,7 @@ impl<T> const FromResidual for NeverShortCircuit<T> {
 }
 #[rustc_const_unstable(feature = "const_never_short_circuit", issue = "none")]
 impl<T: [const] Destruct> const Residual<T> for NeverShortCircuitResidual {
-    type TryType = NeverShortCircuit<T>;
+    type Try = NeverShortCircuit<T>;
 }
 
 /// Implement `FromResidual<Yeet<T>>` on your type to enable

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -378,9 +378,7 @@ pub const trait Residual<O>: Sized {
 #[expect(unreachable_pub)]
 #[inline] // FIXME: force would be nice, but fails -- see #148915
 #[lang = "into_try"]
-pub const fn residual_into_try<R: [const] Residual<O>, O>(
-    r: R,
-) -> <R as Residual<O>>::Try {
+pub const fn residual_into_try<R: [const] Residual<O>, O>(r: R) -> <R as Residual<O>>::Try {
     FromResidual::from_residual(r)
 }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1860,7 +1860,7 @@ impl<T> Option<T> {
     pub fn get_or_try_insert_with<'a, R, F>(
         &'a mut self,
         f: F,
-    ) -> <R::Residual as Residual<&'a mut T>>::TryType
+    ) -> <R::Residual as Residual<&'a mut T>>::Try
     where
         F: FnOnce() -> R,
         R: Try<Output = T, Residual: Residual<&'a mut T>>,
@@ -2808,7 +2808,7 @@ impl<T> const ops::FromResidual<ops::Yeet<()>> for Option<T> {
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 impl<T> const ops::Residual<T> for Option<convert::Infallible> {
-    type TryType = Option<T>;
+    type Try = Option<T>;
 }
 
 impl<T> Option<Option<T>> {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -2203,5 +2203,5 @@ impl<T, E, F: [const] From<E>> const ops::FromResidual<ops::Yeet<E>> for Result<
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]
 #[rustc_const_unstable(feature = "const_try", issue = "74935")]
 impl<T, E> const ops::Residual<T> for Result<convert::Infallible, E> {
-    type TryType = Result<T, E>;
+    type Try = Result<T, E>;
 }

--- a/src/tools/clippy/clippy_lints/src/matches/try_err.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/try_err.rs
@@ -24,7 +24,7 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, scrutine
     // };
     if let ExprKind::Call(match_fun, [try_arg]) = scrutinee.kind
         && let ExprKind::Path(match_fun_path) = match_fun.kind
-        && cx.tcx.qpath_is_lang_item(match_fun_path, LangItem::TryTraitBranch)
+        && cx.tcx.qpath_is_lang_item(match_fun_path, LangItem::TryBranch)
         && let ExprKind::Call(err_fun, [err_arg]) = try_arg.kind
         && err_fun.res(cx).ctor_parent(cx).is_lang_item(cx, ResultErr)
         && let Some(return_ty) = find_return_type(cx, &expr.kind)

--- a/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
@@ -48,7 +48,7 @@ pub(super) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, receiver: &Expr<'_>) 
                 ExprKind::Call(hir_callee, [_]) => matches!(
                     hir_callee.kind,
                     ExprKind::Path(qpath)
-                    if cx.tcx.qpath_is_lang_item(qpath, rustc_hir::LangItem::TryTraitBranch)
+                    if cx.tcx.qpath_is_lang_item(qpath, rustc_hir::LangItem::TryBranch)
                 ),
                 ExprKind::MethodCall(_, self_arg, ..) if expr.hir_id == self_arg.hir_id => true,
                 ExprKind::Match(_, _, MatchSource::TryDesugar(_) | MatchSource::AwaitDesugar)

--- a/src/tools/clippy/clippy_lints/src/methods/str_splitn.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/str_splitn.rs
@@ -337,7 +337,7 @@ fn parse_iter_usage<'tcx>(
                     ..
                 },
                 [_],
-            ) if cx.tcx.qpath_is_lang_item(qpath, LangItem::TryTraitBranch) => {
+            ) if cx.tcx.qpath_is_lang_item(qpath, LangItem::TryBranch) => {
                 let parent_span = e.span.parent_callsite().unwrap();
                 if parent_span.ctxt() == ctxt {
                     (Some(UnwrapKind::QuestionMark), parent_span)

--- a/src/tools/clippy/clippy_lints/src/needless_question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_question_mark.rs
@@ -106,7 +106,7 @@ fn check(cx: &LateContext<'_>, expr: &Expr<'_>) {
         && let ExprKind::Match(inner_expr_with_q, _, MatchSource::TryDesugar(_)) = &arg.kind
         && let ExprKind::Call(called, [inner_expr]) = &inner_expr_with_q.kind
         && let ExprKind::Path(qpath) = called.kind
-        && cx.tcx.qpath_is_lang_item(qpath, LangItem::TryTraitBranch)
+        && cx.tcx.qpath_is_lang_item(qpath, LangItem::TryBranch)
         && expr.span.eq_ctxt(inner_expr.span)
         && let expr_ty = cx.typeck_results().expr_ty(expr)
         && let inner_ty = cx.typeck_results().expr_ty(inner_expr)

--- a/src/tools/clippy/clippy_lints/src/question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/question_mark.rs
@@ -539,7 +539,7 @@ fn is_try_block(cx: &LateContext<'_>, bl: &Block<'_>) -> bool {
     if let Some(expr) = bl.expr
         && let ExprKind::Call(callee, [_]) = expr.kind
         && let ExprKind::Path(qpath) = callee.kind
-        && cx.tcx.qpath_is_lang_item(qpath, LangItem::TryTraitFromOutput)
+        && cx.tcx.qpath_is_lang_item(qpath, LangItem::TryFromOutput)
     {
         true
     } else {

--- a/src/tools/clippy/clippy_lints/src/returns/needless_return.rs
+++ b/src/tools/clippy/clippy_lints/src/returns/needless_return.rs
@@ -135,7 +135,7 @@ fn check_final_expr<'tcx>(
                 // if desugar of `do yeet`, don't lint
                 if let ExprKind::Call(path_expr, [_]) = inner_expr.kind
                     && let ExprKind::Path(qpath) = path_expr.kind
-                    && cx.tcx.qpath_is_lang_item(qpath, LangItem::TryTraitFromYeet)
+                    && cx.tcx.qpath_is_lang_item(qpath, LangItem::TryFromYeet)
                 {
                     return;
                 }

--- a/src/tools/clippy/clippy_lints/src/unused_io_amount.rs
+++ b/src/tools/clippy/clippy_lints/src/unused_io_amount.rs
@@ -259,7 +259,7 @@ fn unpack_call_chain<'a>(mut expr: &'a hir::Expr<'a>) -> &'a hir::Expr<'a> {
 fn unpack_try<'a>(cx: &LateContext<'_>, mut expr: &'a hir::Expr<'a>) -> &'a hir::Expr<'a> {
     while let ExprKind::Call(func, [arg_0]) = expr.kind
         && let ExprKind::Path(qpath) = func.kind
-        && cx.tcx.qpath_is_lang_item(qpath, hir::LangItem::TryTraitBranch)
+        && cx.tcx.qpath_is_lang_item(qpath, hir::LangItem::TryBranch)
     {
         expr = arg_0;
     }

--- a/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
@@ -1750,7 +1750,7 @@ impl<'db> ExprCollector<'db> {
     /// `try { <stmts>; }` into `'<new_label>: { <stmts>; ::std::ops::Try::from_output(()) }`
     /// and save the `<new_label>` to use it as a break target for desugaring of the `?` operator.
     fn desugar_try_block(&mut self, e: BlockExpr, result_type: Option<ast::Type>) -> ExprId {
-        let try_from_output = self.lang_path(self.lang_items().TryTraitFromOutput);
+        let try_from_output = self.lang_path(self.lang_items().TryFromOutput);
         let label = self.generate_new_name();
         let label = self.alloc_label_desugared(Label { name: label }, AstPtr::new(&e).wrap_right());
         let try_block_info = match result_type {
@@ -1960,7 +1960,7 @@ impl<'db> ExprCollector<'db> {
     ///     ControlFlow::Continue(val) => val,
     ///     ControlFlow::Break(residual) =>
     ///         // If there is an enclosing `try {...}`:
-    ///         break 'catch_target Residual::into_try_type(residual),
+    ///         break 'catch_target Residual::into_try(residual),
     ///         // If there is an enclosing `try bikeshed Ty {...}`:
     ///         break 'catch_target Try::from_residual(residual),
     ///         // Otherwise:
@@ -1969,7 +1969,7 @@ impl<'db> ExprCollector<'db> {
     /// ```
     fn collect_try_operator(&mut self, syntax_ptr: AstPtr<ast::Expr>, e: ast::TryExpr) -> ExprId {
         let lang_items = self.lang_items();
-        let try_branch = self.lang_path(lang_items.TryTraitBranch);
+        let try_branch = self.lang_path(lang_items.TryBranch);
         let cf_continue = self.lang_path(lang_items.ControlFlowContinue);
         let cf_break = self.lang_path(lang_items.ControlFlowBreak);
         let operand = self.collect_expr_opt(e.expr());
@@ -2010,10 +2010,10 @@ impl<'db> ExprCollector<'db> {
                 let it = self.alloc_expr(Expr::Path(Path::from(break_name)), syntax_ptr);
                 let convert_fn = match self.current_try_block {
                     Some(TryBlock::Homogeneous { .. }) => {
-                        self.lang_path(lang_items.ResidualIntoTryType)
+                        self.lang_path(lang_items.ResidualIntoTry)
                     }
                     Some(TryBlock::Heterogeneous { .. }) | None => {
-                        self.lang_path(lang_items.TryTraitFromResidual)
+                        self.lang_path(lang_items.TryFromResidual)
                     }
                 };
                 let callee =

--- a/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/expr_store/lower.rs
@@ -2010,7 +2010,7 @@ impl<'db> ExprCollector<'db> {
                 let it = self.alloc_expr(Expr::Path(Path::from(break_name)), syntax_ptr);
                 let convert_fn = match self.current_try_block {
                     Some(TryBlock::Homogeneous { .. }) => {
-                        self.lang_path(lang_items.ResidualIntoTry)
+                        self.lang_path(lang_items.ResidualIntoTry.or(lang_items.ResidualIntoTryOld))
                     }
                     Some(TryBlock::Heterogeneous { .. }) | None => {
                         self.lang_path(lang_items.TryFromResidual)

--- a/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
@@ -457,6 +457,9 @@ language_item_table! { LangItems =>
     TryBranch,          sym::branch,              FunctionId;
     TryFromYeet,        sym::from_yeet,           FunctionId;
     ResidualIntoTry,    sym::into_try,            FunctionId;
+    // TODO: remove when dropping support for the last stable toolchain using `into_try_type`,
+    //       see https://github.com/rust-lang/rust/pull/155229
+    ResidualIntoTryOld, sym::into_try_type,       FunctionId;
 
     PointerLike,             sym::pointer_like,        TraitId;
 

--- a/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/lang_item.rs
@@ -452,11 +452,11 @@ language_item_table! { LangItems =>
     SliceLen,                sym::slice_len_fn,        FunctionId;
 
     // Language items from AST lowering
-    TryTraitFromResidual,    sym::from_residual,       FunctionId;
-    TryTraitFromOutput,      sym::from_output,         FunctionId;
-    TryTraitBranch,          sym::branch,              FunctionId;
-    TryTraitFromYeet,        sym::from_yeet,           FunctionId;
-    ResidualIntoTryType,     sym::into_try_type,       FunctionId;
+    TryFromResidual,    sym::from_residual,       FunctionId;
+    TryFromOutput,      sym::from_output,         FunctionId;
+    TryBranch,          sym::branch,              FunctionId;
+    TryFromYeet,        sym::from_yeet,           FunctionId;
+    ResidualIntoTry,    sym::into_try,            FunctionId;
 
     PointerLike,             sym::pointer_like,        TraitId;
 

--- a/src/tools/rust-analyzer/crates/hir/src/source_analyzer.rs
+++ b/src/tools/rust-analyzer/crates/hir/src/source_analyzer.rs
@@ -803,7 +803,7 @@ impl<'db> SourceAnalyzer<'db> {
     ) -> Option<Function> {
         let ty = self.ty_of_expr(try_expr.expr()?)?;
 
-        let op_fn = self.lang_items(db).TryTraitBranch?;
+        let op_fn = self.lang_items(db).TryBranch?;
         // HACK: subst for `branch()` coincides with that for `Try` because `branch()` itself
         // doesn't have any generic parameters, so we skip building another subst for `branch()`.
         let substs = GenericArgs::new_from_slice(&[ty.into()]);

--- a/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
+++ b/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
@@ -286,7 +286,7 @@ define_symbols! {
     Into,
     into_future,
     into_iter,
-    into_try_type,
+    into_try,
     IntoFuture,
     IntoIter,
     IntoIterator,

--- a/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
+++ b/src/tools/rust-analyzer/crates/intern/src/symbol/symbols.rs
@@ -287,6 +287,7 @@ define_symbols! {
     into_future,
     into_iter,
     into_try,
+    into_try_type,
     IntoFuture,
     IntoIter,
     IntoIterator,

--- a/src/tools/rust-analyzer/crates/test-utils/src/minicore.rs
+++ b/src/tools/rust-analyzer/crates/test-utils/src/minicore.rs
@@ -955,7 +955,7 @@ pub mod ops {
             fn from_residual(residual: R) -> Self;
         }
         pub const trait Residual<O>: Sized {
-            type TryType: [const] Try<Output = O, Residual = Self>;
+            type Try: [const] Try<Output = O, Residual = Self>;
         }
         #[lang = "Try"]
         pub trait Try: FromResidual<Self::Residual> {
@@ -966,10 +966,10 @@ pub mod ops {
             #[lang = "branch"]
             fn branch(self) -> ControlFlow<Self::Residual, Self::Output>;
         }
-        #[lang = "into_try_type"]
-        pub const fn residual_into_try_type<R: [const] Residual<O>, O>(
+        #[lang = "into_try"]
+        pub const fn residual_into_try<R: [const] Residual<O>, O>(
             r: R,
-        ) -> <R as Residual<O>>::TryType {
+        ) -> <R as Residual<O>>::Try {
             FromResidual::from_residual(r)
         }
 
@@ -997,7 +997,7 @@ pub mod ops {
         }
 
         impl<B, C> Residual<C> for ControlFlow<B, Infallible> {
-            type TryType = ControlFlow<B, C>;
+            type Try = ControlFlow<B, C>;
         }
         // region:option
         impl<T> Try for Option<T> {
@@ -1024,7 +1024,7 @@ pub mod ops {
         }
 
         impl<T> const Residual<T> for Option<Infallible> {
-            type TryType = Option<T>;
+            type Try = Option<T>;
         }
         // endregion:option
         // region:result
@@ -1057,7 +1057,7 @@ pub mod ops {
         }
 
         impl<T, E> const Residual<T> for Result<Infallible, E> {
-            type TryType = Result<T, E>;
+            type Try = Result<T, E>;
         }
         // endregion:from
         // endregion:result

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-abort.mir
@@ -34,7 +34,7 @@ fn option_traits(_1: Option<u32>) -> Option<u32> {
     }
 
     bb3: {
-        _0 = ops::try_trait::residual_into_try_type::<Option<Infallible>, u32>(const Option::<Infallible>::None) -> [return: bb4, unwind unreachable];
+        _0 = ops::try_trait::residual_into_try::<Option<Infallible>, u32>(const Option::<Infallible>::None) -> [return: bb4, unwind unreachable];
     }
 
     bb4: {

--- a/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/option_bubble_debug.option_traits.PreCodegen.after.panic-unwind.mir
@@ -34,7 +34,7 @@ fn option_traits(_1: Option<u32>) -> Option<u32> {
     }
 
     bb3: {
-        _0 = ops::try_trait::residual_into_try_type::<Option<Infallible>, u32>(const Option::<Infallible>::None) -> [return: bb4, unwind continue];
+        _0 = ops::try_trait::residual_into_try::<Option<Infallible>, u32>(const Option::<Infallible>::None) -> [return: bb4, unwind continue];
     }
 
     bb4: {

--- a/tests/ui/traits/const-traits/auxiliary/minicore.rs
+++ b/tests/ui/traits/const-traits/auxiliary/minicore.rs
@@ -133,7 +133,7 @@ pub const trait Drop {
 }
 
 pub const trait Residual<O> {
-    type TryType: [const] Try<Output = O, Residual = Self> + Try<Output = O, Residual = Self>;
+    type Try: [const] Try<Output = O, Residual = Self> + Try<Output = O, Residual = Self>;
 }
 
 const fn size_of<T>() -> usize {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Feature: `try_trait_v2_residual` (rust-lang/rust#91285)

The main part is renaming `Residual::TryType` into `Try` (+ `residual_into_try_type` into `residual_into_try`) to reflect the symmetry between `Try::Residual: Residual` and `Residual::Try: Try`. I went ahead and changed all similar references except for `try_trait*` (there it makes sense because it distinguishes the trait feature from the block feature and prevents clashing with the keyword).

r? @scottmcm