### PR TITLE
Avoid linting `doc_cfg` as unused in rustc

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -44,7 +44,7 @@ use rustc_session::config::CrateType;
 use rustc_session::cstore::{CrateStoreDyn, Untracked};
 use rustc_session::lint::Lint;
 use rustc_span::def_id::{CRATE_DEF_ID, DefPathHash, StableCrateId};
-use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw};
+use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_type_ir::TyKind::*;
 pub use rustc_type_ir::lift::Lift;
 use rustc_type_ir::{CollectAndApply, TypeFlags, WithCachedTypeInfo, elaborate, search_graph};
@@ -1705,6 +1705,10 @@ impl<'tcx> TyCtxt<'tcx> {
                 // in downstream crates. It should never be linted, but should we
                 // hack this in the linter to ignore it?
                 && f.as_str() != "restricted_std"
+                // `doc_cfg` affects rustdoc behavior: rustdoc checks it via
+                // `tcx.features().doc_cfg()`, but a normal rustc compilation may
+                // never observe that use. Do not lint it as unused here.
+                && *f != sym::doc_cfg
             })
             .collect::<Vec<_>>();
 

--- a/tests/ui/lint/unused-features/used-doc-cfg.rs
+++ b/tests/ui/lint/unused-features/used-doc-cfg.rs
@@ -1,5 +1,7 @@
 //@ check-pass
 //@ compile-flags: --check-cfg=cfg(feature,values("enabled_feature"))
+// Regression test for https://github.com/rust-lang/rust/issues/154487
+
 #![crate_type = "lib"]
 #![deny(unused_features)]
 #![feature(doc_cfg)]

--- a/tests/ui/lint/unused-features/used-doc-cfg.rs
+++ b/tests/ui/lint/unused-features/used-doc-cfg.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+//@ compile-flags: --check-cfg=cfg(feature,values("enabled_feature"))
+#![crate_type = "lib"]
+#![deny(unused_features)]
+#![feature(doc_cfg)]
+
+#[cfg(feature = "enabled_feature")]
+pub fn foo() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#154487

https://github.com/rust-lang/rust/blob/af80b0f2cd0505bcc86eaa675d1ab403110d373a/src/librustdoc/passes/propagate_doc_cfg.rs#L19-L26