### PR TITLE
compiletest: add a new diff for compare-out-by-lines tests.

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -22,7 +22,7 @@ use crate::directives::{AuxCrate, TestProps};
 use crate::errors::{Error, ErrorKind, load_errors};
 use crate::output_capture::ConsoleOut;
 use crate::read2::{Truncated, read2_abbreviated};
-use crate::runtest::compute_diff::{DiffLine, make_diff, write_diff};
+use crate::runtest::compute_diff::{DiffLine, diff_by_lines, make_diff, write_diff};
 use crate::util::{Utf8PathBufExt, add_dylib_path, static_regex};
 use crate::{json, stamp_file_path};
 
@@ -2794,6 +2794,7 @@ impl<'test> TestCx<'test> {
                     expected,
                     actual,
                     actual_unnormalized,
+                    compare_output_by_lines || compare_output_by_lines_subset,
                 );
             }
         } else {
@@ -2831,6 +2832,7 @@ impl<'test> TestCx<'test> {
         expected: &str,
         actual: &str,
         actual_unnormalized: &str,
+        show_diff_by_lines: bool,
     ) {
         writeln!(self.stderr, "diff of {stream}:\n");
         if let Some(diff_command) = self.config.diff_command.as_deref() {
@@ -2896,6 +2898,10 @@ impl<'test> TestCx<'test> {
                 "{}",
                 write_diff(&mismatches_unnormalized, &mismatches_normalized, 0)
             );
+        }
+
+        if show_diff_by_lines {
+            write!(self.stderr, "{}", diff_by_lines(expected, actual));
         }
     }
 

--- a/src/tools/compiletest/src/runtest/compute_diff.rs
+++ b/src/tools/compiletest/src/runtest/compute_diff.rs
@@ -104,3 +104,54 @@ pub(crate) fn write_diff(expected: &str, actual: &str, context_size: usize) -> S
     }
     output
 }
+
+pub(crate) fn diff_by_lines(expected: &str, actual: &str) -> String {
+    use std::collections::HashMap;
+    use std::fmt::Write;
+    let mut output = String::new();
+    let mut expected_counts: HashMap<&str, usize> = HashMap::new();
+    let mut actual_counts: HashMap<&str, usize> = HashMap::new();
+
+    for line in expected.lines() {
+        *expected_counts.entry(line).or_insert(0) += 1;
+    }
+    for line in actual.lines() {
+        *actual_counts.entry(line).or_insert(0) += 1;
+    }
+
+    fn write_expected_only_lines(
+        output: &mut String,
+        expected_lines: &HashMap<&str, usize>,
+        actual_lines: &HashMap<&str, usize>,
+    ) {
+        let mut expected_only: Vec<(&str, usize)> = expected_lines
+            .iter()
+            .filter_map(|(&line, &expected_count)| {
+                let actual_count = actual_lines.get(line).copied().unwrap_or(0);
+                if expected_count > actual_count {
+                    Some((line, expected_count - actual_count))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        expected_only.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        if expected_only.is_empty() {
+            writeln!(output, "(no lines found)").unwrap();
+        } else {
+            for (line, diff) in expected_only {
+                for _ in 0..diff {
+                    writeln!(output, "{line}").unwrap();
+                }
+            }
+        }
+    }
+
+    writeln!(output, "Compare output by lines enabled, diff by lines:").unwrap();
+    writeln!(output, "Expected contains these lines that are not in actual:").unwrap();
+    write_expected_only_lines(&mut output, &expected_counts, &actual_counts);
+    writeln!(output, "Actual contains these lines that are not in expected:").unwrap();
+    write_expected_only_lines(&mut output, &actual_counts, &expected_counts);
+    output
+}


### PR DESCRIPTION
Previously, when comparing output by lines, only the actual diff was shown. This is unhelpful since we expect lines to be shuffled around.

With this new print, we can see the exact lines that are missing or have appeared without the noise of the moved around lines.

Example, in this case a note has moved slightly so there is one more separator line "|":

```
+	   |
+	   = help: maybe it is overwritten before being read?

Compare output by lines enabled, diff by lines:
Expected contains these lines that are not in actual:
(no lines found)
Actual contains these lines that are not in expected:
   |

The actual stderr differed from the expected stderr
To update references, rerun the tests and pass the `--bless` flag
To only update this specific test, also pass `--test-args liveness/liveness-consts.rs`
```

r? @jieyouxu 
cc @zetanumbers @ywxt 
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
