### PR TITLE
compiletest: inject LLVM_PROFILE_FILE when COMPILETEST_LLVM_PROFILE_DIR is set

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1347,6 +1347,14 @@ impl<'test> TestCx<'test> {
 
         rustc.envs(self.props.rustc_env.clone());
         self.props.unset_rustc_env.iter().fold(&mut rustc, Command::env_remove);
+
+        // If COMPILETEST_LLVM_PROFILE_DIR is set, inject LLVM_PROFILE_FILE so
+        // an instrumented rustc emits coverage data using %m (one file per
+        // binary, merged atomically across invocations — no file accumulation).
+        if let Ok(profile_dir) = std::env::var("COMPILETEST_LLVM_PROFILE_DIR") {
+            rustc.env("LLVM_PROFILE_FILE", format!("{}/rustc_%m.profraw", profile_dir));
+        }
+
         self.compose_and_run(
             rustc,
             self.config.host_compile_lib_path.as_path(),


### PR DESCRIPTION
When `COMPILETEST_LLVM_PROFILE_DIR` is set, inject `LLVM_PROFILE_FILE` into every rustc invocation inside `compose_and_run_compiler` so an instrumented compiler emits coverage data automatically as tests run normally — with the correct flags, editions, and revisions already handled by compiletest.

Uses `%m` (binary hash) instead of `%p` (process ID) so all invocations of the same binary merge into one file atomically via LLVM's file locking. This means no file accumulation regardless of how many tests are run, and no external merge loop needed.

This is fully opt-in normal runs are completely unaffected.

Part of the "Code coverage of the Rust compiler at scale" project.

r? jackh726