### PR TITLE
[AIX] update linker default to bcdtors

### DIFF
--- a/compiler/rustc_target/src/spec/targets/powerpc64_ibm_aix.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_ibm_aix.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(
         LinkerFlavor::Unix(Cc::No),
-        &["-b64", "-bpT:0x100000000", "-bpD:0x110000000", "-bcdtors:all:0:s"],
+        &["-b64", "-bpT:0x100000000", "-bpD:0x110000000", "-bcdtors:mbr:0:s"],
     );
 
     Target {


### PR DESCRIPTION
The bcdtor mode affects how the AIX linker choose to pull in static constructors and destructors (https://www.ibm.com/docs/en/aix/7.2.0?topic=l-ld-command) to the link.

The current setting of all makes static init in archive members live regardless of if the archive member would be otherwise referenced, causing that whole archive member to become part of the link.

This default was initially retained for compatibility purposes with historical compilers on the platform which defaulted to this setting. Unfortunately this greedy pulling in of static init can have unintended consequences for applications, for example for programs linked against parts of compiler-rt which contain optional instrumentation (containing static initializers) which may be unused as these now become live in all programs regardless of use.

For that reason and similar reasons, this PR switches the default to mbr, which only extracts static init from archive members which would otherwise be referenced. This gives a behaviour very consistent with linkers on other platforms (e.g. Linux).

Users requiring the old default behaviour can manually pass `-bcdtors:all` on the link step which will override any default we pass here.

(Note: this mirrors LLVM change: https://github.com/llvm/llvm-project/pull/191265)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
