### PR TITLE
Recover on attribute in use tree

### DIFF
--- a/compiler/rustc_parse/src/diagnostics.rs
+++ b/compiler/rustc_parse/src/diagnostics.rs
@@ -1119,6 +1119,27 @@ pub(crate) struct ArrayBracketsInsteadOfBracesSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag("attributes are not allowed inside imports")]
+pub(crate) struct AttrInUseTree {
+    #[primary_span]
+    pub attr_span: Span,
+    #[subdiagnostic]
+    pub sub: Option<AttrInUseTreeSugg>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion("move the import to its own item", style = "verbose")]
+pub(crate) struct AttrInUseTreeSugg {
+    #[suggestion_part(code = "{code}")]
+    pub use_lo: Span,
+    #[suggestion_part(code = "")]
+    pub attr_span: Span,
+    #[suggestion_part(code = "")]
+    pub tree_span: Span,
+    pub code: String,
+}
+
+#[derive(Diagnostic)]
 #[diag("`match` arm body without braces")]
 pub(crate) struct MatchArmBodyWithoutBraces {
     #[primary_span]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1103,6 +1103,27 @@ pub(crate) struct ArrayBracketsInsteadOfBracesSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag("attributes are not allowed inside imports")]
+pub(crate) struct AttrInUseTree {
+    #[primary_span]
+    pub attr_span: Span,
+    #[subdiagnostic]
+    pub sub: Option<AttrInUseTreeSugg>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion("move the import to its own item", style = "verbose")]
+pub(crate) struct AttrInUseTreeSugg {
+    #[suggestion_part(code = "{code}")]
+    pub use_lo: Span,
+    #[suggestion_part(code = "")]
+    pub attr_span: Span,
+    #[suggestion_part(code = "")]
+    pub tree_span: Span,
+    pub code: String,
+}
+
+#[derive(Diagnostic)]
 #[diag("`match` arm body without braces")]
 pub(crate) struct MatchArmBodyWithoutBraces {
     #[primary_span]

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1102,6 +1102,27 @@ pub(crate) struct ArrayBracketsInsteadOfBracesSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag("attributes are not allowed inside imports")]
+pub(crate) struct AttrInUseTree {
+    #[primary_span]
+    pub attr_span: Span,
+    #[subdiagnostic]
+    pub sub: Option<AttrInUseTreeSugg>,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion("move the import to its own item", style = "verbose")]
+pub(crate) struct AttrInUseTreeSugg {
+    #[suggestion_part(code = "{code}")]
+    pub use_lo: Span,
+    #[suggestion_part(code = "")]
+    pub attr_span: Span,
+    #[suggestion_part(code = "")]
+    pub tree_span: Span,
+    pub code: String,
+}
+
+#[derive(Diagnostic)]
 #[diag("`match` arm body without braces")]
 pub(crate) struct MatchArmBodyWithoutBraces {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -302,11 +302,15 @@ impl<'a> Parser<'a> {
     /// Parses an inner part of an attribute (the path and following tokens).
     /// The tokens must be either a delimited token stream, or empty token stream,
     /// or the "legacy" key-value form.
+    ///
+    /// ```none
     ///     PATH `(` TOKEN_STREAM `)`
     ///     PATH `[` TOKEN_STREAM `]`
     ///     PATH `{` TOKEN_STREAM `}`
     ///     PATH
     ///     PATH `=` UNSUFFIXED_LIT
+    /// ```
+    ///
     /// The delimiters or `=` are still put into the resulting token stream.
     pub fn parse_attr_item(&mut self, force_collect: ForceCollect) -> PResult<'a, ast::AttrItem> {
         if let Some(item) = self.eat_metavar_seq_with_matcher(

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -302,11 +302,15 @@ impl<'a> Parser<'a> {
     /// Parses an inner part of an attribute (the path and following tokens).
     /// The tokens must be either a delimited token stream, or empty token stream,
     /// or the "legacy" key-value form.
-    ///     PATH `(` TOKEN_STREAM `)`
-    ///     PATH `[` TOKEN_STREAM `]`
-    ///     PATH `{` TOKEN_STREAM `}`
-    ///     PATH
-    ///     PATH `=` UNSUFFIXED_LIT
+    ///
+    /// ```text
+    /// PATH `(` TOKEN_STREAM `)`
+    /// PATH `[` TOKEN_STREAM `]`
+    /// PATH `{` TOKEN_STREAM `}`
+    /// PATH
+    /// PATH `=` UNSUFFIXED_LIT
+    /// ```
+    ///
     /// The delimiters or `=` are still put into the resulting token stream.
     pub fn parse_attr_item(&mut self, force_collect: ForceCollect) -> PResult<'a, ast::AttrItem> {
         if let Some(item) = self.eat_metavar_seq_with_matcher(

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -310,11 +310,15 @@ impl<'a> Parser<'a> {
     /// Parses an inner part of an attribute (the path and following tokens).
     /// The tokens must be either a delimited token stream, or empty token stream,
     /// or the "legacy" key-value form.
-    ///     PATH `(` TOKEN_STREAM `)`
-    ///     PATH `[` TOKEN_STREAM `]`
-    ///     PATH `{` TOKEN_STREAM `}`
-    ///     PATH
-    ///     PATH `=` UNSUFFIXED_LIT
+    ///
+    /// ```text
+    /// PATH `(` TOKEN_STREAM `)`
+    /// PATH `[` TOKEN_STREAM `]`
+    /// PATH `{` TOKEN_STREAM `}`
+    /// PATH
+    /// PATH `=` UNSUFFIXED_LIT
+    /// ```
+    ///
     /// The delimiters or `=` are still put into the resulting token stream.
     pub fn parse_attr_item(
         &mut self,

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -430,7 +430,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_use_item(&mut self) -> PResult<'a, ItemKind> {
-        let tree = self.parse_use_tree()?;
+        let use_token_span = self.prev_token.span;
+        let tree = self.parse_use_tree(use_token_span, None)?;
         if let Err(mut e) = self.expect_semi() {
             match tree.kind {
                 UseTreeKind::Glob(_) => {
@@ -1291,7 +1292,11 @@ impl<'a> Parser<'a> {
     ///            PATH `::` `{` USE_TREE_LIST `}` |
     ///            PATH [`as` IDENT]
     /// ```
-    fn parse_use_tree(&mut self) -> PResult<'a, UseTree> {
+    fn parse_use_tree<'b>(
+        &mut self,
+        use_token_span: Span,
+        use_path: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, UseTree> {
         let lo = self.token.span;
 
         let mut prefix =
@@ -1306,13 +1311,14 @@ impl<'a> Parser<'a> {
                         .push(PathSegment::path_root(lo.shrink_to_lo().with_ctxt(mod_sep_ctxt)));
                 }
 
-                self.parse_use_tree_glob_or_nested()?
+                self.parse_use_tree_glob_or_nested(use_token_span, use_path)?
             } else {
                 // `use path::*;` or `use path::{...};` or `use path;` or `use path as bar;`
                 prefix = self.parse_path(PathStyle::Mod)?;
 
                 if self.eat_path_sep() {
-                    self.parse_use_tree_glob_or_nested()?
+                    let use_path = UsePathList { element: &prefix.segments, prev: use_path };
+                    self.parse_use_tree_glob_or_nested(use_token_span, Some(&use_path))?
                 } else {
                     // Recover from using a colon as path separator.
                     while self.eat_noexpect(&token::Colon) {
@@ -1332,13 +1338,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses `*` or `{...}`.
-    fn parse_use_tree_glob_or_nested(&mut self) -> PResult<'a, UseTreeKind> {
+    fn parse_use_tree_glob_or_nested<'b>(
+        &mut self,
+        use_token_span: Span,
+        use_path: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, UseTreeKind> {
         Ok(if self.eat(exp!(Star)) {
             UseTreeKind::Glob(self.prev_token.span)
         } else {
             let lo = self.token.span;
             UseTreeKind::Nested {
-                items: self.parse_use_tree_list()?,
+                items: self.parse_use_tree_list(use_token_span, use_path)?,
                 span: lo.to(self.prev_token.span),
             }
         })
@@ -1349,12 +1359,103 @@ impl<'a> Parser<'a> {
     /// ```text
     /// USE_TREE_LIST = ∅ | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
-    fn parse_use_tree_list(&mut self) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
+    fn parse_use_tree_list<'b>(
+        &mut self,
+        use_token_span: Span,
+        prefix: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
         self.parse_delim_comma_seq(exp!(OpenBrace), exp!(CloseBrace), |p| {
             p.recover_vcs_conflict_marker();
-            Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+            let mut attr_span = None;
+            if p.check_noexpect(&TokenKind::Pound)
+                && p.look_ahead(1, |tok| matches!(tok.kind, TokenKind::OpenBracket))
+            {
+                let attr_wrapper = p.parse_outer_attributes()?;
+                let raw_attrs = attr_wrapper.take_for_recovery(&p.psess);
+                attr_span =
+                    Some(raw_attrs.first().unwrap().span.to(raw_attrs.last().unwrap().span));
+            }
+            let use_tree = p.parse_use_tree(use_token_span, prefix)?;
+            if let Some(attr_span) = attr_span {
+                p.emit_error_attr_in_use_tree(use_token_span, prefix, use_tree.span(), attr_span);
+            }
+
+            Ok((use_tree, DUMMY_NODE_ID))
         })
         .map(|(r, _)| r)
+    }
+
+    fn emit_error_attr_in_use_tree<'b>(
+        &self,
+        use_token_span: Span,
+        prefix: Option<&'b UsePathList<'b>>,
+        use_tree_span: Span,
+        attr_span: Span,
+    ) {
+        {
+            let mut prefix = prefix;
+            let attr = self
+                .psess
+                .source_map()
+                .span_to_source(attr_span, |s, start, end| Ok(s[start..end].to_string()))
+                .unwrap();
+
+            let prefix = {
+                let mut tmp = Vec::new();
+                while let Some(prefix_) = prefix {
+                    tmp.push(prefix_.element);
+                    prefix = prefix_.prev;
+                }
+                tmp.reverse();
+                tmp.iter().flat_map(|segments| segments.iter()).collect::<Vec<_>>()
+            };
+
+            let global_path = prefix
+                .first()
+                .map(|first_segment| first_segment.ident.name == kw::PathRoot)
+                .unwrap_or_default();
+            let global_path = if global_path { "::" } else { "" };
+
+            let prefix = prefix
+                .iter()
+                .filter_map(|segment| {
+                    if !segment.ident.is_special() { Some(segment.ident.as_str()) } else { None }
+                })
+                .collect::<Vec<_>>()
+                .join("::");
+
+            let mut comma_reached = false;
+            let tree_span = self
+                .psess
+                .source_map()
+                .span_extend_while(use_tree_span, |c| {
+                    if comma_reached {
+                        return false;
+                    }
+                    comma_reached = c == ',';
+                    c.is_whitespace() || comma_reached
+                })
+                .unwrap();
+
+            let use_tree = self
+                .psess
+                .source_map()
+                .span_to_source(use_tree_span, |s, start, end| Ok(s[start..end].to_string()))
+                .unwrap();
+
+            let code = format!("{attr}\nuse {global_path}{prefix}::{use_tree};\n");
+
+            let err = crate::errors::AttrInUseTree {
+                attr_span,
+                sub: Some(crate::errors::AttrInUseTreeSugg {
+                    use_lo: use_token_span.shrink_to_lo(),
+                    attr_span,
+                    tree_span,
+                    code,
+                }),
+            };
+            self.dcx().emit_err(err);
+        }
     }
 
     fn parse_rename(&mut self) -> PResult<'a, Option<Ident>> {
@@ -3656,4 +3757,9 @@ pub(super) enum FrontMatterParsingMode {
     /// Parse the front matter of a function pointet type.
     /// For function pointer types, the `const` and `async` keywords are not permitted.
     FunctionPtrType,
+}
+
+struct UsePathList<'a> {
+    element: &'a [ast::PathSegment],
+    prev: Option<&'a Self>,
 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 use std::fmt::Write;
 use std::mem;
 
@@ -435,7 +437,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_use_item(&mut self) -> PResult<'a, ItemKind> {
-        let tree = self.parse_use_tree()?;
+        let use_token_span = self.prev_token.span;
+        let tree = self.parse_use_tree(use_token_span, None)?;
         if let Err(mut e) = self.expect_semi() {
             match tree.kind {
                 UseTreeKind::Glob(_) => {
@@ -1295,7 +1298,11 @@ impl<'a> Parser<'a> {
     ///            PATH `::` `{` USE_TREE_LIST `}` |
     ///            PATH [`as` IDENT]
     /// ```
-    fn parse_use_tree(&mut self) -> PResult<'a, UseTree> {
+    fn parse_use_tree<'b>(
+        &mut self,
+        use_token_span: Span,
+        use_path: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, UseTree> {
         let lo = self.token.span;
 
         let mut prefix =
@@ -1310,13 +1317,14 @@ impl<'a> Parser<'a> {
                         .push(PathSegment::path_root(lo.shrink_to_lo().with_ctxt(mod_sep_ctxt)));
                 }
 
-                self.parse_use_tree_glob_or_nested()?
+                self.parse_use_tree_glob_or_nested(use_token_span, use_path)?
             } else {
                 // `use path::*;` or `use path::{...};` or `use path;` or `use path as bar;`
                 prefix = self.parse_path(PathStyle::Mod)?;
 
                 if self.eat_path_sep() {
-                    self.parse_use_tree_glob_or_nested()?
+                    let use_path = UsePathList { elements: &prefix.segments, prev: use_path };
+                    self.parse_use_tree_glob_or_nested(use_token_span, Some(&use_path))?
                 } else {
                     // Recover from using a colon as path separator.
                     while self.eat_noexpect(&token::Colon) {
@@ -1336,13 +1344,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses `*` or `{...}`.
-    fn parse_use_tree_glob_or_nested(&mut self) -> PResult<'a, UseTreeKind> {
+    fn parse_use_tree_glob_or_nested<'b>(
+        &mut self,
+        use_token_span: Span,
+        use_path: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, UseTreeKind> {
         Ok(if self.eat(exp!(Star)) {
             UseTreeKind::Glob(self.prev_token.span)
         } else {
             let lo = self.token.span;
             UseTreeKind::Nested {
-                items: self.parse_use_tree_list()?,
+                items: self.parse_use_tree_list(use_token_span, use_path)?,
                 span: lo.to(self.prev_token.span),
             }
         })
@@ -1353,12 +1365,91 @@ impl<'a> Parser<'a> {
     /// ```text
     /// USE_TREE_LIST = ∅ | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
-    fn parse_use_tree_list(&mut self) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
+    fn parse_use_tree_list<'b>(
+        &mut self,
+        use_token_span: Span,
+        prefix: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
         self.parse_delim_comma_seq(exp!(OpenBrace), exp!(CloseBrace), |p| {
             p.recover_vcs_conflict_marker();
-            Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+            let mut attr_span = None;
+            let attrs = p.parse_outer_attributes()?;
+            if !attrs.is_empty() {
+                let raw_attrs = attrs.take_for_recovery(&p.psess);
+                attr_span =
+                    Some(raw_attrs.first().unwrap().span.to(raw_attrs.last().unwrap().span));
+            }
+            let use_tree = p.parse_use_tree(use_token_span, prefix)?;
+            if let Some(attr_span) = attr_span {
+                p.emit_error_attr_in_use_tree(use_token_span, prefix, use_tree.span(), attr_span);
+            }
+
+            Ok((use_tree, DUMMY_NODE_ID))
         })
         .map(|(r, _)| r)
+    }
+
+    fn emit_error_attr_in_use_tree<'b>(
+        &self,
+        use_token_span: Span,
+        prefix: Option<&'b UsePathList<'b>>,
+        use_tree_span: Span,
+        attr_span: Span,
+    ) {
+        {
+            let mut prefix = prefix;
+            let Ok(attr) = self.psess.source_map().span_to_snippet(attr_span) else {
+                return;
+            };
+
+            let prefix = {
+                let mut tmp = Vec::new();
+                while let Some(prefix_) = prefix {
+                    tmp.push(prefix_.elements);
+                    prefix = prefix_.prev;
+                }
+                tmp.reverse();
+                tmp.iter().flat_map(|segments| segments.iter()).collect::<Vec<_>>()
+            };
+
+            let prefix =
+                prefix
+                    .iter()
+                    .map(|segment| {
+                        if segment.ident.name == kw::PathRoot { "" } else { segment.ident.as_str() }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("::");
+
+            let mut comma_reached = false;
+            let Ok(tree_span) = self.psess.source_map().span_extend_while(use_tree_span, |c| {
+                if comma_reached {
+                    return false;
+                }
+                comma_reached = c == ',';
+                c.is_whitespace() || comma_reached
+            }) else {
+                return;
+            };
+
+            let Ok(use_tree) = self.psess.source_map().span_to_snippet(use_tree_span) else {
+                return;
+            };
+
+            // FIXME: duplicate the attributes that are at the root of the initial use-item.
+            let code = format!("{attr}\nuse {prefix}::{use_tree};\n");
+
+            let err = crate::errors::AttrInUseTree {
+                attr_span,
+                sub: Some(crate::errors::AttrInUseTreeSugg {
+                    use_lo: use_token_span.shrink_to_lo(),
+                    attr_span,
+                    tree_span,
+                    code,
+                }),
+            };
+            self.dcx().emit_err(err);
+        }
     }
 
     fn parse_rename(&mut self) -> PResult<'a, Option<Ident>> {
@@ -3711,4 +3802,9 @@ pub(super) enum FrontMatterParsingMode {
     /// Parse the front matter of a function pointet type.
     /// For function pointer types, the `const` and `async` keywords are not permitted.
     FunctionPtrType,
+}
+
+struct UsePathList<'a> {
+    elements: &'a [ast::PathSegment],
+    prev: Option<&'a Self>,
 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -434,7 +434,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_use_item(&mut self) -> PResult<'a, ItemKind> {
-        let tree = self.parse_use_tree()?;
+        let use_token_span = self.prev_token.span;
+        let tree = self.parse_use_tree(use_token_span, None)?;
         if let Err(mut e) = self.expect_semi() {
             match tree.kind {
                 UseTreeKind::Glob(_) => {
@@ -1317,7 +1318,11 @@ impl<'a> Parser<'a> {
     ///            PATH `::` `{` USE_TREE_LIST `}` |
     ///            PATH [`as` IDENT]
     /// ```
-    fn parse_use_tree(&mut self) -> PResult<'a, UseTree> {
+    fn parse_use_tree<'b>(
+        &mut self,
+        use_token_span: Span,
+        use_path: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, UseTree> {
         let lo = self.token.span;
 
         let mut prefix = ast::Path { segments: ThinVec::new(), span: lo.shrink_to_lo() };
@@ -1331,13 +1336,14 @@ impl<'a> Parser<'a> {
                         .push(PathSegment::path_root(lo.shrink_to_lo().with_ctxt(mod_sep_ctxt)));
                 }
 
-                self.parse_use_tree_glob_or_nested()?
+                self.parse_use_tree_glob_or_nested(use_token_span, use_path)?
             } else {
                 // `use path::*;` or `use path::{...};` or `use path;` or `use path as bar;`
                 prefix = self.parse_path(PathStyle::Mod)?;
 
                 if self.eat_path_sep() {
-                    self.parse_use_tree_glob_or_nested()?
+                    let use_path = UsePathList { elements: &prefix.segments, prev: use_path };
+                    self.parse_use_tree_glob_or_nested(use_token_span, Some(&use_path))?
                 } else {
                     // Recover from using a colon as path separator.
                     while self.eat_noexpect(&token::Colon) {
@@ -1358,13 +1364,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses `*` or `{...}`.
-    fn parse_use_tree_glob_or_nested(&mut self) -> PResult<'a, UseTreeKind> {
+    fn parse_use_tree_glob_or_nested<'b>(
+        &mut self,
+        use_token_span: Span,
+        use_path: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, UseTreeKind> {
         Ok(if self.eat(exp!(Star)) {
             UseTreeKind::Glob(self.prev_token.span)
         } else {
             let lo = self.token.span;
             UseTreeKind::Nested {
-                items: self.parse_use_tree_list()?,
+                items: self.parse_use_tree_list(use_token_span, use_path)?,
                 span: lo.to(self.prev_token.span),
             }
         })
@@ -1375,12 +1385,91 @@ impl<'a> Parser<'a> {
     /// ```text
     /// USE_TREE_LIST = ∅ | (USE_TREE `,`)* USE_TREE [`,`]
     /// ```
-    fn parse_use_tree_list(&mut self) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
+    fn parse_use_tree_list<'b>(
+        &mut self,
+        use_token_span: Span,
+        prefix: Option<&'b UsePathList<'b>>,
+    ) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
         self.parse_delim_comma_seq(exp!(OpenBrace), exp!(CloseBrace), |p| {
             p.recover_vcs_conflict_marker();
-            Ok((p.parse_use_tree()?, DUMMY_NODE_ID))
+            let mut attr_span = None;
+            let attrs = p.parse_outer_attributes()?;
+            if !attrs.is_empty() {
+                let raw_attrs = attrs.take_for_recovery(&p.psess);
+                attr_span =
+                    Some(raw_attrs.first().unwrap().span.to(raw_attrs.last().unwrap().span));
+            }
+            let use_tree = p.parse_use_tree(use_token_span, prefix)?;
+            if let Some(attr_span) = attr_span {
+                p.emit_error_attr_in_use_tree(use_token_span, prefix, use_tree.span(), attr_span);
+            }
+
+            Ok((use_tree, DUMMY_NODE_ID))
         })
         .map(|(r, _)| r)
+    }
+
+    fn emit_error_attr_in_use_tree<'b>(
+        &self,
+        use_token_span: Span,
+        prefix: Option<&'b UsePathList<'b>>,
+        use_tree_span: Span,
+        attr_span: Span,
+    ) {
+        {
+            let mut prefix = prefix;
+            let Ok(attr) = self.psess.source_map().span_to_snippet(attr_span) else {
+                return;
+            };
+
+            let prefix = {
+                let mut tmp = Vec::new();
+                while let Some(prefix_) = prefix {
+                    tmp.push(prefix_.elements);
+                    prefix = prefix_.prev;
+                }
+                tmp.reverse();
+                tmp.iter().flat_map(|segments| segments.iter()).collect::<Vec<_>>()
+            };
+
+            let prefix =
+                prefix
+                    .iter()
+                    .map(|segment| {
+                        if segment.ident.name == kw::PathRoot { "" } else { segment.ident.as_str() }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("::");
+
+            let mut comma_reached = false;
+            let Ok(tree_span) = self.psess.source_map().span_extend_while(use_tree_span, |c| {
+                if comma_reached {
+                    return false;
+                }
+                comma_reached = c == ',';
+                c.is_whitespace() || comma_reached
+            }) else {
+                return;
+            };
+
+            let Ok(use_tree) = self.psess.source_map().span_to_snippet(use_tree_span) else {
+                return;
+            };
+
+            // FIXME: duplicate the attributes that are at the root of the initial use-item.
+            let code = format!("{attr}\nuse {prefix}::{use_tree};\n");
+
+            let err = crate::diagnostics::AttrInUseTree {
+                attr_span,
+                sub: Some(crate::diagnostics::AttrInUseTreeSugg {
+                    use_lo: use_token_span.shrink_to_lo(),
+                    attr_span,
+                    tree_span,
+                    code,
+                }),
+            };
+            self.dcx().emit_err(err);
+        }
     }
 
     fn parse_rename(&mut self) -> PResult<'a, Option<Ident>> {
@@ -2737,7 +2826,13 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
 enum IsMacroRulesItem {
     Yes { has_bang: bool },
     No,
+}
+
+struct UsePathList<'a> {
+    elements: &'a [ast::PathSegment],
+    prev: Option<&'a Self>,
 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1392,6 +1392,7 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, ThinVec<(UseTree, ast::NodeId)>> {
         self.parse_delim_comma_seq(exp!(OpenBrace), exp!(CloseBrace), |p| {
             p.recover_vcs_conflict_marker();
+
             let mut attr_span = None;
             let attrs = p.parse_outer_attributes()?;
             if !attrs.is_empty() {
@@ -1399,7 +1400,9 @@ impl<'a> Parser<'a> {
                 attr_span =
                     Some(raw_attrs.first().unwrap().span.to(raw_attrs.last().unwrap().span));
             }
+
             let use_tree = p.parse_use_tree(use_token_span, prefix)?;
+
             if let Some(attr_span) = attr_span {
                 p.emit_error_attr_in_use_tree(use_token_span, prefix, use_tree.span(), attr_span);
             }
@@ -1409,67 +1412,56 @@ impl<'a> Parser<'a> {
         .map(|(r, _)| r)
     }
 
-    fn emit_error_attr_in_use_tree<'b>(
+    fn emit_error_attr_in_use_tree(
         &self,
         use_token_span: Span,
-        prefix: Option<&'b UsePathList<'b>>,
+        mut prefix: Option<&UsePathList<'_>>,
         use_tree_span: Span,
         attr_span: Span,
     ) {
-        {
-            let mut prefix = prefix;
-            let Ok(attr) = self.psess.source_map().span_to_snippet(attr_span) else {
-                return;
-            };
+        let Ok(attr) = self.psess.source_map().span_to_snippet(attr_span) else { return };
 
-            let prefix = {
-                let mut tmp = Vec::new();
-                while let Some(prefix_) = prefix {
-                    tmp.push(prefix_.elements);
-                    prefix = prefix_.prev;
-                }
-                tmp.reverse();
-                tmp.iter().flat_map(|segments| segments.iter()).collect::<Vec<_>>()
-            };
+        let prefix: Vec<_> = {
+            let mut tmp = Vec::new();
+            while let Some(prefix_) = prefix {
+                tmp.push(prefix_.elements);
+                prefix = prefix_.prev;
+            }
+            tmp.reverse();
+            tmp.into_iter().flatten().collect()
+        };
 
-            let prefix =
-                prefix
-                    .iter()
-                    .map(|segment| {
-                        if segment.ident.name == kw::PathRoot { "" } else { segment.ident.as_str() }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("::");
+        let prefix: String = prefix
+            .iter()
+            .map(|seg| if seg.ident.name == kw::PathRoot { "" } else { seg.ident.as_str() })
+            .intersperse("::")
+            .collect();
 
-            let mut comma_reached = false;
-            let Ok(tree_span) = self.psess.source_map().span_extend_while(use_tree_span, |c| {
-                if comma_reached {
-                    return false;
-                }
-                comma_reached = c == ',';
-                c.is_whitespace() || comma_reached
-            }) else {
-                return;
-            };
+        let mut comma_reached = false;
+        let Ok(tree_span) = self.psess.source_map().span_extend_while(use_tree_span, |c| {
+            if comma_reached {
+                return false;
+            }
+            comma_reached = c == ',';
+            c.is_whitespace() || comma_reached
+        }) else {
+            return;
+        };
 
-            let Ok(use_tree) = self.psess.source_map().span_to_snippet(use_tree_span) else {
-                return;
-            };
+        let Ok(use_tree) = self.psess.source_map().span_to_snippet(use_tree_span) else { return };
 
-            // FIXME: duplicate the attributes that are at the root of the initial use-item.
-            let code = format!("{attr}\nuse {prefix}::{use_tree};\n");
+        // FIXME: duplicate the attributes that are at the root of the initial use-item.
+        let code = format!("{attr}\nuse {prefix}::{use_tree};\n");
 
-            let err = crate::diagnostics::AttrInUseTree {
+        self.dcx().emit_err(crate::diagnostics::AttrInUseTree {
+            attr_span,
+            sub: Some(crate::diagnostics::AttrInUseTreeSugg {
+                use_lo: use_token_span.shrink_to_lo(),
                 attr_span,
-                sub: Some(crate::diagnostics::AttrInUseTreeSugg {
-                    use_lo: use_token_span.shrink_to_lo(),
-                    attr_span,
-                    tree_span,
-                    code,
-                }),
-            };
-            self.dcx().emit_err(err);
-        }
+                tree_span,
+                code,
+            }),
+        });
     }
 
     fn parse_rename(&mut self) -> PResult<'a, Option<Ident>> {

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -562,9 +562,13 @@ impl SourceMap {
     /// Extracts the source surrounding the given `Span` using the `extract_source` function. The
     /// extract function takes three arguments: a string slice containing the source, an index in
     /// the slice for the beginning of the span and an index in the slice for the end of the span.
-    pub fn span_to_source<F, T>(&self, sp: Span, extract_source: F) -> Result<T, SpanSnippetError>
+    pub fn span_to_source<F, T>(
+        &self,
+        sp: Span,
+        mut extract_source: F,
+    ) -> Result<T, SpanSnippetError>
     where
-        F: Fn(&str, usize, usize) -> Result<T, SpanSnippetError>,
+        F: FnMut(&str, usize, usize) -> Result<T, SpanSnippetError>,
     {
         let local_begin = self.lookup_byte_offset(sp.lo());
         let local_end = self.lookup_byte_offset(sp.hi());
@@ -719,7 +723,7 @@ impl SourceMap {
     pub fn span_extend_while(
         &self,
         span: Span,
-        f: impl Fn(char) -> bool,
+        mut f: impl FnMut(char) -> bool,
     ) -> Result<Span, SpanSnippetError> {
         self.span_to_source(span, |s, _start, end| {
             let n = s[end..].char_indices().find(|&(_, c)| !f(c)).map_or(s.len() - end, |(i, _)| i);

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -596,9 +596,13 @@ impl SourceMap {
     /// Extracts the source surrounding the given `Span` using the `extract_source` function. The
     /// extract function takes three arguments: a string slice containing the source, an index in
     /// the slice for the beginning of the span and an index in the slice for the end of the span.
-    pub fn span_to_source<F, T>(&self, sp: Span, extract_source: F) -> Result<T, SpanSnippetError>
+    pub fn span_to_source<F, T>(
+        &self,
+        sp: Span,
+        mut extract_source: F,
+    ) -> Result<T, SpanSnippetError>
     where
-        F: Fn(&str, usize, usize) -> Result<T, SpanSnippetError>,
+        F: FnMut(&str, usize, usize) -> Result<T, SpanSnippetError>,
     {
         let local_begin = self.lookup_byte_offset(sp.lo());
         let local_end = self.lookup_byte_offset(sp.hi());
@@ -753,7 +757,7 @@ impl SourceMap {
     pub fn span_extend_while(
         &self,
         span: Span,
-        f: impl Fn(char) -> bool,
+        mut f: impl FnMut(char) -> bool,
     ) -> Result<Span, SpanSnippetError> {
         self.span_to_source(span, |s, _start, end| {
             let n = s[end..].char_indices().find(|&(_, c)| !f(c)).map_or(s.len() - end, |(i, _)| i);

--- a/tests/ui/use/attr-in-use-tree.fixed
+++ b/tests/ui/use/attr-in-use-tree.fixed
@@ -2,20 +2,26 @@
 
 #![allow(unused_imports)]
 
+#[cfg(true)]
+use foo::bar;
+#[cfg(false)]
+use foo::baz;
 use foo::{
-    #[cfg(true)]
+    
     //~^ ERROR attributes are not allowed inside imports
-    bar,
-    #[cfg(false)]
+    
+    
     //~^ ERROR attributes are not allowed inside imports
-    baz,
+    
 };
 
 // Make sure we handle reserved symbols (leading `::` is `sym::PathRoot`).
+#[cfg(false)]
+use ::foo::qux;
 use ::foo::{
-    #[cfg(false)]
+    
     //~^ ERROR attributes are not allowed inside imports
-    qux,
+    
 };
 
 mod foo {

--- a/tests/ui/use/attr-in-use-tree.rs
+++ b/tests/ui/use/attr-in-use-tree.rs
@@ -1,0 +1,23 @@
+#![allow(unused_imports)]
+
+use foo::{
+    #[cfg(true)]
+    //~^ ERROR expected identifier, found `#`
+    bar,
+    #[cfg(false)]
+    baz,
+};
+
+// Make sure we handle reserved symbols (leading `::` is `sym::PathRoot`).
+use ::foo::{
+    #[cfg(false)]
+    qux,
+};
+
+mod foo {
+    pub(crate) mod bar {}
+    pub(crate) mod baz {}
+    pub(crate) mod qux {}
+}
+
+fn main() {}

--- a/tests/ui/use/attr-in-use-tree.stderr
+++ b/tests/ui/use/attr-in-use-tree.stderr
@@ -1,8 +1,53 @@
-error: expected identifier, found `#`
-  --> $DIR/attr-in-use-tree.rs:4:5
+error: attributes are not allowed inside imports
+  --> $DIR/attr-in-use-tree.rs:6:5
    |
 LL |     #[cfg(true)]
-   |     ^ expected identifier
+   |     ^^^^^^^^^^^^
+   |
+help: move the import to its own item
+   |
+LL + #[cfg(true)]
+LL + use foo::bar;
+LL | use foo::{
+LL ~     
+LL |
+LL ~     
+   |
 
-error: aborting due to 1 previous error
+error: attributes are not allowed inside imports
+  --> $DIR/attr-in-use-tree.rs:9:5
+   |
+LL |     #[cfg(false)]
+   |     ^^^^^^^^^^^^^
+   |
+help: move the import to its own item
+   |
+LL + #[cfg(false)]
+LL + use foo::baz;
+LL | use foo::{
+LL |     #[cfg(true)]
+LL |
+LL |     bar,
+LL ~     
+LL |
+LL ~     
+   |
+
+error: attributes are not allowed inside imports
+  --> $DIR/attr-in-use-tree.rs:16:5
+   |
+LL |     #[cfg(false)]
+   |     ^^^^^^^^^^^^^
+   |
+help: move the import to its own item
+   |
+LL + #[cfg(false)]
+LL + use ::foo::qux;
+LL | use ::foo::{
+LL ~     
+LL |
+LL ~     
+   |
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/use/attr-in-use-tree.stderr
+++ b/tests/ui/use/attr-in-use-tree.stderr
@@ -1,0 +1,8 @@
+error: expected identifier, found `#`
+  --> $DIR/attr-in-use-tree.rs:4:5
+   |
+LL |     #[cfg(true)]
+   |     ^ expected identifier
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155254)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

Renders as:
<img src="https://github.com/user-attachments/assets/169cd4d3-75e5-483c-8d1a-7cec13dfc4c0">
This requires passing two more arguments to `Parser::parse_use_tree` and I'm not super happy about it. I did consider adding more context to `Parser` instead, but that did not sound like a good idea. Happy to rework my code to make it less ugly :)

I am also not very happy that the deletion shows up as a green `~` in the suggestion. I tried very hard to make it render properly but failed. I am not sure it's actually possible but would love to be proven wrong hehe

<!-- homu-ignore:end -->
