### PR TITLE
explicit-tail-calls: disable two tests on LoongArch

### DIFF
--- a/tests/ui/explicit-tail-calls/support/bystack.rs
+++ b/tests/ui/explicit-tail-calls/support/bystack.rs
@@ -36,9 +36,11 @@
 //@ revisions: loongarch32
 //@[loongarch32] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32] needs-llvm-components: loongarch
+//@[loongarch32] ignore-llvm-version: 23
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
+//@[loongarch64] ignore-llvm-version: 23
 //@ revisions: bpf
 //@[bpf] compile-flags: --target bpfeb-unknown-none
 //@[bpf] needs-llvm-components: bpf

--- a/tests/ui/explicit-tail-calls/support/byval.rs
+++ b/tests/ui/explicit-tail-calls/support/byval.rs
@@ -36,9 +36,11 @@
 //@ revisions: loongarch32
 //@[loongarch32] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32] needs-llvm-components: loongarch
+//@[loongarch32] ignore-llvm-version: 23
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
+//@[loongarch64] ignore-llvm-version: 23
 //@ revisions: bpf
 //@[bpf] compile-flags: --target bpfeb-unknown-none
 //@[bpf] needs-llvm-components: bpf


### PR DESCRIPTION
A [recent LLVM change](https://github.com/llvm/llvm-project/pull/191508) broke these on LLVM 23.

I suspect these will eventually be fixed, so maybe it'd be okay/better to just leave this pending so it applies to our CI without merging it? I'm open to opinions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
