### PR TITLE
limit duplicate-profiler-builtins test to targets that can do dynamic linking

### DIFF
--- a/tests/run-make/duplicate-profiler-builtins/rmake.rs
+++ b/tests/run-make/duplicate-profiler-builtins/rmake.rs
@@ -2,6 +2,7 @@
 // together without getting an error about duplicate profiler_builtins.
 
 //@ needs-profiler-runtime
+//@ needs-dynamic-linking
 
 use run_make_support::{dynamic_lib_name, rustc};
 


### PR DESCRIPTION
this is the error I got for an example of such a target
```
=== STDERR ===
error: extern location for dylib_a does not exist: libdylib_a.so
 --> main.rs:2:5
  |
2 |     dylib_a::something();
  |     ^^^^^^^

error: extern location for dylib_b does not exist: libdylib_b.so
 --> main.rs:3:5
  |
3 |     dylib_b::something_else();
  |     ^^^^^^^