### PR TITLE
Test/lexer unicode pattern white space

### DIFF
--- a/tests/ui/lexer/unicode-pattern-white-space.rs
+++ b/tests/ui/lexer/unicode-pattern-white-space.rs
@@ -1,0 +1,12 @@
+//@ run-pass
+// Test that the Rust lexer accepts vertical tab (\x0B) as valid whitespace
+// between tokens. Vertical tab is part of Unicode Pattern_White_Space, which
+// the Rust language specification uses to define whitespace tokens.
+// See: https://unicode.org/reports/tr31/#Pattern_White_Space
+//
+// The space between "let" and "_" below is a vertical tab character (\x0B),
+// not a regular space.
+
+fn main() {
+    let_ = 1;
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds a test for the Rust lexer to verify it correctly accepts vertical tab (`\x0B`) as valid whitespace between tokens. Vertical tab is part of Unicode Pattern_White_Space, which the Rust language specification uses to define whitespace.

Related: Outreachy tracking [Pattern_White_Space](https://www.unicode.org/reports/tr31/#R3a)
