### PR TITLE
Revert "allow `windows-gnu` targets to embed gdb visualizer scripts"

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -99,7 +99,7 @@ pub(crate) fn opts() -> TargetOptions {
         late_link_args_dynamic,
         late_link_args_static,
         abi_return_struct_as_int: true,
-        emit_debug_gdb_scripts: true,
+        emit_debug_gdb_scripts: false,
         requires_uwtable: true,
         eh_frame_header: false,
         debuginfo_kind: DebuginfoKind::Dwarf,

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -42,7 +42,7 @@ pub(crate) fn opts() -> TargetOptions {
         link_self_contained: LinkSelfContainedDefault::InferredForMingw,
         late_link_args,
         abi_return_struct_as_int: true,
-        emit_debug_gdb_scripts: true,
+        emit_debug_gdb_scripts: false,
         requires_uwtable: true,
         eh_frame_header: false,
         no_default_libraries: false,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/155277

This reverts commit 472b96654882374a5bd5371d1953541ebe2d6c30.

This was merged as https://github.com/rust-lang/rust/pull/154840, but causes linker errors in the wild.

cc @Walnut356 @mati865 
r? @ghost