### PR TITLE
[stable] Revert "Build shared LLVM lib for windows-gnullvm"

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -712,7 +712,6 @@ auto:
         --target=aarch64-pc-windows-gnullvm,i686-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
-        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
       CC_i686_pc_windows_gnullvm: i686-w64-mingw32-clang
@@ -725,7 +724,6 @@ auto:
         --build=x86_64-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
-        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-windows


### PR DESCRIPTION
This reverts commit 1d1280a.

Looks like this causes problems (rust-lang/rust#155268) with certain LLVM bin tools not finding `libLLVM` on `*-windows-gnullvm`. This PR is a _minimal_ revert to return us to known state to alleviate time pressure to investigate.