### PR TITLE
net::tcp/udp: fix docs about how set_nonblocking is implemented

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -582,8 +582,8 @@ impl TcpStream {
     /// to be retried, an error with kind [`io::ErrorKind::WouldBlock`] is
     /// returned.
     ///
-    /// On Unix platforms, calling this method corresponds to calling `fcntl`
-    /// `FIONBIO`. On Windows calling this method corresponds to calling
+    /// On most Unix platforms, calling this method corresponds to calling `ioctl`
+    /// `FIONBIO`. On Windows, calling this method corresponds to calling
     /// `ioctlsocket` `FIONBIO`.
     ///
     /// # Examples
@@ -988,8 +988,8 @@ impl TcpListener {
     /// IO operation could not be completed and needs to be retried, an error
     /// with kind [`io::ErrorKind::WouldBlock`] is returned.
     ///
-    /// On Unix platforms, calling this method corresponds to calling `fcntl`
-    /// `FIONBIO`. On Windows calling this method corresponds to calling
+    /// On most Unix platforms, calling this method corresponds to calling `ioctl`
+    /// `FIONBIO`. On Windows, calling this method corresponds to calling
     /// `ioctlsocket` `FIONBIO`.
     ///
     /// # Examples

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -786,8 +786,8 @@ impl UdpSocket {
     /// and needs to be retried, an error with kind
     /// [`io::ErrorKind::WouldBlock`] is returned.
     ///
-    /// On Unix platforms, calling this method corresponds to calling `fcntl`
-    /// `FIONBIO`. On Windows calling this method corresponds to calling
+    /// On most Unix platforms, calling this method corresponds to calling `ioctl`
+    /// `FIONBIO`. On Windows, calling this method corresponds to calling
     /// `ioctlsocket` `FIONBIO`.
     ///
     /// # Examples


### PR DESCRIPTION
`fcntl` `FIONBIO` doesn't even make sense, it should be `fcntl` `F_SETFL`. However, for some reason we are using `ioctl` by default -- except on Solaris where this doesn't seem to work very well.

Honestly what I would have expected is that we just always use `FileDesc::set_nonblocking` also for network sockets, but for some reason we don't and there are no comments explaining this choice. Cc @nikarh (for "vita") @joboet 