### PR TITLE
Use unchecked indexing in integer `_fmt_inner` to keep bounds checks elided

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -210,10 +210,19 @@ macro_rules! impl_Display {
                     remain /= scale;
                     let pair1 = (quad / 100) as usize;
                     let pair2 = (quad % 100) as usize;
-                    buf[offset + 0].write(DECIMAL_PAIRS[pair1 * 2 + 0]);
-                    buf[offset + 1].write(DECIMAL_PAIRS[pair1 * 2 + 1]);
-                    buf[offset + 2].write(DECIMAL_PAIRS[pair2 * 2 + 0]);
-                    buf[offset + 3].write(DECIMAL_PAIRS[pair2 * 2 + 1]);
+                    // Unchecked indexing here avoids relying on LLVM to elide the
+                    // bounds checks from the surrounding `assert_unchecked` hints;
+                    // this regressed under `opt-level=z` + fat LTO on LLVM 21
+                    // (see rust-lang/rust#152061).
+                    //
+                    // SAFETY: `offset + 4 <= buf.len()`, and `pair1, pair2 < 100`
+                    // so all `DECIMAL_PAIRS` indices are `< 200 == DECIMAL_PAIRS.len()`.
+                    unsafe {
+                        buf.get_unchecked_mut(offset).write(*DECIMAL_PAIRS.get_unchecked(pair1 * 2));
+                        buf.get_unchecked_mut(offset + 1).write(*DECIMAL_PAIRS.get_unchecked(pair1 * 2 + 1));
+                        buf.get_unchecked_mut(offset + 2).write(*DECIMAL_PAIRS.get_unchecked(pair2 * 2));
+                        buf.get_unchecked_mut(offset + 3).write(*DECIMAL_PAIRS.get_unchecked(pair2 * 2 + 1));
+                    }
                 }
 
                 // Format per two digits from the lookup table.
@@ -228,8 +237,14 @@ macro_rules! impl_Display {
 
                     let pair = (remain % 100) as usize;
                     remain /= 100;
-                    buf[offset + 0].write(DECIMAL_PAIRS[pair * 2 + 0]);
-                    buf[offset + 1].write(DECIMAL_PAIRS[pair * 2 + 1]);
+                    // See the outer loop for the rationale (rust-lang/rust#152061).
+                    //
+                    // SAFETY: `offset + 2 <= buf.len()`, and `pair < 100` so the
+                    // `DECIMAL_PAIRS` indices are `< 200 == DECIMAL_PAIRS.len()`.
+                    unsafe {
+                        buf.get_unchecked_mut(offset).write(*DECIMAL_PAIRS.get_unchecked(pair * 2));
+                        buf.get_unchecked_mut(offset + 1).write(*DECIMAL_PAIRS.get_unchecked(pair * 2 + 1));
+                    }
                 }
 
                 // Format the last remaining digit, if any.
@@ -242,10 +257,14 @@ macro_rules! impl_Display {
                     unsafe { core::hint::assert_unchecked(offset <= buf.len()) }
                     offset -= 1;
 
-                    // Either the compiler sees that remain < 10, or it prevents
-                    // a boundary check up next.
                     let last = (remain & 15) as usize;
-                    buf[offset].write(DECIMAL_PAIRS[last * 2 + 1]);
+                    // See the outer loop for the rationale (rust-lang/rust#152061).
+                    //
+                    // SAFETY: `offset < buf.len()`, and `last < 16` so
+                    // `last * 2 + 1 < 32 < 200 == DECIMAL_PAIRS.len()`.
+                    unsafe {
+                        buf.get_unchecked_mut(offset).write(*DECIMAL_PAIRS.get_unchecked(last * 2 + 1));
+                    }
                     // not used: remain = 0;
                 }
 

--- a/tests/codegen-llvm/issues/fmt-display-no-bounds-check-152061.rs
+++ b/tests/codegen-llvm/issues/fmt-display-no-bounds-check-152061.rs
@@ -1,0 +1,48 @@
+//@ revisions: opt-3 opt-z
+//@[opt-3] compile-flags: -Copt-level=3
+//@[opt-z] compile-flags: -Copt-level=z
+// Regression test for https://github.com/rust-lang/rust/issues/152061.
+//
+// `impl fmt::Display` for integers, lowered through `_fmt_inner` in
+// `library/core/src/fmt/num.rs`, used to leave a `panic_bounds_check`
+// path in optimised LLVM IR when LLVM failed to propagate the
+// `assume`-based range information (notably under `opt-level=z` + fat
+// LTO with LLVM 21). The implementation was rewritten to use
+// `get_unchecked{_mut}` for the buffer writes, so the `panic_bounds_check`
+// path must not appear regardless of the optimiser's propagation.
+
+#![crate_type = "lib"]
+
+use std::fmt::Write;
+
+pub struct NoopWriter;
+impl Write for NoopWriter {
+    fn write_str(&mut self, _s: &str) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+// CHECK-LABEL: @format_usize
+#[no_mangle]
+pub fn format_usize(w: &mut NoopWriter, x: usize) {
+    // The Display path through `_fmt_inner` must not emit a bounds check.
+    // CHECK-NOT: panic_bounds_check
+    let _ = write!(w, "{}", x);
+}
+
+// CHECK-LABEL: @format_u64
+#[no_mangle]
+pub fn format_u64(w: &mut NoopWriter, x: u64) {
+    // CHECK-NOT: panic_bounds_check
+    let _ = write!(w, "{}", x);
+}
+
+// Sanity check: make sure `panic_bounds_check` is still the symbol LLVM
+// emits for a non-elidable out-of-bounds index, so the `CHECK-NOT`s
+// above are guarding against something real and cannot pass vacuously.
+// CHECK-LABEL: @test_check
+#[no_mangle]
+pub fn test_check(arr: &[u8], i: usize) -> u8 {
+    // CHECK: panic_bounds_check
+    arr[i]
+}


### PR DESCRIPTION
Fixes rust-lang/rust#152061.

The `_fmt_inner` helper in `core::fmt::num` writes into its `MaybeUninit<u8>` buffer through regular `[]` indexing and relies on surrounding `core::hint::assert_unchecked` hints to convince LLVM to elide the resulting bounds checks. Under `-Copt-level=z` with fat LTO the hints were dropped by LLVM 21 and the optimizer left a `panic_bounds_check` call on the hot integer-formatting path, regressing 1.92 → 1.93. LLVM 22 (shipping with 1.95) fixes the propagation upstream, so this change is primarily **defensive**: it removes the reliance on LLVM's propagation of `assert_unchecked`-derived ranges across the `_fmt_inner` inliner/LTO boundary, and makes `fmt::Display` for integers usable today for 1.93 / 1.94 users on fat-LTO no-panic builds without waiting for LLVM 22.

This PR switches the per-pair buffer writes to `get_unchecked_mut` / `get_unchecked` on both `buf` and `DECIMAL_PAIRS`, in three places:

1. The 4-byte main loop (two pairs per iteration).
2. The 2-byte branch for the next pair.
3. The 1-byte branch for the final digit.

Each `unsafe` block has a short rationale comment and a tight `SAFETY:` comment stating just the invariants (`offset + N <= buf.len()`, and the numeric bound on the `DECIMAL_PAIRS` index). The `assert_unchecked`s themselves are retained — they still document the `offset` / `buf.len()` invariant of the function and help downstream codegen for the parts of the routine outside these `unsafe` blocks.

A codegen-llvm regression test is added under `tests/codegen-llvm/issues/` with `opt-3` and `opt-z` revisions, checking that the `Display` path for `usize` and `u64` does not contain any `panic_bounds_check`, paired with a sanity check that confirms `panic_bounds_check` is still the symbol emitted for a real non-elidable index — so the `CHECK-NOT`s cannot pass vacuously. Note: a single-crate codegen test can only check the *caller's* IR; the LTO-conditional aspect of the original bug is out of reach for this harness. A before/after IR demo against a real no_std-style bin with fat LTO is included in the review reply.

r? libs

---

_LLM disclosure: this PR was roughly a 50/50 collaboration between me and a Claude-based coding agent team. Agent-side: read `library/core/src/fmt/num.rs`, identified the three `_fmt_inner` bounds-check call sites from the issue's MCVE, drafted the `get_unchecked` conversion with the surrounding `SAFETY` comments, and drafted the codegen-llvm regression test. Human-side: reproduced the original bug locally (stable + fat LTO + opt-z), reviewed the diff, validated that the patched stage1 eliminates the two `panic_bounds_check(-4, 20)` / `(-2, 10)` calls from the LTO IR, and opened the PR. Happy to answer any question about the reasoning or the reproduction steps._