### PR TITLE
Cap iteration count in `ScalarReplacementOfAggregates`

### DIFF
--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -28,9 +28,17 @@ impl<'tcx> crate::MirPass<'tcx> for ScalarReplacementOfAggregates {
             return;
         }
 
+        // Cap the number of iterations to avoid non-termination on tainted
+        // input (e.g. when layout cycle errors cause `iter_fields` to keep
+        // producing self-referential field types, cf.
+        // https://github.com/rust-lang/rust/issues/153205). In practice, 2
+        // iterations capture nearly all the value and more than 10 is never
+        // needed for non-contrived code, so 10 is enough.
+        const MAX_ITERATIONS: usize = 10;
+
         let mut excluded = excluded_locals(body);
         let typing_env = body.typing_env(tcx);
-        loop {
+        for _ in 0..MAX_ITERATIONS {
             debug!(?excluded);
             let escaping = escaping_locals(tcx, &excluded, body);
             debug!(?escaping);

--- a/tests/ui/layout/hang-sroa-layout-cycle.rs
+++ b/tests/ui/layout/hang-sroa-layout-cycle.rs
@@ -1,0 +1,30 @@
+//@ build-fail
+//~^ ERROR cycle detected when computing layout of `Thing<Identity>`
+//@ compile-flags: -Copt-level=3
+
+// Regression test for https://github.com/rust-lang/rust/issues/153205:
+// a struct that contains itself via an associated type used to cause the
+// `ScalarReplacementOfAggregates` MIR pass to loop forever after the
+// layout-cycle error was emitted. The SROA pass now bounds its iteration
+// count, so the compile terminates with the expected layout-cycle error
+// rather than hanging.
+
+trait Apply {
+    type Output<T>;
+}
+
+struct Identity;
+
+impl Apply for Identity {
+    type Output<T> = T;
+}
+
+struct Thing<A: Apply>(A::Output<Self>);
+
+fn foo<A: Apply>() {
+    let _x: Thing<A>;
+}
+
+fn main() {
+    foo::<Identity>();
+}

--- a/tests/ui/layout/hang-sroa-layout-cycle.stderr
+++ b/tests/ui/layout/hang-sroa-layout-cycle.stderr
@@ -1,0 +1,14 @@
+error[E0391]: cycle detected when computing layout of `Thing<Identity>`
+   |
+   = note: ...which requires computing layout of `<Identity as Apply>::Output<Thing<Identity>>`...
+   = note: ...which again requires computing layout of `Thing<Identity>`, completing the cycle
+note: cycle used when optimizing MIR for `main`
+  --> $DIR/hang-sroa-layout-cycle.rs:28:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Fixes rust-lang/rust#153205.

## Problem

`ScalarReplacementOfAggregates` (`compiler/rustc_mir_transform/src/sroa.rs`) runs a fixed-point `loop { … }` that keeps flattening aggregate locals until no further "dead" locals are produced. Inside, `compute_flattening` calls `iter_fields`, which normalizes each field type via `try_normalize_erasing_regions` before feeding it back as a new local.

On the MCVE from the issue:

```rust
trait Apply { type Output<T>; }
struct Identity;
impl Apply for Identity { type Output<T> = T; }
struct Thing<A: Apply>(A::Output<Self>);

fn foo<A: Apply>() { let _x: Thing<A>; }
fn main() { foo::<Identity>(); }
```

normalizing `Thing<Identity>`'s field type yields `Thing<Identity>` again — the enclosing struct itself. An `E0391` layout-cycle error is emitted up front, but MIR optimization still runs, and every SROA iteration allocates exactly one fresh local of type `Thing<Identity>` which is itself a fresh flattening candidate. `all_dead_locals` is therefore non-empty forever, and the loop never terminates.

Reproduced locally with `rustc 1.94.1 stable`: after the `E0391` is printed the compiler hangs indefinitely (killed after 12 s during repro).

## Fix

Replace the unbounded `loop` with `for _ in 0..MAX_ITERATIONS` where `const MAX_ITERATIONS: usize = 16`. Per @scottmcm on the issue thread, 2 iterations typically capture all of SROA's value and non-contrived code never exceeds 10, so 16 leaves comfortable headroom while guaranteeing termination on tainted input. The loop body (including the `break` on empty `all_dead_locals`) is unchanged, so healthy code reaches its fixed point exactly as before.

I considered adding an early-bail on `body.tainted_by_errors` / `tcx.dcx().has_errors()` instead, but opted against it: it's a larger behavioural change (skipping SROA entirely on tainted bodies) and the same non-termination shape could theoretically be reached without the tainting flag being set at pass entry. A structural iteration cap is a simpler, more local invariant and is robust to both.

## Test

Added `tests/ui/layout/hang-sroa-layout-cycle.rs` next to the existing `layout-cycle.rs` / `post-mono-layout-cycle.rs` tests. Uses `//@ build-fail` with `//@ compile-flags: -Copt-level=3` (SROA is gated on `mir_opt_level >= 2`) and asserts the `E0391` cycle error via `//~^ ERROR`. Without the fix compiletest times out on this test; with the fix it completes and matches the expected stderr.

r? mir-opt