### PR TITLE
codegen_ssa: copy tupled rust-call constant args before indirect pass

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1799,7 +1799,23 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         args: &[ArgAbi<'tcx, Ty<'tcx>>],
         lifetime_ends_after_call: &mut Vec<(Bx::Value, Size)>,
     ) -> usize {
-        let tuple = self.codegen_operand(bx, operand);
+        let mut tuple = self.codegen_operand(bx, operand);
+
+        // Mirrors the safety-copy in `codegen_call_terminator` (see #45996): if the
+        // tuple is a non-immediate `Copy` or `Constant` operand, its backing memory
+        // may be shared (e.g. it points into `.rodata` for a promoted constant), but
+        // the `extern "rust-call"` callee owns its argument storage by ABI and is
+        // free to write through it. Copy the tuple into a fresh alloca first so that
+        // the fields projected out of it below point at caller-owned memory.
+        if let &mir::Operand::Copy(_) | &mir::Operand::Constant(_) = operand
+            && let Ref(PlaceValue { llextra: None, .. }) = tuple.val
+        {
+            let tmp = PlaceRef::alloca(bx, tuple.layout);
+            bx.lifetime_start(tmp.val.llval, tmp.layout.size);
+            tuple.store_with_annotation(bx, tmp);
+            tuple.val = Ref(tmp.val);
+            lifetime_ends_after_call.push((tmp.val.llval, tmp.layout.size));
+        }
 
         // Handle both by-ref and immediate tuples.
         if let Ref(place_val) = tuple.val {

--- a/tests/ui/closures/rust-call-const-arg-alias.rs
+++ b/tests/ui/closures/rust-call-const-arg-alias.rs
@@ -1,0 +1,61 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/155241>.
+//!
+//! When a closure with the `extern "rust-call"` ABI is invoked with a constant
+//! tuple whose layout is passed indirectly, `codegen_arguments_untupled` used
+//! to hand the callee a pointer straight into the caller's operand (typically
+//! promoted into `.rodata`). Because the callee owns its argument storage by
+//! ABI contract, a mutation inside the closure would write through a read-only
+//! pointer and abort with SIGBUS / `STATUS_HEAP_CORRUPTION`.
+//!
+//! The safety-copy added in PR #45996 for `codegen_call_terminator` was never
+//! ported to the tupled `rust-call` path; this test locks in that fix.
+//
+//@ run-pass
+//@ revisions: opt0 opt3
+//@[opt0] compile-flags: -Copt-level=0
+//@[opt3] compile-flags: -Copt-level=3
+
+#![feature(fn_traits)]
+
+use std::hint::black_box;
+
+#[derive(Copy, Clone)]
+struct Thing {
+    x: usize,
+    y: usize,
+    z: usize,
+}
+
+// A tuple large enough to be passed indirectly (BackendRepr::Memory).
+const VALUE: (Thing,) = (Thing { x: 0, y: 0, z: 0 },);
+
+fn main() {
+    // The original 2017 reproducer: invoke the closure through `Fn::call`,
+    // which forces the tupled `rust-call` code path in the caller.
+    let observed = (|mut thing: Thing| {
+        thing.z = 1;
+        // Prevent the optimizer from eliminating the write entirely.
+        black_box(&thing);
+        thing.z
+    })
+    .call(VALUE);
+    assert_eq!(observed, 1);
+
+    // Same shape, but exercised through `FnMut::call_mut` to cover the other
+    // trait method that lowers to the same tupled path.
+    let mut sum = 0usize;
+    (|t: Thing| {
+        sum = sum.wrapping_add(t.x).wrapping_add(t.y).wrapping_add(t.z);
+    })
+    .call_mut(VALUE);
+    assert_eq!(sum, 0);
+
+    // And via `FnOnce::call_once` for good measure.
+    let taken = (|mut t: Thing| {
+        t.z = 42;
+        black_box(&t);
+        t.z
+    })
+    .call_once(VALUE);
+    assert_eq!(taken, 42);
+}


### PR DESCRIPTION
Fixes rust-lang/rust#155241 (the `const`-argument / indirect-ABI half of the issue; the MIR-GVN half is tracked separately).

## Problem

Invoking a closure with the `extern "rust-call"` ABI on a constant tuple whose layout is passed indirectly has been miscompiling since `nightly-2017-11-18`. On Linux the program SIGBUSes; on Windows it aborts with `STATUS_HEAP_CORRUPTION`.

Original reproducer (still a smoking gun at `-Copt-level=0` today):

```rust
#![feature(fn_traits)]

#[derive(Copy, Clone)]
struct Thing { x: usize, y: usize, z: usize }

const VALUE: (Thing,) = (Thing { x: 0, y: 0, z: 0 },);

fn main() {
    (|mut thing: Thing| { thing.z = 1; }).call(VALUE);
}
```

The root cause is in `codegen_arguments_untupled` (`compiler/rustc_codegen_ssa/src/mir/block.rs`). When the MIR operand is `Operand::Copy` or `Operand::Constant` and the tuple's backend layout is by-ref (`BackendRepr::Memory`), `codegen_operand` returns `OperandValue::Ref(alloc_addr)` where `alloc_addr` points into a shared, read-only allocation (typically a promoted constant in `.rodata`). The field projections downstream load field pointers out of *that* memory, so the `extern "rust-call"` callee — which owns its argument storage by ABI contract — writes through read-only memory when it mutates.

## Fix

This is exactly the hazard that rust-lang/rust#45996 fixed for the normal (non-tupled) call path in `codegen_call_terminator`, by spilling `Copy`/`Constant` operands that arrive by-ref into a fresh alloca before passing a pointer. That safety-copy was never applied to the tupled `rust-call` path; this PR ports the same logic across, spilling the whole tuple before the field projections and wiring the `lifetime_start` / `lifetime_end` pair into the existing `lifetime_ends_after_call` bookkeeping. The new block is a line-for-line parallel of the existing code a few hundred lines above in the same file.

## Test

Adds a `//@ run-pass` regression test at `tests/ui/closures/rust-call-const-arg-alias.rs` exercising the 2017 reproducer through `Fn::call` / `FnMut::call_mut` / `FnOnce::call_once`, at both `-Copt-level=0` (where the bug aborts deterministically without the fix) and `-Copt-level=3` (coverage that the fix does not regress release codegen). The test uses `assert_eq!` on the observed mutation so a future regression that silently ignores the write, rather than crashing, is also caught.

## Verification

Bug reproduction was confirmed locally on `rustc 1.97.0-nightly (17584a181 2026-04-13)` using the MCVE above: exit 138 (SIGBUS) at `-Copt-level=0`. A full bootstrap of the patched compiler was not performed; the patch is a mechanical port of a proven safety-copy with no deviation in data-flow after `tuple.val` is updated, so the behaviour from that point on is already exercised by every non-constant `rust-call` invocation today.

r? compiler