### PR TITLE
Add test for coalescing of diagnostic attribute duplicates

### DIFF
--- a/tests/ui/diagnostic_namespace/duplicate_coalescing.both.stderr
+++ b/tests/ui/diagnostic_namespace/duplicate_coalescing.both.stderr
@@ -1,0 +1,25 @@
+error[E0277]: this message
+  --> $DIR/duplicate_coalescing.rs:15:17
+   |
+LL |     takes_trait(());
+   |     ----------- ^^ this label
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Trait` is not implemented for `()`
+   = note: a note
+   = note: another note
+help: this trait has no implementations, consider adding one
+  --> $DIR/duplicate_coalescing.rs:10:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
+note: required by a bound in `takes_trait`
+  --> $DIR/duplicate_coalescing.rs:12:24
+   |
+LL | fn takes_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `takes_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/duplicate_coalescing.label.stderr
+++ b/tests/ui/diagnostic_namespace/duplicate_coalescing.label.stderr
@@ -1,0 +1,24 @@
+error[E0277]: this message
+  --> $DIR/duplicate_coalescing.rs:15:17
+   |
+LL |     takes_trait(());
+   |     ----------- ^^ this label
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Trait` is not implemented for `()`
+   = note: a note
+help: this trait has no implementations, consider adding one
+  --> $DIR/duplicate_coalescing.rs:10:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
+note: required by a bound in `takes_trait`
+  --> $DIR/duplicate_coalescing.rs:12:24
+   |
+LL | fn takes_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `takes_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/duplicate_coalescing.note.stderr
+++ b/tests/ui/diagnostic_namespace/duplicate_coalescing.note.stderr
@@ -1,0 +1,24 @@
+error[E0277]: this message
+  --> $DIR/duplicate_coalescing.rs:15:17
+   |
+LL |     takes_trait(());
+   |     ----------- ^^ the trait `Trait` is not implemented for `()`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: a note
+   = note: another note
+help: this trait has no implementations, consider adding one
+  --> $DIR/duplicate_coalescing.rs:10:1
+   |
+LL | trait Trait {}
+   | ^^^^^^^^^^^
+note: required by a bound in `takes_trait`
+  --> $DIR/duplicate_coalescing.rs:12:24
+   |
+LL | fn takes_trait(_: impl Trait) {}
+   |                        ^^^^^ required by this bound in `takes_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/duplicate_coalescing.rs
+++ b/tests/ui/diagnostic_namespace/duplicate_coalescing.rs
@@ -1,0 +1,22 @@
+//@ revisions: label note both
+//@[both] compile-flags: --cfg label --cfg note
+//@ dont-require-annotations: NOTE
+
+//! Example and test of multiple diagnostic attributes coalescing together.
+
+#[diagnostic::on_unimplemented(message = "this message", note = "a note")]
+#[cfg_attr(label, diagnostic::on_unimplemented(label = "this label"))]
+#[cfg_attr(note, diagnostic::on_unimplemented(note = "another note"))]
+trait Trait {}
+
+fn takes_trait(_: impl Trait) {}
+
+fn main() {
+    takes_trait(());
+    //~^ERROR this message
+    //[label]~|NOTE this label
+    //[both]~|NOTE this label
+    //~|NOTE a note
+    //[note]~|NOTE another note
+    //[both]~|NOTE another note
+}


### PR DESCRIPTION
There is an existing [test](github.com/rust-lang/rust/blob/main/tests/ui/diagnostic_namespace/on_unimplemented/report_warning_on_duplicated_options.rs) that warnings for duplicates are emitted, but not for the messages themselves.
