### PR TITLE
Fix misleading "borrowed data escapes outside of function" diagnostic

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -686,6 +686,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             || (*category == ConstraintCategory::Assignment
                 && self.regioncx.universal_regions().defining_ty.is_fn_def())
             || self.regioncx.universal_regions().defining_ty.is_const()
+            || (fr_name_and_span.is_none()
+                && self.regioncx.universal_regions().defining_ty.is_fn_def())
         {
             return self.report_general_error(errci);
         }

--- a/tests/ui/borrowck/fn-ptr-lifetime-mismatch-with-impl-trait-arg.rs
+++ b/tests/ui/borrowck/fn-ptr-lifetime-mismatch-with-impl-trait-arg.rs
@@ -1,0 +1,8 @@
+// Regression test for https://github.com/rust-lang/rust/issues/154350
+
+fn func<'a>(f: impl FnOnce(fn(&'a i32)), x: fn(&'static i32)) {
+    f(x);
+    //~^ ERROR lifetime may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/borrowck/fn-ptr-lifetime-mismatch-with-impl-trait-arg.stderr
+++ b/tests/ui/borrowck/fn-ptr-lifetime-mismatch-with-impl-trait-arg.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/fn-ptr-lifetime-mismatch-with-impl-trait-arg.rs:4:5
+   |
+LL | fn func<'a>(f: impl FnOnce(fn(&'a i32)), x: fn(&'static i32)) {
+   |         -- lifetime `'a` defined here
+LL |     f(x);
+   |     ^^^^ argument requires that `'a` must outlive `'static`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#154350 

Fall back to `report_general_error()` when `fr_name_and_span` is `None` in function items, since the "escaping data" framing is only appropriate for closures capturing outside variables.