### PR TITLE
remove ibraheemdev from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1479,7 +1479,6 @@ libs = [
     "@jhpratt",
     "@tgross35",
     "@thomcc",
-    "@ibraheemdev",
     "@joboet",
 ]
 infra-ci = [


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


@ibraheemdev haven't reviewed any r-l/r PRs since October last year and has a backlog of [8 PRs at the moment of writing this](https://github.com/rust-lang/rust/pulls?q=is%3Aopen+is%3Apr+assignee%3Aibraheemdev+label%3AS-waiting-on-review).

@ibraheemdev thank you for the reviews that you have done in the past! feel free to re-add yourself once you have time for this again :)