### PR TITLE
remove PointeeParser

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -4,8 +4,8 @@ use super::prelude::*;
 use crate::attributes::{NoArgsAttributeParser, OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
+use crate::target_checking::AllowedTargets;
 use crate::target_checking::Policy::{Allow, Warn};
-use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 
 pub(crate) struct RustcSkipDuringMethodDispatchParser;
 impl<S: Stage> SingleAttributeParser<S> for RustcSkipDuringMethodDispatchParser {
@@ -140,12 +140,4 @@ impl<S: Stage> NoArgsAttributeParser<S> for FundamentalParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Struct), Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Fundamental;
-}
-
-pub(crate) struct PointeeParser;
-impl<S: Stage> NoArgsAttributeParser<S> for PointeeParser {
-    const PATH: &[Symbol] = &[sym::pointee];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
-    const CREATE: fn(Span) -> AttributeKind = AttributeKind::Pointee;
 }

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -269,7 +269,6 @@ attribute_parsers!(
         Single<WithoutArgs<PanicHandlerParser>>,
         Single<WithoutArgs<PanicRuntimeParser>>,
         Single<WithoutArgs<PinV2Parser>>,
-        Single<WithoutArgs<PointeeParser>>,
         Single<WithoutArgs<PreludeImportParser>>,
         Single<WithoutArgs<ProcMacroAttributeParser>>,
         Single<WithoutArgs<ProcMacroParser>>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1233,9 +1233,6 @@ pub enum AttributeKind {
     /// Represents `#[pin_v2]`
     PinV2(Span),
 
-    /// Represents `#[pointee]`
-    Pointee(Span),
-
     /// Represents `#[prelude_import]`
     PreludeImport,
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -86,7 +86,6 @@ impl AttributeKind {
             Path(..) => No,
             PatternComplexityLimit { .. } => No,
             PinV2(..) => Yes,
-            Pointee(..) => No,
             PreludeImport => No,
             ProcMacro(..) => No,
             ProcMacroAttribute(..) => No,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -281,7 +281,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::Path(..)
                     | AttributeKind::PatternComplexityLimit { .. }
                     | AttributeKind::PinV2(..)
-                    | AttributeKind::Pointee(..)
                     | AttributeKind::PreludeImport
                     | AttributeKind::ProfilerRuntime
                     | AttributeKind::RecursionLimit { .. }


### PR DESCRIPTION
this parser does nothing currently, as the current scope of `rustc_attr_parsing` only includes builtin attributes, and not derive macros

it isn't defined in `compiler/rustc_feature/src/builtin_attrs.rs`

all the actual parsing for `#[pointee]` is actually handled in `compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs`

r? @JonathanBrouwer 