### PR TITLE
Make `convert_while_ascii` unsafe

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -378,7 +378,9 @@ impl str {
                   without modifying the original"]
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_lowercase(&self) -> String {
-        let (mut s, rest) = convert_while_ascii(self, u8::to_ascii_lowercase);
+        // SAFETY: `to_ascii_lowercase` preserves ASCII bytes, so the converted
+        // prefix remains valid UTF-8.
+        let (mut s, rest) = unsafe { convert_while_ascii(self, u8::to_ascii_lowercase) };
 
         let prefix_len = s.len();
 
@@ -463,7 +465,9 @@ impl str {
                   without modifying the original"]
     #[stable(feature = "unicode_case_mapping", since = "1.2.0")]
     pub fn to_uppercase(&self) -> String {
-        let (mut s, rest) = convert_while_ascii(self, u8::to_ascii_uppercase);
+        // SAFETY: `to_ascii_uppercase` preserves ASCII bytes, so the converted
+        // prefix remains valid UTF-8.
+        let (mut s, rest) = unsafe { convert_while_ascii(self, u8::to_ascii_uppercase) };
 
         for c in rest.chars() {
             match conversions::to_upper(c) {
@@ -626,11 +630,15 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
 ///
 /// This function is only public so that it can be verified in a codegen test,
 /// see `issue-123712-str-to-lower-autovectorization.rs`.
+///
+/// # Safety
+///
+/// `convert` must return an ASCII byte for every ASCII input byte.
 #[unstable(feature = "str_internals", issue = "none")]
 #[doc(hidden)]
 #[inline]
 #[cfg(not(no_global_oom_handling))]
-pub fn convert_while_ascii(s: &str, convert: fn(&u8) -> u8) -> (String, &str) {
+pub unsafe fn convert_while_ascii(s: &str, convert: fn(&u8) -> u8) -> (String, &str) {
     // Process the input in chunks of 16 bytes to enable auto-vectorization.
     // Previously the chunk size depended on the size of `usize`,
     // but on 32-bit platforms with sse or neon is also the better choice.

--- a/tests/codegen-llvm/issues/issue-123712-str-to-lower-autovectorization.rs
+++ b/tests/codegen-llvm/issues/issue-123712-str-to-lower-autovectorization.rs
@@ -19,5 +19,6 @@ extern crate alloc;
 // CHECK-NEXT: [[C:%[0-9]]] = bitcast <16 x i1> [[B]] to i16
 #[no_mangle]
 pub fn lower_while_ascii(s: &str) -> (alloc::string::String, &str) {
-    alloc::str::convert_while_ascii(s, u8::to_ascii_lowercase)
+    // SAFETY: `to_ascii_lowercase` preserves ASCII bytes.
+    unsafe { alloc::str::convert_while_ascii(s, u8::to_ascii_lowercase) }
 }


### PR DESCRIPTION
`convert_while_ascii` assumes `convert` only returns ASCII to ensure the output remains valid UTF-8. This adds that requirement as a safety precondition.