### PR TITLE
Stabilize `--remap-path-prefix` in rustdoc

### DIFF
--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -183,6 +183,18 @@ affect that.
 The arguments to this flag are the same as those for the `-C` flag on rustc. Run `rustc -C help` to
 get the full list.
 
+## `--remap-path-prefix`: remap source paths in output
+
+This flag is the equivalent flag from `rustc`: `--remap-path-prefix`.
+
+```bash
+$ rustdoc src/lib.rs --remap-path-prefix="$PWD=/foo"
+```
+
+It permits remapping (as a best effort) source path prefixes in all output, including diagnostics,
+debug information, macro expansions, generated documentation, etc. It takes a value of the
+form `FROM=TO` where a path prefix equal to `FROM` is rewritten to the value `TO`.
+
 ## `--test`: run code examples as tests
 
 Using this flag looks like this:

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -751,14 +751,6 @@ pass `--doctest-build-arg ARG` for each argument `ARG`.
 
 This flag enables the generation of toggles to expand macros in the HTML source code pages.
 
-## `--remap-path-prefix`: Remap source code paths in output
-
-This flag is the equivalent flag from `rustc` `--remap-path-prefix`.
-
-it permits remapping source path prefixes in all output, including compiler diagnostics,
-debug information, macro expansions, etc. It takes a value of the form `FROM=TO`
-where a path prefix equal to `FROM` is rewritten to the value `TO`.
-
 ## `--remap-path-scope`: Scopes to which the source remapping should be done
 
 This flag is the equivalent flag from `rustc` `--remap-path-scope`.

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -456,6 +456,14 @@ fn opts() -> Vec<RustcOptGroup> {
                 By default, it is at `forbid` level.",
             "LEVEL",
         ),
+        opt(
+            Stable,
+            Multi,
+            "",
+            "remap-path-prefix",
+            "Remap source names in compiler messages",
+            "FROM=TO",
+        ),
         opt(Unstable, Opt, "", "index-page", "Markdown file to be used as index page", "PATH"),
         opt(
             Unstable,
@@ -547,14 +555,6 @@ fn opts() -> Vec<RustcOptGroup> {
             "merge-doctests",
             "Force all doctests to be compiled as a single binary, instead of one binary per test. If merging fails, rustdoc will emit a hard error.",
             "yes|no|auto",
-        ),
-        opt(
-            Unstable,
-            Multi,
-            "",
-            "remap-path-prefix",
-            "Remap source names in compiler messages",
-            "FROM=TO",
         ),
         opt(
             Unstable,

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -125,6 +125,8 @@ Options:
                         Set the most restrictive lint level. More restrictive
                         lints are capped at this level. By default, it is at
                         `forbid` level.
+        --remap-path-prefix FROM=TO
+                        Remap source names in compiler messages
         --index-page PATH
                         Markdown file to be used as index page
         --enable-index-page 
@@ -158,8 +160,6 @@ Options:
                         Force all doctests to be compiled as a single binary,
                         instead of one binary per test. If merging fails,
                         rustdoc will emit a hard error.
-        --remap-path-prefix FROM=TO
-                        Remap source names in compiler messages
         --remap-path-scope [macro,diagnostics,debuginfo,coverage,object,all]
                         Defines which scopes of paths should be remapped by
                         `--remap-path-prefix`

--- a/tests/rustdoc-html/auxiliary/remapped-paths.rs
+++ b/tests/rustdoc-html/auxiliary/remapped-paths.rs
@@ -1,4 +1,4 @@
-//@ compile-flags:-Zunstable-options --remap-path-prefix={{src-base}}=
+//@ compile-flags:--remap-path-prefix={{src-base}}=
 
 pub struct MyStruct {
     field: u32,

--- a/tests/rustdoc-ui/lints/remap-path-prefix-lint.rs
+++ b/tests/rustdoc-ui/lints/remap-path-prefix-lint.rs
@@ -1,7 +1,7 @@
 // Regression test for remapped paths in rustdoc errors
 // <https://github.com/rust-lang/rust/issues/69264>.
 
-//@ compile-flags:-Z unstable-options --remap-path-prefix={{src-base}}=remapped_path
+//@ compile-flags:--remap-path-prefix={{src-base}}=remapped_path
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![deny(rustdoc::invalid_html_tags)]

--- a/tests/rustdoc-ui/remap-path-prefix-doctest.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-doctest.rs
@@ -9,7 +9,7 @@
 //@ revisions: without-scope
 
 //@ compile-flags:--test --test-args --test-threads=1
-//@ compile-flags:-Z unstable-options --remap-path-prefix={{src-base}}=remapped_path
+//@ compile-flags:--remap-path-prefix={{src-base}}=remapped_path
 
 //@[with-diag-scope] compile-flags: -Zunstable-options --remap-path-scope=diagnostics
 //@[with-macro-scope] compile-flags: -Zunstable-options --remap-path-scope=macro

--- a/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
@@ -2,7 +2,7 @@
 // adapted to use that, and that normalize line can go away
 
 //@ failure-status: 101
-//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ compile-flags:--test --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout: "exit (status|code): 101" -> "exit status: 101"

--- a/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
@@ -2,7 +2,7 @@
 // adapted to use that, and that normalize line can go away
 
 //@ failure-status: 101
-//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ compile-flags:--test --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 

--- a/tests/rustdoc-ui/remap-path-prefix-macro-138520.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-macro-138520.rs
@@ -2,7 +2,7 @@
 // when using --remap-path-prefix with macro rendering.
 // <https://github.com/rust-lang/rust/issues/138520>
 
-//@ compile-flags:-Z unstable-options --remap-path-prefix={{src-base}}=remapped_path
+//@ compile-flags:--remap-path-prefix={{src-base}}=remapped_path
 //@ rustc-env:RUST_BACKTRACE=0
 //@ build-pass
 

--- a/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
@@ -4,7 +4,7 @@
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be
 // adapted to use that, and that normalize line can go away
 
-//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ compile-flags:--test --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // doctest passes at runtime

--- a/tests/rustdoc-ui/remap-path-prefix.rs
+++ b/tests/rustdoc-ui/remap-path-prefix.rs
@@ -7,11 +7,11 @@
 //@ revisions: with-diag-scope with-macro-scope with-debuginfo-scope with-doc-scope
 //@ revisions: without-scopes without-remap
 
-//@[with-diag-scope] compile-flags: -Zunstable-options --remap-path-prefix={{src-base}}=remapped
-//@[with-macro-scope] compile-flags: -Zunstable-options --remap-path-prefix={{src-base}}=remapped
-//@[with-debuginfo-scope] compile-flags: -Zunstable-options --remap-path-prefix={{src-base}}=remapped
-//@[with-doc-scope] compile-flags: -Zunstable-options --remap-path-prefix={{src-base}}=remapped
-//@[without-scopes] compile-flags: -Zunstable-options --remap-path-prefix={{src-base}}=remapped
+//@[with-diag-scope] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-macro-scope] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-debuginfo-scope] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-doc-scope] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[without-scopes] compile-flags: --remap-path-prefix={{src-base}}=remapped
 
 //@[with-diag-scope] compile-flags: -Zunstable-options --remap-path-scope=diagnostics
 //@[with-macro-scope] compile-flags: -Zunstable-options --remap-path-scope=macro


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155307)*
<!-- homu-ignore:end -->

# Stabilization report of  `--remap-path-prefix` in rustdoc

## Summary

`rustc` supports remapping source paths prefixes as a best effort in all compiler generated output, including compiler diagnostics, debugging information, macro expansions, documentation, doctests, etc.

This is useful for normalizing build products, for example, by removing the current directory out of the paths emitted into object files.

This stabilization stabilize the same flag used by `rustc` in `rustdoc`.

There are no tracking issue.

Stabilization was discussed at the last meeting, [#t-rustdoc/meetings > 2026-04-13 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/393423-t-rustdoc.2Fmeetings/topic/2026-04-13/near/585264347).

### What is stabilized

The rustdoc `--remap-path-prefix` flag is being stabilized by this PR. (It's equivalent to rustc flag)

It permits remapping (as a best effort) source path prefixes in all output, including diagnostics, debug information, macro expansions, generated documentation, etc.

It takes a value of the form `FROM=TO` where a path prefix equal to `FROM` is rewritten to the value `TO`.

#### Example

```sh
rustdoc src/lib.rs --remap-path-prefix="$PWD=/foo"
```

### What isn't stabilized

Neither `--remap-path-scope` (~~soon to be added as unstable in `rustdoc`~~ https://github.com/rust-lang/rust/issues/155451) or the already unstable in `rustc` `documentation` scope are being stabilized or added here.

## Design

### Implementation history

- rust-lang/rust#107099

### Unresolved questions

There are no unresolved questions.

### Post-implementation changes

The implementation has evolved with `rustc`, but no changes to the flag it-self have been made.

### Nightly extensions

The `documentation` scope, which currently can only be set from `rustc`, as we need to add an equivalent to the `--remap-path-scope` flag, ~~which is planned~~ (EDIT: https://github.com/rust-lang/rust/issues/155451), but not required, the current `--remap-path-prefix` defaults to the `all` scope, like `rustc`.

### Doors closed

We are committing to having to having a flag that permits remapping paths. The compiler team already made the same commitment.

## Feedback

### Call for testing

No call for testing has been done.

### Nightly use

Unable to determine. A [GitHub search](https://github.com/search?q=%20%2F--remap-path-prefix%2F&type=code) only seems to only reveals the `rustc` usage (over 6k though).

Rust-for-Linux is using the [flag](https://github.com/torvalds/linux/blob/e80d033851b3bc94c3d254ac66660ddd0a49d72c/Makefile#L1151-L1153).

## Implementation

### Major parts

- rust-lang/rust#107099
- rust-lang/rust#149709
- rust-lang/rust#150172
- rust-lang/rust#151589

### Coverage

- [`tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs)
- [`tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs)
- [`tests/rustdoc-ui/remap-path-prefix-macro.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-ui/remap-path-prefix-macro.rs)
- [`tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs)
- [`tests/rustdoc-ui/lints/remap-path-prefix-lint.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-ui/lints/remap-path-prefix-lint.rs)
- [`tests/rustdoc-html/import-remapped-paths.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-html/import-remapped-paths.rs)
- [`tests/rustdoc-html/macro/external-macro-src.rs`](https://github.com/rust-lang/rust/blob/12f35ad39ed3e39df4d953c46d4f6cc6c82adc96/tests/rustdoc-html/macro/external-macro-src.rs)

### Outstanding bugs

There are no outstanding bugs regarding `--remap-path-prefix` in `rustdoc`.

There are [caveats and limitation](https://doc.rust-lang.org/nightly/rustc/remap-source-paths.html#caveats-and-limitations) in `rustc`, but they mostly concern generated object files, which we don't really have. 

### Outstanding FIXMEs

There are no FIXME regarding `--remap-path-prefix`.

## Acknowledgments

- @edward-shen
- @Urgau

<!-- homu-ignore:start -->
@rustbot labels +T-rustdoc +F-trim-paths
cc @ojeda (for Rust-for-Linux)
r? rustdoc
<!-- homu-ignore:end -->
