### PR TITLE
`BorrowedBuf`: Update outdated safety comments in `set_init` users.

### DIFF
--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -21,11 +21,11 @@ pub struct Buffer {
     // Each call to `fill_buf` sets `filled` to indicate how many bytes at the start of `buf` are
     // initialized with bytes from a read.
     filled: usize,
-    // This is the max number of bytes returned across all `fill_buf` calls. We track this so that we
-    // can accurately tell `read_buf` how many bytes of buf are initialized, to bypass as much of its
-    // defensive initialization as possible. Note that while this often the same as `filled`, it
-    // doesn't need to be. Calls to `fill_buf` are not required to actually fill the buffer, and
-    // omitting this is a huge perf regression for `Read` impls that do not.
+    // Whether `buf` has been fully initialized. We track this so that we can accurately tell
+    // `read_buf` how many bytes of buf are initialized, to bypass as much of its defensive
+    // initialization as possible. Note that while this often the same as `filled`, it doesn't need
+    // to be. Calls to `fill_buf` are not required to actually fill the buffer, and omitting this
+    // is a huge perf regression for `Read` impls that do not.
     initialized: bool,
 }
 
@@ -112,6 +112,9 @@ impl Buffer {
         let mut buf = BorrowedBuf::from(&mut self.buf[self.filled..]);
 
         if self.initialized {
+            // SAFETY: `self.initialized` is only set after `self.buf` was
+            // fully initialized, and once `self.buf` is fully initialized
+            // no part will become uninitialized.
             unsafe { buf.set_init() };
         }
 
@@ -138,9 +141,11 @@ impl Buffer {
             debug_assert!(self.pos == self.filled);
 
             let mut buf = BorrowedBuf::from(&mut *self.buf);
-            // SAFETY: `self.filled` bytes will always have been initialized.
 
             if self.initialized {
+                // SAFETY: `self.initialized` is only set after `self.buf` was
+                // fully initialized, and once `self.buf` is fully initialized
+                // no part will become uninitialized.
                 unsafe { buf.set_init() };
             }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3087,8 +3087,9 @@ impl<T: Read> Read for Take<T> {
 
             let mut sliced_buf: BorrowedBuf<'_> = ibuf.into();
 
-            // SAFETY: extra_init bytes of ibuf are known to be initialized
             if is_init {
+                // SAFETY: `sliced_buf` is a subslice of `buf`, so if `buf` was initialized then
+                // `sliced_buf` is.
                 unsafe { sliced_buf.set_init() };
             }
 


### PR DESCRIPTION
These comments appear to have been written before `BorrowedBuf`'s init tracking was simplified in
https://github.com/rust-lang/rust/pull/150129. The `BufWriter` comment of the usage within `BufWriter` will be handled separately.

CC rust-lang/rust#78485, rust-lang/rust#117693.
