### PR TITLE
`std::io::Take`: Clarify & optimize `BorrowedBuf::set_init` usage.

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3100,7 +3100,7 @@ impl<T: Read> Read for Take<T> {
 
             // Avoid accidentally quadratic behaviour by initializing the whole
             // cursor if only part of it was initialized.
-            if did_init_up_to_limit {
+            if did_init_up_to_limit && !is_init {
                 // SAFETY: No uninit data will be written.
                 let unfilled_before_advance = unsafe { buf.as_mut() };
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3083,8 +3083,7 @@ impl<T: Read> Read for Take<T> {
             let is_init = buf.is_init();
 
             // SAFETY: no uninit data is written to ibuf
-            let ibuf = unsafe { &mut buf.as_mut()[..limit] };
-            let mut sliced_buf: BorrowedBuf<'_> = ibuf.into();
+            let mut sliced_buf = BorrowedBuf::from(unsafe { &mut buf.as_mut()[..limit] });
 
             if is_init {
                 // SAFETY: `sliced_buf` is a subslice of `buf`, so if `buf` was initialized then
@@ -3092,13 +3091,12 @@ impl<T: Read> Read for Take<T> {
                 unsafe { sliced_buf.set_init() };
             }
 
-            let mut cursor = sliced_buf.unfilled();
-            let result = self.inner.read_buf(cursor.reborrow());
+            let result = self.inner.read_buf(sliced_buf.unfilled());
 
             let did_init_up_to_limit = sliced_buf.is_init();
             let filled = sliced_buf.len();
 
-            // cursor / sliced_buf / ibuf must drop here
+            // sliced_buf must drop here
 
             // Avoid accidentally quadratic behaviour by initializing the whole
             // cursor if only part of it was initialized.

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3084,7 +3084,6 @@ impl<T: Read> Read for Take<T> {
 
             // SAFETY: no uninit data is written to ibuf
             let ibuf = unsafe { &mut buf.as_mut()[..limit] };
-
             let mut sliced_buf: BorrowedBuf<'_> = ibuf.into();
 
             if is_init {
@@ -3096,14 +3095,14 @@ impl<T: Read> Read for Take<T> {
             let mut cursor = sliced_buf.unfilled();
             let result = self.inner.read_buf(cursor.reborrow());
 
-            let should_init = cursor.is_init();
+            let did_init_up_to_limit = sliced_buf.is_init();
             let filled = sliced_buf.len();
 
             // cursor / sliced_buf / ibuf must drop here
 
             // Avoid accidentally quadratic behaviour by initializing the whole
             // cursor if only part of it was initialized.
-            if should_init {
+            if did_init_up_to_limit {
                 // SAFETY: no uninit data is written
                 let uninit = unsafe { &mut buf.as_mut()[limit..] };
                 uninit.write_filled(0);

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -3101,11 +3101,13 @@ impl<T: Read> Read for Take<T> {
             // Avoid accidentally quadratic behaviour by initializing the whole
             // cursor if only part of it was initialized.
             if did_init_up_to_limit {
-                // SAFETY: no uninit data is written
-                let uninit = unsafe { &mut buf.as_mut()[limit..] };
-                uninit.write_filled(0);
-                // SAFETY: all bytes that were not initialized by `T::read_buf`
-                // have just been written to.
+                // SAFETY: No uninit data will be written.
+                let unfilled_before_advance = unsafe { buf.as_mut() };
+
+                unfilled_before_advance[limit..].write_filled(0);
+
+                // SAFETY: `unfilled_before_advance[..limit]` was initialized by `T::read_buf`, and
+                // `unfilled_before_advance[limit..]` was just initialized.
                 unsafe { buf.set_init() };
             }
 


### PR DESCRIPTION
Don't initialize `buf` if it was already initialized. Clarify safety comments.

Move the `buf.advance()` call to make the initialization more like
calling `buf.ensure_init()`, then clarify how the code here is an
optimized variant of `ensure_init`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
