### PR TITLE
Use mutable pointers for Unix path buffers

### DIFF
--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -339,7 +339,7 @@ fn get_path_from_fd(fd: c_int) -> Option<PathBuf> {
         // alternatives. If a better method is invented, it should be used
         // instead.
         let mut buf = vec![0; libc::PATH_MAX as usize];
-        let n = unsafe { libc::fcntl(fd, libc::F_GETPATH, buf.as_ptr()) };
+        let n = unsafe { libc::fcntl(fd, libc::F_GETPATH, buf.as_mut_ptr()) };
         if n == -1 {
             cfg_select! {
                 target_os = "netbsd" => {
@@ -375,7 +375,7 @@ fn get_path_from_fd(fd: c_int) -> Option<PathBuf> {
     #[cfg(target_os = "vxworks")]
     fn get_path(fd: c_int) -> Option<PathBuf> {
         let mut buf = vec![0; libc::PATH_MAX as usize];
-        let n = unsafe { libc::ioctl(fd, libc::FIOGETNAME, buf.as_ptr()) };
+        let n = unsafe { libc::ioctl(fd, libc::FIOGETNAME, buf.as_mut_ptr()) };
         if n == -1 {
             return None;
         }

--- a/library/std/src/sys/paths/unix.rs
+++ b/library/std/src/sys/paths/unix.rs
@@ -207,7 +207,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
             cvt(libc::sysctl(
                 mib.as_ptr(),
                 mib.len() as libc::c_uint,
-                path.as_ptr() as *mut libc::c_void,
+                path.as_mut_ptr() as *mut libc::c_void,
                 &mut path_len,
                 ptr::null(),
                 0,


### PR DESCRIPTION
This gets mutable pointers for Unix path buffers to ensure they have the right provenance.