### PR TITLE
Remove dead diagnostic structs.

### DIFF
--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -234,16 +234,6 @@ pub struct ConflictingAllocErrorHandler {
 pub struct GlobalAllocRequired;
 
 #[derive(Diagnostic)]
-#[diag(
-    "the crate `{$crate_name}` cannot depend on a crate that needs {$needs_crate_name}, but it depends on `{$deps_crate_name}`"
-)]
-pub struct NoTransitiveNeedsDep<'a> {
-    pub crate_name: Symbol,
-    pub needs_crate_name: &'a str,
-    pub deps_crate_name: Symbol,
-}
-
-#[derive(Diagnostic)]
 #[diag("failed to write {$filename}: {$err}")]
 pub struct FailedWriteError {
     pub filename: PathBuf,

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -36,21 +36,6 @@ pub(crate) struct OpaqueHiddenTypeMismatch<'tcx> {
     pub sub: TypeMismatchReason,
 }
 
-#[derive(Diagnostic)]
-#[diag("we don't support unions yet: '{$ty_name}'")]
-pub struct UnsupportedUnion {
-    pub ty_name: String,
-}
-
-// FIXME(autodiff): I should get used somewhere
-#[derive(Diagnostic)]
-#[diag("reading from a `Duplicated` const {$ty} is unsafe")]
-pub struct AutodiffUnsafeInnerConstRef<'tcx> {
-    #[primary_span]
-    pub span: Span,
-    pub ty: Ty<'tcx>,
-}
-
 #[derive(Subdiagnostic)]
 pub enum TypeMismatchReason {
     #[label("this expression supplies two conflicting concrete types for the same opaque type")]


### PR DESCRIPTION
One of these has a "FIXME(autodiff): I should get used somewhere" comment, but I figure YAGNI applies and it's so small that reinstating it if necessary would be trivial.

r? @Kivooeo 