### PR TITLE
refactor `TypeRelativePath::AssocItem` to use `AliasTerm`

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -298,7 +298,7 @@ pub enum PermitVariants {
 
 #[derive(Debug, Clone, Copy)]
 enum TypeRelativePath<'tcx> {
-    AssocItem(ty::AliasTyKind<'tcx>, GenericArgsRef<'tcx>),
+    AssocItem(ty::AliasTerm<'tcx>),
     Variant { adt: Ty<'tcx>, variant_did: DefId },
     Ctor { ctor_def_id: DefId, args: GenericArgsRef<'tcx> },
 }
@@ -1400,9 +1400,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Type(permit_variants),
         )? {
-            TypeRelativePath::AssocItem(alias_kind, args) => {
-                let def_id = alias_kind.def_id();
-                let alias_ty = ty::AliasTy::new_from_args(tcx, alias_kind, args);
+            TypeRelativePath::AssocItem(alias_term) => {
+                let def_id = alias_term.def_id;
+                let alias_kind = ty::AliasTyKind::new_from_def_id(tcx, def_id);
+                let alias_ty = ty::AliasTy::new_from_args(tcx, alias_kind, alias_term.args);
                 let ty = Ty::new_alias(tcx, alias_ty);
                 let ty = self.check_param_uses_if_mcg(ty, span, false);
                 Ok((ty, tcx.def_kind(def_id), def_id))
@@ -1437,10 +1438,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Const,
         )? {
-            TypeRelativePath::AssocItem(alias_kind, args) => {
-                let def_id = alias_kind.def_id();
+            TypeRelativePath::AssocItem(alias_term) => {
+                let def_id = alias_term.def_id;
                 self.require_type_const_attribute(def_id, span)?;
-                let ct = Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, args));
+                let ct =
+                    Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, alias_term.args));
                 let ct = self.check_param_uses_if_mcg(ct, span, false);
                 Ok(ct)
             }
@@ -1578,7 +1580,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 mode.assoc_tag(),
             )? {
-                return Ok(TypeRelativePath::AssocItem(ty::Inherent { def_id }, args));
+                return Ok(TypeRelativePath::AssocItem(ty::AliasTerm::new_from_args(
+                    tcx, def_id, args,
+                )));
             }
         }
 
@@ -1612,7 +1616,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             );
         }
 
-        Ok(TypeRelativePath::AssocItem(ty::Projection { def_id: item_def_id }, args))
+        Ok(TypeRelativePath::AssocItem(ty::AliasTerm::new_from_args(tcx, item_def_id, args)))
     }
 
     /// Resolve a [type-relative](hir::QPath::TypeRelative) (and type-level) path.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -298,7 +298,7 @@ pub enum PermitVariants {
 
 #[derive(Debug, Clone, Copy)]
 enum TypeRelativePath<'tcx> {
-    AssocItem(DefId, GenericArgsRef<'tcx>),
+    AssocItem(ty::AliasTyKind<'tcx>, GenericArgsRef<'tcx>),
     Variant { adt: Ty<'tcx>, variant_did: DefId },
     Ctor { ctor_def_id: DefId, args: GenericArgsRef<'tcx> },
 }
@@ -1400,12 +1400,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Type(permit_variants),
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                let alias_ty = ty::AliasTy::new_from_args(
-                    tcx,
-                    ty::AliasTyKind::new_from_def_id(tcx, def_id),
-                    args,
-                );
+            TypeRelativePath::AssocItem(alias_kind, args) => {
+                let def_id = alias_kind.def_id();
+                let alias_ty = ty::AliasTy::new_from_args(tcx, alias_kind, args);
                 let ty = Ty::new_alias(tcx, alias_ty);
                 let ty = self.check_param_uses_if_mcg(ty, span, false);
                 Ok((ty, tcx.def_kind(def_id), def_id))
@@ -1440,7 +1437,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Const,
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
+            TypeRelativePath::AssocItem(alias_kind, args) => {
+                let def_id = alias_kind.def_id();
                 self.require_type_const_attribute(def_id, span)?;
                 let ct = Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, args));
                 let ct = self.check_param_uses_if_mcg(ct, span, false);
@@ -1572,7 +1570,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
 
             // FIXME(inherent_associated_types, #106719): Support self types other than ADTs.
-            if let Some((did, args)) = self.probe_inherent_assoc_item(
+            if let Some((def_id, args)) = self.probe_inherent_assoc_item(
                 segment,
                 adt_def.did(),
                 self_ty,
@@ -1580,7 +1578,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 mode.assoc_tag(),
             )? {
-                return Ok(TypeRelativePath::AssocItem(did, args));
+                return Ok(TypeRelativePath::AssocItem(ty::Inherent { def_id }, args));
             }
         }
 
@@ -1614,7 +1612,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             );
         }
 
-        Ok(TypeRelativePath::AssocItem(item_def_id, args))
+        Ok(TypeRelativePath::AssocItem(ty::Projection { def_id: item_def_id }, args))
     }
 
     /// Resolve a [type-relative](hir::QPath::TypeRelative) (and type-level) path.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -297,7 +297,7 @@ pub enum PermitVariants {
 
 #[derive(Debug, Clone, Copy)]
 enum TypeRelativePath<'tcx> {
-    AssocItem(DefId, GenericArgsRef<'tcx>),
+    AssocItem(ty::AliasTerm<'tcx>),
     Variant { adt: Ty<'tcx>, variant_did: DefId },
     Ctor { ctor_def_id: DefId, args: GenericArgsRef<'tcx> },
 }
@@ -1356,15 +1356,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Type(permit_variants),
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                let alias_ty = ty::AliasTy::new_from_args(
-                    tcx,
-                    ty::AliasTyKind::new_from_def_id(tcx, def_id),
-                    args,
-                );
-                let ty = Ty::new_alias(tcx, alias_ty);
+            TypeRelativePath::AssocItem(alias_term) => {
+                let ty = alias_term.expect_ty().to_ty(tcx);
                 let ty = self.check_param_uses_if_mcg(ty, span, false);
-                Ok((ty, tcx.def_kind(def_id), def_id))
+                Ok((ty, tcx.def_kind(alias_term.def_id()), alias_term.def_id()))
             }
             TypeRelativePath::Variant { adt, variant_did } => {
                 let adt = self.check_param_uses_if_mcg(adt, span, false);
@@ -1396,16 +1391,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Const,
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                self.require_type_const_attribute(def_id, span)?;
-                let ct = Const::new_unevaluated(
-                    tcx,
-                    ty::UnevaluatedConst::new(
-                        tcx,
-                        ty::UnevaluatedConstKind::new_from_def_id(tcx, def_id),
-                        args,
-                    ),
-                );
+            TypeRelativePath::AssocItem(alias_term) => {
+                self.require_type_const_attribute(alias_term.def_id(), span)?;
+                let ct = Const::new_unevaluated(tcx, alias_term.expect_ct());
                 let ct = self.check_param_uses_if_mcg(ct, span, false);
                 Ok(ct)
             }
@@ -1487,7 +1475,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
 
             // FIXME(inherent_associated_types, #106719): Support self types other than ADTs.
-            if let Some((did, args)) = self.probe_inherent_assoc_item(
+            if let Some(alias_term) = self.probe_inherent_assoc_item(
                 segment,
                 adt_def.did(),
                 self_ty,
@@ -1495,7 +1483,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 mode.assoc_tag(),
             )? {
-                return Ok(TypeRelativePath::AssocItem(did, args));
+                return Ok(TypeRelativePath::AssocItem(alias_term));
             }
         }
 
@@ -1529,7 +1517,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             );
         }
 
-        Ok(TypeRelativePath::AssocItem(item_def_id, args))
+        Ok(TypeRelativePath::AssocItem(ty::AliasTerm::new_from_def_id(tcx, item_def_id, args)))
     }
 
     /// Resolve a [type-relative](hir::QPath::TypeRelative) (and type-level) path.
@@ -1609,7 +1597,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         block: HirId,
         span: Span,
         assoc_tag: ty::AssocTag,
-    ) -> Result<Option<(DefId, GenericArgsRef<'tcx>)>, ErrorGuaranteed> {
+    ) -> Result<Option<ty::AliasTerm<'tcx>>, ErrorGuaranteed> {
         let tcx = self.tcx();
 
         if !tcx.features().inherent_associated_types() {
@@ -1692,7 +1680,18 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 .chain(args.into_iter().skip(parent_args.len())),
         );
 
-        Ok(Some((assoc_item, args)))
+        let kind = match assoc_tag {
+            ty::AssocTag::Type => ty::AliasTermKind::InherentTy { def_id: assoc_item },
+            ty::AssocTag::Const => {
+                // drop once `InherentConst` accepts IAC-shaped args (issue #156181)
+                // without this, `new_from_args` errors (#155341).
+                self.require_type_const_attribute(assoc_item, span)?;
+                ty::AliasTermKind::InherentConst { def_id: assoc_item }
+            }
+            ty::AssocTag::Fn => unreachable!(),
+        };
+
+        Ok(Some(ty::AliasTerm::new_from_args(tcx, kind, args)))
     }
 
     /// Given name and kind search for the assoc item in the provided scope and check if it's accessible[^1].

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -1683,7 +1683,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let kind = match assoc_tag {
             ty::AssocTag::Type => ty::AliasTermKind::InherentTy { def_id: assoc_item },
             ty::AssocTag::Const => {
-                // drop once `InherentConst` accepts IAC-shaped args (issue #156181)
+                // FIXME(mgca): drop once `InherentConst` accepts IAC-shaped args (issue #156181)
                 // without this, `new_from_args` errors (#155341).
                 self.require_type_const_attribute(assoc_item, span)?;
                 ty::AliasTermKind::InherentConst { def_id: assoc_item }

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -187,21 +187,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.adt_def(adt_def_id)
     }
 
-    fn alias_ty_kind_from_def_id(self, def_id: DefId) -> ty::AliasTyKind<'tcx> {
-        match self.def_kind(def_id) {
-            DefKind::AssocTy
-                if let DefKind::Impl { of_trait: false } = self.def_kind(self.parent(def_id)) =>
-            {
-                ty::Inherent { def_id }
-            }
-            DefKind::AssocTy => ty::Projection { def_id },
-
-            DefKind::OpaqueTy => ty::Opaque { def_id },
-            DefKind::TyAlias => ty::Free { def_id },
-            kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),
-        }
-    }
-
     fn alias_term_kind(self, alias: ty::AliasTerm<'tcx>) -> ty::AliasTermKind {
         match self.def_kind(alias.def_id) {
             DefKind::AssocTy => {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -187,6 +187,21 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.adt_def(adt_def_id)
     }
 
+    fn alias_ty_kind_from_def_id(self, def_id: DefId) -> ty::AliasTyKind<'tcx> {
+        match self.def_kind(def_id) {
+            DefKind::AssocTy
+                if let DefKind::Impl { of_trait: false } = self.def_kind(self.parent(def_id)) =>
+            {
+                ty::Inherent { def_id }
+            }
+            DefKind::AssocTy => ty::Projection { def_id },
+
+            DefKind::OpaqueTy => ty::Opaque { def_id },
+            DefKind::TyAlias => ty::Free { def_id },
+            kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),
+        }
+    }
+
     fn alias_term_kind(self, alias: ty::AliasTerm<'tcx>) -> ty::AliasTermKind {
         match self.def_kind(alias.def_id) {
             DefKind::AssocTy => {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -208,21 +208,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.adt_def(adt_def_id)
     }
 
-    fn alias_ty_kind_from_def_id(self, def_id: DefId) -> ty::AliasTyKind<'tcx> {
-        match self.def_kind(def_id) {
-            DefKind::AssocTy
-                if let DefKind::Impl { of_trait: false } = self.def_kind(self.parent(def_id)) =>
-            {
-                ty::Inherent { def_id }
-            }
-            DefKind::AssocTy => ty::Projection { def_id },
-
-            DefKind::OpaqueTy => ty::Opaque { def_id },
-            DefKind::TyAlias => ty::Free { def_id },
-            kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),
-        }
-    }
-
     fn unevaluated_const_kind_from_def_id(
         self,
         def_id: Self::DefId,

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -212,8 +212,6 @@ pub trait Interner:
     type AdtDef: AdtDef<Self>;
     fn adt_def(self, adt_def_id: Self::AdtId) -> Self::AdtDef;
 
-    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> ty::AliasTyKind<Self>;
-
     fn alias_term_kind(self, alias: ty::AliasTerm<Self>) -> ty::AliasTermKind;
 
     fn trait_ref_and_own_args_for_alias(

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -212,6 +212,8 @@ pub trait Interner:
     type AdtDef: AdtDef<Self>;
     fn adt_def(self, adt_def_id: Self::AdtId) -> Self::AdtDef;
 
+    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> ty::AliasTyKind<Self>;
+
     fn alias_term_kind(self, alias: ty::AliasTerm<Self>) -> ty::AliasTermKind;
 
     fn trait_ref_and_own_args_for_alias(

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -244,8 +244,6 @@ pub trait Interner:
     type AdtDef: AdtDef<Self>;
     fn adt_def(self, adt_def_id: Self::AdtId) -> Self::AdtDef;
 
-    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> ty::AliasTyKind<Self>;
-
     fn unevaluated_const_kind_from_def_id(
         self,
         def_id: Self::DefId,

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -63,10 +63,6 @@ pub enum AliasTyKind<I: Interner> {
 }
 
 impl<I: Interner> AliasTyKind<I> {
-    pub fn new_from_def_id(interner: I, def_id: I::DefId) -> Self {
-        interner.alias_ty_kind_from_def_id(def_id)
-    }
-
     pub fn descr(self) -> &'static str {
         match self {
             AliasTyKind::Projection { .. } => "associated type",

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -63,6 +63,10 @@ pub enum AliasTyKind<I: Interner> {
 }
 
 impl<I: Interner> AliasTyKind<I> {
+    pub fn new_from_def_id(interner: I, def_id: I::DefId) -> Self {
+        interner.alias_ty_kind_from_def_id(def_id)
+    }
+
     pub fn descr(self) -> &'static str {
         match self {
             AliasTyKind::Projection { .. } => "associated type",

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -65,10 +65,6 @@ pub enum AliasTyKind<I: Interner> {
 }
 
 impl<I: Interner> AliasTyKind<I> {
-    pub fn new_from_def_id(interner: I, def_id: I::DefId) -> Self {
-        interner.alias_ty_kind_from_def_id(def_id)
-    }
-
     pub fn descr(self) -> &'static str {
         match self {
             AliasTyKind::Projection { .. } => "associated type",

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -19,7 +19,7 @@ use rustc_middle::traits::EvaluationResult;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, DerefAdjustKind};
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{
-    self, AdtDef, AliasTy, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
+    self, AdtDef, AliasTy, AssocContainer, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
     GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor, UintTy, Upcast, VariantDef, VariantDiscr,
 };
@@ -1023,11 +1023,13 @@ pub fn make_projection<'tcx>(
         #[cfg(debug_assertions)]
         assert_generic_args_match(tcx, assoc_item.def_id, args);
 
-        Some(AliasTy::new_from_args(
-            tcx,
-            ty::AliasTyKind::new_from_def_id(tcx, assoc_item.def_id),
-            args,
-        ))
+        let alias_kind = match assoc_item.container {
+            AssocContainer::Trait | AssocContainer::TraitImpl(_) => {
+                ty::Projection { def_id: assoc_item.def_id }
+            }
+            AssocContainer::InherentImpl => ty::Inherent { def_id: assoc_item.def_id },
+        };
+        Some(AliasTy::new_from_args(tcx, alias_kind, args))
     }
     helper(
         tcx,

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -19,7 +19,7 @@ use rustc_middle::traits::EvaluationResult;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, DerefAdjustKind};
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{
-    self, AdtDef, AliasTy, AssocContainer, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
+    self, AdtDef, AliasTy, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
     GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor, UintTy, Upcast, VariantDef, VariantDiscr,
 };
@@ -1023,13 +1023,11 @@ pub fn make_projection<'tcx>(
         #[cfg(debug_assertions)]
         assert_generic_args_match(tcx, assoc_item.def_id, args);
 
-        let alias_kind = match assoc_item.container {
-            AssocContainer::Trait | AssocContainer::TraitImpl(_) => {
-                ty::Projection { def_id: assoc_item.def_id }
-            }
-            AssocContainer::InherentImpl => ty::Inherent { def_id: assoc_item.def_id },
-        };
-        Some(AliasTy::new_from_args(tcx, alias_kind, args))
+        Some(AliasTy::new_from_args(
+            tcx,
+            ty::AliasTyKind::new_from_def_id(tcx, assoc_item.def_id),
+            args,
+        ))
     }
     helper(
         tcx,

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -1050,11 +1050,13 @@ pub fn make_projection<'tcx>(
         #[cfg(debug_assertions)]
         assert_generic_args_match(tcx, assoc_item.def_id, args);
 
-        Some(AliasTy::new_from_args(
-            tcx,
-            ty::AliasTyKind::new_from_def_id(tcx, assoc_item.def_id),
-            args,
-        ))
+        let kind = if let DefKind::Impl { of_trait: false } = tcx.def_kind(tcx.parent(assoc_item.def_id)) {
+            ty::AliasTyKind::Inherent { def_id: assoc_item.def_id }
+        } else {
+            ty::AliasTyKind::Projection { def_id: assoc_item.def_id }
+        };
+
+        Some(AliasTy::new_from_args(tcx, kind, args))
     }
     helper(
         tcx,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155323)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @WaffleLapkin 

related issue: https://github.com/rust-lang/rust/issues/154941

tackling the task:

- [ ] remove calls to `new_from_def_id` and `alias_ty_kind_from_def_id` and replace them with calls to e.g. `new_projection` directly

also doing: 
- `probe_inherent_assoc_item` returns `AliasTerm<'tcx>`
