### PR TITLE
docs(std): fix typo in Scope::spawn doc comment

### DIFF
--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -177,7 +177,7 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// Spawns a new thread within a scope, returning a [`ScopedJoinHandle`] for it.
     ///
     /// Unlike non-scoped threads, threads spawned with this function may
-    /// borrow non-`'static` data from the outside the scope. See [`scope`] for
+    /// borrow non-`'static` data from outside the scope. See [`scope`] for
     /// details.
     ///
     /// The join handle provides a [`join`] method that can be used to join the spawned


### PR DESCRIPTION
Per rust-lang/rust#155275, the doc comment on `Scope::spawn` says "from the outside the scope" — should be "from outside the scope".

Closes rust-lang/rust#155275