### PR TITLE
docs: drop stray "the" in `Scope::spawn` doc comment

### DIFF
--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -177,7 +177,7 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// Spawns a new thread within a scope, returning a [`ScopedJoinHandle`] for it.
     ///
     /// Unlike non-scoped threads, threads spawned with this function may
-    /// borrow non-`'static` data from the outside the scope. See [`scope`] for
+    /// borrow non-`'static` data from outside the scope. See [`scope`] for
     /// details.
     ///
     /// The join handle provides a [`join`] method that can be used to join the spawned


### PR DESCRIPTION
## Summary

`library/std/src/thread/scoped.rs:180` reads:

> borrow non-\`'static\` data from **the outside the scope**. See \[\`scope\`\] for details.

Dropping the stray "the" so it reads "from outside the scope", matching natural English and the phrasing already used elsewhere in this module.

Fixes rust-lang/rust#155275

## Test plan

- [x] One-word docs-only change, no behavior impact