### PR TITLE
docs: Use `0b1` instead of `NonZero::MIN` in `NonZero::bit_width` doctests

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1950,7 +1950,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// #
         /// # fn main() { test().unwrap(); }
         /// # fn test() -> Option<()> {
-        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::MIN.bit_width(), NonZero::new(1)?);")]
+        #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b1)?.bit_width(), NonZero::new(1)?);")]
         #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b111)?.bit_width(), NonZero::new(3)?);")]
         #[doc = concat!("assert_eq!(NonZero::<", stringify!($Int), ">::new(0b1110)?.bit_width(), NonZero::new(4)?);")]
         /// # Some(())


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This pull request updates the doctests for the `NonZero::bit_width` method. It replaces the use of the `NonZero::MIN` constant with an explicit binary literal `0b1`.

I think using `0b1` is more intuitive for illustrating the method's behavior than `NonZero::MIN`. Since other examples in the same doctests already use `0b111` and `0b1110`, this change brings the first example into alignment with the rest of the doctests.

I followed the existing pattern in the `NonZero::highest_one` and `NonZero::lowest_one` methods, which already use `0b1` in their doctests.

I also followed the convention of `uint::bit_width`, which uses the literal `0` instead of the `uint::MIN` constant in its doctests.