### PR TITLE
add cargo as dependency to nix dev shell

### DIFF
--- a/src/tools/nix-dev-shell/shell.nix
+++ b/src/tools/nix-dev-shell/shell.nix
@@ -16,6 +16,7 @@ pkgs.mkShell {
     pkgs.nix
     pkgs.glibc.out
     pkgs.glibc.static
+    pkgs.cargo # needed for rust-analyzer vscode extension
     x
     # Get the runtime deps of the x wrapper
   ] ++ lists.flatten (attrsets.attrValues env);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
The rust-analyzer vscode extension needs to execute `cargo metadata` before being able to build anything. This PR adds this dependency to the nix shell for it to work.
The ideal solution would be to remove this dependency in rust-analyzer or use the locally built version, so help / hints to achieve that would be appreciated.

The problematic error:
```txt
rust-analyzer failed to load workspace: Failed to load the project at /rust/src/tools/rust-analyzer/Cargo.toml: Failed to read Cargo metadata from Cargo.toml file /rust/src/tools/rust-analyzer/Cargo.toml, None: Failed to run `cd "/rust/src/tools/rust-analyzer" && RUSTC_BOOTSTRAP="1" RUSTUP_AUTO_INSTALL="0" "cargo" "metadata" "--format-version" "1" "--manifest-path" "/rust/src/tools/rust-analyzer/Cargo.toml" "--filter-platform" "x86_64-unknown-linux-gnu"`: No such file or directory (os error 2)
```