### PR TITLE
`single_use_lifetimes`: respect `anonymous_lifetime_in_impl_trait`

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -367,6 +367,9 @@ enum LifetimeRibKind {
 
     /// This rib acts as a barrier to forbid reference to lifetimes of a parent item.
     Item,
+
+    /// Lifetimes cannot be elided in `impl Trait` types without `#![feature(anonymous_lifetime_in_impl_trait)]`.
+    ImplTrait,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -943,7 +946,7 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
             }
             TyKind::ImplTrait(..) => {
                 let candidates = self.lifetime_elision_candidates.take();
-                visit::walk_ty(self, ty);
+                self.with_lifetime_rib(LifetimeRibKind::ImplTrait, |this| visit::walk_ty(this, ty));
                 self.lifetime_elision_candidates = candidates;
             }
             TyKind::TraitObject(bounds, ..) => {
@@ -1355,6 +1358,7 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
                         LifetimeRibKind::AnonymousCreateParameter { .. }
                         | LifetimeRibKind::AnonymousReportError
                         | LifetimeRibKind::StaticIfNoLifetimeInScope { .. }
+                        | LifetimeRibKind::ImplTrait
                         | LifetimeRibKind::Elided(_)
                         | LifetimeRibKind::ElisionFailure
                         | LifetimeRibKind::ConcreteAnonConst(_)
@@ -1782,6 +1786,15 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                     LifetimeRibKind::ConcreteAnonConst(_) => {
                                         span_bug!(ident.span, "unexpected rib kind: {:?}", rib.kind)
                                     }
+
+                                    LifetimeRibKind::ImplTrait => {
+                                        if self.r.tcx.features().anonymous_lifetime_in_impl_trait()
+                                        {
+                                            None
+                                        } else {
+                                            Some(LifetimeUseSet::Many)
+                                        }
+                                    }
                                 })
                                 .unwrap_or(LifetimeUseSet::Many);
                             debug!(?use_ctxt, ?use_set);
@@ -1821,6 +1834,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 | LifetimeRibKind::Generics { .. }
                 | LifetimeRibKind::ElisionFailure
                 | LifetimeRibKind::AnonymousReportError
+                | LifetimeRibKind::ImplTrait
                 | LifetimeRibKind::StaticIfNoLifetimeInScope { .. } => {}
             }
         }
@@ -2002,7 +2016,9 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     return;
                 }
                 LifetimeRibKind::Item => break,
-                LifetimeRibKind::Generics { .. } | LifetimeRibKind::ConstParamTy => {}
+                LifetimeRibKind::Generics { .. }
+                | LifetimeRibKind::ConstParamTy
+                | LifetimeRibKind::ImplTrait => {}
                 LifetimeRibKind::ConcreteAnonConst(_) => {
                     // There is always an `Elided(LifetimeRes::Infer)` inside an `AnonConst`.
                     span_bug!(lifetime.ident.span, "unexpected rib kind: {:?}", rib.kind)
@@ -2325,7 +2341,9 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         }
                         break;
                     }
-                    LifetimeRibKind::Generics { .. } | LifetimeRibKind::ConstParamTy => {}
+                    LifetimeRibKind::Generics { .. }
+                    | LifetimeRibKind::ConstParamTy
+                    | LifetimeRibKind::ImplTrait => {}
                     LifetimeRibKind::ConcreteAnonConst(_) => {
                         // There is always an `Elided(LifetimeRes::Infer)` inside an `AnonConst`.
                         span_bug!(elided_lifetime_span, "unexpected rib kind: {:?}", rib.kind)

--- a/tests/ui/single-use-lifetime/anonymous_lifetime_in_impl_trait.rs
+++ b/tests/ui/single-use-lifetime/anonymous_lifetime_in_impl_trait.rs
@@ -1,0 +1,20 @@
+//@ revisions: with-gate without-gate
+//@ [with-gate] run-rustfix
+//@ [without-gate] check-pass
+
+#![cfg_attr(with_gate, feature(anonymous_lifetime_in_impl_trait))]
+
+#![deny(single_use_lifetimes)]
+
+// https://github.com/rust-lang/rust/issues/153836
+
+fn foo<'a>(x: impl IntoIterator<Item = &'a i32>) {
+//[with-gate]~^ ERROR: lifetime parameter `'a` only used once [single_use_lifetimes]
+  for i in x {
+    dbg!(i);
+  }
+}
+
+fn main() {
+  foo(&[1, 2, 3]);
+}

--- a/tests/ui/single-use-lifetime/anonymous_lifetime_in_impl_trait.with-gate.fixed
+++ b/tests/ui/single-use-lifetime/anonymous_lifetime_in_impl_trait.with-gate.fixed
@@ -1,0 +1,20 @@
+//@ revisions: with-gate without-gate
+//@ [with-gate] run-rustfix
+//@ [without-gate] check-pass
+
+#![cfg_attr(with_gate, feature(anonymous_lifetime_in_impl_trait))]
+
+#![deny(single_use_lifetimes)]
+
+// https://github.com/rust-lang/rust/issues/153836
+
+fn foo(x: impl IntoIterator<Item = &i32>) {
+//[with-gate]~^ ERROR: lifetime parameter `'a` only used once [single_use_lifetimes]
+  for i in x {
+    dbg!(i);
+  }
+}
+
+fn main() {
+  foo(&[1, 2, 3]);
+}

--- a/tests/ui/single-use-lifetime/anonymous_lifetime_in_impl_trait.with-gate.stderr
+++ b/tests/ui/single-use-lifetime/anonymous_lifetime_in_impl_trait.with-gate.stderr
@@ -1,0 +1,19 @@
+error: lifetime parameter `'a` only used once
+  --> $DIR/anonymous_lifetime_in_impl_trait.rs:11:8
+   |
+LL | fn foo<'a>(x: impl IntoIterator<Item = &'a i32>) {
+   |        ^^ this lifetime...              -- ...is used only here
+   |
+note: the lint level is defined here
+  --> $DIR/anonymous_lifetime_in_impl_trait.rs:7:9
+   |
+LL | #![deny(single_use_lifetimes)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+help: elide the single-use lifetime
+   |
+LL - fn foo<'a>(x: impl IntoIterator<Item = &'a i32>) {
+LL + fn foo(x: impl IntoIterator<Item = &i32>) {
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Tracking issue: rust-lang/rust#44752 (for the `single_use_lifetimes` lint; the `anonymous_lifetime_in_impl_trait` feature seems to have no tracking issue).

Closes rust-lang/rust#129255
Closes rust-lang/rust#135550

@rustbot label A-diagnostics A-lifetimes A-lints D-incorrect L-single_use_lifetimes