### PR TITLE
remove calls to AliasTyKind::def_id

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -211,7 +211,7 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'a, 'tcx> {
         // See note in `rustc_trait_selection::traits::project` about why we
         // wait to fold the args.
         let res = match data.kind {
-            ty::Opaque { .. } => {
+            ty::Opaque { def_id } => {
                 // Only normalize `impl Trait` outside of type inference, usually in codegen.
                 match self.infcx.typing_mode() {
                     TypingMode::Coherence
@@ -236,7 +236,7 @@ impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'a, 'tcx> {
                             return Ok(Ty::new_error(self.cx(), guar));
                         }
 
-                        let generic_ty = self.cx().type_of(data.kind.def_id());
+                        let generic_ty = self.cx().type_of(def_id);
                         let mut concrete_ty = generic_ty.instantiate(self.cx(), args);
                         self.anon_depth += 1;
                         if concrete_ty == ty {

--- a/compiler/rustc_ty_utils/src/opaque_types.rs
+++ b/compiler/rustc_ty_utils/src/opaque_types.rs
@@ -92,12 +92,14 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     fn visit_opaque_ty(&mut self, alias_ty: ty::AliasTy<'tcx>) {
-        if !self.seen.insert(alias_ty.kind.def_id().expect_local()) {
+        let ty::Opaque { def_id } = alias_ty.kind else { bug!("{alias_ty:?}") };
+
+        if !self.seen.insert(def_id.expect_local()) {
             return;
         }
 
         // TAITs outside their defining scopes are ignored.
-        match self.tcx.local_opaque_ty_origin(alias_ty.kind.def_id().expect_local()) {
+        match self.tcx.local_opaque_ty_origin(def_id.expect_local()) {
             rustc_hir::OpaqueTyOrigin::FnReturn { .. }
             | rustc_hir::OpaqueTyOrigin::AsyncFn { .. } => {}
             rustc_hir::OpaqueTyOrigin::TyAlias { in_assoc_ty, .. } => match self.mode {
@@ -122,9 +124,9 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
         }
 
         trace!(?alias_ty, "adding");
-        self.opaques.push(alias_ty.kind.def_id().expect_local());
+        self.opaques.push(def_id.expect_local());
 
-        let parent_count = self.tcx.generics_of(alias_ty.kind.def_id()).parent_count;
+        let parent_count = self.tcx.generics_of(def_id).parent_count;
         // Only check that the parent generics of the TAIT/RPIT are unique.
         // the args owned by the opaque are going to always be duplicate
         // lifetime params for RPITs, and empty for TAITs.
@@ -140,9 +142,7 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
                 // Collect opaque types nested within the associated type bounds of this opaque type.
                 // We use identity args here, because we already know that the opaque type uses
                 // only generic parameters, and thus instantiating would not give us more information.
-                for (pred, span) in
-                    self.tcx.explicit_item_bounds(alias_ty.kind.def_id()).iter_identity_copied()
-                {
+                for (pred, span) in self.tcx.explicit_item_bounds(def_id).iter_identity_copied() {
                     trace!(?pred);
                     self.visit_spanned(span, pred);
                 }
@@ -151,14 +151,14 @@ impl<'tcx> OpaqueTypeCollector<'tcx> {
                 self.tcx.dcx().emit_err(NotParam {
                     arg,
                     span: self.span(),
-                    opaque_span: self.tcx.def_span(alias_ty.kind.def_id()),
+                    opaque_span: self.tcx.def_span(def_id),
                 });
             }
             Err(NotUniqueParam::DuplicateParam(arg)) => {
                 self.tcx.dcx().emit_err(DuplicateArg {
                     arg,
                     span: self.span(),
-                    opaque_span: self.tcx.def_span(alias_ty.kind.def_id()),
+                    opaque_span: self.tcx.def_span(def_id),
                 });
             }
         }


### PR DESCRIPTION
ref https://github.com/rust-lang/rust/issues/154941

I asked the LSP where `AliasTyKind::def_id` and then checked where the `AliasTyKind::def_id` was trivial to change. Could only find 2 places, and I am not sure about the `opaque_types.rs` (open to feedback!! :) ). All the others need refactoring or will end up with a logic as complex as `AliasTyKind::def_id`

This is the list checked:
- [X] compiler/rustc_borrowck/src/region_infer/opaque_types/member_constraints.rs — 1
- [X] compiler/rustc_borrowck/src/region_infer/opaque_types/mod.rs — 1
- [X] compiler/rustc_hir_analysis/src/check/compare_impl_item/refine.rs — 5
- [X] compiler/rustc_hir_analysis/src/check/mod.rs — 1
- [X] compiler/rustc_infer/src/infer/outlives/for_liveness.rs — 2
- [X] compiler/rustc_infer/src/infer/outlives/obligations.rs — 1
- [X] compiler/rustc_infer/src/infer/outlives/verify.rs — 3
- [X] compiler/rustc_middle/src/ty/print/pretty.rs — 1
- [X] compiler/rustc_middle/src/ty/sty.rs — 1
- [X] compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs — 3
- [X] compiler/rustc_next_trait_solver/src/solve/effect_goals.rs — 3
- [X] compiler/rustc_pattern_analysis/src/rustc.rs — 1
- [X] compiler/rustc_public/src/unstable/convert/stable/ty.rs — 1
- [X] compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs — 2
- [X] compiler/rustc_trait_selection/src/error_reporting/infer/note_and_explain.rs — 4
- [X] compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs — 2
- [X] compiler/rustc_trait_selection/src/traits/effects.rs — 1
- [X] compiler/rustc_trait_selection/src/traits/query/normalize.rs — 1
- [X] compiler/rustc_ty_utils/src/opaque_types.rs — 7
- [X] compiler/rustc_ty_utils/src/ty.rs — 1
- [X] compiler/rustc_type_ir/src/outlives.rs — 1
- [X] compiler/rustc_type_ir/src/predicate.rs — 1
- [X] compiler/rustc_type_ir/src/relate.rs — 5
- [X] compiler/rustc_type_ir/src/ty_kind.rs — 2


r? @WaffleLapkin 