### PR TITLE
Document that CFI diverges from Rust wrt. ABI-compatibility rules

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1908,10 +1908,8 @@ mod prim_ref {}
 /// CFI uses the name of the type for its compatibility check.
 ///
 /// When not using the `-Zsanitizer-cfi-normalize-integers` flag, the CFI sanitizer further
-/// restricts the rules by considering `usize` incompatible with the `uN` integer type of the same
-/// size, and similarly for `isize`. In addition, different C integer types are also given
-/// incompatible CFI types even if they boil down to the same size/signedness. Without this flag,
-/// there are some C integers that do not correspond to *any* Rust integer type.
+/// restricts the rules by considering `usize`/`isize` incompatible with the `uN`/`iN` integer type
+/// of the same size.
 ///
 /// As sanitizers are unstable, these rules may change in the future. This section only documents
 /// cases where CFI disagrees with the usual Rust ABI-compatibility rules, and is not meant to be a

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1896,7 +1896,7 @@ mod prim_ref {}
 /// There are some caveats to the above ABI-compatibility rules due to how the [CFI (control flow
 /// integrity)][cfi-docs] sanitizer is implemented. CFI is a tool that can be used to validate
 /// that dynamic function calls respect the ABI, but due to its C/C++ origins, it disagrees with the
-/// above documented guarantees in the following manner:
+/// above documented guarantees in a few ways.
 ///
 /// When running the CFI sanitizer, pointer types are only ABI-compatible if the target type and
 /// mutability is the same. This means that `*mut String` and `*mut i32` are incompatible when using

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1893,6 +1893,9 @@ mod prim_ref {}
 /// #### Control Flow Integrity
 /// [Control Flow Integrity]: #control-flow-integrity
 ///
+/// <div class="stab unstable"><span class="emoji">&#128300;</span><span>This is a nightly-only experimental API.
+/// (<code>-Zsanitizer=cfi</code>&nbsp;<a href="https://github.com/rust-lang/rust/issues/89653">#89653</a>)</span></div>
+///
 /// There are some caveats to the above ABI-compatibility rules due to how the [CFI (control flow
 /// integrity)][cfi-docs] sanitizer is implemented. CFI is a tool that can be used to validate
 /// that dynamic function calls respect the ABI, but due to its C/C++ origins, it disagrees with the
@@ -1901,11 +1904,8 @@ mod prim_ref {}
 /// When running the CFI sanitizer, pointer types are only ABI-compatible if the target type and
 /// mutability is the same. This means that `*mut String` and `*mut i32` are incompatible when using
 /// CFI. It also means that `*mut i32` is incompatible with `*const i32`. The `NonNull<_>` and
-/// `Box<_>` pointer types are currently considered immutable.
-///
-/// Furthermore, CFI will also compare the *name* of aggregate types. This means that even if two
-/// `#[repr(C)]` structs have the same fields in the same order, CFI does not consider them to be
-/// ABI-compatible unless they have the same name.
+/// `Box<_>` pointer types are currently considered immutable under CFI. For non-primitive types,
+/// CFI uses the name of the type for its compatibility check.
 ///
 /// When not using the `-Zsanitizer-cfi-normalize-integers` flag, the CFI sanitizer further
 /// restricts the rules by considering `usize` incompatible with the `uN` integer type of the same

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1831,7 +1831,7 @@ mod prim_ref {}
 /// - `*const T`, `*mut T`, `&T`, `&mut T`, `Box<T>` (specifically, only `Box<T, Global>`), and
 ///   `NonNull<T>` are all ABI-compatible with each other for all `T`. They are also ABI-compatible
 ///   with each other for _different_ `T` if they have the same metadata type (`<T as
-///   Pointee>::Metadata`).
+///   Pointee>::Metadata`). However, see the [Control Flow Integrity] section below for caveats.
 /// - `usize` is ABI-compatible with the `uN` integer type of the same size, and likewise `isize` is
 ///   ABI-compatible with the `iN` integer type of the same size.
 /// - `char` is ABI-compatible with `u32`.
@@ -1889,6 +1889,33 @@ mod prim_ref {}
 /// `Option<NonZero<i32>>`, and the value used for the argument is `None`, then this call is Undefined
 /// Behavior since transmuting `None::<NonZero<i32>>` to `NonZero<i32>` violates the non-zero
 /// requirement.
+///
+/// #### Control Flow Integrity
+/// [Control Flow Integrity]: #control-flow-integrity
+///
+/// There are some caveats to the above ABI-compatibility rules due to how the [CFI (control flow
+/// integrity)][cfi-docs] sanitizer is implemented. CFI is a tool that can be used to validate
+/// that dynamic function calls respect the ABI, but due to its C/C++ origins, it disagrees with the
+/// above documented guarantees in the following manner:
+///
+/// When running the CFI sanitizer, pointer types are only ABI-compatible if the target type and
+/// mutability is the same. This means that `*mut String` and `*mut i32` are incompatible when using
+/// CFI. It also means that `*mut i32` is incompatible with `*const i32`. The `NonNull<_>` pointer
+/// type is considered immutable.
+///
+/// Furthermore, CFI will also compare the *name* of aggregate types. This means that even if two
+/// `#[repr(C)]` structs have the same fields in the same order, CFI does not consider them to be
+/// ABI-compatible unless they have the same name.
+///
+/// When not using the `-Zsanitizer-cfi-normalize-integers` flag, the CFI sanitizer further
+/// restricts the rules by considering `usize` incompatible with the `uN` integer type of the same
+/// size, and similarly for `isize`.
+///
+/// As sanitizers are unstable, these rules may change in the future. This section only documents
+/// cases where CFI disagrees with the usual Rust ABI-compatibility rules, and is not meant to be a
+/// complete explanation of how CFI works.
+///
+/// [cfi-docs]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#controlflowintegrity
 ///
 /// ### Trait implementations
 ///

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1794,6 +1794,7 @@ mod prim_ref {}
 /// have different sizes.
 ///
 /// ### ABI compatibility
+/// [ABI compatibility]: #abi-compatibility
 ///
 /// Generally, when a function is declared with one signature and called via a function pointer with
 /// a different signature, the two signatures must be *ABI-compatible* or else calling the function
@@ -1899,7 +1900,8 @@ mod prim_ref {}
 /// There are some caveats to the above ABI-compatibility rules due to how the [CFI (control flow
 /// integrity)][cfi-docs] sanitizer is implemented. CFI is a tool that can be used to validate
 /// that dynamic function calls respect the ABI, but due to its C/C++ origins, it disagrees with the
-/// above documented guarantees in a few ways.
+/// above documented guarantees in a few ways, see below. As CFI is unstable, the details may change
+/// in the future.
 ///
 /// When running the CFI sanitizer, pointer types are only ABI-compatible if the target type and
 /// mutability is the same. This means that `*mut String` and `*mut i32` are incompatible when using
@@ -1911,9 +1913,9 @@ mod prim_ref {}
 /// restricts the rules by considering `usize`/`isize` incompatible with the `uN`/`iN` integer type
 /// of the same size.
 ///
-/// As sanitizers are unstable, these rules may change in the future. This section only documents
-/// cases where CFI disagrees with the usual Rust ABI-compatibility rules, and is not meant to be a
-/// complete explanation of how CFI works.
+/// This section only covers cases where CFI disagrees with [the ABI-compatibility rules for
+/// Rust-to-Rust calls][ABI compatibility]. It is not meant to be a complete explanation of how CFI
+/// works, and details important for to C-to-Rust or Rust-to-C calls are omitted.
 ///
 /// [cfi-docs]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#controlflowintegrity
 ///

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1909,7 +1909,9 @@ mod prim_ref {}
 ///
 /// When not using the `-Zsanitizer-cfi-normalize-integers` flag, the CFI sanitizer further
 /// restricts the rules by considering `usize` incompatible with the `uN` integer type of the same
-/// size, and similarly for `isize`.
+/// size, and similarly for `isize`. In addition, different C integer types are also given
+/// incompatible CFI types even if they boil down to the same size/signedness. Without this flag,
+/// there are some C integers that do not correspond to *any* Rust integer type.
 ///
 /// As sanitizers are unstable, these rules may change in the future. This section only documents
 /// cases where CFI disagrees with the usual Rust ABI-compatibility rules, and is not meant to be a

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1900,8 +1900,8 @@ mod prim_ref {}
 ///
 /// When running the CFI sanitizer, pointer types are only ABI-compatible if the target type and
 /// mutability is the same. This means that `*mut String` and `*mut i32` are incompatible when using
-/// CFI. It also means that `*mut i32` is incompatible with `*const i32`. The `NonNull<_>` pointer
-/// type is considered immutable.
+/// CFI. It also means that `*mut i32` is incompatible with `*const i32`. The `NonNull<_>` and
+/// `Box<_>` pointer types are currently considered immutable.
 ///
 /// Furthermore, CFI will also compare the *name* of aggregate types. This means that even if two
 /// `#[repr(C)]` structs have the same fields in the same order, CFI does not consider them to be

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1915,7 +1915,7 @@ mod prim_ref {}
 ///
 /// This section only covers cases where CFI disagrees with [the ABI-compatibility rules for
 /// Rust-to-Rust calls][ABI compatibility]. It is not meant to be a complete explanation of how CFI
-/// works, and details important for to C-to-Rust or Rust-to-C calls are omitted.
+/// works, and details important for C-to-Rust or Rust-to-C calls are omitted.
 ///
 /// [cfi-docs]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#controlflowintegrity
 ///

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1794,6 +1794,7 @@ mod prim_ref {}
 /// have different sizes.
 ///
 /// ### ABI compatibility
+/// [ABI compatibility]: #abi-compatibility
 ///
 /// Generally, when a function is declared with one signature and called via a function pointer with
 /// a different signature, the two signatures must be *ABI-compatible* or else calling the function
@@ -1831,7 +1832,7 @@ mod prim_ref {}
 /// - `*const T`, `*mut T`, `&T`, `&mut T`, `Box<T>` (specifically, only `Box<T, Global>`), and
 ///   `NonNull<T>` are all ABI-compatible with each other for all `T`. They are also ABI-compatible
 ///   with each other for _different_ `T` if they have the same metadata type (`<T as
-///   Pointee>::Metadata`).
+///   Pointee>::Metadata`). However, see the [Control Flow Integrity][cfi-docs] docs for caveats.
 /// - `usize` is ABI-compatible with the `uN` integer type of the same size, and likewise `isize` is
 ///   ABI-compatible with the `iN` integer type of the same size.
 /// - `char` is ABI-compatible with `u32`.
@@ -1889,6 +1890,8 @@ mod prim_ref {}
 /// `Option<NonZero<i32>>`, and the value used for the argument is `None`, then this call is Undefined
 /// Behavior since transmuting `None::<NonZero<i32>>` to `NonZero<i32>` violates the non-zero
 /// requirement.
+///
+/// [cfi-docs]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#controlflowintegrity
 ///
 /// ### Trait implementations
 ///

--- a/src/doc/unstable-book/src/compiler-flags/sanitizer.md
+++ b/src/doc/unstable-book/src/compiler-flags/sanitizer.md
@@ -246,6 +246,37 @@ Cargo build-std feature (i.e., `-Zbuild-std`) when enabling CFI.
 
 See the [Clang ControlFlowIntegrity documentation][clang-cfi] for more details.
 
+## Divergence from the Rust ABI
+
+There are some caveats to [the ABI-compatibility rules for Rust-to-Rust
+calls][rust-abi] due to how the CFI sanitizer is implemented. CFI is a tool
+that can be used to validate that dynamic function calls respect the ABI, but
+due to its C/C++ origins, it disagrees with the above documented guarantees in
+a few ways, see below. As CFI is unstable, the details may change in the
+future.
+
+When running the CFI sanitizer, pointer types are only ABI-compatible if the
+target type and mutability is the same. This means that `*mut String` and `*mut
+i32` are incompatible when using CFI. It also means that `*mut i32` is
+incompatible with `*const i32`. The `NonNull<_>` and `Box<_>` pointer types are
+currently considered immutable under CFI. For non-primitive target types, CFI
+uses the name of the type for its compatibility check.
+
+When not using the `-Zsanitizer-cfi-normalize-integers` flag, the CFI sanitizer
+further restricts the rules by considering `usize`/`isize` incompatible with
+the `uN`/`iN` integer type of the same size.
+
+Unlike other cases where the function ABI is violated, function calls that
+violate the CFI-specific ABI-compatibility rules are not undefined behavior.
+They are guaranteed to either function correctly, or to crash the program.
+
+This section only covers cases where CFI disagrees with the ABI-compatibility
+rules for Rust-to-Rust calls. It is not meant to be a complete explanation of
+how CFI works, and details important for C-to-Rust or Rust-to-C calls are
+omitted.
+
+[rust-abi]: https://doc.rust-lang.org/stable/std/primitive.fn.html#abi-compatibility
+
 ## Example 1: Redirecting control flow using an indirect branch/call to an invalid destination
 
 ```rust


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155361)*
<!-- homu-ignore:end -->

The CFI sanitizer is a sanitizer that checks that no ABI-incompatible function calls are made at runtime, but there is currently an unfortunate divergence between the Rust ABI-compatibility rules and what the CFI sanitizer checks. Thus, document that this divergence exists.

There are proposals for how we can align the ABI rules to eliminate this discrepancy, and I would like to follow through with those, but for now I think we can at least document that the discrepancy exists.

For further discussion please see [Re-evaluate ABI compatibility rules in light of CFI](https://github.com/rust-lang/unsafe-code-guidelines/issues/489) and [Can CFI be made compatible with type erasure schemes?](https://github.com/rust-lang/rust/issues/128728) and [`fn_cast!` macro](https://github.com/rust-lang/rust/issues/140803).

cc @rcvalle @samitolvanen @maurer @bjorn3 @RalfJung

Rendered:

<img width="956" height="391" alt="image" src="https://github.com/user-attachments/assets/410d3eaa-9476-4800-9ef8-bbb100a100c5" />
