### PR TITLE
Reduce diagnostic type visibilities.

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -6,11 +6,11 @@ use rustc_hir::attrs::{
     BorrowckGraphvizFormatKind, CguFields, CguKind, DivergingBlockBehavior,
     DivergingFallbackBehavior, RustcCleanAttribute, RustcCleanQueries, RustcMirKind,
 };
-use rustc_session::errors;
 use rustc_span::Symbol;
 
 use super::prelude::*;
 use super::util::parse_single_integer;
+use crate::errors;
 use crate::session_diagnostics::{
     AttributeRequiresOpt, CguFieldsMissing, RustcScalableVectorCountOutOfRange, UnknownLangItem,
 };

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -50,3 +50,10 @@ pub(crate) struct UnreachableCfgSelectPredicateWildcard {
     #[label("always matches")]
     pub wildcard_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("must be a name of an associated function")]
+pub(crate) struct MustBeNameOfAssociatedFunction {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -1069,7 +1069,7 @@ pub(crate) struct TargetFeatureSafeTrait {
 
 #[derive(Diagnostic)]
 #[diag("target feature `{$feature}` cannot be enabled with `#[target_feature]`: {$reason}")]
-pub struct ForbiddenTargetFeatureAttr<'a> {
+pub(crate) struct ForbiddenTargetFeatureAttr<'a> {
     #[primary_span]
     pub span: Span,
     pub feature: &'a str,
@@ -1211,7 +1211,7 @@ pub(crate) struct ForbiddenCTargetFeature<'a> {
     pub reason: &'a str,
 }
 
-pub struct TargetFeatureDisableOrEnable<'a> {
+pub(crate) struct TargetFeatureDisableOrEnable<'a> {
     pub features: &'a [&'a str],
     pub span: Option<Span>,
     pub missing_features: Option<MissingFeatures>,
@@ -1219,7 +1219,7 @@ pub struct TargetFeatureDisableOrEnable<'a> {
 
 #[derive(Subdiagnostic)]
 #[help("add the missing features in a `target_feature` attribute")]
-pub struct MissingFeatures;
+pub(crate) struct MissingFeatures;
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for TargetFeatureDisableOrEnable<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -92,7 +92,7 @@ impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalErrKind {
     }
 }
 
-pub fn get_span_and_frames<'tcx>(
+pub(crate) fn get_span_and_frames<'tcx>(
     tcx: TyCtxtAt<'tcx>,
     stack: &[Frame<'tcx, impl Provenance, impl Sized>],
 ) -> (Span, Vec<errors::FrameNote>) {

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -314,14 +314,14 @@ pub(crate) struct InteriorMutableBorrowEscaping {
     "this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
     If your compilation actually takes a long time, you can safely allow the lint"
 )]
-pub struct LongRunning {
+pub(crate) struct LongRunning {
     #[help("the constant being evaluated")]
     pub item_span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag("constant evaluation is taking a long time")]
-pub struct LongRunningWarn {
+pub(crate) struct LongRunningWarn {
     #[primary_span]
     #[label("the const evaluator is currently interpreting this expression")]
     pub span: Span,
@@ -339,7 +339,7 @@ pub(crate) struct NonConstImplNote {
 }
 
 #[derive(Clone)]
-pub struct FrameNote {
+pub(crate) struct FrameNote {
     pub span: Span,
     pub times: i32,
     pub where_: &'static str,
@@ -377,7 +377,7 @@ impl Subdiagnostic for FrameNote {
 
 #[derive(Subdiagnostic)]
 #[note(r#"the raw bytes of the constant (size: {$size}, align: {$align}) {"{"}{$bytes}{"}"}"#)]
-pub struct RawBytesNote {
+pub(crate) struct RawBytesNote {
     pub size: u64,
     pub align: u64,
     pub bytes: String,
@@ -393,7 +393,7 @@ pub struct RawBytesNote {
 }s"#
 )]
 #[note("`{$ty}` cannot be compared in compile-time, and therefore cannot be used in `match`es")]
-pub struct NonConstMatchEq<'tcx> {
+pub(crate) struct NonConstMatchEq<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -408,7 +408,7 @@ pub struct NonConstMatchEq<'tcx> {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstForLoopIntoIter<'tcx> {
+pub(crate) struct NonConstForLoopIntoIter<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -423,7 +423,7 @@ pub struct NonConstForLoopIntoIter<'tcx> {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstQuestionBranch<'tcx> {
+pub(crate) struct NonConstQuestionBranch<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -438,7 +438,7 @@ pub struct NonConstQuestionBranch<'tcx> {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstQuestionFromResidual<'tcx> {
+pub(crate) struct NonConstQuestionFromResidual<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -453,7 +453,7 @@ pub struct NonConstQuestionFromResidual<'tcx> {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstTryBlockFromOutput<'tcx> {
+pub(crate) struct NonConstTryBlockFromOutput<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -468,7 +468,7 @@ pub struct NonConstTryBlockFromOutput<'tcx> {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstAwait<'tcx> {
+pub(crate) struct NonConstAwait<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -483,7 +483,7 @@ pub struct NonConstAwait<'tcx> {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstClosure {
+pub(crate) struct NonConstClosure {
     #[primary_span]
     pub span: Span,
     pub kind: ConstContext,
@@ -499,14 +499,14 @@ pub struct NonConstClosure {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstCVariadicCall {
+pub(crate) struct NonConstCVariadicCall {
     #[primary_span]
     pub span: Span,
     pub kind: ConstContext,
 }
 
 #[derive(Subdiagnostic)]
-pub enum NonConstClosureNote {
+pub(crate) enum NonConstClosureNote {
     #[note("function defined here, but it is not `const`")]
     FnDef {
         #[primary_span]
@@ -534,7 +534,7 @@ pub enum NonConstClosureNote {
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion("consider dereferencing here", applicability = "machine-applicable")]
-pub struct ConsiderDereferencing {
+pub(crate) struct ConsiderDereferencing {
     pub deref: String,
     #[suggestion_part(code = "{deref}")]
     pub span: Span,
@@ -549,7 +549,7 @@ pub struct ConsiderDereferencing {
     [const_fn] constant function
     *[other] {""}
 }s"#, code = E0015)]
-pub struct NonConstOperator {
+pub(crate) struct NonConstOperator {
     #[primary_span]
     pub span: Span,
     pub kind: ConstContext,
@@ -566,7 +566,7 @@ pub struct NonConstOperator {
     *[other] {""}
 }s"#, code = E0015)]
 #[note("attempting to deref into `{$target_ty}`")]
-pub struct NonConstDerefCoercion<'tcx> {
+pub(crate) struct NonConstDerefCoercion<'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,
@@ -579,7 +579,7 @@ pub struct NonConstDerefCoercion<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag("destructor of `{$dropped_ty}` cannot be evaluated at compile-time", code = E0493)]
-pub struct LiveDrop<'tcx> {
+pub(crate) struct LiveDrop<'tcx> {
     #[primary_span]
     #[label(
         r#"the destructor for this type cannot be evaluated in {$kind ->

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -223,7 +223,7 @@ impl<'tcx> fmt::Display for FrameInfo<'tcx> {
 }
 
 impl<'tcx> FrameInfo<'tcx> {
-    pub fn as_note(&self, tcx: TyCtxt<'tcx>) -> errors::FrameNote {
+    pub(crate) fn as_note(&self, tcx: TyCtxt<'tcx>) -> errors::FrameNote {
         let span = self.span;
         if tcx.def_key(self.instance.def_id()).disambiguated_data.data == DefPathData::Closure {
             errors::FrameNote {

--- a/compiler/rustc_driver_impl/src/session_diagnostics.rs
+++ b/compiler/rustc_driver_impl/src/session_diagnostics.rs
@@ -4,7 +4,7 @@ use rustc_macros::{Diagnostic, Subdiagnostic};
 
 #[derive(Diagnostic)]
 #[diag("could not emit MIR: {$error}")]
-pub struct CantEmitMIR {
+pub(crate) struct CantEmitMIR {
     pub error: std::io::Error,
 }
 

--- a/compiler/rustc_interface/src/errors.rs
+++ b/compiler/rustc_interface/src/errors.rs
@@ -25,7 +25,7 @@ pub(crate) struct CrateNameInvalid<'a> {
 
 #[derive(Diagnostic)]
 #[diag("Ferris cannot be used as an identifier")]
-pub struct FerrisIdentifier {
+pub(crate) struct FerrisIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
     #[suggestion(
@@ -39,7 +39,7 @@ pub struct FerrisIdentifier {
 
 #[derive(Diagnostic)]
 #[diag("identifiers cannot contain emoji: `{$ident}`")]
-pub struct EmojiIdentifier {
+pub(crate) struct EmojiIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
     pub ident: Symbol,
@@ -47,22 +47,22 @@ pub struct EmojiIdentifier {
 
 #[derive(Diagnostic)]
 #[diag("cannot mix `bin` crate type with others")]
-pub struct MixedBinCrate;
+pub(crate) struct MixedBinCrate;
 
 #[derive(Diagnostic)]
 #[diag("cannot mix `proc-macro` crate type with others")]
-pub struct MixedProcMacroCrate;
+pub(crate) struct MixedProcMacroCrate;
 
 #[derive(Diagnostic)]
 #[diag("error writing dependencies to `{$path}`: {$error}")]
-pub struct ErrorWritingDependencies<'a> {
+pub(crate) struct ErrorWritingDependencies<'a> {
     pub path: &'a Path,
     pub error: io::Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("the input file \"{$path}\" would be overwritten by the generated executable")]
-pub struct InputFileWouldBeOverWritten<'a> {
+pub(crate) struct InputFileWouldBeOverWritten<'a> {
     pub path: &'a Path,
 }
 
@@ -70,22 +70,22 @@ pub struct InputFileWouldBeOverWritten<'a> {
 #[diag(
     "the generated executable for the input file \"{$input_path}\" conflicts with the existing directory \"{$dir_path}\""
 )]
-pub struct GeneratedFileConflictsWithDirectory<'a> {
+pub(crate) struct GeneratedFileConflictsWithDirectory<'a> {
     pub input_path: &'a Path,
     pub dir_path: &'a Path,
 }
 
 #[derive(Diagnostic)]
 #[diag("failed to find or create the directory specified by `--temps-dir`")]
-pub struct TempsDirError;
+pub(crate) struct TempsDirError;
 
 #[derive(Diagnostic)]
 #[diag("failed to find or create the directory specified by `--out-dir`")]
-pub struct OutDirError;
+pub(crate) struct OutDirError;
 
 #[derive(Diagnostic)]
 #[diag("failed to write file {$path}: {$error}\"")]
-pub struct FailedWritingFile<'a> {
+pub(crate) struct FailedWritingFile<'a> {
     pub path: &'a Path,
     pub error: io::Error,
 }
@@ -94,25 +94,25 @@ pub struct FailedWritingFile<'a> {
 #[diag(
     "building proc macro crate with `panic=abort` or `panic=immediate-abort` may crash the compiler should the proc-macro panic"
 )]
-pub struct ProcMacroCratePanicAbort;
+pub(crate) struct ProcMacroCratePanicAbort;
 
 #[derive(Diagnostic)]
 #[diag(
     "due to multiple output types requested, the explicitly specified output file name will be adapted for each output type"
 )]
-pub struct MultipleOutputTypesAdaption;
+pub(crate) struct MultipleOutputTypesAdaption;
 
 #[derive(Diagnostic)]
 #[diag("ignoring -C extra-filename flag due to -o flag")]
-pub struct IgnoringExtraFilename;
+pub(crate) struct IgnoringExtraFilename;
 
 #[derive(Diagnostic)]
 #[diag("ignoring --out-dir flag due to -o flag")]
-pub struct IgnoringOutDir;
+pub(crate) struct IgnoringOutDir;
 
 #[derive(Diagnostic)]
 #[diag("can't use option `-o` or `--emit` to write multiple output types to stdout")]
-pub struct MultipleOutputTypesToStdout;
+pub(crate) struct MultipleOutputTypesToStdout;
 
 #[derive(Diagnostic)]
 #[diag(

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -13,7 +13,7 @@ use crate::locator::CrateFlavor;
 #[diag(
     "crate `{$crate_name}` required to be available in rlib format, but was not found in this form"
 )]
-pub struct RlibRequired {
+pub(crate) struct RlibRequired {
     pub crate_name: Symbol,
 }
 
@@ -21,7 +21,7 @@ pub struct RlibRequired {
 #[diag(
     "crate `{$crate_name}` required to be available in {$kind} format, but was not found in this form"
 )]
-pub struct LibRequired<'a> {
+pub(crate) struct LibRequired<'a> {
     pub crate_name: Symbol,
     pub kind: &'a str,
 }
@@ -31,7 +31,7 @@ pub struct LibRequired<'a> {
     "crate `{$crate_name}` required to be available in {$kind} format, but was not found in this form"
 )]
 #[help("try adding `extern crate rustc_driver;` at the top level of this crate")]
-pub struct RustcLibRequired<'a> {
+pub(crate) struct RustcLibRequired<'a> {
     pub crate_name: Symbol,
     pub kind: &'a str,
 }
@@ -39,7 +39,7 @@ pub struct RustcLibRequired<'a> {
 #[derive(Diagnostic)]
 #[diag("cannot satisfy dependencies so `{$crate_name}` only shows up once")]
 #[help("having upstream crates all available in one format will likely make this go away")]
-pub struct CrateDepMultiple {
+pub(crate) struct CrateDepMultiple {
     pub crate_name: Symbol,
     #[subdiagnostic]
     pub non_static_deps: Vec<NonStaticCrateDep>,
@@ -49,14 +49,14 @@ pub struct CrateDepMultiple {
 
 #[derive(Subdiagnostic)]
 #[note("`{$sub_crate_name}` was unavailable as a static crate, preventing fully static linking")]
-pub struct NonStaticCrateDep {
+pub(crate) struct NonStaticCrateDep {
     /// It's different from `crate_name` in main Diagnostic.
     pub sub_crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag("cannot link together two panic runtimes: {$prev_name} and {$cur_name}")]
-pub struct TwoPanicRuntimes {
+pub(crate) struct TwoPanicRuntimes {
     pub prev_name: Symbol,
     pub cur_name: Symbol,
 }
@@ -65,7 +65,7 @@ pub struct TwoPanicRuntimes {
 #[diag(
     "the linked panic runtime `{$runtime}` is not compiled with this crate's panic strategy `{$strategy}`"
 )]
-pub struct BadPanicStrategy {
+pub(crate) struct BadPanicStrategy {
     pub runtime: Symbol,
     pub strategy: PanicStrategy,
 }
@@ -74,7 +74,7 @@ pub struct BadPanicStrategy {
 #[diag(
     "the crate `{$crate_name}` requires panic strategy `{$found_strategy}` which is incompatible with this crate's strategy of `{$desired_strategy}`"
 )]
-pub struct RequiredPanicStrategy {
+pub(crate) struct RequiredPanicStrategy {
     pub crate_name: Symbol,
     pub found_strategy: PanicStrategy,
     pub desired_strategy: PanicStrategy,
@@ -84,7 +84,7 @@ pub struct RequiredPanicStrategy {
 #[diag(
     "the crate `{$crate_name}` was compiled with a panic strategy which is incompatible with `immediate-abort`"
 )]
-pub struct IncompatibleWithImmediateAbort {
+pub(crate) struct IncompatibleWithImmediateAbort {
     pub crate_name: Symbol,
 }
 
@@ -92,13 +92,13 @@ pub struct IncompatibleWithImmediateAbort {
 #[diag(
     "the crate `core` was compiled with a panic strategy which is incompatible with `immediate-abort`"
 )]
-pub struct IncompatibleWithImmediateAbortCore;
+pub(crate) struct IncompatibleWithImmediateAbortCore;
 
 #[derive(Diagnostic)]
 #[diag(
     "the crate `{$crate_name}` is compiled with the panic-in-drop strategy `{$found_strategy}` which is incompatible with this crate's strategy of `{$desired_strategy}`"
 )]
-pub struct IncompatiblePanicInDropStrategy {
+pub(crate) struct IncompatiblePanicInDropStrategy {
     pub crate_name: Symbol,
     pub found_strategy: PanicStrategy,
     pub desired_strategy: PanicStrategy,
@@ -106,18 +106,18 @@ pub struct IncompatiblePanicInDropStrategy {
 
 #[derive(Diagnostic)]
 #[diag("`#[link_ordinal]` is only supported if link kind is `raw-dylib`")]
-pub struct LinkOrdinalRawDylib {
+pub(crate) struct LinkOrdinalRawDylib {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag("library kind `framework` is only supported on Apple targets")]
-pub struct LibFrameworkApple;
+pub(crate) struct LibFrameworkApple;
 
 #[derive(Diagnostic)]
 #[diag("an empty renaming target was specified for library `{$lib_name}`")]
-pub struct EmptyRenamingTarget<'a> {
+pub(crate) struct EmptyRenamingTarget<'a> {
     pub lib_name: &'a str,
 }
 
@@ -125,46 +125,46 @@ pub struct EmptyRenamingTarget<'a> {
 #[diag(
     "renaming of the library `{$lib_name}` was specified, however this crate contains no `#[link(...)]` attributes referencing this library"
 )]
-pub struct RenamingNoLink<'a> {
+pub(crate) struct RenamingNoLink<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag("multiple renamings were specified for library `{$lib_name}`")]
-pub struct MultipleRenamings<'a> {
+pub(crate) struct MultipleRenamings<'a> {
     pub lib_name: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag("overriding linking modifiers from command line is not supported")]
-pub struct NoLinkModOverride {
+pub(crate) struct NoLinkModOverride {
     #[primary_span]
     pub span: Option<Span>,
 }
 
 #[derive(Diagnostic)]
 #[diag("ABI not supported by `#[link(kind = \"raw-dylib\")]` on this architecture")]
-pub struct RawDylibUnsupportedAbi {
+pub(crate) struct RawDylibUnsupportedAbi {
     #[primary_span]
     pub span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag("failed to create file encoder: {$err}")]
-pub struct FailCreateFileEncoder {
+pub(crate) struct FailCreateFileEncoder {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("failed to write to `{$path}`: {$err}")]
-pub struct FailWriteFile<'a> {
+pub(crate) struct FailWriteFile<'a> {
     pub path: &'a Path,
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("the crate `{$crate_name}` is not a panic runtime")]
-pub struct CrateNotPanicRuntime {
+pub(crate) struct CrateNotPanicRuntime {
     pub crate_name: Symbol,
 }
 
@@ -172,26 +172,26 @@ pub struct CrateNotPanicRuntime {
 #[diag(
     "the crate `{$crate_name}` resolved as `compiler_builtins` but is not `#![compiler_builtins]`"
 )]
-pub struct CrateNotCompilerBuiltins {
+pub(crate) struct CrateNotCompilerBuiltins {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag("the crate `{$crate_name}` does not have the panic strategy `{$strategy}`")]
-pub struct NoPanicStrategy {
+pub(crate) struct NoPanicStrategy {
     pub crate_name: Symbol,
     pub strategy: PanicStrategy,
 }
 
 #[derive(Diagnostic)]
 #[diag("the crate `{$crate_name}` is not a profiler runtime")]
-pub struct NotProfilerRuntime {
+pub(crate) struct NotProfilerRuntime {
     pub crate_name: Symbol,
 }
 
 #[derive(Diagnostic)]
 #[diag("cannot define multiple global allocators")]
-pub struct NoMultipleGlobalAlloc {
+pub(crate) struct NoMultipleGlobalAlloc {
     #[primary_span]
     #[label("cannot define a new global allocator")]
     pub span2: Span,
@@ -201,7 +201,7 @@ pub struct NoMultipleGlobalAlloc {
 
 #[derive(Diagnostic)]
 #[diag("cannot define multiple allocation error handlers")]
-pub struct NoMultipleAllocErrorHandler {
+pub(crate) struct NoMultipleAllocErrorHandler {
     #[primary_span]
     #[label("cannot define a new allocation error handler")]
     pub span2: Span,
@@ -213,7 +213,7 @@ pub struct NoMultipleAllocErrorHandler {
 #[diag(
     "the `#[global_allocator]` in {$other_crate_name} conflicts with global allocator in: {$crate_name}"
 )]
-pub struct ConflictingGlobalAlloc {
+pub(crate) struct ConflictingGlobalAlloc {
     pub crate_name: Symbol,
     pub other_crate_name: Symbol,
 }
@@ -222,7 +222,7 @@ pub struct ConflictingGlobalAlloc {
 #[diag(
     "the `#[alloc_error_handler]` in {$other_crate_name} conflicts with allocation error handler in: {$crate_name}"
 )]
-pub struct ConflictingAllocErrorHandler {
+pub(crate) struct ConflictingAllocErrorHandler {
     pub crate_name: Symbol,
     pub other_crate_name: Symbol,
 }
@@ -231,18 +231,18 @@ pub struct ConflictingAllocErrorHandler {
 #[diag(
     "no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait"
 )]
-pub struct GlobalAllocRequired;
+pub(crate) struct GlobalAllocRequired;
 
 #[derive(Diagnostic)]
 #[diag("failed to write {$filename}: {$err}")]
-pub struct FailedWriteError {
+pub(crate) struct FailedWriteError {
     pub filename: PathBuf,
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("failed to copy {$filename} to stdout: {$err}")]
-pub struct FailedCopyToStdout {
+pub(crate) struct FailedCopyToStdout {
     pub filename: PathBuf,
     pub err: Error,
 }
@@ -251,18 +251,18 @@ pub struct FailedCopyToStdout {
 #[diag(
     "option `-o` or `--emit` is used to write binary output type `metadata` to stdout, but stdout is a tty"
 )]
-pub struct BinaryOutputToTty;
+pub(crate) struct BinaryOutputToTty;
 
 #[derive(Diagnostic)]
 #[diag("could not find native static library `{$libname}`, perhaps an -L flag is missing?")]
-pub struct MissingNativeLibrary<'a> {
+pub(crate) struct MissingNativeLibrary<'a> {
     libname: &'a str,
     #[subdiagnostic]
     suggest_name: Option<SuggestLibraryName<'a>>,
 }
 
 impl<'a> MissingNativeLibrary<'a> {
-    pub fn new(libname: &'a str, verbatim: bool) -> Self {
+    pub(crate) fn new(libname: &'a str, verbatim: bool) -> Self {
         // if it looks like the user has provided a complete filename rather just the bare lib name,
         // then provide a note that they might want to try trimming the name
         let suggested_name = if !verbatim {
@@ -289,32 +289,32 @@ impl<'a> MissingNativeLibrary<'a> {
 
 #[derive(Subdiagnostic)]
 #[help("only provide the library name `{$suggested_name}`, not the full filename")]
-pub struct SuggestLibraryName<'a> {
+pub(crate) struct SuggestLibraryName<'a> {
     suggested_name: &'a str,
 }
 
 #[derive(Diagnostic)]
 #[diag("couldn't create a temp dir: {$err}")]
-pub struct FailedCreateTempdir {
+pub(crate) struct FailedCreateTempdir {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("failed to create the file {$filename}: {$err}")]
-pub struct FailedCreateFile<'a> {
+pub(crate) struct FailedCreateFile<'a> {
     pub filename: &'a Path,
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("failed to create encoded metadata from file: {$err}")]
-pub struct FailedCreateEncodedMetadata {
+pub(crate) struct FailedCreateEncodedMetadata {
     pub err: Error,
 }
 
 #[derive(Diagnostic)]
 #[diag("cannot load a crate with a non-ascii name `{$crate_name}`")]
-pub struct NonAsciiName {
+pub(crate) struct NonAsciiName {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -322,7 +322,7 @@ pub struct NonAsciiName {
 
 #[derive(Diagnostic)]
 #[diag("extern location for {$crate_name} does not exist: {$location}")]
-pub struct ExternLocationNotExist<'a> {
+pub(crate) struct ExternLocationNotExist<'a> {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -331,7 +331,7 @@ pub struct ExternLocationNotExist<'a> {
 
 #[derive(Diagnostic)]
 #[diag("extern location for {$crate_name} is not a file: {$location}")]
-pub struct ExternLocationNotFile<'a> {
+pub(crate) struct ExternLocationNotFile<'a> {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -376,7 +376,7 @@ pub(crate) struct FullMetadataNotFound {
 
 #[derive(Diagnostic)]
 #[diag("the current crate is indistinguishable from one of its dependencies: it has the same crate-name `{$crate_name}` and was compiled with the same `-C metadata` arguments, so this will result in symbol conflicts between the two", code = E0519)]
-pub struct SymbolConflictsCurrent {
+pub(crate) struct SymbolConflictsCurrent {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -384,7 +384,7 @@ pub struct SymbolConflictsCurrent {
 
 #[derive(Diagnostic)]
 #[diag("found crates (`{$crate_name0}` and `{$crate_name1}`) with colliding StableCrateId values")]
-pub struct StableCrateIdCollision {
+pub(crate) struct StableCrateIdCollision {
     #[primary_span]
     pub span: Span,
     pub crate_name0: Symbol,
@@ -393,7 +393,7 @@ pub struct StableCrateIdCollision {
 
 #[derive(Diagnostic)]
 #[diag("{$path}{$err}")]
-pub struct DlError {
+pub(crate) struct DlError {
     #[primary_span]
     pub span: Span,
     pub path: String,
@@ -404,7 +404,7 @@ pub struct DlError {
 #[diag("found possibly newer version of crate `{$crate_name}`{$add_info}", code = E0460)]
 #[note("perhaps that crate needs to be recompiled?")]
 #[note("the following crate versions were found:{$found_crates}")]
-pub struct NewerCrateVersion {
+pub(crate) struct NewerCrateVersion {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -415,7 +415,7 @@ pub struct NewerCrateVersion {
 #[derive(Diagnostic)]
 #[diag("couldn't find crate `{$crate_name}` with expected target triple {$locator_triple}{$add_info}", code = E0461)]
 #[note("the following crate versions were found:{$found_crates}")]
-pub struct NoCrateWithTriple<'a> {
+pub(crate) struct NoCrateWithTriple<'a> {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -428,7 +428,7 @@ pub struct NoCrateWithTriple<'a> {
 #[diag("found staticlib `{$crate_name}` instead of rlib or dylib{$add_info}", code = E0462)]
 #[note("the following crate versions were found:{$found_crates}")]
 #[help("please recompile that crate using --crate-type lib")]
-pub struct FoundStaticlib {
+pub(crate) struct FoundStaticlib {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -442,7 +442,7 @@ pub struct FoundStaticlib {
 #[help(
     "please recompile that crate using this compiler ({$rustc_version}) (consider running `cargo clean` first)"
 )]
-pub struct IncompatibleRustc {
+pub(crate) struct IncompatibleRustc {
     #[primary_span]
     pub span: Span,
     pub crate_name: Symbol,
@@ -451,7 +451,7 @@ pub struct IncompatibleRustc {
     pub rustc_version: String,
 }
 
-pub struct InvalidMetadataFiles {
+pub(crate) struct InvalidMetadataFiles {
     pub span: Span,
     pub crate_name: Symbol,
     pub add_info: String,
@@ -477,7 +477,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for InvalidMetadataFiles {
     }
 }
 
-pub struct CannotFindCrate {
+pub(crate) struct CannotFindCrate {
     pub span: Span,
     pub crate_name: Symbol,
     pub add_info: String,
@@ -550,7 +550,7 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for CannotFindCrate {
 
 #[derive(Diagnostic)]
 #[diag("extern location for {$crate_name} is of an unknown type: {$path}")]
-pub struct CrateLocationUnknownType<'a> {
+pub(crate) struct CrateLocationUnknownType<'a> {
     #[primary_span]
     pub span: Span,
     pub path: &'a Path,
@@ -559,7 +559,7 @@ pub struct CrateLocationUnknownType<'a> {
 
 #[derive(Diagnostic)]
 #[diag("file name should be lib*.rlib or {$dll_prefix}*{$dll_suffix}")]
-pub struct LibFilenameForm<'a> {
+pub(crate) struct LibFilenameForm<'a> {
     #[primary_span]
     pub span: Span,
     pub dll_prefix: &'a str,
@@ -589,7 +589,7 @@ pub(crate) struct WasmCAbi {
 #[help(
     "if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error"
 )]
-pub struct IncompatibleTargetModifiers {
+pub(crate) struct IncompatibleTargetModifiers {
     #[primary_span]
     pub span: Span,
     pub extern_crate: Symbol,
@@ -614,7 +614,7 @@ pub struct IncompatibleTargetModifiers {
 #[help(
     "if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error"
 )]
-pub struct IncompatibleTargetModifiersLMissed {
+pub(crate) struct IncompatibleTargetModifiersLMissed {
     #[primary_span]
     pub span: Span,
     pub extern_crate: Symbol,
@@ -638,7 +638,7 @@ pub struct IncompatibleTargetModifiersLMissed {
 #[help(
     "if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error"
 )]
-pub struct IncompatibleTargetModifiersRMissed {
+pub(crate) struct IncompatibleTargetModifiersRMissed {
     #[primary_span]
     pub span: Span,
     pub extern_crate: Symbol,
@@ -652,7 +652,7 @@ pub struct IncompatibleTargetModifiersRMissed {
 #[diag(
     "unknown target modifier `{$flag_name}`, requested by `-Cunsafe-allow-abi-mismatch={$flag_name}`"
 )]
-pub struct UnknownTargetModifierUnsafeAllowed {
+pub(crate) struct UnknownTargetModifierUnsafeAllowed {
     #[primary_span]
     pub span: Span,
     pub flag_name: String,
@@ -665,7 +665,7 @@ pub struct UnknownTargetModifierUnsafeAllowed {
 #[help(
     "if async drop type will be dropped in a crate without `feature(async_drop)`, sync Drop will be used"
 )]
-pub struct AsyncDropTypesInDependency {
+pub(crate) struct AsyncDropTypesInDependency {
     #[primary_span]
     pub span: Span,
     pub extern_crate: Symbol,
@@ -674,7 +674,7 @@ pub struct AsyncDropTypesInDependency {
 
 #[derive(Diagnostic)]
 #[diag("link name must be well-formed if link kind is `raw-dylib`")]
-pub struct RawDylibMalformed {
+pub(crate) struct RawDylibMalformed {
     #[primary_span]
     pub span: Span,
 }
@@ -697,7 +697,7 @@ pub(crate) struct UnusedCrateDependency {
 #[help(
     "it is possible to disable `-Z allow-partial-mitigations={$mitigation_name}` via `-Z deny-partial-mitigations={$mitigation_name}`"
 )]
-pub struct MitigationLessStrictInDependency {
+pub(crate) struct MitigationLessStrictInDependency {
     #[primary_span]
     pub span: Span,
     pub mitigation_name: String,

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -37,7 +37,7 @@ pub(crate) struct OpaqueHiddenTypeMismatch<'tcx> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum TypeMismatchReason {
+pub(crate) enum TypeMismatchReason {
     #[label("this expression supplies two conflicting concrete types for the same opaque type")]
     ConflictType {
         #[primary_span]

--- a/compiler/rustc_pattern_analysis/src/errors.rs
+++ b/compiler/rustc_pattern_analysis/src/errors.rs
@@ -48,7 +48,7 @@ impl Uncovered {
 #[derive(Diagnostic)]
 #[diag("multiple patterns overlap on their endpoints")]
 #[note("you likely meant to write mutually exclusive ranges")]
-pub struct OverlappingRangeEndpoints {
+pub(crate) struct OverlappingRangeEndpoints {
     #[label("... with this range")]
     pub range: Span,
     #[subdiagnostic]
@@ -57,7 +57,7 @@ pub struct OverlappingRangeEndpoints {
 
 #[derive(Subdiagnostic)]
 #[label("this range overlaps on `{$range}`...")]
-pub struct Overlap {
+pub(crate) struct Overlap {
     #[primary_span]
     pub span: Span,
     pub range: String, // a printed pattern
@@ -65,7 +65,7 @@ pub struct Overlap {
 
 #[derive(Diagnostic)]
 #[diag("exclusive range missing `{$max}`")]
-pub struct ExclusiveRangeMissingMax {
+pub(crate) struct ExclusiveRangeMissingMax {
     #[label("this range doesn't match `{$max}` because `..` is an exclusive range")]
     #[suggestion(
         "use an inclusive range instead",
@@ -81,7 +81,7 @@ pub struct ExclusiveRangeMissingMax {
 
 #[derive(Diagnostic)]
 #[diag("multiple ranges are one apart")]
-pub struct ExclusiveRangeMissingGap {
+pub(crate) struct ExclusiveRangeMissingGap {
     #[label("this range doesn't match `{$gap}` because `..` is an exclusive range")]
     #[suggestion(
         "use an inclusive range instead",
@@ -102,7 +102,7 @@ pub struct ExclusiveRangeMissingGap {
 #[label(
     "this could appear to continue range `{$first_range}`, but `{$gap}` isn't matched by either of them"
 )]
-pub struct GappedRange {
+pub(crate) struct GappedRange {
     #[primary_span]
     pub span: Span,
     pub gap: String,         // a printed pattern

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -84,13 +84,6 @@ pub(crate) struct CliFeatureDiagnosticHelp {
 }
 
 #[derive(Diagnostic)]
-#[diag("must be a name of an associated function")]
-pub struct MustBeNameOfAssociatedFunction {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(
     "`-Zunleash-the-miri-inside-of-you` may not be used to circumvent feature gates, except when testing error paths in the CTFE engine"
 )]

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -71,7 +71,7 @@ pub(crate) struct FeatureDiagnosticHelp {
     applicability = "maybe-incorrect",
     code = "#![feature({feature})]\n"
 )]
-pub struct FeatureDiagnosticSuggestion {
+pub(crate) struct FeatureDiagnosticSuggestion {
     pub feature: Symbol,
     #[primary_span]
     pub span: Span,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -1826,7 +1826,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         debug!(?diag);
     }
 
-    pub fn type_error_additional_suggestions(
+    pub(crate) fn type_error_additional_suggestions(
         &self,
         trace: &TypeTrace<'tcx>,
         terr: TypeError<'tcx>,
@@ -2274,6 +2274,7 @@ impl<'tcx> ObligationCause<'tcx> {
             },
         }
     }
+
     fn as_failure_code_diag(
         &self,
         terr: TypeError<'tcx>,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -18,9 +18,8 @@ use crate::errors::{
 use crate::infer::{RegionResolutionError, SubregionOrigin, TypeTrace, ValuePairs};
 use crate::traits::{ObligationCause, ObligationCauseCode};
 
-// HACK(eddyb) maybe move this in a more central location.
 #[derive(Copy, Clone)]
-pub struct Highlighted<'tcx, T> {
+pub(crate) struct Highlighted<'tcx, T> {
     pub tcx: TyCtxt<'tcx>,
     pub highlight: RegionHighlightMode<'tcx>,
     pub value: T,

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -18,17 +18,17 @@ use crate::error_reporting::infer::ObligationCauseAsDiagArg;
 use crate::error_reporting::infer::need_type_info::UnderspecifiedArgKind;
 use crate::error_reporting::infer::nice_region_error::placeholder_error::Highlighted;
 
-pub mod note_and_explain;
+pub(crate) mod note_and_explain;
 
 #[derive(Diagnostic)]
 #[diag("unable to construct a constant value for the unevaluated constant {$unevaluated}")]
-pub struct UnableToConstructConstantValue<'a> {
+pub(crate) struct UnableToConstructConstantValue<'a> {
     #[primary_span]
     pub span: Span,
     pub unevaluated: ty::UnevaluatedConst<'a>,
 }
 
-pub struct NegativePositiveConflict<'tcx> {
+pub(crate) struct NegativePositiveConflict<'tcx> {
     pub impl_span: Span,
     pub trait_desc: ty::TraitRef<'tcx>,
     pub self_ty: Option<Ty<'tcx>>,
@@ -77,13 +77,13 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NegativePositiveConflict<'_> {
 
 #[derive(Diagnostic)]
 #[diag("overflow evaluating associated type `{$ty}`")]
-pub struct InherentProjectionNormalizationOverflow {
+pub(crate) struct InherentProjectionNormalizationOverflow {
     #[primary_span]
     pub span: Span,
     pub ty: String,
 }
 
-pub enum AdjustSignatureBorrow {
+pub(crate) enum AdjustSignatureBorrow {
     Borrow { to_borrow: Vec<(Span, String)> },
     RemoveBorrow { remove_borrow: Vec<(Span, String)> },
 }
@@ -123,7 +123,7 @@ impl Subdiagnostic for AdjustSignatureBorrow {
 
 #[derive(Diagnostic)]
 #[diag("expected a closure that implements the `{$trait_prefix}{$expected}` trait, but this closure only implements `{$trait_prefix}{$found}`", code = E0525)]
-pub struct ClosureKindMismatch {
+pub(crate) struct ClosureKindMismatch {
     #[primary_span]
     #[label("this closure implements `{$trait_prefix}{$found}`, not `{$trait_prefix}{$expected}`")]
     pub closure_span: Span,
@@ -145,7 +145,7 @@ pub struct ClosureKindMismatch {
 #[label(
     "closure is `{$trait_prefix}FnOnce` because it moves the variable `{$place}` out of its environment"
 )]
-pub struct ClosureFnOnceLabel {
+pub(crate) struct ClosureFnOnceLabel {
     #[primary_span]
     pub span: Span,
     pub place: String,
@@ -154,7 +154,7 @@ pub struct ClosureFnOnceLabel {
 
 #[derive(Subdiagnostic)]
 #[label("closure is `{$trait_prefix}FnMut` because it mutates the variable `{$place}` here")]
-pub struct ClosureFnMutLabel {
+pub(crate) struct ClosureFnMutLabel {
     #[primary_span]
     pub span: Span,
     pub place: String,
@@ -178,7 +178,7 @@ pub(crate) struct CoroClosureNotFn {
 [normal] type annotations needed for `{$source_name}`
 *[other] type annotations needed
 }", code = E0282)]
-pub struct AnnotationRequired<'a> {
+pub(crate) struct AnnotationRequired<'a> {
     #[primary_span]
     pub span: Span,
     pub source_kind: &'static str,
@@ -200,7 +200,7 @@ pub struct AnnotationRequired<'a> {
 [normal] type annotations needed for `{$source_name}`
 *[other] type annotations needed
 }", code = E0283)]
-pub struct AmbiguousImpl<'a> {
+pub(crate) struct AmbiguousImpl<'a> {
     #[primary_span]
     pub span: Span,
     pub source_kind: &'static str,
@@ -222,7 +222,7 @@ pub struct AmbiguousImpl<'a> {
 [normal] type annotations needed for `{$source_name}`
 *[other] type annotations needed
 }", code = E0284)]
-pub struct AmbiguousReturn<'a> {
+pub(crate) struct AmbiguousReturn<'a> {
     #[primary_span]
     pub span: Span,
     pub source_kind: &'static str,
@@ -252,7 +252,7 @@ pub struct AmbiguousReturn<'a> {
 }
 }"
 )]
-pub struct InferenceBadError<'a> {
+pub(crate) struct InferenceBadError<'a> {
     #[primary_span]
     pub span: Span,
     pub bad_kind: &'static str,
@@ -265,7 +265,7 @@ pub struct InferenceBadError<'a> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum SourceKindSubdiag<'a> {
+pub(crate) enum SourceKindSubdiag<'a> {
     #[suggestion(
         "{$kind ->
             [with_pattern] consider giving `{$name}` an explicit type
@@ -334,7 +334,7 @@ pub enum SourceKindSubdiag<'a> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum SourceKindMultiSuggestion<'a> {
+pub(crate) enum SourceKindMultiSuggestion<'a> {
     #[multipart_suggestion(
         "try using a fully qualified path to specify the expected types",
         style = "verbose",
@@ -364,7 +364,7 @@ pub enum SourceKindMultiSuggestion<'a> {
 }
 
 impl<'a> SourceKindMultiSuggestion<'a> {
-    pub fn new_fully_qualified(
+    pub(crate) fn new_fully_qualified(
         span: Span,
         def_path: String,
         adjustment: &'a str,
@@ -379,7 +379,7 @@ impl<'a> SourceKindMultiSuggestion<'a> {
         }
     }
 
-    pub fn new_closure_return(
+    pub(crate) fn new_closure_return(
         ty_info: String,
         data: &'a FnRetTy<'a>,
         should_wrap_expr: Option<Span>,
@@ -396,7 +396,7 @@ impl<'a> SourceKindMultiSuggestion<'a> {
     }
 }
 
-pub enum RegionOriginNote<'a> {
+pub(crate) enum RegionOriginNote<'a> {
     Plain {
         span: Span,
         msg: DiagMessage,
@@ -492,7 +492,7 @@ impl Subdiagnostic for RegionOriginNote<'_> {
     }
 }
 
-pub enum LifetimeMismatchLabels {
+pub(crate) enum LifetimeMismatchLabels {
     InRet {
         param_span: Span,
         ret_span: Span,
@@ -573,7 +573,7 @@ impl Subdiagnostic for LifetimeMismatchLabels {
     }
 }
 
-pub struct AddLifetimeParamsSuggestion<'a> {
+pub(crate) struct AddLifetimeParamsSuggestion<'a> {
     pub tcx: TyCtxt<'a>,
     pub generic_param_scope: LocalDefId,
     pub sub: Region<'a>,
@@ -753,7 +753,7 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
 
 #[derive(Diagnostic)]
 #[diag("lifetime mismatch", code = E0623)]
-pub struct LifetimeMismatch<'a> {
+pub(crate) struct LifetimeMismatch<'a> {
     #[primary_span]
     pub span: Span,
     #[subdiagnostic]
@@ -762,7 +762,7 @@ pub struct LifetimeMismatch<'a> {
     pub suggestion: AddLifetimeParamsSuggestion<'a>,
 }
 
-pub struct IntroducesStaticBecauseUnmetLifetimeReq {
+pub(crate) struct IntroducesStaticBecauseUnmetLifetimeReq {
     pub unmet_requirements: MultiSpan,
     pub binding_span: Span,
 }
@@ -782,7 +782,7 @@ impl Subdiagnostic for IntroducesStaticBecauseUnmetLifetimeReq {
 
 // FIXME(#100717): replace with a `Option<Span>` when subdiagnostic supports that
 #[derive(Subdiagnostic)]
-pub enum DoesNotOutliveStaticFromImpl {
+pub(crate) enum DoesNotOutliveStaticFromImpl {
     #[note(
         "...does not necessarily outlive the static lifetime introduced by the compatible `impl`"
     )]
@@ -797,7 +797,7 @@ pub enum DoesNotOutliveStaticFromImpl {
 }
 
 #[derive(Subdiagnostic)]
-pub enum ImplicitStaticLifetimeSubdiag {
+pub(crate) enum ImplicitStaticLifetimeSubdiag {
     #[note("this has an implicit `'static` lifetime requirement")]
     Note {
         #[primary_span]
@@ -817,7 +817,7 @@ pub enum ImplicitStaticLifetimeSubdiag {
 
 #[derive(Diagnostic)]
 #[diag("incompatible lifetime on type")]
-pub struct MismatchedStaticLifetime<'a> {
+pub(crate) struct MismatchedStaticLifetime<'a> {
     #[primary_span]
     pub cause_span: Span,
     #[subdiagnostic]
@@ -831,7 +831,7 @@ pub struct MismatchedStaticLifetime<'a> {
 }
 
 #[derive(Diagnostic)]
-pub enum ExplicitLifetimeRequired<'a> {
+pub(crate) enum ExplicitLifetimeRequired<'a> {
     #[diag("explicit lifetime required in the type of `{$simple_ident}`", code = E0621)]
     WithIdent {
         #[primary_span]
@@ -867,7 +867,7 @@ pub enum ExplicitLifetimeRequired<'a> {
     },
 }
 
-pub enum TyOrSig<'tcx> {
+pub(crate) enum TyOrSig<'tcx> {
     Ty(Highlighted<'tcx, Ty<'tcx>>),
     ClosureSig(Highlighted<'tcx, Binder<'tcx, FnSig<'tcx>>>),
 }
@@ -882,7 +882,7 @@ impl IntoDiagArg for TyOrSig<'_> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum ActualImplExplNotes<'tcx> {
+pub(crate) enum ActualImplExplNotes<'tcx> {
     #[note("{$leading_ellipsis ->
         [true] ...
         *[false] {\"\"}
@@ -1050,13 +1050,13 @@ pub enum ActualImplExplNotes<'tcx> {
     },
 }
 
-pub enum ActualImplExpectedKind {
+pub(crate) enum ActualImplExpectedKind {
     Signature,
     Passive,
     Other,
 }
 
-pub enum ActualImplExpectedLifetimeKind {
+pub(crate) enum ActualImplExpectedLifetimeKind {
     Two,
     Any,
     Some,
@@ -1064,7 +1064,7 @@ pub enum ActualImplExpectedLifetimeKind {
 }
 
 impl<'tcx> ActualImplExplNotes<'tcx> {
-    pub fn new_expected(
+    pub(crate) fn new_expected(
         kind: ActualImplExpectedKind,
         lt_kind: ActualImplExpectedLifetimeKind,
         leading_ellipsis: bool,
@@ -1134,7 +1134,7 @@ impl<'tcx> ActualImplExplNotes<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag("implementation of `{$trait_def_id}` is not general enough")]
-pub struct TraitPlaceholderMismatch<'tcx> {
+pub(crate) struct TraitPlaceholderMismatch<'tcx> {
     #[primary_span]
     pub span: Span,
     #[label("doesn't satisfy where-clause")]
@@ -1150,7 +1150,7 @@ pub struct TraitPlaceholderMismatch<'tcx> {
     pub actual_impl_expl_notes: Vec<ActualImplExplNotes<'tcx>>,
 }
 
-pub struct ConsiderBorrowingParamHelp {
+pub(crate) struct ConsiderBorrowingParamHelp {
     pub spans: Vec<Span>,
 }
 
@@ -1171,7 +1171,7 @@ impl Subdiagnostic for ConsiderBorrowingParamHelp {
 
 #[derive(Diagnostic)]
 #[diag("`impl` item signature doesn't match `trait` item signature")]
-pub struct TraitImplDiff {
+pub(crate) struct TraitImplDiff {
     #[primary_span]
     #[label("found `{$found}`")]
     pub sp: Span,
@@ -1200,7 +1200,7 @@ pub struct TraitImplDiff {
     [true] lifetime `{$lifetime}`
     *[false] an anonymous lifetime `'_`
 } but it needs to satisfy a `'static` lifetime requirement", code = E0759)]
-pub struct ButNeedsToSatisfy {
+pub(crate) struct ButNeedsToSatisfy {
     #[primary_span]
     pub sp: Span,
     #[label(
@@ -1238,7 +1238,7 @@ pub struct ButNeedsToSatisfy {
 
 #[derive(Diagnostic)]
 #[diag("lifetime of reference outlives lifetime of borrowed content...", code = E0312)]
-pub struct OutlivesContent<'a> {
+pub(crate) struct OutlivesContent<'a> {
     #[primary_span]
     pub span: Span,
     #[subdiagnostic]
@@ -1247,7 +1247,7 @@ pub struct OutlivesContent<'a> {
 
 #[derive(Diagnostic)]
 #[diag("lifetime of the source pointer does not outlive lifetime bound of the object type", code = E0476)]
-pub struct OutlivesBound<'a> {
+pub(crate) struct OutlivesBound<'a> {
     #[primary_span]
     pub span: Span,
     #[subdiagnostic]
@@ -1256,7 +1256,7 @@ pub struct OutlivesBound<'a> {
 
 #[derive(Diagnostic)]
 #[diag("the type `{$ty}` does not fulfill the required lifetime", code = E0477)]
-pub struct FulfillReqLifetime<'a> {
+pub(crate) struct FulfillReqLifetime<'a> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'a>,
@@ -1266,7 +1266,7 @@ pub struct FulfillReqLifetime<'a> {
 
 #[derive(Diagnostic)]
 #[diag("lifetime bound not satisfied", code = E0478)]
-pub struct LfBoundNotSatisfied<'a> {
+pub(crate) struct LfBoundNotSatisfied<'a> {
     #[primary_span]
     pub span: Span,
     #[subdiagnostic]
@@ -1275,7 +1275,7 @@ pub struct LfBoundNotSatisfied<'a> {
 
 #[derive(Diagnostic)]
 #[diag("in type `{$ty}`, reference has a longer lifetime than the data it references", code = E0491)]
-pub struct RefLongerThanData<'a> {
+pub(crate) struct RefLongerThanData<'a> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'a>,
@@ -1284,7 +1284,7 @@ pub struct RefLongerThanData<'a> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum WhereClauseSuggestions {
+pub(crate) enum WhereClauseSuggestions {
     #[suggestion(
         "remove the `where` clause",
         code = "",
@@ -1310,7 +1310,7 @@ pub enum WhereClauseSuggestions {
 }
 
 #[derive(Subdiagnostic)]
-pub enum SuggestRemoveSemiOrReturnBinding {
+pub(crate) enum SuggestRemoveSemiOrReturnBinding {
     #[multipart_suggestion(
         "consider removing this semicolon and boxing the expressions",
         applicability = "machine-applicable"
@@ -1357,7 +1357,7 @@ pub enum SuggestRemoveSemiOrReturnBinding {
 }
 
 #[derive(Subdiagnostic)]
-pub enum ConsiderAddingAwait {
+pub(crate) enum ConsiderAddingAwait {
     #[help("consider `await`ing on both `Future`s")]
     BothFuturesHelp,
     #[multipart_suggestion(
@@ -1397,7 +1397,7 @@ pub enum ConsiderAddingAwait {
 }
 
 #[derive(Diagnostic)]
-pub enum PlaceholderRelationLfNotSatisfied {
+pub(crate) enum PlaceholderRelationLfNotSatisfied {
     #[diag("lifetime bound not satisfied")]
     HasBoth {
         #[primary_span]
@@ -1467,7 +1467,7 @@ pub enum PlaceholderRelationLfNotSatisfied {
 
 #[derive(Diagnostic)]
 #[diag("hidden type for `{$opaque_ty}` captures lifetime that does not appear in bounds", code = E0700)]
-pub struct OpaqueCapturesLifetime<'tcx> {
+pub(crate) struct OpaqueCapturesLifetime<'tcx> {
     #[primary_span]
     pub span: Span,
     #[label("opaque type defined here")]
@@ -1476,7 +1476,7 @@ pub struct OpaqueCapturesLifetime<'tcx> {
 }
 
 #[derive(Subdiagnostic)]
-pub enum FunctionPointerSuggestion<'a> {
+pub(crate) enum FunctionPointerSuggestion<'a> {
     #[suggestion(
         "consider using a reference",
         code = "&",
@@ -1557,26 +1557,26 @@ pub enum FunctionPointerSuggestion<'a> {
 
 #[derive(Subdiagnostic)]
 #[note("fn items are distinct from fn pointers")]
-pub struct FnItemsAreDistinct;
+pub(crate) struct FnItemsAreDistinct;
 
 #[derive(Subdiagnostic)]
 #[note("different fn items have unique types, even if their signatures are the same")]
-pub struct FnUniqTypes;
+pub(crate) struct FnUniqTypes;
 
 #[derive(Subdiagnostic)]
 #[help("consider casting the fn item to a fn pointer: `{$casting}`")]
-pub struct FnConsiderCasting {
+pub(crate) struct FnConsiderCasting {
     pub casting: String,
 }
 
 #[derive(Subdiagnostic)]
 #[help("consider casting both fn items to fn pointers using `as {$sig}`")]
-pub struct FnConsiderCastingBoth<'a> {
+pub(crate) struct FnConsiderCastingBoth<'a> {
     pub sig: Binder<'a, FnSig<'a>>,
 }
 
 #[derive(Subdiagnostic)]
-pub enum SuggestAccessingField<'a> {
+pub(crate) enum SuggestAccessingField<'a> {
     #[suggestion(
         "you might have meant to use field `{$name}` whose type is `{$ty}`",
         code = "{snippet}.{name}",
@@ -1610,7 +1610,7 @@ pub enum SuggestAccessingField<'a> {
     "try wrapping the pattern in `{$variant}`",
     applicability = "maybe-incorrect"
 )]
-pub struct SuggestTuplePatternOne {
+pub(crate) struct SuggestTuplePatternOne {
     pub variant: String,
     #[suggestion_part(code = "{variant}(")]
     pub span_low: Span,
@@ -1618,7 +1618,7 @@ pub struct SuggestTuplePatternOne {
     pub span_high: Span,
 }
 
-pub struct SuggestTuplePatternMany {
+pub(crate) struct SuggestTuplePatternMany {
     pub path: String,
     pub cause_span: Span,
     pub compatible_variants: Vec<String>,
@@ -1836,7 +1836,7 @@ pub enum ObligationCauseFailureCode {
 }
 
 #[derive(Subdiagnostic)]
-pub enum AddPreciseCapturing {
+pub(crate) enum AddPreciseCapturing {
     #[suggestion(
         "add a `use<...>` bound to explicitly capture `{$new_lifetime}`",
         style = "verbose",
@@ -1864,7 +1864,7 @@ pub enum AddPreciseCapturing {
     },
 }
 
-pub struct AddPreciseCapturingAndParams {
+pub(crate) struct AddPreciseCapturingAndParams {
     pub suggs: Vec<(Span, String)>,
     pub new_lifetime: Symbol,
     pub apit_spans: Vec<Span>,

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -83,7 +83,7 @@ impl<'a> DescriptionCtx<'a> {
     }
 }
 
-pub enum PrefixKind {
+pub(crate) enum PrefixKind {
     Empty,
     RefValidFor,
     ContentValidFor,
@@ -99,7 +99,7 @@ pub enum PrefixKind {
     DataValidFor,
 }
 
-pub enum SuffixKind {
+pub(crate) enum SuffixKind {
     Empty,
     Continues,
     ReqByBinding,
@@ -139,14 +139,14 @@ impl IntoDiagArg for SuffixKind {
     }
 }
 
-pub struct RegionExplanation<'a> {
+pub(crate) struct RegionExplanation<'a> {
     desc: DescriptionCtx<'a>,
     prefix: PrefixKind,
     suffix: SuffixKind,
 }
 
 impl RegionExplanation<'_> {
-    pub fn new<'tcx>(
+    pub(crate) fn new<'tcx>(
         tcx: TyCtxt<'tcx>,
         generic_param_scope: LocalDefId,
         region: ty::Region<'tcx>,


### PR DESCRIPTION
Most diagnostic types are only used within their own crate, and so have a `pub(crate)` visibility. We have some diagnostic types that are unnecessarily `pub`. This is bad because (a) information hiding, and (b) if a `pub(crate)` type becomes unused the compiler will warn but it won't warn for a `pub` type.

This commit eliminates unnecessary `pub` visibilities for some diagnostic types, and also some related things due to knock-on effects. (I found these types with some ad hoc use of `grep`.)

r? @Kivooeo 