### PR TITLE
Add regression test for dead code elimination with drop + panic

### DIFF
--- a/tests/codegen-llvm/issues/issue-114532.rs
+++ b/tests/codegen-llvm/issues/issue-114532.rs
@@ -1,0 +1,34 @@
+//@ compile-flags: -Copt-level=3
+#![crate_type = "lib"]
+
+// Regression test for #114532.
+// Dead code elimination used to fail when a Drop impl contained a panic
+// and a potentially-panicking function was called after the value was created.
+
+struct Foo(bool);
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        if self.0 {
+            return;
+        }
+        panic!("dead");
+    }
+}
+
+// CHECK-LABEL: @foo(
+// CHECK-NOT: panic
+// CHECK-NOT: call void @{{.*}}panicking
+// CHECK: call {{.*}} @unknown(
+// CHECK-NEXT: ret void
+#[no_mangle]
+pub fn foo() {
+    let _a = Foo(true);
+    unsafe {
+        unknown(9);
+    }
+}
+
+extern "Rust" {
+    fn unknown(x: i32) -> bool;
+}


### PR DESCRIPTION
Add a codegen test for rust-lang/rust#114532.

The bug was that dead code elimination failed when a `Drop` impl contained a `panic!` and a potentially-panicking external function was called after the value was created. This was fixed since 1.82 but no regression test was added.

The test verifies that `foo()` compiles to just a call to `unknown()` + `ret void`, with no panic or panicking call in the function body.

Closes rust-lang/rust#114532