### PR TITLE
remove `new_from_def_id` and `alias_ty_kind_from_def_id`

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -287,6 +287,20 @@ impl LowerTypeRelativePathMode {
             Self::Const => PermitVariants::No,
         }
     }
+
+    fn inherent_alias_term_kind(self) -> ty::AliasTermKind {
+        match self {
+            Self::Type(_) => ty::AliasTermKind::InherentTy,
+            Self::Const => ty::AliasTermKind::InherentConst,
+        }
+    }
+
+    fn projection_alias_term_kind(self) -> ty::AliasTermKind {
+        match self {
+            Self::Type(_) => ty::AliasTermKind::ProjectionTy,
+            Self::Const => ty::AliasTermKind::ProjectionConst,
+        }
+    }
 }
 
 /// Whether to permit a path to resolve to an enum variant.
@@ -298,7 +312,7 @@ pub enum PermitVariants {
 
 #[derive(Debug, Clone, Copy)]
 enum TypeRelativePath<'tcx> {
-    AssocItem(DefId, GenericArgsRef<'tcx>),
+    AssocItem(ty::AliasTermKind, DefId, GenericArgsRef<'tcx>),
     Variant { adt: Ty<'tcx>, variant_did: DefId },
     Ctor { ctor_def_id: DefId, args: GenericArgsRef<'tcx> },
 }
@@ -1400,12 +1414,20 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Type(permit_variants),
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                let alias_ty = ty::AliasTy::new_from_args(
-                    tcx,
-                    ty::AliasTyKind::new_from_def_id(tcx, def_id),
-                    args,
-                );
+            TypeRelativePath::AssocItem(kind, def_id, args) => {
+                let alias_ty_kind = match kind {
+                    ty::AliasTermKind::ProjectionTy => ty::Projection { def_id },
+                    ty::AliasTermKind::InherentTy => ty::Inherent { def_id },
+                    ty::AliasTermKind::OpaqueTy
+                    | ty::AliasTermKind::FreeTy
+                    | ty::AliasTermKind::ProjectionConst
+                    | ty::AliasTermKind::InherentConst
+                    | ty::AliasTermKind::FreeConst
+                    | ty::AliasTermKind::UnevaluatedConst => {
+                        unreachable!()
+                    }
+                };
+                let alias_ty = ty::AliasTy::new_from_args(tcx, alias_ty_kind, args);
                 let ty = Ty::new_alias(tcx, alias_ty);
                 let ty = self.check_param_uses_if_mcg(ty, span, false);
                 Ok((ty, tcx.def_kind(def_id), def_id))
@@ -1440,12 +1462,24 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Const,
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                self.require_type_const_attribute(def_id, span)?;
-                let ct = Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, args));
-                let ct = self.check_param_uses_if_mcg(ct, span, false);
-                Ok(ct)
-            }
+            TypeRelativePath::AssocItem(kind, def_id, args) => match kind {
+                ty::AliasTermKind::ProjectionConst | ty::AliasTermKind::InherentConst => {
+                    self.require_type_const_attribute(def_id, span)?;
+                    let ct = Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, args));
+                    let ct = self.check_param_uses_if_mcg(ct, span, false);
+                    Ok(ct)
+                }
+                ty::AliasTermKind::ProjectionTy
+                | ty::AliasTermKind::InherentTy
+                | ty::AliasTermKind::OpaqueTy
+                | ty::AliasTermKind::FreeTy
+                | ty::AliasTermKind::UnevaluatedConst
+                | ty::AliasTermKind::FreeConst => span_bug!(
+                    span,
+                    "type-relative const path should only produce \
+                     ProjectionConst or InherentConst, got {kind:?}"
+                ),
+            },
             TypeRelativePath::Ctor { ctor_def_id, args } => match tcx.def_kind(ctor_def_id) {
                 DefKind::Ctor(_, CtorKind::Fn) => {
                     Ok(ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, ctor_def_id, args)))
@@ -1572,7 +1606,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
 
             // FIXME(inherent_associated_types, #106719): Support self types other than ADTs.
-            if let Some((did, args)) = self.probe_inherent_assoc_item(
+            if let Some((def_id, args)) = self.probe_inherent_assoc_item(
                 segment,
                 adt_def.did(),
                 self_ty,
@@ -1580,7 +1614,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 mode.assoc_tag(),
             )? {
-                return Ok(TypeRelativePath::AssocItem(did, args));
+                return Ok(TypeRelativePath::AssocItem(
+                    mode.inherent_alias_term_kind(),
+                    def_id,
+                    args,
+                ));
             }
         }
 
@@ -1614,7 +1652,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             );
         }
 
-        Ok(TypeRelativePath::AssocItem(item_def_id, args))
+        Ok(TypeRelativePath::AssocItem(mode.projection_alias_term_kind(), item_def_id, args))
     }
 
     /// Resolve a [type-relative](hir::QPath::TypeRelative) (and type-level) path.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -288,6 +288,20 @@ impl LowerTypeRelativePathMode {
             Self::Const => PermitVariants::No,
         }
     }
+
+    fn inherent_alias_term_kind<'tcx>(self, def_id: DefId) -> ty::AliasTermKind<'tcx> {
+        match self {
+            Self::Type(_) => ty::AliasTermKind::InherentTy { def_id },
+            Self::Const => ty::AliasTermKind::InherentConst { def_id },
+        }
+    }
+
+    fn projection_alias_term_kind<'tcx>(self, def_id: DefId) -> ty::AliasTermKind<'tcx> {
+        match self {
+            Self::Type(_) => ty::AliasTermKind::ProjectionTy { def_id },
+            Self::Const => ty::AliasTermKind::ProjectionConst { def_id },
+        }
+    }
 }
 
 /// Whether to permit a path to resolve to an enum variant.
@@ -299,7 +313,7 @@ pub enum PermitVariants {
 
 #[derive(Debug, Clone, Copy)]
 enum TypeRelativePath<'tcx> {
-    AssocItem(DefId, GenericArgsRef<'tcx>),
+    AssocItem(ty::AliasTermKind<'tcx>, GenericArgsRef<'tcx>),
     Variant { adt: Ty<'tcx>, variant_did: DefId },
     Ctor { ctor_def_id: DefId, args: GenericArgsRef<'tcx> },
 }
@@ -1476,12 +1490,21 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Type(permit_variants),
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                let alias_ty = ty::AliasTy::new_from_args(
-                    tcx,
-                    ty::AliasTyKind::new_from_def_id(tcx, def_id),
-                    args,
-                );
+            TypeRelativePath::AssocItem(kind, args) => {
+                let def_id = kind.def_id();
+                let alias_ty_kind = match kind {
+                    ty::AliasTermKind::ProjectionTy { def_id } => ty::Projection { def_id },
+                    ty::AliasTermKind::InherentTy { def_id } => ty::Inherent { def_id },
+                    ty::AliasTermKind::OpaqueTy { .. }
+                    | ty::AliasTermKind::FreeTy { .. }
+                    | ty::AliasTermKind::ProjectionConst { .. }
+                    | ty::AliasTermKind::InherentConst { .. }
+                    | ty::AliasTermKind::FreeConst { .. }
+                    | ty::AliasTermKind::UnevaluatedConst { .. } => {
+                        unreachable!()
+                    }
+                };
+                let alias_ty = ty::AliasTy::new_from_args(tcx, alias_ty_kind, args);
                 let ty = Ty::new_alias(tcx, alias_ty);
                 let ty = self.check_param_uses_if_mcg(ty, span, false);
                 Ok((ty, tcx.def_kind(def_id), def_id))
@@ -1516,12 +1539,25 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             span,
             LowerTypeRelativePathMode::Const,
         )? {
-            TypeRelativePath::AssocItem(def_id, args) => {
-                self.require_type_const_attribute(def_id, span)?;
-                let ct = Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, args));
-                let ct = self.check_param_uses_if_mcg(ct, span, false);
-                Ok(ct)
-            }
+            TypeRelativePath::AssocItem(kind, args) => match kind {
+                ty::AliasTermKind::ProjectionConst { def_id }
+                | ty::AliasTermKind::InherentConst { def_id } => {
+                    self.require_type_const_attribute(def_id, span)?;
+                    let ct = Const::new_unevaluated(tcx, ty::UnevaluatedConst::new(def_id, args));
+                    let ct = self.check_param_uses_if_mcg(ct, span, false);
+                    Ok(ct)
+                }
+                ty::AliasTermKind::ProjectionTy { .. }
+                | ty::AliasTermKind::InherentTy { .. }
+                | ty::AliasTermKind::OpaqueTy { .. }
+                | ty::AliasTermKind::FreeTy { .. }
+                | ty::AliasTermKind::UnevaluatedConst { .. }
+                | ty::AliasTermKind::FreeConst { .. } => span_bug!(
+                    span,
+                    "type-relative const path should only produce \
+                     ProjectionConst or InherentConst, got {kind:?}"
+                ),
+            },
             TypeRelativePath::Ctor { ctor_def_id, args } => match tcx.def_kind(ctor_def_id) {
                 DefKind::Ctor(_, CtorKind::Fn) => {
                     Ok(ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, ctor_def_id, args)))
@@ -1648,7 +1684,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
 
             // FIXME(inherent_associated_types, #106719): Support self types other than ADTs.
-            if let Some((did, args)) = self.probe_inherent_assoc_item(
+            if let Some((def_id, args)) = self.probe_inherent_assoc_item(
                 segment,
                 adt_def.did(),
                 self_ty,
@@ -1656,7 +1692,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 mode.assoc_tag(),
             )? {
-                return Ok(TypeRelativePath::AssocItem(did, args));
+                return Ok(TypeRelativePath::AssocItem(
+                    mode.inherent_alias_term_kind(def_id),
+                    args,
+                ));
             }
         }
 
@@ -1690,7 +1729,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             );
         }
 
-        Ok(TypeRelativePath::AssocItem(item_def_id, args))
+        Ok(TypeRelativePath::AssocItem(mode.projection_alias_term_kind(item_def_id), args))
     }
 
     /// Resolve a [type-relative](hir::QPath::TypeRelative) (and type-level) path.

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -187,21 +187,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.adt_def(adt_def_id)
     }
 
-    fn alias_ty_kind_from_def_id(self, def_id: DefId) -> ty::AliasTyKind<'tcx> {
-        match self.def_kind(def_id) {
-            DefKind::AssocTy
-                if let DefKind::Impl { of_trait: false } = self.def_kind(self.parent(def_id)) =>
-            {
-                ty::Inherent { def_id }
-            }
-            DefKind::AssocTy => ty::Projection { def_id },
-
-            DefKind::OpaqueTy => ty::Opaque { def_id },
-            DefKind::TyAlias => ty::Free { def_id },
-            kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),
-        }
-    }
-
     fn alias_term_kind(self, alias: ty::AliasTerm<'tcx>) -> ty::AliasTermKind {
         match self.def_kind(alias.def_id) {
             DefKind::AssocTy => {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -184,21 +184,6 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.adt_def(adt_def_id)
     }
 
-    fn alias_ty_kind_from_def_id(self, def_id: DefId) -> ty::AliasTyKind<'tcx> {
-        match self.def_kind(def_id) {
-            DefKind::AssocTy
-                if let DefKind::Impl { of_trait: false } = self.def_kind(self.parent(def_id)) =>
-            {
-                ty::Inherent { def_id }
-            }
-            DefKind::AssocTy => ty::Projection { def_id },
-
-            DefKind::OpaqueTy => ty::Opaque { def_id },
-            DefKind::TyAlias => ty::Free { def_id },
-            kind => bug!("unexpected DefKind in AliasTy: {kind:?}"),
-        }
-    }
-
     fn alias_term_kind_from_def_id(self, def_id: DefId) -> ty::AliasTermKind<'tcx> {
         match self.def_kind(def_id) {
             DefKind::AssocTy => {

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -212,8 +212,6 @@ pub trait Interner:
     type AdtDef: AdtDef<Self>;
     fn adt_def(self, adt_def_id: Self::AdtId) -> Self::AdtDef;
 
-    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> ty::AliasTyKind<Self>;
-
     fn alias_term_kind(self, alias: ty::AliasTerm<Self>) -> ty::AliasTermKind;
 
     fn trait_ref_and_own_args_for_alias(

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -209,8 +209,6 @@ pub trait Interner:
     type AdtDef: AdtDef<Self>;
     fn adt_def(self, adt_def_id: Self::AdtId) -> Self::AdtDef;
 
-    fn alias_ty_kind_from_def_id(self, def_id: Self::DefId) -> ty::AliasTyKind<Self>;
-
     // FIXME: remove in favor of explicit construction
     fn alias_term_kind_from_def_id(self, def_id: Self::DefId) -> ty::AliasTermKind<Self>;
 

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -63,10 +63,6 @@ pub enum AliasTyKind<I: Interner> {
 }
 
 impl<I: Interner> AliasTyKind<I> {
-    pub fn new_from_def_id(interner: I, def_id: I::DefId) -> Self {
-        interner.alias_ty_kind_from_def_id(def_id)
-    }
-
     pub fn descr(self) -> &'static str {
         match self {
             AliasTyKind::Projection { .. } => "associated type",

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -65,10 +65,6 @@ pub enum AliasTyKind<I: Interner> {
 }
 
 impl<I: Interner> AliasTyKind<I> {
-    pub fn new_from_def_id(interner: I, def_id: I::DefId) -> Self {
-        interner.alias_ty_kind_from_def_id(def_id)
-    }
-
     pub fn descr(self) -> &'static str {
         match self {
             AliasTyKind::Projection { .. } => "associated type",

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -19,9 +19,9 @@ use rustc_middle::traits::EvaluationResult;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, DerefAdjustKind};
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{
-    self, AdtDef, AliasTy, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
-    GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
-    TypeVisitableExt, TypeVisitor, UintTy, Upcast, VariantDef, VariantDiscr,
+    self, AdtDef, AliasTy, AssocContainer, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig,
+    GenericArg, GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt,
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, UintTy, Upcast, VariantDef, VariantDiscr,
 };
 use rustc_span::symbol::Ident;
 use rustc_span::{DUMMY_SP, Span, Symbol};
@@ -1023,11 +1023,13 @@ pub fn make_projection<'tcx>(
         #[cfg(debug_assertions)]
         assert_generic_args_match(tcx, assoc_item.def_id, args);
 
-        Some(AliasTy::new_from_args(
-            tcx,
-            ty::AliasTyKind::new_from_def_id(tcx, assoc_item.def_id),
-            args,
-        ))
+        let alias_kind = match assoc_item.container {
+            AssocContainer::Trait | AssocContainer::TraitImpl(_) => {
+                ty::Projection { def_id: assoc_item.def_id }
+            }
+            AssocContainer::InherentImpl => ty::Inherent { def_id: assoc_item.def_id },
+        };
+        Some(AliasTy::new_from_args(tcx, alias_kind, args))
     }
     helper(
         tcx,

--- a/src/tools/clippy/clippy_utils/src/ty/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ty/mod.rs
@@ -19,7 +19,7 @@ use rustc_middle::traits::EvaluationResult;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, DerefAdjustKind};
 use rustc_middle::ty::layout::ValidityRequirement;
 use rustc_middle::ty::{
-    self, AdtDef, AliasTy, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
+    self, AdtDef, AliasTy, AssocContainer, AssocItem, AssocTag, Binder, BoundRegion, BoundVarIndexKind, FnSig, GenericArg,
     GenericArgKind, GenericArgsRef, IntTy, Region, RegionKind, TraitRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
     TypeVisitableExt, TypeVisitor, UintTy, Upcast, VariantDef, VariantDiscr,
     Unnormalized,
@@ -1029,11 +1029,13 @@ pub fn make_projection<'tcx>(
         #[cfg(debug_assertions)]
         assert_generic_args_match(tcx, assoc_item.def_id, args);
 
-        Some(AliasTy::new_from_args(
-            tcx,
-            ty::AliasTyKind::new_from_def_id(tcx, assoc_item.def_id),
-            args,
-        ))
+        let alias_kind = match assoc_item.container {
+            AssocContainer::Trait | AssocContainer::TraitImpl(_) => {
+                ty::Projection { def_id: assoc_item.def_id }
+            }
+            AssocContainer::InherentImpl => ty::Inherent { def_id: assoc_item.def_id },
+        };
+        Some(AliasTy::new_from_args(tcx, alias_kind, args))
     }
     helper(
         tcx,


### PR DESCRIPTION

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @WaffleLapkin

related issue: https://github.com/rust-lang/rust/issues/154941

tackling the task:

- [ ] remove calls to` new_from_def_id` and `alias_ty_kind_from_def_id` and replace them with calls to e.g. `new_projection` directly


as a result of removing the above and a suggestion from [here](https://github.com/rust-lang/rust/pull/155323#discussion_r3089433481), `TypeRelativePath` changes

```diff                                 
enum TypeRelativePath<'tcx> {                      
-    AssocItem(DefId, GenericArgsRef<'tcx>),
+    AssocItem(ty::AliasTermKind<'tcx>, GenericArgsRef<'tcx>),                                                                                                                              
     //...                                                                                                                                         
}                                                                                                                                                                                          
``` 