### PR TITLE
Guarantee allocations do not wrap around the address space

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -123,13 +123,14 @@
 //! side-effects, and writes must become visible to other threads using the usual synchronization
 //! primitives.
 //!
-//! For any allocation with `base` address, `size`, and a set of `addresses`,
-//! the following are guaranteed (using infinite-precision arithmetic):
+//! For any allocation with `base` address, `size`, and a set of
+//! `addresses`, the following are guaranteed:
 //! - For all addresses `a` in `addresses`, `a` is in the range `base .. (base +
 //!   size)` (note that this requires `a < base + size`, not `a <= base + size`)
 //! - `base` is not equal to [`null()`] (i.e., the address with the numerical
 //!   value 0)
-//! - `base + size <= usize::MAX`
+//! - `base + size <= usize::MAX`; `base + size` will not wrap around the
+//!   address space (in other words, will not overflow)
 //! - `size <= isize::MAX`
 //!
 //! As a consequence of these guarantees, given any address `a` within the set
@@ -137,8 +138,7 @@
 //! - It is guaranteed that `a - base` does not overflow `isize`
 //! - It is guaranteed that `a - base` is non-negative
 //! - It is guaranteed that, given `o = a - base` (i.e., the offset of `a` within
-//!   the allocation), `base + o` will not wrap around the address space (in
-//!   other words, will not overflow `usize`)
+//!   the allocation), `base + o` will not wrap around the address space
 //!
 //! [`null()`]: null
 //!

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -123,8 +123,8 @@
 //! side-effects, and writes must become visible to other threads using the usual synchronization
 //! primitives.
 //!
-//! For any allocation with `base` address, `size`, and a set of
-//! `addresses`, the following are guaranteed:
+//! For any allocation with `base` address, `size`, and a set of `addresses`,
+//! the following are guaranteed (using infinite-precision arithmetic):
 //! - For all addresses `a` in `addresses`, `a` is in the range `base .. (base +
 //!   size)` (note that this requires `a < base + size`, not `a <= base + size`)
 //! - `base` is not equal to [`null()`] (i.e., the address with the numerical


### PR DESCRIPTION
This was [noted off-handedly](https://github.com/rust-lang/rust/pull/116675#discussion_r1382413059) in rust-lang/rust#116675 where this section was reworked. It seems worthwhile to note explicitly that an allocation's base and size are not "usize" or "isize" but infinitely-wide types where `<= usize::MAX` cannot be trivially assumed.

I got here trying to figure out if/why `with_exposed_provenance::<(u8, u8)>(usize::MAX)` returns an invalid `*const T`. either `base + size <= usize::MAX` is trivially true, _or_ there's an assumption of wider-than-usize arithmetic and the answer is "it's invalid". seems like the latter, thank goodness! this was discussed in a few places in rust-lang/rust#116675 ([this other comment](https://github.com/rust-lang/rust/pull/116675#pullrequestreview-1683247900) for example) but ended up left to a careful reader in the landed docs.