### PR TITLE
tests/debuginfo/basic-stepping.rs: Remove FIXME related to ZSTs

### DIFF
--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -142,8 +142,8 @@
 fn main () {
     let a = (); // #break
     let b : [i32; 0] = [];
-    // FIXME(#97083): Should we be able to break on initialization of zero-sized types?
-    // FIXME(#97083): Right now the first breakable line is:
+    // The above lines initialize zero-sized types. That does not emit machine
+    // code, so the first breakable line is:
     let mut c = 27;
     let d = c = 99;
     let e = "hi bob";


### PR DESCRIPTION
We don't consider it a bug that users can't break on initialization of some non-zero sized types (see https://github.com/rust-lang/rust/pull/153941 and linked discussions), so it does not make sense to consider it a bug that users can't break on initialization of some zero-sized types.

Closes rust-lang/rust#97083

r? compiler (see https://github.com/rust-lang/rust/pull/155352)
