### PR TITLE
Avoid query cycles in DataflowConstProp

### DIFF
--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -41,6 +41,11 @@ impl<'tcx> crate::MirPass<'tcx> for DataflowConstProp {
 
     #[instrument(skip_all level = "debug")]
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        // Avoid query cycles from coroutines.
+        if body.coroutine.is_some() {
+            return;
+        }
+
         debug!(def_id = ?body.source.def_id());
         if tcx.sess.mir_opt_level() < 4 && body.basic_blocks.len() > BLOCK_LIMIT {
             debug!("aborted dataflow const prop due too many basic blocks");

--- a/tests/ui/dataflow_const_prop/recursive-async.rs
+++ b/tests/ui/dataflow_const_prop/recursive-async.rs
@@ -1,0 +1,11 @@
+//! Ensure DataflowConstProp doesn't cause an error with async recursion as in #155376.
+
+//@ edition:2018
+//@ check-pass
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+DataflowConstProp --crate-type=lib
+
+pub async fn foo(n: usize) {
+    if n > 0 {
+        Box::pin(foo(n - 1)).await;
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#155376 by skipping coroutines.