### PR TITLE
stepping into where-clauses during normalization may be productive

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -280,18 +280,10 @@ where
                 // We currently only consider a cycle coinductive if it steps
                 // into a where-clause of a coinductive trait.
                 CurrentGoalKind::CoinductiveTrait => PathKind::Coinductive,
-                // While normalizing via an impl does step into a where-clause of
-                // an impl, accessing the associated item immediately steps out of
-                // it again. This means cycles/recursive calls are not guarded
-                // by impls used for normalization.
-                //
-                // See tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.rs
-                // for how this can go wrong.
-                CurrentGoalKind::NormalizesTo => PathKind::Inductive,
                 // We probably want to make all traits coinductive in the future,
                 // so we treat cycles involving where-clauses of not-yet coinductive
                 // traits as ambiguous for now.
-                CurrentGoalKind::Misc => PathKind::Unknown,
+                CurrentGoalKind::Misc | CurrentGoalKind::NormalizesTo => PathKind::Unknown,
             },
             // Relating types is always unproductive. If we were to map proof trees to
             // corecursive functions as explained in #136824, relating types never

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -338,18 +338,12 @@ where
                 // We currently only consider a cycle coinductive if it steps
                 // into a where-clause of a coinductive trait.
                 CurrentGoalKind::CoinductiveTrait => PathKind::Coinductive,
-                // While normalizing via an impl does step into a where-clause of
-                // an impl, accessing the associated item immediately steps out of
-                // it again. This means cycles/recursive calls are not guarded
-                // by impls used for normalization.
-                //
-                // See tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.rs
-                // for how this can go wrong.
-                CurrentGoalKind::ProjectionComputeAssocTermCandidate => PathKind::Inductive,
                 // We probably want to make all traits coinductive in the future,
                 // so we treat cycles involving where-clauses of not-yet coinductive
                 // traits as ambiguous for now.
-                CurrentGoalKind::Misc => PathKind::Unknown,
+                CurrentGoalKind::Misc | CurrentGoalKind::ProjectionComputeAssocTermCandidate => {
+                    PathKind::Unknown
+                }
             },
             // Relating types is always unproductive. If we were to map proof trees to
             // corecursive functions as explained in #136824, relating types never

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
@@ -10,9 +10,9 @@ trait Foo {
 trait Baz {}
 
 impl<'a, T> Foo for &'a T //~ ERROR not all trait items implemented, missing: `Item`
-//~| ERROR the trait bound `&'a T: Foo` is not satisfied
+//~| ERROR type annotations needed: cannot satisfy `&'a T: Foo`
 where
-    Self::Item: 'a, //~ ERROR the trait bound `&'a T: Foo` is not satisfied
+    Self::Item: 'a,
 {
 }
 

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.rs
@@ -3,7 +3,7 @@
 
 #![feature(min_specialization)]
 
-trait Foo {
+trait Foo { //~ ERROR cycle detected when coherence checking all impls of trait `Foo`
     type Item;
 }
 
@@ -16,7 +16,6 @@ where
 }
 
 impl<'a, T> Foo for &T
-//~^ ERROR: cycle detected when computing normalized predicates of `<impl at $DIR/next-solver-region-resolution.rs:18:1: 21:21>`
 where
     Self::Item: Baz,
 {

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
@@ -10,14 +10,13 @@ LL | | where
 LL | |     Self::Item: 'a,
    | |___________________^ missing `Item` in implementation
 
-error[E0277]: the trait bound `&'a T: Foo` is not satisfied
+error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
   --> $DIR/next-solver-region-resolution.rs:12:21
    |
 LL | impl<'a, T> Foo for &'a T
-   |                     ^^^^^ the trait `Foo` is not implemented for `&'a T`
+   |                     ^^^^^
    |
-help: the trait `Foo` is not implemented for `&'a _`
-      but it is implemented for `&_`
+note: multiple `impl`s satisfying `&'a T: Foo` found
   --> $DIR/next-solver-region-resolution.rs:12:1
    |
 LL | / impl<'a, T> Foo for &'a T
@@ -25,22 +24,12 @@ LL | |
 LL | | where
 LL | |     Self::Item: 'a,
    | |___________________^
-
-error[E0277]: the trait bound `&'a T: Foo` is not satisfied
-  --> $DIR/next-solver-region-resolution.rs:15:17
-   |
-LL |     Self::Item: 'a,
-   |                 ^^ the trait `Foo` is not implemented for `&'a T`
-   |
-help: the trait `Foo` is not implemented for `&'a _`
-      but it is implemented for `&_`
-  --> $DIR/next-solver-region-resolution.rs:12:1
-   |
-LL | / impl<'a, T> Foo for &'a T
+...
+LL | / impl<'a, T> Foo for &T
 LL | |
 LL | | where
-LL | |     Self::Item: 'a,
-   | |___________________^
+LL | |     Self::Item: Baz,
+   | |____________________^
 
 error[E0046]: not all trait items implemented, missing: `Item`
   --> $DIR/next-solver-region-resolution.rs:19:1
@@ -63,7 +52,7 @@ LL | | where
 LL | |     Self::Item: Baz,
    | |____________________^
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0046, E0277.
+Some errors have detailed explanations: E0046, E0283.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
+++ b/tests/ui/specialization/min_specialization/next-solver-region-resolution.stderr
@@ -1,14 +1,26 @@
-error[E0391]: cycle detected when computing normalized predicates of `<impl at $DIR/next-solver-region-resolution.rs:18:1: 21:21>`
+error[E0391]: cycle detected when coherence checking all impls of trait `Foo`
+  --> $DIR/next-solver-region-resolution.rs:6:1
+   |
+LL | trait Foo {
+   | ^^^^^^^^^
+   |
+   = note: ...which requires building specialization graph of trait `Foo`...
+note: ...which requires computing whether impls specialize one another...
+  --> $DIR/next-solver-region-resolution.rs:12:1
+   |
+LL | / impl<'a, T> Foo for &'a T
+LL | | where
+LL | |     Self::Item: 'a,
+   | |___________________^
+note: ...which requires computing normalized predicates of `<impl at $DIR/next-solver-region-resolution.rs:18:1: 20:21>`...
   --> $DIR/next-solver-region-resolution.rs:18:1
    |
 LL | / impl<'a, T> Foo for &T
-LL | |
 LL | | where
 LL | |     Self::Item: Baz,
    | |____________________^
-   |
-   = note: ...which immediately requires computing normalized predicates of `<impl at $DIR/next-solver-region-resolution.rs:18:1: 21:21>` again
-note: cycle used when computing whether impls specialize one another
+   = note: ...which again requires coherence checking all impls of trait `Foo`, completing the cycle
+note: cycle used when checking that `<impl at $DIR/next-solver-region-resolution.rs:12:1: 14:20>` is well-formed
   --> $DIR/next-solver-region-resolution.rs:12:1
    |
 LL | / impl<'a, T> Foo for &'a T

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.next.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.next.stderr
@@ -1,0 +1,11 @@
+error[E0283]: type annotations needed: cannot satisfy `<Vec<T> as IntoIterator>::IntoIter: Iterator`
+  --> $DIR/normalizes-to-is-not-productive-2.rs:21:41
+   |
+LL |     <Vec<T> as IntoIterator>::IntoIter: Iterator,
+   |                                         ^^^^^^^^
+   |
+   = note: cannot satisfy `<Vec<T> as IntoIterator>::IntoIter: Iterator`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.rs
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.rs
@@ -1,9 +1,9 @@
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
-//@ check-pass
+//@[current] check-pass
 
-// Regression test for trait-system-refactor-initiative#176.
+// Test from trait-system-refactor-initiative#176.
 //
 // Normalizing `<Vec<T> as IntoIterator>::IntoIter` has two candidates
 // inside of the function:
@@ -13,11 +13,13 @@
 //     - where-clause requires `<Vec<T> as IntoIterator>::IntoIter eq Vec<T>`
 //       - normalize `<Vec<T> as IntoIterator>::IntoIter` again, cycle
 //
-// We need to treat this cycle as an error to be able to use the actual impl.
+// The blanket impl is unfortunately also a productive cycle, so we have to
+// break this code, see trait-system-refactor-initiative#273
 
 fn test<T>()
 where
     <Vec<T> as IntoIterator>::IntoIter: Iterator,
+    //[next]~^ ERROR type annotations needed: cannot satisfy `<Vec<T> as IntoIterator>::IntoIter: Iterator`
 {
 }
 

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.rs
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.rs
@@ -3,7 +3,7 @@
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 
-// Regression test for trait-system-refactor-initiative#176.
+// Test from trait-system-refactor-initiative#176.
 //
 // Normalizing `<Vec<T> as IntoIterator>::IntoIter` has two candidates
 // inside of the function:
@@ -13,7 +13,11 @@
 //     - where-clause requires `<Vec<T> as IntoIterator>::IntoIter eq Vec<T>`
 //       - normalize `<Vec<T> as IntoIterator>::IntoIter` again, cycle
 //
-// We need to treat this cycle as an error to be able to use the actual impl.
+// The blanket impl is unfortunately also a productive cycle, so we have to
+// break this code, see trait-system-refactor-initiative#273.
+//
+// As we currently incorrectly treat aliases in the environment as rigid, this compiles
+// even with the new solver, see #158643.
 
 fn test<T>()
 where

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.rs
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.rs
@@ -1,9 +1,10 @@
 //@ ignore-compare-mode-next-solver (explicit)
 //@ compile-flags: -Znext-solver
 
-// Make sure that stepping into impl where-clauses of `NormalizesTo`
-// goals is unproductive. This must not compile, see the inline
-// comments.
+// A test for the cycle handling when stepping into where-clauses of `NormalizesTo`.
+// Whether stepping into where-clauses is productive depends on how they are used.
+//
+// In this concrete test, the cycle must not be productive.
 
 trait Bound {
     fn method();
@@ -30,7 +31,7 @@ fn impls_bound<T: Bound>() {
 
 // The where-clause requires `Foo: Trait<T>` to hold to be wf.
 // If stepping into where-clauses during normalization is considered
-// to be productive, this would be the case:
+// to be productive here, this would be the case:
 //
 // - `Foo: Trait<T>`
 //   - via blanket impls, requires `Foo: Bound`
@@ -40,12 +41,13 @@ fn impls_bound<T: Bound>() {
 fn generic<T>()
 where
     <Foo as Trait<T>>::Assoc: Bound,
-    //~^ ERROR the trait bound `Foo: Bound` is not satisfied
+    //~^ ERROR overflow evaluating the requirement `<Foo as Trait<T>>::Assoc: Bound`
+    //~| ERROR overflow evaluating whether `<Foo as Trait<T>>::Assoc` is well-formed
 {
     // Requires proving `Foo: Bound` by normalizing
     // `<Foo as Trait<T>>::Assoc` to `Foo`.
     impls_bound::<Foo>();
-    //~^ ERROR the trait bound `Foo: Bound` is not satisfied
+    //~^ ERROR  overflow evaluating the requirement `Foo: Bound`
 }
 fn main() {
     // Requires proving `<Foo as Trait<u32>>::Assoc: Bound`.

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.rs
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.rs
@@ -1,9 +1,10 @@
 //@ ignore-compare-mode-next-solver (explicit)
 //@ compile-flags: -Znext-solver
 
-// Make sure that stepping into impl where-clauses of `NormalizesTo`
-// goals is unproductive. This must not compile, see the inline
-// comments.
+// A test for the cycle handling when stepping into where-clauses of `NormalizesTo`.
+// Whether stepping into where-clauses is productive depends on how they are used.
+//
+// In this concrete test, the cycle must not be productive.
 
 trait Bound {
     fn method();
@@ -30,7 +31,7 @@ fn impls_bound<T: Bound>() {
 
 // The where-clause requires `Foo: Trait<T>` to hold to be wf.
 // If stepping into where-clauses during normalization is considered
-// to be productive, this would be the case:
+// to be productive here, this would be the case:
 //
 // - `Foo: Trait<T>`
 //   - via blanket impls, requires `Foo: Bound`
@@ -41,12 +42,13 @@ fn generic<T>()
 //~^ ERROR the trait bound `Foo: Bound` is not satisfied
 where
     <Foo as Trait<T>>::Assoc: Bound,
-    //~^ ERROR the trait bound `Foo: Bound` is not satisfied
+    //~^ ERROR overflow evaluating the requirement `<Foo as Trait<T>>::Assoc: Bound`
+    //~| ERROR overflow evaluating whether `<Foo as Trait<T>>::Assoc` is well-formed
 {
     // Requires proving `Foo: Bound` by normalizing
     // `<Foo as Trait<T>>::Assoc` to `Foo`.
     impls_bound::<Foo>();
-    //~^ ERROR the trait bound `Foo: Bound` is not satisfied
+    //~^ ERROR  overflow evaluating the requirement `Foo: Bound`
 }
 fn main() {
     // Requires proving `<Foo as Trait<u32>>::Assoc: Bound`.

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
@@ -1,56 +1,27 @@
-error[E0277]: the trait bound `Foo: Bound` is not satisfied
-  --> $DIR/normalizes-to-is-not-productive.rs:42:31
+error[E0275]: overflow evaluating the requirement `<Foo as Trait<T>>::Assoc: Bound`
+  --> $DIR/normalizes-to-is-not-productive.rs:43:31
    |
 LL |     <Foo as Trait<T>>::Assoc: Bound,
-   |                               ^^^^^ unsatisfied trait bound
-   |
-help: the trait `Bound` is not implemented for `Foo`
-  --> $DIR/normalizes-to-is-not-productive.rs:18:1
-   |
-LL | struct Foo;
-   | ^^^^^^^^^^
-help: the trait `Bound` is implemented for `u32`
-  --> $DIR/normalizes-to-is-not-productive.rs:11:1
-   |
-LL | impl Bound for u32 {
-   | ^^^^^^^^^^^^^^^^^^
-note: required for `Foo` to implement `Trait<T>`
-  --> $DIR/normalizes-to-is-not-productive.rs:23:19
-   |
-LL | impl<T: Bound, U> Trait<U> for T {
-   |         -----     ^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-note: required by a bound in `Bound`
-  --> $DIR/normalizes-to-is-not-productive.rs:8:1
-   |
-LL | / trait Bound {
-LL | |     fn method();
-LL | | }
-   | |_^ required by this bound in `Bound`
+   |                               ^^^^^
 
-error[E0277]: the trait bound `Foo: Bound` is not satisfied
-  --> $DIR/normalizes-to-is-not-productive.rs:47:19
+error[E0275]: overflow evaluating whether `<Foo as Trait<T>>::Assoc` is well-formed
+  --> $DIR/normalizes-to-is-not-productive.rs:43:31
+   |
+LL |     <Foo as Trait<T>>::Assoc: Bound,
+   |                               ^^^^^
+
+error[E0275]: overflow evaluating the requirement `Foo: Bound`
+  --> $DIR/normalizes-to-is-not-productive.rs:49:19
    |
 LL |     impls_bound::<Foo>();
-   |                   ^^^ unsatisfied trait bound
+   |                   ^^^
    |
-help: the trait `Bound` is not implemented for `Foo`
-  --> $DIR/normalizes-to-is-not-productive.rs:18:1
-   |
-LL | struct Foo;
-   | ^^^^^^^^^^
-help: the trait `Bound` is implemented for `u32`
-  --> $DIR/normalizes-to-is-not-productive.rs:11:1
-   |
-LL | impl Bound for u32 {
-   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `impls_bound`
-  --> $DIR/normalizes-to-is-not-productive.rs:27:19
+  --> $DIR/normalizes-to-is-not-productive.rs:28:19
    |
 LL | fn impls_bound<T: Bound>() {
    |                   ^^^^^ required by this bound in `impls_bound`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0275`.

--- a/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
+++ b/tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Foo: Bound` is not satisfied
-  --> $DIR/normalizes-to-is-not-productive.rs:40:1
+  --> $DIR/normalizes-to-is-not-productive.rs:41:1
    |
 LL | / fn generic<T>()
 LL | |
@@ -8,76 +8,48 @@ LL | |     <Foo as Trait<T>>::Assoc: Bound,
    | |____________________________________^ unsatisfied trait bound
    |
 help: the trait `Bound` is not implemented for `Foo`
-  --> $DIR/normalizes-to-is-not-productive.rs:18:1
+  --> $DIR/normalizes-to-is-not-productive.rs:19:1
    |
 LL | struct Foo;
    | ^^^^^^^^^^
 help: the trait `Bound` is implemented for `u32`
-  --> $DIR/normalizes-to-is-not-productive.rs:11:1
+  --> $DIR/normalizes-to-is-not-productive.rs:12:1
    |
 LL | impl Bound for u32 {
    | ^^^^^^^^^^^^^^^^^^
 note: required for `Foo` to implement `Trait<T>`
-  --> $DIR/normalizes-to-is-not-productive.rs:23:19
+  --> $DIR/normalizes-to-is-not-productive.rs:24:19
    |
 LL | impl<T: Bound, U> Trait<U> for T {
    |         -----     ^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
 
-error[E0277]: the trait bound `Foo: Bound` is not satisfied
-  --> $DIR/normalizes-to-is-not-productive.rs:43:31
+error[E0275]: overflow evaluating the requirement `<Foo as Trait<T>>::Assoc: Bound`
+  --> $DIR/normalizes-to-is-not-productive.rs:44:31
    |
 LL |     <Foo as Trait<T>>::Assoc: Bound,
-   |                               ^^^^^ unsatisfied trait bound
-   |
-help: the trait `Bound` is not implemented for `Foo`
-  --> $DIR/normalizes-to-is-not-productive.rs:18:1
-   |
-LL | struct Foo;
-   | ^^^^^^^^^^
-help: the trait `Bound` is implemented for `u32`
-  --> $DIR/normalizes-to-is-not-productive.rs:11:1
-   |
-LL | impl Bound for u32 {
-   | ^^^^^^^^^^^^^^^^^^
-note: required for `Foo` to implement `Trait<T>`
-  --> $DIR/normalizes-to-is-not-productive.rs:23:19
-   |
-LL | impl<T: Bound, U> Trait<U> for T {
-   |         -----     ^^^^^^^^     ^
-   |         |
-   |         unsatisfied trait bound introduced here
-note: required by a bound in `Bound`
-  --> $DIR/normalizes-to-is-not-productive.rs:8:1
-   |
-LL | / trait Bound {
-LL | |     fn method();
-LL | | }
-   | |_^ required by this bound in `Bound`
+   |                               ^^^^^
 
-error[E0277]: the trait bound `Foo: Bound` is not satisfied
-  --> $DIR/normalizes-to-is-not-productive.rs:48:19
+error[E0275]: overflow evaluating whether `<Foo as Trait<T>>::Assoc` is well-formed
+  --> $DIR/normalizes-to-is-not-productive.rs:44:31
+   |
+LL |     <Foo as Trait<T>>::Assoc: Bound,
+   |                               ^^^^^
+
+error[E0275]: overflow evaluating the requirement `Foo: Bound`
+  --> $DIR/normalizes-to-is-not-productive.rs:50:19
    |
 LL |     impls_bound::<Foo>();
-   |                   ^^^ unsatisfied trait bound
+   |                   ^^^
    |
-help: the trait `Bound` is not implemented for `Foo`
-  --> $DIR/normalizes-to-is-not-productive.rs:18:1
-   |
-LL | struct Foo;
-   | ^^^^^^^^^^
-help: the trait `Bound` is implemented for `u32`
-  --> $DIR/normalizes-to-is-not-productive.rs:11:1
-   |
-LL | impl Bound for u32 {
-   | ^^^^^^^^^^^^^^^^^^
 note: required by a bound in `impls_bound`
-  --> $DIR/normalizes-to-is-not-productive.rs:27:19
+  --> $DIR/normalizes-to-is-not-productive.rs:28:19
    |
 LL | fn impls_bound<T: Bound>() {
    |                   ^^^^^ required by this bound in `impls_bound`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0275, E0277.
+For more information about an error, try `rustc --explain E0275`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155388)*
<!-- homu-ignore:end -->

fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/273, see that issue for more info.

Whether stepping into a where-clause is productive depends not on whether we're proving a `NormalizesTo` or `Trait` goal, but instead on how both the impl and the cycle rely on it.

In the example in tests/ui/traits/next-solver/cycles/normalizes-to-is-not-productive-2.rs this is just a productive use given the way @Nadrieril and I are thinking about it right now.

We're changing such cycles to be ambiguous for now, so this does not commit us to anything.

This previously caused a lot of breakage when normalizing where-clauses, e.g. https://github.com/rust-lang/trait-system-refactor-initiative/issues/176, however with rust-lang/rust#158643 that is no longer an issue. We will need to figure out what to do here if we want to properly fix `ParamEnv` normalization in the future

r? @BoxyUwU or @nikomatsakis  