### PR TITLE
Small refactor of `QueryJob::latch` method

### DIFF
--- a/compiler/rustc_middle/src/query/job.rs
+++ b/compiler/rustc_middle/src/query/job.rs
@@ -36,10 +36,7 @@ impl<'tcx> QueryJob<'tcx> {
     }
 
     pub fn latch(&mut self) -> QueryLatch<'tcx> {
-        if self.latch.is_none() {
-            self.latch = Some(QueryLatch::new());
-        }
-        self.latch.as_ref().unwrap().clone()
+        self.latch.get_or_insert_with(QueryLatch::new).clone()
     }
 
     /// Signals to waiters that the query is complete.


### PR DESCRIPTION
We can use `Option::get_or_insert_with` to avoid unwrapping there.