### PR TITLE
Document panic behavior of `RangeInclusive`'s `From` impl

### DIFF
--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -399,6 +399,9 @@ impl<T> const From<RangeInclusive<T>> for legacy::RangeInclusive<T> {
         Self::new(value.start, value.last)
     }
 }
+/// It is unspecified what will happen if this `From` conversion is done
+/// on a `legacy::RangeInclusive` iterator that has already been exhausted.
+/// Currently, doing so will cause a panic, but this may change in the future.
 #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
 #[rustc_const_unstable(feature = "const_convert", issue = "143773")]
 impl<T> const From<legacy::RangeInclusive<T>> for RangeInclusive<T> {


### PR DESCRIPTION
As per discussion [on zulip](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/RangeInclusive.27s.20From.20impl.20can.20panic/with/585804611), this was intentional.

r? libs-api