### PR TITLE
`as_ref_unchecked` docs link fix

### DIFF
--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -594,7 +594,7 @@ impl<T: PointeeSized> *mut T {
     ///
     /// [`as_mut`]: #method.as_mut
     /// [`as_uninit_mut`]: #method.as_uninit_mut
-    /// [`as_ref_unchecked`]: #method.as_mut_unchecked
+    /// [`as_ref_unchecked`]: #method.as_ref_unchecked
     ///
     /// # Safety
     ///


### PR DESCRIPTION
Fix what's probably a copy-paste-o in a docs link.