### PR TITLE
Add symmetric PartialEq implementations for Vec, slices, and arrays with VecDeque

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -3595,6 +3595,97 @@ __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, [U; N], }
 __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, &[U; N], }
 __impl_slice_eq1! { [const N: usize] VecDeque<T, A>, &mut [U; N], }
 
+// Reverse PartialEq impls: Vec, slices, and arrays compared with VecDeque
+#[stable(feature = "vec_deque_partial_eq_slice", since = "1.17.0")]
+impl<T, U, A1: Allocator, A2: Allocator> PartialEq<VecDeque<U, A2>> for Vec<T, A1>
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &VecDeque<U, A2>) -> bool {
+        other.eq(self)
+    }
+    #[inline]
+    fn ne(&self, other: &VecDeque<U, A2>) -> bool {
+        other.ne(self)
+    }
+}
+
+#[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")]
+impl<T, U, A: Allocator> PartialEq<VecDeque<U, A>> for &[T]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &VecDeque<U, A>) -> bool {
+        other.eq(self)
+    }
+    #[inline]
+    fn ne(&self, other: &VecDeque<U, A>) -> bool {
+        other.ne(self)
+    }
+}
+
+#[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")]
+impl<T, U, A: Allocator> PartialEq<VecDeque<U, A>> for &mut [T]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &VecDeque<U, A>) -> bool {
+        other.eq(self)
+    }
+    #[inline]
+    fn ne(&self, other: &VecDeque<U, A>) -> bool {
+        other.ne(self)
+    }
+}
+
+#[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")]
+impl<T, U, A: Allocator, const N: usize> PartialEq<VecDeque<U, A>> for [T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &VecDeque<U, A>) -> bool {
+        other.eq(self)
+    }
+    #[inline]
+    fn ne(&self, other: &VecDeque<U, A>) -> bool {
+        other.ne(self)
+    }
+}
+
+#[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")]
+impl<T, U, A: Allocator, const N: usize> PartialEq<VecDeque<U, A>> for &[T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &VecDeque<U, A>) -> bool {
+        other.eq(self)
+    }
+    #[inline]
+    fn ne(&self, other: &VecDeque<U, A>) -> bool {
+        other.ne(self)
+    }
+}
+
+#[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")]
+impl<T, U, A: Allocator, const N: usize> PartialEq<VecDeque<U, A>> for &mut [T; N]
+where
+    T: PartialEq<U>,
+{
+    #[inline]
+    fn eq(&self, other: &VecDeque<U, A>) -> bool {
+        other.eq(self)
+    }
+    #[inline]
+    fn ne(&self, other: &VecDeque<U, A>) -> bool {
+        other.ne(self)
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: PartialOrd, A: Allocator> PartialOrd for VecDeque<T, A> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/library/alloc/src/collections/vec_deque/tests.rs
+++ b/library/alloc/src/collections/vec_deque/tests.rs
@@ -1431,3 +1431,51 @@ fn extract_if_pred_panic_leak() {
     assert_eq!(DROPS.get(), 2); // 0 and 1
     assert_eq!(q.len(), 6);
 }
+
+// Test symmetric PartialEq implementations between Vec/Slices/Arrays and VecDeque
+#[test]
+fn test_partialeq_symmetric() {
+    // Vec == VecDeque
+    let mut dq = VecDeque::new();
+    dq.push_back(1);
+    dq.push_back(2);
+    dq.push_back(3);
+    let vec = vec![1, 2, 3];
+    assert_eq!(vec, dq);
+    assert_eq!(dq, vec);
+
+    // &[T] == VecDeque
+    let slice: &[i32] = &[1, 2, 3];
+    assert_eq!(slice, dq);
+    assert_eq!(dq, slice);
+
+    // &mut [T] == VecDeque
+    let mut arr = [1, 2, 3];
+    {
+        let slice_mut: &mut [i32] = &mut arr;
+        assert_eq!(slice_mut, dq);
+        assert_eq!(dq, slice_mut);
+    }
+
+    // [T; N] == VecDeque
+    let array: [i32; 3] = [1, 2, 3];
+    assert_eq!(array, dq);
+    assert_eq!(dq, array);
+
+    // &[T; N] == VecDeque
+    let array_ref: &[i32; 3] = &[1, 2, 3];
+    assert_eq!(array_ref, dq);
+    assert_eq!(dq, array_ref);
+
+    // &mut [T; N] == VecDeque
+    {
+        let array_mut: &mut [i32; 3] = &mut arr;
+        assert_eq!(array_mut, dq);
+        assert_eq!(dq, array_mut);
+    }
+
+    // Test inequality
+    let different_vec = vec![1, 2, 4];
+    assert_ne!(different_vec, dq);
+    assert_ne!(dq, different_vec);
+}


### PR DESCRIPTION
## Summary

This PR adds the missing symmetric `PartialEq` implementations that were requested in issue rust-lang/rust#152830.

Previously, only the 'forward' direction (`VecDeque == Vec`, `VecDeque == &[T]`, etc.) was implemented. This meant expressions like `vec == vec_deque` or `slice == vec_deque` would fail to compile.

## Added Implementations

This PR implements `PartialEq<VecDeque<U>>` for the following types:

| Left-hand type | Status |
|---|---|
| `Vec<T, A1>` (vs `VecDeque<U, A2>`) | ✅ New |
| `&[T]` (vs `VecDeque<U>`) | ✅ New |
| `&mut [T]` (vs `VecDeque<U>`) | ✅ New |
| `[T; N]` (vs `VecDeque<U>`) | ✅ New |
| `&[T; N]` (vs `VecDeque<U>`) | ✅ New |
| `&mut [T; N]` (vs `VecDeque<U>`) | ✅ New |

The implementations delegate to the existing `VecDeque::eq()` and `VecDeque::ne()` methods, ensuring consistent behavior with the existing forward implementations.

## Test

A test `test_partialeq_symmetric` is added in `library/alloc/src/collections/vec_deque/tests.rs` that verifies:
- `vec == vec_deque` and `vec_deque == vec`
- `slice == vec_deque` and `vec_deque == slice`
- `array == vec_deque` and `vec_deque == array`
- `array_ref == vec_deque` and `vec_deque == array_ref`
- Inequality comparisons

## Issue Reference

Fixes rust-lang/rust#152830

---
Co-Authored-By: RoomWithOutRoof <RoomWithOutRoof@users.noreply.github.com>