### PR TITLE
std: Update dependency on `wasi` crate

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -344,8 +344,8 @@ dependencies = [
  "std_detect",
  "unwind",
  "vex-sdk",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasip1",
+ "wasip2",
  "windows-link 0.0.0",
 ]
 
@@ -407,20 +407,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "wasip1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "b5e26842486624357dbeb8f0381cf1fb42f022291fd787d4a816768fec8cc760"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
 
 [[package]]
-name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -513,9 +513,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -79,19 +79,19 @@ hermit-abi = { version = "0.5.0", features = [
 ], public = true }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p1"))'.dependencies]
-wasi = { version = "0.11.0", features = [
+wasip1 = { version = "1.0.0", features = [
     'rustc-dep-of-std',
 ], default-features = false }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p2"))'.dependencies]
-wasip2 = { version = '0.14.4', features = [
+wasip2 = { version = '1.0.2', features = [
     'rustc-dep-of-std',
-], default-features = false, package = 'wasi' }
+], default-features = false }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p3"))'.dependencies]
-wasip2 = { version = '0.14.4', features = [
+wasip2 = { version = '1.0.2', features = [
     'rustc-dep-of-std',
-], default-features = false, package = 'wasi' }
+], default-features = false }
 
 [target.'cfg(target_os = "uefi")'.dependencies]
 r-efi = { version = "5.2.0", features = ['rustc-dep-of-std'] }

--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -246,13 +246,15 @@ impl FileExt for File {
 
     #[cfg(target_env = "p1")]
     fn fdstat_set_flags(&self, flags: u16) -> io::Result<()> {
-        unsafe { wasi::fd_fdstat_set_flags(self.as_raw_fd() as wasi::Fd, flags).map_err(err2io) }
+        unsafe {
+            wasip1::fd_fdstat_set_flags(self.as_raw_fd() as wasip1::Fd, flags).map_err(err2io)
+        }
     }
 
     #[cfg(target_env = "p1")]
     fn fdstat_set_rights(&self, rights: u64, inheriting: u64) -> io::Result<()> {
         unsafe {
-            wasi::fd_fdstat_set_rights(self.as_raw_fd() as wasi::Fd, rights, inheriting)
+            wasip1::fd_fdstat_set_rights(self.as_raw_fd() as wasip1::Fd, rights, inheriting)
                 .map_err(err2io)
         }
     }
@@ -260,12 +262,12 @@ impl FileExt for File {
     #[cfg(target_env = "p1")]
     fn advise(&self, offset: u64, len: u64, advice: u8) -> io::Result<()> {
         let advice = match advice {
-            a if a == wasi::ADVICE_NORMAL.raw() => wasi::ADVICE_NORMAL,
-            a if a == wasi::ADVICE_SEQUENTIAL.raw() => wasi::ADVICE_SEQUENTIAL,
-            a if a == wasi::ADVICE_RANDOM.raw() => wasi::ADVICE_RANDOM,
-            a if a == wasi::ADVICE_WILLNEED.raw() => wasi::ADVICE_WILLNEED,
-            a if a == wasi::ADVICE_DONTNEED.raw() => wasi::ADVICE_DONTNEED,
-            a if a == wasi::ADVICE_NOREUSE.raw() => wasi::ADVICE_NOREUSE,
+            a if a == wasip1::ADVICE_NORMAL.raw() => wasip1::ADVICE_NORMAL,
+            a if a == wasip1::ADVICE_SEQUENTIAL.raw() => wasip1::ADVICE_SEQUENTIAL,
+            a if a == wasip1::ADVICE_RANDOM.raw() => wasip1::ADVICE_RANDOM,
+            a if a == wasip1::ADVICE_WILLNEED.raw() => wasip1::ADVICE_WILLNEED,
+            a if a == wasip1::ADVICE_DONTNEED.raw() => wasip1::ADVICE_DONTNEED,
+            a if a == wasip1::ADVICE_NOREUSE.raw() => wasip1::ADVICE_NOREUSE,
             _ => {
                 return Err(io::const_error!(
                     io::ErrorKind::InvalidInput,
@@ -275,31 +277,35 @@ impl FileExt for File {
         };
 
         unsafe {
-            wasi::fd_advise(self.as_raw_fd() as wasi::Fd, offset, len, advice).map_err(err2io)
+            wasip1::fd_advise(self.as_raw_fd() as wasip1::Fd, offset, len, advice).map_err(err2io)
         }
     }
 
     #[cfg(target_env = "p1")]
     fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
-        unsafe { wasi::fd_allocate(self.as_raw_fd() as wasi::Fd, offset, len).map_err(err2io) }
+        unsafe { wasip1::fd_allocate(self.as_raw_fd() as wasip1::Fd, offset, len).map_err(err2io) }
     }
 
     #[cfg(target_env = "p1")]
     fn create_directory<P: AsRef<Path>>(&self, dir: P) -> io::Result<()> {
         let path = osstr2str(dir.as_ref().as_ref())?;
-        unsafe { wasi::path_create_directory(self.as_raw_fd() as wasi::Fd, path).map_err(err2io) }
+        unsafe {
+            wasip1::path_create_directory(self.as_raw_fd() as wasip1::Fd, path).map_err(err2io)
+        }
     }
 
     #[cfg(target_env = "p1")]
     fn remove_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let path = osstr2str(path.as_ref().as_ref())?;
-        unsafe { wasi::path_unlink_file(self.as_raw_fd() as wasi::Fd, path).map_err(err2io) }
+        unsafe { wasip1::path_unlink_file(self.as_raw_fd() as wasip1::Fd, path).map_err(err2io) }
     }
 
     #[cfg(target_env = "p1")]
     fn remove_directory<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
         let path = osstr2str(path.as_ref().as_ref())?;
-        unsafe { wasi::path_remove_directory(self.as_raw_fd() as wasi::Fd, path).map_err(err2io) }
+        unsafe {
+            wasip1::path_remove_directory(self.as_raw_fd() as wasip1::Fd, path).map_err(err2io)
+        }
     }
 }
 
@@ -388,11 +394,11 @@ pub fn link<P: AsRef<Path>, U: AsRef<Path>>(
     new_path: U,
 ) -> io::Result<()> {
     unsafe {
-        wasi::path_link(
-            old_fd.as_raw_fd() as wasi::Fd,
+        wasip1::path_link(
+            old_fd.as_raw_fd() as wasip1::Fd,
             old_flags,
             osstr2str(old_path.as_ref().as_ref())?,
-            new_fd.as_raw_fd() as wasi::Fd,
+            new_fd.as_raw_fd() as wasip1::Fd,
             osstr2str(new_path.as_ref().as_ref())?,
         )
         .map_err(err2io)
@@ -411,10 +417,10 @@ pub fn rename<P: AsRef<Path>, U: AsRef<Path>>(
     new_path: U,
 ) -> io::Result<()> {
     unsafe {
-        wasi::path_rename(
-            old_fd.as_raw_fd() as wasi::Fd,
+        wasip1::path_rename(
+            old_fd.as_raw_fd() as wasip1::Fd,
             osstr2str(old_path.as_ref().as_ref())?,
-            new_fd.as_raw_fd() as wasi::Fd,
+            new_fd.as_raw_fd() as wasip1::Fd,
             osstr2str(new_path.as_ref().as_ref())?,
         )
         .map_err(err2io)
@@ -432,9 +438,9 @@ pub fn symlink<P: AsRef<Path>, U: AsRef<Path>>(
     new_path: U,
 ) -> io::Result<()> {
     unsafe {
-        wasi::path_symlink(
+        wasip1::path_symlink(
             osstr2str(old_path.as_ref().as_ref())?,
-            fd.as_raw_fd() as wasi::Fd,
+            fd.as_raw_fd() as wasip1::Fd,
             osstr2str(new_path.as_ref().as_ref())?,
         )
         .map_err(err2io)

--- a/library/std/src/os/wasi/net/mod.rs
+++ b/library/std/src/os/wasi/net/mod.rs
@@ -18,6 +18,6 @@ pub trait TcpListenerExt {
 
 impl TcpListenerExt for net::TcpListener {
     fn sock_accept(&self, flags: u16) -> io::Result<u32> {
-        unsafe { wasi::sock_accept(self.as_raw_fd() as wasi::Fd, flags).map_err(err2io) }
+        unsafe { wasip1::sock_accept(self.as_raw_fd() as wasip1::Fd, flags).map_err(err2io) }
     }
 }

--- a/library/std/src/sys/args/wasip1.rs
+++ b/library/std/src/sys/args/wasip1.rs
@@ -11,10 +11,10 @@ pub fn args() -> Args {
 
 fn maybe_args() -> Option<Vec<OsString>> {
     unsafe {
-        let (argc, buf_size) = wasi::args_sizes_get().ok()?;
+        let (argc, buf_size) = wasip1::args_sizes_get().ok()?;
         let mut argv = Vec::with_capacity(argc);
         let mut buf = Vec::with_capacity(buf_size);
-        wasi::args_get(argv.as_mut_ptr(), buf.as_mut_ptr()).ok()?;
+        wasip1::args_get(argv.as_mut_ptr(), buf.as_mut_ptr()).ok()?;
         argv.set_len(argc);
         let mut ret = Vec::with_capacity(argc);
         for ptr in argv {

--- a/library/std/src/sys/net/connection/wasip1.rs
+++ b/library/std/src/sys/net/connection/wasip1.rs
@@ -125,12 +125,12 @@ impl TcpStream {
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         let wasi_how = match how {
-            Shutdown::Read => wasi::SDFLAGS_RD,
-            Shutdown::Write => wasi::SDFLAGS_WR,
-            Shutdown::Both => wasi::SDFLAGS_RD | wasi::SDFLAGS_WR,
+            Shutdown::Read => wasip1::SDFLAGS_RD,
+            Shutdown::Write => wasip1::SDFLAGS_WR,
+            Shutdown::Both => wasip1::SDFLAGS_RD | wasip1::SDFLAGS_WR,
         };
 
-        unsafe { wasi::sock_shutdown(self.socket().as_raw_fd() as _, wasi_how).map_err(err2io) }
+        unsafe { wasip1::sock_shutdown(self.socket().as_raw_fd() as _, wasi_how).map_err(err2io) }
     }
 
     pub fn duplicate(&self) -> io::Result<TcpStream> {
@@ -167,19 +167,20 @@ impl TcpStream {
 
     pub fn set_nonblocking(&self, state: bool) -> io::Result<()> {
         let fdstat = unsafe {
-            wasi::fd_fdstat_get(self.socket().as_inner().as_raw_fd() as wasi::Fd).map_err(err2io)?
+            wasip1::fd_fdstat_get(self.socket().as_inner().as_raw_fd() as wasip1::Fd)
+                .map_err(err2io)?
         };
 
         let mut flags = fdstat.fs_flags;
 
         if state {
-            flags |= wasi::FDFLAGS_NONBLOCK;
+            flags |= wasip1::FDFLAGS_NONBLOCK;
         } else {
-            flags &= !wasi::FDFLAGS_NONBLOCK;
+            flags &= !wasip1::FDFLAGS_NONBLOCK;
         }
 
         unsafe {
-            wasi::fd_fdstat_set_flags(self.socket().as_inner().as_raw_fd() as wasi::Fd, flags)
+            wasip1::fd_fdstat_set_flags(self.socket().as_inner().as_raw_fd() as wasip1::Fd, flags)
                 .map_err(err2io)
         }
     }
@@ -221,7 +222,7 @@ impl TcpListener {
 
     pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         let fd = unsafe {
-            wasi::sock_accept(self.as_inner().as_inner().as_raw_fd() as _, 0).map_err(err2io)?
+            wasip1::sock_accept(self.as_inner().as_inner().as_raw_fd() as _, 0).map_err(err2io)?
         };
 
         Ok((
@@ -258,19 +259,20 @@ impl TcpListener {
 
     pub fn set_nonblocking(&self, state: bool) -> io::Result<()> {
         let fdstat = unsafe {
-            wasi::fd_fdstat_get(self.socket().as_inner().as_raw_fd() as wasi::Fd).map_err(err2io)?
+            wasip1::fd_fdstat_get(self.socket().as_inner().as_raw_fd() as wasip1::Fd)
+                .map_err(err2io)?
         };
 
         let mut flags = fdstat.fs_flags;
 
         if state {
-            flags |= wasi::FDFLAGS_NONBLOCK;
+            flags |= wasip1::FDFLAGS_NONBLOCK;
         } else {
-            flags &= !wasi::FDFLAGS_NONBLOCK;
+            flags &= !wasip1::FDFLAGS_NONBLOCK;
         }
 
         unsafe {
-            wasi::fd_fdstat_set_flags(self.socket().as_inner().as_raw_fd() as wasi::Fd, flags)
+            wasip1::fd_fdstat_set_flags(self.socket().as_inner().as_raw_fd() as wasip1::Fd, flags)
                 .map_err(err2io)
         }
     }

--- a/library/std/src/sys/pal/wasi/mod.rs
+++ b/library/std/src/sys/pal/wasi/mod.rs
@@ -29,7 +29,7 @@ pub fn abort_internal() -> ! {
 
 #[inline]
 #[cfg(target_env = "p1")]
-pub(crate) fn err2io(err: wasi::Errno) -> crate::io::Error {
+pub(crate) fn err2io(err: wasip1::Errno) -> crate::io::Error {
     crate::io::Error::from_raw_os_error(err.raw().into())
 }
 

--- a/library/std/src/sys/random/wasip1.rs
+++ b/library/std/src/sys/random/wasip1.rs
@@ -1,5 +1,5 @@
 pub fn fill_bytes(bytes: &mut [u8]) {
     unsafe {
-        wasi::random_get(bytes.as_mut_ptr(), bytes.len()).expect("failed to generate random data")
+        wasip1::random_get(bytes.as_mut_ptr(), bytes.len()).expect("failed to generate random data")
     }
 }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -539,7 +539,8 @@ const PERMITTED_STDLIB_DEPENDENCIES: &[&str] = &[
     "shlex",
     "unwinding",
     "vex-sdk",
-    "wasi",
+    "wasip1",
+    "wasip2",
     "windows-link",
     "windows-sys",
     "windows-targets",
@@ -881,10 +882,7 @@ fn check_runtime_no_duplicate_dependencies(metadata: &Metadata, check: &mut Runn
             continue;
         }
 
-        // Skip the `wasi` crate here which the standard library explicitly
-        // depends on two version of (one for the `wasm32-wasip1` target and
-        // another for the `wasm32-wasip2` target).
-        if pkg.name.to_string() != "wasi" && !seen_pkgs.insert(&*pkg.name) {
+        if !seen_pkgs.insert(&*pkg.name) {
             check.error(format!(
                 "duplicate package `{}` is not allowed for the standard library",
                 pkg.name


### PR DESCRIPTION
This commit updates the crate dependency that the standard library has on the `wasi` crate. This is now updated to depending explicitly on the `wasip1` crate and the `wasip2` crate published on crates.io. These crates are managed in the [same location][repo] as the `wasi` crate and represent a different versioning scheme which doesn't require multi-version WASI support to require depending on the same crate at multiple versions. The code in libstd is updated to reference `wasip1` and `wasip2` directly as well.

[repo]: https://github.com/bytecodealliance/wasi-rs

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
