### PR TITLE
rustdoc: Fix Managarm C Library name in cfg pretty printer

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32v1_none.rs
@@ -10,7 +10,7 @@
 //! those target flags doesn't automatically rebuild libcore / liballoc with
 //! them, and in order to get those libraries rebuilt you need to use the
 //! nightly Rust feature `-Zbuild-std`. This target is for people who want to
-//! use stable Rust, and target a stable set pf WebAssembly features.
+//! use stable Rust, and target a stable set of WebAssembly features.
 
 use crate::spec::{Arch, Cc, LinkerFlavor, Os, Target, TargetMetadata, base};
 

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -593,7 +593,7 @@ fn human_readable_target_env(env: Symbol) -> Option<&'static str> {
         // tidy-alphabetical-start
         Gnu => "GNU",
         MacAbi => "Catalyst",
-        Mlibc => "mac ABI",
+        Mlibc => "Managarm C Library",
         Msvc => "MSVC",
         Musl => "musl",
         Newlib => "Newlib",

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -516,7 +516,7 @@ fn human_readable_target_os(os: Symbol) -> Option<&'static str> {
         Managarm => "Managarm",
         Motor => "Motor OS",
         NetBsd => "NetBSD",
-        None => "bare-metal", // FIXME(scrabsha): is this appropriate?
+        None => "bare-metal",
         Nto => "QNX Neutrino",
         NuttX => "NuttX",
         OpenBsd => "OpenBSD",

--- a/tests/rustdoc-html/doc-cfg/all-targets.rs
+++ b/tests/rustdoc-html/doc-cfg/all-targets.rs
@@ -2,7 +2,7 @@
 
 //@ has all_targets/fn.foo.html \
 //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-//  'Available on GNU or Catalyst or mac ABI or MSVC or musl or Newlib or \
+//  'Available on GNU or Catalyst or Managarm C Library or MSVC or musl or Newlib or \
 //  Neutrino 7.0 or Neutrino 7.1 or Neutrino 7.1 with io-sock or Neutrino 8.0 or \
 //  OpenHarmony or relibc or SGX or Simulator or WASIp1 or WASIp2 or WASIp3 or \
 //  uClibc or V5 or target_env=fake_env only.'


### PR DESCRIPTION
Like rust-lang/rust#155293, this was introduced in https://github.com/rust-lang/rust/pull/154328.

Unlike that PR, I don't think there's any need to backport, because this cfg is not used anywhere in the standard library.
(I searched for `"mlibc"`, the only place it's used in rust-lang/rust is the HTML doc test.)

#### Other Minor Fixes

Remove a FIXME comment in the pretty printer, `os = "none"` is always bare metal:
https://github.com/rust-lang/rust/blob/d227e48c560e915fe7c0b8b3e821680a3a0ba739/compiler/rustc_target/src/spec/mod.rs#L3179

Fix a comment typo, ignore another typo in vendored sources.