### PR TITLE
compiletest: Remove the `//@ should-ice` directive

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/compiletest.md
+++ b/src/doc/rustc-dev-guide/src/tests/compiletest.md
@@ -190,11 +190,6 @@ substring must not appear anywhere in the compiler output.
 This can be useful to ensure certain errors do not appear, but this can be fragile as error messages
 change over time, and a test may no longer be checking the right thing but will still pass.
 
-`cfail` tests support the `should-ice` directive to specify that a test should
-cause an Internal Compiler Error (ICE).
-This is a highly specialized directive
-to check that the incremental cache continues to work after an ICE.
-
 Incremental tests may use the attribute `#[rustc_clean(...)]` attribute.
 This attribute compares the fingerprint from the current compilation session with the previous one.
 The first revision should never have an active `rustc_clean` attribute, since it will always be dirty.

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -80,8 +80,7 @@ See [Controlling pass/fail expectations](ui.md#controlling-passfail-expectations
 | `run-fail-or-crash`         | Program must `run-fail` or `run-crash`      | `ui`                                      | N/A             |
 | `ignore-pass`               | Ignore `--pass` flag                        | `ui`, `crashes`, `codegen`, `incremental` | N/A             |
 | `dont-check-failure-status` | Don't check exact failure status (i.e. `1`) | `ui`, `incremental`                       | N/A             |
-| `failure-status`            | Check                                       | `ui`, `crashes`                           | Any `u16`       |
-| `should-ice`                | Check failure status is `101`               | `coverage`, `incremental`                 | N/A             |
+| `failure-status`            | On failure, the compiler must exit with this status code. To expect an ICE, use `//@ failure-status: 101`. | `ui`, `crashes`, `incremental`            | Any `u16`       |
 | `should-fail`               | Compiletest self-test                       | All                                       | N/A             |
 
 ### Controlling output snapshots and normalizations
@@ -318,7 +317,6 @@ See [Pretty-printer](compiletest.md#pretty-printer-tests).
 - [`revisions`](compiletest.md#revisions) — compile multiple times
 -[`forbid-output`](compiletest.md#incremental-tests) — incremental cfail rejects
       output pattern
-- [`should-ice`](compiletest.md#incremental-tests) — incremental cfail should ICE
 - [`reference`] — an annotation linking to a rule in the reference
 - `disable-gdb-pretty-printers` — disable gdb pretty printers for debuginfo tests
 

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -185,8 +185,6 @@ pub(crate) struct TestProps {
     // If true, `rustfix` will only apply `MachineApplicable` suggestions.
     pub(crate) rustfix_only_machine_applicable: bool,
     pub(crate) assembly_output: Option<String>,
-    // If true, the test is expected to ICE
-    pub(crate) should_ice: bool,
     // If true, the stderr is expected to be different across bit-widths.
     pub(crate) stderr_per_bitwidth: bool,
     // The MIR opt to unit test, if any
@@ -220,7 +218,6 @@ mod directives {
     pub(crate) const COMPILE_FLAGS: &str = "compile-flags";
     pub(crate) const RUN_FLAGS: &str = "run-flags";
     pub(crate) const DOC_FLAGS: &str = "doc-flags";
-    pub(crate) const SHOULD_ICE: &str = "should-ice";
     pub(crate) const BUILD_AUX_DOCS: &str = "build-aux-docs";
     pub(crate) const UNIQUE_DOC_OUT_DIR: &str = "unique-doc-out-dir";
     pub(crate) const FORCE_HOST: &str = "force-host";
@@ -307,7 +304,6 @@ impl TestProps {
             run_rustfix: false,
             rustfix_only_machine_applicable: false,
             assembly_output: None,
-            should_ice: false,
             stderr_per_bitwidth: false,
             mir_unit_test: None,
             remap_src_base: false,
@@ -375,10 +371,6 @@ impl TestProps {
                     }
                 },
             );
-        }
-
-        if self.should_ice {
-            self.failure_status = Some(101);
         }
 
         if config.mode == TestMode::Incremental {

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -286,7 +286,6 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "rustc-env",
     "rustfix-only-machine-applicable",
     "should-fail",
-    "should-ice",
     "stderr-per-bitwidth",
     "test-mir-pass",
     "unique-doc-out-dir",

--- a/src/tools/compiletest/src/directives/handlers.rs
+++ b/src/tools/compiletest/src/directives/handlers.rs
@@ -115,9 +115,6 @@ fn make_directive_handlers_map() -> HashMap<&'static str, Handler> {
                 props.pp_exact = config.parse_pp_exact(ln);
             }
         }),
-        handler(SHOULD_ICE, |config, ln, props| {
-            config.set_name_directive(ln, SHOULD_ICE, &mut props.should_ice);
-        }),
         handler(BUILD_AUX_DOCS, |config, ln, props| {
             config.set_name_directive(ln, BUILD_AUX_DOCS, &mut props.build_aux_docs);
         }),

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -266,12 +266,6 @@ impl<'test> TestCx<'test> {
     /// Code executed for each revision in turn (or, if there are no
     /// revisions, exactly once, with revision == None).
     fn run_revision(&self) {
-        if self.props.should_ice
-            && self.config.mode != TestMode::Incremental
-            && self.config.mode != TestMode::Crashes
-        {
-            self.fatal("cannot use should-ice in a test that is not cfail");
-        }
         // Run the test multiple times if requested.
         // This is useful for catching flaky tests under the parallel frontend.
         for _ in 0..self.config.iteration_count {
@@ -669,16 +663,6 @@ impl<'test> TestCx<'test> {
             } else {
                 missing_patterns.push(pattern.to_string());
             }
-        }
-    }
-
-    fn check_no_compiler_crash(&self, proc_res: &ProcRes, should_ice: bool) {
-        match proc_res.status.code() {
-            Some(101) if !should_ice => {
-                self.fatal_proc_rec("compiler encountered internal error", proc_res)
-            }
-            None => self.fatal_proc_rec("compiler terminated by signal", proc_res),
-            _ => (),
         }
     }
 

--- a/src/tools/compiletest/src/runtest/codegen_units.rs
+++ b/src/tools/compiletest/src/runtest/codegen_units.rs
@@ -14,8 +14,6 @@ impl TestCx<'_> {
             self.fatal_proc_rec("compilation failed!", &proc_res);
         }
 
-        self.check_no_compiler_crash(&proc_res, self.props.should_ice);
-
         const PREFIX: &str = "MONO_ITEM ";
         const CGU_MARKER: &str = "@@";
 

--- a/src/tools/compiletest/src/runtest/incremental.rs
+++ b/src/tools/compiletest/src/runtest/incremental.rs
@@ -32,14 +32,8 @@ impl TestCx<'_> {
         }
 
         if revision.starts_with("cpass") {
-            if self.props.should_ice {
-                self.fatal("can only use should-ice in cfail tests");
-            }
             self.run_cpass_test();
         } else if revision.starts_with("rpass") {
-            if self.props.should_ice {
-                self.fatal("can only use should-ice in cfail tests");
-            }
             self.run_rpass_test();
         } else if revision.starts_with("cfail") {
             self.run_cfail_test();
@@ -84,16 +78,7 @@ impl TestCx<'_> {
         let pm = self.pass_mode();
         let proc_res = self.compile_test(WillExecute::No, self.should_emit_metadata(pm));
         self.check_if_test_should_compile(Some(FailMode::Build), pm, &proc_res);
-        self.check_no_compiler_crash(&proc_res, self.props.should_ice);
-
         self.check_compiler_output_for_incr(&proc_res);
-
-        if self.props.should_ice {
-            match proc_res.status.code() {
-                Some(101) => (),
-                _ => self.fatal("expected ICE"),
-            }
-        }
     }
 
     fn check_compiler_output_for_incr(&self, proc_res: &ProcRes) {

--- a/tests/incremental/delayed_span_bug.rs
+++ b/tests/incremental/delayed_span_bug.rs
@@ -1,5 +1,5 @@
 //@ revisions: cfail1 cfail2
-//@ should-ice
+//@ failure-status: 101
 
 #![feature(rustc_attrs)]
 


### PR DESCRIPTION
The `//@ should-ice` directive was only being used by one test, which can just as easily use the more general `//@ failure-status` directive instead.

All of the removed exit-code checks were redundant with other exit-code checks that are still present.

---

I have manually verified that `tests/incremental/delayed_span_bug.rs` fails if the failure-status directive is modified or removed.