### PR TITLE
Add tests for `make_bat_command_line` argument reconstruction

### DIFF
--- a/library/std/src/sys/args/windows.rs
+++ b/library/std/src/sys/args/windows.rs
@@ -317,8 +317,6 @@ pub(crate) fn make_bat_command_line(
     cmd.push(b'"' as u16);
 
     // Append the arguments.
-    // FIXME: This needs tests to ensure that the arguments are properly
-    // reconstructed by the batch script by default.
     for arg in args {
         cmd.push(' ' as u16);
         match arg {

--- a/library/std/src/sys/args/windows/tests.rs
+++ b/library/std/src/sys/args/windows/tests.rs
@@ -89,3 +89,84 @@ fn post_2008() {
     chk(r#"EXE """Call Me Ishmael""""#, &["EXE", r#""Call Me Ishmael""#]);
     chk(r#"EXE """"Call Me Ishmael"" b c"#, &["EXE", r#""Call"#, "Me", "Ishmael", "b", "c"]);
 }
+
+fn bat_cmd(script: &str, args: &[&str], force_quotes: bool) -> crate::io::Result<String> {
+    // build a bat command line and decode it back to a UTF-8 String for easy assertions.
+    let script_wide: Vec<u16> = OsString::from(script).encode_wide().collect();
+    let args: Vec<Arg> = args.iter().map(|s| Arg::Regular(OsString::from(s))).collect();
+    let cmd = make_bat_command_line(&script_wide, &args, force_quotes)?;
+    Ok(String::from_utf16_lossy(&cmd).into_owned())
+}
+
+#[test]
+fn bat_no_args() {
+    let result = bat_cmd("script.bat", &[], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat""#);
+}
+
+#[test]
+fn bat_simple_arg() {
+    let result = bat_cmd("script.bat", &["hello"], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" hello""#);
+}
+
+#[test]
+fn bat_arg_with_spaces() {
+    let result = bat_cmd("script.bat", &["hello world"], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" "hello world"""#);
+}
+
+#[test]
+fn bat_empty_arg() {
+    let result = bat_cmd("script.bat", &[""], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" """#);
+}
+
+#[test]
+fn bat_arg_with_double_quote() {
+    let result = bat_cmd("script.bat", &[r#"say "hi""#], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" "say ""hi""""#);
+}
+
+#[test]
+fn bat_arg_with_backslash_before_quote() {
+    let result = bat_cmd("script.bat", &[r#"a\"#], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" "a\\"""#);
+}
+
+#[test]
+fn bat_arg_with_percent() {
+    let result = bat_cmd("script.bat", &["%PATH%"], false).unwrap();
+    assert!(result.contains("%%cd:~,"), "percent should be escaped: {result}");
+    assert!(!result.contains("%PATH%"), "raw %PATH% must not appear: {result}");
+}
+
+#[test]
+fn bat_force_quotes() {
+    let result = bat_cmd("script.bat", &["plain"], true).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" "plain"""#);
+}
+
+#[test]
+fn bat_multiple_args() {
+    let result = bat_cmd("script.bat", &["one", "two", "three"], false).unwrap();
+    assert_eq!(result, r#"cmd.exe /e:ON /v:OFF /d /c ""script.bat" one two three""#);
+}
+
+#[test]
+fn bat_rejects_newline_in_arg() {
+    assert!(bat_cmd("script.bat", &["bad\narg"], false).is_err());
+    assert!(bat_cmd("script.bat", &["bad\rarg"], false).is_err());
+}
+
+#[test]
+fn bat_rejects_script_with_quote() {
+    let script_wide: Vec<u16> = OsString::from(r#"scr"ipt.bat"#).encode_wide().collect();
+    assert!(make_bat_command_line(&script_wide, &[], false).is_err());
+}
+
+#[test]
+fn bat_rejects_script_ending_with_backslash() {
+    let script_wide: Vec<u16> = OsString::from(r"dir\").encode_wide().collect();
+    assert!(make_bat_command_line(&script_wide, &[], false).is_err());
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Resolves the FIXME in `library/std/src/sys/args/windows.rs` that noted tests were needed to ensure arguments are properly reconstructed by batch scripts.
