### PR TITLE
Link to proposed LLM policy in CONTRIBUTING and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 <!-- homu-ignore:start -->
 <!--
+Please read our [LLM policy] before opening a PR.
+
+[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+
 If this PR is related to an unstable feature or an otherwise tracked effort,
 please link to the relevant tracking issue here. If you don't know of a related
 tracking issue or there are none, feel free to ignore this.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,16 @@
 <!-- homu-ignore:start -->
+
+- [ ] I did not use an LLM to create a change in this PR.
+- [ ] I used an LLM to create a change in this PR, and I have explained below how it was used.
+
 <!--
+Please read our [LLM policy] before opening a PR,
+and check one of the boxes above to indicate whether you've used an LLM.
+If you do not check a box, a reviewer may ask you whether an LLM was involved.
+LLM contributions are not banned, but are held to a higher standard of review and correctness.
+
+[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+
 If this PR is related to an unstable feature or an otherwise tracked effort,
 please link to the relevant tracking issue here. If you don't know of a related
 tracking issue or there are none, feel free to ignore this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,13 @@ that you read and understand the [rustc-dev-guide] before making a contribution.
 talks about the different bots in the Rust ecosystem, the Rust development tools,
 bootstrapping, the compiler architecture, source code representation, and more.
 
+## LLM policy
+
+We have a policy for how LLMs are allowed to be used in contributions to `rust-lang/rust`.
+You can read it [on Forge][LLM policy].
+
+[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+
 ## [Getting help](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions)
 
 There are many ways you can get help when you're stuck. Rust has two platforms for this:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,15 @@ that you read and understand the [rustc-dev-guide] before making a contribution.
 talks about the different bots in the Rust ecosystem, the Rust development tools,
 bootstrapping, the compiler architecture, source code representation, and more.
 
+## LLM policy
+
+We have a policy for how LLMs are allowed to be used in contributions to `rust-lang/rust`.
+You can read it [on Forge][LLM policy].
+For suggestions about how to use LLMs *well*, and how to review LLM-created PRs, see [the dev-guide][llm-guidance].
+
+[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
+[llm-guidance]: https://rustc-dev-guide.rust-lang.org/llm-guidance.html
+
 ## [Getting help](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions)
 
 There are many ways you can get help when you're stuck. Rust has two platforms for this:


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155424)*
<!-- homu-ignore:end -->

**Blocked** until https://github.com/rust-lang/rust-forge/pull/1040 merges.

As described in https://github.com/rust-lang/blog.rust-lang.org/pull/1897, this adds a checkbox for authors to confirm that they have/have not used an LLM. For that reason I would like to merge it *before* the blog post.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
