### PR TITLE
Add temporary scope to assert_matches

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -168,7 +168,7 @@ macro_rules! assert_ne {
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semiopaque"]
 pub macro assert_matches {
-    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {{
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
@@ -179,8 +179,8 @@ pub macro assert_matches {
                 );
             }
         }
-    },
-    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )?, $($arg:tt)+) => {
+    }},
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )?, $($arg:tt)+) => {{
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
@@ -191,7 +191,7 @@ pub macro assert_matches {
                 );
             }
         }
-    },
+    }},
 }
 
 /// Selects code at compile-time based on `cfg` predicates.

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -1,5 +1,7 @@
 #![allow(unused_must_use)]
 
+use std::{assert_matches, debug_assert_matches};
+
 #[allow(dead_code)]
 trait Trait {
     fn blah(&self);
@@ -218,4 +220,25 @@ fn _expression() {
 fn _matches_does_not_trigger_non_exhaustive_omitted_patterns_lint(o: core::sync::atomic::Ordering) {
     // Ordering is a #[non_exhaustive] enum from a separate crate
     let _m = matches!(o, core::sync::atomic::Ordering::Relaxed);
+}
+
+struct MutRefWithDrop<'a>(&'a mut u32);
+
+// MutRefWithDrop needs to have a non-trivial drop to encounter potential lifetime issues if the
+// macros don't introduce a temporary scope.
+impl Drop for MutRefWithDrop<'_> {
+    fn drop(&mut self) {
+        *self.0 = u32::MAX;
+    }
+}
+
+#[test]
+fn temporary_scope_introduction() {
+    // Fails to compile if the macros don't introduce a temporary scope, since `&mut val` would
+    // create a second mutable borrow while `MutRefWithDrop` still holds a unique ref.
+    let mut val = 0;
+
+    (assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
+
+    (debug_assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
 }

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -236,9 +236,12 @@ impl Drop for MutRefWithDrop<'_> {
 fn temporary_scope_introduction() {
     // Fails to compile if the macros don't introduce a temporary scope, since `&mut val` would
     // create a second mutable borrow while `MutRefWithDrop` still holds a unique ref.
+    // See https://github.com/rust-lang/rust/issues/154406 for reference.
     let mut val = 0;
 
     (assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
+    (assert_matches!(*MutRefWithDrop(&mut val).0, 0, "msg"), std::mem::take(&mut val));
 
     (debug_assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
+    (debug_assert_matches!(*MutRefWithDrop(&mut val).0, 0, "msg"), std::mem::take(&mut val));
 }


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/154406 in part. `assert_eq` will be done in a separate PR.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
