### PR TITLE
rustdoc: Fix `redundant_explicit_links` incorrectly firing (or not firing) under certain scenarios

### DIFF
--- a/src/librustdoc/passes/lint/redundant_explicit_links.rs
+++ b/src/librustdoc/passes/lint/redundant_explicit_links.rs
@@ -90,12 +90,23 @@ fn check_redundant_explicit_link<'md>(
     .into_offset_iter();
 
     while let Some((event, link_range)) = offset_iter.next() {
-        if let Event::Start(Tag::Link { link_type, dest_url, .. }) = event {
+        if let Event::Start(Tag::Link { link_type, dest_url, title, .. }) = event {
+            if !title.is_empty() {
+                // Skips if the link specifies a title, e.g. `[Option](Option "title")`,
+                // in which case the explicit link cannot be removed without also
+                // removing the title.
+                continue;
+            }
+
             let link_data = collect_link_data(&mut offset_iter);
 
-            if let Some(resolvable_link) = link_data.resolvable_link.as_ref()
-                && &link_data.display_link.replace('`', "") != resolvable_link
-            {
+            let Some(resolvable_link) = link_data.resolvable_link.as_ref() else {
+                // collect_link_data didn't return a resolvable_link
+                // most likely due to the displayed link containing inline markup
+                continue;
+            };
+
+            if &link_data.display_link.replace('`', "") != resolvable_link {
                 // Skips if display link does not match to actual
                 // resolvable link, usually happens if display link
                 // has several segments, e.g.
@@ -103,10 +114,7 @@ fn check_redundant_explicit_link<'md>(
                 continue;
             }
 
-            let explicit_link = dest_url.to_string();
-            let display_link = link_data.resolvable_link.clone()?;
-
-            if explicit_link.ends_with(&display_link) || display_link.ends_with(&explicit_link) {
+            if dest_url.ends_with(resolvable_link) || resolvable_link.ends_with(&*dest_url) {
                 match link_type {
                     LinkType::Inline | LinkType::ReferenceUnknown => {
                         check_inline_or_reference_unknown_redundancy(

--- a/tests/rustdoc-ui/lints/redundant_explicit_links-some-skipped.fixed
+++ b/tests/rustdoc-ui/lints/redundant_explicit_links-some-skipped.fixed
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+// There was a logic error in `redundant_explicit_links` that caused the lint
+// to skip all remaining links once it skipped a link containing inline markups.
+// This test asserts that the lint continues after skipping such links.
+
+#![deny(rustdoc::redundant_explicit_links)]
+
+/// [Option]
+///~^ ERROR redundant explicit link target
+///
+/// [**u8**](u8)
+/// This link should not lint.
+///
+/// [Result]
+///~^ ERROR redundant explicit link target
+pub fn func() {}

--- a/tests/rustdoc-ui/lints/redundant_explicit_links-some-skipped.rs
+++ b/tests/rustdoc-ui/lints/redundant_explicit_links-some-skipped.rs
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+// There was a logic error in `redundant_explicit_links` that caused the lint
+// to skip all remaining links once it skipped a link containing inline markups.
+// This test asserts that the lint continues after skipping such links.
+
+#![deny(rustdoc::redundant_explicit_links)]
+
+/// [Option][Option]
+///~^ ERROR redundant explicit link target
+///
+/// [**u8**](u8)
+/// This link should not lint.
+///
+/// [Result][Result]
+///~^ ERROR redundant explicit link target
+pub fn func() {}

--- a/tests/rustdoc-ui/lints/redundant_explicit_links-some-skipped.stderr
+++ b/tests/rustdoc-ui/lints/redundant_explicit_links-some-skipped.stderr
@@ -1,0 +1,39 @@
+error: redundant explicit link target
+  --> $DIR/redundant_explicit_links-some-skipped.rs:9:14
+   |
+LL | /// [Option][Option]
+   |      ------  ^^^^^^ explicit target is redundant
+   |      |
+   |      because label contains path that resolves to same destination
+   |
+   = note: when a link's destination is not specified,
+           the label is used to resolve intra-doc links
+note: the lint level is defined here
+  --> $DIR/redundant_explicit_links-some-skipped.rs:7:9
+   |
+LL | #![deny(rustdoc::redundant_explicit_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: remove explicit link target
+   |
+LL - /// [Option][Option]
+LL + /// [Option]
+   |
+
+error: redundant explicit link target
+  --> $DIR/redundant_explicit_links-some-skipped.rs:15:14
+   |
+LL | /// [Result][Result]
+   |      ------  ^^^^^^ explicit target is redundant
+   |      |
+   |      because label contains path that resolves to same destination
+   |
+   = note: when a link's destination is not specified,
+           the label is used to resolve intra-doc links
+help: remove explicit link target
+   |
+LL - /// [Result][Result]
+LL + /// [Result]
+   |
+
+error: aborting due to 2 previous errors
+

--- a/tests/rustdoc-ui/lints/redundant_explicit_links-with-title.rs
+++ b/tests/rustdoc-ui/lints/redundant_explicit_links-with-title.rs
@@ -1,0 +1,15 @@
+//@ check-pass
+
+#![deny(rustdoc::redundant_explicit_links)]
+
+/// [drop](drop "This function is not magic")
+///
+/// This link should not lint, because it specifies a link title, and it is
+/// not possible to remove the explicit link without also removing the title.
+///
+/// [Vec][vec]
+///
+/// [vec]: std::vec::Vec "A contiguous growable array type"
+///
+/// This also applies to reference-style links.
+pub fn func() {}


### PR DESCRIPTION
Hi! I found some issues with the `rustdoc::redundant_explicit_links` lint while working on a personal project.

- After skipping a link that contains inline markups, the lint would incorrectly skip all the remaining links.

  For example, with the following snippet, the lint is fired for `[Option][Option]`, but not `[Result][Result]`:

  ```rs
  //! [Option][Option]
  //! [**u8**][u8]     (skipped)
  //! [Result][Result]
  ```

  Happening because of a `?` causing a loop to bail early:

  https://github.com/rust-lang/rust/blob/a4a37ed163a6c1d227b58047d91457589c611cf8/src/librustdoc/passes/lint/redundant_explicit_links.rs#L107

- The lint is fired for links that specify titles (like `[link](link "title")`), except that wouldn't be applicable because it's not possible to specify a title without there also being an explicit target. For example:

  ```
  error: redundant explicit link target
  --> <anon>:5:12
    |
  5 | /// [drop](drop "This function is not magic")
    |      ----  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ explicit target is redundant
    |      |
    |      because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
  help: remove explicit link target
    |
  5 - /// [drop](drop "This function is not magic")
  5 + /// [drop]
    |
  ```

These are found as of:

```
rustdoc 1.97.0-nightly (1b8f2e46e 2026-04-17)
binary: rustdoc
commit-hash: 1b8f2e46e14b08208a53585570edd9206374aae8
commit-date: 2026-04-17
host: aarch64-apple-darwin
release: 1.97.0-nightly
LLVM version: 22.1.2
```

(Note: I ran `./x test tests/rustdoc-ui` locally, but not `./x tidy` due to my slow internet. There was an unrelated failed test at `tests/rustdoc-ui/ice-bug-report-url.rs` which I'm not sure about)