### PR TITLE
make tests/run-make/used-proc-macro more reliable

### DIFF
--- a/tests/run-make/used-proc-macro/dep.rs
+++ b/tests/run-make/used-proc-macro/dep.rs
@@ -1,4 +1,5 @@
 #![crate_type = "lib"]
 
 #[used]
+#[no_mangle] // so we can refer to this variable by name from the proc-macro library
 static VERY_IMPORTANT_SYMBOL: u32 = 12345;

--- a/tests/run-make/used-proc-macro/proc_macro.rs
+++ b/tests/run-make/used-proc-macro/proc_macro.rs
@@ -1,3 +1,24 @@
 #![crate_type = "proc-macro"]
 
+use proc_macro::TokenStream;
+
 extern crate dep as _;
+extern crate proc_macro;
+
+#[proc_macro]
+pub fn mymacro(input: TokenStream) -> TokenStream {
+    extern "C" {
+        static VERY_IMPORTANT_SYMBOL: u32;
+    }
+
+    // read the symbol otherwise the _linker_ may discard it
+    // `#[used]` only preserves the symbol up to the compiler output (.o file)
+    // which is then passed to the linker. the linker is free to discard the
+    // `#[used]` symbol if it's not accessed/referred-to by other object
+    // files (crates)
+    let symbol_value = unsafe { core::ptr::addr_of!(VERY_IMPORTANT_SYMBOL).read_volatile() };
+
+    // the exact logic here is unimportant for the rmake check
+    let is_that_version = symbol_value == 12345;
+    if is_that_version { input } else { panic!() }
+}


### PR DESCRIPTION
the test was relying on the linker not discarding the `#[used]` symbol

this commit modifies the proc macro to read the `#[used]` symbol to ensure it is not discarded by the linker

fixes rust-lang/rust#155434

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
