### PR TITLE
Update the cc crate for rustc_llvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,10 +544,11 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,10 +560,11 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.73"
 [build-dependencies]
 # tidy-alphabetical-start
 # `cc` updates often break things, so we pin it here.
-cc = "=1.2.16"
+cc = "=1.2.50"
 shlex = "1.3.0"
 # tidy-alphabetical-end
 

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.73"
 [build-dependencies]
 # tidy-alphabetical-start
 # `cc` updates often break things, so we pin it here.
-cc = "=1.2.16"
+cc = "=1.2.39"
 shlex = "1.3.0"
 # tidy-alphabetical-end
 

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -25,7 +25,7 @@ use std::collections::HashSet;
 use std::iter;
 use std::path::{Path, PathBuf};
 
-use crate::core::config::{CompressDebuginfo, TargetSelection};
+use crate::core::config::{CompressDebuginfo, RustcLto, TargetSelection};
 use crate::utils::exec::{BootstrapCommand, command};
 use crate::{Build, CLang, GitRepo};
 
@@ -59,6 +59,15 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
             if target.contains("musl") {
                 cfg.static_flag(true);
             }
+        }
+    }
+    match build.config.rust_lto {
+        RustcLto::Off | RustcLto::ThinLocal => {}
+        RustcLto::Thin => {
+            cfg.flag_if_supported("-flto=thin");
+        }
+        RustcLto::Fat => {
+            cfg.flag_if_supported("-flto=full");
         }
     }
     cfg


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155438)*
<!-- homu-ignore:end -->

Latest stacker needs a newer cc than 1.2.16 as older versions don't have windows arm64ec support.