### PR TITLE
Enable Cargo's new build-dir layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "unified-diff",

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -181,7 +181,7 @@ fn configure_and_expand(
         if cfg!(windows) {
             old_path = env::var_os("PATH").unwrap_or(old_path);
             let mut new_path = Vec::from_iter(
-                sess.host_filesearch().search_paths(PathKind::All).map(|p| p.dir.clone()),
+                sess.host_filesearch().search_paths(PathKind::Native).map(|p| p.dir.clone()),
             );
             for path in env::split_paths(&old_path) {
                 if !new_path.contains(&path) {

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -7,7 +7,7 @@ default-run = "bootstrap"
 
 [features]
 build-metrics = ["dep:sysinfo", "build_helper/metrics"]
-tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "dep:chrono", "dep:tempfile"]
+tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "dep:chrono"]
 
 [lib]
 path = "src/lib.rs"
@@ -55,6 +55,7 @@ termcolor = "1.4"
 toml = "0.5"
 walkdir = "2.4"
 xz2 = "0.1"
+tempfile = "3.15.0"
 
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.39.2", default-features = false, optional = true, features = ["system"] }
@@ -64,7 +65,6 @@ chrono = { version = "0.4", default-features = false, optional = true, features 
 tracing = { version = "0.1", optional = true, features = ["attributes"] }
 tracing-chrome = { version = "0.7", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt", "registry", "std"] }
-tempfile = { version = "3.15.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.junction]
 version = "1.3.0"
@@ -83,7 +83,6 @@ features = [
 
 [dev-dependencies]
 pretty_assertions = "1.4"
-tempfile = "3.15.0"
 insta = "1.43"
 
 # We care a lot about bootstrap's compile times, so don't include debuginfo for

--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 use std::time::Instant;
 
+use arg_file_command::ArgFileCommand;
 use shared_helpers::{
     dylib_path, dylib_path_var, exe, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
     parse_value_from_args,
@@ -27,6 +28,9 @@ use shared_helpers::{
 
 #[path = "../utils/shared_helpers.rs"]
 mod shared_helpers;
+
+#[path = "../../../build_helper/src/arg_file_command.rs"]
+mod arg_file_command;
 
 #[path = "../utils/proc_macro_deps.rs"]
 mod proc_macro_deps;
@@ -112,11 +116,11 @@ fn main() {
 
     let mut cmd = match env::var_os("RUSTC_WRAPPER_REAL") {
         Some(wrapper) if !wrapper.is_empty() => {
-            let mut cmd = Command::new(wrapper);
+            let mut cmd = ArgFileCommand::new(wrapper);
             cmd.arg(rustc_driver);
             cmd
         }
-        _ => Command::new(rustc_driver),
+        _ => ArgFileCommand::new(rustc_driver),
     };
     cmd.args(&args).env(dylib_path_var(), env::join_paths(&dylib_path).unwrap());
 
@@ -271,6 +275,7 @@ fn main() {
         eprintln!("{prefix} libdir: {libdir:?}");
     }
 
+    let (mut cmd, arg_file) = cmd.build().unwrap();
     maybe_dump(format!("stage{}-rustc", stage + 1), &cmd);
 
     let start = Instant::now();
@@ -280,6 +285,8 @@ fn main() {
         let status = child.wait().expect(&errmsg);
         (child, status)
     };
+
+    drop(arg_file);
 
     if (env::var_os("RUSTC_PRINT_STEP_TIMINGS").is_some()
         || env::var_os("RUSTC_PRINT_STEP_RUSAGE").is_some())

--- a/src/bootstrap/src/bin/rustdoc.rs
+++ b/src/bootstrap/src/bin/rustdoc.rs
@@ -4,8 +4,8 @@
 
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
 
+use arg_file_command::ArgFileCommand;
 use shared_helpers::{
     dylib_path, dylib_path_var, maybe_dump, parse_rustc_stage, parse_rustc_verbose,
     parse_value_from_args,
@@ -13,6 +13,9 @@ use shared_helpers::{
 
 #[path = "../utils/shared_helpers.rs"]
 mod shared_helpers;
+
+#[path = "../../../build_helper/src/arg_file_command.rs"]
+mod arg_file_command;
 
 fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
@@ -31,7 +34,7 @@ fn main() {
     let mut dylib_path = dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir.clone()));
 
-    let mut cmd = Command::new(rustdoc);
+    let mut cmd = ArgFileCommand::new(rustdoc);
 
     if target.is_some() {
         // The stage0 compiler has a special sysroot distinct from what we
@@ -81,6 +84,7 @@ fn main() {
         }
     }
 
+    let (mut cmd, arg_file) = cmd.build().unwrap();
     maybe_dump(format!("stage{}-rustdoc", stage + 1), &cmd);
 
     if verbose > 1 {
@@ -94,7 +98,10 @@ fn main() {
         eprintln!("libdir: {libdir:?}");
     }
 
-    std::process::exit(match cmd.status() {
+    let status = cmd.status();
+    drop(arg_file);
+
+    std::process::exit(match status {
         Ok(s) => s.code().unwrap_or(1),
         Err(e) => panic!("\n\nfailed to run {cmd:?}: {e}\n\n"),
     })

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2644,16 +2644,18 @@ pub enum ArtifactKeepMode {
 
 pub fn run_cargo(
     builder: &Builder<'_>,
-    cargo: Cargo,
+    mut cargo: Cargo,
     tail_args: Vec<String>,
     stamp: &BuildStamp,
     additional_target_deps: Vec<(PathBuf, DependencyType)>,
     artifact_keep_mode: ArtifactKeepMode,
 ) -> Vec<PathBuf> {
+    cargo.arg("-Zbuild-dir-new-layout");
+
     // `target_root_dir` looks like $dir/$target/release
     let target_root_dir = stamp.path().parent().unwrap();
-    // `target_deps_dir` looks like $dir/$target/release/deps
-    let target_deps_dir = target_root_dir.join("deps");
+    // `target_build_dir` looks like $dir/$target/release/build
+    let target_build_dir = target_root_dir.join("build");
     // `host_root_dir` looks like $dir/release
     let host_root_dir = target_root_dir
         .parent()
@@ -2724,7 +2726,7 @@ pub fn run_cargo(
 
             // If this was output in the `deps` dir then this is a precise file
             // name (hash included) so we start tracking it.
-            if filename.starts_with(&target_deps_dir) {
+            if filename.starts_with(&target_build_dir) {
                 deps.push((filename.to_path_buf(), DependencyType::Target));
                 continue;
             }
@@ -2759,11 +2761,18 @@ pub fn run_cargo(
 
     // Ok now we need to actually find all the files listed in `toplevel`. We've
     // got a list of prefix/extensions and we basically just need to find the
-    // most recent file in the `deps` folder corresponding to each one.
-    let contents = target_deps_dir
+    // most recent file in the `build` folder corresponding to each one.
+    //
+    // Cargo's build folder is structured as `build/<pkg>/<hash>/out/<artifacts>` so
+    // we need to traverse multiple directory layers to get to actual files.
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let contents = target_build_dir
         .read_dir()
-        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", target_deps_dir.display(), e))
-        .map(|e| t!(e))
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", target_build_dir.display(), e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
         .map(|e| (e.path(), e.file_name().into_string().unwrap(), t!(e.metadata())))
         .collect::<Vec<_>>();
     for (prefix, extension, expected_len) in toplevel {

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2666,8 +2666,8 @@ pub fn run_cargo(
 ) -> Vec<PathBuf> {
     // `target_root_dir` looks like $dir/$target/release
     let target_root_dir = stamp.path().parent().unwrap();
-    // `target_deps_dir` looks like $dir/$target/release/deps
-    let target_deps_dir = target_root_dir.join("deps");
+    // `target_build_dir` looks like $dir/$target/release/build
+    let target_build_dir = target_root_dir.join("build");
     // `host_root_dir` looks like $dir/release
     let host_root_dir = target_root_dir
         .parent()
@@ -2738,7 +2738,7 @@ pub fn run_cargo(
 
             // If this was output in the `deps` dir then this is a precise file
             // name (hash included) so we start tracking it.
-            if filename.starts_with(&target_deps_dir) {
+            if filename.starts_with(&target_build_dir) {
                 deps.push((filename.to_path_buf(), DependencyType::Target));
                 continue;
             }
@@ -2773,11 +2773,18 @@ pub fn run_cargo(
 
     // Ok now we need to actually find all the files listed in `toplevel`. We've
     // got a list of prefix/extensions and we basically just need to find the
-    // most recent file in the `deps` folder corresponding to each one.
-    let contents = target_deps_dir
+    // most recent file in the `build` folder corresponding to each one.
+    //
+    // Cargo's build folder is structured as `build/<pkg>/<hash>/out/<artifacts>` so
+    // we need to traverse multiple directory layers to get to actual files.
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let contents = target_build_dir
         .read_dir()
-        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", target_deps_dir.display(), e))
-        .map(|e| t!(e))
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", target_build_dir.display(), e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
         .map(|e| (e.path(), e.file_name().into_string().unwrap(), t!(e.metadata())))
         .collect::<Vec<_>>();
     for (prefix, extension, expected_len) in toplevel {

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1628,8 +1628,9 @@ impl Builder<'_> {
         //
         // Notably this munges the dynamic library lookup path to point to the
         // right location to run `compiler`.
-        let mut lib_paths: Vec<PathBuf> =
-            discover_out_dirs(self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("build"));
+        let mut lib_paths: Vec<PathBuf> = discover_out_dirs_with_dylibs(
+            self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("build"),
+        );
 
         // On MSVC a tool may invoke a C compiler (e.g., compiletest in run-make
         // mode) and that C compiler may need some extra PATH modification. Do
@@ -1659,18 +1660,21 @@ impl Builder<'_> {
 }
 
 /// Gets all of the `out` dirs in a given Cargo `build-dir/<profile>/build` dir.
-fn discover_out_dirs(dir: PathBuf) -> Vec<PathBuf> {
+fn discover_out_dirs_with_dylibs(dir: PathBuf) -> Vec<PathBuf> {
     if !dir.exists() {
         return Vec::new();
     }
-
     let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let has_dylib = |path: &Path| {
+        read_dir(path)
+            .any(|e| e.path().extension().is_some_and(|ext| ext == std::env::consts::DLL_EXTENSION))
+    };
     dir.read_dir()
         .unwrap_or_else(|e| panic!("Couldn't read {}: {}", dir.display(), e))
         .map(|e| e.unwrap())
         .flat_map(|e| read_dir(&e.path()))
         .flat_map(|e| read_dir(&e.path()))
         .map(|e| e.path())
-        .filter(|path| path.ends_with("out"))
+        .filter(|path| path.ends_with("out") && has_dylib(path))
         .collect::<Vec<_>>()
 }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -10,7 +10,7 @@
 //! return `ToolBuildResult` and should never prepare `cargo` invocations manually.
 
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use crate::core::build_steps::compile::is_lto_stage;
@@ -1629,7 +1629,7 @@ impl Builder<'_> {
         // Notably this munges the dynamic library lookup path to point to the
         // right location to run `compiler`.
         let mut lib_paths: Vec<PathBuf> =
-            vec![self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("deps")];
+            discover_out_dirs(self.cargo_out(compiler, Mode::ToolBootstrap, *host).join("build"));
 
         // On MSVC a tool may invoke a C compiler (e.g., compiletest in run-make
         // mode) and that C compiler may need some extra PATH modification. Do
@@ -1656,4 +1656,21 @@ impl Builder<'_> {
 
         cmd
     }
+}
+
+/// Gets all of the `out` dirs in a given Cargo `build-dir/<profile>/build` dir.
+fn discover_out_dirs(dir: PathBuf) -> Vec<PathBuf> {
+    if !dir.exists() {
+        return Vec::new();
+    }
+
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    dir.read_dir()
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", dir.display(), e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .map(|e| e.path())
+        .filter(|path| path.ends_with("out"))
+        .collect::<Vec<_>>()
 }

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -595,6 +595,8 @@ impl Builder<'_> {
 
         let mut hostflags = HostFlags::default();
 
+        cargo.env("CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT", "true");
+
         // Codegen backends are not yet tracked by -Zbinary-dep-depinfo,
         // so we need to explicitly clear out if they've been updated.
         for backend in self.codegen_backends(compiler) {

--- a/src/build_helper/src/arg_file_command.rs
+++ b/src/build_helper/src/arg_file_command.rs
@@ -1,0 +1,121 @@
+//! This module is explictly not `mod`ed as it's shared across multiple crates
+//! like bootstrap and compiletest via `#[path]` moduled declarations.
+//! It's important to keep this file isolated from the rest of build_helper so it can be compiled
+//! without build_helper.
+
+// Roughly match the `std::process::Command` API
+#![allow(dead_code, unreachable_pub)]
+
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, CommandEnvs};
+
+use tempfile::NamedTempFile;
+
+/// A wrapper around [`Command`] that adds support for arg files.
+/// This is useful as we have some commands that can get very long and at times
+/// hit the OS limit (usually Windows)
+///
+/// This implementation is based off the `ProcessBuilder` implementation in Cargo
+/// but simplified.
+///
+/// NOTE: In most scenarios we want to avoid arg files as it makes debugging more complicated
+///       so we try to avoid it if the command is not close to the OS limit.
+#[derive(Debug)]
+pub struct ArgFileCommand {
+    command: Command,
+    args: Vec<OsString>,
+}
+
+impl ArgFileCommand {
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
+        let command = Command::new(program);
+        Self { command, args: Vec::new() }
+    }
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.args.push(arg.as_ref().to_os_string());
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.args.extend(args.into_iter().map(|s| s.as_ref().to_os_string()));
+        self
+    }
+
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.env(key, val);
+        self
+    }
+
+    pub fn get_envs(&self) -> CommandEnvs<'_> {
+        self.command.get_envs()
+    }
+
+    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+        self.command.env_remove(key);
+        self
+    }
+
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.command.current_dir(dir);
+        self
+    }
+
+    pub fn stdin(&mut self, stdin: std::process::Stdio) -> &mut Self {
+        self.command.stdin(stdin);
+        self
+    }
+
+    pub fn build(mut self) -> std::io::Result<(Command, Option<NamedTempFile>)> {
+        // On Windows there is a hard limit of ~32KB, so we cut off at 30KB to
+        // give some buffer just incase.
+        #[cfg(windows)]
+        let threshold: usize = 30 * 1024;
+        // On unix the limit is defined by ARG_MAX. If its not explicitly set we set it to 1MB
+        // which is fairly large but lower than the ~2MB that it defaults to on most systems.
+        #[cfg(unix)]
+        let threshold: usize =
+            std::env::var("ARG_MAX").ok().and_then(|v| v.parse().ok()).unwrap_or(1024 * 1024);
+
+        let total_arg_len: usize = self.args.iter().map(|a| a.len() + 1).sum();
+        if total_arg_len <= threshold {
+            self.command.args(self.args);
+            return Ok((self.command, None));
+        }
+
+        let mut tmp = tempfile::Builder::new().prefix("bootstrap-argfile.").tempfile()?;
+
+        let mut arg = OsString::from("@");
+        arg.push(tmp.path());
+        self.command.arg(arg);
+
+        let mut buf = Vec::with_capacity(total_arg_len);
+        for arg in &self.args {
+            let arg = arg.to_str().ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "argument for argfile contains invalid UTF-8 characters: `{}`",
+                    arg.to_string_lossy()
+                ))
+            })?;
+            if arg.contains('\n') {
+                return Err(std::io::Error::other(format!(
+                    "argument for argfile contains newlines: `{arg}`"
+                )));
+            }
+            writeln!(buf, "{arg}")?;
+        }
+        tmp.write_all(&buf)?;
+        tmp.flush()?;
+
+        Ok((self.command, Some(tmp)))
+    }
+}

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -2,7 +2,12 @@
 # dynamically in CI from ci.yml.
 runners:
   - &base-job
-    env: { }
+    env:
+      # This force enables the new Cargo build-dir layout for all CI jobs.
+      # The new layout will become the default soon so we enable it on everything
+      # to catch issues as soon as possible.
+      # See: https://github.com/rust-lang/cargo/issues/15010
+      CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
 
   - &job-linux-4c
     os: ubuntu-24.04

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -31,6 +31,7 @@ rustfix = "0.8.1"
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.23.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"] }
 unified-diff = "0.2.1"

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -23,7 +23,7 @@ use crate::errors::{Error, ErrorKind, load_errors};
 use crate::output_capture::ConsoleOut;
 use crate::read2::{Truncated, read2_abbreviated};
 use crate::runtest::compute_diff::{DiffLine, diff_by_lines, make_diff, write_diff};
-use crate::util::{Utf8PathBufExt, add_dylib_path, static_regex};
+use crate::util::{ArgFileCommand, Utf8PathBufExt, add_dylib_path, static_regex};
 use crate::{json, stamp_file_path};
 
 // Helper modules that implement test running logic for each test suite.
@@ -383,7 +383,7 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    /// Runs a [`Command`] and waits for it to finish, then converts its exit
+    /// Runs a [`ArgFileCommand`] and waits for it to finish, then converts its exit
     /// status and output streams into a [`ProcRes`].
     ///
     /// The command might have succeeded or failed; it is the caller's
@@ -393,7 +393,8 @@ impl<'test> TestCx<'test> {
     /// Panics if the command couldn't be executed at all
     /// (e.g. because the executable could not be found).
     #[must_use = "caller should check whether the command succeeded"]
-    fn run_command_to_procres(&self, cmd: &mut Command) -> ProcRes {
+    fn run_command_to_procres(&self, cmd: ArgFileCommand) -> ProcRes {
+        let (mut cmd, _arg_file) = cmd.build().unwrap();
         let output = cmd
             .output()
             .unwrap_or_else(|e| self.fatal(&format!("failed to exec `{cmd:?}` because: {e}")));

--- a/src/tools/compiletest/src/runtest/coverage.rs
+++ b/src/tools/compiletest/src/runtest/coverage.rs
@@ -8,7 +8,7 @@ use glob::glob;
 
 use crate::common::{TestSuite, UI_COVERAGE, UI_COVERAGE_MAP};
 use crate::runtest::{Emit, ProcRes, TestCx, WillExecute};
-use crate::util::static_regex;
+use crate::util::{ArgFileCommand, static_regex};
 
 impl<'test> TestCx<'test> {
     fn coverage_dump_path(&self) -> &Utf8Path {
@@ -27,9 +27,9 @@ impl<'test> TestCx<'test> {
         }
         drop(proc_res);
 
-        let mut dump_command = Command::new(coverage_dump_path);
+        let mut dump_command = ArgFileCommand::new(coverage_dump_path);
         dump_command.arg(llvm_ir_path);
-        let proc_res = self.run_command_to_procres(&mut dump_command);
+        let proc_res = self.run_command_to_procres(dump_command);
         if !proc_res.status.success() {
             self.fatal_proc_rec("coverage-dump failed!", &proc_res);
         }
@@ -227,7 +227,11 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    fn run_llvm_tool(&self, name: &str, configure_cmd_fn: impl FnOnce(&mut Command)) -> ProcRes {
+    fn run_llvm_tool(
+        &self,
+        name: &str,
+        configure_cmd_fn: impl FnOnce(&mut ArgFileCommand),
+    ) -> ProcRes {
         let tool_path = self
             .config
             .llvm_bin_dir
@@ -235,10 +239,10 @@ impl<'test> TestCx<'test> {
             .expect("this test expects the LLVM bin dir to be available")
             .join(name);
 
-        let mut cmd = Command::new(tool_path);
+        let mut cmd = ArgFileCommand::new(tool_path);
         configure_cmd_fn(&mut cmd);
 
-        self.run_command_to_procres(&mut cmd)
+        self.run_command_to_procres(cmd)
     }
 
     fn normalize_coverage_output(&self, coverage: &str) -> Result<String, String> {

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 use super::debugger::DebuggerCommands;
 use super::{Debugger, Emit, ProcRes, TestCx, Truncated, WillExecute};
 use crate::debuggers::extract_gdb_version;
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_debuginfo_test(&self) {
@@ -468,7 +469,7 @@ impl TestCx<'_> {
         // make sure `PATH` points to all the dlls necessary to run the debugee
         let path = prepend_to_path(&self.config.target_run_lib_path);
 
-        let mut cmd = Command::new(lldb);
+        let mut cmd = ArgFileCommand::new(lldb);
         cmd.arg("--one-line")
             .arg("script --language python -- import lldb_batchmode; lldb_batchmode.main()")
             .env("LLDB_BATCHMODE_TARGET_PATH", test_executable)
@@ -477,7 +478,7 @@ impl TestCx<'_> {
             .env("PYTHONPATH", pythonpath)
             .env("PATH", path);
 
-        self.run_command_to_procres(&mut cmd)
+        self.run_command_to_procres(cmd)
     }
 }
 

--- a/src/tools/compiletest/src/runtest/js_doc.rs
+++ b/src/tools/compiletest/src/runtest/js_doc.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
 use super::{DocKind, TestCx};
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_rustdoc_js_test(&self) {
@@ -10,18 +9,18 @@ impl TestCx<'_> {
             self.document(&out_dir, DocKind::Html);
 
             let file_stem = self.testpaths.file.file_stem().expect("no file stem");
-            let res = self.run_command_to_procres(
-                Command::new(&nodejs)
-                    .arg(self.config.src_root.join("src/tools/rustdoc-js/tester.js"))
-                    .arg("--doc-folder")
-                    .arg(out_dir)
-                    .arg("--crate-name")
-                    .arg(file_stem.replace("-", "_"))
-                    .arg("--test-file")
-                    .arg(self.testpaths.file.with_extension("js"))
-                    .arg("--revision")
-                    .arg(self.revision.unwrap_or_default()),
-            );
+
+            let mut cmd = ArgFileCommand::new(&nodejs);
+            cmd.arg(self.config.src_root.join("src/tools/rustdoc-js/tester.js"))
+                .arg("--doc-folder")
+                .arg(out_dir)
+                .arg("--crate-name")
+                .arg(file_stem.replace("-", "_"))
+                .arg("--test-file")
+                .arg(self.testpaths.file.with_extension("js"))
+                .arg("--revision")
+                .arg(self.revision.unwrap_or_default());
+            let res = self.run_command_to_procres(cmd);
             if !res.status.success() {
                 self.fatal_proc_rec("rustdoc-js test failed!", &res);
             }

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
 
@@ -66,8 +67,8 @@ impl TestCx<'_> {
         // build/<target_triple>/
         // ├── bootstrap-tools/
         // │   ├── <host_triple>/release/librun_make_support.rlib   // <- support rlib itself
-        // │   ├── <host_triple>/release/deps/                      // <- deps
-        // │   └── release/deps/                                    // <- deps of deps
+        // │   ├── <host_triple>/release/build/<pkg>/<hash>/out     // <- deps
+        // │   └── release/build/<pkg>/<hash>/out                   // <- deps of deps
         // ```
         //
         // FIXME(jieyouxu): there almost certainly is a better way to do this (specifically how the
@@ -77,8 +78,8 @@ impl TestCx<'_> {
         let support_host_path = tools_bin.join(&self.config.host).join("release");
         let support_lib_path = support_host_path.join("librun_make_support.rlib");
 
-        let support_lib_deps = support_host_path.join("deps");
-        let support_lib_deps_deps = tools_bin.join("release").join("deps");
+        let support_lib_deps = discover_out_dirs(support_host_path.join("build"));
+        let support_lib_deps_deps = discover_out_dirs(tools_bin.join("release").join("build"));
 
         // To compile the recipe with rustc, we need to provide suitable dynamic library search
         // paths to rustc. This includes both:
@@ -100,6 +101,10 @@ impl TestCx<'_> {
             p
         };
 
+        let out_dirs_to_args = |paths: Vec<PathBuf>| {
+            paths.into_iter().map(|p| format!("-Ldependency={}", p.display())).collect::<Vec<_>>()
+        };
+
         // run-make-support and run-make tests are compiled using the stage0 compiler
         // If the stage is 0, then the compiler that we test (either bootstrap or an explicitly
         // set compiler) is the one that actually compiled run-make-support.
@@ -119,8 +124,8 @@ impl TestCx<'_> {
             .arg(&recipe_bin)
             // Specify library search paths for `run_make_support`.
             .arg(format!("-Ldependency={}", &support_lib_path.parent().unwrap()))
-            .arg(format!("-Ldependency={}", &support_lib_deps))
-            .arg(format!("-Ldependency={}", &support_lib_deps_deps))
+            .args(out_dirs_to_args(support_lib_deps))
+            .args(out_dirs_to_args(support_lib_deps_deps))
             // Provide `run_make_support` as extern prelude, so test writers don't need to write
             // `extern run_make_support;`.
             .arg("--extern")
@@ -336,4 +341,20 @@ impl TestCx<'_> {
             self.fatal_proc_rec("rmake recipe failed to complete", &res);
         }
     }
+}
+
+/// Gets all of the `out` dirs in a given Cargo `build-dir/<profile>/build` dir.
+fn discover_out_dirs(dir: Utf8PathBuf) -> Vec<PathBuf> {
+    let read_dir = |path: &Path| path.read_dir().ok().into_iter().flatten().filter_map(Result::ok);
+    let contents = dir
+        .read_dir()
+        .unwrap_or_else(|e| panic!("Couldn't read {}: {}", dir, e))
+        .map(|e| e.unwrap())
+        .flat_map(|e| read_dir(&e.path()))
+        .flat_map(|e| read_dir(&e.path()))
+        .map(|e| e.path())
+        .filter(|path| path.ends_with("out"))
+        .collect::<Vec<_>>();
+
+    return contents;
 }

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 
 use super::{ProcRes, TestCx, disable_error_reporting};
 use crate::common::TestSuite;
-use crate::util::{copy_dir_all, dylib_env_var};
+use crate::util::{ArgFileCommand, copy_dir_all, dylib_env_var};
 
 impl TestCx<'_> {
     pub(super) fn run_rmake_test(&self) {
@@ -113,7 +113,7 @@ impl TestCx<'_> {
             .stage0_rustc_path
             .as_ref()
             .expect("stage0 rustc is required to run run-make tests");
-        let mut rustc = Command::new(&stage0_rustc);
+        let mut rustc = ArgFileCommand::new(&stage0_rustc);
         rustc
             // `rmake.rs` **must** be buildable by a stable compiler, it may not use *any* unstable
             // library or compiler features. Here, we force the stage 0 rustc to consider itself as
@@ -139,7 +139,7 @@ impl TestCx<'_> {
         rustc.arg("-Dunused_must_use");
 
         // Now run rustc to build the recipe.
-        let res = self.run_command_to_procres(&mut rustc);
+        let res = self.run_command_to_procres(rustc);
         if !res.status.success() {
             self.fatal_proc_rec("run-make test failed: could not build `rmake.rs` recipe", &res);
         }

--- a/src/tools/compiletest/src/runtest/rustdoc.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
 use super::{DocKind, TestCx, remove_and_create_dir_all};
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_rustdoc_html_test(&self) {
@@ -19,14 +18,14 @@ impl TestCx<'_> {
         if self.props.check_test_line_numbers_match {
             self.check_rustdoc_test_option(proc_res);
         } else {
-            let mut cmd = Command::new(&self.config.python);
+            let mut cmd = ArgFileCommand::new(&self.config.python);
             cmd.arg(self.config.src_root.join("src/etc/htmldocck.py"))
                 .arg(&out_dir)
                 .arg(&self.testpaths.file);
             if self.config.bless {
                 cmd.arg("--bless");
             }
-            let res = self.run_command_to_procres(&mut cmd);
+            let res = self.run_command_to_procres(cmd);
             if !res.status.success() {
                 self.fatal_proc_rec("htmldocck failed!", &res);
             }

--- a/src/tools/compiletest/src/runtest/rustdoc_json.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc_json.rs
@@ -1,6 +1,5 @@
-use std::process::Command;
-
 use super::{DocKind, TestCx, remove_and_create_dir_all};
+use crate::util::ArgFileCommand;
 
 impl TestCx<'_> {
     pub(super) fn run_rustdoc_json_test(&self) {
@@ -23,13 +22,9 @@ impl TestCx<'_> {
             self.fatal_proc_rec("rustdoc failed!", &proc_res);
         }
 
-        let res = self.run_command_to_procres(
-            Command::new(self.config.jsondocck_path.as_ref().unwrap())
-                .arg("--doc-dir")
-                .arg(&out_dir)
-                .arg("--template")
-                .arg(&self.testpaths.file),
-        );
+        let mut cmd = ArgFileCommand::new(self.config.jsondocck_path.as_ref().unwrap());
+        cmd.arg("--doc-dir").arg(&out_dir).arg("--template").arg(&self.testpaths.file);
+        let res = self.run_command_to_procres(cmd);
 
         if !res.status.success() {
             self.fatal_proc_rec_general("jsondocck failed!", None, &res, || {
@@ -41,9 +36,9 @@ impl TestCx<'_> {
         let mut json_out = out_dir.join(self.testpaths.file.file_stem().unwrap());
         json_out.set_extension("json");
 
-        let res = self.run_command_to_procres(
-            Command::new(self.config.jsondoclint_path.as_ref().unwrap()).arg(&json_out),
-        );
+        let mut cmd = ArgFileCommand::new(self.config.jsondoclint_path.as_ref().unwrap());
+        cmd.arg(&json_out);
+        let res = self.run_command_to_procres(cmd);
 
         if !res.status.success() {
             self.fatal_proc_rec("jsondoclint failed!", &res);

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -6,6 +6,11 @@ use camino::{Utf8Path, Utf8PathBuf};
 #[cfg(test)]
 mod tests;
 
+#[path = "../../../build_helper/src/arg_file_command.rs"]
+mod arg_file_command;
+
+pub(crate) use arg_file_command::ArgFileCommand;
+
 pub(crate) fn make_new_path(path: &str) -> String {
     assert!(cfg!(windows));
     // Windows just uses PATH as the library search path, so we have to

--- a/src/tools/miri/test-cargo-miri/run-test.py
+++ b/src/tools/miri/test-cargo-miri/run-test.py
@@ -215,7 +215,7 @@ for target_dir in ["target", "custom-run", "custom-test", "config-cli"]:
     if os.listdir(target_dir) != ["miri"]:
         fail(f"`{target_dir}` contains unexpected files")
     # Ensure something exists inside that target dir.
-    os.access(os.path.join(target_dir, "miri", "debug", "deps"), os.F_OK)
+    os.access(os.path.join(target_dir, "miri", "debug"), os.F_OK)
 
 print("\nTEST SUCCESSFUL!")
 sys.exit(0)

--- a/src/tools/rustfmt/.github/workflows/linux.yml
+++ b/src/tools/rustfmt/.github/workflows/linux.yml
@@ -36,4 +36,7 @@ jobs:
         rustup target add ${{ matrix.target }}
 
     - name: Build and Test
+      env:
+        RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: ./ci/build_and_test.sh

--- a/src/tools/rustfmt/.github/workflows/mac.yml
+++ b/src/tools/rustfmt/.github/workflows/mac.yml
@@ -32,4 +32,7 @@ jobs:
         rustup target add ${{ matrix.target }}
 
     - name: Build and Test
+      env:
+        RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: ./ci/build_and_test.sh

--- a/src/tools/rustfmt/.github/workflows/windows.yml
+++ b/src/tools/rustfmt/.github/workflows/windows.yml
@@ -59,4 +59,7 @@ jobs:
 
     - name: Build and Test
       shell: cmd
+      env:
+        RUSTFLAGS: -D warnings
+        CARGO_UNSTABLE_BUILD_DIR_NEW_LAYOUT: true
       run: ci\build_and_test.bat

--- a/src/tools/rustfmt/src/test/mod.rs
+++ b/src/tools/rustfmt/src/test/mod.rs
@@ -1077,8 +1077,23 @@ fn rustfmt() -> PathBuf {
     let mut me = env::current_exe().expect("failed to get current executable");
     // Chop of the test name.
     me.pop();
-    // Chop off `deps`.
-    me.pop();
+
+    // Handle Cargo's old and new filesystem layouts
+    // * v1: `target/<profile>/deps/test-bin-[HASH][EXE]`
+    // * v2: `target/<profile>/build/<pkgname>/[HASH]/out/test-bin-[HASH][EXE]`
+    if me.ends_with("deps") {
+        // Chop off `deps`.
+        me.pop();
+    } else if me.ends_with("out") {
+        // Chop off `out`.
+        me.pop();
+        // Chop off `<hash>`.
+        me.pop();
+        // Chop off `<pkgname>`.
+        me.pop();
+        // Chop off `build`.
+        me.pop();
+    }
 
     me.push("rustfmt");
     assert!(

--- a/src/tools/rustfmt/tests/cargo-fmt/main.rs
+++ b/src/tools/rustfmt/tests/cargo-fmt/main.rs
@@ -10,8 +10,17 @@ use rustfmt_config_proc_macro::rustfmt_only_ci_test;
 fn cargo_fmt(args: &[&str]) -> (String, String) {
     let mut bin_dir = env::current_exe().unwrap();
     bin_dir.pop(); // chop off test exe name
+
+    // Handle Cargo's old and new filesystem layouts
+    // * v1: `target/<profile>/deps/test-bin-[HASH][EXE]`
+    // * v2: `target/<profile>/build/<pkgname>/[HASH]/out/test-bin-[HASH][EXE]`
     if bin_dir.ends_with("deps") {
         bin_dir.pop();
+    } else if bin_dir.ends_with("out") {
+        bin_dir.pop(); // chop off `out`
+        bin_dir.pop(); // chop off `<hash>`
+        bin_dir.pop(); // chop off `<pkgname>`
+        bin_dir.pop(); // chop off `build`
     }
     let cmd = bin_dir.join(format!("cargo-fmt{}", env::consts::EXE_SUFFIX));
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155439)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR enables the new Cargo `build-dir` layout in boostrap builds with `-Zbuild-dir-new-layout`.


See: [#t-infra/bootstrap > Has anyone tested &#96;./x&#96; with the new build-dir layout?](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Has.20anyone.20tested.20.60.2E.2Fx.60.20with.20the.20new.20build-dir.20layout.3F/with/581660716)


Tracked in: https://github.com/rust-lang/cargo/issues/15010


r? @bjorn3 

cc: @epage 

