### PR TITLE
Experiment: Remove overflow checks from hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ exclude = [
 # FIXME: This workaround should be removed once #90227 is fixed.
 overflow-checks = false
 
+[profile.release.package.hashbrown]
+overflow-checks = false
+
 # These are very thin wrappers around executing lld with the right binary name.
 # Basically nothing within them can go wrong without having been explicitly logged anyway.
 # We ship these in every rustc tarball and even after compression they add up


### PR DESCRIPTION
Hashbrown is one of the most established crates there, which I don't think requires overflow checks. Rustc has a lot of hash tables, so maybe we could expect some performance benefits by disabling those checks?

r? @petrochenkov 