### PR TITLE
Remove unnecessary safety conditions related to unchecked uint arithmetic

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -866,7 +866,7 @@ macro_rules! uint_impl {
         /// # Safety
         ///
         /// This results in undefined behavior when
-        #[doc = concat!("`self + rhs > ", stringify!($SelfT), "::MAX` or `self + rhs < ", stringify!($SelfT), "::MIN`,")]
+        #[doc = concat!("`self + rhs > ", stringify!($SelfT), "::MAX`,")]
         /// i.e. when [`checked_add`] would return `None`.
         ///
         /// [`unwrap_unchecked`]: option/enum.Option.html#method.unwrap_unchecked
@@ -1045,7 +1045,7 @@ macro_rules! uint_impl {
         /// # Safety
         ///
         /// This results in undefined behavior when
-        #[doc = concat!("`self - rhs > ", stringify!($SelfT), "::MAX` or `self - rhs < ", stringify!($SelfT), "::MIN`,")]
+        #[doc = concat!("`self - rhs < ", stringify!($SelfT), "::MIN`,")]
         /// i.e. when [`checked_sub`] would return `None`.
         ///
         /// [`unwrap_unchecked`]: option/enum.Option.html#method.unwrap_unchecked
@@ -1254,7 +1254,7 @@ macro_rules! uint_impl {
         /// # Safety
         ///
         /// This results in undefined behavior when
-        #[doc = concat!("`self * rhs > ", stringify!($SelfT), "::MAX` or `self * rhs < ", stringify!($SelfT), "::MIN`,")]
+        #[doc = concat!("`self * rhs > ", stringify!($SelfT), "::MAX`,")]
         /// i.e. when [`checked_mul`] would return `None`.
         ///
         /// [`unwrap_unchecked`]: option/enum.Option.html#method.unwrap_unchecked


### PR DESCRIPTION
Improve the safety documentation of three unsafe APIs related to unsigned integer arithmetic.

- [unchecked_add](https://doc.rust-lang.org/nightly/core/primitive.usize.html#method.unchecked_add): It is impossible for `self + rhs < usize::MIN`.
- [unchecked_sub](https://doc.rust-lang.org/nightly/core/primitive.usize.html#method.unchecked_sub): It is impossible for `self - rhs > usize::MAX`.
- [unchecked_mul](https://doc.rust-lang.org/nightly/core/primitive.usize.html#method.unchecked_mul): It is impossible for `self * rhs < usize::MIN`.

The examples use `usize` for demonstration. All unsigned integer types suffer from the same issue because their APIs are generated by the same macro `uint_impl`, and fixing the macro documentation will fix them all.