### PR TITLE
docs: Fix typo in std/src/thready/scoped.rs

### DIFF
--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -177,7 +177,7 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// Spawns a new thread within a scope, returning a [`ScopedJoinHandle`] for it.
     ///
     /// Unlike non-scoped threads, threads spawned with this function may
-    /// borrow non-`'static` data from the outside the scope. See [`scope`] for
+    /// borrow non-`'static` data from outside the scope. See [`scope`] for
     /// details.
     ///
     /// The join handle provides a [`join`] method that can be used to join the spawned


### PR DESCRIPTION
# Fix typo in std/src/thread/scoped.rs

## Why this pr

This PR closes rust-lang/rust#155275 fixing the mentioned typo.

I know this was originally fixed in rust-lang/rust#155325 and then in rust-lang/rust#155328.

But since the first issue was closed due to some ai slop and the second one was closed because the first one was already opened, it seems to me that this PR is still needed.

## What this pr does

This PR "just" fixes a typo inside the `std/src/thread/scoped.rs` file

Changing the comment from this:

```
/// borrow non-`'static` data from the outside the scope. See [`scope`] for
/// details.
``` 

to this:

```
/// borrow non-`'static` data from outside the scope. See [`scope`] for
/// details.
``` 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
