### PR TITLE
Rename incremental `cfail`/`cpass` revisions to `bfail`/`bpass`

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/compiletest.md
+++ b/src/doc/rustc-dev-guide/src/tests/compiletest.md
@@ -158,8 +158,8 @@ then runs the compiler for each revision, reusing the incremental results from p
 
 The revisions should start with:
 
-* `cfail` — the test should fail to compile
-* `cpass` — the test should compile successully
+* `bfail` — the test should fail to compile
+* `bpass` — the test should compile successully
 * `rpass` — the test should compile and run successfully
 
 To make the revisions unique, you should add a suffix like `rpass1` and `rpass2`.

--- a/src/doc/rustc-dev-guide/src/tests/compiletest.md
+++ b/src/doc/rustc-dev-guide/src/tests/compiletest.md
@@ -185,7 +185,7 @@ fn foo() {
 fn main() { foo(); }
 ```
 
-`cfail` tests support the `forbid-output` directive to specify that a certain
+Incremental tests support the `forbid-output` directive to specify that a certain
 substring must not appear anywhere in the compiler output.
 This can be useful to ensure certain errors do not appear, but this can be fragile as error messages
 change over time, and a test may no longer be checking the right thing but will still pass.

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -106,7 +106,7 @@ comparison](ui.md#output-comparison) and [Rustfix tests](ui.md#rustfix-tests) fo
 | `exec-env`                        | Env var to set when executing a test                                                                                     | `ui`, `crashes`                              | `<KEY>=<VALUE>`                                                                         |
 | `unset-exec-env`                  | Env var to unset when executing a test                                                                                   | `ui`, `crashes`                              | Any env var name                                                                        |
 | `stderr-per-bitwidth`             | Generate a stderr snapshot for each bitwidth                                                                             | `ui`                                         | N/A                                                                                     |
-| `forbid-output`                   | A pattern which must not appear in stderr/`cfail` output                                                                 | `ui`, `incremental`                          | Regex pattern                                                                           |
+| `forbid-output`                   | Check that compile/run output does not contain a specific string                                                         | `ui`, `incremental`                          | String                                                                                  |
 | `run-flags`                       | Flags passed to the test executable                                                                                      | `ui`                                         | Arbitrary flags                                                                         |
 | `known-bug`                       | No error annotation needed due to known bug                                                                              | `ui`, `crashes`, `incremental`               | Issue number `#123456`                                                                  |
 | `compare-output-by-lines`         | Compare the output by lines, rather than as a single string                                                              | All                                          | N/A                                                                                     |
@@ -315,8 +315,7 @@ See [Pretty-printer](compiletest.md#pretty-printer-tests).
 
 - `no-auto-check-cfg` — disable auto check-cfg (only for `--check-cfg` tests)
 - [`revisions`](compiletest.md#revisions) — compile multiple times
--[`forbid-output`](compiletest.md#incremental-tests) — incremental cfail rejects
-      output pattern
+- [`forbid-output`](compiletest.md#incremental-tests) — check that output does not contain a specified string
 - [`reference`] — an annotation linking to a rule in the reference
 - `disable-gdb-pretty-printers` — disable gdb pretty printers for debuginfo tests
 

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -442,8 +442,8 @@ impl TestProps {
             (TestMode::Incremental, _) => {
                 // FIXME(Zalathar): This only detects forbidden directives that are
                 // declared _after_ the incompatible `//@ revisions:` directive(s).
-                if self.revisions.iter().any(|r| !r.starts_with("cfail")) {
-                    panic!("`{s}` directive is only supported in `cfail` incremental tests")
+                if self.revisions.iter().any(|r| !r.starts_with("bfail")) {
+                    panic!("`{s}` directive is only supported in `bfail` incremental tests")
                 }
             }
             (mode, _) => panic!("`{s}` directive is not supported in `{mode}` tests"),

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -135,7 +135,7 @@ pub(crate) struct TestProps {
     pub(crate) pretty_mode: String,
     // Only compare pretty output and don't try compiling
     pub(crate) pretty_compare_only: bool,
-    // Patterns which must not appear in the output of a cfail test.
+    /// Strings that must not appear in compile/run output.
     pub(crate) forbid_output: Vec<String>,
     // Revisions to test for incremental compilation.
     pub(crate) revisions: Vec<String>,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -327,12 +327,12 @@ impl<'test> TestCx<'test> {
             TestMode::Incremental => {
                 let revision =
                     self.revision.expect("incremental tests require a list of revisions");
-                if revision.starts_with("cpass") || revision.starts_with("rpass") {
+                if revision.starts_with("bpass") || revision.starts_with("rpass") {
                     true
-                } else if revision.starts_with("cfail") {
+                } else if revision.starts_with("bfail") {
                     pm.is_some()
                 } else {
-                    panic!("revision name must begin with `cfail`, `cpass`, or `rpass`");
+                    panic!("revision name must begin with `bfail`, `bpass`, or `rpass`");
                 }
             }
             mode => panic!("unimplemented for mode {:?}", mode),

--- a/src/tools/compiletest/src/runtest/incremental.rs
+++ b/src/tools/compiletest/src/runtest/incremental.rs
@@ -3,17 +3,17 @@ use super::{FailMode, ProcRes, TestCx, WillExecute};
 impl TestCx<'_> {
     pub(super) fn run_incremental_test(&self) {
         // Basic plan for a test incremental/foo/bar.rs:
-        // - load list of revisions rpass1, cfail2, rpass3
-        //   - each should begin with `cfail`, `cpass`, or `rpass`
-        //   - if `cpass`, expect compilation to succeed, don't execute
+        // - load list of revisions rpass1, bfail2, rpass3
+        //   - each should begin with `bfail`, `bpass`, or `rpass`
+        //   - if `bfail`, expect compilation to fail
+        //   - if `bpass`, expect compilation to succeed, don't execute
         //   - if `rpass`, expect compilation and execution to succeed
-        //   - if `cfail`, expect compilation to fail
         // - create a directory build/foo/bar.incremental
         // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C rpass1
         //   - because name of revision starts with "rpass", expect success
-        // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C cfail2
-        //   - because name of revision starts with "cfail", expect an error
-        //   - load expected errors as usual, but filter for those with `[cfail2]`
+        // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C bfail2
+        //   - because name of revision starts with "bfail", expect an error
+        //   - load expected errors as usual, but filter for those with `[bfail2]`
         // - compile foo/bar.rs with -C incremental=.../foo/bar.incremental and -C rpass3
         //   - because name of revision starts with "rpass", expect success
         // - execute build/foo/bar.exe and save output
@@ -31,18 +31,18 @@ impl TestCx<'_> {
             write!(self.stdout, "revision={:?} props={:#?}", revision, self.props);
         }
 
-        if revision.starts_with("cpass") {
-            self.run_cpass_test();
+        if revision.starts_with("bpass") {
+            self.run_bpass_test();
         } else if revision.starts_with("rpass") {
             self.run_rpass_test();
-        } else if revision.starts_with("cfail") {
-            self.run_cfail_test();
+        } else if revision.starts_with("bfail") {
+            self.run_bfail_test();
         } else {
-            self.fatal("revision name must begin with `cfail`, `cpass`, or `rpass`");
+            self.fatal("revision name must begin with `bfail`, `bpass`, or `rpass`");
         }
     }
 
-    fn run_cpass_test(&self) {
+    fn run_bpass_test(&self) {
         let emit_metadata = self.should_emit_metadata(self.pass_mode());
         let proc_res = self.compile_test(WillExecute::No, emit_metadata);
 
@@ -74,7 +74,7 @@ impl TestCx<'_> {
         }
     }
 
-    fn run_cfail_test(&self) {
+    fn run_bfail_test(&self) {
         let pm = self.pass_mode();
         let proc_res = self.compile_test(WillExecute::No, self.should_emit_metadata(pm));
         self.check_if_test_should_compile(Some(FailMode::Build), pm, &proc_res);

--- a/tests/incremental/add_private_fn_at_krate_root_cc/struct_point.rs
+++ b/tests/incremental/add_private_fn_at_krate_root_cc/struct_point.rs
@@ -2,7 +2,7 @@
 // crate. This should not cause anything we use to be invalidated.
 // Regression test for #36168.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ aux-build:point.rs
 //@ build-pass
@@ -12,11 +12,11 @@
 #![allow(dead_code)]
 #![crate_type = "rlib"]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_calls_free_fn", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_free_fn", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
 
 extern crate point;
 
@@ -24,7 +24,7 @@ extern crate point;
 pub mod fn_calls_methods_in_same_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();
@@ -35,7 +35,7 @@ pub mod fn_calls_methods_in_same_impl {
 pub mod fn_calls_free_fn {
     use point::{self, Point};
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         point::distance_squared(&x);
@@ -46,7 +46,7 @@ pub mod fn_calls_free_fn {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -56,7 +56,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -66,7 +66,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/auxiliary/incremental_proc_macro_aux.rs
+++ b/tests/incremental/auxiliary/incremental_proc_macro_aux.rs
@@ -3,12 +3,12 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 // Add a function to shift DefIndex of registrar function
-#[cfg(cfail2)]
+#[cfg(bfail2)]
 fn foo() {}
 
 #[proc_macro_derive(IncrementalMacro)]
 pub fn derive(input: TokenStream) -> TokenStream {
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     {
         foo();
     }

--- a/tests/incremental/cache-lint-expectation.rs
+++ b/tests/incremental/cache-lint-expectation.rs
@@ -1,5 +1,5 @@
 // Regression test for #154878
-//@ revisions: cpass1 cpass2
+//@ revisions: bpass1 bpass2
 
 pub fn main() {
     let x = 42.0;

--- a/tests/incremental/change_add_field/struct_point.rs
+++ b/tests/incremental/change_add_field/struct_point.rs
@@ -3,7 +3,7 @@
 // Fns with that type used only in their body are also recompiled, but
 // their callers are not.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ build-pass
 //@ ignore-backends: gcc
@@ -13,24 +13,24 @@
 #![crate_type = "rlib"]
 
 // These are expected to require codegen.
-#![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-fn_with_type_in_sig", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-call_fn_with_type_in_sig", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-fn_with_type_in_body", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-fn_make_struct", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-fn_write_field", cfg="cfail2")]
+#![rustc_partition_codegened(module="struct_point-point", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-fn_with_type_in_sig", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-call_fn_with_type_in_sig", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-fn_with_type_in_body", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-fn_make_struct", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-fn_write_field", cfg="bfail2")]
 
-#![rustc_partition_reused(module="struct_point-call_fn_with_type_in_body", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-call_fn_with_type_in_body", cfg="bfail2")]
 
 pub mod point {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub struct Point {
         pub x: f32,
         pub y: f32,
     }
 
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     pub struct Point {
         pub x: f32,
         pub y: f32,
@@ -39,18 +39,18 @@ pub mod point {
 
     impl Point {
         pub fn origin() -> Point {
-            #[cfg(cfail1)]
+            #[cfg(bfail1)]
             return Point { x: 0.0, y: 0.0 };
 
-            #[cfg(cfail2)]
+            #[cfg(bfail2)]
             return Point { x: 0.0, y: 0.0, z: 0.0 };
         }
 
         pub fn total(&self) -> f32 {
-            #[cfg(cfail1)]
+            #[cfg(bfail1)]
             return self.x + self.y;
 
-            #[cfg(cfail2)]
+            #[cfg(bfail2)]
             return self.x + self.y + self.z;
         }
 
@@ -70,7 +70,7 @@ pub mod point {
 pub mod fn_with_type_in_sig {
     use point::Point;
 
-    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="bfail2")]
     pub fn boop(p: Option<&Point>) -> f32 {
         p.map(|p| p.total()).unwrap_or(0.0)
     }
@@ -86,7 +86,7 @@ pub mod fn_with_type_in_sig {
 pub mod call_fn_with_type_in_sig {
     use fn_with_type_in_sig;
 
-    #[rustc_clean(except="typeck_root,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,optimized_mir", cfg="bfail2")]
     pub fn bip() -> f32 {
         fn_with_type_in_sig::boop(None)
     }
@@ -102,7 +102,7 @@ pub mod call_fn_with_type_in_sig {
 pub mod fn_with_type_in_body {
     use point::Point;
 
-    #[rustc_clean(except="typeck_root,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,optimized_mir", cfg="bfail2")]
     pub fn boop() -> f32 {
         Point::origin().total()
     }
@@ -115,7 +115,7 @@ pub mod fn_with_type_in_body {
 pub mod call_fn_with_type_in_body {
     use fn_with_type_in_body;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn bip() -> f32 {
         fn_with_type_in_body::boop()
     }
@@ -125,7 +125,7 @@ pub mod call_fn_with_type_in_body {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="bfail2")]
     pub fn make_origin(p: Point) -> Point {
         Point { ..p }
     }
@@ -135,7 +135,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -145,7 +145,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,fn_sig,optimized_mir", cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_crate_dep_kind.rs
+++ b/tests/incremental/change_crate_dep_kind.rs
@@ -2,16 +2,16 @@
 // detected then -Zincremental-verify-ich will trigger an assertion.
 
 //@ needs-unwind
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph -Cpanic=unwind
 //@ needs-unwind
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
 
-#![cfg_attr(cfail1, feature(panic_unwind))]
+#![cfg_attr(bfail1, feature(panic_unwind))]
 
 // Turn the panic_unwind crate from an explicit into an implicit query:
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 extern crate panic_unwind;
 
 fn main() {}

--- a/tests/incremental/change_private_fn/struct_point.rs
+++ b/tests/incremental/change_private_fn/struct_point.rs
@@ -1,7 +1,7 @@
 // Test where we change the body of a private method in an impl.
 // We then test what sort of functions must be rebuilt as a result.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
@@ -10,13 +10,13 @@
 #![allow(dead_code)]
 #![crate_type = "rlib"]
 
-#![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
+#![rustc_partition_codegened(module="struct_point-point", cfg="bfail2")]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
 
 pub mod point {
     pub struct Point {
@@ -25,10 +25,10 @@ pub mod point {
     }
 
     fn distance_squared(this: &Point) -> f32 {
-        #[cfg(cfail1)]
+        #[cfg(bfail1)]
         return this.x + this.y;
 
-        #[cfg(cfail2)]
+        #[cfg(bfail2)]
         return this.x * this.x + this.y * this.y;
     }
 
@@ -55,7 +55,7 @@ pub mod fn_calls_methods_in_same_impl {
     // (not just marked green) - for example, `DeadVisitor`
     // always runs during compilation as a "pass", and loads
     // the typeck_root results for bodies.
-    #[rustc_clean(cfg="cfail2", loaded_from_disk="typeck_root")]
+    #[rustc_clean(cfg="bfail2", loaded_from_disk="typeck_root")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();
@@ -66,7 +66,7 @@ pub mod fn_calls_methods_in_same_impl {
 pub mod fn_calls_methods_in_another_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let mut x = Point { x: 2.0, y: 2.0 };
         x.translate(3.0, 3.0);
@@ -77,7 +77,7 @@ pub mod fn_calls_methods_in_another_impl {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -87,7 +87,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -97,7 +97,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_private_fn_cc/auxiliary/point.rs
+++ b/tests/incremental/change_private_fn_cc/auxiliary/point.rs
@@ -4,10 +4,10 @@ pub struct Point {
 }
 
 fn distance_squared(this: &Point) -> f32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     return this.x + this.y;
 
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     return this.x * this.x + this.y * this.y;
 }
 

--- a/tests/incremental/change_private_fn_cc/struct_point.rs
+++ b/tests/incremental/change_private_fn_cc/struct_point.rs
@@ -1,7 +1,7 @@
 // Test where we change the body of a private method in an impl.
 // We then test what sort of functions must be rebuilt as a result.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ aux-build:point.rs
 //@ build-pass (FIXME(62277): could be check-pass?)
@@ -11,11 +11,11 @@
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
 
 extern crate point;
 
@@ -23,7 +23,7 @@ extern crate point;
 pub mod fn_calls_methods_in_same_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();
@@ -34,7 +34,7 @@ pub mod fn_calls_methods_in_same_impl {
 pub mod fn_calls_methods_in_another_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let mut x = Point { x: 2.0, y: 2.0 };
         x.translate(3.0, 3.0);
@@ -45,7 +45,7 @@ pub mod fn_calls_methods_in_another_impl {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -55,7 +55,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -65,7 +65,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_private_impl_method/struct_point.rs
+++ b/tests/incremental/change_private_impl_method/struct_point.rs
@@ -1,7 +1,7 @@
 // Test where we change the body of a private method in an impl.
 // We then test what sort of functions must be rebuilt as a result.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ build-pass
 //@ ignore-backends: gcc
@@ -10,13 +10,13 @@
 #![allow(dead_code)]
 #![crate_type = "rlib"]
 
-#![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
+#![rustc_partition_codegened(module="struct_point-point", cfg="bfail2")]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
 
 pub mod point {
     pub struct Point {
@@ -26,10 +26,10 @@ pub mod point {
 
     impl Point {
         pub fn distance_squared(&self) -> f32 {
-            #[cfg(cfail1)]
+            #[cfg(bfail1)]
             return self.x + self.y;
 
-            #[cfg(cfail2)]
+            #[cfg(bfail2)]
             return self.x * self.x + self.y * self.y;
         }
 
@@ -51,7 +51,7 @@ pub mod point {
 pub mod fn_calls_methods_in_same_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();
@@ -62,7 +62,7 @@ pub mod fn_calls_methods_in_same_impl {
 pub mod fn_calls_methods_in_another_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let mut x = Point { x: 2.0, y: 2.0 };
         x.translate(3.0, 3.0);
@@ -73,7 +73,7 @@ pub mod fn_calls_methods_in_another_impl {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -83,7 +83,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -93,7 +93,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_private_impl_method_cc/auxiliary/point.rs
+++ b/tests/incremental/change_private_impl_method_cc/auxiliary/point.rs
@@ -5,10 +5,10 @@ pub struct Point {
 
 impl Point {
     fn distance_squared(&self) -> f32 {
-        #[cfg(cfail1)]
+        #[cfg(bfail1)]
         return self.x + self.y;
 
-        #[cfg(cfail2)]
+        #[cfg(bfail2)]
         return self.x * self.x + self.y * self.y;
     }
 

--- a/tests/incremental/change_private_impl_method_cc/struct_point.rs
+++ b/tests/incremental/change_private_impl_method_cc/struct_point.rs
@@ -1,7 +1,7 @@
 // Test where we change the body of a private method in an impl.
 // We then test what sort of functions must be rebuilt as a result.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ aux-build:point.rs
 //@ build-pass (FIXME(62277): could be check-pass?)
@@ -11,12 +11,12 @@
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_same_impl", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_methods_in_another_impl", cfg="bfail2")]
 
 extern crate point;
 
@@ -24,7 +24,7 @@ extern crate point;
 pub mod fn_calls_methods_in_same_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let x = Point { x: 2.0, y: 2.0 };
         x.distance_from_origin();
@@ -35,7 +35,7 @@ pub mod fn_calls_methods_in_same_impl {
 pub mod fn_calls_methods_in_another_impl {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn dirty() {
         let mut x = Point { x: 2.0, y: 2.0 };
         x.translate(3.0, 3.0);
@@ -46,7 +46,7 @@ pub mod fn_calls_methods_in_another_impl {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -56,7 +56,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -66,7 +66,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_pub_inherent_method_body/struct_point.rs
+++ b/tests/incremental/change_pub_inherent_method_body/struct_point.rs
@@ -1,6 +1,6 @@
 // Test where we change the body of a public, inherent method.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ build-pass
 //@ ignore-backends: gcc
@@ -9,13 +9,13 @@
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 
-#![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
+#![rustc_partition_codegened(module="struct_point-point", cfg="bfail2")]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_changed_method", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_calls_another_method", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_changed_method", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_another_method", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
 
 pub mod point {
     pub struct Point {
@@ -25,10 +25,10 @@ pub mod point {
 
     impl Point {
         pub fn distance_from_origin(&self) -> f32 {
-            #[cfg(cfail1)]
+            #[cfg(bfail1)]
             return self.x * self.x + self.y * self.y;
 
-            #[cfg(cfail2)]
+            #[cfg(bfail2)]
             return (self.x * self.x + self.y * self.y).sqrt();
         }
 
@@ -42,7 +42,7 @@ pub mod point {
 pub mod fn_calls_changed_method {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let p = Point { x: 2.0, y: 2.0 };
         p.distance_from_origin();
@@ -53,7 +53,7 @@ pub mod fn_calls_changed_method {
 pub mod fn_calls_another_method {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let p = Point { x: 2.0, y: 2.0 };
         p.x();
@@ -64,7 +64,7 @@ pub mod fn_calls_another_method {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -74,7 +74,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -84,7 +84,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/tests/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -1,6 +1,6 @@
 // Test where we change the *signature* of a public, inherent method.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ build-pass
 //@ ignore-backends: gcc
@@ -10,13 +10,13 @@
 #![allow(dead_code)]
 
 // These are expected to require codegen.
-#![rustc_partition_codegened(module="struct_point-point", cfg="cfail2")]
-#![rustc_partition_codegened(module="struct_point-fn_calls_changed_method", cfg="cfail2")]
+#![rustc_partition_codegened(module="struct_point-point", cfg="bfail2")]
+#![rustc_partition_codegened(module="struct_point-fn_calls_changed_method", cfg="bfail2")]
 
-#![rustc_partition_reused(module="struct_point-fn_calls_another_method", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="cfail2")]
-#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="cfail2")]
+#![rustc_partition_reused(module="struct_point-fn_calls_another_method", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_make_struct", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_read_field", cfg="bfail2")]
+#![rustc_partition_reused(module="struct_point-fn_write_field", cfg="bfail2")]
 
 pub mod point {
     pub struct Point {
@@ -25,7 +25,7 @@ pub mod point {
     }
 
     impl Point {
-        #[cfg(cfail1)]
+        #[cfg(bfail1)]
         pub fn distance_from_point(&self, p: Option<Point>) -> f32 {
             let p = p.unwrap_or(Point { x: 0.0, y: 0.0 });
             let x_diff = self.x - p.x;
@@ -33,7 +33,7 @@ pub mod point {
             return x_diff * x_diff + y_diff * y_diff;
         }
 
-        #[cfg(cfail2)]
+        #[cfg(bfail2)]
         pub fn distance_from_point(&self, p: Option<&Point>) -> f32 {
             const ORIGIN: &Point = &Point { x: 0.0, y: 0.0 };
             let p = p.unwrap_or(ORIGIN);
@@ -52,7 +52,7 @@ pub mod point {
 pub mod fn_calls_changed_method {
     use point::Point;
 
-    #[rustc_clean(except="typeck_root,optimized_mir", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root,optimized_mir", cfg="bfail2")]
     pub fn check() {
         let p = Point { x: 2.0, y: 2.0 };
         p.distance_from_point(None);
@@ -63,7 +63,7 @@ pub mod fn_calls_changed_method {
 pub mod fn_calls_another_method {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn check() {
         let p = Point { x: 2.0, y: 2.0 };
         p.x();
@@ -74,7 +74,7 @@ pub mod fn_calls_another_method {
 pub mod fn_make_struct {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn make_origin() -> Point {
         Point { x: 2.0, y: 2.0 }
     }
@@ -84,7 +84,7 @@ pub mod fn_make_struct {
 pub mod fn_read_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn get_x(p: Point) -> f32 {
         p.x
     }
@@ -94,7 +94,7 @@ pub mod fn_read_field {
 pub mod fn_write_field {
     use point::Point;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="bfail2")]
     pub fn inc_x(p: &mut Point) {
         p.x += 1.0;
     }

--- a/tests/incremental/circular-dependencies.rs
+++ b/tests/incremental/circular-dependencies.rs
@@ -1,20 +1,20 @@
 // ignore-tidy-linelength
-//@ revisions: cpass1 cfail2
+//@ revisions: bpass1 bfail2
 //@ edition: 2021
-//@ [cpass1] compile-flags: --crate-type lib --emit dep-info,metadata
-//@ [cfail2] aux-build: circular-dependencies-aux.rs
-//@ [cfail2] compile-flags: --test --extern aux={{build-base}}/circular-dependencies/auxiliary/libcircular_dependencies_aux.rmeta -L dependency={{build-base}}/circular-dependencies
+//@ [bpass1] compile-flags: --crate-type lib --emit dep-info,metadata
+//@ [bfail2] aux-build: circular-dependencies-aux.rs
+//@ [bfail2] compile-flags: --test --extern aux={{build-base}}/circular-dependencies/auxiliary/libcircular_dependencies_aux.rmeta -L dependency={{build-base}}/circular-dependencies
 
 pub struct Foo;
-//[cfail2]~^ NOTE there are multiple different versions of crate `circular_dependencies` in the dependency graph
-//[cfail2]~| NOTE there are multiple different versions of crate `circular_dependencies` in the dependency graph
-//[cfail2]~| NOTE this is the expected type
-//[cfail2]~| NOTE this is the expected type
-//[cfail2]~| NOTE this is the found type
-//[cfail2]~| NOTE this is the found type
+//[bfail2]~^ NOTE there are multiple different versions of crate `circular_dependencies` in the dependency graph
+//[bfail2]~| NOTE there are multiple different versions of crate `circular_dependencies` in the dependency graph
+//[bfail2]~| NOTE this is the expected type
+//[bfail2]~| NOTE this is the expected type
+//[bfail2]~| NOTE this is the found type
+//[bfail2]~| NOTE this is the found type
 
 pub fn consume_foo(_: Foo) {}
-//[cfail2]~^ NOTE function defined here
+//[bfail2]~^ NOTE function defined here
 
 pub fn produce_foo() -> Foo {
     Foo
@@ -23,13 +23,13 @@ pub fn produce_foo() -> Foo {
 #[test]
 fn test() {
     aux::consume_foo(produce_foo());
-    //[cfail2]~^ ERROR mismatched types [E0308]
-    //[cfail2]~| NOTE expected `circular_dependencies::Foo`, found `Foo`
-    //[cfail2]~| NOTE arguments to this function are incorrect
-    //[cfail2]~| NOTE function defined here
+    //[bfail2]~^ ERROR mismatched types [E0308]
+    //[bfail2]~| NOTE expected `circular_dependencies::Foo`, found `Foo`
+    //[bfail2]~| NOTE arguments to this function are incorrect
+    //[bfail2]~| NOTE function defined here
 
     consume_foo(aux::produce_foo());
-    //[cfail2]~^ ERROR mismatched types [E0308]
-    //[cfail2]~| NOTE expected `Foo`, found `circular_dependencies::Foo`
-    //[cfail2]~| NOTE arguments to this function are incorrect
+    //[bfail2]~^ ERROR mismatched types [E0308]
+    //[bfail2]~| NOTE expected `Foo`, found `circular_dependencies::Foo`
+    //[bfail2]~| NOTE arguments to this function are incorrect
 }

--- a/tests/incremental/clean.rs
+++ b/tests/incremental/clean.rs
@@ -1,4 +1,4 @@
-//@ revisions: rpass1 cfail2
+//@ revisions: rpass1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ ignore-backends: gcc
 
@@ -17,7 +17,7 @@ mod x {
         22
     }
 
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     pub fn x() -> u32 {
         22
     }
@@ -28,22 +28,22 @@ mod y {
 
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig",
-        cfg="cfail2",
+        cfg="bfail2",
     )]
     pub fn y() {
-        //[cfail2]~^ ERROR `opt_hir_owner_nodes(y)` should be dirty but is not
-        //[cfail2]~| ERROR `generics_of(y)` should be dirty but is not
-        //[cfail2]~| ERROR `predicates_of(y)` should be dirty but is not
-        //[cfail2]~| ERROR `type_of(y)` should be dirty but is not
-        //[cfail2]~| ERROR `fn_sig(y)` should be dirty but is not
-        //[cfail2]~| ERROR `typeck_root(y)` should be clean but is not
+        //[bfail2]~^ ERROR `opt_hir_owner_nodes(y)` should be dirty but is not
+        //[bfail2]~| ERROR `generics_of(y)` should be dirty but is not
+        //[bfail2]~| ERROR `predicates_of(y)` should be dirty but is not
+        //[bfail2]~| ERROR `type_of(y)` should be dirty but is not
+        //[bfail2]~| ERROR `fn_sig(y)` should be dirty but is not
+        //[bfail2]~| ERROR `typeck_root(y)` should be clean but is not
         x::x();
     }
 }
 
 mod z {
-    #[rustc_clean(except="typeck_root", cfg="cfail2")]
+    #[rustc_clean(except="typeck_root", cfg="bfail2")]
     pub fn z() {
-        //[cfail2]~^ ERROR `typeck_root(z)` should be dirty but is not
+        //[bfail2]~^ ERROR `typeck_root(z)` should be dirty but is not
     }
 }

--- a/tests/incremental/const-generic-type-cycle.rs
+++ b/tests/incremental/const-generic-type-cycle.rs
@@ -2,16 +2,16 @@
 // cycle.
 //
 //@ compile-flags: -Zincremental-ignore-spans
-//@ revisions: cpass cfail
+//@ revisions: bpass bfail
 
 #![feature(trait_alias)]
 #![crate_type="lib"]
 
-#[cfg(cpass)]
+#[cfg(bpass)]
 trait Bar<const N: usize> {}
 
-#[cfg(cfail)]
+#[cfg(bfail)]
 trait Bar<const N: dyn BB> {}
-//[cfail]~^ ERROR cycle detected when computing type of `Bar::N`
+//[bfail]~^ ERROR cycle detected when computing type of `Bar::N`
 
 trait BB = Bar<{ 2 + 1 }>;

--- a/tests/incremental/const-generics/hash-tyvid-regression-1.rs
+++ b/tests/incremental/const-generics/hash-tyvid-regression-1.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail
+//@ revisions: bfail
 #![feature(generic_const_exprs, adt_const_params)]
 #![allow(incomplete_features)]
 

--- a/tests/incremental/const-generics/hash-tyvid-regression-2.rs
+++ b/tests/incremental/const-generics/hash-tyvid-regression-2.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail
+//@ revisions: bfail
 #![feature(generic_const_exprs, adt_const_params)]
 #![allow(incomplete_features)]
 

--- a/tests/incremental/const-generics/hash-tyvid-regression-3.rs
+++ b/tests/incremental/const-generics/hash-tyvid-regression-3.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail
+//@ revisions: bfail
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 // regression test for #79251

--- a/tests/incremental/const-generics/hash-tyvid-regression-4.rs
+++ b/tests/incremental/const-generics/hash-tyvid-regression-4.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail
+//@ revisions: bfail
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 // regression test for #79251

--- a/tests/incremental/const-generics/issue-62536.rs
+++ b/tests/incremental/const-generics/issue-62536.rs
@@ -1,4 +1,4 @@
-//@ revisions:cfail1
+//@ revisions: bfail1
 
 #![allow(unused_variables)]
 
@@ -8,5 +8,5 @@ fn f<T, const N: usize>(x: T) -> S<T, {N}> { panic!() }
 
 fn main() {
     f(0u8);
-    //[cfail1]~^ ERROR type annotations needed
+    //[bfail1]~^ ERROR type annotations needed
 }

--- a/tests/incremental/const-generics/issue-64087.rs
+++ b/tests/incremental/const-generics/issue-64087.rs
@@ -1,11 +1,11 @@
-//@ revisions:cfail1
+//@ revisions: bfail1
 
 fn combinator<T, const S: usize>() -> [T; S] {}
-//[cfail1]~^ ERROR mismatched types
+//[bfail1]~^ ERROR mismatched types
 
 fn main() {
     combinator().into_iter();
-    //[cfail1]~^ ERROR type annotations needed
-    //[cfail1]~| ERROR type annotations needed
-    //[cfail1]~| ERROR type annotations needed
+    //[bfail1]~^ ERROR type annotations needed
+    //[bfail1]~| ERROR type annotations needed
+    //[bfail1]~| ERROR type annotations needed
 }

--- a/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-77708-1.rs
+++ b/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-77708-1.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail
+//@ revisions: bfail
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features, unused_braces, unused_variables)]
 

--- a/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-88022.rs
+++ b/tests/incremental/const-generics/try_unify_abstract_const_regression_tests/issue-88022.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail
+//@ revisions: bfail
 #![feature(generic_const_exprs)]
 #![allow(incomplete_features, unused_braces)]
 

--- a/tests/incremental/cyclic-trait-hierarchy.rs
+++ b/tests/incremental/cyclic-trait-hierarchy.rs
@@ -1,12 +1,12 @@
 // Adapted from rust-lang/rust#58813
 
-//@ revisions: rpass1 cfail2
+//@ revisions: rpass1 bfail2
 
 #[cfg(rpass1)]
 pub trait T2 {}
-#[cfg(cfail2)]
+#[cfg(bfail2)]
 pub trait T2: T1 {}
-//[cfail2]~^ ERROR cycle detected when computing the super predicates of `T2`
+//[bfail2]~^ ERROR cycle detected when computing the super predicates of `T2`
 
 pub trait T1: T2 {}
 

--- a/tests/incremental/define-opaques.rs
+++ b/tests/incremental/define-opaques.rs
@@ -1,13 +1,13 @@
-//@ revisions: rpass1 cfail2
+//@ revisions: rpass1 bfail2
 
 #![feature(type_alias_impl_trait)]
 
 pub type Foo = impl Sized;
 
 #[cfg_attr(rpass1, define_opaque())]
-#[cfg_attr(cfail2, define_opaque(Foo))]
+#[cfg_attr(bfail2, define_opaque(Foo))]
 fn a() {
-    //[cfail2]~^ ERROR item does not constrain `Foo::{opaque#0}`
+    //[bfail2]~^ ERROR item does not constrain `Foo::{opaque#0}`
     let _: Foo = b();
 }
 

--- a/tests/incremental/delayed_span_bug.rs
+++ b/tests/incremental/delayed_span_bug.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ failure-status: 101
 
 #![feature(rustc_attrs)]

--- a/tests/incremental/env/env_macro.rs
+++ b/tests/incremental/env/env_macro.rs
@@ -3,17 +3,17 @@
 // This test is intentionally written to not use any `#[cfg(rpass*)]`, to
 // _really_ test that we re-compile if the environment variable changes.
 
-//@ revisions: cfail1 rpass2 rpass3 cfail4
-//@ [cfail1]unset-rustc-env:EXAMPLE_ENV
+//@ revisions: bfail1 rpass2 rpass3 bfail4
+//@ [bfail1]unset-rustc-env:EXAMPLE_ENV
 //@ [rpass2]rustc-env:EXAMPLE_ENV=one
 //@ [rpass2]exec-env:EXAMPLE_ENV=one
 //@ [rpass3]rustc-env:EXAMPLE_ENV=two
 //@ [rpass3]exec-env:EXAMPLE_ENV=two
-//@ [cfail4]unset-rustc-env:EXAMPLE_ENV
+//@ [bfail4]unset-rustc-env:EXAMPLE_ENV
 //@ ignore-backends: gcc
 
 fn main() {
     assert_eq!(env!("EXAMPLE_ENV"), std::env::var("EXAMPLE_ENV").unwrap());
-    //[cfail1]~^ ERROR environment variable `EXAMPLE_ENV` not defined at compile time
-    //[cfail4]~^^ ERROR environment variable `EXAMPLE_ENV` not defined at compile time
+    //[bfail1]~^ ERROR environment variable `EXAMPLE_ENV` not defined at compile time
+    //[bfail4]~^^ ERROR environment variable `EXAMPLE_ENV` not defined at compile time
 }

--- a/tests/incremental/feature_gate.rs
+++ b/tests/incremental/feature_gate.rs
@@ -1,6 +1,6 @@
 // This test makes sure that we detect changed feature gates.
 
-//@ revisions:rpass1 cfail2
+//@ revisions: rpass1 bfail2
 //@ compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
@@ -10,4 +10,4 @@ fn main() {
 }
 
 extern "unadjusted" fn foo() {}
-//[cfail2]~^ ERROR: "unadjusted" ABI is an implementation detail and perma-unstable
+//[bfail2]~^ ERROR: "unadjusted" ABI is an implementation detail and perma-unstable

--- a/tests/incremental/hashes/call_expressions.rs
+++ b/tests/incremental/hashes/call_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 
@@ -23,16 +23,16 @@ fn callee2(_x: u32, _y: i64) {}
 
 
 // Change Callee (Function)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_callee_function() {
     callee1(1, 2)
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_callee_function() {
     callee2(1, 2)
 }
@@ -40,16 +40,16 @@ pub fn change_callee_function() {
 
 
 // Change Argument (Function)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_argument_function() {
     callee1(1, 2)
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_argument_function() {
     callee1(1, 3)
 }
@@ -58,15 +58,15 @@ pub fn change_argument_function() {
 
 // Change Callee Indirectly (Function)
 mod change_callee_indirectly_function {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::callee1 as callee;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::callee2 as callee;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn change_callee_indirectly_function() {
         callee(1, 2)
     }
@@ -80,17 +80,17 @@ impl Struct {
 }
 
 // Change Callee (Method)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_callee_method() {
     let s = Struct;
     s.method1('x', true);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_callee_method() {
     let s = Struct;
     s.method2('x', true);
@@ -99,17 +99,17 @@ pub fn change_callee_method() {
 
 
 // Change Argument (Method)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_argument_method() {
     let s = Struct;
     s.method1('x', true);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_argument_method() {
     let s = Struct;
     s.method1('y', true);
@@ -118,17 +118,17 @@ pub fn change_argument_method() {
 
 
 // Change Callee (Method, UFCS)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_ufcs_callee_method() {
     let s = Struct;
     Struct::method1(&s, 'x', true);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_ufcs_callee_method() {
     let s = Struct;
     Struct::method2(&s, 'x', true);
@@ -137,17 +137,17 @@ pub fn change_ufcs_callee_method() {
 
 
 // Change Argument (Method, UFCS)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_argument_method_ufcs() {
     let s = Struct;
     Struct::method1(&s, 'x', true);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_argument_method_ufcs() {
     let s = Struct;
     Struct::method1(&s, 'x',false);
@@ -156,17 +156,17 @@ pub fn change_argument_method_ufcs() {
 
 
 // Change To UFCS
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_to_ufcs() {
     let s = Struct;
     s.method1('x', true); // ------
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 // One might think this would be expanded in the opt_hir_owner_nodes/Mir, but it actually
 // results in slightly different hir_owner/Mir.
 pub fn change_to_ufcs() {
@@ -182,15 +182,15 @@ impl Struct2 {
 
 // Change UFCS Callee Indirectly
 pub mod change_ufcs_callee_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Struct as Struct;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Struct2 as Struct;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn change_ufcs_callee_indirectly() {
         let s = Struct;
         Struct::method1(&s, 'q', false)

--- a/tests/incremental/hashes/closure_expressions.rs
+++ b/tests/incremental/hashes/closure_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,16 +19,16 @@
 
 
 // Change closure body
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_closure_body() {
     let _ = || 1u32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_closure_body() {
     let _ = || 3u32;
 }
@@ -36,17 +36,17 @@ pub fn change_closure_body() {
 
 
 // Add parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_parameter() {
     let x = 0u32;
     let _ = |      | x + 1;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_parameter() {
     let x = 0u32;
     let _ = |x: u32| x + 1;
@@ -55,16 +55,16 @@ pub fn add_parameter() {
 
 
 // Change parameter pattern
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_parameter_pattern() {
     let _ = | x  : (u32,)| x;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_parameter_pattern() {
     let _ = |(x,): (u32,)| x;
 }
@@ -72,16 +72,16 @@ pub fn change_parameter_pattern() {
 
 
 // Add `move` to closure
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_move() {
     let _ =      || 1;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_move() {
     let _ = move || 1;
 }
@@ -89,17 +89,17 @@ pub fn add_move() {
 
 
 // Add type ascription to parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_type_ascription_to_parameter() {
     let closure = |x     | x + 1u32;
     let _: u32 = closure(1);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn add_type_ascription_to_parameter() {
     let closure = |x: u32| x + 1u32;
     let _: u32 = closure(1);
@@ -108,17 +108,17 @@ pub fn add_type_ascription_to_parameter() {
 
 
 // Change parameter type
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_parameter_type() {
     let closure = |x: u32| (x as u64) + 1;
     let _ = closure(1);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_parameter_type() {
     let closure = |x: u16| (x as u64) + 1;
     let _ = closure(1);

--- a/tests/incremental/hashes/consts.rs
+++ b/tests/incremental/hashes/consts.rs
@@ -6,7 +6,7 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -O
 //@ ignore-backends: gcc
 
@@ -16,75 +16,75 @@
 
 
 // Change const visibility
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 const CONST_VISIBILITY: u8 = 0;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 pub const CONST_VISIBILITY: u8 = 0;
 
 
 // Change type from i32 to u32
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 const CONST_CHANGE_TYPE_1: i32 = 0;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
 const CONST_CHANGE_TYPE_1: u32 = 0;
 
 
 // Change type from Option<u32> to Option<u64>
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 const CONST_CHANGE_TYPE_2: Option<u32> = None;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
 const CONST_CHANGE_TYPE_2: Option<u64> = None;
 
 
 // Change value between simple literals
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 const CONST_CHANGE_VALUE_1: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     { 1 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     { 2 }
 };
 
 
 // Change value between expressions
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 const CONST_CHANGE_VALUE_2: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     { 1 + 1 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     { 1 + 2 }
 };
 
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 const CONST_CHANGE_VALUE_3: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     { 2 + 3 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     { 2 * 3 }
 };
 
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 const CONST_CHANGE_VALUE_4: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     { 1 + 2 * 3 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     { 1 + 2 * 4 }
 };
 
@@ -94,17 +94,17 @@ struct ReferencedType1;
 struct ReferencedType2;
 
 mod const_change_type_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     use super::ReferencedType1 as Type;
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     use super::ReferencedType2 as Type;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="bfail3")]
     const CONST_CHANGE_TYPE_INDIRECTLY_1: Type = Type;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="bfail3")]
     const CONST_CHANGE_TYPE_INDIRECTLY_2: Option<Type> = None;
 }

--- a/tests/incremental/hashes/delayed_lints.rs
+++ b/tests/incremental/hashes/delayed_lints.rs
@@ -3,7 +3,7 @@
 // This test tests that the delayed hints are correctly hashed for incremental.
 
 //@ check-pass
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -O -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 #![feature(rustc_attrs)]
@@ -15,13 +15,13 @@
 // Between revision 1 and 2, the only thing we change is that we add "test = 2"
 // This will emit an extra delayed lint, but it will not change the HIR hash.
 // We check that even tho the HIR hash didn't change, the extra lint is emitted
-#[cfg_attr(cfail1, doc(hidden))]
-#[cfg_attr(not(cfail1), doc(hidden, test = 2))]
-//[cfail2,cfail3]~^ WARN `#[doc(test(...)]` takes a list of attributes [invalid_doc_attributes]
+#[cfg_attr(bfail1, doc(hidden))]
+#[cfg_attr(not(bfail1), doc(hidden, test = 2))]
+//[bfail2,bfail3]~^ WARN `#[doc(test(...)]` takes a list of attributes [invalid_doc_attributes]
 
 // The HIR hash should not change between revisions, for this test to be representative
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
 trait Test {}
 
 fn main() {}

--- a/tests/incremental/hashes/enum_constructors.rs
+++ b/tests/incremental/hashes/enum_constructors.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -28,7 +28,7 @@ pub enum Enum {
 }
 
 // Change field value (struct-like) -----------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_value_struct_like() -> Enum {
     Enum::Struct {
         x: 0,
@@ -37,11 +37,11 @@ pub fn change_field_value_struct_like() -> Enum {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_field_value_struct_like() -> Enum {
     Enum::Struct {
         x: 0,
@@ -53,7 +53,7 @@ pub fn change_field_value_struct_like() -> Enum {
 
 
 // Change field order (struct-like) -----------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_order_struct_like() -> Enum {
     Enum::Struct {
         x: 3,
@@ -62,11 +62,11 @@ pub fn change_field_order_struct_like() -> Enum {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 // FIXME(michaelwoerister):Interesting. I would have thought that that changes the MIR. And it
 // would if it were not all constants
 pub fn change_field_order_struct_like() -> Enum {
@@ -94,7 +94,7 @@ pub enum Enum2 {
 }
 
 // Change constructor path (struct-like) ------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_path_struct_like() {
     let _ = Enum ::Struct {
         x: 0,
@@ -103,11 +103,11 @@ pub fn change_constructor_path_struct_like() {
     };
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_path_struct_like() {
     let _ = Enum2::Struct {
         x: 0,
@@ -119,7 +119,7 @@ pub fn change_constructor_path_struct_like() {
 
 
 // Change variant (regular struct) ------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_variant_struct_like() {
     let _ = Enum2::Struct  {
         x: 0,
@@ -128,11 +128,11 @@ pub fn change_constructor_variant_struct_like() {
     };
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_variant_struct_like() {
     let _ = Enum2::Struct2 {
         x: 0,
@@ -144,15 +144,15 @@ pub fn change_constructor_variant_struct_like() {
 
 // Change constructor path indirectly (struct-like) -------------------------
 pub mod change_constructor_path_indirectly_struct_like {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Enum as TheEnum;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Enum2 as TheEnum;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> TheEnum {
         TheEnum::Struct {
             x: 0,
@@ -166,15 +166,15 @@ pub mod change_constructor_path_indirectly_struct_like {
 // Change constructor variant indirectly (struct-like) ---------------------------
 pub mod change_constructor_variant_indirectly_struct_like {
     use super::Enum2;
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Enum2::Struct as Variant;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Enum2::Struct2 as Variant;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> Enum2 {
         Variant {
             x: 0,
@@ -186,16 +186,16 @@ pub mod change_constructor_variant_indirectly_struct_like {
 
 
 // Change field value (tuple-like) -------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_value_tuple_like() -> Enum {
     Enum::Tuple(0, 1, 2)
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_field_value_tuple_like() -> Enum {
     Enum::Tuple(0, 1, 3)
 }
@@ -203,22 +203,22 @@ pub fn change_field_value_tuple_like() -> Enum {
 
 
 // Change constructor path (tuple-like) --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_path_tuple_like() {
     let _ = Enum ::Tuple(0, 1, 2);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg="cfail2",
+    cfg="bfail2",
     except="opt_hir_owner_nodes,typeck_root"
 )]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail3")]
 #[rustc_clean(
-    cfg="cfail5",
+    cfg="bfail5",
     except="opt_hir_owner_nodes,typeck_root"
 )]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_path_tuple_like() {
     let _ = Enum2::Tuple(0, 1, 2);
 }
@@ -226,22 +226,22 @@ pub fn change_constructor_path_tuple_like() {
 
 
 // Change constructor variant (tuple-like) --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_variant_tuple_like() {
     let _ = Enum2::Tuple (0, 1, 2);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg="cfail2",
+    cfg="bfail2",
     except="opt_hir_owner_nodes,typeck_root"
 )]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail3")]
 #[rustc_clean(
-    cfg="cfail5",
+    cfg="bfail5",
     except="opt_hir_owner_nodes,typeck_root"
 )]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_variant_tuple_like() {
     let _ = Enum2::Tuple2(0, 1, 2);
 }
@@ -249,15 +249,15 @@ pub fn change_constructor_variant_tuple_like() {
 
 // Change constructor path indirectly (tuple-like) ---------------------------
 pub mod change_constructor_path_indirectly_tuple_like {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Enum as TheEnum;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Enum2 as TheEnum;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> TheEnum {
         TheEnum::Tuple(0, 1, 2)
     }
@@ -268,15 +268,15 @@ pub mod change_constructor_path_indirectly_tuple_like {
 // Change constructor variant indirectly (tuple-like) ---------------------------
 pub mod change_constructor_variant_indirectly_tuple_like {
     use super::Enum2;
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Enum2::Tuple as Variant;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Enum2::Tuple2 as Variant;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> Enum2 {
         Variant(0, 1, 2)
     }
@@ -296,16 +296,16 @@ pub enum Clike2 {
 }
 
 // Change constructor path (C-like) --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_path_c_like() {
     let _x = Clike ::B;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_path_c_like() {
     let _x = Clike2::B;
 }
@@ -313,16 +313,16 @@ pub fn change_constructor_path_c_like() {
 
 
 // Change constructor variant (C-like) --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_variant_c_like() {
     let _x = Clike::A;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_variant_c_like() {
     let _x = Clike::C;
 }
@@ -330,15 +330,15 @@ pub fn change_constructor_variant_c_like() {
 
 // Change constructor path indirectly (C-like) ---------------------------
 pub mod change_constructor_path_indirectly_c_like {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Clike as TheEnum;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Clike2 as TheEnum;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> TheEnum {
         TheEnum::B
     }
@@ -349,15 +349,15 @@ pub mod change_constructor_path_indirectly_c_like {
 // Change constructor variant indirectly (C-like) ---------------------------
 pub mod change_constructor_variant_indirectly_c_like {
     use super::Clike;
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::Clike::A as Variant;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::Clike::B as Variant;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> Clike {
         Variant
     }

--- a/tests/incremental/hashes/enum_defs.rs
+++ b/tests/incremental/hashes/enum_defs.rs
@@ -11,11 +11,11 @@
 // the same between rev2 and rev3.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -26,30 +26,30 @@
 
 
 // Change enum visibility -----------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum     EnumVisibility { A }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub enum EnumVisibility { A }
 
 
 
 // Change name of a c-style variant -------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeNameCStyleVariant {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeNameCStyleVariant {
     Variant1,
     Variant2Changed,
@@ -58,17 +58,17 @@ enum EnumChangeNameCStyleVariant {
 
 
 // Change name of a tuple-style variant ---------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeNameTupleStyleVariant {
     Variant1,
     Variant2(u32, f32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeNameTupleStyleVariant {
     Variant1,
     Variant2Changed(u32, f32),
@@ -77,17 +77,17 @@ enum EnumChangeNameTupleStyleVariant {
 
 
 // Change name of a struct-style variant --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeNameStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: f32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeNameStructStyleVariant {
     Variant1,
     Variant2Changed { a: u32, b: f32 },
@@ -96,33 +96,33 @@ enum EnumChangeNameStructStyleVariant {
 
 
 // Change the value of a c-style variant --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeValueCStyleVariant0 {
     Variant1,
     Variant2 = 11,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeValueCStyleVariant0 {
     Variant1,
     Variant2 = 22,
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeValueCStyleVariant1 {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeValueCStyleVariant1 {
     Variant1,
     Variant2 = 11,
@@ -131,16 +131,16 @@ enum EnumChangeValueCStyleVariant1 {
 
 
 // Add a c-style variant ------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddCStyleVariant {
     Variant1,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddCStyleVariant {
     Variant1,
     Variant2,
@@ -149,17 +149,17 @@ enum EnumAddCStyleVariant {
 
 
 // Remove a c-style variant ---------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumRemoveCStyleVariant {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumRemoveCStyleVariant {
     Variant1,
 }
@@ -167,16 +167,16 @@ enum EnumRemoveCStyleVariant {
 
 
 // Add a tuple-style variant --------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddTupleStyleVariant {
     Variant1,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddTupleStyleVariant {
     Variant1,
     Variant2(u32, f32),
@@ -185,17 +185,17 @@ enum EnumAddTupleStyleVariant {
 
 
 // Remove a tuple-style variant -----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumRemoveTupleStyleVariant {
     Variant1,
     Variant2(u32, f32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumRemoveTupleStyleVariant {
     Variant1,
 }
@@ -203,16 +203,16 @@ enum EnumRemoveTupleStyleVariant {
 
 
 // Add a struct-style variant -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddStructStyleVariant {
     Variant1,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: f32 },
@@ -221,17 +221,17 @@ enum EnumAddStructStyleVariant {
 
 
 // Remove a struct-style variant ----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumRemoveStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: f32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumRemoveStructStyleVariant {
     Variant1,
 }
@@ -239,16 +239,16 @@ enum EnumRemoveStructStyleVariant {
 
 
 // Change the type of a field in a tuple-style variant ------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeFieldTypeTupleStyleVariant {
     Variant1(u32, u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeFieldTypeTupleStyleVariant {
     Variant1(u32,
         u64),
@@ -257,17 +257,17 @@ enum EnumChangeFieldTypeTupleStyleVariant {
 
 
 // Change the type of a field in a struct-style variant -----------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeFieldTypeStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: u32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeFieldTypeStructStyleVariant {
     Variant1,
     Variant2 {
@@ -279,16 +279,16 @@ enum EnumChangeFieldTypeStructStyleVariant {
 
 
 // Change the name of a field in a struct-style variant -----------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeFieldNameStructStyleVariant {
     Variant1 { a: u32, b: u32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeFieldNameStructStyleVariant {
     Variant1 { a: u32, c: u32 },
 }
@@ -296,16 +296,16 @@ enum EnumChangeFieldNameStructStyleVariant {
 
 
 // Change order of fields in a tuple-style variant ----------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeOrderTupleStyleVariant {
     Variant1(u32, u64),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeOrderTupleStyleVariant {
     Variant1(
         u64,
@@ -315,16 +315,16 @@ enum EnumChangeOrderTupleStyleVariant {
 
 
 // Change order of fields in a struct-style variant ---------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeFieldOrderStructStyleVariant {
     Variant1 { a: u32, b: f32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeFieldOrderStructStyleVariant {
     Variant1 { b: f32, a: u32 },
 }
@@ -332,16 +332,16 @@ enum EnumChangeFieldOrderStructStyleVariant {
 
 
 // Add a field to a tuple-style variant ---------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddFieldTupleStyleVariant {
     Variant1(u32, u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddFieldTupleStyleVariant {
     Variant1(u32, u32, u32),
 }
@@ -349,16 +349,16 @@ enum EnumAddFieldTupleStyleVariant {
 
 
 // Add a field to a struct-style variant --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddFieldStructStyleVariant {
     Variant1 { a: u32, b: u32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddFieldStructStyleVariant {
     Variant1 { a: u32, b: u32, c: u32 },
 }
@@ -366,17 +366,17 @@ enum EnumAddFieldStructStyleVariant {
 
 
 // Add #[must_use] to the enum ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddMustUse {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 #[must_use]
 enum EnumAddMustUse {
     Variant1,
@@ -386,17 +386,17 @@ enum EnumAddMustUse {
 
 
 // Add #[repr(C)] to the enum -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddReprC {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="type_of")]
+#[rustc_clean(cfg="bfail6")]
 #[repr(C)]
 enum EnumAddReprC {
     Variant1,
@@ -406,16 +406,16 @@ enum EnumAddReprC {
 
 
 // Change the name of a type parameter ----------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeNameOfTypeParameter<S> {
     Variant1(S),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeNameOfTypeParameter<T> {
     Variant1(T),
 }
@@ -423,17 +423,17 @@ enum EnumChangeNameOfTypeParameter<T> {
 
 
 // Add a type parameter ------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddTypeParameter<S> {
     Variant1(S),
     Variant2(S),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddTypeParameter<S, T> {
     Variant1(S),
     Variant2(T),
@@ -442,16 +442,16 @@ enum EnumAddTypeParameter<S, T> {
 
 
 // Change the name of a lifetime parameter ------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumChangeNameOfLifetimeParameter<'a> {
     Variant1(&'a u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumChangeNameOfLifetimeParameter<'b> {
     Variant1(&'b u32),
 }
@@ -459,17 +459,17 @@ enum EnumChangeNameOfLifetimeParameter<'b> {
 
 
 // Add a lifetime parameter ---------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddLifetimeParameter<'a> {
     Variant1(&'a u32),
     Variant2(&'a u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddLifetimeParameter<'a, 'b> {
     Variant1(&'a u32),
     Variant2(&'b u32),
@@ -478,34 +478,34 @@ enum EnumAddLifetimeParameter<'a, 'b> {
 
 
 // Add a lifetime bound to a lifetime parameter -------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddLifetimeParameterBound<'a, 'b> {
     Variant1(&'a u32),
     Variant2(&'b u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddLifetimeParameterBound<'a, 'b: 'a> {
     Variant1(&'a u32),
     Variant2(&'b u32),
 }
 
 // Add a lifetime bound to a type parameter -----------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddLifetimeBoundToParameter<'a, T> {
     Variant1(T),
     Variant2(&'a u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddLifetimeBoundToParameter<'a, T: 'a> {
     Variant1(T),
     Variant2(&'a u32),
@@ -514,16 +514,16 @@ enum EnumAddLifetimeBoundToParameter<'a, T: 'a> {
 
 
 // Add a trait bound to a type parameter --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddTraitBound<S> {
     Variant1(S),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddTraitBound<T: Sync> {
     Variant1(T),
 }
@@ -531,17 +531,17 @@ enum EnumAddTraitBound<T: Sync> {
 
 
 // Add a lifetime bound to a lifetime parameter in where clause ---------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddLifetimeParameterBoundWhere<'a, 'b> {
     Variant1(&'a u32),
     Variant2(&'b u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddLifetimeParameterBoundWhere<'a, 'b> where 'b: 'a {
     Variant1(&'a u32),
     Variant2(&'b u32),
@@ -550,17 +550,17 @@ enum EnumAddLifetimeParameterBoundWhere<'a, 'b> where 'b: 'a {
 
 
 // Add a lifetime bound to a type parameter in where clause -------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddLifetimeBoundToParameterWhere<'a, T> {
     Variant1(T),
     Variant2(&'a u32),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddLifetimeBoundToParameterWhere<'a, T> where T: 'a {
     Variant1(T),
     Variant2(&'a u32),
@@ -569,16 +569,16 @@ enum EnumAddLifetimeBoundToParameterWhere<'a, T> where T: 'a {
 
 
 // Add a trait bound to a type parameter in where clause ----------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumAddTraitBoundWhere<S> {
     Variant1(S),
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumAddTraitBoundWhere<T> where T: Sync {
     Variant1(T),
 }
@@ -586,17 +586,17 @@ enum EnumAddTraitBoundWhere<T> where T: Sync {
 
 
 // In an enum with two variants, swap usage of type parameters ----------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumSwapUsageTypeParameters<A, B> {
     Variant1 { a: A },
     Variant2 { a: B },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumSwapUsageTypeParameters<A, B> {
     Variant1 {
         a: B
@@ -609,17 +609,17 @@ enum EnumSwapUsageTypeParameters<A, B> {
 
 
 // In an enum with two variants, swap usage of lifetime parameters ------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 enum EnumSwapUsageLifetimeParameters<'a, 'b> {
     Variant1 { a: &'a u32 },
     Variant2 { b: &'b u32 },
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 enum EnumSwapUsageLifetimeParameters<'a, 'b> {
     Variant1 {
         a: &'b u32
@@ -638,15 +638,15 @@ struct ReferencedType2;
 
 // Change field type in tuple-style variant indirectly by modifying a use statement
 mod change_field_type_indirectly_tuple_style {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as FieldType;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail6")]
     enum TupleStyle {
         Variant1(
             FieldType
@@ -658,15 +658,15 @@ mod change_field_type_indirectly_tuple_style {
 
 // Change field type in record-style variant indirectly by modifying a use statement
 mod change_field_type_indirectly_struct_style {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as FieldType;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail6")]
     enum StructStyle {
         Variant1 {
             a: FieldType
@@ -683,15 +683,15 @@ trait ReferencedTrait2 {}
 
 // Change trait bound of type parameter indirectly by modifying a use statement
 mod change_trait_bound_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="bfail6")]
     enum Enum<T: Trait> {
         Variant1(T)
     }
@@ -701,15 +701,15 @@ mod change_trait_bound_indirectly {
 
 // Change trait bound of type parameter in where clause indirectly by modifying a use statement
 mod change_trait_bound_indirectly_where {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="bfail6")]
     enum Enum<T> where T: Trait {
         Variant1(T)
     }

--- a/tests/incremental/hashes/exported_vs_not.rs
+++ b/tests/incremental/hashes/exported_vs_not.rs
@@ -1,9 +1,9 @@
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -14,16 +14,16 @@
 //         the hash of the opt_hir_owner_nodes node should change, but not the hash of
 //         either the hir_owner or the Metadata node.
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn body_not_exported_to_metadata() -> u32 {
     1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn body_not_exported_to_metadata() -> u32 {
     2
 }
@@ -34,17 +34,17 @@ pub fn body_not_exported_to_metadata() -> u32 {
 //         marked as #[inline]. Only the hash of the hir_owner depnode should be
 //         unaffected by a change to the body.
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[inline]
 pub fn body_exported_to_metadata_because_of_inline() -> u32 {
     1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[inline]
 pub fn body_exported_to_metadata_because_of_inline() -> u32 {
     2
@@ -56,17 +56,17 @@ pub fn body_exported_to_metadata_because_of_inline() -> u32 {
 //         generic. Only the hash of the hir_owner depnode should be
 //         unaffected by a change to the body.
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[inline]
 pub fn body_exported_to_metadata_because_of_generic() -> u32 {
     1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[inline]
 pub fn body_exported_to_metadata_because_of_generic() -> u32 {
     2

--- a/tests/incremental/hashes/extern_mods.rs
+++ b/tests/incremental/hashes/extern_mods.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,168 +19,168 @@
 #![crate_type = "rlib"]
 
 // Change function name --------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn change_function_name1(c: i64) -> i32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn change_function_name2(c: i64) -> i32;
 }
 
 // Change parameter name -------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn change_parameter_name(c: i64) -> i32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn change_parameter_name(d: i64) -> i32;
 }
 
 // Change parameter type -------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn change_parameter_type(c: i64) -> i32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn change_parameter_type(c: i32) -> i32;
 }
 
 // Change return type ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn change_return_type(c: i32) -> i32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn change_return_type(c: i32) -> i8 ;
 }
 
 // Add parameter ---------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn add_parameter(c: i32        ) -> i32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn add_parameter(c: i32, d: i32) -> i32;
 }
 
 // Add return type -------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn add_return_type(c: i32)       ;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn add_return_type(c: i32) -> i32;
 }
 
 // Make function variadic ------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn make_function_variadic(c: i32     );
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn make_function_variadic(c: i32, ...);
 }
 
 // Change calling convention ---------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn change_calling_convention(c: (i32,));
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail6")]
 extern "rust-call" {
     pub fn change_calling_convention(c: (i32,));
 }
 
 // Make function public --------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     fn     make_function_public(c: i32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn make_function_public(c: i32);
 }
 
 // Add function ----------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 extern "C" {
     pub fn add_function1(c: i32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail6")]
 extern "C" {
     pub fn add_function1(c: i32);
     pub fn add_function2();
 }
 
 // Change link-name ------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[link(name = "foo")]
 extern "C" {
     pub fn change_link_name(c: i32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 #[link(name = "bar")]
 extern "C" {
     pub fn change_link_name(c: i32);
@@ -191,15 +191,15 @@ type c_i64 = i64;
 
 // Indirectly change parameter type --------------------------------------------
 mod indirectly_change_parameter_type {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::c_i32 as c_int;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::c_i64 as c_int;
 
-    #[rustc_clean(cfg = "cfail2")]
-    #[rustc_clean(cfg = "cfail3")]
-    #[rustc_clean(cfg = "cfail5")]
-    #[rustc_clean(cfg = "cfail6")]
+    #[rustc_clean(cfg = "bfail2")]
+    #[rustc_clean(cfg = "bfail3")]
+    #[rustc_clean(cfg = "bfail5")]
+    #[rustc_clean(cfg = "bfail6")]
     extern "C" {
         pub fn indirectly_change_parameter_type(c: c_int);
     }
@@ -207,15 +207,15 @@ mod indirectly_change_parameter_type {
 
 // Indirectly change return type --------------------------------------------
 mod indirectly_change_return_type {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::c_i32 as c_int;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::c_i64 as c_int;
 
-    #[rustc_clean(cfg = "cfail2")]
-    #[rustc_clean(cfg = "cfail3")]
-    #[rustc_clean(cfg = "cfail5")]
-    #[rustc_clean(cfg = "cfail6")]
+    #[rustc_clean(cfg = "bfail2")]
+    #[rustc_clean(cfg = "bfail3")]
+    #[rustc_clean(cfg = "bfail5")]
+    #[rustc_clean(cfg = "bfail6")]
     extern "C" {
         pub fn indirectly_change_return_type() -> c_int;
     }

--- a/tests/incremental/hashes/for_loops.rs
+++ b/tests/incremental/hashes/for_loops.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,7 +19,7 @@
 
 
 // Change loop body ------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -28,11 +28,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -44,7 +44,7 @@ pub fn change_loop_body() {
 
 
 // Change iteration variable name ----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_iteration_variable_name() {
     let mut _x = 0;
     for _i in 0..1 {
@@ -53,11 +53,11 @@ pub fn change_iteration_variable_name() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_iteration_variable_name() {
     let mut _x = 0;
     for _a in 0..1 {
@@ -69,7 +69,7 @@ pub fn change_iteration_variable_name() {
 
 
 // Change iteration variable pattern -------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_iteration_variable_pattern() {
     let mut _x = 0;
     for  _i in &[0, 1, 2] {
@@ -78,11 +78,11 @@ pub fn change_iteration_variable_pattern() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_iteration_variable_pattern() {
     let mut _x = 0;
     for &_i in &[0, 1, 2] {
@@ -94,7 +94,7 @@ pub fn change_iteration_variable_pattern() {
 
 
 // Change iterable -------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_iterable() {
     let mut _x = 0;
     for _ in &[0, 1, 2] {
@@ -103,11 +103,11 @@ pub fn change_iterable() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, promoted_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, promoted_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, promoted_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, promoted_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_iterable() {
     let mut _x = 0;
     for _ in &[0, 1, 3] {
@@ -119,7 +119,7 @@ pub fn change_iterable() {
 
 
 // Add break -------------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_break() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -128,11 +128,11 @@ pub fn add_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_break() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -144,7 +144,7 @@ pub fn add_break() {
 
 
 // Add loop label --------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
             for _ in 0..1 {
@@ -153,11 +153,11 @@ pub fn add_loop_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -169,7 +169,7 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break -----------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -178,11 +178,11 @@ pub fn add_loop_label_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -194,7 +194,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -205,11 +205,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -223,7 +223,7 @@ pub fn change_break_label() {
 
 
 // Add loop label to continue --------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -232,11 +232,11 @@ pub fn add_loop_label_to_continue() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -248,7 +248,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -259,11 +259,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -277,7 +277,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break ----------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -286,11 +286,11 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     for _ in 0..1 {

--- a/tests/incremental/hashes/function_interfaces.rs
+++ b/tests/incremental/hashes/function_interfaces.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -20,309 +20,309 @@
 
 // Add Parameter ---------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_parameter() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn add_parameter(p: i32) {}
 
 // Add Return Type -------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_return_type()       {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn add_return_type() -> () {}
 
 // Change Parameter Type -------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn type_of_parameter(p: i32) {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn type_of_parameter(p: i64) {}
 
 // Change Parameter Type Reference ---------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn type_of_parameter_ref(p: &i32) {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn type_of_parameter_ref(p: &mut i32) {}
 
 // Change Parameter Order ------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn order_of_parameters(p1: i32, p2: i64) {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn order_of_parameters(p2: i64, p1: i32) {}
 
 // Unsafe ----------------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub        fn make_unsafe() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, typeck_root, fn_sig"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub unsafe fn make_unsafe() {}
 
 // Extern ----------------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub            fn make_extern() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
+#[rustc_clean(cfg = "bfail6")]
 pub extern "C" fn make_extern() {}
 
 // Type Parameter --------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn type_parameter   () {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, generics_of, type_of, predicates_of"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, generics_of, type_of, predicates_of"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn type_parameter<T>() {}
 
 // Lifetime Parameter ----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn lifetime_parameter    () {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, generics_of,fn_sig")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, generics_of,fn_sig")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, generics_of,fn_sig")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, generics_of,fn_sig")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn lifetime_parameter<'a>() {}
 
 // Trait Bound -----------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn trait_bound<T    >() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, predicates_of")]
-#[rustc_clean(cfg = "cfail3")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "bfail3")]
 pub fn trait_bound<T: Eq>() {}
 
 // Builtin Bound ---------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn builtin_bound<T      >() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, predicates_of")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, predicates_of")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn builtin_bound<T: Send>() {}
 
 // Lifetime Bound --------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn lifetime_bound<'a, T>() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig,optimized_mir"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn lifetime_bound<'a, T: 'a>() {}
 
 // Second Trait Bound ----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn second_trait_bound<T: Eq        >() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, predicates_of")]
-#[rustc_clean(cfg = "cfail3")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "bfail3")]
 pub fn second_trait_bound<T: Eq + Clone>() {}
 
 // Second Builtin Bound --------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn second_builtin_bound<T: Send        >() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, predicates_of")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn second_builtin_bound<T: Send + Sized>() {}
 
 // Second Lifetime Bound -------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn second_lifetime_bound<'a, 'b, T: 'a     >() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 #[rustc_clean(
-    cfg = "cfail2",
+    cfg = "bfail2",
     except = "opt_hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig"
 )]
-#[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "bfail3")]
 #[rustc_clean(
-    cfg = "cfail5",
+    cfg = "bfail5",
     except = "opt_hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig"
 )]
-#[rustc_clean(cfg = "cfail6")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn second_lifetime_bound<'a, 'b, T: 'a + 'b>() {}
 
 // Inline ----------------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn inline() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 #[inline]
 pub fn inline() {}
 
 // Inline Never ----------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[inline(always)]
 pub fn inline_never() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 #[inline(never)]
 pub fn inline_never() {}
 
 // No Mangle -------------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn no_mangle() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 #[unsafe(no_mangle)]
 pub fn no_mangle() {}
 
 // Linkage ---------------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn linkage() {}
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5")]
+#[rustc_clean(cfg = "bfail6")]
 #[linkage = "weak_odr"]
 pub fn linkage() {}
 
 // Return Impl Trait -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn return_impl_trait() -> i32        {
     0
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root, fn_sig, optimized_mir")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, typeck_root, fn_sig")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, typeck_root, fn_sig, optimized_mir")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn return_impl_trait() -> impl Clone {
     0
 }
 
 // Change Return Impl Trait ----------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_return_impl_trait() -> impl Clone {
     0u32
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes")]
-#[rustc_clean(cfg = "cfail3")]
-#[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg = "cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes")]
+#[rustc_clean(cfg = "bfail3")]
+#[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg = "bfail6")]
 pub fn change_return_impl_trait() -> impl  Copy {
     0u32
 }
@@ -333,21 +333,21 @@ pub struct ReferencedType1;
 pub struct ReferencedType2;
 
 pub mod change_return_type_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as ReturnType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as ReturnType;
 
     #[rustc_clean(
-        cfg = "cfail2",
+        cfg = "bfail2",
         except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
-    #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(cfg = "bfail3")]
     #[rustc_clean(
-        cfg = "cfail5",
+        cfg = "bfail5",
         except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
-    #[rustc_clean(cfg = "cfail6")]
+    #[rustc_clean(cfg = "bfail6")]
     pub fn indirect_return_type() -> ReturnType {
         ReturnType {}
     }
@@ -356,21 +356,21 @@ pub mod change_return_type_indirectly {
 // Change Parameter Type Indirectly --------------------------------------------
 
 pub mod change_parameter_type_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as ParameterType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as ParameterType;
 
     #[rustc_clean(
-        cfg = "cfail2",
+        cfg = "bfail2",
         except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
-    #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(cfg = "bfail3")]
     #[rustc_clean(
-        cfg = "cfail5",
+        cfg = "bfail5",
         except = "opt_hir_owner_nodes, optimized_mir, typeck_root, fn_sig"
     )]
-    #[rustc_clean(cfg = "cfail6")]
+    #[rustc_clean(cfg = "bfail6")]
     pub fn indirect_parameter_type(p: ParameterType) {}
 }
 
@@ -380,30 +380,30 @@ pub trait ReferencedTrait1 {}
 pub trait ReferencedTrait2 {}
 
 pub mod change_trait_bound_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, predicates_of")]
-    #[rustc_clean(cfg = "cfail3")]
-    #[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, predicates_of")]
-    #[rustc_clean(cfg = "cfail6")]
+    #[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, predicates_of")]
+    #[rustc_clean(cfg = "bfail3")]
+    #[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, predicates_of")]
+    #[rustc_clean(cfg = "bfail6")]
     pub fn indirect_trait_bound<T: Trait>(p: T) {}
 }
 
 // Change Trait Bound Indirectly In Where Clause -------------------------------
 
 pub mod change_trait_bound_indirectly_in_where_clause {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(cfg = "cfail2", except = "opt_hir_owner_nodes, predicates_of")]
-    #[rustc_clean(cfg = "cfail3")]
-    #[rustc_clean(cfg = "cfail5", except = "opt_hir_owner_nodes, predicates_of")]
-    #[rustc_clean(cfg = "cfail6")]
+    #[rustc_clean(cfg = "bfail2", except = "opt_hir_owner_nodes, predicates_of")]
+    #[rustc_clean(cfg = "bfail3")]
+    #[rustc_clean(cfg = "bfail5", except = "opt_hir_owner_nodes, predicates_of")]
+    #[rustc_clean(cfg = "bfail6")]
     pub fn indirect_trait_bound_where<T>(p: T)
     where
         T: Trait,

--- a/tests/incremental/hashes/if_expressions.rs
+++ b/tests/incremental/hashes/if_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -18,7 +18,7 @@
 #![crate_type="rlib"]
 
 // Change condition (if)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_condition(x: bool) -> u32 {
     if  x {
         return 1
@@ -27,11 +27,11 @@ pub fn change_condition(x: bool) -> u32 {
     return 0
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_condition(x: bool) -> u32 {
     if !x {
         return 1
@@ -41,7 +41,7 @@ pub fn change_condition(x: bool) -> u32 {
 }
 
 // Change then branch (if)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_then_branch(x: bool) -> u32 {
     if x {
         return 1
@@ -50,11 +50,11 @@ pub fn change_then_branch(x: bool) -> u32 {
     return 0
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_then_branch(x: bool) -> u32 {
     if x {
         return 2
@@ -66,7 +66,7 @@ pub fn change_then_branch(x: bool) -> u32 {
 
 
 // Change else branch (if)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_else_branch(x: bool) -> u32 {
     if x {
         1
@@ -75,11 +75,11 @@ pub fn change_else_branch(x: bool) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_else_branch(x: bool) -> u32 {
     if x {
         1
@@ -91,7 +91,7 @@ pub fn change_else_branch(x: bool) -> u32 {
 
 
 // Add else branch (if)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_else_branch(x: bool) -> u32 {
     let mut ret = 1;
 
@@ -103,11 +103,11 @@ pub fn add_else_branch(x: bool) -> u32 {
     ret
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_else_branch(x: bool) -> u32 {
     let mut ret = 1;
 
@@ -122,7 +122,7 @@ pub fn add_else_branch(x: bool) -> u32 {
 
 
 // Change condition (if let)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_condition_if_let(x: Option<u32>) -> u32 {
     if let Some(_x) = x {
         return 1
@@ -131,11 +131,11 @@ pub fn change_condition_if_let(x: Option<u32>) -> u32 {
     0
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_condition_if_let(x: Option<u32>) -> u32 {
     if let Some(_ ) = x {
         return 1
@@ -147,7 +147,7 @@ pub fn change_condition_if_let(x: Option<u32>) -> u32 {
 
 
 // Change then branch (if let)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         return x //-
@@ -156,11 +156,11 @@ pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
     0
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         return x + 1
@@ -172,7 +172,7 @@ pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
 
 
 // Change else branch (if let)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         x
@@ -181,11 +181,11 @@ pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         x
@@ -197,7 +197,7 @@ pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
 
 
 // Add else branch (if let)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     let mut ret = 1;
 
@@ -209,11 +209,11 @@ pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     ret
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     let mut ret = 1;
 

--- a/tests/incremental/hashes/indexing_expressions.rs
+++ b/tests/incremental/hashes/indexing_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -18,16 +18,16 @@
 #![crate_type="rlib"]
 
 // Change simple index
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn change_simple_index(slice: &[u32]) -> u32 {
     slice[3]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn change_simple_index(slice: &[u32]) -> u32 {
     slice[4]
 }
@@ -35,16 +35,16 @@ fn change_simple_index(slice: &[u32]) -> u32 {
 
 
 // Change lower bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn change_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[3..5]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn change_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[2..5]
 }
@@ -52,16 +52,16 @@ fn change_lower_bound(slice: &[u32]) -> &[u32] {
 
 
 // Change upper bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn change_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..5]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn change_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
 }
@@ -69,16 +69,16 @@ fn change_upper_bound(slice: &[u32]) -> &[u32] {
 
 
 // Add lower bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn add_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[ ..4]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn add_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[3..4]
 }
@@ -86,16 +86,16 @@ fn add_lower_bound(slice: &[u32]) -> &[u32] {
 
 
 // Add upper bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn add_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3.. ]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn add_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
 }
@@ -103,16 +103,16 @@ fn add_upper_bound(slice: &[u32]) -> &[u32] {
 
 
 // Change mutability
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn change_mutability(slice: &mut [u32]) -> u32 {
     (&mut slice[3..5])[0]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn change_mutability(slice: &mut [u32]) -> u32 {
     (&    slice[3..5])[0]
 }
@@ -120,16 +120,16 @@ fn change_mutability(slice: &mut [u32]) -> u32 {
 
 
 // Exclusive to inclusive range
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
     &slice[3.. 7]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
     &slice[3..=7]
 }

--- a/tests/incremental/hashes/inherent_impls.rs
+++ b/tests/incremental/hashes/inherent_impls.rs
@@ -7,11 +7,11 @@
 
 //@ edition: 2024
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 
@@ -22,26 +22,26 @@
 pub struct Foo;
 
 // Change Method Name -----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     pub fn method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,associated_item_def_ids")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,associated_item_def_ids")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,associated_item_def_ids")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,associated_item_def_ids")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn method_name2() { }
 }
 
 // Change Method Body -----------------------------------------------------------
 //
 // This should affect the method itself, but not the impl.
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //------------------------------------------------------------------------------------------
     //--------------------------
@@ -52,16 +52,16 @@ impl Foo {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5",except="opt_hir_owner_nodes,optimized_mir,promoted_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn method_body() {
         println!("Hello, world!");
     }
@@ -71,7 +71,7 @@ impl Foo {
 // Change Method Body (inlined) ------------------------------------------------
 //
 // This should affect the method itself, but not the impl.
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //-----------------------------------------------------------------------------
     //--------------------------
@@ -83,16 +83,16 @@ impl Foo {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     #[inline]
     pub fn method_body_inlined() {
         println!("Hello, world!");
@@ -101,7 +101,7 @@ impl Foo {
 
 
 // Change Method Privacy -------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //--------------------------
     //--------------------------
@@ -110,21 +110,21 @@ impl Foo {
     pub fn method_privacy() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail6")]
     fn     method_privacy() { }
 }
 
 // Change Method Selfness -----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //------------
     //---------------
@@ -139,27 +139,27 @@ impl Foo {
     pub fn method_selfness() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
     #[rustc_clean(
-        cfg="cfail2",
+        cfg="bfail2",
         except="opt_hir_owner_nodes,fn_sig,generics_of,typeck_root,associated_item,optimized_mir",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
-        cfg="cfail5",
+        cfg="bfail5",
         except="opt_hir_owner_nodes,fn_sig,generics_of,typeck_root,associated_item,optimized_mir",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn method_selfness(&self) { }
 }
 
 // Change Method Selfmutness ---------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //------------------------------------------------------------------------------------
     //--------------------------
@@ -168,48 +168,48 @@ impl Foo {
     pub fn method_selfmutness(&    self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn method_selfmutness(&mut self) { }
 }
 
 
 
 // Add Method To Impl ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     pub fn add_method_to_impl1(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,associated_item_def_ids")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,associated_item_def_ids")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,associated_item_def_ids")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,associated_item_def_ids")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_method_to_impl1(&self) { }
 
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_method_to_impl2(&self) { }
 }
 
 
 
 // Add Method Parameter --------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //------------------------------------------------------------------------------------
     //--------------------------
@@ -218,23 +218,23 @@ impl Foo {
     pub fn add_method_parameter(&self        ) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_method_parameter(&self, _: i32) { }
 }
 
 
 
 // Change Method Parameter Name ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //----------------------------------------------------------------------
     //--------------------------
@@ -243,23 +243,23 @@ impl Foo {
     pub fn change_method_parameter_name(&self, a: i64) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn change_method_parameter_name(&self, b: i64) { }
 }
 
 
 
 // Change Method Return Type ---------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //------------------------------------------------------------------------------------
     //--------------------------
@@ -268,23 +268,23 @@ impl Foo {
     pub fn change_method_return_type(&self) -> u16 { 0 }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn change_method_return_type(&self) -> u32 { 0 }
 }
 
 
 
 // Make Method #[inline] -------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //--------------------------
     //--------------------------
@@ -294,16 +294,16 @@ impl Foo {
     pub fn make_method_inline(&self) -> u8 { 0 }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     #[inline]
     pub fn make_method_inline(&self) -> u8 { 0 }
 }
@@ -311,7 +311,7 @@ impl Foo {
 
 
 //  Change order of parameters -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //----------------------------------------------------------------------
     //--------------------------
@@ -320,23 +320,23 @@ impl Foo {
     pub fn change_method_parameter_order(&self, a: i64, b: i64) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn change_method_parameter_order(&self, b: i64, a: i64) { }
 }
 
 
 
 // Make method unsafe ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //----------------------------------------------------------------------
     //--------------------------
@@ -345,23 +345,23 @@ impl Foo {
     pub        fn make_method_unsafe(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub unsafe fn make_method_unsafe(&self) { }
 }
 
 
 
 // Make method extern ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //----------------------------------------------------------------------
     //--------------------------
@@ -370,23 +370,23 @@ impl Foo {
     pub            fn make_method_extern(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub extern "C" fn make_method_extern(&self) { }
 }
 
 
 
 // Change method calling convention --------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //----------------------------------------------------------------------
     //--------------------------
@@ -395,23 +395,23 @@ impl Foo {
     pub extern "C"      fn change_method_calling_convention(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub extern "system" fn change_method_calling_convention(&self) { }
 }
 
 
 
 // Add Lifetime Parameter to Method --------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     // -----------------------------------------------------
     // ---------------------------------------------------------
@@ -429,11 +429,11 @@ impl Foo {
     pub fn add_lifetime_parameter_to_method    (&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of lifetime parameters that don't
@@ -444,17 +444,17 @@ impl Foo {
     // if we lower generics before the body, then the `HirId` for
     // things in the body will be affected. So if you start to see
     // `typeck_root` appear dirty, that might be the cause. -nmatsakis
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,fn_sig")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,fn_sig,generics_of")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,fn_sig")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,fn_sig,generics_of")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_lifetime_parameter_to_method<'a>(&self) { }
 }
 
 
 
 // Add Type Parameter To Method ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     // -----------------------------------------------------
     // ---------------------------------------------------------------
@@ -478,11 +478,11 @@ impl Foo {
     pub fn add_type_parameter_to_method   (&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of type parameters that don't appear in
@@ -494,22 +494,22 @@ impl Foo {
     // body will be affected. So if you start to see `typeck_root`
     // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(
-        cfg="cfail2",
+        cfg="bfail2",
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
-        cfg="cfail5",
+        cfg="bfail5",
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_type_parameter_to_method<T>(&self) { }
 }
 
 
 
 // Add Lifetime Bound to Lifetime Parameter of Method --------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //------------
     //---------------
@@ -524,29 +524,29 @@ impl Foo {
     pub fn add_lifetime_bound_to_lifetime_param_of_method<'a, 'b    >(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
     #[rustc_clean(
-        cfg="cfail2",
+        cfg="bfail2",
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
-        cfg="cfail5",
+        cfg="bfail5",
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_lifetime_bound_to_lifetime_param_of_method<'a, 'b: 'a>(&self) { }
 }
 
 
 
 // Add Lifetime Bound to Type Parameter of Method ------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     // -----------------------------------------------------
     // ----------------------------------------------------------
@@ -570,11 +570,11 @@ impl Foo {
     pub fn add_lifetime_bound_to_type_param_of_method<'a, T    >(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of bounds that don't appear in the
@@ -586,22 +586,22 @@ impl Foo {
     // body will be affected. So if you start to see `typeck_root`
     // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(
-        cfg="cfail2",
+        cfg="bfail2",
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
-        cfg="cfail5",
+        cfg="bfail5",
         except="opt_hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_lifetime_bound_to_type_param_of_method<'a, T: 'a>(&self) { }
 }
 
 
 
 // Add Trait Bound to Type Parameter of Method ------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     // -----------------------------------------------------
     // ----------------------------------------------------------
@@ -619,11 +619,11 @@ impl Foo {
     pub fn add_trait_bound_to_type_param_of_method<T       >(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
     // Warning: Note that `typeck_root` are coming up clean here.
     // The addition or removal of bounds that don't appear in the
@@ -634,17 +634,17 @@ impl Foo {
     // generics before the body, then the `HirId` for things in the
     // body will be affected. So if you start to see `typeck_root`
     // appear dirty, that might be the cause. -nmatsakis
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,predicates_of")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_trait_bound_to_type_param_of_method<T: Clone>(&self) { }
 }
 
 
 
 // Add #[no_mangle] to Method --------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Foo {
     //--------------------------
     //--------------------------
@@ -654,16 +654,16 @@ impl Foo {
     pub fn add_no_mangle_to_method(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     #[unsafe(no_mangle)]
     pub fn add_no_mangle_to_method(&self) { }
 }
@@ -673,90 +673,90 @@ impl Foo {
 struct Bar<T>(T);
 
 // Add Type Parameter To Impl --------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Bar<u32> {
     pub fn add_type_parameter_to_impl(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,generics_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,generics_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,generics_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,generics_of")]
+#[rustc_clean(cfg="bfail6")]
 impl<T> Bar<T> {
     #[rustc_clean(
-        cfg="cfail2",
+        cfg="bfail2",
         except="generics_of,fn_sig,typeck_root,type_of,optimized_mir"
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
-        cfg="cfail5",
+        cfg="bfail5",
         except="generics_of,fn_sig,typeck_root,type_of,optimized_mir"
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_type_parameter_to_impl(&self) { }
 }
 
 
 
 // Change Self Type of Impl ----------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl Bar<u32> {
     pub fn change_impl_self_type(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 impl Bar<u64> {
-    #[rustc_clean(cfg="cfail2", except="fn_sig,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="fn_sig,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="fn_sig,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn change_impl_self_type(&self) { }
 }
 
 
 
 // Add Lifetime Bound to Impl --------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl<T> Bar<T> {
     pub fn add_lifetime_bound_to_impl_parameter(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 impl<T: 'static> Bar<T> {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_lifetime_bound_to_impl_parameter(&self) { }
 }
 
 
 
 // Add Trait Bound to Impl Parameter -------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl<T> Bar<T> {
     pub fn add_trait_bound_to_impl_parameter(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 impl<T: Clone> Bar<T> {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn add_trait_bound_to_impl_parameter(&self) { }
 }
 
@@ -765,12 +765,12 @@ impl<T: Clone> Bar<T> {
 pub fn instantiation_root() {
     Foo::method_privacy();
 
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     {
         Bar(0u32).change_impl_self_type();
     }
 
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     {
         Bar(0u64).change_impl_self_type();
     }

--- a/tests/incremental/hashes/inline_asm.rs
+++ b/tests/incremental/hashes/inline_asm.rs
@@ -6,12 +6,12 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
 //@ needs-asm-support
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -21,7 +21,7 @@
 use std::arch::asm;
 
 // Change template
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_template(_a: i32) -> i32 {
     let c: i32;
@@ -33,11 +33,11 @@ pub fn change_template(_a: i32) -> i32 {
     c
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_template(_a: i32) -> i32 {
     let c: i32;
@@ -52,7 +52,7 @@ pub fn change_template(_a: i32) -> i32 {
 
 
 // Change output
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_output(a: i32) -> i32 {
     let mut _out1: i32 = 0;
@@ -66,11 +66,11 @@ pub fn change_output(a: i32) -> i32 {
     _out1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_output(a: i32) -> i32 {
     let mut _out1: i32 = 0;
@@ -87,7 +87,7 @@ pub fn change_output(a: i32) -> i32 {
 
 
 // Change input
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -100,11 +100,11 @@ pub fn change_input(_a: i32, _b: i32) -> i32 {
     _out
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -120,7 +120,7 @@ pub fn change_input(_a: i32, _b: i32) -> i32 {
 
 
 // Change input constraint
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -133,11 +133,11 @@ pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     _out
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -152,7 +152,7 @@ pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
 
 
 // Change clobber
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_clobber(_a: i32) -> i32 {
     let _out;
@@ -166,11 +166,11 @@ pub fn change_clobber(_a: i32) -> i32 {
     _out
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_clobber(_a: i32) -> i32 {
     let _out;
@@ -187,7 +187,7 @@ pub fn change_clobber(_a: i32) -> i32 {
 
 
 // Change options
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_options(_a: i32) -> i32 {
     let _out;
@@ -201,11 +201,11 @@ pub fn change_options(_a: i32) -> i32 {
     _out
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_options(_a: i32) -> i32 {
     let _out;

--- a/tests/incremental/hashes/let_expressions.rs
+++ b/tests/incremental/hashes/let_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -18,16 +18,16 @@
 #![crate_type="rlib"]
 
 // Change Name -----------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_name() {
     let _x = 2u64;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_name() {
     let _y = 2u64;
 }
@@ -35,16 +35,16 @@ pub fn change_name() {
 
 
 // Add Type --------------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_type() {
     let _x      = 2u32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_type() {
     let _x: u32 = 2u32;
 }
@@ -52,16 +52,16 @@ pub fn add_type() {
 
 
 // Change Type -----------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_type() {
     let _x: u64 = 2;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_type() {
     let _x: u8  = 2;
 }
@@ -69,16 +69,16 @@ pub fn change_type() {
 
 
 // Change Mutability of Reference Type -----------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_mutability_of_reference_type() {
     let _x: &    u64;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_mutability_of_reference_type() {
     let _x: &mut u64;
 }
@@ -86,16 +86,16 @@ pub fn change_mutability_of_reference_type() {
 
 
 // Change Mutability of Slot ---------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_mutability_of_slot() {
     let mut _x: u64 = 0;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_mutability_of_slot() {
     let     _x: u64 = 0;
 }
@@ -103,16 +103,16 @@ pub fn change_mutability_of_slot() {
 
 
 // Change Simple Binding to Pattern --------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_simple_binding_to_pattern() {
     let  _x      = (0u8, 'x');
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_simple_binding_to_pattern() {
     let (_a, _b) = (0u8, 'x');
 }
@@ -120,16 +120,16 @@ pub fn change_simple_binding_to_pattern() {
 
 
 // Change Name in Pattern ------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_name_in_pattern() {
     let (_a, _b) = (1u8, 'y');
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_name_in_pattern() {
     let (_a, _c) = (1u8, 'y');
 }
@@ -137,16 +137,16 @@ pub fn change_name_in_pattern() {
 
 
 // Add `ref` in Pattern --------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_ref_in_pattern() {
     let (    _a, _b) = (1u8, 'y');
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_ref_in_pattern() {
     let (ref _a, _b) = (1u8, 'y');
 }
@@ -154,16 +154,16 @@ pub fn add_ref_in_pattern() {
 
 
 // Add `&` in Pattern ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_amp_in_pattern() {
     let ( _a, _b) = (&1u8, 'y');
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_amp_in_pattern() {
     let (&_a, _b) = (&1u8, 'y');
 }
@@ -171,16 +171,16 @@ pub fn add_amp_in_pattern() {
 
 
 // Change Mutability of Binding in Pattern -------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_mutability_of_binding_in_pattern() {
     let (    _a, _b) = (99u8, 'q');
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_mutability_of_binding_in_pattern() {
     let (mut _a, _b) = (99u8, 'q');
 }
@@ -188,16 +188,16 @@ pub fn change_mutability_of_binding_in_pattern() {
 
 
 // Add Initializer -------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_initializer() {
     let _x: i16       ;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_initializer() {
     let _x: i16 = 3i16;
 }
@@ -205,16 +205,16 @@ pub fn add_initializer() {
 
 
 // Change Initializer ----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_initializer() {
     let _x = 4u16;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_initializer() {
     let _x = 5u16;
 }

--- a/tests/incremental/hashes/loop_expressions.rs
+++ b/tests/incremental/hashes/loop_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,7 +19,7 @@
 
 
 // Change loop body
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     loop {
@@ -28,11 +28,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     loop {
@@ -44,7 +44,7 @@ pub fn change_loop_body() {
 
 
 // Add break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_break() {
     let mut _x = 0;
     loop {
@@ -53,11 +53,11 @@ pub fn add_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_break() {
     let mut _x = 0;
     loop {
@@ -69,7 +69,7 @@ pub fn add_break() {
 
 
 // Add loop label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
     /*---*/ loop {
@@ -78,11 +78,11 @@ pub fn add_loop_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: loop {
@@ -94,7 +94,7 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: loop {
@@ -103,11 +103,11 @@ pub fn add_loop_label_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: loop {
@@ -119,7 +119,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: loop {
@@ -130,11 +130,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: loop {
@@ -148,7 +148,7 @@ pub fn change_break_label() {
 
 
 // Add loop label to continue
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: loop {
@@ -157,11 +157,11 @@ pub fn add_loop_label_to_continue() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: loop {
@@ -173,7 +173,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: loop {
@@ -184,11 +184,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: loop {
@@ -202,7 +202,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     loop {
@@ -211,11 +211,11 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, typeck_root, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, typeck_root, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     loop {

--- a/tests/incremental/hashes/match_expressions.rs
+++ b/tests/incremental/hashes/match_expressions.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -18,7 +18,7 @@
 #![crate_type="rlib"]
 
 // Add Arm ---------------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -28,11 +28,11 @@ pub fn add_arm(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -45,7 +45,7 @@ pub fn add_arm(x: u32) -> u32 {
 
 
 // Change Order Of Arms --------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_order_of_arms(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -54,11 +54,11 @@ pub fn change_order_of_arms(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_order_of_arms(x: u32) -> u32 {
     match x {
         1 => 1,
@@ -70,7 +70,7 @@ pub fn change_order_of_arms(x: u32) -> u32 {
 
 
 // Add Guard Clause ------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
@@ -79,11 +79,11 @@ pub fn add_guard_clause(x: u32, y: bool) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
@@ -95,7 +95,7 @@ pub fn add_guard_clause(x: u32, y: bool) -> u32 {
 
 
 // Change Guard Clause ------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
@@ -104,11 +104,11 @@ pub fn change_guard_clause(x: u32, y: bool) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
@@ -120,7 +120,7 @@ pub fn change_guard_clause(x: u32, y: bool) -> u32 {
 
 
 // Add @-Binding ---------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -129,11 +129,11 @@ pub fn add_at_binding(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -145,7 +145,7 @@ pub fn add_at_binding(x: u32) -> u32 {
 
 
 // Change Name of @-Binding ----------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_name_of_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -154,11 +154,11 @@ pub fn change_name_of_at_binding(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_name_of_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -170,7 +170,7 @@ pub fn change_name_of_at_binding(x: u32) -> u32 {
 
 
 // Change Simple Binding To Pattern --------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_simple_name_to_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (0, 0) => 0,
@@ -178,11 +178,11 @@ pub fn change_simple_name_to_pattern(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_simple_name_to_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (0, 0) => 0,
@@ -193,7 +193,7 @@ pub fn change_simple_name_to_pattern(x: u32) -> u32 {
 
 
 // Change Name In Pattern ------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_name_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (a, 0) => 0,
@@ -202,11 +202,11 @@ pub fn change_name_in_pattern(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_name_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (b, 0) => 0,
@@ -218,7 +218,7 @@ pub fn change_name_in_pattern(x: u32) -> u32 {
 
 
 // Change Mutability Of Binding In Pattern -------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (    a, 0) => 0,
@@ -226,12 +226,12 @@ pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
     }
 }
 
-// Ignore optimized_mir in cfail2, the only change to optimized MIR is a span.
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+// Ignore optimized_mir in bfail2, the only change to optimized MIR is a span.
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (mut a, 0) => 0,
@@ -242,7 +242,7 @@ pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
 
 
 // Add `ref` To Binding In Pattern -------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (    a, 0) => 0,
@@ -250,11 +250,11 @@ pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (ref a, 0) => 0,
@@ -265,7 +265,7 @@ pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
 
 
 // Add `&` To Binding In Pattern -------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
     match (&x, x & 1) {
         ( a, 0) => 0,
@@ -273,11 +273,11 @@ pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
     match (&x, x & 1) {
         (&a, 0) => 0,
@@ -288,7 +288,7 @@ pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
 
 
 // Change RHS Of Arm -----------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_rhs_of_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -297,11 +297,11 @@ pub fn change_rhs_of_arm(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_rhs_of_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -313,7 +313,7 @@ pub fn change_rhs_of_arm(x: u32) -> u32 {
 
 
 // Add Alternative To Arm ------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_alternative_to_arm(x: u32) -> u32 {
     match x {
         0     => 0,
@@ -322,11 +322,11 @@ pub fn add_alternative_to_arm(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_alternative_to_arm(x: u32) -> u32 {
     match x {
         0 | 7 => 0,

--- a/tests/incremental/hashes/panic_exprs.rs
+++ b/tests/incremental/hashes/panic_exprs.rs
@@ -9,7 +9,7 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -C debug-assertions -O
 //@ ignore-backends: gcc
 
@@ -19,14 +19,14 @@
 
 
 // Indexing expression
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn indexing(slice: &[u8]) -> u8 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         slice[100]
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         slice[100]
     }
@@ -34,14 +34,14 @@ pub fn indexing(slice: &[u8]) -> u8 {
 
 
 // Arithmetic overflow plus
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn arithmetic_overflow_plus(val: i32) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         val + 1
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         val + 1
     }
@@ -49,14 +49,14 @@ pub fn arithmetic_overflow_plus(val: i32) -> i32 {
 
 
 // Arithmetic overflow minus
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn arithmetic_overflow_minus(val: i32) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         val - 1
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         val - 1
     }
@@ -64,14 +64,14 @@ pub fn arithmetic_overflow_minus(val: i32) -> i32 {
 
 
 // Arithmetic overflow mult
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn arithmetic_overflow_mult(val: i32) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         val * 2
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         val * 2
     }
@@ -79,14 +79,14 @@ pub fn arithmetic_overflow_mult(val: i32) -> i32 {
 
 
 // Arithmetic overflow negation
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn arithmetic_overflow_negation(val: i32) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         -val
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         -val
     }
@@ -94,28 +94,28 @@ pub fn arithmetic_overflow_negation(val: i32) -> i32 {
 
 
 // Division by zero
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn division_by_zero(val: i32) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         2 / val
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         2 / val
     }
 }
 
 // Division by zero
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn mod_by_zero(val: i32) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         2 % val
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         2 % val
     }
@@ -123,14 +123,14 @@ pub fn mod_by_zero(val: i32) -> i32 {
 
 
 // shift left
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn shift_left(val: i32, shift: usize) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         val << shift
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         val << shift
     }
@@ -138,14 +138,14 @@ pub fn shift_left(val: i32, shift: usize) -> i32 {
 
 
 // shift right
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
 pub fn shift_right(val: i32, shift: usize) -> i32 {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         val >> shift
     }
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     {
         val >> shift
     }

--- a/tests/incremental/hashes/statics.rs
+++ b/tests/incremental/hashes/statics.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -21,140 +21,140 @@
 
 
 // Change static visibility
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static     STATIC_VISIBILITY: u8 = 0;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub static STATIC_VISIBILITY: u8 = 0;
 
 
 // Change static mutability
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static STATIC_MUTABILITY: u8 = 0;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 static mut STATIC_MUTABILITY: u8 = 0;
 
 
 // Add linkage attribute
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static STATIC_LINKAGE: u8 = 0;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 #[linkage="weak_odr"]
 static STATIC_LINKAGE: u8 = 0;
 
 
 // Add no_mangle attribute
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static STATIC_NO_MANGLE: u8 = 0;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 #[unsafe(no_mangle)]
 static STATIC_NO_MANGLE: u8 = 0;
 
 
 // Add thread_local attribute
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static STATIC_THREAD_LOCAL: u8 = 0;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 #[thread_local]
 static STATIC_THREAD_LOCAL: u8 = 0;
 
 
 // Change type from i16 to u64
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static STATIC_CHANGE_TYPE_1: i16 = 0;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 static STATIC_CHANGE_TYPE_1: u64 = 0;
 
 
 // Change type from Option<i8> to Option<u16>
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 static STATIC_CHANGE_TYPE_2: Option<i8> = None;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 static STATIC_CHANGE_TYPE_2: Option<u16> = None;
 
 
 // Change value between simple literals
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 static STATIC_CHANGE_VALUE_1: i16 = {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     { 1 }
 
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     { 2 }
 };
 
 
 // Change value between expressions
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 static STATIC_CHANGE_VALUE_2: i16 = {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     { 1 + 1 }
 
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     { 1 + 2 }
 };
 
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 static STATIC_CHANGE_VALUE_3: i16 = {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     { 2 + 3 }
 
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     { 2 * 3 }
 };
 
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 static STATIC_CHANGE_VALUE_4: i16 = {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     { 1 + 2 * 3 }
 
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     { 1 + 2 * 4 }
 };
 
@@ -164,21 +164,21 @@ struct ReferencedType1;
 struct ReferencedType2;
 
 mod static_change_type_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as Type;
 
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as Type;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="bfail6")]
     static STATIC_CHANGE_TYPE_INDIRECTLY_1: Type = Type;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,type_of")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="bfail6")]
     static STATIC_CHANGE_TYPE_INDIRECTLY_2: Option<Type> = None;
 }

--- a/tests/incremental/hashes/struct_constructors.rs
+++ b/tests/incremental/hashes/struct_constructors.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -25,7 +25,7 @@ pub struct RegularStruct {
 }
 
 // Change field value (regular struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_value_regular_struct() -> RegularStruct {
     RegularStruct {
         x: 0,
@@ -34,11 +34,11 @@ pub fn change_field_value_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_field_value_regular_struct() -> RegularStruct {
     RegularStruct {
         x: 0,
@@ -50,7 +50,7 @@ pub fn change_field_value_regular_struct() -> RegularStruct {
 
 
 // Change field order (regular struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_order_regular_struct() -> RegularStruct {
     RegularStruct {
         x: 3,
@@ -59,11 +59,11 @@ pub fn change_field_order_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_field_order_regular_struct() -> RegularStruct {
     RegularStruct {
         y: 4,
@@ -75,7 +75,7 @@ pub fn change_field_order_regular_struct() -> RegularStruct {
 
 
 // Add field (regular struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_field_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -90,11 +90,11 @@ pub fn add_field_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_field_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -112,7 +112,7 @@ pub fn add_field_regular_struct() -> RegularStruct {
 
 
 // Change field label (regular struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_label_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -127,11 +127,11 @@ pub fn change_field_label_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_field_label_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -155,7 +155,7 @@ pub struct RegularStruct2 {
 }
 
 // Change constructor path (regular struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_path_regular_struct() {
     let _ = RegularStruct  {
         x: 0,
@@ -164,11 +164,11 @@ pub fn change_constructor_path_regular_struct() {
     };
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_path_regular_struct() {
     let _ = RegularStruct2 {
         x: 0,
@@ -181,15 +181,15 @@ pub fn change_constructor_path_regular_struct() {
 
 // Change constructor path indirectly (regular struct)
 pub mod change_constructor_path_indirectly_regular_struct {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::RegularStruct as Struct;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::RegularStruct2 as Struct;
 
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
     pub fn function() -> Struct {
         Struct {
             x: 0,
@@ -204,16 +204,16 @@ pub mod change_constructor_path_indirectly_regular_struct {
 pub struct TupleStruct(i32, i64, i16);
 
 // Change field value (tuple struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_field_value_tuple_struct() -> TupleStruct {
     TupleStruct(0, 1, 2)
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_field_value_tuple_struct() -> TupleStruct {
     TupleStruct(0, 1, 3)
 }
@@ -223,16 +223,16 @@ pub fn change_field_value_tuple_struct() -> TupleStruct {
 pub struct TupleStruct2(u16, u16, u16);
 
 // Change constructor path (tuple struct)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_constructor_path_tuple_struct() {
     let _ = TupleStruct (0, 1, 2);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_constructor_path_tuple_struct() {
     let _ = TupleStruct2(0, 1, 2);
 }
@@ -241,15 +241,15 @@ pub fn change_constructor_path_tuple_struct() {
 
 // Change constructor path indirectly (tuple struct)
 pub mod change_constructor_path_indirectly_tuple_struct {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::TupleStruct as Struct;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::TupleStruct2 as Struct;
 
-    #[rustc_clean(cfg="cfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail6")]
-    #[rustc_clean(cfg="cfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail5", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail6")]
+    #[rustc_clean(cfg="bfail2", except="fn_sig,opt_hir_owner_nodes,optimized_mir,typeck_root")]
+    #[rustc_clean(cfg="bfail3")]
     pub fn function() -> Struct {
         Struct(0, 1, 2)
     }

--- a/tests/incremental/hashes/struct_defs.rs
+++ b/tests/incremental/hashes/struct_defs.rs
@@ -11,11 +11,11 @@
 // the same between rev2 and rev3.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -23,39 +23,39 @@
 #![crate_type="rlib"]
 
 // Layout ----------------------------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub struct LayoutPacked;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="type_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="type_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="type_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="type_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 #[repr(packed)]
 pub struct LayoutPacked;
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct LayoutC;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="type_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="type_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="type_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="type_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 #[repr(C)]
 struct LayoutC;
 
 
 // Tuple Struct Change Field Type ----------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct TupleStructFieldType(i32);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 // Note that changing the type of a field does not change the type of the struct or enum, but
 // adding/removing fields or changing a fields name or visibility does.
 struct TupleStructFieldType(
@@ -65,14 +65,14 @@ struct TupleStructFieldType(
 
 // Tuple Struct Add Field ------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct TupleStructAddField(i32);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct TupleStructAddField(
     i32,
     u32
@@ -81,27 +81,27 @@ struct TupleStructAddField(
 
 // Tuple Struct Field Visibility -----------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct TupleStructFieldVisibility(    char);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 struct TupleStructFieldVisibility(pub char);
 
 
 // Record Struct Field Type ----------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct RecordStructFieldType { x: f32 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 // Note that changing the type of a field does not change the type of the struct or enum, but
 // adding/removing fields or changing a fields name or visibility does.
 struct RecordStructFieldType {
@@ -111,27 +111,27 @@ struct RecordStructFieldType {
 
 // Record Struct Field Name ----------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct RecordStructFieldName { x: f32 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct RecordStructFieldName { y: f32 }
 
 
 // Record Struct Add Field -----------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct RecordStructAddField { x: f32 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct RecordStructAddField {
     x: f32,
     y: () }
@@ -139,53 +139,53 @@ struct RecordStructAddField {
 
 // Record Struct Field Visibility ----------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct RecordStructFieldVisibility {     x: f32 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="type_of")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,type_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="type_of")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="bfail6")]
 struct RecordStructFieldVisibility { pub x: f32 }
 
 
 // Add Lifetime Parameter ------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct AddLifetimeParameter<'a>(&'a f32, &'a f64);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct AddLifetimeParameter<'a, 'b>(&'a f32, &'b f64);
 
 
 // Add Lifetime Parameter Bound ------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct AddLifetimeParameterBound<'a, 'b>(&'a f32, &'b f64);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct AddLifetimeParameterBound<'a, 'b: 'a>(
     &'a f32,
     &'b f64
 );
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct AddLifetimeParameterBoundWhereClause<'a, 'b>(&'a f32, &'b f64);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct AddLifetimeParameterBoundWhereClause<'a, 'b>(
     &'a f32,
     &'b f64)
@@ -194,14 +194,14 @@ struct AddLifetimeParameterBoundWhereClause<'a, 'b>(
 
 // Add Type Parameter ----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct AddTypeParameter<T1>(T1, T1);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,type_of,generics_of,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct AddTypeParameter<T1, T2>(
      // The field contains the parent's Generics, so it's dirty even though its
      // type hasn't changed.
@@ -212,27 +212,27 @@ struct AddTypeParameter<T1, T2>(
 
 // Add Type Parameter Bound ----------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct AddTypeParameterBound<T>(T);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct AddTypeParameterBound<T: Send>(
     T
 );
 
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct AddTypeParameterBoundWhereClause<T>(T);
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 struct AddTypeParameterBoundWhereClause<T>(
     T
 ) where T: Sync;
@@ -243,23 +243,23 @@ struct AddTypeParameterBoundWhereClause<T>(
 // fingerprint is stable (i.e., that there are no random influences like memory
 // addresses taken into account by the hashing algorithm).
 // Note: there is no #[cfg(...)], so this is ALWAYS compiled
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub struct EmptyStruct;
 
 
 // Visibility ------------------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 struct     Visibility;
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub struct Visibility;
 
 struct ReferencedType1;
@@ -267,15 +267,15 @@ struct ReferencedType2;
 
 // Tuple Struct Change Field Type Indirectly -----------------------------------
 mod tuple_struct_change_field_type_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as FieldType;
 
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     struct TupleStruct(
         FieldType
     );
@@ -284,15 +284,15 @@ mod tuple_struct_change_field_type_indirectly {
 
 // Record Struct Change Field Type Indirectly -----------------------------------
 mod record_struct_change_field_type_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedType2 as FieldType;
 
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     struct RecordStruct {
         _x: FieldType
     }
@@ -306,28 +306,28 @@ trait ReferencedTrait2 {}
 
 // Change Trait Bound Indirectly -----------------------------------------------
 mod change_trait_bound_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     struct Struct<T: Trait>(T);
 }
 
 // Change Trait Bound Indirectly In Where Clause -------------------------------
 mod change_trait_bound_indirectly_in_where_clause {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     struct Struct<T>(T) where T : Trait;
 }

--- a/tests/incremental/hashes/trait_defs.rs
+++ b/tests/incremental/hashes/trait_defs.rs
@@ -11,11 +11,11 @@
 // the same between rev2 and rev3.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -25,41 +25,41 @@
 
 
 // Change trait visibility
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitVisibility { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,predicates_of")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="bfail6")]
 pub trait TraitVisibility { }
 
 
 
 // Change trait unsafety
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitUnsafety { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 unsafe trait TraitUnsafety { }
 
 
 
 // Add method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddMethod {
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub trait TraitAddMethod {
     fn method();
 }
@@ -67,16 +67,16 @@ pub trait TraitAddMethod {
 
 
 // Change name of method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeMethodName {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeMethodName {
     fn methodChanged();
 }
@@ -84,7 +84,7 @@ trait TraitChangeMethodName {
 
 
 // Add return type to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddReturnType {
     //---------------------------------------------------------------
     //--------------------------
@@ -93,23 +93,23 @@ trait TraitAddReturnType {
     fn method()       ;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddReturnType {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method() -> u32;
 }
 
 
 
 // Change return type of method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeReturnType {
     // --------------------------------------------------------------
     // -------------------------
@@ -118,23 +118,23 @@ trait TraitChangeReturnType {
     fn method() -> u32;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeReturnType {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method() -> u64;
 }
 
 
 
 // Add parameter to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddParameterToMethod {
     // --------------------------------------------------------------
     // -------------------------
@@ -143,23 +143,23 @@ trait TraitAddParameterToMethod {
     fn method(      );
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddParameterToMethod {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(a: u32);
 }
 
 
 
 // Change name of method parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeMethodParameterName {
     //------------------------------------------------------
     //--------------------------------------------------------
@@ -175,30 +175,30 @@ trait TraitChangeMethodParameterName {
     fn with_default(x: i32) {}
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeMethodParameterName {
     // FIXME(#38501) This should preferably always be clean.
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(b: u32);
 
-    #[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn with_default(y: i32) {}
 }
 
 
 
 // Change type of method parameter (i32 => i64)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeMethodParameterType {
     // --------------------------------------------------------------
     // -------------------------
@@ -207,23 +207,23 @@ trait TraitChangeMethodParameterType {
     fn method(a: i32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeMethodParameterType {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(a: i64);
 }
 
 
 
 // Change type of method parameter (&i32 => &mut i32)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeMethodParameterTypeRef {
     // --------------------------------------------------------------
     // -------------------------
@@ -232,23 +232,23 @@ trait TraitChangeMethodParameterTypeRef {
     fn method(a: &    i32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeMethodParameterTypeRef {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(a: &mut i32);
 }
 
 
 
 // Change order of method parameters
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeMethodParametersOrder {
     // --------------------------------------------------------------
     // -------------------------
@@ -257,23 +257,23 @@ trait TraitChangeMethodParametersOrder {
     fn method(a: i32, b: i64);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeMethodParametersOrder {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(b: i64, a: i32);
 }
 
 
 
 // Add default implementation to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddMethodAutoImplementation {
     // -------------------------------------------------------
     // -------------------------
@@ -282,33 +282,33 @@ trait TraitAddMethodAutoImplementation {
     fn method()  ;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddMethodAutoImplementation {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method() {}
 }
 
 
 
 // Change order of methods
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeOrderOfMethods {
     fn method0();
     fn method1();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeOrderOfMethods {
     fn method1();
     fn method0();
@@ -317,7 +317,7 @@ trait TraitChangeOrderOfMethods {
 
 
 // Change mode of self parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeModeSelfRefToMut {
     // --------------------------------------------------------------
     // -------------------------
@@ -326,22 +326,22 @@ trait TraitChangeModeSelfRefToMut {
     fn method(&    self);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeModeSelfRefToMut {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(&mut self);
 }
 
 
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeModeSelfOwnToMut: Sized {
     // ----------------------------------------------------------------------------
     // -------------------------
@@ -350,22 +350,22 @@ trait TraitChangeModeSelfOwnToMut: Sized {
     fn method(    self) {}
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeModeSelfOwnToMut: Sized {
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(mut self) {}
 }
 
 
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeModeSelfOwnToRef {
     // --------------------------------------------------------------------------
     // -------------------------
@@ -374,23 +374,23 @@ trait TraitChangeModeSelfOwnToRef {
     fn method( self);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeModeSelfOwnToRef {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method(&self);
 }
 
 
 
 // Add unsafe modifier to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddUnsafeModifier {
     // --------------------------------------------------------------
     // -------------------------
@@ -399,23 +399,23 @@ trait TraitAddUnsafeModifier {
     fn        method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddUnsafeModifier {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     unsafe fn method();
 }
 
 
 
 // Add extern modifier to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddExternModifier {
     // --------------------------------------------------------------
     // -------------------------
@@ -424,23 +424,23 @@ trait TraitAddExternModifier {
     fn            method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddExternModifier {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     extern "C" fn method();
 }
 
 
 
 // Change extern "C" to extern "stdcall"
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeExternCToExternSystem {
     // --------------------------------------------------------------
     // -------------------------
@@ -449,23 +449,23 @@ trait TraitChangeExternCToExternSystem {
     extern "C"       fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeExternCToRustIntrinsic {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     extern "system" fn method();
 }
 
 
 
 // Add type parameter to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTypeParameterToMethod {
     // --------------------------------------------------------------------------
     // ---------------
@@ -476,25 +476,25 @@ trait TraitAddTypeParameterToMethod {
     fn method   ();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTypeParameterToMethod {
     #[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of,type_of",
-        cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
+        cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of,type_of",
-        cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+        cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<T>();
 }
 
 
 
 // Add lifetime parameter to method
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeParameterToMethod {
     // --------------------------------------------------------------------------
     // -------------------------
@@ -503,16 +503,16 @@ trait TraitAddLifetimeParameterToMethod {
     fn method    ();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeParameterToMethod {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,generics_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<'a>();
 }
 
@@ -523,7 +523,7 @@ trait ReferencedTrait0 { }
 trait ReferencedTrait1 { }
 
 // Add trait bound to method type parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTraitBoundToMethodTypeParameter {
     // ---------------------------------------------------------------------
     // -------------------------
@@ -532,23 +532,23 @@ trait TraitAddTraitBoundToMethodTypeParameter {
     fn method<T                  >();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTraitBoundToMethodTypeParameter {
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<T: ReferencedTrait0>();
 }
 
 
 
 // Add builtin bound to method type parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
     // ---------------------------------------------------------------------
     // -------------------------
@@ -557,23 +557,23 @@ trait TraitAddBuiltinBoundToMethodTypeParameter {
     fn method<T       >();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<T: Sized>();
 }
 
 
 
 // Add lifetime bound to method lifetime parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeBoundToMethodLifetimeParameter {
     // -----------
     // -----------------------------------------------------------------------
@@ -588,29 +588,29 @@ trait TraitAddLifetimeBoundToMethodLifetimeParameter {
     fn method<'a, 'b    >(a: &'a u32, b: &'b u32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeBoundToMethodLifetimeParameter {
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
-        cfg="cfail2",
+        cfg="bfail2",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
-        cfg="cfail5",
+        cfg="bfail5",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<'a, 'b: 'a>(a: &'a u32, b: &'b u32);
 }
 
 
 
 // Add second trait bound to method type parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondTraitBoundToMethodTypeParameter {
     // ---------------------------------------------------------------------
     // -------------------------
@@ -619,23 +619,23 @@ trait TraitAddSecondTraitBoundToMethodTypeParameter {
     fn method<T: ReferencedTrait0                   >();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondTraitBoundToMethodTypeParameter {
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<T: ReferencedTrait0 + ReferencedTrait1>();
 }
 
 
 
 // Add second builtin bound to method type parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
     // ---------------------------------------------------------------------
     // -------------------------
@@ -644,23 +644,23 @@ trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
     fn method<T: Sized       >();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<T: Sized + Sync>();
 }
 
 
 
 // Add second lifetime bound to method lifetime parameter
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
     // -----------
     // -----------------------------------------------------------------------
@@ -675,29 +675,29 @@ trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
     fn method<'a, 'b, 'c: 'a     >(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
-        cfg="cfail2",
+        cfg="bfail2",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
-        cfg="cfail5",
+        cfg="bfail5",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     fn method<'a, 'b, 'c: 'a + 'b>(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 
 
 
 // Add associated type
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddAssociatedType {
     //--------------------------
     //--------------------------
@@ -710,27 +710,27 @@ trait TraitAddAssociatedType {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddAssociatedType {
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail6")]
     type Associated;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method();
 }
 
 
 
 // Add trait bound to associated type
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTraitBoundToAssociatedType {
     // -------------------------------------------------------
     // -------------------------
@@ -744,16 +744,16 @@ trait TraitAddTraitBoundToAssociatedType {
 
 // Apparently the type bound contributes to the predicates of the trait, but
 // does not change the associated item itself.
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTraitBoundToAssociatedType {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     type Associated: ReferencedTrait0;
 
     fn method();
@@ -762,7 +762,7 @@ trait TraitAddTraitBoundToAssociatedType {
 
 
 // Add lifetime bound to associated type
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeBoundToAssociatedType<'a> {
     // -------------------------------------------------------
     // -------------------------
@@ -773,16 +773,16 @@ trait TraitAddLifetimeBoundToAssociatedType<'a> {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeBoundToAssociatedType<'a> {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     type Associated: 'a;
 
     fn method();
@@ -791,7 +791,7 @@ trait TraitAddLifetimeBoundToAssociatedType<'a> {
 
 
 // Add default to associated type
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddDefaultToAssociatedType {
     //--------------------------------------------------------
     //--------------------------
@@ -802,16 +802,16 @@ trait TraitAddDefaultToAssociatedType {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddDefaultToAssociatedType {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     type Associated = ReferenceType0;
 
     fn method();
@@ -820,16 +820,16 @@ trait TraitAddDefaultToAssociatedType {
 
 
 // Add associated constant
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddAssociatedConstant {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddAssociatedConstant {
     const Value: u32;
 
@@ -839,7 +839,7 @@ trait TraitAddAssociatedConstant {
 
 
 // Add initializer to associated constant
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddInitializerToAssociatedConstant {
     //--------------------------------------------------------
     //--------------------------
@@ -854,29 +854,29 @@ trait TraitAddInitializerToAssociatedConstant {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddInitializerToAssociatedConstant {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     const Value: u32 = 1;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method();
 }
 
 
 
 // Change type of associated constant
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitChangeTypeOfAssociatedConstant {
     // ---------------------------------------------------------------
     // -------------------------
@@ -891,287 +891,287 @@ trait TraitChangeTypeOfAssociatedConstant {
     fn method();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitChangeTypeOfAssociatedConstant {
-    #[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,type_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     const Value: f64;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method();
 }
 
 
 
 // Add super trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSuperTrait { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSuperTrait : ReferencedTrait0 { }
 
 
 
 // Add builtin bound (Send or Copy)
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddBuiltiBound { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddBuiltiBound : Send { }
 
 
 
 // Add 'static lifetime bound to trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddStaticLifetimeBound { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddStaticLifetimeBound : 'static { }
 
 
 
 // Add super trait as second bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTraitAsSecondBound : ReferencedTrait0 { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTraitAsSecondBound : ReferencedTrait0 + ReferencedTrait1 { }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTraitAsSecondBoundFromBuiltin : Send { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTraitAsSecondBoundFromBuiltin : Send + ReferencedTrait0 { }
 
 
 
 // Add builtin bound as second bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddBuiltinBoundAsSecondBound : ReferencedTrait0 { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddBuiltinBoundAsSecondBound : ReferencedTrait0 + Send { }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin : Send { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin: Send + Copy { }
 
 
 
 // Add 'static bounds as second bound
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddStaticBoundAsSecondBound : ReferencedTrait0 { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddStaticBoundAsSecondBound : ReferencedTrait0 + 'static { }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send + 'static { }
 
 
 
 // Add type parameter to trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTypeParameterToTrait { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTypeParameterToTrait<T> { }
 
 
 
 // Add lifetime parameter to trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeParameterToTrait { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeParameterToTrait<'a> { }
 
 
 
 // Add trait bound to type parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTraitBoundToTypeParameterOfTrait<T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 
 
 
 // Add lifetime bound to type parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T: 'a> { }
 
 
 
 // Add lifetime bound to lifetime parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTrait<'a, 'b> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTrait<'a: 'b, 'b> { }
 
 
 
 // Add builtin bound to type parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddBuiltinBoundToTypeParameterOfTrait<T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddBuiltinBoundToTypeParameterOfTrait<T: Send> { }
 
 
 
 // Add second type parameter to trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondTypeParameterToTrait<T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondTypeParameterToTrait<T, S> { }
 
 
 
 // Add second lifetime parameter to trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondLifetimeParameterToTrait<'a> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondLifetimeParameterToTrait<'a, 'b> { }
 
 
 
 // Add second trait bound to type parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0 + ReferencedTrait1> { }
 
 
 
 // Add second lifetime bound to type parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a + 'b> { }
 
 
 
 // Add second lifetime bound to lifetime parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTrait<'a: 'b, 'b, 'c> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTrait<'a: 'b + 'c, 'b, 'c> { }
 
 
 
 // Add second builtin bound to type parameter of trait
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTrait<T: Send> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTrait<T: Send + Sync> { }
 
 
@@ -1182,125 +1182,125 @@ struct ReferenceType1 {}
 
 
 // Add trait bound to type parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0 { }
 
 
 
 // Add lifetime bound to type parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> where T: 'a { }
 
 
 
 // Add lifetime bound to lifetime parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b> where 'a: 'b { }
 
 
 
 // Add builtin bound to type parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
 
 
 
 // Add second trait bound to type parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0 { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T>
     where T: ReferencedTrait0 + ReferencedTrait1 { }
 
 
 
 // Add second lifetime bound to type parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a + 'b { }
 
 
 
 // Add second lifetime bound to lifetime parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b, 'c> where 'a: 'b { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b, 'c> where 'a: 'b + 'c { }
 
 
 
 // Add second builtin bound to type parameter of trait in where clause
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send + Sync { }
 
 
 // Change return type of method indirectly by modifying a use statement
 mod change_return_type_of_method_indirectly_use {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferenceType0 as ReturnType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferenceType1 as ReturnType;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     trait TraitChangeReturnType {
-        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-        #[rustc_clean(cfg="cfail3")]
-        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-        #[rustc_clean(cfg="cfail6")]
+        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+        #[rustc_clean(cfg="bfail3")]
+        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+        #[rustc_clean(cfg="bfail6")]
         fn method() -> ReturnType;
     }
 }
@@ -1309,20 +1309,20 @@ mod change_return_type_of_method_indirectly_use {
 
 // Change type of method parameter indirectly by modifying a use statement
 mod change_method_parameter_type_indirectly_by_use {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferenceType0 as ArgType;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferenceType1 as ArgType;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     trait TraitChangeArgType {
-        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail2")]
-        #[rustc_clean(cfg="cfail3")]
-        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="cfail5")]
-        #[rustc_clean(cfg="cfail6")]
+        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail2")]
+        #[rustc_clean(cfg="bfail3")]
+        #[rustc_clean(except="opt_hir_owner_nodes,fn_sig", cfg="bfail5")]
+        #[rustc_clean(cfg="bfail6")]
         fn method(a: ArgType);
     }
 }
@@ -1331,20 +1331,20 @@ mod change_method_parameter_type_indirectly_by_use {
 
 // Change trait bound of method type parameter indirectly by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait1 as Bound;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     trait TraitChangeBoundOfMethodTypeParameter {
-        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-        #[rustc_clean(cfg="cfail3")]
-        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-        #[rustc_clean(cfg="cfail6")]
+        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+        #[rustc_clean(cfg="bfail3")]
+        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+        #[rustc_clean(cfg="bfail6")]
         fn method<T: Bound>(a: T);
     }
 }
@@ -1354,20 +1354,20 @@ mod change_method_parameter_type_bound_indirectly_by_use {
 // Change trait bound of method type parameter in where clause indirectly
 // by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use_where {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait1 as Bound;
 
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     trait TraitChangeBoundOfMethodTypeParameterWhere {
-        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-        #[rustc_clean(cfg="cfail3")]
-        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-        #[rustc_clean(cfg="cfail6")]
+        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+        #[rustc_clean(cfg="bfail3")]
+        #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+        #[rustc_clean(cfg="bfail6")]
         fn method<T>(a: T) where T: Bound;
     }
 }
@@ -1376,15 +1376,15 @@ mod change_method_parameter_type_bound_indirectly_by_use_where {
 
 // Change trait bound of trait type parameter indirectly by modifying a use statement
 mod change_method_type_parameter_bound_indirectly {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait1 as Bound;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     trait TraitChangeTraitBound<T: Bound> {
         fn method(a: T);
     }
@@ -1395,15 +1395,15 @@ mod change_method_type_parameter_bound_indirectly {
 // Change trait bound of trait type parameter in where clause indirectly
 // by modifying a use statement
 mod change_method_type_parameter_bound_indirectly_where {
-    #[cfg(any(cfail1,cfail4))]
+    #[cfg(any(bfail1,bfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(any(cfail1,cfail4)))]
+    #[cfg(not(any(bfail1,bfail4)))]
     use super::ReferencedTrait1 as Bound;
 
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,predicates_of", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     trait TraitChangeTraitBoundWhere<T> where T: Bound {
         fn method(a: T);
     }

--- a/tests/incremental/hashes/trait_impls.rs
+++ b/tests/incremental/hashes/trait_impls.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -22,35 +22,35 @@ struct Foo;
 
 // Change Method Name -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait ChangeMethodNameTrait {
     fn method_name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeMethodNameTrait for Foo {
     fn method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids,predicates_of", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub trait ChangeMethodNameTrait {
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name2();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeMethodNameTrait for Foo {
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name2() { }
 }
 
@@ -62,7 +62,7 @@ pub trait ChangeMethodBodyTrait {
     fn method_name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeMethodBodyTrait for Foo {
     // --------------------------------------------------------------
     // -------------------------
@@ -73,16 +73,16 @@ impl ChangeMethodBodyTrait for Foo {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeMethodBodyTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name() {
         ()
     }
@@ -96,7 +96,7 @@ pub trait ChangeMethodBodyTraitInlined {
     fn method_name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeMethodBodyTraitInlined for Foo {
     // ----------------------------------------------------------------------------
     // -------------------------
@@ -108,16 +108,16 @@ impl ChangeMethodBodyTraitInlined for Foo {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeMethodBodyTraitInlined for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,typeck_root,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     #[inline]
     fn method_name() {
         panic!()
@@ -126,37 +126,37 @@ impl ChangeMethodBodyTraitInlined for Foo {
 
 // Change Method Selfness ------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait ChangeMethodSelfnessTrait {
     fn method_name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeMethodSelfnessTrait for Foo {
     fn method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait ChangeMethodSelfnessTrait {
     fn method_name(&self);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeMethodSelfnessTrait for Foo {
     #[rustc_clean(
         except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
-        cfg="cfail2",
+        cfg="bfail2",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
         except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
-        cfg="cfail5",
+        cfg="bfail5",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name(&self) {
         ()
     }
@@ -164,48 +164,48 @@ impl ChangeMethodSelfnessTrait for Foo {
 
 // Change Method Selfness -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait RemoveMethodSelfnessTrait {
     fn method_name(&self);
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl RemoveMethodSelfnessTrait for Foo {
     fn method_name(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait RemoveMethodSelfnessTrait {
     fn method_name();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl RemoveMethodSelfnessTrait for Foo {
     #[rustc_clean(
         except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
-        cfg="cfail2",
+        cfg="bfail2",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
         except="opt_hir_owner_nodes,associated_item,generics_of,fn_sig,typeck_root,optimized_mir",
-        cfg="cfail5",
+        cfg="bfail5",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name() {}
 }
 
 // Change Method Selfmutness -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait ChangeMethodSelfmutnessTrait {
     fn method_name(&self);
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeMethodSelfmutnessTrait for Foo {
     // -----------------------------------------------------------------------------------
     // -------------------------
@@ -214,101 +214,101 @@ impl ChangeMethodSelfmutnessTrait for Foo {
     fn method_name(&    self) {}
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait ChangeMethodSelfmutnessTrait {
     fn method_name(&mut self);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeMethodSelfmutnessTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name(&mut self) {}
 }
 
 // Change item kind -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait ChangeItemKindTrait {
     fn name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeItemKindTrait for Foo {
     fn name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait ChangeItemKindTrait {
     type name;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeItemKindTrait for Foo {
     type name = ();
 }
 
 // Remove item -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait RemoveItemTrait {
     type TypeName;
     fn method_name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl RemoveItemTrait for Foo {
     type TypeName = ();
     fn method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait RemoveItemTrait {
     type TypeName;
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl RemoveItemTrait for Foo {
     type TypeName = ();
 }
 
 // Add item -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait AddItemTrait {
     type TypeName;
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl AddItemTrait for Foo {
     type TypeName = ();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait AddItemTrait {
     type TypeName;
     fn method_name();
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,associated_item_def_ids", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl AddItemTrait for Foo {
     type TypeName = ();
     fn method_name() { }
@@ -316,7 +316,7 @@ impl AddItemTrait for Foo {
 
 // Change has-value -----------------------------------------------------------
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait ChangeHasValueTrait {
     //--------------------------------------------------------
     //--------------------------
@@ -325,29 +325,29 @@ pub trait ChangeHasValueTrait {
     fn method_name()   ;
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeHasValueTrait for Foo {
     fn method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub trait ChangeHasValueTrait {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeHasValueTrait for Foo {
     fn method_name() { }
 }
@@ -358,7 +358,7 @@ pub trait AddDefaultTrait {
     fn method_name();
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl AddDefaultTrait for Foo {
     // -------------------------------------------------------
     // -------------------------
@@ -367,27 +367,27 @@ impl AddDefaultTrait for Foo {
     fn         method_name() { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl AddDefaultTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     default fn method_name() { }
 }
 
 // Add arguments
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait AddArgumentTrait {
     fn method_name(&self);
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl AddArgumentTrait for Foo {
     // -----------------------------------------------------------------------------------
     // -------------------------
@@ -396,32 +396,32 @@ impl AddArgumentTrait for Foo {
     fn method_name(&self         ) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait AddArgumentTrait {
     fn method_name(&self, x: u32);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl AddArgumentTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name(&self, _x: u32) { }
 }
 
 // Change argument type
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub trait ChangeArgumentTypeTrait {
     fn method_name(&self, x: u32);
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeArgumentTypeTrait for Foo {
     // -----------------------------------------------------------------------------------
     // -------------------------
@@ -430,21 +430,21 @@ impl ChangeArgumentTypeTrait for Foo {
     fn method_name(&self, _x: u32 ) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
+#[cfg(not(any(bfail1,bfail4)))]
 pub trait ChangeArgumentTypeTrait {
     fn method_name(&self, x: char);
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeArgumentTypeTrait for Foo {
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="opt_hir_owner_nodes,fn_sig,typeck_root,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn method_name(&self, _x: char) { }
 }
 
@@ -457,27 +457,27 @@ trait AddTypeParameterToImpl<T> {
     fn id(t: T) -> T;
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl AddTypeParameterToImpl<u32> for Bar<u32> {
     fn id(t: u32) -> u32 { t }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,impl_trait_header", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,generics_of,impl_trait_header", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,impl_trait_header", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,generics_of,impl_trait_header", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl<TTT> AddTypeParameterToImpl<TTT> for Bar<TTT> {
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,fn_sig,type_of,typeck_root,optimized_mir",
-        cfg="cfail2",
+        cfg="bfail2",
     )]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail3")]
     #[rustc_clean(
         except="opt_hir_owner_nodes,generics_of,fn_sig,type_of,typeck_root,optimized_mir",
-        cfg="cfail5",
+        cfg="bfail5",
     )]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail6")]
     fn id(t: TTT) -> TTT { t }
 }
 
@@ -488,21 +488,21 @@ trait ChangeSelfTypeOfImpl {
     fn id(self) -> Self;
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl ChangeSelfTypeOfImpl for u32 {
     fn id(self) -> Self { self }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,impl_trait_header", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,impl_trait_header", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,impl_trait_header", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,impl_trait_header", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl ChangeSelfTypeOfImpl for u64 {
-    #[rustc_clean(except="fn_sig,typeck_root,optimized_mir", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="fn_sig,typeck_root,optimized_mir", cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(except="fn_sig,typeck_root,optimized_mir", cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(except="fn_sig,typeck_root,optimized_mir", cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn id(self) -> Self { self }
 }
 
@@ -513,21 +513,21 @@ trait AddLifetimeBoundToImplParameter {
     fn id(self) -> Self;
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl<T> AddLifetimeBoundToImplParameter for T {
     fn id(self) -> Self { self }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl<T: 'static> AddLifetimeBoundToImplParameter for T {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn id(self) -> Self { self }
 }
 
@@ -538,21 +538,21 @@ trait AddTraitBoundToImplParameter {
     fn id(self) -> Self;
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl<T> AddTraitBoundToImplParameter for T {
     fn id(self) -> Self { self }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl<T: Clone> AddTraitBoundToImplParameter for T {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     fn id(self) -> Self { self }
 }
 
@@ -563,7 +563,7 @@ trait AddNoMangleToMethod {
     fn add_no_mangle_to_method(&self) { }
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl AddNoMangleToMethod for Foo {
     // -------------------------
     // -------------------------
@@ -573,16 +573,16 @@ impl AddNoMangleToMethod for Foo {
     fn add_no_mangle_to_method(&self) { }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl AddNoMangleToMethod for Foo {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     #[unsafe(no_mangle)]
     fn add_no_mangle_to_method(&self) { }
 }
@@ -593,7 +593,7 @@ trait MakeMethodInline {
     fn make_method_inline(&self) -> u8 { 0 }
 }
 
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 impl MakeMethodInline for Foo {
     // -------------------------
     // -------------------------
@@ -603,16 +603,16 @@ impl MakeMethodInline for Foo {
     fn make_method_inline(&self) -> u8 { 0 }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 impl MakeMethodInline for Foo {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(cfg="cfail5")]
-    #[rustc_clean(cfg="cfail6")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
+    #[rustc_clean(cfg="bfail5")]
+    #[rustc_clean(cfg="bfail6")]
     #[inline]
     fn make_method_inline(&self) -> u8 { 0 }
 }

--- a/tests/incremental/hashes/type_defs.rs
+++ b/tests/incremental/hashes/type_defs.rs
@@ -11,7 +11,7 @@
 // the same between rev2 and rev3.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -O
 //@ ignore-backends: gcc
 
@@ -21,34 +21,34 @@
 
 
 // Change type (primitive) -----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangePrimitiveType = i32;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangePrimitiveType = i64;
 
 
 
 // Change mutability -----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangeMutability = &'static i32;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangeMutability = &'static mut i32;
 
 
 
 // Change mutability -----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangeLifetime<'a> = (&'static i32, &'a i32);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangeLifetime<'a> = (&'a i32, &'a i32);
 
 
@@ -57,23 +57,23 @@ type ChangeLifetime<'a> = (&'a i32, &'a i32);
 struct Struct1;
 struct Struct2;
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangeTypeStruct = Struct1;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangeTypeStruct = Struct2;
 
 
 
 // Change type (tuple) ---------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangeTypeTuple = (u32, u64);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangeTypeTuple = (u32, i64);
 
 
@@ -88,102 +88,102 @@ enum Enum2 {
     Var2,
 }
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangeTypeEnum = Enum1;
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangeTypeEnum = Enum2;
 
 
 
 // Add tuple field -------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddTupleField = (i32, i64);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddTupleField = (i32, i64, i16);
 
 
 
 // Change nested tuple field ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type ChangeNestedTupleField = (i32, (i64, i16));
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type ChangeNestedTupleField = (i32, (i64, i8));
 
 
 
 // Add type param --------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddTypeParam<T1> = (T1, T1);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddTypeParam<T1, T2> = (T1, T2);
 
 
 
 // Add type param bound --------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddTypeParamBound<T1> = (T1, u32);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddTypeParamBound<T1: Clone> = (T1, u32);
 
 
 
 // Add type param bound in where clause ----------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddTypeParamBoundWhereClause<T1> where T1: Clone = (T1, u32);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddTypeParamBoundWhereClause<T1> where T1: Clone+Copy = (T1, u32);
 
 
 
 // Add lifetime param ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddLifetimeParam<'a> = (&'a u32, &'a u32);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddLifetimeParam<'a, 'b> = (&'a u32, &'b u32);
 
 
 
 // Add lifetime param bound ----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddLifetimeParamBound<'a, 'b> = (&'a u32, &'b u32);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddLifetimeParamBound<'a, 'b: 'a> = (&'a u32, &'b u32);
 
 
 
 // Add lifetime param bound in where clause ------------------------------------
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 type AddLifetimeParamBoundWhereClause<'a, 'b, 'c>
 where 'b: 'a
     = (&'a u32, &'b u32, &'c u32);
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
+#[cfg(not(bfail1))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
 type AddLifetimeParamBoundWhereClause<'a, 'b, 'c>
 where 'b: 'a,
       'c: 'a
@@ -196,13 +196,13 @@ trait ReferencedTrait1 {}
 trait ReferencedTrait2 {}
 
 mod change_trait_bound_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail3")]
     type ChangeTraitBoundIndirectly<T: Trait> = (T, u32);
 }
 
@@ -210,12 +210,12 @@ mod change_trait_bound_indirectly {
 
 // Change Trait Bound Indirectly In Where Clause -------------------------------
 mod change_trait_bound_indirectly_in_where_clause {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     use super::ReferencedTrait2 as Trait;
 
-    #[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+    #[rustc_clean(cfg="bfail3")]
     type ChangeTraitBoundIndirectly<T> where T : Trait = (T, u32);
 }

--- a/tests/incremental/hashes/unary_and_binary_exprs.rs
+++ b/tests/incremental/hashes/unary_and_binary_exprs.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,16 +19,16 @@
 
 
 // Change constant operand of negation -----------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn const_negation() -> i32 {
     -10
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn const_negation() -> i32 {
      -1
 }
@@ -36,16 +36,16 @@ pub fn const_negation() -> i32 {
 
 
 // Change constant operand of bitwise not --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn const_bitwise_not() -> i32 {
     !100
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn const_bitwise_not() -> i32 {
      !99
 }
@@ -53,16 +53,16 @@ pub fn const_bitwise_not() -> i32 {
 
 
 // Change variable operand of negation -----------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn var_negation(x: i32, y: i32) -> i32 {
     -x
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn var_negation(x: i32, y: i32) -> i32 {
     -y
 }
@@ -70,16 +70,16 @@ pub fn var_negation(x: i32, y: i32) -> i32 {
 
 
 // Change variable operand of bitwise not --------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn var_bitwise_not(x: i32, y: i32) -> i32 {
     !x
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn var_bitwise_not(x: i32, y: i32) -> i32 {
     !y
 }
@@ -87,16 +87,16 @@ pub fn var_bitwise_not(x: i32, y: i32) -> i32 {
 
 
 // Change variable operand of deref --------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn var_deref(x: &i32, y: &i32) -> i32 {
     *x
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn var_deref(x: &i32, y: &i32) -> i32 {
     *y
 }
@@ -104,16 +104,16 @@ pub fn var_deref(x: &i32, y: &i32) -> i32 {
 
 
 // Change first constant operand of addition -----------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn first_const_add() -> i32 {
     1 + 3
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn first_const_add() -> i32 {
     2 + 3
 }
@@ -121,16 +121,16 @@ pub fn first_const_add() -> i32 {
 
 
 // Change second constant operand of addition -----------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn second_const_add() -> i32 {
     1 + 2
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn second_const_add() -> i32 {
     1 + 3
 }
@@ -138,16 +138,16 @@ pub fn second_const_add() -> i32 {
 
 
 // Change first variable operand of addition -----------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn first_var_add(a: i32, b: i32) -> i32 {
     a + 2
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn first_var_add(a: i32, b: i32) -> i32 {
     b + 2
 }
@@ -155,16 +155,16 @@ pub fn first_var_add(a: i32, b: i32) -> i32 {
 
 
 // Change second variable operand of addition ----------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn second_var_add(a: i32, b: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn second_var_add(a: i32, b: i32) -> i32 {
     1 + b
 }
@@ -172,16 +172,16 @@ pub fn second_var_add(a: i32, b: i32) -> i32 {
 
 
 // Change operator from + to - -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn plus_to_minus(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn plus_to_minus(a: i32) -> i32 {
     1 - a
 }
@@ -189,16 +189,16 @@ pub fn plus_to_minus(a: i32) -> i32 {
 
 
 // Change operator from + to * -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn plus_to_mult(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn plus_to_mult(a: i32) -> i32 {
     1 * a
 }
@@ -206,16 +206,16 @@ pub fn plus_to_mult(a: i32) -> i32 {
 
 
 // Change operator from + to / -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn plus_to_div(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn plus_to_div(a: i32) -> i32 {
     1 / a
 }
@@ -223,16 +223,16 @@ pub fn plus_to_div(a: i32) -> i32 {
 
 
 // Change operator from + to % -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn plus_to_mod(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn plus_to_mod(a: i32) -> i32 {
     1 % a
 }
@@ -240,16 +240,16 @@ pub fn plus_to_mod(a: i32) -> i32 {
 
 
 // Change operator from && to || -----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn and_to_or(a: bool, b: bool) -> bool {
     a && b
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn and_to_or(a: bool, b: bool) -> bool {
     a || b
 }
@@ -257,16 +257,16 @@ pub fn and_to_or(a: bool, b: bool) -> bool {
 
 
 // Change operator from & to | -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn bitwise_and_to_bitwise_or(a: i32) -> i32 {
     1 & a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn bitwise_and_to_bitwise_or(a: i32) -> i32 {
     1 | a
 }
@@ -274,16 +274,16 @@ pub fn bitwise_and_to_bitwise_or(a: i32) -> i32 {
 
 
 // Change operator from & to ^ -------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn bitwise_and_to_bitwise_xor(a: i32) -> i32 {
     1 & a
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn bitwise_and_to_bitwise_xor(a: i32) -> i32 {
     1 ^ a
 }
@@ -291,16 +291,16 @@ pub fn bitwise_and_to_bitwise_xor(a: i32) -> i32 {
 
 
 // Change operator from & to << ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn bitwise_and_to_lshift(a: i32) -> i32 {
     a  & 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn bitwise_and_to_lshift(a: i32) -> i32 {
     a << 1
 }
@@ -308,16 +308,16 @@ pub fn bitwise_and_to_lshift(a: i32) -> i32 {
 
 
 // Change operator from & to >> ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn bitwise_and_to_rshift(a: i32) -> i32 {
     a  & 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn bitwise_and_to_rshift(a: i32) -> i32 {
     a >> 1
 }
@@ -325,16 +325,16 @@ pub fn bitwise_and_to_rshift(a: i32) -> i32 {
 
 
 // Change operator from == to != -----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn eq_to_uneq(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn eq_to_uneq(a: i32) -> bool {
     a != 1
 }
@@ -342,16 +342,16 @@ pub fn eq_to_uneq(a: i32) -> bool {
 
 
 // Change operator from == to < ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn eq_to_lt(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn eq_to_lt(a: i32) -> bool {
     a  < 1
 }
@@ -359,16 +359,16 @@ pub fn eq_to_lt(a: i32) -> bool {
 
 
 // Change operator from == to > ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn eq_to_gt(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn eq_to_gt(a: i32) -> bool {
     a  > 1
 }
@@ -376,16 +376,16 @@ pub fn eq_to_gt(a: i32) -> bool {
 
 
 // Change operator from == to <= -----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn eq_to_le(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn eq_to_le(a: i32) -> bool {
     a <= 1
 }
@@ -393,16 +393,16 @@ pub fn eq_to_le(a: i32) -> bool {
 
 
 // Change operator from == to >= -----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn eq_to_ge(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn eq_to_ge(a: i32) -> bool {
     a >= 1
 }
@@ -410,18 +410,18 @@ pub fn eq_to_ge(a: i32) -> bool {
 
 
 // Change type in cast expression ----------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn type_cast(a: u8) -> u64 {
     let b = a as i32;
     let c = b as u64;
     c
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck_root", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck_root", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck_root", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir,typeck_root", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn type_cast(a: u8) -> u64 {
     let b = a as u32;
     let c = b as u64;
@@ -431,16 +431,16 @@ pub fn type_cast(a: u8) -> u64 {
 
 
 // Change value in cast expression ---------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn value_cast(a: u32) -> i32 {
     1 as i32
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn value_cast(a: u32) -> i32 {
     2 as i32
 }
@@ -448,7 +448,7 @@ pub fn value_cast(a: u32) -> i32 {
 
 
 // Change place in assignment --------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn place() -> i32 {
     let mut x = 10;
     let mut y = 11;
@@ -456,11 +456,11 @@ pub fn place() -> i32 {
     x
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn place() -> i32 {
     let mut x = 10;
     let mut y = 11;
@@ -471,18 +471,18 @@ pub fn place() -> i32 {
 
 
 // Change r-value in assignment ------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn rvalue() -> i32 {
     let mut x = 10;
     x = 9;
     x
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn rvalue() -> i32 {
     let mut x = 10;
     x = 8;
@@ -492,16 +492,16 @@ pub fn rvalue() -> i32 {
 
 
 // Change index into slice -----------------------------------------------------
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn index_to_slice(s: &[u8], i: usize, j: usize) -> u8 {
     s[i]
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail2")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="cfail5")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail2")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(except="opt_hir_owner_nodes,optimized_mir", cfg="bfail5")]
+#[rustc_clean(cfg="bfail6")]
 pub fn index_to_slice(s: &[u8], i: usize, j: usize) -> u8 {
     s[j]
 }

--- a/tests/incremental/hashes/while_let_loops.rs
+++ b/tests/incremental/hashes/while_let_loops.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,7 +19,7 @@
 
 
 // Change loop body
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -28,11 +28,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -44,7 +44,7 @@ pub fn change_loop_body() {
 
 
 // Change loop body
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -53,11 +53,11 @@ pub fn change_loop_condition() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while let Some(1u32) = None {
@@ -69,7 +69,7 @@ pub fn change_loop_condition() {
 
 
 // Add break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -78,11 +78,11 @@ pub fn add_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -94,7 +94,7 @@ pub fn add_break() {
 
 
 // Add loop label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
             while let Some(0u32) = None {
@@ -103,11 +103,11 @@ pub fn add_loop_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -119,7 +119,7 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -128,11 +128,11 @@ pub fn add_loop_label_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -144,7 +144,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -155,11 +155,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -171,7 +171,7 @@ pub fn change_break_label() {
 }
 
 // Add loop label to continue
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -180,11 +180,11 @@ pub fn add_loop_label_to_continue() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -196,7 +196,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -207,11 +207,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -225,7 +225,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -234,11 +234,11 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while let Some(0u32) = None {

--- a/tests/incremental/hashes/while_loops.rs
+++ b/tests/incremental/hashes/while_loops.rs
@@ -6,11 +6,11 @@
 // rev3 and make sure that the hash has not changed.
 
 //@ build-pass (FIXME(62277): could be check-pass?)
-//@ revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+//@ revisions: bfail1 bfail2 bfail3 bfail4 bfail5 bfail6
 //@ compile-flags: -Z query-dep-graph -O
-//@ [cfail1]compile-flags: -Zincremental-ignore-spans
-//@ [cfail2]compile-flags: -Zincremental-ignore-spans
-//@ [cfail3]compile-flags: -Zincremental-ignore-spans
+//@ [bfail1]compile-flags: -Zincremental-ignore-spans
+//@ [bfail2]compile-flags: -Zincremental-ignore-spans
+//@ [bfail3]compile-flags: -Zincremental-ignore-spans
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
@@ -19,7 +19,7 @@
 
 
 // Change loop body
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     while true {
@@ -28,11 +28,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     while true {
@@ -44,7 +44,7 @@ pub fn change_loop_body() {
 
 
 // Change loop body
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while true  {
@@ -53,11 +53,11 @@ pub fn change_loop_condition() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while false {
@@ -69,7 +69,7 @@ pub fn change_loop_condition() {
 
 
 // Add break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_break() {
     let mut _x = 0;
     while true {
@@ -78,11 +78,11 @@ pub fn add_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir, typeck_root")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_break() {
     let mut _x = 0;
     while true {
@@ -94,7 +94,7 @@ pub fn add_break() {
 
 
 // Add loop label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
             while true {
@@ -103,11 +103,11 @@ pub fn add_loop_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: while true {
@@ -119,7 +119,7 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while true {
@@ -128,11 +128,11 @@ pub fn add_loop_label_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while true {
@@ -144,7 +144,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while true {
@@ -155,11 +155,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while true {
@@ -173,7 +173,7 @@ pub fn change_break_label() {
 
 
 // Add loop label to continue
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while true {
@@ -182,11 +182,11 @@ pub fn add_loop_label_to_continue() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while true {
@@ -198,7 +198,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while true {
@@ -209,11 +209,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while true {
@@ -227,7 +227,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break
-#[cfg(any(cfail1,cfail4))]
+#[cfg(any(bfail1,bfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while true {
@@ -236,11 +236,11 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes, optimized_mir")]
-#[rustc_clean(cfg="cfail6")]
+#[cfg(not(any(bfail1,bfail4)))]
+#[rustc_clean(cfg="bfail2", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail3")]
+#[rustc_clean(cfg="bfail5", except="opt_hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="bfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while true {

--- a/tests/incremental/ich_nested_items.rs
+++ b/tests/incremental/ich_nested_items.rs
@@ -1,7 +1,7 @@
 // Check that the hash of `foo` doesn't change just because we ordered
 // the nested items (or even added new ones).
 
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ compile-flags: -Z query-dep-graph
 //@ ignore-backends: gcc
@@ -10,15 +10,15 @@
 #![feature(rustc_attrs)]
 #![allow(dead_code)]
 
-#[rustc_clean(except = "opt_hir_owner_nodes", cfg = "cfail2")]
+#[rustc_clean(except = "opt_hir_owner_nodes", cfg = "bfail2")]
 pub fn foo() {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub fn baz() {} // order is different...
 
-    #[rustc_clean(cfg = "cfail2")]
+    #[rustc_clean(cfg = "bfail2")]
     pub fn bar() {} // but that doesn't matter.
 
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     pub fn baz() {} // order is different...
 
     pub fn bap() {} // neither does adding a new item

--- a/tests/incremental/incremental_proc_macro.rs
+++ b/tests/incremental/incremental_proc_macro.rs
@@ -1,5 +1,5 @@
 //@ proc-macro: incremental_proc_macro_aux.rs
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
 

--- a/tests/incremental/issue-101518.rs
+++ b/tests/incremental/issue-101518.rs
@@ -1,4 +1,4 @@
-//@ revisions: cpass
+//@ revisions: bpass
 
 #[derive(PartialEq, Eq)]
 struct Id<'a> {

--- a/tests/incremental/issue-108481-feed-eval-always.rs
+++ b/tests/incremental/issue-108481-feed-eval-always.rs
@@ -1,4 +1,4 @@
-//@ revisions: cpass1 cpass2
+//@ revisions: bpass1 bpass2
 //@ ignore-backends: gcc
 
 #![crate_type = "rlib"]
@@ -13,5 +13,5 @@ pub struct ConstGeneric<const CHUNK_SIZE: usize> {
     _p: [(); CHUNK_SIZE],
 }
 
-#[cfg(cpass1)]
+#[cfg(bpass1)]
 impl<const CHUNK_SIZE: usize> ConstGeneric<CHUNK_SIZE> {}

--- a/tests/incremental/issue-110457-same-span-closures/main.rs
+++ b/tests/incremental/issue-110457-same-span-closures/main.rs
@@ -1,12 +1,12 @@
 //@ proc-macro: egui_inspect_derive.rs
-//@ revisions: cpass1 cpass2
+//@ revisions: bpass1 bpass2
 //@ ignore-backends: gcc
 
 extern crate egui_inspect_derive;
 
 pub struct TileDef {
     pub layer: (),
-    #[cfg(cpass2)]
+    #[cfg(bpass2)]
     pub blend_graphic: String,
 }
 

--- a/tests/incremental/issue-42602.rs
+++ b/tests/incremental/issue-42602.rs
@@ -6,7 +6,7 @@
 // This was fixed by improving the resolution of the `FnOnce` trait
 // selection node.
 
-//@ revisions:cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags:-Zquery-dep-graph
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
@@ -19,14 +19,14 @@ fn main() {
 }
 
 mod a {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub fn foo() {
         let x = vec![1, 2, 3];
         let v = || ::std::mem::drop(x);
         v();
     }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     pub fn foo() {
         let x = vec![1, 2, 3, 4];
         let v = || ::std::mem::drop(x);
@@ -35,8 +35,8 @@ mod a {
 }
 
 mod b {
-    #[rustc_clean(cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="bfail2")]
+    #[rustc_clean(cfg="bfail3")]
     pub fn bar() {
         let x = vec![1, 2, 3];
         let v = || ::std::mem::drop(x);

--- a/tests/incremental/issue-49043.rs
+++ b/tests/incremental/issue-49043.rs
@@ -4,9 +4,9 @@
 // would then produce a `?0` which -- in turn -- triggered an ICE in
 // hashing.
 
-//@ revisions:cfail1
+//@ revisions: bfail1
 
 fn main() {
     println!("Hello, world! {}",*thread_rng().choose(&[0, 1, 2, 3]).unwrap());
-    //[cfail1]~^ ERROR cannot find function `thread_rng`
+    //[bfail1]~^ ERROR cannot find function `thread_rng`
 }

--- a/tests/incremental/issue-49595/issue-49595.rs
+++ b/tests/incremental/issue-49595/issue-49595.rs
@@ -1,4 +1,4 @@
-//@ revisions:cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph --test
 //@ build-pass
 //@ ignore-backends: gcc
@@ -6,11 +6,11 @@
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]
 
-#![rustc_partition_codegened(module="issue_49595-tests", cfg="cfail2")]
-#![rustc_partition_codegened(module="issue_49595-lit_test", cfg="cfail3")]
+#![rustc_partition_codegened(module="issue_49595-tests", cfg="bfail2")]
+#![rustc_partition_codegened(module="issue_49595-lit_test", cfg="bfail3")]
 
 mod tests {
-    #[cfg_attr(not(cfail1), test)]
+    #[cfg_attr(not(bfail1), test)]
     fn _test() {
     }
 }
@@ -20,8 +20,8 @@ mod tests {
 // takes effect.
 
 // replacing a module to have a stable span
-#[cfg_attr(not(cfail3), path = "auxiliary/lit_a.rs")]
-#[cfg_attr(cfail3, path = "auxiliary/lit_b.rs")]
+#[cfg_attr(not(bfail3), path = "auxiliary/lit_a.rs")]
+#[cfg_attr(bfail3, path = "auxiliary/lit_b.rs")]
 mod lit;
 
 pub mod lit_test {

--- a/tests/incremental/issue-54242.rs
+++ b/tests/incremental/issue-54242.rs
@@ -1,4 +1,4 @@
-//@ revisions: rpass cfail
+//@ revisions: rpass bfail
 
 trait Tr
 where
@@ -12,9 +12,9 @@ where
 impl Tr for str {
     #[cfg(rpass)]
     type Arr = [u8; 8];
-    #[cfg(cfail)]
+    #[cfg(bfail)]
     type Arr = [u8; Self::C];
-    //[cfail]~^ ERROR cycle detected when
+    //[bfail]~^ ERROR cycle detected when
 }
 
 fn main() {}

--- a/tests/incremental/issue-59523-on-implemented-is-not-unused.rs
+++ b/tests/incremental/issue-59523-on-implemented-is-not-unused.rs
@@ -2,7 +2,7 @@
 // rustc_on_unimplemented, but with this bug we are seeing it fire (on
 // subsequent runs) if incremental compilation is enabled.
 
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
 

--- a/tests/incremental/issue-59524-layout-scalar-valid-range-is-not-unused.rs
+++ b/tests/incremental/issue-59524-layout-scalar-valid-range-is-not-unused.rs
@@ -3,7 +3,7 @@
 // seeing it fire (on subsequent runs) if incremental compilation is
 // enabled.
 
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
 

--- a/tests/incremental/issue-61323.rs
+++ b/tests/incremental/issue-61323.rs
@@ -1,14 +1,14 @@
-//@ revisions: rpass cfail
+//@ revisions: rpass bfail
 
 enum A {
-    //[cfail]~^ ERROR recursive types `A` and `C` have infinite size [E0072]
+    //[bfail]~^ ERROR recursive types `A` and `C` have infinite size [E0072]
     B(C),
 }
 
 #[cfg(rpass)]
 struct C(Box<A>);
 
-#[cfg(cfail)]
+#[cfg(bfail)]
 struct C(A);
 
 fn main() {}

--- a/tests/incremental/issue-72386.rs
+++ b/tests/incremental/issue-72386.rs
@@ -1,4 +1,4 @@
-//@ revisions: rpass1 cfail1 rpass3
+//@ revisions: rpass1 bfail1 rpass3
 //@ needs-asm-support
 //@ only-x86_64
 //@ ignore-backends: gcc
@@ -13,10 +13,10 @@ fn main() {
     unsafe { asm!("nop") }
 }
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 fn main() {
     unsafe {
         asm!("nop",out("invalid_reg")_)
-        //[cfail1]~^ ERROR invalid register
+        //[bfail1]~^ ERROR invalid register
     }
 }

--- a/tests/incremental/issue-84252-global-alloc.rs
+++ b/tests/incremental/issue-84252-global-alloc.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass
 //@ needs-crate-type: cdylib
 
@@ -8,6 +8,6 @@
 #[allow(unused_imports)]
 use std::alloc::System;
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 #[global_allocator]
 static ALLOC: System = System;

--- a/tests/incremental/issue-85360-eval-obligation-ice.rs
+++ b/tests/incremental/issue-85360-eval-obligation-ice.rs
@@ -1,6 +1,6 @@
-//@ revisions:cfail1 cfail2
-//@[cfail1] compile-flags: --crate-type=lib -Zassert-incr-state=not-loaded
-//@[cfail2] compile-flags: --crate-type=lib -Zassert-incr-state=loaded
+//@ revisions: bfail1 bfail2
+//@[bfail1] compile-flags: --crate-type=lib -Zassert-incr-state=not-loaded
+//@[bfail2] compile-flags: --crate-type=lib -Zassert-incr-state=loaded
 //@ edition: 2021
 //@ build-pass
 //@ ignore-backends: gcc

--- a/tests/incremental/krate-inherent.rs
+++ b/tests/incremental/krate-inherent.rs
@@ -1,11 +1,11 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
-#![rustc_partition_reused(module = "krate_inherent-x", cfg = "cfail2")]
+#![rustc_partition_reused(module = "krate_inherent-x", cfg = "bfail2")]
 #![crate_type = "rlib"]
 
 pub mod x {
@@ -20,5 +20,5 @@ pub mod x {
     }
 }
 
-#[cfg(cfail1)]
-pub fn bar() {} // remove this unrelated fn in cfail2, which should not affect `x::method`
+#[cfg(bfail1)]
+pub fn bar() {} // remove this unrelated fn in bfail2, which should not affect `x::method`

--- a/tests/incremental/link_order/auxiliary/my_lib.rs
+++ b/tests/incremental/link_order/auxiliary/my_lib.rs
@@ -1,3 +1,3 @@
 //@ no-prefer-dynamic
-//@[cfail1] compile-flags: -lbar -lfoo --crate-type lib -Zassert-incr-state=not-loaded
-//@[cfail2] compile-flags: -lfoo -lbar --crate-type lib -Zassert-incr-state=not-loaded
+//@[bfail1] compile-flags: -lbar -lfoo --crate-type lib -Zassert-incr-state=not-loaded
+//@[bfail2] compile-flags: -lfoo -lbar --crate-type lib -Zassert-incr-state=not-loaded

--- a/tests/incremental/link_order/main.rs
+++ b/tests/incremental/link_order/main.rs
@@ -1,5 +1,5 @@
 //@ aux-build:my_lib.rs
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags:-Z query-dep-graph
 //@ ignore-backends: gcc
 

--- a/tests/incremental/lint-unused-features.rs
+++ b/tests/incremental/lint-unused-features.rs
@@ -1,4 +1,4 @@
-//@ revisions: rpass cfail
+//@ revisions: rpass bfail
 //@ ignore-backends: gcc
 
 #![deny(unused_features)]
@@ -10,9 +10,9 @@
 
 // Used library features
 #![feature(error_iter)]
-//[cfail]~^ ERROR feature `error_iter` is declared but not used
+//[bfail]~^ ERROR feature `error_iter` is declared but not used
 #![cfg_attr(all(), feature(allocator_api))]
-//[cfail]~^ ERROR feature `allocator_api` is declared but not used
+//[bfail]~^ ERROR feature `allocator_api` is declared but not used
 
 pub fn use_box_patterns(b: Box<i32>) -> i32 {
     let box x = b;

--- a/tests/incremental/lto-in-linker.rs
+++ b/tests/incremental/lto-in-linker.rs
@@ -1,9 +1,9 @@
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph --crate-type rlib -C linker-plugin-lto -O
 //@ no-prefer-dynamic
 //@ build-pass
 
 #![feature(rustc_attrs)]
-#![rustc_partition_reused(module = "lto_in_linker", cfg = "cfail2")]
+#![rustc_partition_reused(module = "lto_in_linker", cfg = "bfail2")]
 
 pub fn foo() {}

--- a/tests/incremental/macro_export.rs
+++ b/tests/incremental/macro_export.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ build-pass (FIXME(62277): could be check-pass?)
 //@ ignore-backends: gcc
 

--- a/tests/incremental/no_mangle.rs
+++ b/tests/incremental/no_mangle.rs
@@ -1,4 +1,4 @@
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ check-pass
 //@ compile-flags: --crate-type cdylib
 //@ needs-crate-type: cdylib

--- a/tests/incremental/overlapping-impls-in-new-solver-issue-135514.rs
+++ b/tests/incremental/overlapping-impls-in-new-solver-issue-135514.rs
@@ -4,7 +4,7 @@
 // In this specially crafted example, @steffahn was able to trigger unsoundness with an overlapping
 // impl that was accepted during the incremental rebuild.
 
-//@ revisions: cpass1 cfail2
+//@ revisions: bpass1 bfail2
 //@ compile-flags: -Znext-solver
 
 pub trait Trait {}
@@ -27,14 +27,14 @@ impl<T: Trait> Other for T {
 
 // second impl
 impl<T> Other for S<T> {
-    //[cfail2]~^ ERROR conflicting implementations of trait
+    //[bfail2]~^ ERROR conflicting implementations of trait
     type Choose<L, R> = R;
 }
 
-#[cfg(cpass1)]
+#[cfg(bpass1)]
 impl Trait for W {}
 
-#[cfg(cfail2)]
+#[cfg(bfail2)]
 impl Trait for S<W> {}
 
 fn main() {}

--- a/tests/incremental/remove_source_file/main.rs
+++ b/tests/incremental/remove_source_file/main.rs
@@ -1,7 +1,7 @@
 // This test case makes sure that the compiler doesn't crash due to a failing
 // table lookup when a source file is removed.
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 
 // Note that we specify -g so that the SourceFiles actually get referenced by the
 // incr. comp. cache:
@@ -10,15 +10,15 @@
 
 #![crate_type= "rlib"]
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 mod auxiliary;
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 pub fn foo() {
     auxiliary::print_hello();
 }
 
-#[cfg(cfail2)]
+#[cfg(bfail2)]
 pub fn foo() {
     println!("hello");
 }

--- a/tests/incremental/rlib-lto.rs
+++ b/tests/incremental/rlib-lto.rs
@@ -1,8 +1,8 @@
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph --crate-type rlib -C lto
 //@ build-pass
 
 #![feature(rustc_attrs)]
-#![rustc_partition_reused(module = "rlib_lto", cfg = "cfail2")]
+#![rustc_partition_reused(module = "rlib_lto", cfg = "bfail2")]
 
 pub fn foo() {}

--- a/tests/incremental/string_constant.rs
+++ b/tests/incremental/string_constant.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -Z query-dep-graph -Copt-level=0
 //@ build-pass (FIXME(62277): could be check-pass?)
 
@@ -11,13 +11,13 @@
 // needed even for callers of `x`.
 
 pub mod x {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub fn x() {
         println!("{}", "1");
     }
 
-    #[cfg(cfail2)]
-    #[rustc_clean(except = "opt_hir_owner_nodes,optimized_mir", cfg = "cfail2")]
+    #[cfg(bfail2)]
+    #[rustc_clean(except = "opt_hir_owner_nodes,optimized_mir", cfg = "bfail2")]
     pub fn x() {
         println!("{}", "2");
     }
@@ -26,7 +26,7 @@ pub mod x {
 pub mod y {
     use x;
 
-    #[rustc_clean(cfg = "cfail2")]
+    #[rustc_clean(cfg = "bfail2")]
     pub fn y() {
         x::x();
     }
@@ -35,7 +35,7 @@ pub mod y {
 pub mod z {
     use y;
 
-    #[rustc_clean(cfg = "cfail2")]
+    #[rustc_clean(cfg = "bfail2")]
     pub fn z() {
         y::y();
     }

--- a/tests/incremental/struct_change_field_name.rs
+++ b/tests/incremental/struct_change_field_name.rs
@@ -1,9 +1,9 @@
 // Test incremental compilation tracking where we change field names
 // in between revisions (hashing should be stable).
 
-//@ revisions:rpass1 cfail2
+//@ revisions: rpass1 bfail2
 //@ compile-flags: -Z query-dep-graph
-//@ [cfail2] compile-flags: -Z query-dep-graph -Z assert-incr-state=loaded
+//@ [bfail2] compile-flags: -Z query-dep-graph -Z assert-incr-state=loaded
 
 #![feature(rustc_attrs)]
 #![allow(unused_variables)]
@@ -13,7 +13,7 @@ pub struct X {
     pub x: u32
 }
 
-#[cfg(cfail2)]
+#[cfg(bfail2)]
 pub struct X {
     pub y: u32
 }
@@ -26,21 +26,21 @@ pub struct Y {
     pub y: char
 }
 
-#[rustc_clean(except="typeck_root", cfg="cfail2")]
+#[rustc_clean(except="typeck_root", cfg="bfail2")]
 pub fn use_x() -> u32 {
     let x: X = X { x: 22 };
-    //[cfail2]~^ ERROR struct `X` has no field named `x`
+    //[bfail2]~^ ERROR struct `X` has no field named `x`
     x.x as u32
-    //[cfail2]~^ ERROR no field `x` on type `X`
+    //[bfail2]~^ ERROR no field `x` on type `X`
 }
 
-#[rustc_clean(except="typeck_root", cfg="cfail2")]
+#[rustc_clean(except="typeck_root", cfg="bfail2")]
 pub fn use_embed_x(embed: EmbedX) -> u32 {
     embed.x.x as u32
-    //[cfail2]~^ ERROR no field `x` on type `X`
+    //[bfail2]~^ ERROR no field `x` on type `X`
 }
 
-#[rustc_clean(cfg="cfail2")]
+#[rustc_clean(cfg="bfail2")]
 pub fn use_y() {
     let x: Y = Y { y: 'c' };
 }

--- a/tests/incremental/thinlto/cgu_invalidated_via_import.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_via_import.rs
@@ -2,7 +2,7 @@
 // via ThinLTO and that imported thing changes while the definition of the CGU
 // stays untouched.
 
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -O
 //@ build-pass
 //@ ignore-backends: gcc
@@ -11,28 +11,28 @@
 #![crate_type="rlib"]
 
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-foo",
-                            cfg="cfail2",
+                            cfg="bfail2",
                             kind="no")]
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-foo",
-                            cfg="cfail3",
+                            cfg="bfail3",
                             kind="pre-lto")] // Should be "post-lto", see issue #119076
 
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-bar",
-                            cfg="cfail2",
+                            cfg="bfail2",
                             kind="pre-lto")]
 #![rustc_expected_cgu_reuse(module="cgu_invalidated_via_import-bar",
-                            cfg="cfail3",
+                            cfg="bfail3",
                             kind="pre-lto")] // Should be "post-lto", see issue #119076
 
 mod foo {
 
     // Trivial functions like this one are imported very reliably by ThinLTO.
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub fn inlined_fn() -> u32 {
         1234
     }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     pub fn inlined_fn() -> u32 {
         // See `cgu_keeps_identical_fn.rs` for why this is different
         // from the other version of this function.

--- a/tests/incremental/thinlto/cgu_invalidated_when_export_added.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_when_export_added.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass
 //@ ignore-backends: gcc
 
@@ -18,7 +18,7 @@ impl Drop for Foo {
 pub extern "C" fn run() {
     thread_local! { pub static FOO : Foo = Foo { } ; }
 
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     {
         FOO.with(|_f| ())
     }

--- a/tests/incremental/thinlto/cgu_invalidated_when_export_removed.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_when_export_removed.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ build-pass
 //@ ignore-backends: gcc
 
@@ -18,7 +18,7 @@ impl Drop for Foo {
 pub extern "C" fn run() {
     thread_local! { pub static FOO : Foo = Foo { } ; }
 
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     {
         FOO.with(|_f| ())
     }

--- a/tests/incremental/thinlto/cgu_invalidated_when_import_added.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_when_import_added.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -O -Zhuman-readable-cgu-names -Cllvm-args=-import-instr-limit=10
 //@ build-pass
 //@ ignore-backends: gcc
@@ -28,16 +28,16 @@ fn main() {
 
 mod foo {
 
-    // In cfail1, ThinLTO decides that foo() does not get inlined into main, and
+    // In bfail1, ThinLTO decides that foo() does not get inlined into main, and
     // instead bar() gets inlined into foo().
-    // In cfail2, foo() gets inlined into main.
+    // In bfail2, foo() gets inlined into main.
     pub fn foo(){
         bar()
     }
 
     // This function needs to be big so that it does not get inlined by ThinLTO
     // but *does* get inlined into foo() when it is declared `internal` in
-    // cfail1 (alone).
+    // bfail1 (alone).
     pub fn bar(){
         println!("quux1");
         println!("quux2");
@@ -55,7 +55,7 @@ mod bar {
 
     #[inline(never)]
     pub fn baz() {
-        #[cfg(cfail2)]
+        #[cfg(bfail2)]
         {
             crate::foo::bar();
         }

--- a/tests/incremental/thinlto/cgu_invalidated_when_import_removed.rs
+++ b/tests/incremental/thinlto/cgu_invalidated_when_import_removed.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: -O -Zhuman-readable-cgu-names -Cllvm-args=-import-instr-limit=10
 //@ build-pass
 //@ ignore-backends: gcc
@@ -38,8 +38,8 @@ fn main() {
 
 mod foo {
 
-    // In cfail1, foo() gets inlined into main.
-    // In cfail2, ThinLTO decides that foo() does not get inlined into main, and
+    // In bfail1, foo() gets inlined into main.
+    // In bfail2, ThinLTO decides that foo() does not get inlined into main, and
     // instead bar() gets inlined into foo(). But faulty logic in our incr.
     // ThinLTO implementation thought that `main()` is unchanged and thus reused
     // the object file still containing a call to the now non-existent bar().
@@ -49,7 +49,7 @@ mod foo {
 
     // This function needs to be big so that it does not get inlined by ThinLTO
     // but *does* get inlined into foo() once it is declared `internal` in
-    // cfail2.
+    // bfail2.
     pub fn bar(){
         println!("quux1");
         println!("quux2");
@@ -67,7 +67,7 @@ mod bar {
 
     #[inline(never)]
     pub fn baz() {
-        #[cfg(cfail1)]
+        #[cfg(bfail1)]
         {
             crate::foo::bar();
         }

--- a/tests/incremental/thinlto/cgu_keeps_identical_fn.rs
+++ b/tests/incremental/thinlto/cgu_keeps_identical_fn.rs
@@ -3,7 +3,7 @@
 // ends up with any spans in its LLVM bitecode, so LLVM is able to skip
 // re-building any modules which import 'inlined_fn'
 
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -O
 //@ build-pass
 //@ ignore-backends: gcc
@@ -12,34 +12,34 @@
 #![crate_type = "rlib"]
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-foo",
-    cfg = "cfail2",
+    cfg = "bfail2",
     kind = "pre-lto"
 )]
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-foo",
-    cfg = "cfail3",
+    cfg = "bfail3",
     kind = "pre-lto" // Should be "post-lto", see issue #119076
 )]
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-bar",
-    cfg = "cfail2",
+    cfg = "bfail2",
     kind = "pre-lto" // Should be "post-lto", see issue #119076
 )]
 #![rustc_expected_cgu_reuse(
     module = "cgu_keeps_identical_fn-bar",
-    cfg = "cfail3",
+    cfg = "bfail3",
     kind = "pre-lto" // Should be "post-lto", see issue #119076
 )]
 
 mod foo {
 
     // Trivial functions like this one are imported very reliably by ThinLTO.
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub fn inlined_fn() -> u32 {
         1234
     }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     pub fn inlined_fn() -> u32 {
         1234
     }

--- a/tests/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
+++ b/tests/incremental/thinlto/independent_cgus_dont_affect_each_other.rs
@@ -1,7 +1,7 @@
 // This test checks that a change in a CGU does not invalidate an unrelated CGU
 // during incremental ThinLTO.
 
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Z query-dep-graph -O
 //@ build-pass
 //@ ignore-backends: gcc
@@ -10,33 +10,33 @@
 #![crate_type="rlib"]
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-foo",
-                            cfg="cfail2",
+                            cfg="bfail2",
                             kind="no")]
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-foo",
-                            cfg="cfail3",
+                            cfg="bfail3",
                             kind="pre-lto")] // Should be "post-lto", see issue #119076
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-bar",
-                            cfg="cfail2",
+                            cfg="bfail2",
                             kind="pre-lto")]
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-bar",
-                            cfg="cfail3",
+                            cfg="bfail3",
                             kind="pre-lto")] // Should be "post-lto", see issue #119076
 
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-baz",
-                            cfg="cfail2",
+                            cfg="bfail2",
                             kind="pre-lto")] // Should be "post-lto", see issue #119076
 #![rustc_expected_cgu_reuse(module="independent_cgus_dont_affect_each_other-baz",
-                            cfg="cfail3",
+                            cfg="bfail3",
                             kind="pre-lto")] // Should be "post-lto", see issue #119076
 mod foo {
 
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     pub fn inlined_fn() -> u32 {
         1234
     }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(bfail1))]
     pub fn inlined_fn() -> u32 {
         // See `cgu_keeps_identical_fn.rs` for why this is different
         // from the other version of this function.

--- a/tests/incremental/track-deps-in-new-solver.rs
+++ b/tests/incremental/track-deps-in-new-solver.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2
+//@ revisions: bfail1 bfail2
 
 //@ compile-flags: -Znext-solver
 //@ check-pass
@@ -18,10 +18,10 @@ impl Future for S {
     }
 }
 
-#[cfg(cfail1)]
+#[cfg(bfail1)]
 pub struct Error(());
 
-#[cfg(cfail2)]
+#[cfg(bfail2)]
 pub struct Error();
 
 fn main() {}

--- a/tests/incremental/unchecked_clean.rs
+++ b/tests/incremental/unchecked_clean.rs
@@ -1,4 +1,4 @@
-//@ revisions: rpass1 cfail2
+//@ revisions: rpass1 bfail2
 //@ compile-flags: -Z query-dep-graph
 //@ ignore-backends: gcc
 
@@ -11,25 +11,25 @@
 
 fn main() {
 
-    #[rustc_clean(except="hir_owner", cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
+    #[rustc_clean(except="hir_owner", cfg="bfail2")]
+    //[bfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
     {
         // empty block
     }
 
-    #[rustc_clean(cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
+    #[rustc_clean(cfg="bfail2")]
+    //[bfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
     {
         // empty block
     }
 }
 
 struct _Struct {
-    #[rustc_clean(except="hir_owner", cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
+    #[rustc_clean(except="hir_owner", cfg="bfail2")]
+    //[bfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
     _field1: i32,
 
-    #[rustc_clean(cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
+    #[rustc_clean(cfg="bfail2")]
+    //[bfail2]~^ ERROR found unchecked `#[rustc_clean]` attribute
     _field2: i32,
 }

--- a/tests/incremental/unrecoverable_query.rs
+++ b/tests/incremental/unrecoverable_query.rs
@@ -4,7 +4,7 @@
 // In this test prior to fixing compiler was having problems figuring out
 // drop impl for T inside of m
 
-//@ revisions:cfail1 cfail2
+//@ revisions: bfail1 bfail2
 //@ compile-flags: --crate-type=lib
 //@ build-pass
 //@ ignore-backends: gcc
@@ -32,9 +32,9 @@ impl<D: P> T<D> {
 }
 
 enum C {
-    #[cfg(cfail1)]
+    #[cfg(bfail1)]
     Up(()),
-    #[cfg(cfail2)]
+    #[cfg(bfail2)]
     Lorry(()),
 }
 

--- a/tests/incremental/warnings-reemitted.rs
+++ b/tests/incremental/warnings-reemitted.rs
@@ -1,4 +1,4 @@
-//@ revisions: cfail1 cfail2 cfail3
+//@ revisions: bfail1 bfail2 bfail3
 //@ compile-flags: -Coverflow-checks=on
 //@ build-pass
 //@ ignore-backends: gcc


### PR DESCRIPTION
Long ago, UI tests were divided into *compile* and *run* tests. Later, the compile tests were further subdivided into *check* and *build* tests, to speed up tests that don't need a full build.

The same split was never applied to incremental test revisions, so the only way to perform a check build in incremental tests is (confusingly) to use a `cfail` revision and then specify `//@ check-fail` or `//@ check-pass`.

This PR makes room for dedicated check-fail and check-pass revisions by renaming the existing `cfail` and `cpass` revisions to `bfail` and `bpass`, since they currently perform a full build.

---

The test updates were done with a regex whole-word find-and-replace for `c(fail|pass)(\d*)`, and I also took the opportunity to manually add a space after `revisions:` on affected lines.

r? jieyouxu