### PR TITLE
Make reparsed guard metavars collect tokens

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3464,7 +3464,9 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn eat_metavar_guard(&mut self) -> Option<Box<Guard>> {
-        self.eat_metavar_seq(MetaVarKind::Guard, |this| this.parse_match_arm_guard()).flatten()
+        self.eat_metavar_seq(MetaVarKind::Guard, |this| {
+            this.expect_match_arm_guard(ForceCollect::Yes)
+        })
     }
 
     fn parse_match_arm_guard(&mut self) -> PResult<'a, Option<Box<Guard>>> {

--- a/tests/ui/macros/macro-guard-matcher-recursion.rs
+++ b/tests/ui/macros/macro-guard-matcher-recursion.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/155333>
+#![feature(macro_guard_matcher)]
+fn main() {
+    macro_rules! m {
+        ($g : guard) => {
+            m!($g) //~ ERROR recursion limit reached while expanding `m!`
+        };
+    }
+    m!(if x)
+}

--- a/tests/ui/macros/macro-guard-matcher-recursion.stderr
+++ b/tests/ui/macros/macro-guard-matcher-recursion.stderr
@@ -1,0 +1,14 @@
+error: recursion limit reached while expanding `m!`
+  --> $DIR/macro-guard-matcher-recursion.rs:6:13
+   |
+LL |             m!($g)
+   |             ^^^^^^
+...
+LL |     m!(if x)
+   |     -------- in this macro invocation
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`macro_guard_matcher_recursion`)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This should avoid missing tokens.

Closes rust-lang/rust#155333

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
