### PR TITLE
Delete `SizeSkeleton::Generic`

### DIFF
--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -55,9 +55,6 @@ fn skeleton_string<'tcx>(
                 bug!("{:?} overflow for u128", size)
             }
         }
-        Ok(SizeSkeleton::Generic(size)) => {
-            format!("generic size {size}")
-        }
         Err(LayoutError::TooGeneric(bad)) => {
             if *bad == ty {
                 "this type does not have a fixed size".to_owned()

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -317,12 +317,6 @@ pub enum SizeSkeleton<'tcx> {
     /// Alignment can be `None` if unknown.
     Known(Size, Option<Align>),
 
-    /// This is a generic const expression (i.e. N * 2), which may contain some parameters.
-    /// It must be of type usize, and represents the size of a type in bytes.
-    /// It is not required to be evaluatable to a concrete value, but can be used to check
-    /// that another SizeSkeleton is of equal size.
-    Generic(ty::Const<'tcx>),
-
     /// A potentially-wide pointer.
     Pointer {
         /// If true, this pointer is never null.
@@ -426,7 +420,7 @@ impl<'tcx> SizeSkeleton<'tcx> {
                         }
                         Err(err)
                     }
-                    SizeSkeleton::Pointer { .. } | SizeSkeleton::Generic(_) => Err(err),
+                    SizeSkeleton::Pointer { .. } => Err(err),
                 }
             }
 
@@ -459,9 +453,6 @@ impl<'tcx> SizeSkeleton<'tcx> {
                                     return Err(err);
                                 }
                                 ptr = Some(field);
-                            }
-                            SizeSkeleton::Generic(_) => {
-                                return Err(err);
                             }
                         }
                     }
@@ -516,7 +507,7 @@ impl<'tcx> SizeSkeleton<'tcx> {
                     // But in the case of `!null` patterns we need to note that in the
                     // raw pointer.
                     ty::PatternKind::NotNull => match base? {
-                        SizeSkeleton::Known(..) | SizeSkeleton::Generic(_) => base,
+                        SizeSkeleton::Known(..) => base,
                         SizeSkeleton::Pointer { non_zero: _, tail } => {
                             Ok(SizeSkeleton::Pointer { non_zero: true, tail })
                         }
@@ -534,9 +525,6 @@ impl<'tcx> SizeSkeleton<'tcx> {
             (SizeSkeleton::Pointer { tail: a, .. }, SizeSkeleton::Pointer { tail: b, .. }) => {
                 a == b
             }
-            // constants are always pre-normalized into a canonical form so this
-            // only needs to check if their pointers are identical.
-            (SizeSkeleton::Generic(a), SizeSkeleton::Generic(b)) => a == b,
             _ => false,
         }
     }


### PR DESCRIPTION
This variant was never constructed anywhere.

r? @scottmcm 
