### PR TITLE
docs(num): fix stale link to `mem::Alignment`

### DIFF
--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -122,7 +122,7 @@ pub enum IntErrorKind {
     /// This variant will be emitted when converting an integer that is not a power of
     /// two. This is required in some cases such as constructing an [`Alignment`].
     ///
-    /// [`Alignment`]: core::ptr::Alignment "ptr::Alignment"
+    /// [`Alignment`]: core::mem::Alignment "mem::Alignment"
     #[unstable(feature = "try_from_int_error_kind", issue = "153978")]
     // Also, #[unstable(feature = "ptr_alignment_type", issue = "102070")]
     NotAPowerOfTwo,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This pull request updates a stale link to `mem::Alignment` in `num::IntErrorKind`.

In rust-lang/rust#153178, I added a link to `Alignment` in `IntErrorKind`, but I overlooked that `Alignment` had been moved from `core::ptr` to `core::mem`. Although it is still re-exported in `core::ptr`, this pull request points the link to its canonical location.

@rustbot label +A-docs