### PR TITLE
error on empty `export_name`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -5,8 +5,8 @@ use rustc_span::edition::Edition::Edition2024;
 use super::prelude::*;
 use crate::attributes::AttributeSafety;
 use crate::session_diagnostics::{
-    NakedFunctionIncompatibleAttribute, NullOnExport, NullOnObjcClass, NullOnObjcSelector,
-    ObjcClassExpectedStringLiteral, ObjcSelectorExpectedStringLiteral,
+    EmptyExportName, NakedFunctionIncompatibleAttribute, NullOnExport, NullOnObjcClass,
+    NullOnObjcSelector, ObjcClassExpectedStringLiteral, ObjcSelectorExpectedStringLiteral,
 };
 use crate::target_checking::Policy::AllowSilent;
 
@@ -131,6 +131,12 @@ impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
             // `#[export_name = ...]` will be converted to a null-terminated string,
             // so it may not contain any null characters.
             cx.emit_err(NullOnExport { span: cx.attr_span });
+            return None;
+        }
+        if name.is_empty() {
+            // LLVM will make up a name if the empty string is given, but that name will be
+            // inconsistent between compilation units, causing linker errors.
+            cx.emit_err(EmptyExportName { span: cx.attr_span });
             return None;
         }
         Some(AttributeKind::ExportName { name, span: cx.attr_span })

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -397,6 +397,13 @@ pub(crate) struct UnusedMultiple {
 }
 
 #[derive(Diagnostic)]
+#[diag("`export_name` may not be empty")]
+pub(crate) struct EmptyExportName {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("`export_name` may not contain null characters", code = E0648)]
 pub(crate) struct NullOnExport {
     #[primary_span]

--- a/tests/ui/attributes/invalid-export-name.rs
+++ b/tests/ui/attributes/invalid-export-name.rs
@@ -1,0 +1,22 @@
+#![crate_type = "lib"]
+
+#[export_name = "\0foo"]
+//~^ ERROR `export_name` may not contain null characters
+fn has_null_byte() {}
+
+#[export_name = "foo\0"]
+//~^ ERROR `export_name` may not contain null characters
+fn null_terminated() {}
+
+#[export_name = "\0"]
+//~^ ERROR `export_name` may not contain null characters
+fn empty_null() {}
+
+#[export_name = ""]
+//~^ ERROR `export_name` may not be empty
+fn empty() {}
+
+#[export_name = "\
+"]
+//~^^ ERROR `export_name` may not be empty
+fn empty_newline() {}

--- a/tests/ui/attributes/invalid-export-name.stderr
+++ b/tests/ui/attributes/invalid-export-name.stderr
@@ -1,0 +1,34 @@
+error[E0648]: `export_name` may not contain null characters
+  --> $DIR/invalid-export-name.rs:3:1
+   |
+LL | #[export_name = "\0foo"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0648]: `export_name` may not contain null characters
+  --> $DIR/invalid-export-name.rs:7:1
+   |
+LL | #[export_name = "foo\0"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0648]: `export_name` may not contain null characters
+  --> $DIR/invalid-export-name.rs:11:1
+   |
+LL | #[export_name = "\0"]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: `export_name` may not be empty
+  --> $DIR/invalid-export-name.rs:15:1
+   |
+LL | #[export_name = ""]
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: `export_name` may not be empty
+  --> $DIR/invalid-export-name.rs:19:1
+   |
+LL | / #[export_name = "\
+LL | | "]
+   | |__^
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0648`.


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/155495

Using an empty string as the name makes LLVM make up a name. However this name can be inconsistent between compilation units, which is UB and can cause linking errors, and some parts of LLVM just crash on the empty name (see the linked issue). 

As far as we know there is only one valid pattern that could use this, a `#[used]` static that is not referenced by the program at all. That is not UB, but the `export_name` is not required for that to work, just normal rust name mangling would do fine.

Technically this is a breaking change, but it seems unlikely that this actually breaks code in the wild that wasn't already broken. I'll leave it up to T-lang to determine what is required here (crater run, FCW, ...), but my gut feeling is that we could just merge this and nobody would notice.