### PR TITLE
Add a test for Mach-O `#[link_section]` API inherited from LLVM

### DIFF
--- a/tests/run-make/macho-link-section/foo.rs
+++ b/tests/run-make/macho-link-section/foo.rs
@@ -1,0 +1,14 @@
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "__TEXT,custom_code,regular,pure_instructions")]
+static CODE: [u8; 10] = *b"0123456789";
+
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "__DATA,all_attributes,regular,pure_instructions\
+                        +no_toc+strip_static_syms+no_dead_strip+live_support\
+                        +self_modifying_code+debug")]
+static ALL_THE_ATTRIBUTES: u32 = 42;
+
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "__DATA,__mod_init_func,mod_init_funcs")]
+static CONSTRUCTOR: extern "C" fn() = constructor;
+extern "C" fn constructor() {}

--- a/tests/run-make/macho-link-section/rmake.rs
+++ b/tests/run-make/macho-link-section/rmake.rs
@@ -1,0 +1,47 @@
+//! Test that various Mach-O `#[link_section]` values are parsed and passed on correctly by codegen
+//! backends.
+//@ only-apple
+use run_make_support::{llvm_objdump, rustc};
+
+fn main() {
+    rustc().input("foo.rs").crate_type("lib").arg("--emit=obj").run();
+
+    let stdout =
+        llvm_objdump().arg("--macho").arg("--private-headers").input("foo.o").run().stdout_utf8();
+
+    let expected = [
+        ("__TEXT", "custom_code", "S_REGULAR", "PURE_INSTRUCTIONS"),
+        ("__DATA", "__mod_init_func", "S_MOD_INIT_FUNC_POINTERS", "(none)"),
+        (
+            "__DATA",
+            "all_attributes",
+            "S_REGULAR",
+            "PURE_INSTRUCTIONS NO_TOC STRIP_STATIC_SYMS \
+             NO_DEAD_STRIP LIVE_SUPPORT SELF_MODIFYING_CODE DEBUG",
+        ),
+    ];
+
+    for (segment, section, section_type, section_attributes) in expected {
+        let mut found = false;
+        // Skip header.
+        for section_info in stdout.split("Section").skip(1) {
+            if section_info.contains(&format!("segname {segment}"))
+                && section_info.contains(&format!("sectname {section}"))
+            {
+                assert!(
+                    section_info.contains(&format!("type {section_type}")),
+                    "should have type {section_type:?}"
+                );
+                assert!(
+                    section_info.contains(&format!("attributes {section_attributes}\n")),
+                    "should have attributes {section_attributes:?}"
+                );
+                found = true;
+            }
+        }
+
+        if !found {
+            panic!("could not find section {section} in binary");
+        }
+    }
+}


### PR DESCRIPTION
The format of the `#[link_section]` attribute is under-documented, but on Mach-O, I think it's roughly the following BNF (I've opened https://github.com/rust-lang/reference/pull/2236 to document it):
```
LinkSection -> Segment `,` Section (`,` (SectionType (`,` (SectionAttributes)?)?)?)?
Segment -> <0 to 16 bytes>
Section -> <0 to 16 bytes>
SectionType -> `regular` | `zerofill` | `cstring_literals` | `4byte_literals` | `8byte_literals` | `literal_pointers` | `non_lazy_symbol_pointers` | `lazy_symbol_pointers` | `symbol_stubs` | `mod_init_funcs` | `mod_term_funcs` | `coalesced` | `interposing` | `16byte_literals` | `thread_local_regular` | `thread_local_zerofill` | `thread_local_variables` | `thread_local_variable_pointers` | `thread_local_init_function_pointers`
SectionAttributes -> SectionAttribute (`+` SectionAttribute)*
SectionAttribute -> `pure_instructions` | `no_toc` | `strip_static_syms` | `no_dead_strip` | `live_support`, `self_modifying_code` | `debug`
```

This PR adds a small test for a little part of this.

Once https://github.com/rust-lang/rust/issues/154429 is resolved, this should make it possible to test https://github.com/rust-lang/rustc_codegen_cranelift/pull/1648 end-to-end.

r? bjorn3