### PR TITLE
cmse: test returning `MaybeUninit<T>`

### DIFF
--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -27,6 +27,7 @@
     decl_macro,
     f16,
     f128,
+    transparent_unions,
     asm_experimental_arch,
     unboxed_closures
 )]
@@ -126,6 +127,25 @@ pub struct ManuallyDrop<T: PointeeSized> {
     value: T,
 }
 impl<T: Copy + PointeeSized> Copy for ManuallyDrop<T> {}
+
+#[lang = "maybe_uninit"]
+#[repr(transparent)]
+pub union MaybeUninit<T> {
+    uninit: (),
+    value: ManuallyDrop<T>,
+}
+
+impl<T: Copy + PointeeSized> Copy for MaybeUninit<T> {}
+
+impl<T> MaybeUninit<T> {
+    pub const fn uninit() -> Self {
+        Self { uninit: () }
+    }
+
+    pub const fn new(value: T) -> Self {
+        Self { value: ManuallyDrop { value } }
+    }
+}
 
 #[repr(transparent)]
 #[rustc_nonnull_optimization_guaranteed]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
@@ -42,13 +42,13 @@ struct Test {
     i128: extern "cmse-nonsecure-call" fn() -> i128, //~ ERROR [E0798]
 }
 
-#[repr(C)]
-pub union ReprCUnionU64 {
+#[repr(Rust)]
+pub union ReprRustUnionU64 {
     _unused: u64,
 }
 
-#[repr(Rust)]
-pub union ReprRustUnionU64 {
+#[repr(C)]
+pub union ReprCUnionU64 {
     _unused: u64,
 }
 
@@ -56,5 +56,11 @@ pub union ReprRustUnionU64 {
 pub fn test_union(
     f1: extern "cmse-nonsecure-call" fn() -> ReprRustUnionU64, //~ ERROR [E0798]
     f2: extern "cmse-nonsecure-call" fn() -> ReprCUnionU64,    //~ ERROR [E0798]
+
+    // MaybeUninit is a transparent union, and hence MaybeUninit<u64> is abi-compatible with u64,
+    // and thus allowed as a return type.
+    f3: extern "cmse-nonsecure-call" fn() -> MaybeUninit<u32>,
+    f4: extern "cmse-nonsecure-call" fn() -> MaybeUninit<u64>,
+    f5: extern "cmse-nonsecure-call" fn() -> MaybeUninit<f64>,
 ) {
 }

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
@@ -45,3 +45,26 @@ pub extern "cmse-nonsecure-entry" fn four(_: Four) {}
 
 #[no_mangle]
 pub extern "cmse-nonsecure-entry" fn five(_: Five) {} //~ ERROR [E0798]
+
+#[repr(Rust)]
+pub union ReprRustUnionU64 {
+    _unused: u64,
+}
+
+#[repr(C)]
+pub union ReprCUnionU64 {
+    _unused: u64,
+}
+
+#[no_mangle]
+#[allow(improper_ctypes_definitions)]
+pub extern "cmse-nonsecure-entry" fn union_rust(_: ReprRustUnionU64) {}
+
+#[no_mangle]
+pub extern "cmse-nonsecure-entry" fn union_c(_: ReprCUnionU64) {}
+
+#[no_mangle]
+pub extern "cmse-nonsecure-entry" fn maybe_uninit_32bit(_: MaybeUninit<u32>) {}
+
+#[no_mangle]
+pub extern "cmse-nonsecure-entry" fn maybe_uninit_64bit(_: MaybeUninit<f64>) {}


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/81391
tracking issue: https://github.com/rust-lang/rust/issues/75835

Some tests from https://github.com/rust-lang/rust/pull/147697 that already work and are useful. Extracting them shrinks that (currently blocked) PR.

The code in `tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs` checks that `MaybeUninit<T>` is considered abi-compatible with `T`. The code in `tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs` really only tests that no errors/warnings are emitted.

r? davidtwco 
