### PR TITLE
Tweak `is_ascii_punctuation()` docs wording

### DIFF
--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -949,7 +949,8 @@ impl AsciiChar {
         self.to_u8().is_ascii_hexdigit()
     }
 
-    /// Checks if the value is a punctuation character:
+    /// Checks if the value is a punctuation or symbol character
+    /// (i.e. not alphanumeric, whitespace, or control):
     ///
     /// - 0x21 ..= 0x2F `! " # $ % & ' ( ) * + , - . /`, or
     /// - 0x3A ..= 0x40 `: ; < = > ? @`, or
@@ -989,7 +990,8 @@ impl AsciiChar {
         self.to_u8().is_ascii_punctuation()
     }
 
-    /// Checks if the value is a graphic character:
+    /// Checks if the value is a graphic character
+    /// (i.e. not whitespace or control):
     /// 0x21 '!' ..= 0x7E '~'.
     ///
     /// # Examples

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1984,7 +1984,8 @@ impl char {
         matches!(*self, '0'..='9') | matches!(*self, 'A'..='F') | matches!(*self, 'a'..='f')
     }
 
-    /// Checks if the value is an ASCII punctuation character:
+    /// Checks if the value is an ASCII punctuation or symbol character
+    /// (i.e. not alphanumeric, whitespace, or control):
     ///
     /// - U+0021 ..= U+002F `! " # $ % & ' ( ) * + , - . /`, or
     /// - U+003A ..= U+0040 `: ; < = > ? @`, or
@@ -2025,7 +2026,8 @@ impl char {
             | matches!(*self, '{'..='~')
     }
 
-    /// Checks if the value is an ASCII graphic character:
+    /// Checks if the value is an ASCII graphic character
+    /// (i.e. not whitespace or control):
     /// U+0021 '!' ..= U+007E '~'.
     ///
     /// # Examples

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -986,7 +986,8 @@ impl u8 {
         matches!(*self, b'0'..=b'9') | matches!(*self, b'A'..=b'F') | matches!(*self, b'a'..=b'f')
     }
 
-    /// Checks if the value is an ASCII punctuation character:
+    /// Checks if the value is an ASCII punctuation or symbol character
+    /// (i.e. not alphanumeric, whitespace, or control):
     ///
     /// - U+0021 ..= U+002F `! " # $ % & ' ( ) * + , - . /`, or
     /// - U+003A ..= U+0040 `: ; < = > ? @`, or
@@ -1027,7 +1028,8 @@ impl u8 {
             | matches!(*self, b'{'..=b'~')
     }
 
-    /// Checks if the value is an ASCII graphic character:
+    /// Checks if the value is an ASCII graphic character
+    /// (i.e. not whitespace or control):
     /// U+0021 '!' ..= U+007E '~'.
     ///
     /// # Examples


### PR DESCRIPTION
These methods return `true` for characters with Unicode general category of punctuation (P), but also for those with general category of symbol (S).

@rustbot label A-docs
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
