### PR TITLE
Fix redundant boolean comparison in `Mutex::try_lock`

### DIFF
--- a/library/std/src/sys/sync/mutex/no_threads.rs
+++ b/library/std/src/sys/sync/mutex/no_threads.rs
@@ -26,6 +26,6 @@ impl Mutex {
 
     #[inline]
     pub fn try_lock(&self) -> bool {
-        self.locked.replace(true) == false
+        !self.locked.replace(true)
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Simplify boolean return in `Mutex::try_lock`.  
Replace `expr == false` with `!expr` for cleaner code.