### PR TITLE
export symbols: support macos/windows(32/64)

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -47,7 +47,7 @@ use rustc_session::{Session, filesearch};
 use rustc_span::Symbol;
 use rustc_target::spec::crt_objects::CrtObjects;
 use rustc_target::spec::{
-    BinaryFormat, Cc, CfgAbi, Env, LinkOutputKind, LinkSelfContainedComponents,
+    Arch, BinaryFormat, Cc, CfgAbi, Env, LinkOutputKind, LinkSelfContainedComponents,
     LinkSelfContainedDefault, LinkerFeatures, LinkerFlavor, LinkerFlavorCli, Lld, Os, RelocModel,
     RelroLevel, SanitizerSet, SplitDebuginfo,
 };
@@ -2413,6 +2413,69 @@ fn add_rpath_args(
     }
 }
 
+fn strip_numeric_suffix<'a>(base: &'a str, suffix: impl AsRef<str>, fallback: &'a str) -> &'a str {
+    if suffix.as_ref().parse::<u32>().is_ok() { base } else { fallback }
+}
+
+fn undecorate_c_symbol<'a>(
+    name: &'a str,
+    sess: &Session,
+    kind: SymbolExportKind,
+) -> Option<&'a str> {
+    match sess.target.binary_format {
+        BinaryFormat::MachO => {
+            // Mach-O: strip the leading underscore that all external symbols have.
+            // The Darwin linker's export_symbols will add it back.
+            name.strip_prefix('_')
+        }
+        BinaryFormat::Coff => {
+            // MSVC C++ mangled names start with '?' and use a completely different
+            // decorating scheme that includes '@@' as structural delimiters.
+            // They must not be subjected to C calling-convention undecoration.
+            if name.starts_with('?') {
+                return Some(name);
+            }
+            Some(match sess.target.arch {
+                Arch::X86 => {
+                    // COFF 32-bit: strip calling-convention decorations.
+                    if let Some(rest) = name.strip_prefix('@') {
+                        // fastcall: @foo@N -> foo
+                        rest.rsplit_once('@')
+                            .map(|(base, suffix)| strip_numeric_suffix(base, suffix, name))
+                            .unwrap_or(name)
+                    } else if let Some(stripped) = name.strip_prefix('_') {
+                        if let Some((base, suffix)) = stripped.rsplit_once('@') {
+                            // stdcall: _foo@N -> foo
+                            strip_numeric_suffix(base, suffix, stripped)
+                        } else {
+                            // cdecl: _foo -> foo
+                            stripped
+                        }
+                    } else {
+                        // vectorcall: foo@@N -> foo
+                        name.rsplit_once("@@")
+                            .map(|(base, suffix)| strip_numeric_suffix(base, suffix, name))
+                            .unwrap_or(name)
+                    }
+                }
+                Arch::X86_64 => {
+                    // COFF 64-bit: vectorcall mangling (foo@@N -> foo) also applies on x86_64.
+                    name.rsplit_once("@@")
+                        .map(|(base, suffix)| strip_numeric_suffix(base, suffix, name))
+                        .unwrap_or(name)
+                }
+                Arch::Arm64EC if kind == SymbolExportKind::Text => {
+                    // Arm64EC: `#` prefix distinguishes ARM64EC text symbols from x64 thunks.
+                    name.strip_prefix('#').unwrap_or(name)
+                }
+                _ => name,
+            })
+        }
+        // ELF: no decoration
+        _ => Some(name),
+    }
+}
+
 fn add_c_staticlib_symbols(
     sess: &Session,
     lib: &NativeLib,
@@ -2454,7 +2517,14 @@ fn add_c_staticlib_symbols(
         }
 
         for symbol in object.symbols() {
-            if symbol.scope() != object::SymbolScope::Dynamic {
+            // The `object` crate returns `Dynamic` for ELF/Mach-O global symbols,
+            // but always returns `Linkage` for COFF external symbols.
+            // Accept both for COFF (Windows and UEFI).
+            let scope = symbol.scope();
+            if scope != object::SymbolScope::Dynamic
+                && !(sess.target.binary_format == BinaryFormat::Coff
+                    && scope == object::SymbolScope::Linkage)
+            {
                 continue;
             }
 
@@ -2469,9 +2539,10 @@ fn add_c_staticlib_symbols(
                 _ => continue,
             };
 
-            // FIXME:The symbol mangle rules are slightly different in Windows(32-bit) and Apple.
-            // Need to be resolved.
-            out.push((name.to_string(), export_kind));
+            let Some(undecorated) = undecorate_c_symbol(name, sess, export_kind) else {
+                continue;
+            };
+            out.push((undecorated.to_string(), export_kind));
         }
     }
 

--- a/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
@@ -1,41 +1,54 @@
 //@ ignore-nvptx64
 //@ ignore-wasm
 //@ ignore-cross-compile
-// FIXME:The symbol mangle rules are slightly different in Windows(32-bit) and Apple.
-// Need to be resolved.
-//@ ignore-windows
-//@ ignore-apple
 // Reason: the compiled binary is executed
 
 use run_make_support::{
-    build_native_static_lib, cc, dynamic_lib_name, is_aix, is_darwin, llvm_nm, rustc,
+    build_native_static_lib, cc, dynamic_lib_name, is_aix, is_darwin, is_windows, is_windows_msvc,
+    llvm_ar, llvm_nm, llvm_readobj, rfs, rustc, static_lib_name,
 };
 
 fn main() {
-    cc().input("foo.c").arg("-c").out_exe("foo.o").run();
-    build_native_static_lib("foo");
+    let obj_file = if is_windows_msvc() { "foo.obj" } else { "foo.o" };
+    cc().input("foo.c").arg("-c").arg("-fno-lto").out_exe(obj_file).run();
+    llvm_ar().obj_to_ar().output_input(&static_lib_name("foo"), obj_file).run();
 
     rustc().input("foo.rs").arg("-lstatic=foo").crate_type("cdylib").run();
 
-    let out = llvm_nm()
-        .input(dynamic_lib_name("foo"))
-        .run()
-        .assert_stdout_not_contains_regex("T *my_function");
+    if is_darwin() {
+        llvm_nm().input(dynamic_lib_name("foo")).run().assert_stdout_not_contains("T _my_function");
+    } else if is_windows() {
+        llvm_readobj()
+            .arg("--coff-exports")
+            .input(dynamic_lib_name("foo"))
+            .run()
+            .assert_stdout_not_contains("my_function");
+    } else {
+        llvm_nm().input(dynamic_lib_name("foo")).run().assert_stdout_not_contains("T my_function");
+    }
+
+    rfs::remove_file(dynamic_lib_name("foo"));
 
     rustc().input("foo_export.rs").arg("-lstatic:+export-symbols=foo").crate_type("cdylib").run();
 
     if is_darwin() {
-        let out = llvm_nm()
+        llvm_nm()
             .input(dynamic_lib_name("foo_export"))
             .run()
             .assert_stdout_contains("T _my_function");
+    } else if is_windows() {
+        llvm_readobj()
+            .arg("--coff-exports")
+            .input(dynamic_lib_name("foo_export"))
+            .run()
+            .assert_stdout_contains("my_function");
     } else if is_aix() {
-        let out = llvm_nm()
+        llvm_nm()
             .input(dynamic_lib_name("foo_export"))
             .run()
             .assert_stdout_contains("T .my_function");
     } else {
-        let out = llvm_nm()
+        llvm_nm()
             .input(dynamic_lib_name("foo_export"))
             .run()
             .assert_stdout_contains("T my_function");


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155535)*
<!-- homu-ignore:end -->

Previously, in the pr rust-lang/rust#150992 , export symbols only supported Linux. The special prefix and suffix rules for some symbols in macOS and Windows were not fully supported. This pull request attempts to clarify these rules and add corresponding support.

Currently, the `undecorate_c_symbol()` function has been added to handle macOS `_` prefixes, Windows x86 calling convention modifiers (cdecl/stdcall/fastcall/vectorcall), and Arm64EC `#` prefixes.

*Update: Handling of Windows C++ mangled symbols has now been added(Linux/macOS don't need).

r? @bjorn3 @petrochenkov 