### PR TITLE
Simplify some `Deref` impls.

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -85,11 +85,11 @@ rustc_index::newtype_index! {
 // but *not* an encoding of the discriminant (e.g., a tag value).
 // See issue #49298 for more details on the need to leave space
 // for non-ZST uninhabited data (mostly partial initialization).
-fn absent<'a, FieldIdx, VariantIdx, F>(fields: &IndexSlice<FieldIdx, F>) -> bool
+fn absent<FieldIdx, VariantIdx, F>(fields: &IndexSlice<FieldIdx, F>) -> bool
 where
     FieldIdx: Idx,
     VariantIdx: Idx,
-    F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
+    F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
 {
     let uninhabited = fields.iter().any(|f| f.is_uninhabited());
     // We cannot ignore alignment; that might lead us to entirely discard a variant and
@@ -239,8 +239,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     /// This uses dedicated code instead of [`Self::layout_of_struct_or_enum`], as coroutine
     /// fields may be shared between multiple variants (see the [`coroutine`] module for details).
     pub fn coroutine<
-        'a,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
         VariantIdx: Idx,
         FieldIdx: Idx,
         LocalIdx: Idx,
@@ -263,10 +262,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 
     pub fn univariant<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
     >(
         &self,
         fields: &IndexSlice<FieldIdx, F>,
@@ -338,10 +336,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 
     pub fn layout_of_struct_or_enum<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
     >(
         &self,
         repr: &ReprOptions,
@@ -394,10 +391,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 
     pub fn layout_of_union<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
     >(
         &self,
         repr: &ReprOptions,
@@ -520,10 +516,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
 
     /// single-variant enums are just structs, if you think about it
     fn layout_of_struct<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
     >(
         &self,
         repr: &ReprOptions,
@@ -620,10 +615,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 
     fn layout_of_enum<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
     >(
         &self,
         repr: &ReprOptions,
@@ -1158,10 +1152,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 
     fn univariant_biased<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
     >(
         &self,
         fields: &IndexSlice<FieldIdx, F>,
@@ -1499,10 +1492,9 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
     }
 
     fn format_field_niches<
-        'a,
         FieldIdx: Idx,
         VariantIdx: Idx,
-        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
+        F: Deref<Target = LayoutData<FieldIdx, VariantIdx>> + fmt::Debug,
     >(
         &self,
         layout: &LayoutData<FieldIdx, VariantIdx>,

--- a/compiler/rustc_abi/src/layout/coroutine.rs
+++ b/compiler/rustc_abi/src/layout/coroutine.rs
@@ -137,8 +137,7 @@ fn coroutine_saved_local_eligibility<VariantIdx: Idx, FieldIdx: Idx, LocalIdx: I
 
 /// Compute the full coroutine layout.
 pub(super) fn layout<
-    'a,
-    F: core::ops::Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + core::fmt::Debug + Copy,
+    F: core::ops::Deref<Target = LayoutData<FieldIdx, VariantIdx>> + core::fmt::Debug + Copy,
     VariantIdx: Idx,
     FieldIdx: Idx,
     LocalIdx: Idx,

--- a/compiler/rustc_abi/src/layout/ty.rs
+++ b/compiler/rustc_abi/src/layout/ty.rs
@@ -24,9 +24,9 @@ impl<'a> fmt::Debug for Layout<'a> {
 }
 
 impl<'a> Deref for Layout<'a> {
-    type Target = &'a LayoutData<FieldIdx, VariantIdx>;
-    fn deref(&self) -> &&'a LayoutData<FieldIdx, VariantIdx> {
-        &self.0.0
+    type Target = LayoutData<FieldIdx, VariantIdx>;
+    fn deref(&self) -> &Self::Target {
+        self.0.0
     }
 }
 
@@ -88,9 +88,9 @@ impl<'a, Ty: fmt::Display> fmt::Debug for TyAndLayout<'a, Ty> {
 }
 
 impl<'a, Ty> Deref for TyAndLayout<'a, Ty> {
-    type Target = &'a LayoutData<FieldIdx, VariantIdx>;
-    fn deref(&self) -> &&'a LayoutData<FieldIdx, VariantIdx> {
-        &self.layout.0.0
+    type Target = LayoutData<FieldIdx, VariantIdx>;
+    fn deref(&self) -> &Self::Target {
+        self.layout.0.0
     }
 }
 

--- a/compiler/rustc_const_eval/src/interpret/discriminant.rs
+++ b/compiler/rustc_const_eval/src/interpret/discriminant.rs
@@ -64,7 +64,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // declared list of variants -- they can differ with explicitly assigned discriminants.
         // We use "tag" to refer to how the discriminant is encoded in memory, which can be either
         // straight-forward (`TagEncoding::Direct`) or with a niche (`TagEncoding::Niche`).
-        let (tag_scalar_layout, tag_encoding, tag_field) = match op.layout().variants {
+        let layout = op.layout();
+        let (tag_scalar_layout, tag_encoding, tag_field) = match layout.variants {
             Variants::Empty => {
                 throw_ub!(UninhabitedEnumVariantRead(None));
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -3074,10 +3074,10 @@ struct CallCtxt<'a, 'b, 'tcx> {
 }
 
 impl<'a, 'b, 'tcx> Deref for CallCtxt<'a, 'b, 'tcx> {
-    type Target = &'a FnCtxt<'b, 'tcx>;
+    type Target = FnCtxt<'b, 'tcx>;
 
     fn deref(&self) -> &Self::Target {
-        &self.fn_ctxt
+        self.fn_ctxt
     }
 }
 

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -63,11 +63,11 @@ impl<'tcx> ValTree<'tcx> {
 }
 
 impl<'tcx> Deref for ValTree<'tcx> {
-    type Target = &'tcx ty::ValTreeKind<TyCtxt<'tcx>>;
+    type Target = ty::ValTreeKind<TyCtxt<'tcx>>;
 
     #[inline]
-    fn deref(&self) -> &&'tcx ty::ValTreeKind<TyCtxt<'tcx>> {
-        &self.0.0
+    fn deref(&self) -> &Self::Target {
+        self.0.0
     }
 }
 
@@ -168,7 +168,7 @@ impl<'tcx> Value<'tcx> {
     /// if this constant is some other kind.
     #[inline]
     pub fn to_leaf(self) -> ScalarInt {
-        match &**self.valtree {
+        match &*self.valtree {
             ValTreeKind::Leaf(s) => *s,
             ValTreeKind::Branch(..) => bug!("expected leaf, got {:?}", self),
         }
@@ -178,7 +178,7 @@ impl<'tcx> Value<'tcx> {
     /// if this constant is some other kind.
     #[inline]
     pub fn to_branch(self) -> &'tcx [ty::Const<'tcx>] {
-        match &**self.valtree {
+        match &*self.valtree {
             ValTreeKind::Branch(branch) => &**branch,
             ValTreeKind::Leaf(..) => bug!("expected branch, got {:?}", self),
         }
@@ -186,7 +186,7 @@ impl<'tcx> Value<'tcx> {
 
     /// Attempts to convert to a `ValTreeKind::Leaf` value.
     pub fn try_to_leaf(self) -> Option<ScalarInt> {
-        match &**self.valtree {
+        match &*self.valtree {
             ValTreeKind::Leaf(s) => Some(*s),
             ValTreeKind::Branch(_) => None,
         }
@@ -199,7 +199,7 @@ impl<'tcx> Value<'tcx> {
 
     /// Attempts to convert to a `ValTreeKind::Branch` value.
     pub fn try_to_branch(self) -> Option<&'tcx [ty::Const<'tcx>]> {
-        match &**self.valtree {
+        match &*self.valtree {
             ValTreeKind::Branch(branch) => Some(&**branch),
             ValTreeKind::Leaf(_) => None,
         }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2005,10 +2005,10 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             (ty::ValTreeKind::Leaf(leaf), ty::Ref(_, inner_ty, _)) => {
                 write!(self, "&")?;
-                return self.pretty_print_const_scalar_int(*leaf, inner_ty, print_ty);
+                return self.pretty_print_const_scalar_int(leaf, inner_ty, print_ty);
             }
             (ty::ValTreeKind::Leaf(leaf), _) => {
-                return self.pretty_print_const_scalar_int(*leaf, cv.ty, print_ty);
+                return self.pretty_print_const_scalar_int(leaf, cv.ty, print_ty);
             }
             (_, ty::FnDef(def_id, args)) => {
                 // Never allowed today, but we still encounter them in invalid const args.

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -2947,7 +2947,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if branch.len() != 1 {
                     bug!("malformed valtree for an enum")
                 };
-                let ValTreeKind::Leaf(actual_variant_idx) = **branch[0].to_value().valtree else {
+                let ValTreeKind::Leaf(actual_variant_idx) = *branch[0].to_value().valtree else {
                     bug!("malformed valtree for an enum")
                 };
 


### PR DESCRIPTION
`Deref` has an associated type `Target`. Normally it's a non-reference type, because the `deref` method provides the reference in its return type `&Self::Type`.

There are several impls where `Target` is a reference type, which means the return type of `deref` is a double reference. This is necessary for `DiagCtxtHandle` and `TyCtxt` (due to how the lifetimes work) but unnecessary for the others. This commit changes the others to be more normal, which simplifies things in a few places.

r? @mejrs 