### PR TITLE
Improve E0308 error message for `impl Trait` return mismatches

### DIFF
--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -173,6 +173,12 @@ pub(crate) enum ExpectedReturnTypeLabel<'tcx> {
         span: Span,
         expected: Ty<'tcx>,
     },
+    #[label("expected a single type implementing `{$trait_name}` because of return type")]
+    ImplTrait {
+        #[primary_span]
+        span: Span,
+        trait_name: String,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -931,6 +931,42 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             hir::FnRetTy::Return(hir_ty) => {
                 if let hir::TyKind::OpaqueDef(op_ty, ..) = hir_ty.kind
+                    && let [hir::GenericBound::Trait(trait_ref)] = op_ty.bounds
+                    && !trait_ref
+                        .trait_ref
+                        .path
+                        .segments
+                        .last()
+                        .and_then(|seg| seg.args)
+                        .map_or(false, |args| !args.constraints.is_empty())
+                {
+                    // Use the path to get the trait name string
+                    let trait_name = trait_ref
+                        .trait_ref
+                        .path
+                        .segments
+                        .iter()
+                        .map(|seg| seg.ident.as_str())
+                        .collect::<Vec<_>>()
+                        .join("::");
+
+                    err.subdiagnostic(errors::ExpectedReturnTypeLabel::ImplTrait {
+                        span: hir_ty.span,
+                        trait_name,
+                    });
+
+                    if let Some(ret_coercion_span) = self.ret_coercion_span.get() {
+                        let expected_name = expected.to_string();
+                        err.span_label(
+                            ret_coercion_span,
+                            format!("return type resolved to be `{expected_name}`"),
+                        );
+                    }
+
+                    self.try_suggest_return_impl_trait(err, expected, found, fn_id);
+                    self.try_note_caller_chooses_ty_for_ty_param(err, expected, found);
+                    return true;
+                } else if let hir::TyKind::OpaqueDef(op_ty, ..) = hir_ty.kind
                     // FIXME: account for RPITIT.
                     && let [hir::GenericBound::Trait(trait_ref)] = op_ty.bounds
                     && let Some(hir::PathSegment { args: Some(generic_args), .. }) =

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-impl-trait.stderr
@@ -2,8 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/dyn-incompatible-trait-in-return-position-impl-trait.rs:36:5
    |
 LL | fn can() -> impl DynIncompatible {
-   |             -------------------- expected `A` because of return type
-...
+   |             -------------------- expected a single type implementing `DynIncompatible` because of return type
+LL |     if true {
+LL |         return A;
+   |                - return type resolved to be `A`
+LL |     }
 LL |     B
    |     ^ expected `A`, found `B`
 
@@ -11,8 +14,11 @@ error[E0308]: mismatched types
   --> $DIR/dyn-incompatible-trait-in-return-position-impl-trait.rs:43:5
    |
 LL | fn cat() -> impl DynCompatible {
-   |             ------------------ expected `A` because of return type
-...
+   |             ------------------ expected a single type implementing `DynCompatible` because of return type
+LL |     if true {
+LL |         return A;
+   |                - return type resolved to be `A`
+LL |     }
 LL |     B
    |     ^ expected `A`, found `B`
 

--- a/tests/ui/impl-trait/equality.stderr
+++ b/tests/ui/impl-trait/equality.stderr
@@ -2,8 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/equality.rs:17:5
    |
 LL | fn two(x: bool) -> impl Foo {
-   |                    -------- expected `i32` because of return type
-...
+   |                    -------- expected a single type implementing `Foo` because of return type
+LL |     if x {
+LL |         return 1_i32;
+   |                ----- return type resolved to be `i32`
+LL |     }
 LL |     0_u32
    |     ^^^^^ expected `i32`, found `u32`
    |

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -64,8 +64,11 @@ error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:5:5
    |
 LL | fn foo() -> impl std::fmt::Display {
-   |             ---------------------- expected `i32` because of return type
-...
+   |             ---------------------- expected a single type implementing `std::fmt::Display` because of return type
+LL |     if false {
+LL |         return 0i32;
+   |                ---- return type resolved to be `i32`
+LL |     }
 LL |     1u32
    |     ^^^^ expected `i32`, found `u32`
    |
@@ -79,8 +82,11 @@ error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:12:16
    |
 LL | fn bar() -> impl std::fmt::Display {
-   |             ---------------------- expected `i32` because of return type
-...
+   |             ---------------------- expected a single type implementing `std::fmt::Display` because of return type
+LL |     if false {
+LL |         return 0i32;
+   |                ---- return type resolved to be `i32`
+LL |     } else {
 LL |         return 1u32;
    |                ^^^^ expected `i32`, found `u32`
    |
@@ -94,8 +100,11 @@ error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:20:9
    |
 LL | fn baz() -> impl std::fmt::Display {
-   |             ---------------------- expected `i32` because of return type
-...
+   |             ---------------------- expected a single type implementing `std::fmt::Display` because of return type
+LL |     if false {
+LL |         return 0i32;
+   |                ---- return type resolved to be `i32`
+LL |     } else {
 LL |         1u32
    |         ^^^^ expected `i32`, found `u32`
    |
@@ -137,8 +146,10 @@ error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:35:14
    |
 LL | fn bat() -> impl std::fmt::Display {
-   |             ---------------------- expected `i32` because of return type
-...
+   |             ---------------------- expected a single type implementing `std::fmt::Display` because of return type
+LL |     match 13 {
+LL |         0 => return 0i32,
+   |                     ---- return type resolved to be `i32`
 LL |         _ => 1u32,
    |              ^^^^ expected `i32`, found `u32`
    |
@@ -151,9 +162,10 @@ error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:40:5
    |
 LL |   fn can() -> impl std::fmt::Display {
-   |               ---------------------- expected `i32` because of return type
+   |               ---------------------- expected a single type implementing `std::fmt::Display` because of return type
 LL | /     match 13 {
 LL | |         0 => return 0i32,
+   | |                     ---- return type resolved to be `i32`
 LL | |         1 => 1u32,
 LL | |         _ => 2u32,
 LL | |     }
@@ -168,7 +180,10 @@ error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:53:13
    |
 LL | fn cat() -> impl std::fmt::Display {
-   |             ---------------------- expected `i32` because of return type
+   |             ---------------------- expected a single type implementing `std::fmt::Display` because of return type
+...
+LL |             return 0i32;
+   |                    ---- return type resolved to be `i32`
 ...
 LL |             1u32
    |             ^^^^ expected `i32`, found `u32`


### PR DESCRIPTION
When a function returns `impl Trait`, all branches must return the same concrete type. Previously, the compiler showed:

    expected `First` because of return type

This was misleading, as it suggested the return type was `First`, rather than any single type implementing the trait.

Update the diagnostic to:

    expected a single type implementing `Value` because of return type

Also highlight the first return expression to make it clearer why subsequent returns do not match.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
