### PR TITLE
add warning message when using x fix

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1184,6 +1184,12 @@ impl Config {
             exit!(1);
         }
 
+        if matches!(flags_cmd, Subcommand::Fix) {
+            eprintln!(
+                "WARNING: `x fix` is provided on a best-effort basis and does not support all `cargo fix` options correctly."
+            );
+        }
+
         // CI should always run stage 2 builds, unless it specifically states otherwise
         #[cfg(not(test))]
         if flags_stage.is_none() && ci_env.is_running_in_ci() {


### PR DESCRIPTION
Fix for issue: https://github.com/rust-lang/rust/issues/155545

Before:
<img width="1880" height="329" alt="image" src="https://github.com/user-attachments/assets/b713d940-f229-4c63-8df8-93634f017793" />

After:
<img width="1897" height="387" alt="image" src="https://github.com/user-attachments/assets/5bbca701-b319-45ca-9d46-39847c50b6f8" />


Text added

```
WARNING: `x fix` is provided on a best-effort basis and does not support all `cargo fix` options correctly.
```