### PR TITLE
 compiletest: Report filtered and --skip-ed tests in metrics 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,8 @@ name = "compiletest"
 version = "0.0.0"
 dependencies = [
  "anstyle-svg",
+ "assert_cmd",
+ "bstr",
  "build_helper",
  "camino",
  "colored",
@@ -854,11 +856,14 @@ dependencies = [
  "libc",
  "miow",
  "miropt-test-tools",
+ "predicates",
+ "rand 0.9.2",
  "rayon",
  "regex",
  "rustfix",
  "semver",
  "serde",
+ "serde_derive",
  "serde_json",
  "tracing",
  "tracing-subscriber",
@@ -1404,6 +1409,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2525,6 +2539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "normpath"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,7 +3028,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,15 +1412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fluent-bundle"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,12 +2530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "normpath"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,16 +3007,13 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
- "float-cmp",
- "normalize-line-endings",
  "predicates-core",
- "regex",
 ]
 
 [[package]]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -35,7 +35,7 @@ test = false
 cc = "=1.2.28"
 cmake = "=0.1.54"
 
-build_helper = { path = "../build_helper" }
+build_helper = { path = "../build_helper", features = ["metrics"] }
 clap = { version = "4.4", default-features = false, features = ["std", "usage", "help", "derive", "error-context"] }
 clap_complete = "4.4"
 home = "0.5"

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -899,6 +899,11 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         // right is important, as `compiletest` is intended to only support one target spec JSON
         // format, namely that of the staged compiler.
         cargo.env("TEST_RUSTC", builder.rustc(staged_compiler));
+        builder.ensure(Std::new(staged_compiler, host));
+
+        // run_cargo_test will automatically add the dylib paths for the bootstrap compiler,
+        // but some UI tests expect that it's also set for the tested compiler.
+        cargo.env("COMPILETEST_RUNTIME_PATH", builder.sysroot_target_libdir(staged_compiler, host));
 
         run_cargo_test(cargo, &[], &[], "compiletest self test", host, builder);
     }

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -2162,6 +2162,7 @@ mod snapshot {
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 0 <host>
+        [build] rustc 1 <host> -> std 1 <host>
         ");
     }
 

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -155,7 +155,9 @@ impl<'a> Renderer<'a> {
     }
 
     fn render_test_outcome(&mut self, outcome: Outcome<'_>, test: &TestOutcome) {
-        self.executed_tests += 1;
+        if !matches!(outcome, Outcome::FilteredOut) {
+            self.executed_tests += 1;
+        }
 
         if let Outcome::Ignored { reason } = outcome {
             self.ignored_tests += 1;
@@ -171,6 +173,7 @@ impl<'a> Renderer<'a> {
             match outcome {
                 Outcome::Ok | Outcome::BenchOk => build_helper::metrics::TestOutcome::Passed,
                 Outcome::Failed => build_helper::metrics::TestOutcome::Failed,
+                Outcome::FilteredOut => build_helper::metrics::TestOutcome::FilteredOut,
                 Outcome::Ignored { reason } => build_helper::metrics::TestOutcome::Ignored {
                     ignore_reason: reason.map(|s| s.to_string()),
                 },
@@ -209,7 +212,9 @@ impl<'a> Renderer<'a> {
             self.terse_tests_in_line = 0;
         }
 
-        self.terse_tests_in_line += 1;
+        if !matches!(outcome, Outcome::FilteredOut) {
+            self.terse_tests_in_line += 1;
+        }
         self.builder.colored_stdout(|stdout| outcome.write_short(stdout, &test.name)).unwrap();
         let _ = std::io::stdout().flush();
     }
@@ -359,6 +364,9 @@ impl<'a> Renderer<'a> {
                     &outcome,
                 );
             }
+            Message::Test(TestMessage::FilteredOut(outcome)) => {
+                self.render_test_outcome(Outcome::FilteredOut, &outcome);
+            }
             Message::Test(TestMessage::Failed(outcome)) => {
                 self.render_test_outcome(Outcome::Failed, &outcome);
                 self.failures.push(outcome);
@@ -371,11 +379,13 @@ impl<'a> Renderer<'a> {
     }
 }
 
+#[derive(Debug)]
 enum Outcome<'a> {
     Ok,
     BenchOk,
     Failed,
     Ignored { reason: Option<&'a str> },
+    FilteredOut,
 }
 
 impl Outcome<'_> {
@@ -400,6 +410,7 @@ impl Outcome<'_> {
                 writer.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))?;
                 write!(writer, "i")?;
             }
+            Outcome::FilteredOut => {}
         }
         writer.reset()
     }
@@ -425,13 +436,14 @@ impl Outcome<'_> {
                     write!(writer, ", {reason}")?;
                 }
             }
+            Outcome::FilteredOut => {}
         }
         writer.reset()
     }
 
     fn write_ci(&self, writer: &mut dyn WriteColor, name: &str) -> Result<(), std::io::Error> {
         match self {
-            Outcome::Ok | Outcome::BenchOk | Outcome::Ignored { .. } => {}
+            Outcome::Ok | Outcome::BenchOk | Outcome::FilteredOut | Outcome::Ignored { .. } => {}
             Outcome::Failed => {
                 writer.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
                 writeln!(writer, "   {name} ... FAILED")?;

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -10,6 +10,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::process::ChildStdout;
 use std::time::Duration;
 
+use build_helper::metrics::compiletest::*;
 use termcolor::{Color, ColorSpec, WriteColor};
 
 use crate::core::builder::Builder;
@@ -438,65 +439,4 @@ impl Outcome<'_> {
         }
         writer.reset()
     }
-}
-
-#[derive(serde_derive::Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum Message {
-    Suite(SuiteMessage),
-    Test(TestMessage),
-    Bench(BenchOutcome),
-    Report(Report),
-}
-
-#[derive(serde_derive::Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-enum SuiteMessage {
-    Ok(SuiteOutcome),
-    Failed(SuiteOutcome),
-    Started { test_count: usize },
-}
-
-#[derive(serde_derive::Deserialize)]
-struct SuiteOutcome {
-    passed: usize,
-    failed: usize,
-    ignored: usize,
-    measured: usize,
-    filtered_out: usize,
-    /// The time it took to execute this test suite, or `None` if time measurement was not possible
-    /// (e.g. due to running on wasm).
-    exec_time: Option<f64>,
-}
-
-#[derive(serde_derive::Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-enum TestMessage {
-    Ok(TestOutcome),
-    Failed(TestOutcome),
-    Ignored(TestOutcome),
-    Timeout { name: String },
-    Started,
-}
-
-#[derive(serde_derive::Deserialize)]
-struct BenchOutcome {
-    name: String,
-    median: f64,
-    deviation: f64,
-}
-
-#[derive(serde_derive::Deserialize)]
-struct TestOutcome {
-    name: String,
-    exec_time: Option<f64>,
-    stdout: Option<String>,
-    message: Option<String>,
-}
-
-/// Emitted when running doctests.
-#[derive(serde_derive::Deserialize)]
-struct Report {
-    total_time: f64,
-    compilation_time: f64,
 }

--- a/src/build_helper/src/metrics.rs
+++ b/src/build_helper/src/metrics.rs
@@ -2,6 +2,69 @@ use std::time::Duration;
 
 use serde_derive::{Deserialize, Serialize};
 
+pub mod compiletest {
+    #[derive(serde_derive::Deserialize, Debug)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    pub enum Message {
+        Suite(SuiteMessage),
+        Test(TestMessage),
+        Bench(BenchOutcome),
+        Report(Report),
+    }
+
+    #[derive(serde_derive::Deserialize, Debug)]
+    #[serde(tag = "event", rename_all = "snake_case")]
+    pub enum SuiteMessage {
+        Ok(SuiteOutcome),
+        Failed(SuiteOutcome),
+        Started { test_count: usize },
+    }
+
+    #[derive(serde_derive::Deserialize, Debug)]
+    pub struct SuiteOutcome {
+        pub passed: usize,
+        pub failed: usize,
+        pub ignored: usize,
+        pub measured: usize,
+        pub filtered_out: usize,
+        /// The time it took to execute this test suite, or `None` if time measurement was not possible
+        /// (e.g. due to running on wasm).
+        pub exec_time: Option<f64>,
+    }
+
+    #[derive(serde_derive::Deserialize, Debug)]
+    #[serde(tag = "event", rename_all = "snake_case")]
+    pub enum TestMessage {
+        Ok(TestOutcome),
+        Failed(TestOutcome),
+        Ignored(TestOutcome),
+        Timeout { name: String },
+        Started,
+    }
+
+    #[derive(serde_derive::Deserialize, Debug)]
+    pub struct BenchOutcome {
+        pub name: String,
+        pub median: f64,
+        pub deviation: f64,
+    }
+
+    #[derive(serde_derive::Deserialize, Debug)]
+    pub struct TestOutcome {
+        pub name: String,
+        pub exec_time: Option<f64>,
+        pub stdout: Option<String>,
+        pub message: Option<String>,
+    }
+
+    /// Emitted when running doctests.
+    #[derive(serde_derive::Deserialize, Debug)]
+    pub struct Report {
+        pub total_time: f64,
+        pub compilation_time: f64,
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct JsonRoot {

--- a/src/build_helper/src/metrics.rs
+++ b/src/build_helper/src/metrics.rs
@@ -38,6 +38,7 @@ pub mod compiletest {
         Ok(TestOutcome),
         Failed(TestOutcome),
         Ignored(TestOutcome),
+        FilteredOut(TestOutcome),
         Timeout { name: String },
         Started,
     }
@@ -155,6 +156,7 @@ pub struct Test {
 pub enum TestOutcome {
     Passed,
     Failed,
+    FilteredOut,
     Ignored { ignore_reason: Option<String> },
 }
 

--- a/src/build_helper/src/metrics.rs
+++ b/src/build_helper/src/metrics.rs
@@ -2,12 +2,14 @@ use std::time::Duration;
 
 use serde_derive::{Deserialize, Serialize};
 
+/// Metrics that compiletest *emits*.
 pub mod compiletest {
     #[derive(serde_derive::Deserialize, Debug)]
     #[serde(tag = "type", rename_all = "snake_case")]
     pub enum Message {
         Suite(SuiteMessage),
         Test(TestMessage),
+        /// Never emitted; remnant from libtest refactor.
         Bench(BenchOutcome),
         Report(Report),
     }

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -155,7 +155,9 @@ fn report_debuginfo_statistics(suites: &[&TestSuite]) {
                         debugger_test_record.entry(kind).or_insert(TestSuiteRecord::default());
                     match test.outcome {
                         TestOutcome::Passed => record.passed += 1,
-                        TestOutcome::Ignored { .. } => record.ignored += 1,
+                        TestOutcome::Ignored { .. } | TestOutcome::FilteredOut => {
+                            record.ignored += 1
+                        }
                         TestOutcome::Failed => record.failed += 1,
                     }
                 }
@@ -336,7 +338,7 @@ fn aggregate_test_suites(suites: &[&TestSuite]) -> BTreeMap<String, TestSuiteRec
                 TestOutcome::Failed => {
                     record.failed += 1;
                 }
-                TestOutcome::Ignored { .. } => {
+                TestOutcome::Ignored { .. } | TestOutcome::FilteredOut => {
                     record.ignored += 1;
                 }
             }
@@ -470,6 +472,7 @@ fn report_test_diffs(
         match outcome {
             TestOutcome::Passed => "pass".to_string(),
             TestOutcome::Failed => "fail".to_string(),
+            TestOutcome::FilteredOut => "ignore".to_string(),
             TestOutcome::Ignored { ignore_reason } => {
                 let reason = match ignore_reason {
                     Some(reason) => format!(" ({reason})"),

--- a/src/ci/citool/src/analysis.rs
+++ b/src/ci/citool/src/analysis.rs
@@ -472,7 +472,7 @@ fn report_test_diffs(
         match outcome {
             TestOutcome::Passed => "pass".to_string(),
             TestOutcome::Failed => "fail".to_string(),
-            TestOutcome::FilteredOut => "ignore".to_string(),
+            TestOutcome::FilteredOut => "ignore (filtered out)".to_string(),
             TestOutcome::Ignored { ignore_reason } => {
                 let reason = match ignore_reason {
                     Some(reason) => format!(" ({reason})"),

--- a/src/ci/citool/src/test_dashboard.rs
+++ b/src/ci/citool/src/test_dashboard.rs
@@ -77,7 +77,7 @@ fn gather_test_suites(job_metrics: &HashMap<JobName, JobMetrics>) -> TestSuites<
                     TestOutcome::Passed => {
                         variant_entry.passed.push(test_metadata);
                     }
-                    TestOutcome::Ignored { ignore_reason: _ } => {
+                    TestOutcome::Ignored { ignore_reason: _ } | TestOutcome::FilteredOut => {
                         variant_entry.ignored.push(test_metadata);
                     }
                     TestOutcome::Failed => {

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -49,3 +49,11 @@ features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",
 ]
+
+[dev-dependencies]
+assert_cmd = "=2.1.1"
+predicates = "3.1.3"
+build_helper = { path = "../../build_helper", features = ["metrics"] }
+serde_derive = "1.0.228"
+bstr = "1.12.1"
+rand = "0.9.2"

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -51,8 +51,8 @@ features = [
 ]
 
 [dev-dependencies]
-assert_cmd = "=2.1.1"
-predicates = "3.1.3"
+assert_cmd = "2.1.1"
+predicates = { version = "3.1.3", default-features = false }
 build_helper = { path = "../../build_helper", features = ["metrics"] }
 serde_derive = "1.0.228"
 bstr = "1.12.1"

--- a/src/tools/compiletest/src/executor.rs
+++ b/src/tools/compiletest/src/executor.rs
@@ -23,7 +23,7 @@ mod json;
 
 pub(crate) fn run_tests(config: &Config, tests: Vec<CollectedTest>) -> bool {
     let tests_len = tests.len();
-    let filtered = filter_tests(config, tests);
+    let (filtered, ignored) = filter_tests(config, tests);
     // Iterator yielding tests that haven't been started yet.
     let mut fresh_tests = (0..).map(TestId).zip(&filtered);
 
@@ -40,6 +40,11 @@ pub(crate) fn run_tests(config: &Config, tests: Vec<CollectedTest>) -> bool {
 
     let num_filtered_out = tests_len - filtered.len();
     listener.suite_started(filtered.len(), num_filtered_out);
+
+    for (id, test) in (filtered.len()..).map(TestId).zip(ignored) {
+        let completion = TestCompletion { id, outcome: TestOutcome::FilteredOut, stdout: None };
+        listener.test_finished(&test, &completion);
+    }
 
     // Channel used by test threads to report the test outcome when done.
     let (completion_tx, completion_rx) = mpsc::channel::<TestCompletion>();
@@ -263,6 +268,7 @@ enum TestOutcome {
     Succeeded,
     Failed { message: Option<&'static str> },
     Ignored,
+    FilteredOut,
 }
 
 impl TestOutcome {
@@ -278,9 +284,10 @@ impl TestOutcome {
 /// FIXME(#139660): Now that libtest has been removed, redesign the whole filtering system to
 /// do a better job of understanding and filtering _paths_, instead of being tied to libtest's
 /// substring/exact matching behaviour.
-fn filter_tests(opts: &Config, tests: Vec<CollectedTest>) -> Vec<CollectedTest> {
-    let mut filtered = tests;
-
+fn filter_tests(
+    opts: &Config,
+    tests: Vec<CollectedTest>,
+) -> (Vec<CollectedTest>, Vec<CollectedTest>) {
     let matches_filter = |test: &CollectedTest, filter_str: &str| {
         if opts.filter_exact {
             // When `--exact` is used we must use `filterable_path` to get
@@ -293,17 +300,23 @@ fn filter_tests(opts: &Config, tests: Vec<CollectedTest>) -> Vec<CollectedTest> 
         }
     };
 
-    // Remove tests that don't match the test filter
-    if !opts.filters.is_empty() {
-        filtered.retain(|test| opts.filters.iter().any(|filter| matches_filter(test, filter)));
-    }
+    let should_run = |test: &CollectedTest| {
+        // Remove tests that don't match the test filter
+        if !opts.filters.is_empty()
+            && !opts.filters.iter().any(|filter| matches_filter(test, filter))
+        {
+            return false;
+        }
 
-    // Skip tests that match any of the skip filters
-    if !opts.skip.is_empty() {
-        filtered.retain(|test| !opts.skip.iter().any(|sf| matches_filter(test, sf)));
-    }
+        // Skip tests that match any of the skip filters
+        if opts.skip.iter().any(|sf| matches_filter(test, sf)) {
+            return false;
+        }
 
-    filtered
+        true
+    };
+
+    tests.into_iter().partition(should_run)
 }
 
 /// Determines the number of tests to run concurrently.

--- a/src/tools/compiletest/src/executor/json.rs
+++ b/src/tools/compiletest/src/executor/json.rs
@@ -71,6 +71,10 @@ impl Listener {
                 maybe_message = test.desc.ignore_message.as_deref();
                 event = "ignored";
             }
+            TestOutcome::FilteredOut => {
+                maybe_message = test.desc.ignore_message.as_deref();
+                event = "filtered_out";
+            }
         };
 
         // This emits optional fields as `null`, instead of omitting them

--- a/src/tools/compiletest/tests/flags.rs
+++ b/src/tools/compiletest/tests/flags.rs
@@ -1,0 +1,135 @@
+use std::ops::Deref;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::assert::Assert;
+use assert_cmd::{Command, cargo_bin_cmd};
+use bstr::ByteSlice;
+use build_helper::metrics::compiletest::{Message, TestMessage};
+use predicates::str::is_empty;
+use rand::Rng;
+
+fn path_str(p: PathBuf) -> String {
+    p.canonicalize().unwrap().to_str().unwrap().to_owned()
+}
+
+// NOTE: incomplete, you'll probably need to extend this if you add more self-tests.
+fn compiletest() -> Command {
+    let src_root = path_str(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../"));
+    let build_host_root = path_str(Path::new(env!("CARGO_TARGET_DIR")).join("../"));
+    let build_root = path_str(Path::new(&build_host_root).join("../"));
+    let host = env!("CFG_COMPILER_BUILD_TRIPLE");
+    let sysroot =
+        path_str(Path::new(&std::env::var("TEST_RUSTC").unwrap()).parent().unwrap().join(".."));
+    let mut rng = rand::rng();
+
+    let mut compiletest = cargo_bin_cmd!("compiletest");
+    compiletest.args([
+        "--mode",
+        "ui",
+        "--suite",
+        "ui",
+        "--compile-lib-path=",
+        "--run-lib-path",
+        &std::env::var("COMPILETEST_RUNTIME_PATH").unwrap(),
+        "--python=",
+        "--jsondocck-path=",
+        "--src-root",
+        &src_root,
+        "--src-test-suite-root",
+        &(src_root.clone() + "/tests/ui"),
+        "--build-root",
+        &build_root,
+        "--build-test-suite-root",
+        // needs to be random so different tests don't conflict with each other
+        &(build_host_root.clone()
+            + "/test/compiletest-integration-test-"
+            + &rng.random::<u32>().to_string()),
+        "--sysroot-base",
+        &sysroot,
+        "--cc=c",
+        "--cxx=c++",
+        "--cflags=",
+        "--cxxflags=",
+        "--llvm-components=",
+        "--android-cross-path=",
+        "--stage",
+        "2",
+        "--stage-id",
+        &format!("stage2-{host}"),
+        "--channel",
+        env!("CFG_RELEASE_CHANNEL"),
+        "--host",
+        host,
+        "--target",
+        host,
+        "--nightly-branch=",
+        "--git-merge-commit-email=",
+        "--minicore-path=",
+        "--jobs=0",
+        "--rustc-path",
+        &std::env::var("TEST_RUSTC").expect("run this test through bootstrap"),
+        "compiletest-self-test",
+    ]);
+
+    compiletest.current_dir(src_root);
+
+    compiletest
+}
+
+fn run_ok(mut compiletest: Command) -> Assert {
+    compiletest.assert().success().stderr(is_empty())
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
+struct CompiletestMetrics(Vec<Message>);
+
+impl CompiletestMetrics {
+    fn find_test(&self, expected: &str) -> Option<&TestMessage> {
+        self.0.iter().find_map(|msg| {
+            let (msg, name) = match msg {
+                Message::Test(
+                    inner @ TestMessage::Ok(outcome)
+                    | inner @ TestMessage::Ignored(outcome)
+                    | inner @ TestMessage::Failed(outcome)
+                    | inner @ TestMessage::FilteredOut(outcome),
+                ) => (inner, &outcome.name),
+                Message::Test(inner @ TestMessage::Timeout { name }) => (inner, name),
+                _ => return None,
+            };
+            let stripped = name.strip_prefix("[ui] tests/ui/compiletest-self-test/").unwrap()
+                .strip_suffix(".rs").unwrap();
+            if stripped == expected {
+                Some(msg)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl Deref for CompiletestMetrics {
+    type Target = Vec<Message>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+trait CompiletestMetricsExt {
+    fn metrics(&self) -> CompiletestMetrics;
+}
+
+impl CompiletestMetricsExt for Assert {
+    fn metrics(&self) -> CompiletestMetrics {
+        let lines = self.get_output().stdout.lines();
+        let parsed = lines.map(serde_json::from_slice).collect::<Result<_, _>>().unwrap();
+        CompiletestMetrics(parsed)
+    }
+}
+
+#[test]
+fn ignore_directive_tests_reported_ignored() {
+    let mut ct = compiletest();
+    let metrics = dbg!(run_ok(ct).metrics());
+    assert!(matches!(metrics.find_test("ignore-directive").unwrap(), TestMessage::Ignored(..)));
+}

--- a/src/tools/compiletest/tests/flags.rs
+++ b/src/tools/compiletest/tests/flags.rs
@@ -96,13 +96,12 @@ impl CompiletestMetrics {
                 Message::Test(inner @ TestMessage::Timeout { name }) => (inner, name),
                 _ => return None,
             };
-            let stripped = name.strip_prefix("[ui] tests/ui/compiletest-self-test/").unwrap()
-                .strip_suffix(".rs").unwrap();
-            if stripped == expected {
-                Some(msg)
-            } else {
-                None
-            }
+            let stripped = name
+                .strip_prefix("[ui] ")
+                .unwrap_or_else(|| panic!("unknown name format {name}"))
+                // This can be None if compiletest prints ignored tests from other directories.
+                .strip_prefix("tests/ui/compiletest-self-test/");
+            if stripped == Some(expected) { Some(msg) } else { None }
         })
     }
 }
@@ -129,7 +128,18 @@ impl CompiletestMetricsExt for Assert {
 
 #[test]
 fn ignore_directive_tests_reported_ignored() {
+    let ct = compiletest();
+    let metrics = run_ok(ct).metrics();
+    assert!(matches!(metrics.find_test("ignore-directive.rs").unwrap(), TestMessage::Ignored(..)));
+}
+
+#[test]
+fn skipped_tests_reported_filtered() {
     let mut ct = compiletest();
-    let metrics = dbg!(run_ok(ct).metrics());
-    assert!(matches!(metrics.find_test("ignore-directive").unwrap(), TestMessage::Ignored(..)));
+    ct.arg("--skip=ignore-directive");
+    let metrics = run_ok(ct).metrics();
+    assert!(matches!(
+        metrics.find_test("ignore-directive.rs").unwrap(),
+        TestMessage::FilteredOut(..)
+    ));
 }

--- a/src/tools/compiletest/tests/flags.rs
+++ b/src/tools/compiletest/tests/flags.rs
@@ -72,6 +72,7 @@ fn compiletest() -> Command {
     ]);
 
     compiletest.current_dir(src_root);
+    compiletest.env_remove("COMPILETEST_REQUIRE_ALL_LLVM_COMPONENTS");
 
     compiletest
 }

--- a/tests/ui/compiletest-self-test/ignore-directive.rs
+++ b/tests/ui/compiletest-self-test/ignore-directive.rs
@@ -1,0 +1,1 @@
+//@ ignore-test


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155555)*
<!-- homu-ignore:end -->

Ferrocene depends on these metrics for our certification. For various reasons our CI invokes bootstrap with `--skip` flags, so we want to report ignored tests even if they're ignored manually with `--skip`.

To make sure this doesn't regress, add an integration test suite for compiletest itself. This can't fit into the existing `compiletest-self-test` suite because it's testing the interface between bootstrap and compiletest, not just whether the tests pass or fail. Hopefully this will come in handy for more things in the future.

---

Changes in this PR:
- Move deserialization of compiletest JSON from bootstrap to `build_helper`. Derive `Debug` on all its types.
- Add std to the sysroot before running compiletest self-tests, so that it can run integration tests and not just unit tests.
- Add a new `FilteredOut` metric kind. Handle it appropriately (by not doing anything) in progress reporting, but save it to the metrics.json file.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
