### PR TITLE
add safety doc (section header) to two unsafe methods in `NonZero`

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1118,7 +1118,10 @@ macro_rules! nonzero_integer {
             /// assuming overflow cannot occur.
             /// Overflow is unchecked, and it is undefined behavior to overflow
             /// *even if the result would wrap to a non-zero value*.
-            /// The behavior is undefined as soon as
+            ///
+            /// # Safety
+            ///
+            /// This results in undefined behavior when
             #[doc = sign_dependent_expr!{
                 $signedness ?
                 if signed {
@@ -1695,7 +1698,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// assuming overflow cannot occur.
         /// Overflow is unchecked, and it is undefined behavior to overflow
         /// *even if the result would wrap to a non-zero value*.
-        /// The behavior is undefined as soon as
+        ///
+        /// # Safety
+        ///
+        /// This results in undefined behavior when
         #[doc = concat!("`self + rhs > ", stringify!($Int), "::MAX`.")]
         ///
         /// # Examples


### PR DESCRIPTION
This PR adds a Safety section to two unsafe methods in `NonZero`:
- [unchecked_add](https://doc.rust-lang.org/nightly/core/num/struct.NonZero.html#method.unchecked_add)
- [unchecked_mul](https://doc.rust-lang.org/nightly/core/num/struct.NonZero.html#method.unchecked_mul)

The safety documentation is now consistent with that of [`u8::unchecked_add`](https://doc.rust-lang.org/nightly/core/primitive.u8.html#method.unchecked_add) and [`u8::unchecked_mul`](https://doc.rust-lang.org/nightly/core/primitive.u8.html#method.unchecked_mul).