### PR TITLE
Use singular wording for single _ placeholders in type suggestions

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -27,7 +27,7 @@ use crate::errors::{
     AmbiguousImpl, AmbiguousReturn, AnnotationRequired, InferenceBadError,
     SourceKindMultiSuggestion, SourceKindSubdiag,
 };
-use crate::infer::InferCtxt;
+use crate::infer::{InferCtxt, TyOrConstInferVar};
 
 pub enum TypeAnnotationNeeded {
     /// ```compile_fail,E0282
@@ -81,13 +81,27 @@ impl InferenceDiagnosticsData {
         !(self.name == "_" && matches!(self.kind, UnderspecifiedArgKind::Type { .. }))
     }
 
-    fn where_x_is_kind(&self, in_type: Ty<'_>) -> &'static str {
+    fn where_x_is_kind<'tcx>(&self, infcx: &InferCtxt<'tcx>, in_type: Ty<'tcx>) -> &'static str {
         if in_type.is_ty_or_numeric_infer() {
             ""
         } else if self.name == "_" {
-            // FIXME: Consider specializing this message if there is a single `_`
-            // in the type.
-            "underscore"
+            let displayed_ty = infcx
+                .resolve_vars_if_possible(in_type)
+                .fold_with(&mut ClosureEraser { infcx, depth: 0 });
+            if displayed_ty.is_ty_or_numeric_infer() {
+                ""
+            } else {
+                match displayed_ty
+                    .walk()
+                    .filter_map(TyOrConstInferVar::maybe_from_generic_arg)
+                    .take(2)
+                    .count()
+                {
+                    0 => "",
+                    1 => "underscore_single",
+                    _ => "underscore_multiple",
+                }
+            }
         } else {
             "has_name"
         }
@@ -554,7 +568,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags.push(SourceKindSubdiag::LetLike {
                     span: insert_span,
                     name: pattern_name.map(|name| name.to_string()).unwrap_or_else(String::new),
-                    x_kind: arg_data.where_x_is_kind(ty),
+                    x_kind: arg_data.where_x_is_kind(self.infcx, ty),
                     prefix_kind: arg_data.kind.clone(),
                     prefix: arg_data.kind.try_get_prefix().unwrap_or_default(),
                     arg_name: arg_data.name,
@@ -566,7 +580,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags.push(SourceKindSubdiag::LetLike {
                     span: insert_span,
                     name: String::new(),
-                    x_kind: arg_data.where_x_is_kind(ty),
+                    x_kind: arg_data.where_x_is_kind(self.infcx, ty),
                     prefix_kind: arg_data.kind.clone(),
                     prefix: arg_data.kind.try_get_prefix().unwrap_or_default(),
                     arg_name: arg_data.name,

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -277,7 +277,8 @@ pub enum SourceKindSubdiag<'a> {
                 [const_with_param] value of const parameter
                 [const] value of the constant
             } `{$arg_name}` is specified
-            [underscore] , where the placeholders `_` are specified
+            [underscore_single] , where the placeholder `_` is specified
+            [underscore_multiple] , where the placeholders `_` are specified
             *[empty] {\"\"}
         }",
         style = "verbose",

--- a/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.stderr
+++ b/tests/ui/autoref-autoderef/deref-ambiguity-becomes-nonambiguous.stderr
@@ -7,7 +7,7 @@ LL |     let var_fn = Value::wrap();
 LL |     let _ = var_fn.clone();
    |             ------ type must be known at this point
    |
-help: consider giving `var_fn` an explicit type, where the placeholders `_` are specified
+help: consider giving `var_fn` an explicit type, where the placeholder `_` is specified
    |
 LL |     let var_fn: Value<Rc<_>> = Value::wrap();
    |               ++++++++++++++

--- a/tests/ui/editions/edition-raw-pointer-method-2018.stderr
+++ b/tests/ui/editions/edition-raw-pointer-method-2018.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     let _ = y.is_null();
    |               ------- cannot call a method on a raw pointer with an unknown pointee type
    |
-help: consider giving `y` an explicit type, where the placeholders `_` are specified
+help: consider giving `y` an explicit type, where the placeholder `_` is specified
    |
 LL |     let y: *const _ = &x as *const _;
    |          ++++++++++

--- a/tests/ui/impl-trait/recursive-in-exhaustiveness.next.stderr
+++ b/tests/ui/impl-trait/recursive-in-exhaustiveness.next.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `(_,)`
 LL |     let (x,) = (build(x),);
    |         ^^^^
    |
-help: consider giving this pattern a type, where the placeholders `_` are specified
+help: consider giving this pattern a type, where the placeholder `_` is specified
    |
 LL |     let (x,): (_,) = (build(x),);
    |             ++++++
@@ -15,7 +15,7 @@ error[E0282]: type annotations needed for `((_,),)`
 LL |     let (x,) = (build2(x),);
    |         ^^^^
    |
-help: consider giving this pattern a type, where the placeholders `_` are specified
+help: consider giving this pattern a type, where the placeholder `_` is specified
    |
 LL |     let (x,): ((_,),) = (build2(x),);
    |             +++++++++

--- a/tests/ui/indexing/ambiguity-after-deref-step.stderr
+++ b/tests/ui/indexing/ambiguity-after-deref-step.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     x[1];
    |     - type must be known at this point
    |
-help: consider giving `x` an explicit type, where the placeholders `_` are specified
+help: consider giving `x` an explicit type, where the placeholder `_` is specified
    |
 LL |     let x: &_ = &Default::default();
    |          ++++

--- a/tests/ui/inference/need_type_info/underscore-placeholder-wording.rs
+++ b/tests/ui/inference/need_type_info/underscore-placeholder-wording.rs
@@ -1,0 +1,16 @@
+// Check that `need_type_info` distinguishes between a single placeholder and
+// multiple placeholders when suggesting an explicit type.
+
+fn singular() {
+    let v = &[];
+    //~^ ERROR type annotations needed
+    let _ = v.iter();
+}
+
+fn plural() {
+    let x = (vec![], vec![]);
+    //~^ ERROR type annotations needed
+    let _ = x;
+}
+
+fn main() {}

--- a/tests/ui/inference/need_type_info/underscore-placeholder-wording.stderr
+++ b/tests/ui/inference/need_type_info/underscore-placeholder-wording.stderr
@@ -1,0 +1,25 @@
+error[E0282]: type annotations needed for `&[_; 0]`
+  --> $DIR/underscore-placeholder-wording.rs:5:9
+   |
+LL |     let v = &[];
+   |         ^   --- type must be known at this point
+   |
+help: consider giving `v` an explicit type, where the placeholder `_` is specified
+   |
+LL |     let v: &[_; 0] = &[];
+   |          +++++++++
+
+error[E0282]: type annotations needed for `(Vec<_>, Vec<_>)`
+  --> $DIR/underscore-placeholder-wording.rs:11:9
+   |
+LL |     let x = (vec![], vec![]);
+   |         ^   ---------------- type must be known at this point
+   |
+help: consider giving `x` an explicit type, where the placeholders `_` are specified
+   |
+LL |     let x: (Vec<_>, Vec<_>) = (vec![], vec![]);
+   |          ++++++++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/methods/call_method_unknown_pointee.stderr
+++ b/tests/ui/methods/call_method_unknown_pointee.stderr
@@ -15,7 +15,7 @@ LL |
 LL |         let _b: u8 = b.read();
    |                        ---- cannot call a method on a raw pointer with an unknown pointee type
    |
-help: consider giving `b` an explicit type, where the placeholders `_` are specified
+help: consider giving `b` an explicit type, where the placeholder `_` is specified
    |
 LL |         let b: *const _ = ptr as *const _;
    |              ++++++++++
@@ -37,7 +37,7 @@ LL |
 LL |         let _d: u8 = d.read();
    |                        ---- cannot call a method on a raw pointer with an unknown pointee type
    |
-help: consider giving `d` an explicit type, where the placeholders `_` are specified
+help: consider giving `d` an explicit type, where the placeholder `_` is specified
    |
 LL |         let d: *mut _ = ptr as *mut _;
    |              ++++++++

--- a/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
+++ b/tests/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
@@ -43,7 +43,7 @@ error[E0282]: type annotations needed for `Vec<_>`
 LL |   let v : Vec<(u32,_) = vec![];
    |       ^                 ------ type must be known at this point
    |
-help: consider giving `v` an explicit type, where the placeholders `_` are specified
+help: consider giving `v` an explicit type, where the placeholder `_` is specified
    |
 LL |   let v: Vec<_> : Vec<(u32,_) = vec![];
    |        ++++++++
@@ -54,7 +54,7 @@ error[E0282]: type annotations needed for `Vec<_>`
 LL |   let v : Vec<'a = vec![];
    |       ^            ------ type must be known at this point
    |
-help: consider giving `v` an explicit type, where the placeholders `_` are specified
+help: consider giving `v` an explicit type, where the placeholder `_` is specified
    |
 LL |   let v: Vec<_> : Vec<'a = vec![];
    |        ++++++++

--- a/tests/ui/pattern/slice-patterns-irrefutable.stderr
+++ b/tests/ui/pattern/slice-patterns-irrefutable.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     [a, b] = Default::default();
    |      - type must be known at this point
    |
-help: consider giving `b` an explicit type, where the placeholders `_` are specified
+help: consider giving `b` an explicit type, where the placeholder `_` is specified
    |
 LL |     let b: [_; 3];
    |          ++++++++

--- a/tests/ui/repeat-expr/copy-inference-side-effects-are-lazy.stderr
+++ b/tests/ui/repeat-expr/copy-inference-side-effects-are-lazy.stderr
@@ -7,7 +7,7 @@ LL |
 LL |     extract(x).max(2);
    |     ---------- type must be known at this point
    |
-help: consider giving `x` an explicit type, where the placeholders `_` are specified
+help: consider giving `x` an explicit type, where the placeholder `_` is specified
    |
 LL |     let x: [Foo<T>; 2] = [Foo(PhantomData); 2];
    |          +++++++++++++

--- a/tests/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[_; 0]`
 LL |     let x = [];
    |         ^   -- type must be known at this point
    |
-help: consider giving `x` an explicit type, where the placeholders `_` are specified
+help: consider giving `x` an explicit type, where the placeholder `_` is specified
    |
 LL |     let x: [_; 0] = [];
    |          ++++++++

--- a/tests/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `Vec<_>`
 LL |     let x = vec![];
    |         ^   ------ type must be known at this point
    |
-help: consider giving `x` an explicit type, where the placeholders `_` are specified
+help: consider giving `x` an explicit type, where the placeholder `_` is specified
    |
 LL |     let x: Vec<_> = vec![];
    |          ++++++++

--- a/tests/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/tests/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `(Vec<_>,)`
 LL |     let (x, ) = (vec![], );
    |         ^^^^^   ---------- type must be known at this point
    |
-help: consider giving this pattern a type, where the placeholders `_` are specified
+help: consider giving this pattern a type, where the placeholder `_` is specified
    |
 LL |     let (x, ): (Vec<_>,) = (vec![], );
    |              +++++++++++

--- a/tests/ui/typeck/issue-7813.stderr
+++ b/tests/ui/typeck/issue-7813.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `&[_; 0]`
 LL |     let v = &[];
    |         ^   --- type must be known at this point
    |
-help: consider giving `v` an explicit type, where the placeholders `_` are specified
+help: consider giving `v` an explicit type, where the placeholder `_` is specified
    |
 LL |     let v: &[_; 0] = &[];
    |          +++++++++

--- a/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -7,7 +7,7 @@ LL |     let mut closure0 = None;
 LL |                         return c();
    |                                - type must be known at this point
    |
-help: consider giving `closure0` an explicit type, where the placeholders `_` are specified
+help: consider giving `closure0` an explicit type, where the placeholder `_` is specified
    |
 LL |     let mut closure0: Option<T> = None;
    |                     +++++++++++


### PR DESCRIPTION
While looking this part of code, I noticed this FIXME and fixed it :)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
