### PR TITLE
enable dynamic linking on the vita target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_sony_vita_newlibeabihf.rs
@@ -47,6 +47,7 @@ pub(crate) fn target() -> Target {
             exe_suffix: ".elf".into(),
             has_thumb_interworking: true,
             max_atomic_width: Some(64),
+            dynamic_linking: true,
             ..Default::default()
         },
     }


### PR DESCRIPTION
the vita os has support for dynamic linking so this should be set enabled on the target definition