### PR TITLE
Implement const Default for &CStr

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -176,7 +176,8 @@ impl fmt::Debug for CStr {
 }
 
 #[stable(feature = "cstr_default", since = "1.10.0")]
-impl Default for &CStr {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl const Default for &CStr {
     #[inline]
     fn default() -> Self {
         c""

--- a/library/coretests/tests/ffi/cstr.rs
+++ b/library/coretests/tests/ffi/cstr.rs
@@ -1,6 +1,12 @@
 use core::ffi::CStr;
 
 #[test]
+fn const_default() {
+    const S: &CStr = <_>::default();
+    assert_eq!(S, c"");
+}
+
+#[test]
 fn compares_as_u8s() {
     let a: &CStr = c"Hello!"; // Starts with ascii
     let a_bytes: &[u8] = a.to_bytes();


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Implements `const Default` for `&CStr`.

Tracking issue: rust-lang/rust#143894.