### PR TITLE
constify `Vec` comparisons

### DIFF
--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -4,11 +4,11 @@ use crate::alloc::Allocator;
 use crate::borrow::Cow;
 
 macro_rules! __impl_slice_eq1 {
-    ([$($vars:tt)*] $lhs:ty, $rhs:ty $(where $ty:ty: $bound:ident)?, #[$stability:meta]) => {
-        #[$stability]
-        impl<T, U, $($vars)*> PartialEq<$rhs> for $lhs
+    ($($const:ident, )? [$($vars:tt)*] $lhs:ty, $rhs:ty $(where $ty:ty: $bound:ident)?, $(#[$stability:meta])+ ) => {
+        $(#[$stability])+
+        impl<T, U, $($vars)*> $($const)? PartialEq<$rhs> for $lhs
         where
-            T: PartialEq<U>,
+            T: $([$const])? PartialEq<U>,
             $($ty: $bound)?
         {
             #[inline]
@@ -19,21 +19,21 @@ macro_rules! __impl_slice_eq1 {
     }
 }
 
-__impl_slice_eq1! { [A1: Allocator, A2: Allocator] Vec<T, A1>, Vec<U, A2>, #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, &[U], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, &mut [U], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] &[T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
-__impl_slice_eq1! { [A: Allocator] &mut [T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, [U], #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
-__impl_slice_eq1! { [A: Allocator] [T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
+__impl_slice_eq1! { const, [A1: Allocator, A2: Allocator] Vec<T, A1>, Vec<U, A2>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator] Vec<T, A>, &[U], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator] Vec<T, A>, &mut [U], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator] &[T], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
+__impl_slice_eq1! { const, [A: Allocator] &mut [T], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
+__impl_slice_eq1! { const, [A: Allocator] Vec<T, A>, [U], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")] }
+__impl_slice_eq1! { const, [A: Allocator] [T], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [A: Allocator] Cow<'_, [T]>, Vec<U, A> where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
 
 // NOTE: some less important impls are omitted to reduce code bloat
 // FIXME(Centril): Reconsider this?


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/143800

Due to `Cow` not implementing `const Deref` (https://github.com/rust-lang/rust/issues/147964), the comparisons including a `Cow` were not constified.
