### PR TITLE
Move diagnostic attribute target checks from check_attr

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -33,9 +33,12 @@ impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
         }
 
         if !matches!(cx.target, Target::Impl { of_trait: true }) {
+            let target_span = cx.target_span;
             cx.emit_dyn_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| IncorrectDoNotRecommendLocation.into_diag(dcx, level),
+                move |dcx, level| {
+                    IncorrectDoNotRecommendLocation { target_span }.into_diag(dcx, level)
+                },
                 attr_span,
             );
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -1,11 +1,16 @@
+use rustc_errors::Diagnostic;
 use rustc_feature::{AttributeTemplate, template};
+use rustc_hir::Target;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::lints::AttributeLintKind;
-use rustc_session::lint::builtin::MALFORMED_DIAGNOSTIC_ATTRIBUTES;
+use rustc_session::lint::builtin::{
+    MALFORMED_DIAGNOSTIC_ATTRIBUTES, MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+};
 use rustc_span::{Symbol, sym};
 
 use crate::attributes::{OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
+use crate::errors::IncorrectDoNotRecommendLocation;
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 
@@ -13,7 +18,8 @@ pub(crate) struct DoNotRecommendParser;
 impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
     const PATH: &[Symbol] = &[sym::diagnostic, sym::do_not_recommend];
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Checked in check_attr.
+    // "Allowed" on any target, noop on all but trait impls
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word /*doesn't matter */);
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
@@ -25,6 +31,16 @@ impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
                 attr_span,
             );
         }
+
+        if !matches!(cx.target, Target::Impl { of_trait: true }) {
+            cx.emit_dyn_lint(
+                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                move |dcx, level| IncorrectDoNotRecommendLocation.into_diag(dcx, level),
+                attr_span,
+            );
+            return None;
+        }
+
         Some(AttributeKind::DoNotRecommend { attr_span })
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -1,8 +1,10 @@
+use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
+use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
-
+use crate::errors::DiagnosticOnConstOnlyForTraitImpls;
 #[derive(Default)]
 pub(crate) struct OnConstParser {
     span: Option<Span>,
@@ -21,6 +23,21 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
 
             let span = cx.attr_span;
             this.span = Some(span);
+
+            // FIXME(mejrs) no constness field on `Target`,
+            // so non-constness is still checked in check_attr.rs
+            if !matches!(cx.target, Target::Impl { of_trait: true }) {
+                let target_span = cx.target_span;
+                cx.emit_dyn_lint(
+                    MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                    move |dcx, level| {
+                        DiagnosticOnConstOnlyForTraitImpls { target_span }.into_diag(dcx, level)
+                    },
+                    span,
+                );
+                return;
+            }
+
             let mode = Mode::DiagnosticOnConst;
 
             let Some(items) = parse_list(cx, args, mode) else { return };
@@ -32,7 +49,8 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
         },
     )];
 
-    //FIXME Still checked in `check_attr.rs`
+    // "Allowed" on all targets; noop on anything but non-const trait impls;
+    // this linted on in parser.
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -1,10 +1,13 @@
+use rustc_errors::Diagnostic;
 use rustc_feature::template;
 use rustc_hir::attrs::AttributeKind;
+use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::sym;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
 use crate::context::{AcceptContext, Stage};
+use crate::errors::DiagnosticOnMoveOnlyForAdt;
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 
@@ -29,6 +32,15 @@ impl OnMoveParser {
         let span = cx.attr_span;
         self.span = Some(span);
 
+        if !matches!(cx.target, Target::Enum | Target::Struct | Target::Union) {
+            cx.emit_dyn_lint(
+                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                move |dcx, level| DiagnosticOnMoveOnlyForAdt.into_diag(dcx, level),
+                span,
+            );
+            return;
+        }
+
         let Some(items) = parse_list(cx, args, mode) else { return };
 
         if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
@@ -44,6 +56,8 @@ impl<S: Stage> AttributeParser<S> for OnMoveParser {
             this.parse(cx, args, Mode::DiagnosticOnMove);
         },
     )];
+
+    // "Allowed" for all targets but noop if used on not-adt.
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -1,7 +1,10 @@
+use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
+use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
+use crate::errors::DiagnosticOnUnimplementedOnlyForTraits;
 
 #[derive(Default)]
 pub(crate) struct OnUnimplementedParser {
@@ -19,11 +22,12 @@ impl OnUnimplementedParser {
         let span = cx.attr_span;
         self.span = Some(span);
 
-        // If target is not a trait, returning early will make `finalize` emit a
-        // `AttributeKind::OnUnimplemented {span, directive: None }`, to prevent it being
-        // accidentally used on non-trait items like trait aliases.
         if !matches!(cx.target, Target::Trait) {
-            // Lint later emitted in check_attr
+            cx.emit_dyn_lint(
+                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                move |dcx, level| DiagnosticOnUnimplementedOnlyForTraits.into_diag(dcx, level),
+                span,
+            );
             return;
         }
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -1,7 +1,11 @@
+use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
+use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
+use crate::ShouldEmit;
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
+use crate::errors::DiagnosticOnUnknownOnlyForImports;
 
 #[derive(Default)]
 pub(crate) struct OnUnknownParser {
@@ -25,6 +29,22 @@ impl OnUnknownParser {
         let span = cx.attr_span;
         self.span = Some(span);
 
+        // At early parsing we get passed `Target::Crate` regardless of the item we're on.
+        // Only do target checking if we're late.
+        let early = matches!(cx.stage.should_emit(), ShouldEmit::Nothing);
+
+        if !early && !matches!(cx.target, Target::Use) {
+            let target_span = cx.target_span;
+            cx.emit_dyn_lint(
+                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
+                move |dcx, level| {
+                    DiagnosticOnUnknownOnlyForImports { target_span }.into_diag(dcx, level)
+                },
+                span,
+            );
+            return;
+        }
+
         let Some(items) = parse_list(cx, args, mode) else { return };
 
         if let Some(directive) = parse_directive_items(cx, mode, items.mixed(), true) {
@@ -41,7 +61,7 @@ impl<S: Stage> AttributeParser<S> for OnUnknownParser {
             this.parse(cx, args, Mode::DiagnosticOnUnknown);
         },
     )];
-    //FIXME attribute is not parsed for non-use statements but diagnostics are issued in `check_attr.rs`
+    // "Allowed" for all targets, but noop for all but use statements.
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
     fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -267,3 +267,10 @@ pub(crate) struct DiagnosticOnMoveOnlyForAdt;
 #[derive(Diagnostic)]
 #[diag("`#[diagnostic::on_unimplemented]` can only be applied to trait definitions")]
 pub(crate) struct DiagnosticOnUnimplementedOnlyForTraits;
+
+#[derive(Diagnostic)]
+#[diag("`#[diagnostic::on_unknown]` can only be applied to `use` statements")]
+pub(crate) struct DiagnosticOnUnknownOnlyForImports {
+    #[label("not an import")]
+    pub target_span: Span,
+}

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -259,3 +259,7 @@ pub(crate) struct DiagnosticOnConstOnlyForTraitImpls {
     #[label("not a trait impl")]
     pub target_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("`#[diagnostic::on_move]` can only be applied to enums, structs or unions")]
+pub(crate) struct DiagnosticOnMoveOnlyForAdt;

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -254,9 +254,9 @@ pub(crate) struct DocUnknownAny {
 pub(crate) struct DocAutoCfgWrongLiteral;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait impls")]
+#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait implementations")]
 pub(crate) struct DiagnosticOnConstOnlyForTraitImpls {
-    #[label("not a trait impl")]
+    #[label("not a trait implementation")]
     pub target_span: Span,
 }
 
@@ -277,4 +277,7 @@ pub(crate) struct DiagnosticOnUnknownOnlyForImports {
 
 #[derive(Diagnostic)]
 #[diag("`#[diagnostic::do_not_recommend]` can only be placed on trait implementations")]
-pub(crate) struct IncorrectDoNotRecommendLocation;
+pub(crate) struct IncorrectDoNotRecommendLocation {
+    #[label("not a trait implementation")]
+    pub target_span: Span,
+}

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -254,7 +254,7 @@ pub(crate) struct DocUnknownAny {
 pub(crate) struct DocAutoCfgWrongLiteral;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to trait impls")]
+#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait impls")]
 pub(crate) struct DiagnosticOnConstOnlyForTraitImpls {
     #[label("not a trait impl")]
     pub target_span: Span,

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -252,3 +252,10 @@ pub(crate) struct DocUnknownAny {
 #[derive(Diagnostic)]
 #[diag("expected boolean for `#[doc(auto_cfg = ...)]`")]
 pub(crate) struct DocAutoCfgWrongLiteral;
+
+#[derive(Diagnostic)]
+#[diag("`#[diagnostic::on_const]` can only be applied to trait impls")]
+pub(crate) struct DiagnosticOnConstOnlyForTraitImpls {
+    #[label("not a trait impl")]
+    pub target_span: Span,
+}

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -263,3 +263,7 @@ pub(crate) struct DiagnosticOnConstOnlyForTraitImpls {
 #[derive(Diagnostic)]
 #[diag("`#[diagnostic::on_move]` can only be applied to enums, structs or unions")]
 pub(crate) struct DiagnosticOnMoveOnlyForAdt;
+
+#[derive(Diagnostic)]
+#[diag("`#[diagnostic::on_unimplemented]` can only be applied to trait definitions")]
+pub(crate) struct DiagnosticOnUnimplementedOnlyForTraits;

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -274,3 +274,7 @@ pub(crate) struct DiagnosticOnUnknownOnlyForImports {
     #[label("not an import")]
     pub target_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("`#[diagnostic::do_not_recommend]` can only be placed on trait implementations")]
+pub(crate) struct IncorrectDoNotRecommendLocation;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -57,13 +57,6 @@ struct DiagnosticOnConstOnlyForNonConstTraitImpls {
     item_span: Span,
 }
 
-#[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_unknown]` can only be applied to `use` statements")]
-struct DiagnosticOnUnknownOnlyForImports {
-    #[label("not an import")]
-    item_span: Span,
-}
-
 fn target_from_impl_item<'tcx>(tcx: TyCtxt<'tcx>, impl_item: &hir::ImplItem<'_>) -> Target {
     match impl_item.kind {
         hir::ImplItemKind::Const(..) => Target::AssocConst,
@@ -208,7 +201,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 },
                 Attribute::Parsed(AttributeKind::DoNotRecommend{attr_span}) => {self.check_do_not_recommend(*attr_span, hir_id, target, item)},
                 Attribute::Parsed(AttributeKind::OnUnimplemented{directive,..}) => {self.check_diagnostic_on_unimplemented(hir_id, directive.as_deref())},
-                Attribute::Parsed(AttributeKind::OnUnknown { span, .. }) => { self.check_diagnostic_on_unknown(*span, hir_id, target) },
                 Attribute::Parsed(AttributeKind::OnConst{span, ..}) => {self.check_diagnostic_on_const(*span, hir_id, target, item)}
                 Attribute::Parsed(AttributeKind::OnMove { directive , .. }) => {
                     self.check_diagnostic_on_move(hir_id, directive.as_deref())
@@ -260,6 +252,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::NoMain
                     | AttributeKind::NoMangle(..)
                     | AttributeKind::NoStd { .. }
+                    | AttributeKind::OnUnknown { .. }
                     | AttributeKind::Optimize(..)
                     | AttributeKind::PanicRuntime
                     | AttributeKind::PatchableFunctionEntry { .. }
@@ -622,19 +615,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     }
                 });
             }
-        }
-    }
-
-    /// Checks if `#[diagnostic::on_unknown]` is applied to a trait impl
-    fn check_diagnostic_on_unknown(&self, attr_span: Span, hir_id: HirId, target: Target) {
-        if !matches!(target, Target::Use) {
-            let item_span = self.tcx.hir_span(hir_id);
-            self.tcx.emit_node_span_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                hir_id,
-                attr_span,
-                DiagnosticOnUnknownOnlyForImports { item_span },
-            );
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -62,10 +62,6 @@ struct DiagnosticOnConstOnlyForNonConstTraitImpls {
 }
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_move]` can only be applied to enums, structs or unions")]
-struct DiagnosticOnMoveOnlyForAdt;
-
-#[derive(Diagnostic)]
 #[diag("`#[diagnostic::on_unknown]` can only be applied to `use` statements")]
 struct DiagnosticOnUnknownOnlyForImports {
     #[label("not an import")]
@@ -218,8 +214,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 Attribute::Parsed(AttributeKind::OnUnimplemented{span, directive}) => {self.check_diagnostic_on_unimplemented(*span, hir_id, target,directive.as_deref())},
                 Attribute::Parsed(AttributeKind::OnUnknown { span, .. }) => { self.check_diagnostic_on_unknown(*span, hir_id, target) },
                 Attribute::Parsed(AttributeKind::OnConst{span, ..}) => {self.check_diagnostic_on_const(*span, hir_id, target, item)}
-                Attribute::Parsed(AttributeKind::OnMove { span, directive }) => {
-                    self.check_diagnostic_on_move(*span, hir_id, target, directive.as_deref())
+                Attribute::Parsed(AttributeKind::OnMove { directive , .. }) => {
+                    self.check_diagnostic_on_move(hir_id, directive.as_deref())
                 },
                 Attribute::Parsed(
                     // tidy-alphabetical-start
@@ -613,23 +609,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         // ...whose generics would that be, anyway? The traits' or the impls'?
     }
 
-    /// Checks if `#[diagnostic::on_move]` is applied to an ADT definition
-    fn check_diagnostic_on_move(
-        &self,
-        attr_span: Span,
-        hir_id: HirId,
-        target: Target,
-        directive: Option<&Directive>,
-    ) {
-        if !matches!(target, Target::Enum | Target::Struct | Target::Union) {
-            self.tcx.emit_node_span_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                hir_id,
-                attr_span,
-                DiagnosticOnMoveOnlyForAdt,
-            );
-        }
-
+    /// Checks use of generic formatting parameters in `#[diagnostic::on_move]`
+    fn check_diagnostic_on_move(&self, hir_id: HirId, directive: Option<&Directive>) {
         if let Some(directive) = directive {
             if let Node::Item(Item {
                 kind:

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -199,7 +199,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 Attribute::Parsed(AttributeKind::RustcMustImplementOneOf { attr_span, fn_names }) => {
                     self.check_rustc_must_implement_one_of(*attr_span, fn_names, hir_id,target)
                 },
-                Attribute::Parsed(AttributeKind::DoNotRecommend{attr_span}) => {self.check_do_not_recommend(*attr_span, hir_id, target, item)},
                 Attribute::Parsed(AttributeKind::OnUnimplemented{directive,..}) => {self.check_diagnostic_on_unimplemented(hir_id, directive.as_deref())},
                 Attribute::Parsed(AttributeKind::OnConst{span, ..}) => {self.check_diagnostic_on_const(*span, hir_id, target, item)}
                 Attribute::Parsed(AttributeKind::OnMove { directive , .. }) => {
@@ -222,6 +221,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | AttributeKind::CustomMir(..)
                     | AttributeKind::DebuggerVisualizer(..)
                     | AttributeKind::DefaultLibAllocator
+                    | AttributeKind::DoNotRecommend {..}
                     // `#[doc]` is actually a lot more than just doc comments, so is checked below
                     | AttributeKind::DocComment {..}
                     | AttributeKind::EiiDeclaration { .. }
@@ -487,30 +487,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     },
                 });
             }
-        }
-    }
-
-    /// Checks if `#[diagnostic::do_not_recommend]` is applied on a trait impl
-    fn check_do_not_recommend(
-        &self,
-        attr_span: Span,
-        hir_id: HirId,
-        target: Target,
-        item: Option<ItemLike<'_>>,
-    ) {
-        if !matches!(target, Target::Impl { .. })
-            || matches!(
-                item,
-                Some(ItemLike::Item(hir::Item {  kind: hir::ItemKind::Impl(_impl),.. }))
-                    if _impl.of_trait.is_none()
-            )
-        {
-            self.tcx.emit_node_span_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                hir_id,
-                attr_span,
-                errors::IncorrectDoNotRecommendLocation,
-            );
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -51,10 +51,6 @@ use rustc_trait_selection::traits::ObligationCtxt;
 use crate::errors;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_unimplemented]` can only be applied to trait definitions")]
-struct DiagnosticOnUnimplementedOnlyForTraits;
-
-#[derive(Diagnostic)]
 #[diag("`#[diagnostic::on_const]` can only be applied to non-const trait impls")]
 struct DiagnosticOnConstOnlyForNonConstTraitImpls {
     #[label("this is a const trait impl")]
@@ -211,7 +207,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.check_rustc_must_implement_one_of(*attr_span, fn_names, hir_id,target)
                 },
                 Attribute::Parsed(AttributeKind::DoNotRecommend{attr_span}) => {self.check_do_not_recommend(*attr_span, hir_id, target, item)},
-                Attribute::Parsed(AttributeKind::OnUnimplemented{span, directive}) => {self.check_diagnostic_on_unimplemented(*span, hir_id, target,directive.as_deref())},
+                Attribute::Parsed(AttributeKind::OnUnimplemented{directive,..}) => {self.check_diagnostic_on_unimplemented(hir_id, directive.as_deref())},
                 Attribute::Parsed(AttributeKind::OnUnknown { span, .. }) => { self.check_diagnostic_on_unknown(*span, hir_id, target) },
                 Attribute::Parsed(AttributeKind::OnConst{span, ..}) => {self.check_diagnostic_on_const(*span, hir_id, target, item)}
                 Attribute::Parsed(AttributeKind::OnMove { directive , .. }) => {
@@ -525,23 +521,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
     }
 
-    /// Checks if `#[diagnostic::on_unimplemented]` is applied to a trait definition
-    fn check_diagnostic_on_unimplemented(
-        &self,
-        attr_span: Span,
-        hir_id: HirId,
-        target: Target,
-        directive: Option<&Directive>,
-    ) {
-        if !matches!(target, Target::Trait) {
-            self.tcx.emit_node_span_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                hir_id,
-                attr_span,
-                DiagnosticOnUnimplementedOnlyForTraits,
-            );
-        }
-
+    /// Checks use of generic formatting parameters in `#[diagnostic::on_unimplemented]`
+    fn check_diagnostic_on_unimplemented(&self, hir_id: HirId, directive: Option<&Directive>) {
         if let Some(directive) = directive {
             if let Node::Item(Item {
                 kind: ItemKind::Trait(_, _, _, _, trait_name, generics, _, _),

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -51,9 +51,9 @@ use rustc_trait_selection::traits::ObligationCtxt;
 use crate::errors;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait impls")]
+#[diag("`#[diagnostic::on_const]` can only be applied to non-const trait implementations")]
 struct DiagnosticOnConstOnlyForNonConstTraitImpls {
-    #[label("this is a const trait impl")]
+    #[label("this is a const trait implementation")]
     item_span: Span,
 }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -55,13 +55,6 @@ use crate::errors;
 struct DiagnosticOnUnimplementedOnlyForTraits;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::on_const]` can only be applied to trait impls")]
-struct DiagnosticOnConstOnlyForTraitImpls {
-    #[label("not a trait impl")]
-    item_span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("`#[diagnostic::on_const]` can only be applied to non-const trait impls")]
 struct DiagnosticOnConstOnlyForNonConstTraitImpls {
     #[label("this is a const trait impl")]
@@ -587,7 +580,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         }
     }
 
-    /// Checks if `#[diagnostic::on_const]` is applied to a trait impl
+    /// Checks if `#[diagnostic::on_const]` is applied to a on-const trait impl
     fn check_diagnostic_on_const(
         &self,
         attr_span: Span,
@@ -595,6 +588,8 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         target: Target,
         item: Option<ItemLike<'_>>,
     ) {
+        // We only check the non-constness here. A diagnostic for use
+        // on not-trait impl items is issued during attribute parsing.
         if target == (Target::Impl { of_trait: true }) {
             match item.unwrap() {
                 ItemLike::Item(it) => match it.expect_impl().constness {
@@ -613,16 +608,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 ItemLike::ForeignItem => {}
             }
         }
-        let item_span = self.tcx.hir_span(hir_id);
-        self.tcx.emit_node_span_lint(
-            MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-            hir_id,
-            attr_span,
-            DiagnosticOnConstOnlyForTraitImpls { item_span },
-        );
-
-        // We don't check the validity of generic args here...whose generics would that be, anyway?
-        // The traits' or the impls'?
+        // FIXME(#155570) Can we do something with generic args here?
+        // regardless, we don't check the validity of generic args here
+        // ...whose generics would that be, anyway? The traits' or the impls'?
     }
 
     /// Checks if `#[diagnostic::on_move]` is applied to an ADT definition

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -14,10 +14,6 @@ use crate::check_attr::ProcMacroKind;
 use crate::lang_items::Duplicate;
 
 #[derive(Diagnostic)]
-#[diag("`#[diagnostic::do_not_recommend]` can only be placed on trait implementations")]
-pub(crate) struct IncorrectDoNotRecommendLocation;
-
-#[derive(Diagnostic)]
 #[diag("`#[loop_match]` should be applied to a loop")]
 pub(crate) struct LoopMatchAttr {
     #[primary_span]

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.current.stderr
@@ -3,6 +3,9 @@ warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implement
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | const CONST: () = ();
+   | --------------------- not a trait implementation
    |
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
@@ -11,48 +14,72 @@ warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implement
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | static STATIC: () = ();
+   | ----------------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:15:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | type Type = ();
+   | --------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:19:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | enum Enum {}
+   | ------------ not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:23:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | impl Enum {}
+   | ------------ not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:27:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | extern "C" {}
+   | ------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:31:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | fn fun() {}
+   | ----------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:35:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | struct Struct {}
+   | ---------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:39:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | trait Trait {}
+   | -------------- not a trait implementation
 
 warning: 9 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/incorrect-locations.next.stderr
@@ -3,6 +3,9 @@ warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implement
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | const CONST: () = ();
+   | --------------------- not a trait implementation
    |
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
@@ -11,48 +14,72 @@ warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implement
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | static STATIC: () = ();
+   | ----------------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:15:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | type Type = ();
+   | --------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:19:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | enum Enum {}
+   | ------------ not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:23:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | impl Enum {}
+   | ------------ not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:27:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | extern "C" {}
+   | ------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:31:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | fn fun() {}
+   | ----------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:35:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | struct Struct {}
+   | ---------------- not a trait implementation
 
 warning: `#[diagnostic::do_not_recommend]` can only be placed on trait implementations
   --> $DIR/incorrect-locations.rs:39:1
    |
 LL | #[diagnostic::do_not_recommend]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | trait Trait {}
+   | -------------- not a trait implementation
 
 warning: 9 warnings emitted
 

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -2,7 +2,7 @@
 #![deny(misplaced_diagnostic_attributes)]
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to trait impls
+//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
 pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
@@ -14,7 +14,7 @@ impl const PartialEq for Foo {
 }
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to trait impls
+//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
 impl Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true
@@ -23,7 +23,7 @@ impl Foo {
 
 impl PartialOrd for Foo {
     #[diagnostic::on_const(message = "tadaa", note = "boing")]
-    //~^ ERROR: `#[diagnostic::on_const]` can only be applied to trait impls
+    //~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
         None
     }

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.rs
@@ -2,11 +2,11 @@
 #![deny(misplaced_diagnostic_attributes)]
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
 pub struct Foo;
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
 impl const PartialEq for Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true
@@ -14,7 +14,7 @@ impl const PartialEq for Foo {
 }
 
 #[diagnostic::on_const(message = "tadaa", note = "boing")]
-//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+//~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
 impl Foo {
     fn eq(&self, _other: &Foo) -> bool {
         true
@@ -23,7 +23,7 @@ impl Foo {
 
 impl PartialOrd for Foo {
     #[diagnostic::on_const(message = "tadaa", note = "boing")]
-    //~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+    //~^ ERROR: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
         None
     }

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -13,7 +13,7 @@ note: the lint level is defined here
 LL | #![deny(misplaced_diagnostic_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[diagnostic::on_const]` can only be applied to trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
   --> $DIR/misplaced_attr.rs:4:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
@@ -22,7 +22,7 @@ LL |
 LL | pub struct Foo;
    | --------------- not a trait impl
 
-error: `#[diagnostic::on_const]` can only be applied to trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
   --> $DIR/misplaced_attr.rs:16:1
    |
 LL |   #[diagnostic::on_const(message = "tadaa", note = "boing")]
@@ -35,7 +35,7 @@ LL | |     }
 LL | | }
    | |_- not a trait impl
 
-error: `#[diagnostic::on_const]` can only be applied to trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
   --> $DIR/misplaced_attr.rs:25:5
    |
 LL |       #[diagnostic::on_const(message = "tadaa", note = "boing")]

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -1,11 +1,11 @@
-error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
   --> $DIR/misplaced_attr.rs:8:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | impl const PartialEq for Foo {
-   | ---------------------------- this is a const trait impl
+   | ---------------------------- this is a const trait implementation
    |
 note: the lint level is defined here
   --> $DIR/misplaced_attr.rs:2:9
@@ -13,16 +13,16 @@ note: the lint level is defined here
 LL | #![deny(misplaced_diagnostic_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
   --> $DIR/misplaced_attr.rs:4:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | pub struct Foo;
-   | --------------- not a trait impl
+   | --------------- not a trait implementation
 
-error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
   --> $DIR/misplaced_attr.rs:16:1
    |
 LL |   #[diagnostic::on_const(message = "tadaa", note = "boing")]
@@ -33,9 +33,9 @@ LL | |     fn eq(&self, _other: &Foo) -> bool {
 LL | |         true
 LL | |     }
 LL | | }
-   | |_- not a trait impl
+   | |_- not a trait implementation
 
-error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
+error: `#[diagnostic::on_const]` can only be applied to non-const trait implementations
   --> $DIR/misplaced_attr.rs:25:5
    |
 LL |       #[diagnostic::on_const(message = "tadaa", note = "boing")]
@@ -44,7 +44,7 @@ LL |
 LL | /     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
 LL | |         None
 LL | |     }
-   | |_____- not a trait impl
+   | |_____- not a trait implementation
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
+++ b/tests/ui/diagnostic_namespace/on_const/misplaced_attr.stderr
@@ -1,18 +1,3 @@
-error: `#[diagnostic::on_const]` can only be applied to trait impls
-  --> $DIR/misplaced_attr.rs:4:1
-   |
-LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL | pub struct Foo;
-   | -------------- not a trait impl
-   |
-note: the lint level is defined here
-  --> $DIR/misplaced_attr.rs:2:9
-   |
-LL | #![deny(misplaced_diagnostic_attributes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: `#[diagnostic::on_const]` can only be applied to non-const trait impls
   --> $DIR/misplaced_attr.rs:8:1
    |
@@ -21,24 +6,45 @@ LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
 LL |
 LL | impl const PartialEq for Foo {
    | ---------------------------- this is a const trait impl
+   |
+note: the lint level is defined here
+  --> $DIR/misplaced_attr.rs:2:9
+   |
+LL | #![deny(misplaced_diagnostic_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `#[diagnostic::on_const]` can only be applied to trait impls
-  --> $DIR/misplaced_attr.rs:16:1
+  --> $DIR/misplaced_attr.rs:4:1
    |
 LL | #[diagnostic::on_const(message = "tadaa", note = "boing")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
-LL | impl Foo {
-   | -------- not a trait impl
+LL | pub struct Foo;
+   | --------------- not a trait impl
+
+error: `#[diagnostic::on_const]` can only be applied to trait impls
+  --> $DIR/misplaced_attr.rs:16:1
+   |
+LL |   #[diagnostic::on_const(message = "tadaa", note = "boing")]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | / impl Foo {
+LL | |     fn eq(&self, _other: &Foo) -> bool {
+LL | |         true
+LL | |     }
+LL | | }
+   | |_- not a trait impl
 
 error: `#[diagnostic::on_const]` can only be applied to trait impls
   --> $DIR/misplaced_attr.rs:25:5
    |
-LL |     #[diagnostic::on_const(message = "tadaa", note = "boing")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |       #[diagnostic::on_const(message = "tadaa", note = "boing")]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
-LL |     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
-   |     ---------------------------------------------------------------- not a trait impl
+LL | /     fn partial_cmp(&self, other: &Foo) -> Option<std::cmp::Ordering> {
+LL | |         None
+LL | |     }
+   | |_____- not a trait impl
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_accept_options_of_the_internal_rustc_attribute.stderr
@@ -1,11 +1,3 @@
-warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
-  --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:22:1
-   |
-LL | #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
-
 warning: there is no parameter `from_desugaring` on trait `Baz`
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:29:17
    |
@@ -151,6 +143,14 @@ LL | #[diagnostic::on_unimplemented = "Message"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
    |
    = help: only `message`, `note` and `label` are allowed as options
+
+warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+  --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:22:1
+   |
+LL | #[diagnostic::on_unimplemented(message = "Not allowed to apply it on a impl")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 error[E0277]: trait has `()` and `i32` as params
   --> $DIR/do_not_accept_options_of_the_internal_rustc_attribute.rs:53:15

--- a/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/do_not_fail_parsing_on_invalid_options_1.stderr
@@ -1,11 +1,3 @@
-warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
-  --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:7:1
-   |
-LL | #[diagnostic::on_unimplemented(message = "Baz")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
-
 warning: there is no parameter `DoesNotExist` on trait `Test`
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:31:44
    |
@@ -23,6 +15,14 @@ LL | #[diagnostic::on_unimplemented(unsupported = "foo")]
    |
    = help: only `message`, `note` and `label` are allowed as options
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
+
+warning: `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
+  --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:7:1
+   |
+LL | #[diagnostic::on_unimplemented(message = "Baz")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `diagnostic::on_unimplemented` attribute
   --> $DIR/do_not_fail_parsing_on_invalid_options_1.rs:11:50

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect-locations.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect-locations.stderr
@@ -5,7 +5,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | extern crate std as other_std;
-   | ----------------------------- not an import
+   | ------------------------------ not an import
    |
    = note: `#[warn(misplaced_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
@@ -16,7 +16,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | const CONST: () = ();
-   | --------------- not an import
+   | --------------------- not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:13:1
@@ -25,7 +25,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | static STATIC: () = ();
-   | ----------------- not an import
+   | ----------------------- not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:17:1
@@ -34,7 +34,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | type Type = ();
-   | --------- not an import
+   | --------------- not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:21:1
@@ -43,7 +43,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | enum Enum {}
-   | --------- not an import
+   | ------------ not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:25:1
@@ -52,7 +52,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | impl Enum {}
-   | --------- not an import
+   | ------------ not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:29:1
@@ -70,7 +70,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | fn fun() {}
-   | -------- not an import
+   | ----------- not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:37:1
@@ -79,7 +79,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | struct Struct {}
-   | ------------- not an import
+   | ---------------- not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:41:1
@@ -88,7 +88,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | trait Trait {}
-   | ----------- not an import
+   | -------------- not an import
 
 warning: `#[diagnostic::on_unknown]` can only be applied to `use` statements
   --> $DIR/incorrect-locations.rs:45:1
@@ -97,7 +97,7 @@ LL | #[diagnostic::on_unknown(message = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL | impl Trait for i32 {}
-   | ------------------ not an import
+   | --------------------- not an import
 
 warning: 11 warnings emitted
 


### PR DESCRIPTION
Move diagnostic attribute target checks into their targets. Part of https://github.com/rust-lang/rust/issues/131229#issuecomment-3959910413 

This is much easier with `emit_dyn_lint` :) (thanks @GuillaumeGomez !)

I think there might be some opportunity to simplify all these `check_diagnostic_*` methods in `check_attr`. However there are some diagnostic attribute prs in flight and I'd like to wait for those to land first and then think about it. So that PR is not for today.

r? @JonathanBrouwer (or @GuillaumeGomez if you want)
