### PR TITLE
Move `std::io::RawOsError` to `core::io`

### DIFF
--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -2,6 +2,20 @@
 
 use crate::fmt;
 
+/// The type of raw OS error codes.
+///
+/// This is an [`i32`] on all currently supported platforms, but platforms
+/// added in the future (such as UEFI) may use a different primitive type like
+/// [`usize`]. Use `as` or [`into`] conversions where applicable to ensure maximum
+/// portability.
+///
+/// [`into`]: Into::into
+#[unstable(feature = "raw_os_error_ty", issue = "107792")]
+pub type RawOsError = cfg_select! {
+    target_os = "uefi" => usize,
+    _ => i32,
+};
+
 /// A list specifying general categories of I/O error.
 ///
 /// This list is intended to grow over time and it is not recommended to

--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -7,3 +7,5 @@ mod error;
 pub use self::borrowed_buf::{BorrowedBuf, BorrowedCursor};
 #[unstable(feature = "core_io", issue = "154046")]
 pub use self::error::ErrorKind;
+#[unstable(feature = "raw_os_error_ty", issue = "107792")]
+pub use self::error::RawOsError;

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -3,6 +3,8 @@ mod tests;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::io::ErrorKind;
+#[unstable(feature = "raw_os_error_ty", issue = "107792")]
+pub use core::io::RawOsError;
 
 // On 64-bit platforms, `io::Error` may use a bit-packed representation to
 // reduce size. However, this representation assumes that error codes are
@@ -139,17 +141,6 @@ enum ErrorData<C> {
     SimpleMessage(&'static SimpleMessage),
     Custom(C),
 }
-
-/// The type of raw OS error codes.
-///
-/// This is an [`i32`] on all currently supported platforms, but platforms
-/// added in the future (such as UEFI) may use a different primitive type like
-/// [`usize`]. Use `as` or [`into`] conversions where applicable to ensure maximum
-/// portability.
-///
-/// [`into`]: Into::into
-#[unstable(feature = "raw_os_error_ty", issue = "107792")]
-pub type RawOsError = sys::io::RawOsError;
 
 // `#[repr(align(4))]` is probably redundant, it should have that value or
 // higher already. We include it just because repr_bitpacked.rs's encoding

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -140,11 +140,11 @@ enum ErrorData<C> {
     Custom(C),
 }
 
-/// The type of raw OS error codes returned by [`Error::raw_os_error`].
+/// The type of raw OS error codes.
 ///
 /// This is an [`i32`] on all currently supported platforms, but platforms
 /// added in the future (such as UEFI) may use a different primitive type like
-/// [`usize`]. Use `as`or [`into`] conversions where applicable to ensure maximum
+/// [`usize`]. Use `as` or [`into`] conversions where applicable to ensure maximum
 /// portability.
 ///
 /// [`into`]: Into::into

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -363,6 +363,7 @@
 #![feature(ptr_as_uninit)]
 #![feature(ptr_mask)]
 #![feature(random)]
+#![feature(raw_os_error_ty)]
 #![feature(slice_internals)]
 #![feature(slice_ptr_get)]
 #![feature(slice_range)]

--- a/library/std/src/sys/io/error/mod.rs
+++ b/library/std/src/sys/io/error/mod.rs
@@ -48,8 +48,3 @@ cfg_select! {
         pub use generic::*;
     }
 }
-
-pub type RawOsError = cfg_select! {
-    target_os = "uefi" => usize,
-    _ => i32,
-};

--- a/library/std/src/sys/io/error/motor.rs
+++ b/library/std/src/sys/io/error/motor.rs
@@ -1,7 +1,6 @@
 use crate::io;
-use crate::sys::io::RawOsError;
 
-pub fn errno() -> RawOsError {
+pub fn errno() -> io::RawOsError {
     // Not used in Motor OS because it is ambiguous: Motor OS
     // is micro-kernel-based, and I/O happens via a shared-memory
     // ring buffer, so an I/O operation that on a unix is a syscall
@@ -57,7 +56,7 @@ pub fn decode_error_kind(code: io::RawOsError) -> io::ErrorKind {
     }
 }
 
-pub fn error_string(errno: RawOsError) -> String {
+pub fn error_string(errno: io::RawOsError) -> String {
     let error: moto_rt::Error = match errno {
         x if x < 0 => moto_rt::Error::Unknown,
         x if x > u16::MAX.into() => moto_rt::Error::Unknown,

--- a/library/std/src/sys/io/mod.rs
+++ b/library/std/src/sys/io/mod.rs
@@ -62,7 +62,7 @@ pub use error::errno_location;
     target_os = "wasi",
 ))]
 pub use error::set_errno;
-pub use error::{RawOsError, decode_error_kind, errno, error_string, is_interrupted};
+pub use error::{decode_error_kind, errno, error_string, is_interrupted};
 pub use io_slice::{IoSlice, IoSliceMut};
 pub use is_terminal::is_terminal;
 pub use kernel_copy::{CopyState, kernel_copy};


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Related: https://github.com/rust-lang/rust/pull/154654

## Description

As a part of moving components of `std::io` into `alloc::io` and `core::io`, there will need to be a new home for the type `RawOsError`. In this PR, I propose moving it to `core::io`, and removing it from `std::sys`. I suspect this will be quite controversial as it is a platform dependent type, but this is not the only instance of a type being conditioned on `target_os` in `core` (e.g., `core::os` and `core::ffi`).

Since `RawOsError` is currently unstable, I think it's reasonable to make this move now, and worry about making it platform independent if/when it is stabilized (e.g., replacing it with a wrapper around `isize` on all platforms).

---

## Notes

* No AI tooling of any kind was used during the creation of this PR.
