### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
+++ b/compiler/rustc_codegen_llvm/src/builder/gpu_offload.rs
@@ -448,14 +448,19 @@ pub(crate) fn gen_define_handling<'ll>(
         transfer.iter().map(|m| m.intersection(valid_begin_mappings).bits()).collect();
     let transfer_from: Vec<u64> =
         transfer.iter().map(|m| m.intersection(MappingFlags::FROM).bits()).collect();
+    let valid_kernel_mappings = MappingFlags::LITERAL | MappingFlags::IMPLICIT;
     // FIXME(offload): add `OMP_MAP_TARGET_PARAM = 0x20` only if necessary
-    let transfer_kernel = vec![MappingFlags::TARGET_PARAM.bits(); transfer_to.len()];
+    let transfer_kernel: Vec<u64> = transfer
+        .iter()
+        .map(|m| (m.intersection(valid_kernel_mappings) | MappingFlags::TARGET_PARAM).bits())
+        .collect();
 
     let actual_sizes = sizes
         .iter()
         .map(|s| match s {
             OffloadSize::Static(sz) => *sz,
-            OffloadSize::Dynamic => 0,
+            // NOTE(Sa4dUs): set `.offload_sizes` entry to 0 for sizes that we determine at runtime, just like clang
+            _ => 0,
         })
         .collect::<Vec<_>>();
     let offload_sizes =
@@ -542,12 +547,20 @@ pub(crate) fn scalar_width<'ll>(cx: &'ll SimpleCx<'_>, ty: &'ll Type) -> u64 {
 }
 
 fn get_runtime_size<'ll, 'tcx>(
-    _cx: &CodegenCx<'ll, 'tcx>,
-    _val: &'ll Value,
-    _meta: &OffloadMetadata,
+    builder: &mut Builder<'_, 'll, 'tcx>,
+    args: &[&'ll Value],
+    index: usize,
+    meta: &OffloadMetadata,
 ) -> &'ll Value {
-    // FIXME(Sa4dUs): handle dynamic-size data (e.g. slices)
-    bug!("offload does not support dynamic sizes yet");
+    match meta.payload_size {
+        OffloadSize::Slice { element_size } => {
+            let length_idx = index + 1;
+            let length = args[length_idx];
+            let length_i64 = builder.intcast(length, builder.cx.type_i64(), false);
+            builder.mul(length_i64, builder.cx.get_const_i64(element_size))
+        }
+        _ => bug!("unexpected offload size {:?}", meta.payload_size),
+    }
 }
 
 // For each kernel *call*, we now use some of our previous declared globals to move data to and from
@@ -588,7 +601,7 @@ pub(crate) fn gen_call_handling<'ll, 'tcx>(
     let OffloadKernelDims { num_workgroups, threads_per_block, workgroup_dims, thread_dims } =
         offload_dims;
 
-    let has_dynamic = metadata.iter().any(|m| matches!(m.payload_size, OffloadSize::Dynamic));
+    let has_dynamic = metadata.iter().any(|m| !matches!(m.payload_size, OffloadSize::Static(_)));
 
     let tgt_decl = offload_globals.launcher_fn;
     let tgt_target_kernel_ty = offload_globals.launcher_ty;
@@ -683,9 +696,9 @@ pub(crate) fn gen_call_handling<'ll, 'tcx>(
         let gep2 = builder.inbounds_gep(ty, a2, &[i32_0, idx]);
         builder.store(geps[i as usize], gep2, Align::EIGHT);
 
-        if matches!(metadata[i as usize].payload_size, OffloadSize::Dynamic) {
+        if !matches!(metadata[i as usize].payload_size, OffloadSize::Static(_)) {
             let gep3 = builder.inbounds_gep(ty2, a4, &[i32_0, idx]);
-            let size_val = get_runtime_size(cx, args[i as usize], &metadata[i as usize]);
+            let size_val = get_runtime_size(builder, args, i as usize, &metadata[i as usize]);
             builder.store(size_val, gep3, Align::EIGHT);
         }
     }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1437,9 +1437,20 @@ fn codegen_offload<'ll, 'tcx>(
     let sig = tcx.instantiate_bound_regions_with_erased(sig);
     let inputs = sig.inputs();
 
-    let metadata = inputs.iter().map(|ty| OffloadMetadata::from_ty(tcx, *ty)).collect::<Vec<_>>();
+    let fn_abi = cx.fn_abi_of_instance(fn_target, ty::List::empty());
 
-    let types = inputs.iter().map(|ty| cx.layout_of(*ty).llvm_type(cx)).collect::<Vec<_>>();
+    let mut metadata = Vec::new();
+    let mut types = Vec::new();
+
+    for (i, arg_abi) in fn_abi.args.iter().enumerate() {
+        let ty = inputs[i];
+        let decomposed = OffloadMetadata::handle_abi(cx, tcx, ty, arg_abi);
+
+        for (meta, entry_ty) in decomposed {
+            metadata.push(meta);
+            types.push(bx.cx.layout_of(entry_ty).llvm_type(bx.cx));
+        }
+    }
 
     let offload_globals_ref = cx.offload_globals.borrow();
     let offload_globals = match offload_globals_ref.as_ref() {

--- a/compiler/rustc_middle/src/ty/offload_meta.rs
+++ b/compiler/rustc_middle/src/ty/offload_meta.rs
@@ -1,7 +1,10 @@
 use bitflags::bitflags;
+use rustc_abi::{BackendRepr, TyAbiInterface};
+use rustc_target::callconv::ArgAbi;
 
 use crate::ty::{self, PseudoCanonicalInput, Ty, TyCtxt, TypingEnv};
 
+#[derive(Debug, Copy, Clone)]
 pub struct OffloadMetadata {
     pub payload_size: OffloadSize,
     pub mode: MappingFlags,
@@ -9,13 +12,13 @@ pub struct OffloadMetadata {
 
 #[derive(Debug, Copy, Clone)]
 pub enum OffloadSize {
-    Dynamic,
     Static(u64),
+    Slice { element_size: u64 },
 }
 
 bitflags! {
     /// Mirrors `OpenMPOffloadMappingFlags` from Clang/OpenMP.
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[repr(transparent)]
     pub struct MappingFlags: u64 {
         /// No flags.
@@ -62,11 +65,38 @@ impl OffloadMetadata {
             mode: MappingFlags::from_ty(tcx, ty),
         }
     }
+
+    pub fn handle_abi<'tcx, C>(
+        cx: &C,
+        tcx: TyCtxt<'tcx>,
+        ty: Ty<'tcx>,
+        arg_abi: &ArgAbi<'tcx, Ty<'tcx>>,
+    ) -> Vec<(Self, Ty<'tcx>)>
+    where
+        Ty<'tcx>: TyAbiInterface<'tcx, C>,
+    {
+        match arg_abi.layout.backend_repr {
+            BackendRepr::ScalarPair(_, _) => (0..2)
+                .map(|i| {
+                    let ty = arg_abi.layout.field(cx, i).ty;
+                    (OffloadMetadata::from_ty(tcx, ty), ty)
+                })
+                .collect(),
+            _ => vec![(OffloadMetadata::from_ty(tcx, ty), ty)],
+        }
+    }
 }
 
 // FIXME(Sa4dUs): implement a solid logic to determine the payload size
 fn get_payload_size<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> OffloadSize {
     match ty.kind() {
+        ty::Slice(elem_ty) => {
+            let layout = tcx.layout_of(PseudoCanonicalInput {
+                typing_env: TypingEnv::fully_monomorphized(),
+                value: *elem_ty,
+            });
+            OffloadSize::Slice { element_size: layout.unwrap().size.bytes() }
+        }
         ty::RawPtr(inner, _) | ty::Ref(_, inner, _) => get_payload_size(tcx, *inner),
         _ => OffloadSize::Static(
             tcx.layout_of(PseudoCanonicalInput {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -15,8 +15,9 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AutoBorrow, DerefAdjustKind};
 use rustc_middle::ty::print::{FmtPrinter, PrettyPrinter, Print, Printer};
 use rustc_middle::ty::{
-    self, GenericArg, GenericArgKind, GenericArgsRef, InferConst, IsSuggestable, Term, TermKind,
-    Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt, TypeckResults,
+    self, GenericArg, GenericArgKind, GenericArgsRef, GenericParamDefKind, InferConst,
+    IsSuggestable, Term, TermKind, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
+    TypeVisitableExt, TypeckResults,
 };
 use rustc_span::{BytePos, DUMMY_SP, Ident, Span, sym};
 use tracing::{debug, instrument, warn};
@@ -592,15 +593,19 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             (true, parent.prefix.to_string(), parent.name)
                         });
 
+                let param = &generics.own_params[argument_index];
+                let param_name = param.name.to_string();
+
                 infer_subdiags.push(SourceKindSubdiag::GenericLabel {
                     span,
                     is_type,
-                    param_name: generics.own_params[argument_index].name.to_string(),
+                    param_name: param_name.clone(),
                     parent_exists,
                     parent_prefix,
                     parent_name,
                 });
 
+                let mut used_fallback = false;
                 let args = if self.tcx.get_diagnostic_item(sym::iterator_collect_fn)
                     == Some(generics_def_id)
                 {
@@ -634,9 +639,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     let mut p = fmt_printer(self, Namespace::TypeNS);
                     p.comma_sep(generic_args.iter().copied().map(|arg| {
                         if arg.is_suggestable(self.tcx, true) {
+                            used_fallback = true;
                             return arg;
                         }
-
                         match arg.kind() {
                             GenericArgKind::Lifetime(_) => bug!("unexpected lifetime"),
                             GenericArgKind::Type(_) => self.next_ty_var(DUMMY_SP).into(),
@@ -648,11 +653,31 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 };
 
                 if !have_turbofish {
-                    infer_subdiags.push(SourceKindSubdiag::GenericSuggestion {
-                        span: insert_span,
-                        arg_count: generic_args.len(),
-                        args,
-                    });
+                    if generic_args.len() == 1 && used_fallback {
+                        match param.kind {
+                            GenericParamDefKind::Type { .. } => {
+                                infer_subdiags.push(SourceKindSubdiag::GenericTypeSuggestion {
+                                    span: insert_span,
+                                    param: param_name,
+                                });
+                            }
+                            GenericParamDefKind::Const { .. } => {
+                                infer_subdiags.push(SourceKindSubdiag::ConstGenericSuggestion {
+                                    span: insert_span,
+                                    param: param_name,
+                                });
+                            }
+                            GenericParamDefKind::Lifetime => {
+                                bug!("unexpected lifetime")
+                            }
+                        }
+                    } else {
+                        infer_subdiags.push(SourceKindSubdiag::GenericSuggestion {
+                            span: insert_span,
+                            arg_count: generic_args.len(),
+                            args,
+                        });
+                    }
                 }
             }
             InferSourceKind::FullyQualifiedMethodCall { receiver, successor, args, def_id } => {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -243,6 +243,15 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
     }
 }
 
+/// A single layer of `&` peeled from an expression, used by
+/// [`TypeErrCtxt::peel_expr_refs`].
+struct PeeledRef<'tcx> {
+    /// The span covering the `&` (and any whitespace/mutability keyword) to remove.
+    span: Span,
+    /// The type after peeling this layer (and all prior layers).
+    peeled_ty: Ty<'tcx>,
+}
+
 impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     pub fn note_field_shadowed_by_private_candidate_in_cause(
         &self,
@@ -1818,6 +1827,85 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         );
     }
 
+    /// Peel `&`-borrows from an expression, following through untyped let-bindings.
+    /// Returns a list of removable `&` layers (each with the span to remove and the
+    /// resulting type), plus an optional terminal [`hir::Param`] when the chain ends
+    /// at a function parameter (including async-fn desugared parameters).
+    fn peel_expr_refs(
+        &self,
+        mut expr: &'tcx hir::Expr<'tcx>,
+        mut ty: Ty<'tcx>,
+    ) -> (Vec<PeeledRef<'tcx>>, Option<&'tcx hir::Param<'tcx>>) {
+        let mut refs = Vec::new();
+        'outer: loop {
+            while let hir::ExprKind::AddrOf(_, _, borrowed) = expr.kind {
+                let span =
+                    if let Some(borrowed_span) = borrowed.span.find_ancestor_inside(expr.span) {
+                        expr.span.until(borrowed_span)
+                    } else {
+                        break 'outer;
+                    };
+
+                // Double check that the span actually corresponds to a borrow,
+                // rather than some macro garbage.
+                // The span may include leading parens from parenthesized expressions
+                // (e.g., `(&expr)` where HIR removes the Paren but keeps the span).
+                // In that case, trim the span to start at the `&`.
+                let span = match self.tcx.sess.source_map().span_to_snippet(span) {
+                    Ok(ref snippet) if snippet.starts_with("&") => span,
+                    Ok(ref snippet) if let Some(amp) = snippet.find('&') => {
+                        span.with_lo(span.lo() + BytePos(amp as u32))
+                    }
+                    _ => break 'outer,
+                };
+
+                let ty::Ref(_, inner_ty, _) = ty.kind() else {
+                    break 'outer;
+                };
+                ty = *inner_ty;
+                refs.push(PeeledRef { span, peeled_ty: ty });
+                expr = borrowed;
+            }
+            if let hir::ExprKind::Path(hir::QPath::Resolved(None, path)) = expr.kind
+                && let Res::Local(hir_id) = path.res
+                && let hir::Node::Pat(binding) = self.tcx.hir_node(hir_id)
+            {
+                match self.tcx.parent_hir_node(binding.hir_id) {
+                    // Untyped let-binding: follow to its initializer.
+                    hir::Node::LetStmt(local)
+                        if local.ty.is_none()
+                            && let Some(init) = local.init =>
+                    {
+                        expr = init;
+                        continue;
+                    }
+                    // Async fn desugared parameter: `let x = __arg0;` with AsyncFn source.
+                    // Follow to the original parameter.
+                    hir::Node::LetStmt(local)
+                        if matches!(local.source, hir::LocalSource::AsyncFn)
+                            && let Some(init) = local.init
+                            && let hir::ExprKind::Path(hir::QPath::Resolved(None, arg_path)) =
+                                init.kind
+                            && let Res::Local(arg_hir_id) = arg_path.res
+                            && let hir::Node::Pat(arg_binding) = self.tcx.hir_node(arg_hir_id)
+                            && let hir::Node::Param(param) =
+                                self.tcx.parent_hir_node(arg_binding.hir_id) =>
+                    {
+                        return (refs, Some(param));
+                    }
+                    // Direct parameter reference.
+                    hir::Node::Param(param) => {
+                        return (refs, Some(param));
+                    }
+                    _ => break 'outer,
+                }
+            } else {
+                break 'outer;
+            }
+        }
+        (refs, None)
+    }
+
     /// Whenever references are used by mistake, like `for (i, e) in &vec.iter().enumerate()`,
     /// suggest removing these references until we reach a type that implements the trait.
     pub(super) fn suggest_remove_reference(
@@ -1894,53 +1982,40 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         // Maybe suggest removal of borrows from expressions, like in `for i in &&&foo {}`.
-        let Some(mut expr) = expr_finder.result else {
+        let Some(expr) = expr_finder.result else {
             return false;
         };
-        let mut count = 0;
-        let mut suggestions = vec![];
         // Skipping binder here, remapping below
-        let mut suggested_ty = trait_pred.self_ty().skip_binder();
-        'outer: loop {
-            while let hir::ExprKind::AddrOf(_, _, borrowed) = expr.kind {
-                count += 1;
-                let span =
-                    if let Some(borrowed_span) = borrowed.span.find_ancestor_inside(expr.span) {
-                        expr.span.until(borrowed_span)
-                    } else {
-                        break 'outer;
-                    };
+        let suggested_ty = trait_pred.self_ty().skip_binder();
+        let (peeled_refs, _) = self.peel_expr_refs(expr, suggested_ty);
+        for (i, peeled) in peeled_refs.iter().enumerate() {
+            let suggestions: Vec<_> =
+                peeled_refs[..=i].iter().map(|r| (r.span, String::new())).collect();
+            if maybe_suggest(peeled.peeled_ty, i + 1, suggestions) {
+                return true;
+            }
+        }
+        false
+    }
 
-                // Double check that the span we extracted actually corresponds to a borrow,
-                // rather than some macro garbage.
-                match self.tcx.sess.source_map().span_to_snippet(span) {
-                    Ok(snippet) if snippet.starts_with("&") => {}
-                    _ => break 'outer,
-                }
-
-                suggestions.push((span, String::new()));
-
-                let ty::Ref(_, inner_ty, _) = suggested_ty.kind() else {
-                    break 'outer;
-                };
-                suggested_ty = *inner_ty;
-
-                expr = borrowed;
-
-                if maybe_suggest(suggested_ty, count, suggestions.clone()) {
+    /// Suggest removing `&` from a function parameter type like `&impl Future`.
+    fn suggest_remove_ref_from_param(&self, param: &hir::Param<'_>, err: &mut Diag<'_>) -> bool {
+        if let Some(decl) = self.tcx.parent_hir_node(param.hir_id).fn_decl()
+            && let Some(input_ty) = decl.inputs.iter().find(|t| param.ty_span.contains(t.span))
+            && let hir::TyKind::Ref(_, mut_ty) = input_ty.kind
+        {
+            let ref_span = input_ty.span.until(mut_ty.ty.span);
+            match self.tcx.sess.source_map().span_to_snippet(ref_span) {
+                Ok(snippet) if snippet.starts_with("&") => {
+                    err.span_suggestion_verbose(
+                        ref_span,
+                        "consider removing the `&` from the parameter type",
+                        "",
+                        Applicability::MaybeIncorrect,
+                    );
                     return true;
                 }
-            }
-            if let hir::ExprKind::Path(hir::QPath::Resolved(None, path)) = expr.kind
-                && let Res::Local(hir_id) = path.res
-                && let hir::Node::Pat(binding) = self.tcx.hir_node(hir_id)
-                && let hir::Node::LetStmt(local) = self.tcx.parent_hir_node(binding.hir_id)
-                && let None = local.ty
-                && let Some(binding_expr) = local.init
-            {
-                expr = binding_expr;
-            } else {
-                break 'outer;
+                _ => {}
             }
         }
         false
@@ -1958,6 +2033,89 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // and if not maybe suggest doing something else? If we kept the expression around we
             // could also check if it is an fn call (very likely) and suggest changing *that*, if
             // it is from the local crate.
+
+            // If the type is `&..&T` where `T: Future`, suggest removing `&`
+            // instead of removing `.await`.
+            if let ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) =
+                obligation.predicate.kind().skip_binder()
+            {
+                let self_ty = pred.self_ty();
+                let future_trait =
+                    self.tcx.require_lang_item(LangItem::Future, obligation.cause.span);
+
+                // Peel through references to check if there's a Future underneath.
+                let has_future = {
+                    let mut ty = self_ty;
+                    loop {
+                        match *ty.kind() {
+                            ty::Ref(_, inner_ty, _)
+                                if !matches!(inner_ty.kind(), ty::Dynamic(..)) =>
+                            {
+                                if self
+                                    .type_implements_trait(
+                                        future_trait,
+                                        [inner_ty],
+                                        obligation.param_env,
+                                    )
+                                    .must_apply_modulo_regions()
+                                {
+                                    break true;
+                                }
+                                ty = inner_ty;
+                            }
+                            _ => break false,
+                        }
+                    }
+                };
+
+                if has_future {
+                    let (peeled_refs, terminal_param) = self.peel_expr_refs(expr, self_ty);
+
+                    // Try removing `&`s from the expression.
+                    for (i, peeled) in peeled_refs.iter().enumerate() {
+                        if self
+                            .type_implements_trait(
+                                future_trait,
+                                [peeled.peeled_ty],
+                                obligation.param_env,
+                            )
+                            .must_apply_modulo_regions()
+                        {
+                            let count = i + 1;
+                            let msg = if count == 1 {
+                                "consider removing the leading `&`-reference".to_string()
+                            } else {
+                                format!("consider removing {count} leading `&`-references")
+                            };
+                            let suggestions: Vec<_> =
+                                peeled_refs[..=i].iter().map(|r| (r.span, String::new())).collect();
+                            err.multipart_suggestion(
+                                msg,
+                                suggestions,
+                                Applicability::MachineApplicable,
+                            );
+                            return;
+                        }
+                    }
+
+                    // Try removing `&` from the parameter type, but only when there's
+                    // no `&` in the expression itself (otherwise removing from the param
+                    // alone wouldn't fix the error).
+                    if peeled_refs.is_empty()
+                        && let Some(param) = terminal_param
+                        && self.suggest_remove_ref_from_param(param, err)
+                    {
+                        return;
+                    }
+
+                    // Fallback: emit a help message when we can't provide a specific span.
+                    err.help(
+                        "a reference to a future is not a future; \
+                     consider removing the leading `&`-reference",
+                    );
+                    return;
+                }
+            }
 
             // use nth(1) to skip one layer of desugaring from `IntoIter::into_iter`
             if let Some((_, hir::Node::Expr(await_expr))) = self.tcx.hir_parent_iter(*hir_id).nth(1)

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -331,6 +331,28 @@ pub(crate) enum SourceKindSubdiag<'a> {
         arg_count: usize,
         args: String,
     },
+    #[suggestion(
+        "consider specifying a concrete type for the type parameter `{$param}`",
+        style = "verbose",
+        code = "::</* Type */>",
+        applicability = "has-placeholders"
+    )]
+    GenericTypeSuggestion {
+        #[primary_span]
+        span: Span,
+        param: String,
+    },
+    #[suggestion(
+        "consider specifying a const for the const parameter `{$param}`",
+        style = "verbose",
+        code = "::</* CONST */>",
+        applicability = "has-placeholders"
+    )]
+    ConstGenericSuggestion {
+        #[primary_span]
+        span: Span,
+        param: String,
+    },
 }
 
 #[derive(Subdiagnostic)]

--- a/src/doc/rustc-dev-guide/src/offload/installation.md
+++ b/src/doc/rustc-dev-guide/src/offload/installation.md
@@ -30,7 +30,7 @@ git clone git@github.com:llvm/llvm-project
 cd llvm-project
 mkdir build
 cd build
-cmake -G Ninja ../llvm -DLLVM_TARGETS_TO_BUILD="host,AMDGPU,NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RUNTIMES="offload,openmp" -DLLVM_ENABLE_PLUGINS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.
+cmake -G Ninja ../llvm -DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX" -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_ENABLE_RUNTIMES="offload;openmp" -DLLVM_ENABLE_PLUGINS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=.
 ninja
 ninja install
 ```

--- a/tests/codegen-llvm/gpu_offload/slice_device.rs
+++ b/tests/codegen-llvm/gpu_offload/slice_device.rs
@@ -1,0 +1,27 @@
+//@ add-minicore
+//@ revisions: amdgpu nvptx
+//@[nvptx] compile-flags: -Copt-level=3 -Zunstable-options -Zoffload=Device --target nvptx64-nvidia-cuda --crate-type=rlib
+//@[nvptx] needs-llvm-components: nvptx
+//@[amdgpu] compile-flags: -Copt-level=3 -Zunstable-options -Zoffload=Device --target amdgcn-amd-amdhsa -Ctarget-cpu=gfx900 --crate-type=rlib
+//@[amdgpu] needs-llvm-components: amdgpu
+//@ no-prefer-dynamic
+//@ needs-offload
+
+#![feature(abi_gpu_kernel, rustc_attrs, no_core)]
+#![no_core]
+
+extern crate minicore;
+
+// CHECK: ; Function Attrs
+// nvptx-NEXT: define ptx_kernel void @foo
+// amdgpu-NEXT: define amdgpu_kernel void @foo
+// CHECK-SAME: ptr readnone captures(none) %dyn_ptr
+// nvptx-SAME: [2 x i64] %0
+// amdgpu-SAME: ptr noalias {{.*}} %0, i64 {{.*}} %1
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret void
+// CHECK-NEXT: }
+
+#[unsafe(no_mangle)]
+#[rustc_offload_kernel]
+pub unsafe extern "gpu-kernel" fn foo(x: &[f32]) {}

--- a/tests/codegen-llvm/gpu_offload/slice_host.rs
+++ b/tests/codegen-llvm/gpu_offload/slice_host.rs
@@ -1,0 +1,35 @@
+//@ compile-flags: -Zoffload=Test -Zunstable-options -C opt-level=1 -Clto=fat
+//@ no-prefer-dynamic
+//@ needs-offload
+
+// This test verifies that offload is properly handling slices passing them properly to the device
+
+#![feature(abi_gpu_kernel)]
+#![feature(rustc_attrs)]
+#![feature(core_intrinsics)]
+#![no_main]
+
+// CHECK: @anon.[[ID:.*]].0 = private unnamed_addr constant [23 x i8] c";unknown;unknown;0;0;;\00", align 1
+
+// CHECK-DAG: @.offload_sizes.[[K:[^ ]*foo]] = private unnamed_addr constant [2 x i64] [i64 0, i64 8]
+// CHECK-DAG: @.offload_maptypes.[[K]].begin = private unnamed_addr constant [2 x i64] [i64 1, i64 768]
+// CHECK-DAG: @.offload_maptypes.[[K]].kernel = private unnamed_addr constant [2 x i64] [i64 32, i64 800]
+// CHECK-DAG: @.offload_maptypes.[[K]].end = private unnamed_addr constant [2 x i64] [i64 2, i64 0]
+
+// CHECK:       define{{( dso_local)?}} void @main()
+// CHECK:       %.offload_sizes = alloca [2 x i64], align 8
+// CHECK:  call void @llvm.memcpy.p0.p0.i64(ptr {{.*}} %.offload_sizes, ptr {{.*}} @.offload_sizes.foo, i64 16, i1 false)
+// CHECK:       store i64 16, ptr %.offload_sizes, align 8
+// CHECK:       call void @__tgt_target_data_begin_mapper(ptr nonnull @anon.[[ID]].1, i64 -1, i32 2, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.[[K]].begin, ptr null, ptr null)
+// CHECK:       %11 = call i32 @__tgt_target_kernel(ptr nonnull @anon.[[ID]].1, i64 -1, i32 1, i32 1, ptr nonnull @.foo.region_id, ptr nonnull %kernel_args)
+// CHECK-NEXT:  call void @__tgt_target_data_end_mapper(ptr nonnull @anon.[[ID]].1, i64 -1, i32 2, ptr nonnull %.offload_baseptrs, ptr nonnull %.offload_ptrs, ptr nonnull %.offload_sizes, ptr nonnull @.offload_maptypes.[[K]].end, ptr null, ptr null)
+
+#[unsafe(no_mangle)]
+fn main() {
+    let mut x = [0.0, 0.0, 0.0, 0.0];
+    core::intrinsics::offload::<_, _, ()>(foo, [1, 1, 1], [1, 1, 1], ((&mut x) as &mut [f64],));
+}
+
+unsafe extern "C" {
+    pub fn foo(x: &mut [f32]);
+}

--- a/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
+++ b/tests/ui/associated-type-bounds/duplicate-bound-err.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     iter::empty::<T>()
-   |                +++++
+LL |     iter::empty::</* Type */>()
+   |                ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/duplicate-bound-err.rs:18:5
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     iter::empty::<T>()
-   |                +++++
+LL |     iter::empty::</* Type */>()
+   |                ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/duplicate-bound-err.rs:22:5
@@ -26,10 +26,10 @@ error[E0282]: type annotations needed
 LL |     iter::empty()
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `empty`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     iter::empty::<T>()
-   |                +++++
+LL |     iter::empty::</* Type */>()
+   |                ++++++++++++++
 
 error: unconstrained opaque type
   --> $DIR/duplicate-bound-err.rs:26:51

--- a/tests/ui/async-await/await-ref-future.rs
+++ b/tests/ui/async-await/await-ref-future.rs
@@ -1,0 +1,43 @@
+//@ edition:2021
+// Regression test for #87211.
+// Test that we suggest removing `&` from references to futures,
+// including let-bindings and parameter types, but not `&dyn Future`.
+
+async fn my_async_fn() {}
+
+async fn foo() {
+    let fut = &my_async_fn();
+    fut.await; //~ ERROR `&impl Future<Output = ()>` is not a future
+}
+
+async fn direct_ref_await() {
+    (&my_async_fn()).await; //~ ERROR `&impl Future<Output = ()>` is not a future
+}
+
+async fn bar(fut: &impl std::future::Future<Output = ()>) {
+    fut.await; //~ ERROR is not a future
+}
+
+async fn dyn_ref_param(fut: &dyn std::future::Future<Output = ()>) {
+    fut.await; //~ ERROR is not a future
+}
+
+async fn typed_let_binding() {
+    let fut: &_ = &my_async_fn();
+    fut.await; //~ ERROR `&impl Future<Output = ()>` is not a future
+}
+
+async fn ref_param_borrowed_expr(fut: &impl std::future::Future<Output = ()>) {
+    (&fut).await; //~ ERROR is not a future
+}
+
+async fn double_ref_direct() {
+    (&&my_async_fn()).await; //~ ERROR is not a future
+}
+
+async fn double_ref_let() {
+    let fut = &&my_async_fn();
+    fut.await; //~ ERROR is not a future
+}
+
+fn main() {}

--- a/tests/ui/async-await/await-ref-future.stderr
+++ b/tests/ui/async-await/await-ref-future.stderr
@@ -1,0 +1,119 @@
+error[E0277]: `&impl Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:10:9
+   |
+LL |     fut.await;
+   |         ^^^^^ `&impl Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&impl Future<Output = ()>`
+   = note: &impl Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `&impl Future<Output = ()>` to implement `IntoFuture`
+help: consider removing the leading `&`-reference
+   |
+LL -     let fut = &my_async_fn();
+LL +     let fut = my_async_fn();
+   |
+
+error[E0277]: `&impl Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:14:22
+   |
+LL |     (&my_async_fn()).await;
+   |                      ^^^^^ `&impl Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&impl Future<Output = ()>`
+   = note: &impl Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `&impl Future<Output = ()>` to implement `IntoFuture`
+help: consider removing the leading `&`-reference
+   |
+LL -     (&my_async_fn()).await;
+LL +     (my_async_fn()).await;
+   |
+
+error[E0277]: `&impl std::future::Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:18:9
+   |
+LL |     fut.await;
+   |         ^^^^^ `&impl std::future::Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&impl std::future::Future<Output = ()>`
+   = note: &impl std::future::Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+help: the trait `Future` is implemented for `&mut F`
+  --> $SRC_DIR/core/src/future/future.rs:LL:COL
+   = note: required for `&impl std::future::Future<Output = ()>` to implement `IntoFuture`
+help: consider removing the `&` from the parameter type
+   |
+LL - async fn bar(fut: &impl std::future::Future<Output = ()>) {
+LL + async fn bar(fut: impl std::future::Future<Output = ()>) {
+   |
+
+error[E0277]: `&dyn Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:22:9
+   |
+LL |     fut.await;
+   |         ^^^^^ `&dyn Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&dyn Future<Output = ()>`
+   = note: &dyn Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `&dyn Future<Output = ()>` to implement `IntoFuture`
+help: remove the `.await`
+   |
+LL -     fut.await;
+LL +     fut;
+   |
+
+error[E0277]: `&impl Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:27:9
+   |
+LL |     fut.await;
+   |         ^^^^^ `&impl Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&impl Future<Output = ()>`
+   = note: &impl Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = help: a reference to a future is not a future; consider removing the leading `&`-reference
+   = note: required for `&impl Future<Output = ()>` to implement `IntoFuture`
+
+error[E0277]: `&&impl std::future::Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:31:12
+   |
+LL |     (&fut).await;
+   |            ^^^^^ `&&impl std::future::Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&&impl std::future::Future<Output = ()>`
+   = note: &&impl std::future::Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = help: a reference to a future is not a future; consider removing the leading `&`-reference
+help: the trait `Future` is implemented for `&mut F`
+  --> $SRC_DIR/core/src/future/future.rs:LL:COL
+   = note: required for `&&impl std::future::Future<Output = ()>` to implement `IntoFuture`
+
+error[E0277]: `&&impl Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:35:23
+   |
+LL |     (&&my_async_fn()).await;
+   |                       ^^^^^ `&&impl Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&&impl Future<Output = ()>`
+   = note: &&impl Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `&&impl Future<Output = ()>` to implement `IntoFuture`
+help: consider removing 2 leading `&`-references
+   |
+LL -     (&&my_async_fn()).await;
+LL +     (my_async_fn()).await;
+   |
+
+error[E0277]: `&&impl Future<Output = ()>` is not a future
+  --> $DIR/await-ref-future.rs:40:9
+   |
+LL |     fut.await;
+   |         ^^^^^ `&&impl Future<Output = ()>` is not a future
+   |
+   = help: the trait `Future` is not implemented for `&&impl Future<Output = ()>`
+   = note: &&impl Future<Output = ()> must be a future or must implement `IntoFuture` to be awaited
+   = note: required for `&&impl Future<Output = ()>` to implement `IntoFuture`
+help: consider removing 2 leading `&`-references
+   |
+LL -     let fut = &&my_async_fn();
+LL +     let fut = my_async_fn();
+   |
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/unresolved_type_param.stderr
+++ b/tests/ui/async-await/unresolved_type_param.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     bar().await;
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `bar`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     bar::<T>().await;
-   |        +++++
+LL |     bar::</* Type */>().await;
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -61,10 +61,10 @@ note: required by a const generic parameter in `uwu`
    |
 LL | fn uwu<const N: u8>() -> impl Traitor<N> {
    |        ^^^^^^^^^^^ required by this const generic parameter in `uwu`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     uwu::<N>();
-   |        +++++
+LL |     uwu::</* CONST */>();
+   |        +++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.adt_const_params.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.adt_const_params.stderr
@@ -19,10 +19,10 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let _ = Checked::<generic::<T>>;
-   |                              +++++
+LL |     let _ = Checked::<generic::</* Type */>>;
+   |                              ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.full.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.full.stderr
@@ -19,10 +19,10 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let _ = Checked::<generic::<T>>;
-   |                              +++++
+LL |     let _ = Checked::<generic::</* Type */>>;
+   |                              ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.min.stderr
@@ -21,10 +21,10 @@ error[E0282]: type annotations needed
 LL |     let _ = Checked::<generic>;
    |                       ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let _ = Checked::<generic::<T>>;
-   |                              +++++
+LL |     let _ = Checked::<generic::</* Type */>>;
+   |                              ++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `use_dyn`
    |
 LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
    |            ^^^^^^^^^^^^^^ required by this const generic parameter in `use_dyn`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     use_dyn::<N>(&());
-   |            +++++
+LL |     use_dyn::</* CONST */>(&());
+   |            +++++++++++++++
 
 error[E0284]: type annotations needed
   --> $DIR/dyn-compatibility-ok-infer-err.rs:19:5
@@ -30,10 +30,10 @@ LL | impl<const N: usize> Foo<N> for () {
    |      |
    |      unsatisfied trait bound introduced here
    = note: required for the cast from `&()` to `&dyn Foo<_>`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     use_dyn::<N>(&());
-   |            +++++
+LL |     use_dyn::</* CONST */>(&());
+   |            +++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
+++ b/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `foo`
    |
 LL | fn foo<const X: usize>() -> usize {
    |        ^^^^^^^^^^^^^^ required by this const generic parameter in `foo`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `X`
    |
-LL |     foo::<X>();
-   |        +++++
+LL |     foo::</* CONST */>();
+   |        +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/infer/method-chain.stderr
+++ b/tests/ui/const-generics/infer/method-chain.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `Foo::baz`
    |
 LL |     fn baz<const N: usize>(self) -> Foo {
    |            ^^^^^^^^^^^^^^ required by this const generic parameter in `Foo::baz`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     Foo.bar().bar().bar().bar().baz::<N>();
-   |                                    +++++
+LL |     Foo.bar().bar().bar().bar().baz::</* CONST */>();
+   |                                    +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/unify_with_nested_expr.stderr
+++ b/tests/ui/const-generics/unify_with_nested_expr.stderr
@@ -9,10 +9,10 @@ note: required by a const generic parameter in `bar`
    |
 LL | fn bar<const N: usize>()
    |        ^^^^^^^^^^^^^^ required by this const generic parameter in `bar`
-help: consider specifying the generic argument
+help: consider specifying a const for the const parameter `N`
    |
-LL |     bar::<N>();
-   |        +++++
+LL |     bar::</* CONST */>();
+   |        +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-64662.stderr
+++ b/tests/ui/consts/issue-64662.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     A = foo(),
    |         ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     A = foo::<T>(),
-   |            +++++
+LL |     A = foo::</* Type */>(),
+   |            ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/issue-64662.rs:3:9
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |     B = foo(),
    |         ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     B = foo::<T>(),
-   |            +++++
+LL |     B = foo::</* Type */>(),
+   |            ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/for-loop-while/for-loop-unconstrained-element-type.stderr
+++ b/tests/ui/for-loop-while/for-loop-unconstrained-element-type.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     for i in Vec::new() {}
    |              ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Vec`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     for i in Vec::<T>::new() {}
-   |                 +++++
+LL |     for i in Vec::</* Type */>::new() {}
+   |                 ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/bugs/issue-88382.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88382.stderr
@@ -15,10 +15,10 @@ note: required by a bound in `test`
    |
 LL | fn test<'a, I: Iterable>(_: &mut I::Iterator<'a>) {}
    |                ^^^^^^^^ required by this bound in `test`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `I`
    |
-LL |     do_something(SomeImplementation(), test::<I>);
-   |                                            +++++
+LL |     do_something(SomeImplementation(), test::</* Type */>);
+   |                                            ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/fallback_inference.stderr
+++ b/tests/ui/impl-trait/fallback_inference.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     PhantomData
    |     ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     PhantomData::<T>
-   |                +++++
+LL |     PhantomData::</* Type */>
+   |                ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
+++ b/tests/ui/impl-trait/in-trait/not-inferred-generic.stderr
@@ -11,10 +11,10 @@ note: required by a bound in `TypedClient::publish_typed::{anon_assoc#0}`
    |
 LL |         F: Clone;
    |            ^^^^^ required by this bound in `TypedClient::publish_typed::{anon_assoc#0}`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `F`
    |
-LL |     ().publish_typed::<F>();
-   |                     +++++
+LL |     ().publish_typed::</* Type */>();
+   |                     ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/dont-collect-stmts-from-parent-body.stderr
+++ b/tests/ui/inference/dont-collect-stmts-from-parent-body.stderr
@@ -13,10 +13,10 @@ error[E0282]: type annotations needed
 LL |                 Type
    |                 ^^^^ cannot infer type of the type parameter `T` declared on the struct `Type`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |                 Type::<T>
-   |                     +++++
+LL |                 Type::</* Type */>
+   |                     ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/inference/issue-71732.stderr
+++ b/tests/ui/inference/issue-71732.stderr
@@ -12,10 +12,10 @@ LL |         .get(&"key".into())
              where T: ?Sized;
 note: required by a bound in `HashMap::<K, V, S, A>::get`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `Q`
    |
-LL |         .get::<Q>(&"key".into())
-   |             +++++
+LL |         .get::</* Type */>(&"key".into())
+   |             ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/issue-86162-1.stderr
+++ b/tests/ui/inference/issue-86162-1.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo(x: impl Clone) {}
    |                ^^^^^ required by this bound in `foo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo(gen::<T>()); //<- Do not suggest `foo::<impl Clone>()`!
-   |            +++++
+LL |     foo(gen::</* Type */>()); //<- Do not suggest `foo::<impl Clone>()`!
+   |            ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/issue-86162-2.stderr
+++ b/tests/ui/inference/issue-86162-2.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `Foo::bar`
    |
 LL |     fn bar(x: impl Clone) {}
    |                    ^^^^^ required by this bound in `Foo::bar`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     Foo::bar(gen::<T>()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
-   |                 +++++
+LL |     Foo::bar(gen::</* Type */>()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
+   |                 ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/channel.stderr
+++ b/tests/ui/inference/need_type_info/channel.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         channel();
    |         ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `channel`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         channel::<T>();
-   |                +++++
+LL |         channel::</* Type */>();
+   |                ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/channel.rs:13:9
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |         channel();
    |         ^^^^^^^ cannot infer type of the type parameter `T` declared on the function `channel`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         channel::<T>();
-   |                +++++
+LL |         channel::</* Type */>();
+   |                ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative-enum.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative-enum.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         needs_infer();
    |         ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_infer`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         needs_infer::<T>();
-   |                    +++++
+LL |         needs_infer::</* Type */>();
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/expr-struct-type-relative.stderr
+++ b/tests/ui/inference/need_type_info/expr-struct-type-relative.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         needs_infer();
    |         ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `needs_infer`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         needs_infer::<T>();
-   |                    +++++
+LL |         needs_infer::</* Type */>();
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/issue-103053.stderr
+++ b/tests/ui/inference/need_type_info/issue-103053.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     None;
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     None::<T>;
-   |         +++++
+LL |     None::</* Type */>;
+   |         ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/issue-113264-incorrect-impl-trait-in-path-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/issue-113264-incorrect-impl-trait-in-path-suggestion.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `S::owo`
    |
 LL |     fn owo(&self, _: Option<&impl T>) {}
    |                                   ^ required by this bound in `S::owo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     (S {}).owo(None::<&_>)
-   |                    ++++++
+LL |     (S {}).owo(None::</* Type */>)
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/self-ty-in-path.stderr
+++ b/tests/ui/inference/need_type_info/self-ty-in-path.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         Self::func_a();
    |         ^^^^^^^^^^^^ cannot infer type of the type parameter `U` declared on the associated function `func_a`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `U`
    |
-LL |         Self::func_a::<U>();
-   |                     +++++
+LL |         Self::func_a::</* Type */>();
+   |                     ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inference/need_type_info/single-const-generic-suggestion.rs
+++ b/tests/ui/inference/need_type_info/single-const-generic-suggestion.rs
@@ -1,0 +1,9 @@
+// compile-fail
+
+fn func<const CONST: usize>() {}
+
+fn main() {
+    func();
+    //~^ ERROR type annotations needed
+    //~| HELP consider specifying a const for the const parameter `CONST`
+}

--- a/tests/ui/inference/need_type_info/single-const-generic-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/single-const-generic-suggestion.stderr
@@ -1,0 +1,19 @@
+error[E0284]: type annotations needed
+  --> $DIR/single-const-generic-suggestion.rs:6:5
+   |
+LL |     func();
+   |     ^^^^ cannot infer the value of the const parameter `CONST` declared on the function `func`
+   |
+note: required by a const generic parameter in `func`
+  --> $DIR/single-const-generic-suggestion.rs:3:9
+   |
+LL | fn func<const CONST: usize>() {}
+   |         ^^^^^^^^^^^^^^^^^^ required by this const generic parameter in `func`
+help: consider specifying a const for the const parameter `CONST`
+   |
+LL |     func::</* CONST */>();
+   |         +++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/inference/need_type_info/single-type-generic-suggestion.rs
+++ b/tests/ui/inference/need_type_info/single-type-generic-suggestion.rs
@@ -1,0 +1,7 @@
+// compile-fail
+
+fn main() {
+    "".parse();
+    //~^ ERROR type annotations needed
+    //~| HELP consider specifying a concrete type for the type parameter `F`
+}

--- a/tests/ui/inference/need_type_info/single-type-generic-suggestion.stderr
+++ b/tests/ui/inference/need_type_info/single-type-generic-suggestion.stderr
@@ -1,0 +1,15 @@
+error[E0284]: type annotations needed
+  --> $DIR/single-type-generic-suggestion.rs:4:8
+   |
+LL |     "".parse();
+   |        ^^^^^ cannot infer type of the type parameter `F` declared on the method `parse`
+   |
+   = note: cannot satisfy `<_ as FromStr>::Err == _`
+help: consider specifying a concrete type for the type parameter `F`
+   |
+LL |     "".parse::</* Type */>();
+   |             ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/inference/question-mark-type-inference-in-chain.rs
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.rs
@@ -9,7 +9,9 @@ type Result<T, E = AnotherError> = core::result::Result<T, E>;
 pub struct Error;
 
 impl From<AnotherError> for Error {
-    fn from(_: AnotherError) -> Self { Error }
+    fn from(_: AnotherError) -> Self {
+        Error
+    }
 }
 
 impl std::error::Error for Error {}
@@ -70,12 +72,12 @@ pub fn error4(lines: &[&str]) -> Result<Vec<Version>> {
         //~^ NOTE: the method call chain might not have had the expected associated types
         //~| NOTE: `Iterator::Item` changed to `Result<Version, Error>` here
         .collect::<Result<Vec<Version>>>()?;
-        //~^ ERROR: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
-        //~| NOTE: value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
-        //~| NOTE: required by a bound introduced by this call
-        //~| HELP: the trait
-        //~| HELP: for that trait implementation, expected `AnotherError`, found `Error`
-        //~| NOTE: required by a bound in `collect`
+    //~^ ERROR: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
+    //~| NOTE: value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
+    //~| NOTE: required by a bound introduced by this call
+    //~| HELP: the trait
+    //~| HELP: for that trait implementation, expected `AnotherError`, found `Error`
+    //~| NOTE: required by a bound in `collect`
     tags.sort();
 
     Ok(tags)

--- a/tests/ui/inference/question-mark-type-inference-in-chain.stderr
+++ b/tests/ui/inference/question-mark-type-inference-in-chain.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/question-mark-type-inference-in-chain.rs:31:9
+  --> $DIR/question-mark-type-inference-in-chain.rs:33:9
    |
 LL |     let mut tags = lines.iter().map(|e| parse(e)).collect()?;
    |         ^^^^^^^^
@@ -13,7 +13,7 @@ LL |     let mut tags: Vec<_> = lines.iter().map(|e| parse(e)).collect()?;
    |                 ++++++++
 
 error[E0283]: type annotations needed
-  --> $DIR/question-mark-type-inference-in-chain.rs:41:65
+  --> $DIR/question-mark-type-inference-in-chain.rs:43:65
    |
 LL |     let mut tags: Vec<Version> = lines.iter().map(|e| parse(e)).collect()?;
    |                                                                 ^^^^^^^ cannot infer type of the type parameter `B` declared on the method `collect`
@@ -27,7 +27,7 @@ LL |     let mut tags: Vec<Version> = lines.iter().map(|e| parse(e)).collect::<R
    |                                                                        ++++++++++++++++
 
 error[E0277]: the `?` operator can only be applied to values that implement `Try`
-  --> $DIR/question-mark-type-inference-in-chain.rs:53:20
+  --> $DIR/question-mark-type-inference-in-chain.rs:55:20
    |
 LL |     let mut tags = lines.iter().map(|e| parse(e)).collect::<Vec<_>>()?;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `?` operator cannot be applied to type `Vec<std::result::Result<Version, Error>>`
@@ -35,7 +35,7 @@ LL |     let mut tags = lines.iter().map(|e| parse(e)).collect::<Vec<_>>()?;
    = help: the nightly-only, unstable trait `Try` is not implemented for `Vec<std::result::Result<Version, Error>>`
 
 error[E0277]: a value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from an iterator over elements of type `std::result::Result<Version, Error>`
-  --> $DIR/question-mark-type-inference-in-chain.rs:72:20
+  --> $DIR/question-mark-type-inference-in-chain.rs:74:20
    |
 LL |         .collect::<Result<Vec<Version>>>()?;
    |          -------   ^^^^^^^^^^^^^^^^^^^^ value of type `std::result::Result<Vec<Version>, AnotherError>` cannot be built from `std::iter::Iterator<Item=std::result::Result<Version, Error>>`
@@ -47,7 +47,7 @@ help: the trait `FromIterator<std::result::Result<_, Error>>` is not implemented
   --> $SRC_DIR/core/src/result.rs:LL:COL
    = help: for that trait implementation, expected `AnotherError`, found `Error`
 note: the method call chain might not have had the expected associated types
-  --> $DIR/question-mark-type-inference-in-chain.rs:69:10
+  --> $DIR/question-mark-type-inference-in-chain.rs:71:10
    |
 LL |     let mut tags = lines
    |                    ----- this expression has type `&[&str]`

--- a/tests/ui/missing/missing-items/missing-type-parameter.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `X` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `X`
    |
-LL |     foo::<X>();
-   |        +++++
+LL |     foo::</* Type */>();
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/shebang/issue-71471-ignore-tidy.rs
+++ b/tests/ui/parser/shebang/issue-71471-ignore-tidy.rs
@@ -1,4 +1,4 @@
 
 #!B //~ ERROR expected `[`, found `B`
 
-//@ reference: input.shebang
+//@ reference: shebang.position

--- a/tests/ui/parser/shebang/shebang-comment.rs
+++ b/tests/ui/parser/shebang/shebang-comment.rs
@@ -1,7 +1,7 @@
 #!//bin/bash
 
 //@ check-pass
-//@ reference: input.shebang
+//@ reference: shebang.syntax
 fn main() {
     println!("a valid shebang (that is also a rust comment)")
 }

--- a/tests/ui/parser/shebang/shebang-empty.rs
+++ b/tests/ui/parser/shebang/shebang-empty.rs
@@ -1,5 +1,5 @@
 #!
 
 //@ check-pass
-//@ reference: input.shebang
+//@ reference: shebang.syntax
 fn main() {}

--- a/tests/ui/parser/shebang/shebang-must-start-file.rs
+++ b/tests/ui/parser/shebang/shebang-must-start-file.rs
@@ -1,7 +1,7 @@
 // something on the first line for tidy
 #!/bin/bash  //~ ERROR expected `[`, found `/`
 
-//@ reference: input.shebang
+//@ reference: shebang.position
 
 fn main() {
     println!("ok!");

--- a/tests/ui/parser/shebang/shebang-space.rs
+++ b/tests/ui/parser/shebang/shebang-space.rs
@@ -1,6 +1,6 @@
 #!    
 
 //@ check-pass
-//@ reference: input.shebang
+//@ reference: shebang.syntax
 // ignore-tidy-end-whitespace
 fn main() {}

--- a/tests/ui/parser/shebang/valid-shebang.rs
+++ b/tests/ui/parser/shebang/valid-shebang.rs
@@ -1,7 +1,7 @@
 #!/usr/bin/env run-cargo-script
 
 //@ check-pass
-//@ reference: input.shebang
+//@ reference: shebang.syntax
 fn main() {
     println!("Hello World!");
 }

--- a/tests/ui/return/tail-expr-as-potential-return.rs
+++ b/tests/ui/return/tail-expr-as-potential-return.rs
@@ -59,7 +59,7 @@ fn method() -> Option<i32> {
     if true {
         Receiver.generic();
         //~^ ERROR type annotations needed
-        //~| HELP consider specifying the generic argument
+        //~| HELP consider specifying a concrete type for the type parameter `T`
     }
 
     None

--- a/tests/ui/return/tail-expr-as-potential-return.stderr
+++ b/tests/ui/return/tail-expr-as-potential-return.stderr
@@ -53,10 +53,10 @@ error[E0282]: type annotations needed
 LL |         Receiver.generic();
    |                  ^^^^^^^ cannot infer type of the type parameter `T` declared on the method `generic`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         Receiver.generic::<T>();
-   |                         +++++
+LL |         Receiver.generic::</* Type */>();
+   |                         ++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/tests/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -6,10 +6,10 @@ LL |     let x: Option<_> = None;
 LL |     x.unwrap().method_that_could_exist_on_some_type();
    |     ---------- type must be known at this point
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let x: Option<_> = None::<T>;
-   |                            +++++
+LL |     let x: Option<_> = None::</* Type */>;
+   |                            ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/issue-42234-unknown-receiver-type.rs:12:16

--- a/tests/ui/span/type-annotations-needed-expr.stderr
+++ b/tests/ui/span/type-annotations-needed-expr.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^ cannot infer type of the type parameter `S` declared on the method `sum`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     let _ = (vec![1,2,3]).into_iter().sum::<S>() as f64;
-   |                                          +++++
+LL |     let _ = (vec![1,2,3]).into_iter().sum::</* Type */>() as f64;
+   |                                          ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/fn-needing-specified-return-type-param.rs
+++ b/tests/ui/suggestions/fn-needing-specified-return-type-param.rs
@@ -1,7 +1,9 @@
-fn f<A>() -> A { unimplemented!() }
+fn f<A>() -> A {
+    unimplemented!()
+}
 fn foo() {
     let _ = f;
     //~^ ERROR type annotations needed
-    //~| HELP consider specifying the generic argument
+    //~| HELP consider specifying a concrete type for the type parameter `A`
 }
 fn main() {}

--- a/tests/ui/suggestions/fn-needing-specified-return-type-param.stderr
+++ b/tests/ui/suggestions/fn-needing-specified-return-type-param.stderr
@@ -1,13 +1,13 @@
 error[E0282]: type annotations needed
-  --> $DIR/fn-needing-specified-return-type-param.rs:3:13
+  --> $DIR/fn-needing-specified-return-type-param.rs:5:13
    |
 LL |     let _ = f;
    |             ^ cannot infer type of the type parameter `A` declared on the function `f`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `A`
    |
-LL |     let _ = f::<A>;
-   |              +++++
+LL |     let _ = f::</* Type */>;
+   |              ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/trait-bounds/projection-predicate-not-satisfied-69455.stderr
+++ b/tests/ui/trait-bounds/projection-predicate-not-satisfied-69455.stderr
@@ -7,10 +7,10 @@ LL |     println!("{}", 23u64.test(xs.iter().sum()));
    |                          type must be known at this point
    |
    = note: cannot satisfy `<u64 as Test<_>>::Output == _`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     println!("{}", 23u64.test(xs.iter().sum::<S>()));
-   |                                            +++++
+LL |     println!("{}", 23u64.test(xs.iter().sum::</* Type */>()));
+   |                                            ++++++++++++++
 
 error[E0283]: type annotations needed
   --> $DIR/projection-predicate-not-satisfied-69455.rs:29:41
@@ -28,10 +28,10 @@ LL | impl Test<u32> for u64 {
 ...
 LL | impl Test<u64> for u64 {
    | ^^^^^^^^^^^^^^^^^^^^^^
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     println!("{}", 23u64.test(xs.iter().sum::<S>()));
-   |                                            +++++
+LL |     println!("{}", 23u64.test(xs.iter().sum::</* Type */>()));
+   |                                            ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -12,10 +12,10 @@ LL |     opts.get(opt.as_ref());
              where T: ?Sized;
 note: required by a bound in `HashMap::<K, V, S, A>::get`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `Q`
    |
-LL |     opts.get::<Q>(opt.as_ref());
-   |             +++++
+LL |     opts.get::</* Type */>(opt.as_ref());
+   |             ++++++++++++++
 
 error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:11:10
@@ -30,10 +30,10 @@ LL |     opts.get(opt.as_ref());
            - impl AsRef<Path> for String;
            - impl AsRef<[u8]> for String;
            - impl AsRef<str> for String;
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `Q`
    |
-LL |     opts.get::<Q>(opt.as_ref());
-   |             +++++
+LL |     opts.get::</* Type */>(opt.as_ref());
+   |             ++++++++++++++
 
 error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:16:59

--- a/tests/ui/traits/next-solver/normalization-shadowing/normalizes_to_ignores_unnormalizable_candidate.stderr
+++ b/tests/ui/traits/next-solver/normalization-shadowing/normalizes_to_ignores_unnormalizable_candidate.stderr
@@ -12,10 +12,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo<T: Trait<Assoc = u8>>(x: T) {}
    |           ^^^^^^^^^^^^^^^^^ required by this bound in `foo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo::<Vec<T>>(unconstrained())
-   |        ++++++++++
+LL |     foo::</* Type */>(unconstrained())
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/overflow-computing-ambiguity.stderr
+++ b/tests/ui/traits/overflow-computing-ambiguity.stderr
@@ -18,10 +18,10 @@ note: required by a bound in `hello`
    |
 LL | fn hello<T: Hello>() {}
    |             ^^^^^ required by this bound in `hello`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     hello::<T>();
-   |          +++++
+LL |     hello::</* Type */>();
+   |          ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/incomplete-inference.stderr
+++ b/tests/ui/type-alias-impl-trait/incomplete-inference.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     None
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     None::<T>
-   |         +++++
+LL |     None::</* Type */>
+   |         ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/send-with-unspecified-type.stderr
+++ b/tests/ui/type-inference/send-with-unspecified-type.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |         tx.send(Foo{ foo: PhantomData });
    |                           ^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |         tx.send(Foo{ foo: PhantomData::<T> });
-   |                                      +++++
+LL |         tx.send(Foo{ foo: PhantomData::</* Type */> });
+   |                                      ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/sort_by_key.stderr
+++ b/tests/ui/type-inference/sort_by_key.stderr
@@ -9,10 +9,10 @@ LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
    = note: the type must implement `Ord`
 note: required by a bound in `slice::<impl [T]>::sort_by_key`
   --> $SRC_DIR/alloc/src/slice.rs:LL:COL
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `S`
    |
-LL |     lst.sort_by_key(|&(v, _)| v.iter().sum::<S>());
-   |                                           +++++
+LL |     lst.sort_by_key(|&(v, _)| v.iter().sum::</* Type */>());
+   |                                           ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/type-inference-none-in-generic-ref.stderr
+++ b/tests/ui/type-inference/type-inference-none-in-generic-ref.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     S { o: &None };
    |     ^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `S`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     S::<T> { o: &None };
-   |      +++++
+LL |     S::</* Type */> { o: &None };
+   |      ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/type-inference-unconstrained-none.stderr
+++ b/tests/ui/type-inference/type-inference-unconstrained-none.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     format!("{:?}", None);
    |                     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     format!("{:?}", None::<T>);
-   |                         +++++
+LL |     format!("{:?}", None::</* Type */>);
+   |                         ++++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/type-inference-unconstrained-none.rs:8:5
@@ -15,10 +15,10 @@ error[E0282]: type annotations needed
 LL |     None;
    |     ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     None::<T>;
-   |         +++++
+LL |     None::</* Type */>;
+   |         ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-inference/unbounded-associated-type.stderr
+++ b/tests/ui/type-inference/unbounded-associated-type.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     S(std::marker::PhantomData).foo();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `PhantomData`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     S(std::marker::PhantomData::<T>).foo();
-   |                               +++++
+LL |     S(std::marker::PhantomData::</* Type */>).foo();
+   |                               ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-inference/unbounded-type-param-in-fn.stderr
+++ b/tests/ui/type-inference/unbounded-type-param-in-fn.stderr
@@ -4,10 +4,10 @@ error[E0282]: type annotations needed
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `T` declared on the function `foo`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo::<T>();
-   |        +++++
+LL |     foo::</* Type */>();
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/type-annotation-needed.stderr
+++ b/tests/ui/type/type-annotation-needed.stderr
@@ -10,10 +10,10 @@ note: required by a bound in `foo`
    |
 LL | fn foo<T: Into<String>>(x: i32) {}
    |           ^^^^^^^^^^^^ required by this bound in `foo`
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     foo::<T>(42);
-   |        +++++
+LL |     foo::</* Type */>(42);
+   |        ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/tests/ui/type/type-check/unknown_type_for_closure.stderr
@@ -27,10 +27,10 @@ error[E0282]: type annotations needed
 LL |     let x = || -> Vec<_> { Vec::new() };
    |                            ^^^^^^^^ cannot infer type of the type parameter `T` declared on the struct `Vec`
    |
-help: consider specifying the generic argument
+help: consider specifying a concrete type for the type parameter `T`
    |
-LL |     let x = || -> Vec<_> { Vec::<T>::new() };
-   |                               +++++
+LL |     let x = || -> Vec<_> { Vec::</* Type */>::new() };
+   |                               ++++++++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153411 (Offload slice support)
 - rust-lang/rust#154557 (Make E0284 generic argument suggestions more explicit)
 - rust-lang/rust#154933 (Suggest removing `&` when awaiting a reference to a future)
 - rust-lang/rust#155524 (Fix LLVM offload install docs to use semicolon-separated CMake lists)
 - rust-lang/rust#155568 (Update books)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153411,154557,154933,155524,155568)
<!-- homu-ignore:end -->

