### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -4,11 +4,11 @@ use crate::alloc::Allocator;
 use crate::borrow::Cow;
 
 macro_rules! __impl_slice_eq1 {
-    ([$($vars:tt)*] $lhs:ty, $rhs:ty $(where $ty:ty: $bound:ident)?, #[$stability:meta]) => {
-        #[$stability]
-        impl<T, U, $($vars)*> PartialEq<$rhs> for $lhs
+    ($($const:ident, )? [$($vars:tt)*] $lhs:ty, $rhs:ty $(where $ty:ty: $bound:ident)?, $(#[$stability:meta])+ ) => {
+        $(#[$stability])+
+        impl<T, U, $($vars)*> $($const)? PartialEq<$rhs> for $lhs
         where
-            T: PartialEq<U>,
+            T: $([$const])? PartialEq<U>,
             $($ty: $bound)?
         {
             #[inline]
@@ -19,21 +19,21 @@ macro_rules! __impl_slice_eq1 {
     }
 }
 
-__impl_slice_eq1! { [A1: Allocator, A2: Allocator] Vec<T, A1>, Vec<U, A2>, #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, &[U], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, &mut [U], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator] &[T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
-__impl_slice_eq1! { [A: Allocator] &mut [T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
-__impl_slice_eq1! { [A: Allocator] Vec<T, A>, [U], #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
-__impl_slice_eq1! { [A: Allocator] [T], Vec<U, A>, #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")]  }
+__impl_slice_eq1! { const, [A1: Allocator, A2: Allocator] Vec<T, A1>, Vec<U, A2>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator] Vec<T, A>, &[U], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator] Vec<T, A>, &mut [U], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator] &[T], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
+__impl_slice_eq1! { const, [A: Allocator] &mut [T], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_ref_slice", since = "1.46.0")] }
+__impl_slice_eq1! { const, [A: Allocator] Vec<T, A>, [U], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")] }
+__impl_slice_eq1! { const, [A: Allocator] [T], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_vec_for_slice", since = "1.48.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [A: Allocator] Cow<'_, [T]>, Vec<U, A> where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 #[cfg(not(no_global_oom_handling))]
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[stable(feature = "rust1", since = "1.0.0")] }
-__impl_slice_eq1! { [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
 
 // NOTE: some less important impls are omitted to reduce code bloat
 // FIXME(Centril): Reconsider this?

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -176,7 +176,8 @@ impl fmt::Debug for CStr {
 }
 
 #[stable(feature = "cstr_default", since = "1.10.0")]
-impl Default for &CStr {
+#[rustc_const_unstable(feature = "const_default", issue = "143894")]
+impl const Default for &CStr {
     #[inline]
     fn default() -> Self {
         c""

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1911,7 +1911,11 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the integer square root of the number, rounded down.
+        ///
+        /// This function returns the **principal (non-negative) square root**.
+        /// For a given number `n`, although both `x` and `-x` satisfy x<sup>2</sup> = n,
+        /// this function always returns the non-negative value.
         ///
         /// Returns `None` if `self` is negative.
         ///
@@ -3206,7 +3210,11 @@ macro_rules! int_impl {
             }
         }
 
-        /// Returns the square root of the number, rounded down.
+        /// Returns the integer square root of the number, rounded down.
+        ///
+        /// This function returns the **principal (non-negative) square root**.
+        /// For a given number `n`, although both `x` and `-x` satisfy x<sup>2</sup> = n,
+        /// this function always returns the non-negative value.
         ///
         /// # Panics
         ///

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1118,7 +1118,10 @@ macro_rules! nonzero_integer {
             /// assuming overflow cannot occur.
             /// Overflow is unchecked, and it is undefined behavior to overflow
             /// *even if the result would wrap to a non-zero value*.
-            /// The behavior is undefined as soon as
+            ///
+            /// # Safety
+            ///
+            /// This results in undefined behavior when
             #[doc = sign_dependent_expr!{
                 $signedness ?
                 if signed {
@@ -1695,7 +1698,10 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// assuming overflow cannot occur.
         /// Overflow is unchecked, and it is undefined behavior to overflow
         /// *even if the result would wrap to a non-zero value*.
-        /// The behavior is undefined as soon as
+        ///
+        /// # Safety
+        ///
+        /// This results in undefined behavior when
         #[doc = concat!("`self + rhs > ", stringify!($Int), "::MAX`.")]
         ///
         /// # Examples

--- a/library/coretests/tests/ffi/cstr.rs
+++ b/library/coretests/tests/ffi/cstr.rs
@@ -1,6 +1,12 @@
 use core::ffi::CStr;
 
 #[test]
+fn const_default() {
+    const S: &CStr = <_>::default();
+    assert_eq!(S, c"");
+}
+
+#[test]
 fn compares_as_u8s() {
     let a: &CStr = c"Hello!"; // Starts with ascii
     let a_bytes: &[u8] = a.to_bytes();

--- a/library/std/src/sys/sync/mutex/no_threads.rs
+++ b/library/std/src/sys/sync/mutex/no_threads.rs
@@ -26,6 +26,6 @@ impl Mutex {
 
     #[inline]
     pub fn try_lock(&self) -> bool {
-        self.locked.replace(true) == false
+        !self.locked.replace(true)
     }
 }


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155532 (Fix redundant boolean comparison in `Mutex::try_lock`)
 - rust-lang/rust#155558 (Clarify that isqrt returns the principal (non-negative) square root)
 - rust-lang/rust#155559 (add safety doc (section header) to two unsafe methods in `NonZero`)
 - rust-lang/rust#155564 (Implement const Default for &CStr)
 - rust-lang/rust#155565 (constify `Vec` comparisons)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155532,155558,155559,155564,155565)
<!-- homu-ignore:end -->

