### PR TITLE
Ensure we don't feed owners from ast lowering if we ever make that query tracked

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -700,6 +700,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// Feeds the HIR delayed owner during AST -> HIR delayed lowering.
     pub fn feed_delayed_owner(self, key: LocalDefId, owner: MaybeOwner<'tcx>) {
+        self.dep_graph.assert_ignored();
         TyCtxtFeed { tcx: self, key }.delayed_owner(owner);
     }
 }


### PR DESCRIPTION
follow-up to rust-lang/rust#153489

I don't expect this to ever really be an issue, but better safe than sorry 😆 