### PR TITLE
Improve the documentation around layout guarantees given by `Box`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -121,6 +121,25 @@
 //! definition is just using `T*` can lead to undefined behavior, as
 //! described in [rust-lang/unsafe-code-guidelines#198][ucg#198].
 //!
+//! Converting between any `Box<T>` and `Box<U>` by using [`core::mem::transmute`]
+//! is equivalent to the following sequence of operations:
+//!
+//! ```rust
+//! # let boxed_value = Box::new(1_i32);
+//! let ptr: *mut i32 = Box::into_raw(boxed_value);
+//! let casted_ptr = ptr as *mut u32;
+//! let new_box: Box<u32> = unsafe {
+//!     Box::from_raw(casted_ptr)
+//! };
+//! ```
+//!
+//! Any such conversion therefore needs to uphold the same guarantees as using
+//! a [pointer-to-pointer cast][ptr-cast] to convert between a `*mut T` and a `*mut U`.
+//! In addition such a `core::mem::transmute` call also needs to uphold the requirements
+//! of [`core::mem::transmute`] for a transmute between `T` and `U`, especially
+//! regarding to size, alignment and the validity of values for both types. Finally
+//! it is required that the pointer `*mut T` is well aligned for both types `T` and `U`.
+//!
 //! # Considerations for unsafe code
 //!
 //! **Warning: This section is not normative and is subject to change, possibly
@@ -180,6 +199,7 @@
 //! [`Layout`]: crate::alloc::Layout
 //! [`Layout::for_value(&*value)`]: crate::alloc::Layout::for_value
 //! [valid]: ptr#safety
+//! [ptr-cast]: https://doc.rust-lang.org/reference/expressions/operator-expr.html#r-expr.as.pointer
 
 #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155597)*
<!-- homu-ignore:end -->

This change extends the memory layout section in the documentation of  `Box` to explicitly state that it is sound to convert between `Box<A>` and `Box<B>` as long a cast between `*mut A` and `*mut B` is valid and
the general requirements of `transmute` are satisfied.

See
https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/Is.20transmuting.20between.20.60Box.3CA.3E.60.20and.20.60Box.3CB.3E.60.20UB.3F/with/585350243 for the relevant discussion.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
