### PR TITLE
Adds a couple UI tests for polonius

### DIFF
--- a/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.nll.stderr
@@ -1,0 +1,14 @@
+error[E0502]: cannot borrow `one` as immutable because it is also borrowed as mutable
+  --> $DIR/location-insensitive-constraints-issue-70044.rs:22:20
+   |
+LL |         let mut y = &mut one;
+   |                     -------- mutable borrow occurs here
+...
+LL |     println!("{}", one);
+   |                    ^^^ immutable borrow occurs here
+LL |     println!("{}", zero);
+   |                    ---- mutable borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.rs
+++ b/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.rs
@@ -1,0 +1,24 @@
+// This test is taken from https://github.com/rust-lang/rust/issues/70044.
+// This test demonstrates how NLL's outlives constraints are flow-insensitive,
+// and are wrongly expected to hold outside the inner scope.
+
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ revisions: nll polonius legacy
+//@ [polonius] check-pass
+//@ [polonius] compile-flags: -Z polonius=next
+//@ [legacy] check-pass
+//@ [legacy] compile-flags: -Z polonius=legacy
+
+fn main() {
+    let mut zero = &mut 0;
+    let mut one = 1;
+
+    {
+        let mut _r = &mut zero;
+        let mut y = &mut one;
+        _r = &mut y;
+    }
+
+    println!("{}", one); //[nll]~ ERROR: cannot borrow `one` as immutable
+    println!("{}", zero);
+}

--- a/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.nll.stderr
@@ -1,0 +1,16 @@
+error[E0499]: cannot borrow `*a` as mutable more than once at a time
+  --> $DIR/nll-problem-case-2-issue-92038.rs:16:26
+   |
+LL | fn reborrow(a: &mut u8) -> &mut u8 {
+   |                - let's call the lifetime of this reference `'1`
+LL |     let b = &mut *a;
+   |             ------- first mutable borrow occurs here
+LL |     if true { b } else { a }
+   |     ---------------------^--
+   |     |                    |
+   |     |                    second mutable borrow occurs here
+   |     returning this value requires that `*a` is borrowed for `'1`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0499`.

--- a/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.rs
@@ -1,0 +1,17 @@
+#![crate_type = "lib"]
+
+// This test demonstrates a shortcoming of NLL known as problem case #2
+// https://rust-lang.github.io/rfcs/2094-nll.html#problem-case-2-conditional-control-flow
+// This MCVE is copied from https://github.com/rust-lang/rust/issues/92038.
+
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ revisions: nll polonius legacy
+//@ [polonius] check-pass
+//@ [polonius] compile-flags: -Z polonius=next
+//@ [legacy] check-pass
+//@ [legacy] compile-flags: -Z polonius=legacy
+
+fn reborrow(a: &mut u8) -> &mut u8 {
+    let b = &mut *a;
+    if true { b } else { a } //[nll]~ ERROR: cannot borrow `*a` as mutable more than once at a time
+}


### PR DESCRIPTION
I went through all the open issues labeled `fixed-by-polonius` and from that created two UI tests based on issues that seemed a little novel.
One for rust-lang/rust#92038 and another for rust-lang/rust#70044.
Both tests fail under NLL but pass with polonius (legacy and alpha).