### PR TITLE
std: Update support for `wasm32-wasip3`

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "vex-sdk",
  "wasip1",
  "wasip2",
+ "wasip3",
  "windows-link 0.0.0",
 ]
 
@@ -418,9 +419,20 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "rustc-std-workspace-alloc",
+ "rustc-std-workspace-core",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.6.0+wasi-0.3.0-rc-2026-03-15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed83456dd6a0b8581998c0365e4651fa2997e5093b49243b7f35391afaa7a3d9"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -513,9 +525,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 dependencies = [
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -84,12 +84,12 @@ wasip1 = { version = "1.0.0", features = [
 ], default-features = false }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p2"))'.dependencies]
-wasip2 = { version = '1.0.2', features = [
+wasip2 = { version = '1.0.3', features = [
     'rustc-dep-of-std',
 ], default-features = false }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p3"))'.dependencies]
-wasip2 = { version = '1.0.2', features = [
+wasip3 = { version = '0.6.0', features = [
     'rustc-dep-of-std',
 ], default-features = false }
 

--- a/library/std/src/sys/args/mod.rs
+++ b/library/std/src/sys/args/mod.rs
@@ -42,8 +42,8 @@ cfg_select! {
         pub use wasip1::*;
     }
     all(target_os = "wasi", any(target_env = "p2", target_env = "p3")) => {
-        mod wasip2;
-        pub use wasip2::*;
+        mod wasi;
+        pub use wasi::*;
     }
     target_os = "xous" => {
         mod xous;

--- a/library/std/src/sys/args/wasi.rs
+++ b/library/std/src/sys/args/wasi.rs
@@ -1,0 +1,11 @@
+#[cfg(target_env = "p2")]
+use wasip2 as wasi;
+#[cfg(target_env = "p3")]
+use wasip3 as wasi;
+
+pub use super::common::Args;
+
+/// Returns the command line arguments
+pub fn args() -> Args {
+    Args::new(wasi::cli::environment::get_arguments().into_iter().map(|arg| arg.into()).collect())
+}

--- a/library/std/src/sys/args/wasip2.rs
+++ b/library/std/src/sys/args/wasip2.rs
@@ -1,6 +1,0 @@
-pub use super::common::Args;
-
-/// Returns the command line arguments
-pub fn args() -> Args {
-    Args::new(wasip2::cli::environment::get_arguments().into_iter().map(|arg| arg.into()).collect())
-}

--- a/library/std/src/sys/random/mod.rs
+++ b/library/std/src/sys/random/mod.rs
@@ -95,8 +95,8 @@ cfg_select! {
         pub use wasip1::fill_bytes;
     }
     all(target_os = "wasi", any(target_env = "p2", target_env = "p3")) => {
-        mod wasip2;
-        pub use wasip2::{fill_bytes, hashmap_random_keys};
+        mod wasi;
+        pub use wasi::{fill_bytes, hashmap_random_keys};
     }
     target_os = "zkvm" => {
         mod zkvm;

--- a/library/std/src/sys/random/wasi.rs
+++ b/library/std/src/sys/random/wasi.rs
@@ -1,0 +1,12 @@
+#[cfg(target_env = "p2")]
+use wasip2::random::{insecure_seed::insecure_seed as get_insecure_seed, random::get_random_bytes};
+#[cfg(target_env = "p3")]
+use wasip3::random::{insecure_seed::get_insecure_seed, random::get_random_bytes};
+
+pub fn fill_bytes(bytes: &mut [u8]) {
+    bytes.copy_from_slice(&get_random_bytes(u64::try_from(bytes.len()).unwrap()));
+}
+
+pub fn hashmap_random_keys() -> (u64, u64) {
+    get_insecure_seed()
+}

--- a/library/std/src/sys/random/wasip2.rs
+++ b/library/std/src/sys/random/wasip2.rs
@@ -1,9 +1,0 @@
-pub fn fill_bytes(bytes: &mut [u8]) {
-    bytes.copy_from_slice(&wasip2::random::random::get_random_bytes(
-        u64::try_from(bytes.len()).unwrap(),
-    ));
-}
-
-pub fn hashmap_random_keys() -> (u64, u64) {
-    wasip2::random::insecure_seed::insecure_seed()
-}

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -541,6 +541,7 @@ const PERMITTED_STDLIB_DEPENDENCIES: &[&str] = &[
     "vex-sdk",
     "wasip1",
     "wasip2",
+    "wasip3",
     "windows-link",
     "windows-sys",
     "windows-targets",


### PR DESCRIPTION
This commit performs some minor update within the standard library for the `wasm32-wasip3` target. This target is a tier 3 target currently due to the WASIp3 specification not being officially released. This commit adds a dependency from the standard library on the `wasip3` crate in the same manner as the `wasip1` and `wasip2` crates that it already depends on. The use-sites, for randomness and environment variables, are then updated to handle the wasip2/wasip3 multiplexing.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
