### PR TITLE
perf: use `get_unchecked` for `TwoWaySearcher`

### DIFF
--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1494,7 +1494,15 @@ impl TwoWaySearcher {
             let start =
                 if long_period { self.crit_pos } else { cmp::max(self.crit_pos, self.memory) };
             for i in start..needle.len() {
-                if needle[i] != haystack[self.position + i] {
+                // SAFETY: on every iteration of `'search`, the `haystack.get(self.position + needle_last)`
+                // check returned `Some`, so `self.position + needle_last < haystack.len()`.
+                // Since `i < needle.len()` implies `i <= needle_last`, we have
+                // `self.position + i < haystack.len()`.
+                // Every path that mutates `self.position` below either returns or re-enters `'search`,
+                // which re-runs the check before reaching the loop again.
+                // `i < needle.len()` also guarantees `needle.get_unchecked(i)` is safe.
+                if unsafe { *needle.get_unchecked(i) != *haystack.get_unchecked(self.position + i) }
+                {
                     self.position += i - self.crit_pos + 1;
                     if !long_period {
                         self.memory = 0;
@@ -1506,7 +1514,15 @@ impl TwoWaySearcher {
             // See if the left part of the needle matches
             let start = if long_period { 0 } else { self.memory };
             for i in (start..self.crit_pos).rev() {
-                if needle[i] != haystack[self.position + i] {
+                // SAFETY: `crit_pos < needle.len()` by construction, so `i < needle.len()` and
+                // `needle.get_unchecked(i)` is safe.
+                // The same `self.position + i < haystack.len()` argument as the right-part
+                // loop applies: `haystack.get(self.position + needle_last)` at the
+                // top of `'search` established the bound for this iteration, and every mutation
+                // of `self.position` is followed by `continue 'search` (which re-runs the check)
+                // or a `return` on match.
+                if unsafe { *needle.get_unchecked(i) != *haystack.get_unchecked(self.position + i) }
+                {
                     self.position += self.period;
                     if !long_period {
                         self.memory = needle.len() - self.period;
@@ -1581,7 +1597,18 @@ impl TwoWaySearcher {
                 cmp::min(self.crit_pos_back, self.memory_back)
             };
             for i in (0..crit).rev() {
-                if needle[i] != haystack[self.end - needle.len() + i] {
+                // SAFETY:
+                // - `i < crit <= crit_pos_back <= needle.len()`, so `needle.get_unchecked(i)` is safe.
+                // - On every iteration of `'search`, `haystack.get(self.end.wrapping_sub(needle.len()))`
+                //   returned `Some`, so `self.end >= needle.len()` and `self.end - needle.len() < haystack.len()`.
+                //   Since `self.end <= haystack.len()` and `i < needle.len()`, we have
+                //   `self.end - needle.len() + i < self.end <= haystack.len()`, so
+                //   `haystack.get_unchecked(self.end - needle.len() + i)` is safe.
+                // - The path that mutates `self.end` either re-enters `'search`, which re-runs the checks
+                //   before reaching this loop again, or returns on match,so the invariant holds.
+                if unsafe {
+                    *needle.get_unchecked(i) != *haystack.get_unchecked(self.end - needle.len() + i)
+                } {
                     self.end -= self.crit_pos_back - i;
                     if !long_period {
                         self.memory_back = needle.len();
@@ -1593,7 +1620,16 @@ impl TwoWaySearcher {
             // See if the right part of the needle matches
             let needle_end = if long_period { needle.len() } else { self.memory_back };
             for i in self.crit_pos_back..needle_end {
-                if needle[i] != haystack[self.end - needle.len() + i] {
+                // SAFETY: `needle_end <= needle.len()`, so `i < needle.len()` and
+                // `needle.get_unchecked(i)` is safe.
+                // The same `self.end - needle.len() + i < haystack.len()` argument as the
+                // left-part loop applies: the `haystack.get(self.end.wrapping_sub(needle.len()))`
+                // check at the top of `'search` established the bound for this iteration, and
+                // every mutation of `self.end` is followed by `continue 'search` (which re-runs
+                // the check) or a `return` (which exits before any further unsafe access).
+                if unsafe {
+                    *needle.get_unchecked(i) != *haystack.get_unchecked(self.end - needle.len() + i)
+                } {
                     self.end -= self.period;
                     if !long_period {
                         self.memory_back = self.period;

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1512,11 +1512,12 @@ impl TwoWaySearcher {
             // See if the left part of the needle matches
             let start = if long_period { 0 } else { self.memory };
             for i in (start..self.crit_pos).rev() {
-                // SAFETY: The same `self.position + i < haystack.len()` argument as the right-part
-                // loop applies: `haystack.get(self.position + needle_last)` at the
-                // top of `'search` established the bound for this iteration, and every mutation
-                // of `self.position` is followed by `continue 'search` (which re-runs the check)
-                // or a `return` on match.
+                // SAFETY: on every iteration of `'search`, the `haystack.get(self.position + needle_last)`
+                // check returned `Some`, so `self.position + needle_last < haystack.len()`.
+                // Since `i < self.crit_pos <= needle.len()`, we have `i <= needle_last`, and thus
+                // `self.position + i <= self.position + needle_last < haystack.len()`.
+                // Every path that mutates `self.position` below either returns or re-enters `'search`,
+                // which re-runs the check before reaching the loop again.
                 if needle[i] != unsafe { *haystack.get_unchecked(self.position + i) } {
                     self.position += self.period;
                     if !long_period {

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -1500,9 +1500,7 @@ impl TwoWaySearcher {
                 // `self.position + i < haystack.len()`.
                 // Every path that mutates `self.position` below either returns or re-enters `'search`,
                 // which re-runs the check before reaching the loop again.
-                // `i < needle.len()` also guarantees `needle.get_unchecked(i)` is safe.
-                if unsafe { *needle.get_unchecked(i) != *haystack.get_unchecked(self.position + i) }
-                {
+                if needle[i] != unsafe { *haystack.get_unchecked(self.position + i) } {
                     self.position += i - self.crit_pos + 1;
                     if !long_period {
                         self.memory = 0;
@@ -1514,15 +1512,12 @@ impl TwoWaySearcher {
             // See if the left part of the needle matches
             let start = if long_period { 0 } else { self.memory };
             for i in (start..self.crit_pos).rev() {
-                // SAFETY: `crit_pos < needle.len()` by construction, so `i < needle.len()` and
-                // `needle.get_unchecked(i)` is safe.
-                // The same `self.position + i < haystack.len()` argument as the right-part
+                // SAFETY: The same `self.position + i < haystack.len()` argument as the right-part
                 // loop applies: `haystack.get(self.position + needle_last)` at the
                 // top of `'search` established the bound for this iteration, and every mutation
                 // of `self.position` is followed by `continue 'search` (which re-runs the check)
                 // or a `return` on match.
-                if unsafe { *needle.get_unchecked(i) != *haystack.get_unchecked(self.position + i) }
-                {
+                if needle[i] != unsafe { *haystack.get_unchecked(self.position + i) } {
                     self.position += self.period;
                     if !long_period {
                         self.memory = needle.len() - self.period;
@@ -1597,18 +1592,14 @@ impl TwoWaySearcher {
                 cmp::min(self.crit_pos_back, self.memory_back)
             };
             for i in (0..crit).rev() {
-                // SAFETY:
-                // - `i < crit <= crit_pos_back <= needle.len()`, so `needle.get_unchecked(i)` is safe.
-                // - On every iteration of `'search`, `haystack.get(self.end.wrapping_sub(needle.len()))`
+                // SAFETY: On every iteration of `'search`, `haystack.get(self.end.wrapping_sub(needle.len()))`
                 //   returned `Some`, so `self.end >= needle.len()` and `self.end - needle.len() < haystack.len()`.
                 //   Since `self.end <= haystack.len()` and `i < needle.len()`, we have
                 //   `self.end - needle.len() + i < self.end <= haystack.len()`, so
                 //   `haystack.get_unchecked(self.end - needle.len() + i)` is safe.
                 // - The path that mutates `self.end` either re-enters `'search`, which re-runs the checks
-                //   before reaching this loop again, or returns on match,so the invariant holds.
-                if unsafe {
-                    *needle.get_unchecked(i) != *haystack.get_unchecked(self.end - needle.len() + i)
-                } {
+                //   before reaching this loop again, or returns on match, so the invariant holds.
+                if needle[i] != unsafe { *haystack.get_unchecked(self.end - needle.len() + i) } {
                     self.end -= self.crit_pos_back - i;
                     if !long_period {
                         self.memory_back = needle.len();
@@ -1620,16 +1611,12 @@ impl TwoWaySearcher {
             // See if the right part of the needle matches
             let needle_end = if long_period { needle.len() } else { self.memory_back };
             for i in self.crit_pos_back..needle_end {
-                // SAFETY: `needle_end <= needle.len()`, so `i < needle.len()` and
-                // `needle.get_unchecked(i)` is safe.
-                // The same `self.end - needle.len() + i < haystack.len()` argument as the
+                // SAFETY: The same `self.end - needle.len() + i < haystack.len()` argument as the
                 // left-part loop applies: the `haystack.get(self.end.wrapping_sub(needle.len()))`
                 // check at the top of `'search` established the bound for this iteration, and
                 // every mutation of `self.end` is followed by `continue 'search` (which re-runs
                 // the check) or a `return` (which exits before any further unsafe access).
-                if unsafe {
-                    *needle.get_unchecked(i) != *haystack.get_unchecked(self.end - needle.len() + i)
-                } {
+                if needle[i] != unsafe { *haystack.get_unchecked(self.end - needle.len() + i) } {
                     self.end -= self.period;
                     if !long_period {
                         self.memory_back = self.period;

--- a/library/coretests/benches/pattern.rs
+++ b/library/coretests/benches/pattern.rs
@@ -39,3 +39,51 @@ fn ends_with_str(b: &mut Bencher) {
         }
     })
 }
+
+fn make_haystack() -> String {
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse quis lorem \
+    sit amet dolor ultricies condimentum. Praesent iaculis purus elit, ac malesuada \
+    quam malesuada in. Duis sed orci eros. Suspendisse sit amet magna mollis, mollis \
+    nunc luctus, imperdiet mi. Integer fringilla non sem ut lacinia. Fusce varius \
+    tortor a risus porttitor hendrerit. Morbi mauris dui, ultricies nec tempus vel, \
+    gravida nec quam. In est dui, tincidunt sed tempus interdum, adipiscing laoreet \
+    ante. Etiam tempor, tellus quis sagittis interdum, nulla purus mattis sem, quis \
+    auctor erat odio ac tellus. In nec nunc sit amet diam volutpat molestie at sed \
+    ipsum. Vestibulum laoreet consequat vulputate. Integer accumsan lorem ac dignissim \
+    placerat. Suspendisse convallis faucibus lorem. Aliquam erat volutpat."
+        .repeat(50)
+}
+
+#[bench]
+fn find_str(b: &mut Bencher) {
+    let s = make_haystack();
+    let haystack = black_box(s.as_str());
+    b.bytes = haystack.len() as u64;
+    b.iter(|| black_box(haystack.find("the english language")))
+}
+
+#[bench]
+fn rfind_str(b: &mut Bencher) {
+    let s = make_haystack();
+    let haystack = black_box(s.as_str());
+    b.bytes = haystack.len() as u64;
+    b.iter(|| black_box(haystack.rfind("the english language")))
+}
+
+#[bench]
+fn find_str_worst_case(b: &mut Bencher) {
+    let near_miss = "the english languagX";
+    let haystack_str = near_miss.repeat(2000);
+    let haystack = black_box(haystack_str.as_str());
+    b.bytes = haystack.len() as u64;
+    b.iter(|| black_box(haystack.find("the english language")))
+}
+
+#[bench]
+fn rfind_str_worst_case(b: &mut Bencher) {
+    let near_miss = "the english languagX";
+    let haystack_str = near_miss.repeat(2000);
+    let haystack = black_box(haystack_str.as_str());
+    b.bytes = haystack.len() as u64;
+    b.iter(|| black_box(haystack.rfind("the english language")))
+}

--- a/typos.toml
+++ b/typos.toml
@@ -13,6 +13,7 @@ extend-exclude = [
     # generated lorem ipsum texts
     "library/alloctests/benches/str.rs",
     "library/alloctests/tests/str.rs",
+    "library/coretests/benches/pattern.rs",
 ]
 
 [default.extend-words]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155607)*
<!-- homu-ignore:end -->

## What is this PR?

*This is related to rust-lang/rust#27721.*

This PR is a proposal for a performance improvement in `std::pattern`.  

Profiling of [https://github.com/quickwit-oss/quickwit](https://github.com/quickwit-oss/quickwit) in production shows that `TwoWaySearcher::next` is one of the most CPU-time-consuming functions, so I thought I would give it a look.  
I read the [contribution guide](https://std-dev-guide.rust-lang.org/development/perf-benchmarking.html) and this seems to be a fitting proposal.

It seems like `TwoWaySearcher::next` and `TwoWaySearcher::next_back` could be made faster by using `get_unchecked` in the inner loop comparisons instead of regular indexing, which is safe in the conditions where it would be done (indices are within bounds by construction).  
I added some `SAFETY` comments in the code to explain why this is safe, as I believe is customary in those cases (and according to [this page as well](https://std-dev-guide.rust-lang.org/policy/safety-comments.html)).

### Benchmarks

I ran the existing bencharmks before/after the changes (only on my laptop, I can run them in other places if that's necessary). 

```
./x.py bench library/coretests -- pattern::
```

We seem to be getting a ~7.5-12% performance improvement at a very low cost, which sounds worthwhile to me.  
But this is the first time I'm proposing a change in Rust, so I'm looking forward to feedback on this.


```
BEFORE CHANGES
    pattern::ends_with_char   3398.91ns/iter +/- 526.28
    pattern::ends_with_str    3545.04ns/iter +/- 1108.76
    pattern::starts_with_char 3348.31ns/iter +/- 352.38
    pattern::starts_with_str  3710.59ns/iter +/- 435.57

AFTER CHANGES
    pattern::ends_with_char   3125.99ns/iter +/- 567.09  (-8.03%)
    pattern::ends_with_str    3106.43ns/iter +/- 258.33  (-12.38%)
    pattern::starts_with_char 3094.55ns/iter +/- 595.42  (-7.59%)
    pattern::starts_with_str  3365.75ns/iter +/- 268.88  (-9.29%)
```

System info for the benchmarks run

<details>

```
Based on commit 8317fef20409adedaa7c385fa6e954867bf626fc

rustc 1.96.0-dev
binary: rustc
commit-hash: unknown
commit-date: unknown
host: aarch64-apple-darwin
release: 1.96.0-dev
LLVM version: 22.1.2

Apple M4 Max
16
64 GB
ProductName:		macOS
ProductVersion:		26.3
BuildVersion:		25D125
(this was run on AC and without any heavy load from other apps or whatnot)
```

</details>

## Final benchmarks

Benchmark results on the latest version of the PR.

Those are the results (run on Linux).

| Benchmark | `main` | Partial | All changes | Partial vs mainline | 
|---|---:|---:|---:|---:|
| `find_str` | 14,163 | 8,190 | 7,017 | -42% |
| `rfind_str` | 23,360 | 11,800 | 8,306 | -49% |
| `find_str_worst_case` | 1,103 | 1,104 | 1,399 | ~0% | 
| `rfind_str_worst_case` | 61,031 | 36,630 | 35,380 | -40% |
