### PR TITLE
Add missing `dyn` keyword to `trait_alias` page of the Unstable Book

### DIFF
--- a/src/doc/unstable-book/src/language-features/trait-alias.md
+++ b/src/doc/unstable-book/src/language-features/trait-alias.md
@@ -26,7 +26,7 @@ pub fn main() {
     foo(&1);
 
     // Use trait alias for trait objects.
-    let a: &Bar = &123;
+    let a: &dyn Bar = &123;
     println!("{:?}", a);
     let b = Box::new(456) as Box<dyn Foo>;
     println!("{:?}", b);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

There seemed to be a small typo in the Rust Unstable Book page for the `trait_alias` feature, where a variable is declared as `&Bar` for a trait `Bar`, rather than `&dyn Bar`.