### PR TITLE
Rewrite use-statement-duplicate-check-7663 test

### DIFF
--- a/tests/ui/modules/use-statement-duplicate-check-7663.explicit_explicit.stderr
+++ b/tests/ui/modules/use-statement-duplicate-check-7663.explicit_explicit.stderr
@@ -1,0 +1,17 @@
+error[E0252]: the name `p` is defined multiple times
+  --> $DIR/use-statement-duplicate-check-7663.rs:34:9
+   |
+LL |     use crate::foo::p;
+   |         ------------- previous import of the value `p` here
+LL |     use crate::bar::p;
+   |         ^^^^^^^^^^^^^ `p` reimported here
+   |
+   = note: `p` must be defined only once in the value namespace of this module
+help: you can use `as` to change the binding name of the import
+   |
+LL |     use crate::bar::p as other_p;
+   |                       ++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0252`.

--- a/tests/ui/modules/use-statement-duplicate-check-7663.glob_glob.stderr
+++ b/tests/ui/modules/use-statement-duplicate-check-7663.glob_glob.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `p` is ambiguous
+  --> $DIR/use-statement-duplicate-check-7663.rs:27:9
+   |
+LL |         p()
+   |         ^ ambiguous name
+   |
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `p` could refer to the function imported here
+  --> $DIR/use-statement-duplicate-check-7663.rs:23:9
+   |
+LL |     use crate::bar::*;
+   |         ^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `p` to disambiguate
+note: `p` could also refer to the function imported here
+  --> $DIR/use-statement-duplicate-check-7663.rs:24:9
+   |
+LL |     use crate::foo::*;
+   |         ^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `p` to disambiguate
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/modules/use-statement-duplicate-check-7663.rs
+++ b/tests/ui/modules/use-statement-duplicate-check-7663.rs
@@ -1,4 +1,4 @@
-// https://github.com/rust-lang/rust/issues/7663
+//! Regression test for #7663.
 //@ revisions: glob_glob explicit_explicit glob_explicit
 //@[glob_glob] check-fail
 //@[explicit_explicit] check-fail

--- a/tests/ui/modules/use-statement-duplicate-check-7663.rs
+++ b/tests/ui/modules/use-statement-duplicate-check-7663.rs
@@ -1,33 +1,48 @@
 // https://github.com/rust-lang/rust/issues/7663
-//@ run-pass
+//@ revisions: glob_glob explicit_explicit glob_explicit
+//@[glob_glob] check-fail
+//@[explicit_explicit] check-fail
+//@[glob_explicit] check-pass
 
 #![allow(unused_imports, dead_code)]
 
-mod test1 {
-
-    mod foo { pub fn p() -> isize { 1 } }
-    mod bar { pub fn p() -> isize { 2 } }
-
-    pub mod baz {
-        use crate::test1::bar::p;
-
-        pub fn my_main() { assert_eq!(p(), 2); }
+mod foo {
+    pub fn p() -> &'static str {
+        "foo"
     }
 }
 
-mod test2 {
-
-    mod foo { pub fn p() -> isize { 1 } }
-    mod bar { pub fn p() -> isize { 2 } }
-
-    pub mod baz {
-        use crate::test2::bar::p;
-
-        pub fn my_main() { assert_eq!(p(), 2); }
+mod bar {
+    pub fn p() -> usize {
+        2
     }
 }
 
-fn main() {
-    test1::baz::my_main();
-    test2::baz::my_main();
+#[cfg(glob_glob)]
+mod case {
+    use crate::bar::*;
+    use crate::foo::*;
+
+    fn check() -> usize {
+        p() //[glob_glob]~ ERROR `p` is ambiguous
+    }
 }
+
+#[cfg(explicit_explicit)]
+mod case {
+    use crate::foo::p;
+    use crate::bar::p;
+    //[explicit_explicit]~^ ERROR the name `p` is defined multiple times
+}
+
+#[cfg(glob_explicit)]
+mod case {
+    use crate::foo::*;
+    use crate::bar::p;
+
+    fn check() -> usize {
+        p()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes rust-lang/rust#140780.

This supersedes the abandoned earlier attempt in rust-lang/rust#141060, which targeted an older test layout.

The existing `use-statement-duplicate-check-7663` test had drifted away from the behavior from rust-lang/rust#7663 and no longer exercised duplicate import handling at all.

This rewrites the test as a revision-based UI test that covers the three relevant cases:
- using the same name through two glob imports is ambiguous
- importing the same name explicitly twice is rejected
- an explicit import still wins over a glob import

## Verification

- `./x test tests/ui/modules --test-args use-statement-duplicate-check-7663`
