### PR TITLE
Streamline `CrateMetadataRef` construction in `provide_one!`.

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -152,13 +152,8 @@ macro_rules! provide_one {
                 $tcx.ensure_ok().crate_hash($def_id.krate);
             }
 
-            let cdata = rustc_data_structures::sync::FreezeReadGuard::map(CStore::from_tcx($tcx), |c| {
-                c.get_crate_data($def_id.krate).cdata
-            });
-            let $cdata = crate::creader::CrateMetadataRef {
-                cdata: &cdata,
-                cstore: &CStore::from_tcx($tcx),
-            };
+            let cstore = CStore::from_tcx($tcx);
+            let $cdata = cstore.get_crate_data($def_id.krate);
 
             $compute
         }


### PR DESCRIPTION
`cstore.get_crate_data()` creates a `CrateMetadataRef`, which is exactly what we need. The current code is very confused and does several unnecessary things: mapping the `FreezeReadGuard` and calling `CStore::from_tcx` a second time to construct a second `CrateMetadataRef`.

This is a small perf win.

r? @mu001999 