### PR TITLE
Fix E0191 suggestion for empty dyn trait args

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1115,12 +1115,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     )
                 })
                 .collect();
-            // FIXME(fmease): Does not account for `dyn Trait<>` (suggs `dyn Trait<, X = Y>`).
-            let code = if let Some(snippet) = snippet.strip_suffix('>') {
-                // The user wrote `Trait<'a>` or similar and we don't have a term we can suggest,
-                // but at least we can clue them to the correct syntax `Trait<'a, Item = /* ... */>`
-                // while accounting for the `<'a>` in the suggestion.
-                format!("{}, {}>", snippet, bindings.join(", "))
+            let code = if let Some(snippet) = snippet.strip_suffix("<>") {
+                // Empty generics
+                format!("{snippet}<{}>", bindings.join(", "))
+            } else if let Some(snippet) = snippet.strip_suffix('>') {
+                // Non-empty generics
+                format!("{snippet}, {}>", bindings.join(", "))
             } else if in_expr_or_pat {
                 // The user wrote `Trait`, so we don't have a term we can suggest, but at least we
                 // can clue them to the correct syntax `Trait::<Item = /* ... */>`.

--- a/tests/ui/traits/cast-as-dyn-trait-wo-assoc-type-issue-21950.rs
+++ b/tests/ui/traits/cast-as-dyn-trait-wo-assoc-type-issue-21950.rs
@@ -12,8 +12,23 @@ impl Add for i32 {
     type Output = i32;
 }
 
+trait Meow {
+    type Assoc;
+}
+
+struct Cat;
+
+impl Meow for Cat {
+    type Assoc = i32;
+}
+
 fn main() {
     let x = &10 as &dyn Add<i32, Output = i32>; //OK
     let x = &10 as &dyn Add;
+    //~^ ERROR E0191
+
+    // Regression test for https://github.com/rust-lang/rust/issues/155578.
+    let cat = Cat;
+    let _: &dyn Meow<> = &cat;
     //~^ ERROR E0191
 }

--- a/tests/ui/traits/cast-as-dyn-trait-wo-assoc-type-issue-21950.stderr
+++ b/tests/ui/traits/cast-as-dyn-trait-wo-assoc-type-issue-21950.stderr
@@ -1,5 +1,5 @@
 error[E0191]: the value of the associated type `Output` in `Add` must be specified
-  --> $DIR/cast-as-dyn-trait-wo-assoc-type-issue-21950.rs:17:25
+  --> $DIR/cast-as-dyn-trait-wo-assoc-type-issue-21950.rs:27:25
    |
 LL |     type Output;
    |     ----------- `Output` defined here
@@ -12,6 +12,20 @@ help: specify the associated type
 LL |     let x = &10 as &dyn Add<Output = /* Type */>;
    |                            +++++++++++++++++++++
 
-error: aborting due to 1 previous error
+error[E0191]: the value of the associated type `Assoc` in `Meow` must be specified
+  --> $DIR/cast-as-dyn-trait-wo-assoc-type-issue-21950.rs:32:17
+   |
+LL |     type Assoc;
+   |     ---------- `Assoc` defined here
+...
+LL |     let _: &dyn Meow<> = &cat;
+   |                 ^^^^^^
+   |
+help: specify the associated type
+   |
+LL |     let _: &dyn Meow<Assoc = /* Type */> = &cat;
+   |                      ++++++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0191`.


### PR DESCRIPTION
Fixes rust-lang/rust#155578.