### PR TITLE
Implement const Deref{,Mut} for String

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2815,7 +2815,8 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl ops::Deref for String {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl const ops::Deref for String {
     type Target = str;
 
     #[inline]
@@ -2828,7 +2829,8 @@ impl ops::Deref for String {
 unsafe impl ops::DerefPure for String {}
 
 #[stable(feature = "derefmut_for_string", since = "1.3.0")]
-impl ops::DerefMut for String {
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl const ops::DerefMut for String {
     #[inline]
     fn deref_mut(&mut self) -> &mut str {
         self.as_mut_str()

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -1,6 +1,7 @@
 #![feature(allocator_api)]
 #![feature(binary_heap_pop_if)]
 #![feature(const_heap)]
+#![feature(const_convert)]
 #![feature(deque_extend_front)]
 #![feature(iter_array_chunks)]
 #![feature(cow_is_borrowed)]

--- a/library/alloctests/tests/string.rs
+++ b/library/alloctests/tests/string.rs
@@ -956,3 +956,27 @@ fn test_str_concat() {
     let s: String = format!("{a}{b}");
     assert_eq!(s.as_bytes()[9], 'd' as u8);
 }
+
+#[test]
+fn test_const_deref() {
+    const fn f(s: &String) -> &str {
+        &*s
+    }
+
+    let s = String::new();
+    let t = f(&s);
+
+    assert_eq!(s.as_str(), t);
+}
+
+#[test]
+fn test_const_deref_mut() {
+    const fn f(s: &mut String) -> &str {
+        &mut *s
+    }
+
+    let mut s = String::new();
+    let t = f(&mut s);
+
+    assert_eq!(t, "");
+}


### PR DESCRIPTION
Implements `const Deref{,Mut}` for `String`.

Tracking issue: rust-lang/rust#143773.