### PR TITLE
Remove non-working code for "running" mir-opt tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -930,14 +930,13 @@ impl<'test> TestCx<'test> {
     }
 
     fn compile_test(&self, will_execute: WillExecute, emit: Emit) -> ProcRes {
-        self.compile_test_general(will_execute, emit, self.props.local_pass_mode(), Vec::new())
+        self.compile_test_general(will_execute, emit, Vec::new())
     }
 
     fn compile_test_general(
         &self,
         will_execute: WillExecute,
         emit: Emit,
-        local_pm: Option<PassMode>,
         passes: Vec<String>,
     ) -> ProcRes {
         let compiler_kind = self.compiler_kind_for_non_aux();
@@ -961,7 +960,7 @@ impl<'test> TestCx<'test> {
                     // Note that we use the local pass mode here as we don't want
                     // to set unused to allow if we've overridden the pass mode
                     // via command line flags.
-                    && local_pm != Some(PassMode::Run)
+                    && self.props.local_pass_mode() != Some(PassMode::Run)
                 {
                     AllowUnused::Yes
                 } else {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -295,14 +295,9 @@ impl<'test> TestCx<'test> {
 
     fn should_run(&self, pm: Option<PassMode>) -> WillExecute {
         let test_should_run = match self.config.mode {
-            TestMode::Ui
-                if pm == Some(PassMode::Run)
-                    || matches!(self.props.fail_mode, Some(FailMode::Run(_))) =>
-            {
-                true
+            TestMode::Ui => {
+                pm == Some(PassMode::Run) || matches!(self.props.fail_mode, Some(FailMode::Run(_)))
             }
-            TestMode::MirOpt if pm == Some(PassMode::Run) => true,
-            TestMode::Ui | TestMode::MirOpt => false,
             mode => panic!("unimplemented for mode {:?}", mode),
         };
         if test_should_run { self.run_if_enabled() } else { WillExecute::No }
@@ -314,7 +309,7 @@ impl<'test> TestCx<'test> {
 
     fn should_run_successfully(&self, pm: Option<PassMode>) -> bool {
         match self.config.mode {
-            TestMode::Ui | TestMode::MirOpt => pm == Some(PassMode::Run),
+            TestMode::Ui => pm == Some(PassMode::Run),
             mode => panic!("unimplemented for mode {:?}", mode),
         }
     }
@@ -936,15 +931,6 @@ impl<'test> TestCx<'test> {
 
     fn compile_test(&self, will_execute: WillExecute, emit: Emit) -> ProcRes {
         self.compile_test_general(will_execute, emit, self.props.local_pass_mode(), Vec::new())
-    }
-
-    fn compile_test_with_passes(
-        &self,
-        will_execute: WillExecute,
-        emit: Emit,
-        passes: Vec<String>,
-    ) -> ProcRes {
-        self.compile_test_general(will_execute, emit, self.props.local_pass_mode(), passes)
     }
 
     fn compile_test_general(

--- a/src/tools/compiletest/src/runtest/mir_opt.rs
+++ b/src/tools/compiletest/src/runtest/mir_opt.rs
@@ -10,9 +10,6 @@ use crate::runtest::compute_diff::write_diff;
 
 impl TestCx<'_> {
     pub(super) fn run_mir_opt_test(&self) {
-        let pm = self.pass_mode();
-        let should_run = self.should_run(pm);
-
         let mut test_info = files_for_miropt_test(
             &self.testpaths.file.as_std_path(),
             self.config.get_pointer_width(),
@@ -21,19 +18,11 @@ impl TestCx<'_> {
 
         let passes = std::mem::take(&mut test_info.passes);
 
-        let proc_res = self.compile_test_with_passes(should_run, Emit::Mir, passes);
+        let proc_res = self.compile_test_general(WillExecute::No, Emit::Mir, None, passes);
         if !proc_res.status.success() {
             self.fatal_proc_rec("compilation failed!", &proc_res);
         }
         self.check_mir_dump(test_info);
-
-        if let WillExecute::Yes = should_run {
-            let proc_res = self.exec_compiled_test();
-
-            if !proc_res.status.success() {
-                self.fatal_proc_rec("test run failed!", &proc_res);
-            }
-        }
     }
 
     fn check_mir_dump(&self, test_info: MiroptTest) {

--- a/src/tools/compiletest/src/runtest/mir_opt.rs
+++ b/src/tools/compiletest/src/runtest/mir_opt.rs
@@ -18,7 +18,7 @@ impl TestCx<'_> {
 
         let passes = std::mem::take(&mut test_info.passes);
 
-        let proc_res = self.compile_test_general(WillExecute::No, Emit::Mir, None, passes);
+        let proc_res = self.compile_test_general(WillExecute::No, Emit::Mir, passes);
         if !proc_res.status.success() {
             self.fatal_proc_rec("compilation failed!", &proc_res);
         }

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -15,10 +15,12 @@ impl TestCx<'_> {
     pub(super) fn run_ui_test(&self) {
         if let Some(FailMode::Build) = self.props.fail_mode {
             // Make sure a build-fail test cannot fail due to failing analysis (e.g. typeck).
-            let pm = Some(PassMode::Check);
-            let proc_res =
-                self.compile_test_general(WillExecute::No, Emit::Metadata, pm, Vec::new());
-            self.check_if_test_should_compile(self.props.fail_mode, pm, &proc_res);
+            let proc_res = self.compile_test(WillExecute::No, Emit::Metadata);
+            self.check_if_test_should_compile(
+                self.props.fail_mode,
+                Some(PassMode::Check),
+                &proc_res,
+            );
         }
 
         let pm = self.pass_mode();


### PR DESCRIPTION
Tests in `tests/mir-opt` always use `--emit=mir`, so the compiler doesn't even produce an executable.

Attempting to "run" these tests (e.g. with `./x test mir-opt --pass=run`) therefore fails when the OS notices that a MIR text file is not executable.

---

The second commit performs some semi-related cleanup.

r? jieyouxu