### PR TITLE
delegation: support self ty propagation for functions in free to trait reuse

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -143,7 +143,8 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
 
                 let (param_count, c_variadic) = self.param_count(sig_id);
 
-                let mut generics = self.uplift_delegation_generics(delegation, sig_id, item_id);
+                let mut generics =
+                    self.uplift_delegation_generics(delegation, sig_id, item_id, is_method);
 
                 let body_id = self.lower_delegation_body(
                     delegation,
@@ -301,6 +302,8 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                 hir::InferDelegationSig::Output(self.arena.alloc(hir::DelegationGenerics {
                     child_args_segment_id: generics.child.args_segment_id,
                     parent_args_segment_id: generics.parent.args_segment_id,
+                    self_ty_id: generics.self_ty_id,
+                    propagate_self_ty: generics.propagate_self_ty,
                 })),
             )),
             span,
@@ -553,6 +556,12 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                     hir::QPath::TypeRelative(ty, self.arena.alloc(segment))
                 }
             };
+
+            generics.self_ty_id = match new_path {
+                hir::QPath::Resolved(ty, _) => ty,
+                hir::QPath::TypeRelative(ty, _) => Some(ty),
+            }
+            .map(|ty| ty.hir_id);
 
             let callee_path = self.arena.alloc(self.mk_expr(hir::ExprKind::Path(new_path), span));
             self.arena.alloc(self.mk_expr(hir::ExprKind::Call(callee_path, args), span))

--- a/compiler/rustc_ast_lowering/src/delegation/generics.rs
+++ b/compiler/rustc_ast_lowering/src/delegation/generics.rs
@@ -67,6 +67,8 @@ pub(super) struct GenericsGenerationResult<'hir> {
 pub(super) struct GenericsGenerationResults<'hir> {
     pub(super) parent: GenericsGenerationResult<'hir>,
     pub(super) child: GenericsGenerationResult<'hir>,
+    pub(super) self_ty_id: Option<HirId>,
+    pub(super) propagate_self_ty: bool,
 }
 
 pub(super) struct GenericArgsPropagationDetails {
@@ -209,6 +211,7 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
         delegation: &Delegation,
         sig_id: DefId,
         item_id: NodeId,
+        is_method: bool,
     ) -> GenericsGenerationResults<'hir> {
         let delegation_parent_kind =
             self.tcx.def_kind(self.tcx.local_parent(self.local_def_id(item_id)));
@@ -230,7 +233,12 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
             let child = DelegationGenerics::trait_impl(sig_params, child_user_specified);
             let child = GenericsGenerationResult::new(child);
 
-            return GenericsGenerationResults { parent, child };
+            return GenericsGenerationResults {
+                parent,
+                child,
+                self_ty_id: None,
+                propagate_self_ty: false,
+            };
         }
 
         let delegation_in_free_ctx =
@@ -238,13 +246,14 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
 
         let sig_parent = self.tcx.parent(sig_id);
         let sig_in_trait = matches!(self.tcx.def_kind(sig_parent), DefKind::Trait);
+        let free_to_trait_delegation = delegation_in_free_ctx && sig_in_trait;
+        let generate_self = free_to_trait_delegation && is_method && delegation.qself.is_none();
 
         let can_add_generics_to_parent = len >= 2
             && self.get_resolution_id(segments[len - 2].id).is_some_and(|def_id| {
                 matches!(self.tcx.def_kind(def_id), DefKind::Trait | DefKind::TraitAlias)
             });
 
-        let generate_self = delegation_in_free_ctx && sig_in_trait;
         let parent_generics = if can_add_generics_to_parent {
             let sig_parent_params = &self.tcx.generics_of(sig_parent).own_params[..];
 
@@ -278,6 +287,8 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
         GenericsGenerationResults {
             parent: GenericsGenerationResult::new(parent_generics),
             child: GenericsGenerationResult::new(child_generics),
+            self_ty_id: None,
+            propagate_self_ty: free_to_trait_delegation && !generate_self,
         }
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3761,6 +3761,8 @@ pub enum OpaqueTyOrigin<D> {
 pub struct DelegationGenerics {
     pub parent_args_segment_id: Option<HirId>,
     pub child_args_segment_id: Option<HirId>,
+    pub self_ty_id: Option<HirId>,
+    pub propagate_self_ty: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, HashStable_Generic)]

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -7,7 +7,7 @@ use std::debug_assert_matches;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::{HirId, PathSegment};
+use rustc_hir::{DelegationGenerics, HirId, PathSegment};
 use rustc_middle::ty::{
     self, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
@@ -65,19 +65,35 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for ParamIndexRemapper<'tcx> {
 }
 
 enum SelfPositionKind {
-    AfterLifetimes,
+    AfterLifetimes(bool /* Should propagate self ty */),
     Zero,
     None,
 }
 
-fn create_self_position_kind(caller_kind: FnKind, callee_kind: FnKind) -> SelfPositionKind {
-    match (caller_kind, callee_kind) {
+fn get_delegation_generics(tcx: TyCtxt<'_>, delegation_id: LocalDefId) -> &DelegationGenerics {
+    tcx.hir_node(tcx.local_def_id_to_hir_id(delegation_id))
+        .fn_sig()
+        .expect("processing delegation")
+        .decl
+        .opt_delegation_generics()
+        .expect("processing delegation")
+}
+
+fn create_self_position_kind(
+    tcx: TyCtxt<'_>,
+    delegation_id: LocalDefId,
+    sig_id: DefId,
+) -> SelfPositionKind {
+    match (fn_kind(tcx, delegation_id), fn_kind(tcx, sig_id)) {
         (FnKind::AssocInherentImpl, FnKind::AssocTrait)
         | (FnKind::AssocTraitImpl, FnKind::AssocTrait)
         | (FnKind::AssocTrait, FnKind::AssocTrait)
         | (FnKind::AssocTrait, FnKind::Free) => SelfPositionKind::Zero,
 
-        (FnKind::Free, FnKind::AssocTrait) => SelfPositionKind::AfterLifetimes,
+        (FnKind::Free, FnKind::AssocTrait) => {
+            let propagate_self_ty = get_delegation_generics(tcx, delegation_id).propagate_self_ty;
+            SelfPositionKind::AfterLifetimes(propagate_self_ty)
+        }
 
         _ => SelfPositionKind::None,
     }
@@ -141,8 +157,7 @@ fn create_mapping<'tcx>(
 ) -> FxHashMap<u32, u32> {
     let mut mapping: FxHashMap<u32, u32> = Default::default();
 
-    let (caller_kind, callee_kind) = (fn_kind(tcx, def_id), fn_kind(tcx, sig_id));
-    let self_pos_kind = create_self_position_kind(caller_kind, callee_kind);
+    let self_pos_kind = create_self_position_kind(tcx, def_id, sig_id);
     let is_self_at_zero = matches!(self_pos_kind, SelfPositionKind::Zero);
 
     // Is self at zero? If so insert mapping, self in sig parent is always at 0.
@@ -156,7 +171,7 @@ fn create_mapping<'tcx>(
     args_index += get_delegation_parent_args_count_without_self(tcx, def_id, sig_id);
 
     let sig_generics = tcx.generics_of(sig_id);
-    let process_sig_parent_generics = matches!(callee_kind, FnKind::AssocTrait);
+    let process_sig_parent_generics = matches!(fn_kind(tcx, sig_id), FnKind::AssocTrait);
 
     if process_sig_parent_generics {
         for i in (sig_generics.has_self as usize)..sig_generics.parent_count {
@@ -176,7 +191,9 @@ fn create_mapping<'tcx>(
     }
 
     // If self after lifetimes insert mapping, relying that self is at 0 in sig parent.
-    if matches!(self_pos_kind, SelfPositionKind::AfterLifetimes) {
+    // If self ty is propagated (meaning there is no generic param `Self`), the specified
+    // self ty will be inserted in args in `create_generic_args`.
+    if matches!(self_pos_kind, SelfPositionKind::AfterLifetimes { .. }) {
         mapping.insert(0, args_index as u32);
         args_index += 1;
     }
@@ -259,6 +276,22 @@ fn get_parent_and_inheritance_kind<'tcx>(
     }
 }
 
+fn get_delegation_self_ty_or_err(tcx: TyCtxt<'_>, delegation_id: LocalDefId) -> Ty<'_> {
+    get_delegation_generics(tcx, delegation_id)
+        .self_ty_id
+        .map(|id| {
+            let ctx = ItemCtxt::new(tcx, delegation_id);
+            ctx.lower_ty(tcx.hir_node(id).expect_ty())
+        })
+        .unwrap_or_else(|| {
+            Ty::new_error_with_message(
+                tcx,
+                tcx.def_span(delegation_id),
+                "the self type must be specified",
+            )
+        })
+}
+
 fn get_delegation_self_ty<'tcx>(tcx: TyCtxt<'tcx>, delegation_id: LocalDefId) -> Option<Ty<'tcx>> {
     let sig_id = tcx.hir_opt_delegation_sig_id(delegation_id).expect("Delegation must have sig_id");
     let (caller_kind, callee_kind) = (fn_kind(tcx, delegation_id), fn_kind(tcx, sig_id));
@@ -269,15 +302,19 @@ fn get_delegation_self_ty<'tcx>(tcx: TyCtxt<'tcx>, delegation_id: LocalDefId) ->
         | (FnKind::Free, FnKind::Free)
         | (FnKind::AssocTrait, FnKind::Free)
         | (FnKind::AssocTrait, FnKind::AssocTrait) => {
-            match create_self_position_kind(caller_kind, callee_kind) {
+            match create_self_position_kind(tcx, delegation_id, sig_id) {
                 SelfPositionKind::None => None,
-                SelfPositionKind::AfterLifetimes => {
-                    // Both sig parent and child lifetimes are in included in this count.
-                    Some(tcx.generics_of(delegation_id).own_counts().lifetimes)
+                SelfPositionKind::AfterLifetimes(propagate_self_ty) => {
+                    if propagate_self_ty {
+                        Some(get_delegation_self_ty_or_err(tcx, delegation_id))
+                    } else {
+                        // Both sig parent and child lifetimes are in included in this count.
+                        let index = tcx.generics_of(delegation_id).own_counts().lifetimes;
+                        Some(Ty::new_param(tcx, index as u32, kw::SelfUpper))
+                    }
                 }
-                SelfPositionKind::Zero => Some(0),
+                SelfPositionKind::Zero => Some(Ty::new_param(tcx, 0, kw::SelfUpper)),
             }
-            .map(|self_index| Ty::new_param(tcx, self_index as u32, kw::SelfUpper))
         }
 
         (FnKind::AssocTraitImpl, FnKind::AssocTrait)
@@ -366,7 +403,7 @@ fn create_generic_args<'tcx>(
 
     let mut new_args = vec![];
 
-    let self_pos_kind = create_self_position_kind(caller_kind, callee_kind);
+    let self_pos_kind = create_self_position_kind(tcx, delegation_id, sig_id);
     let mut lifetimes_end_pos;
 
     if !parent_args.is_empty() {
@@ -374,7 +411,7 @@ fn create_generic_args<'tcx>(
             parent_args.iter().filter(|a| a.as_region().is_some()).count();
 
         match self_pos_kind {
-            SelfPositionKind::AfterLifetimes => {
+            SelfPositionKind::AfterLifetimes { .. } => {
                 new_args.extend(&parent_args[1..1 + parent_args_lifetimes_count]);
 
                 lifetimes_end_pos = parent_args_lifetimes_count;
@@ -407,6 +444,15 @@ fn create_generic_args<'tcx>(
                 .count();
 
         new_args.extend_from_slice(args);
+
+        // Parent args are empty, then if we should propagate self ty (meaning Self generic
+        // param was not generated) then we should insert it, as it won't be in `args`.
+        if matches!(self_pos_kind, SelfPositionKind::AfterLifetimes(true)) {
+            new_args.insert(
+                lifetimes_end_pos,
+                ty::GenericArg::from(get_delegation_self_ty_or_err(tcx, delegation_id)),
+            );
+        }
     }
 
     if !child_args.is_empty() {
@@ -427,7 +473,8 @@ fn create_generic_args<'tcx>(
             new_args.insert(lifetimes_end_pos + i, child_args[i]);
         }
 
-        let skip_self = matches!(self_pos_kind, SelfPositionKind::AfterLifetimes);
+        // If self_ty is propagated it means that Self generic param was not generated.
+        let skip_self = matches!(self_pos_kind, SelfPositionKind::AfterLifetimes(false));
         new_args.extend(&child_args[child_lifetimes_count + skip_self as usize..]);
     }
 
@@ -446,6 +493,7 @@ pub(crate) fn inherit_predicates_for_delegation_item<'tcx>(
         preds: Vec<(ty::Clause<'tcx>, Span)>,
         args: Vec<ty::GenericArg<'tcx>>,
         folder: ParamIndexRemapper<'tcx>,
+        filter_self_preds: bool,
     }
 
     impl<'tcx> PredicatesCollector<'tcx> {
@@ -458,6 +506,16 @@ pub(crate) fn inherit_predicates_for_delegation_item<'tcx>(
             let args = self.args.as_slice();
 
             for pred in preds.predicates {
+                // If self ty is specified then there will be no generic param `Self`,
+                // so we do not need its predicates.
+                if self.filter_self_preds
+                    && let Some(trait_pred) = pred.0.as_trait_clause()
+                    // Rely that `Self` has zero index.
+                    && trait_pred.self_ty().skip_binder().is_param(0)
+                {
+                    continue;
+                }
+
                 let new_pred = pred.0.fold_with(&mut self.folder);
                 self.preds.push((
                     EarlyBinder::bind(new_pred).instantiate(self.tcx, args).skip_norm_wip(),
@@ -484,8 +542,10 @@ pub(crate) fn inherit_predicates_for_delegation_item<'tcx>(
 
     let (parent_args, child_args) = get_delegation_user_specified_args(tcx, def_id);
     let (folder, args) = create_folder_and_args(tcx, def_id, sig_id, parent_args, child_args);
-    let collector = PredicatesCollector { tcx, preds: vec![], args, folder };
+    let self_pos_kind = create_self_position_kind(tcx, def_id, sig_id);
+    let filter_self_preds = matches!(self_pos_kind, SelfPositionKind::AfterLifetimes(true));
 
+    let collector = PredicatesCollector { tcx, preds: vec![], args, folder, filter_self_preds };
     let (parent, inh_kind) = get_parent_and_inheritance_kind(tcx, def_id, sig_id);
 
     // `explicit_predicates_of` is used here to avoid copying `Self: Trait` predicate.
@@ -573,13 +633,7 @@ fn get_delegation_user_specified_args<'tcx>(
     tcx: TyCtxt<'tcx>,
     delegation_id: LocalDefId,
 ) -> (&'tcx [ty::GenericArg<'tcx>], &'tcx [ty::GenericArg<'tcx>]) {
-    let info = tcx
-        .hir_node(tcx.local_def_id_to_hir_id(delegation_id))
-        .fn_sig()
-        .expect("Lowering delegation")
-        .decl
-        .opt_delegation_generics()
-        .expect("Lowering delegation");
+    let info = get_delegation_generics(tcx, delegation_id);
 
     let get_segment = |hir_id: HirId| -> Option<(&'tcx PathSegment<'tcx>, DefId)> {
         let segment = tcx.hir_node(hir_id).expect_path_segment();

--- a/tests/pretty/delegation-inherit-attributes.pp
+++ b/tests/pretty/delegation-inherit-attributes.pp
@@ -114,10 +114,10 @@ mod recursive {
 
         #[attr = MustUse {reason: "some reason"}]
         #[attr = Inline(Hint)]
-        fn foo<Self>(self: _, arg1: _) -> _ { <X as T>::foo(self + 1, arg1) }
+        fn foo(self: _, arg1: _) -> _ { <X as T>::foo(self + 1, arg1) }
         #[attr = MustUse {reason: "some reason"}]
         #[attr = Inline(Hint)]
-        fn bar<Self>(arg0: _, arg1: _) -> _ { foo(self + 1, arg1) }
+        fn bar(arg0: _, arg1: _) -> _ { foo(self + 1, arg1) }
     }
 }
 

--- a/tests/ui/delegation/auxiliary/recursive-delegation-aux.rs
+++ b/tests/ui/delegation/auxiliary/recursive-delegation-aux.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 fn foo() {}
 

--- a/tests/ui/delegation/bad-resolve.rs
+++ b/tests/ui/delegation/bad-resolve.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     const C: u32 = 0;

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -1,5 +1,5 @@
 error[E0324]: item `C` is an associated method, which doesn't match its trait `Trait`
-  --> $DIR/bad-resolve.rs:24:5
+  --> $DIR/bad-resolve.rs:23:5
    |
 LL |     const C: u32 = 0;
    |     ----------------- item in trait
@@ -8,7 +8,7 @@ LL |     reuse <F as Trait>::C;
    |     ^^^^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0324]: item `Type` is an associated method, which doesn't match its trait `Trait`
-  --> $DIR/bad-resolve.rs:27:5
+  --> $DIR/bad-resolve.rs:26:5
    |
 LL |     type Type;
    |     ---------- item in trait
@@ -17,7 +17,7 @@ LL |     reuse <F as Trait>::Type;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0407]: method `baz` is not a member of trait `Trait`
-  --> $DIR/bad-resolve.rs:30:5
+  --> $DIR/bad-resolve.rs:29:5
    |
 LL |     reuse <F as Trait>::baz;
    |     ^^^^^^^^^^^^^^^^^^^^---^
@@ -26,7 +26,7 @@ LL |     reuse <F as Trait>::baz;
    |     not a member of trait `Trait`
 
 error[E0407]: method `foo2` is not a member of trait `Trait`
-  --> $DIR/bad-resolve.rs:37:5
+  --> $DIR/bad-resolve.rs:36:5
    |
 LL |     reuse Trait::foo2 { self.0 }
    |     ^^^^^^^^^^^^^----^^^^^^^^^^^
@@ -35,19 +35,19 @@ LL |     reuse Trait::foo2 { self.0 }
    |     not a member of trait `Trait`
 
 error[E0423]: expected function, found associated constant `Trait::C`
-  --> $DIR/bad-resolve.rs:24:11
+  --> $DIR/bad-resolve.rs:23:11
    |
 LL |     reuse <F as Trait>::C;
    |           ^^^^^^^^^^^^^^^ not a function
 
 error[E0575]: expected method or associated constant, found associated type `Trait::Type`
-  --> $DIR/bad-resolve.rs:27:11
+  --> $DIR/bad-resolve.rs:26:11
    |
 LL |     reuse <F as Trait>::Type;
    |           ^^^^^^^^^^^^^^^^^^ not a method or associated constant
 
 error[E0576]: cannot find method or associated constant `baz` in trait `Trait`
-  --> $DIR/bad-resolve.rs:30:25
+  --> $DIR/bad-resolve.rs:29:25
    |
 LL |     fn bar() {}
    |     -------- similarly named associated function `bar` defined here
@@ -62,13 +62,13 @@ LL +     reuse <F as Trait>::bar;
    |
 
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/bad-resolve.rs:35:11
+  --> $DIR/bad-resolve.rs:34:11
    |
 LL |     reuse foo { &self.0 }
    |           ^^^ not found in this scope
 
 error[E0425]: cannot find function `foo2` in trait `Trait`
-  --> $DIR/bad-resolve.rs:37:18
+  --> $DIR/bad-resolve.rs:36:18
    |
 LL |     fn foo(&self, x: i32) -> i32 { x }
    |     ---------------------------- similarly named associated function `foo` defined here
@@ -83,7 +83,7 @@ LL +     reuse Trait::foo { self.0 }
    |
 
 error[E0046]: not all trait items implemented, missing: `Type`
-  --> $DIR/bad-resolve.rs:22:1
+  --> $DIR/bad-resolve.rs:21:1
    |
 LL |     type Type;
    |     --------- `Type` from trait
@@ -92,7 +92,7 @@ LL | impl Trait for S {
    | ^^^^^^^^^^^^^^^^ missing `Type` in implementation
 
 error[E0433]: cannot find module or crate `unresolved_prefix` in this scope
-  --> $DIR/bad-resolve.rs:43:7
+  --> $DIR/bad-resolve.rs:42:7
    |
 LL | reuse unresolved_prefix::{a, b, c};
    |       ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_prefix`
@@ -100,7 +100,7 @@ LL | reuse unresolved_prefix::{a, b, c};
    = help: you might be missing a crate named `unresolved_prefix`
 
 error[E0433]: `crate` in paths can only be used in start position
-  --> $DIR/bad-resolve.rs:44:29
+  --> $DIR/bad-resolve.rs:43:29
    |
 LL | reuse prefix::{self, super, crate};
    |                             ^^^^^ can only be used in path start position

--- a/tests/ui/delegation/body-identity-glob.rs
+++ b/tests/ui/delegation/body-identity-glob.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) {}

--- a/tests/ui/delegation/body-identity-list.rs
+++ b/tests/ui/delegation/body-identity-list.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) {}

--- a/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.rs
+++ b/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 use std::marker::PhantomData;
 

--- a/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.stderr
+++ b/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.stderr
@@ -1,5 +1,5 @@
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:68
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:68
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |                                                                    ^^ undeclared lifetime
@@ -14,7 +14,7 @@ LL | impl<'a> Trait for Z {
    |     ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:68
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:68
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |                                                                    ^^ undeclared lifetime
@@ -29,7 +29,7 @@ LL | impl<'a> Trait for Z {
    |     ++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:68
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:68
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |                                                                    ^^ undeclared lifetime
@@ -44,7 +44,7 @@ LL | impl<'a> Trait for Z {
    |     ++++
 
 error[E0599]: no associated function or constant named `new` found for struct `InvariantRef<'a, T>` in the current scope
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:9:41
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:8:41
    |
 LL | pub struct InvariantRef<'a, T: ?Sized>(&'a T, PhantomData<&'a mut &'a T>);
    | -------------------------------------- associated function or constant `new` not found for this struct
@@ -53,19 +53,19 @@ LL |     pub const NEW: Self = InvariantRef::new(&());
    |                                         ^^^ associated function or constant not found in `InvariantRef<'_, _>`
 
 error[E0277]: the trait bound `u8: Trait` is not satisfied
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:12
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:12
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
 help: the trait `Trait` is implemented for `Z`
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:1
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:20:1
    |
 LL | impl Trait for Z {
    | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:53
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:53
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `InvariantRef<'_, ()>`
@@ -74,20 +74,20 @@ LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW
             found struct `InvariantRef<'_, ()>`
 
 error[E0277]: the trait bound `u8: Trait` is not satisfied
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:12
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:12
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
 help: the trait `Trait` is implemented for `Z`
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:1
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:20:1
    |
 LL | impl Trait for Z {
    | ^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:53
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:53
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `InvariantRef<'_, ()>`
@@ -97,20 +97,20 @@ LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `u8: Trait` is not satisfied
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:12
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:12
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
 help: the trait `Trait` is implemented for `Z`
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:1
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:20:1
    |
 LL | impl Trait for Z {
    | ^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:53
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:21:53
    |
 LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `InvariantRef<'_, ()>`

--- a/tests/ui/delegation/duplicate-definition-inside-trait-impl.rs
+++ b/tests/ui/delegation/duplicate-definition-inside-trait-impl.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) -> u32 { 0 }

--- a/tests/ui/delegation/duplicate-definition-inside-trait-impl.stderr
+++ b/tests/ui/delegation/duplicate-definition-inside-trait-impl.stderr
@@ -1,5 +1,5 @@
 error[E0201]: duplicate definitions with name `foo`:
-  --> $DIR/duplicate-definition-inside-trait-impl.rs:19:5
+  --> $DIR/duplicate-definition-inside-trait-impl.rs:18:5
    |
 LL |     fn foo(&self) -> u32 { 0 }
    |     -------------------------- item in trait
@@ -10,13 +10,13 @@ LL |     reuse Trait::foo;
    |     ^^^^^^^^^^^^^^^^^ duplicate definition
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> $DIR/duplicate-definition-inside-trait-impl.rs:19:18
+  --> $DIR/duplicate-definition-inside-trait-impl.rs:18:18
    |
 LL |     reuse Trait::foo;
    |                  ^^^ argument #1 of type `&_` is missing
    |
 note: method defined here
-  --> $DIR/duplicate-definition-inside-trait-impl.rs:5:8
+  --> $DIR/duplicate-definition-inside-trait-impl.rs:4:8
    |
 LL |     fn foo(&self) -> u32 { 0 }
    |        ^^^ -----
@@ -26,7 +26,7 @@ LL |     reuse Trait::foo(/* value */);
    |                     +++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/duplicate-definition-inside-trait-impl.rs:19:18
+  --> $DIR/duplicate-definition-inside-trait-impl.rs:18:18
    |
 LL |     reuse Trait::foo;
    |                  ^^^- help: consider using a semicolon here: `;`

--- a/tests/ui/delegation/empty-glob.rs
+++ b/tests/ui/delegation/empty-glob.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {}
 

--- a/tests/ui/delegation/empty-glob.stderr
+++ b/tests/ui/delegation/empty-glob.stderr
@@ -1,5 +1,5 @@
 error: empty glob delegation is not supported
-  --> $DIR/empty-glob.rs:8:5
+  --> $DIR/empty-glob.rs:7:5
    |
 LL |     reuse Trait::*;
    |     ^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/empty-list.rs
+++ b/tests/ui/delegation/empty-list.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod m {}
 

--- a/tests/ui/delegation/empty-list.stderr
+++ b/tests/ui/delegation/empty-list.stderr
@@ -1,5 +1,5 @@
 error: empty list delegation is not supported
-  --> $DIR/empty-list.rs:6:1
+  --> $DIR/empty-list.rs:5:1
    |
 LL | reuse m::{};
    | ^^^^^^^^^^^^

--- a/tests/ui/delegation/explicit-paths-in-traits-pass.rs
+++ b/tests/ui/delegation/explicit-paths-in-traits-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait ToReuse {
     fn foo(&self, x: i32) -> i32 { x }

--- a/tests/ui/delegation/explicit-paths-pass.rs
+++ b/tests/ui/delegation/explicit-paths-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn bar(&self, x: i32) -> i32 { x }

--- a/tests/ui/delegation/explicit-paths-signature-pass.rs
+++ b/tests/ui/delegation/explicit-paths-signature-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     use crate::S;

--- a/tests/ui/delegation/explicit-paths.rs
+++ b/tests/ui/delegation/explicit-paths.rs
@@ -1,6 +1,5 @@
 //@ edition:2015
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo1(&self, x: i32) -> i32 { x }

--- a/tests/ui/delegation/explicit-paths.stderr
+++ b/tests/ui/delegation/explicit-paths.stderr
@@ -1,5 +1,5 @@
 error[E0407]: method `foo3` is not a member of trait `Trait`
-  --> $DIR/explicit-paths.rs:50:9
+  --> $DIR/explicit-paths.rs:49:9
    |
 LL |         reuse to_reuse::foo3;
    |         ^^^^^^^^^^^^^^^^----^
@@ -8,7 +8,7 @@ LL |         reuse to_reuse::foo3;
    |         not a member of trait `Trait`
 
 error[E0407]: method `foo4` is not a member of trait `Trait`
-  --> $DIR/explicit-paths.rs:52:9
+  --> $DIR/explicit-paths.rs:51:9
    |
 LL |         reuse F::foo4 { &self.0 }
    |         ^^^^^^^^^----^^^^^^^^^^^^
@@ -17,49 +17,49 @@ LL |         reuse F::foo4 { &self.0 }
    |         not a member of trait `Trait`
 
 error[E0425]: cannot find function `foo4` in `S`
-  --> $DIR/explicit-paths.rs:28:14
+  --> $DIR/explicit-paths.rs:27:14
    |
 LL |     reuse S::foo4;
    |              ^^^^ not found in `S`
 
 error[E0425]: cannot find function `foo4` in `F`
-  --> $DIR/explicit-paths.rs:39:18
+  --> $DIR/explicit-paths.rs:38:18
    |
 LL |         reuse F::foo4 { &self.0 }
    |                  ^^^^ not found in `F`
    |
 note: function `fn_to_other::foo4` exists but is inaccessible
-  --> $DIR/explicit-paths.rs:28:5
+  --> $DIR/explicit-paths.rs:27:5
    |
 LL |     reuse S::foo4;
    |     ^^^^^^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `foo4` in `F`
-  --> $DIR/explicit-paths.rs:52:18
+  --> $DIR/explicit-paths.rs:51:18
    |
 LL |         reuse F::foo4 { &self.0 }
    |                  ^^^^ not found in `F`
    |
 note: function `fn_to_other::foo4` exists but is inaccessible
-  --> $DIR/explicit-paths.rs:28:5
+  --> $DIR/explicit-paths.rs:27:5
    |
 LL |     reuse S::foo4;
    |     ^^^^^^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `foo4` in `F`
-  --> $DIR/explicit-paths.rs:66:18
+  --> $DIR/explicit-paths.rs:65:18
    |
 LL |         reuse F::foo4 { &F }
    |                  ^^^^ not found in `F`
    |
 note: function `fn_to_other::foo4` exists but is inaccessible
-  --> $DIR/explicit-paths.rs:28:5
+  --> $DIR/explicit-paths.rs:27:5
    |
 LL |     reuse S::foo4;
    |     ^^^^^^^^^^^^^^ not accessible
 
 error[E0119]: conflicting implementations of trait `Trait` for type `S`
-  --> $DIR/explicit-paths.rs:75:5
+  --> $DIR/explicit-paths.rs:74:5
    |
 LL |     impl Trait for S {
    |     ---------------- first implementation here
@@ -68,7 +68,7 @@ LL |     impl Trait for S {
    |     ^^^^^^^^^^^^^^^^ conflicting implementation for `S`
 
 error[E0308]: mismatched types
-  --> $DIR/explicit-paths.rs:62:36
+  --> $DIR/explicit-paths.rs:61:36
    |
 LL |     trait Trait2 : Trait {
    |     -------------------- found this type parameter
@@ -80,24 +80,24 @@ LL |         reuse <F as Trait>::foo1 { self }
    = note: expected reference `&F`
               found reference `&Self`
 note: method defined here
-  --> $DIR/explicit-paths.rs:6:8
+  --> $DIR/explicit-paths.rs:5:8
    |
 LL |     fn foo1(&self, x: i32) -> i32 { x }
    |        ^^^^ -----
 
 error[E0277]: the trait bound `S2: Trait` is not satisfied
-  --> $DIR/explicit-paths.rs:77:16
+  --> $DIR/explicit-paths.rs:76:16
    |
 LL |         reuse <S2 as Trait>::foo1;
    |                ^^ unsatisfied trait bound
    |
 help: the trait `Trait` is not implemented for `S2`
-  --> $DIR/explicit-paths.rs:74:5
+  --> $DIR/explicit-paths.rs:73:5
    |
 LL |     struct S2;
    |     ^^^^^^^^^
 help: the following other types implement trait `Trait`
-  --> $DIR/explicit-paths.rs:11:1
+  --> $DIR/explicit-paths.rs:10:1
    |
 LL | impl Trait for F {}
    | ^^^^^^^^^^^^^^^^ `F`
@@ -109,7 +109,7 @@ LL |     impl Trait for S {
    |     ^^^^^^^^^^^^^^^^ `S`
 
 error[E0308]: mismatched types
-  --> $DIR/explicit-paths.rs:77:30
+  --> $DIR/explicit-paths.rs:76:30
    |
 LL |         reuse <S2 as Trait>::foo1;
    |                              ^^^^
@@ -120,7 +120,7 @@ LL |         reuse <S2 as Trait>::foo1;
    = note: expected reference `&S2`
               found reference `&S`
 note: method defined here
-  --> $DIR/explicit-paths.rs:6:8
+  --> $DIR/explicit-paths.rs:5:8
    |
 LL |     fn foo1(&self, x: i32) -> i32 { x }
    |        ^^^^ -----

--- a/tests/ui/delegation/fn-header-variadic.rs
+++ b/tests/ui/delegation/fn-header-variadic.rs
@@ -3,7 +3,6 @@
 
 #![feature(c_variadic)]
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub unsafe extern "C" fn variadic_fn(n: usize, mut args: ...) {}

--- a/tests/ui/delegation/fn-header-variadic.stderr
+++ b/tests/ui/delegation/fn-header-variadic.stderr
@@ -1,5 +1,5 @@
 error: delegation to C-variadic functions is not allowed
-  --> $DIR/fn-header-variadic.rs:12:17
+  --> $DIR/fn-header-variadic.rs:11:17
    |
 LL |     pub unsafe extern "C" fn variadic_fn(n: usize, mut args: ...) {}
    |     ------------------------------------------------------------- callee defined here
@@ -8,7 +8,7 @@ LL | reuse to_reuse::variadic_fn;
    |                 ^^^^^^^^^^^
 
 error: delegation to C-variadic functions is not allowed
-  --> $DIR/fn-header-variadic.rs:14:22
+  --> $DIR/fn-header-variadic.rs:13:22
    |
 LL | reuse fn_header_aux::variadic_fn_extern;
    |                      ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/fn-header.rs
+++ b/tests/ui/delegation/fn-header.rs
@@ -5,7 +5,6 @@
 
 #![feature(c_variadic)]
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![deny(unused_unsafe)]
 
 mod to_reuse {

--- a/tests/ui/delegation/foreign-fn.rs
+++ b/tests/ui/delegation/foreign-fn.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(unused_unsafe)]
 

--- a/tests/ui/delegation/foreign-fn.stderr
+++ b/tests/ui/delegation/foreign-fn.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/foreign-fn.rs:17:30
+  --> $DIR/foreign-fn.rs:16:30
    |
 LL |     let _: extern "C" fn() = default_unsafe_foo;
    |            ---------------   ^^^^^^^^^^^^^^^^^^ expected safe fn, found unsafe fn
@@ -11,7 +11,7 @@ LL |     let _: extern "C" fn() = default_unsafe_foo;
    = note: unsafe functions cannot be coerced into safe function pointers
 
 error[E0308]: mismatched types
-  --> $DIR/foreign-fn.rs:19:30
+  --> $DIR/foreign-fn.rs:18:30
    |
 LL |     let _: extern "C" fn() = unsafe_foo;
    |            ---------------   ^^^^^^^^^^ expected safe fn, found unsafe fn

--- a/tests/ui/delegation/generics/const-type-ice-153433.rs
+++ b/tests/ui/delegation/generics/const-type-ice-153433.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 fn main() {
     fn foo<const N: dyn for<'a> Foo>() {}

--- a/tests/ui/delegation/generics/const-type-ice-153433.stderr
+++ b/tests/ui/delegation/generics/const-type-ice-153433.stderr
@@ -1,5 +1,5 @@
 error[E0405]: cannot find trait `Foo` in this scope
-  --> $DIR/const-type-ice-153433.rs:5:33
+  --> $DIR/const-type-ice-153433.rs:4:33
    |
 LL |     fn foo<const N: dyn for<'a> Foo>() {}
    |                                 ^^^ not found in this scope

--- a/tests/ui/delegation/generics/const-type-ice-153499.rs
+++ b/tests/ui/delegation/generics/const-type-ice-153499.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait<'a, T, const F: fn(&CStr) -> usize> {
     //~^ ERROR: cannot find type `CStr` in this scope

--- a/tests/ui/delegation/generics/const-type-ice-153499.stderr
+++ b/tests/ui/delegation/generics/const-type-ice-153499.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find type `CStr` in this scope
-  --> $DIR/const-type-ice-153499.rs:4:33
+  --> $DIR/const-type-ice-153499.rs:3:33
    |
 LL | trait Trait<'a, T, const F: fn(&CStr) -> usize> {
    |                                 ^^^^ not found in this scope
@@ -10,7 +10,7 @@ LL + use std::ffi::CStr;
    |
 
 error: using function pointers as const generic parameters is forbidden
-  --> $DIR/const-type-ice-153499.rs:4:29
+  --> $DIR/const-type-ice-153499.rs:3:29
    |
 LL | trait Trait<'a, T, const F: fn(&CStr) -> usize> {
    |                             ^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL | trait Trait<'a, T, const F: fn(&CStr) -> usize> {
    = note: the only supported types are integers, `bool`, and `char`
 
 error: using function pointers as const generic parameters is forbidden
-  --> $DIR/const-type-ice-153499.rs:10:14
+  --> $DIR/const-type-ice-153499.rs:9:14
    |
 LL | reuse Trait::foo;
    |              ^^^

--- a/tests/ui/delegation/generics/const-type-ice-154334.rs
+++ b/tests/ui/delegation/generics/const-type-ice-154334.rs
@@ -5,6 +5,7 @@
 #![feature(fn_delegation)]
 #![feature(adt_const_params)]
 #![feature(unsized_const_params)]
+
 trait Trait<'a, T, const N: str> {
     fn foo<'v, A, B>(&self) {}
 }

--- a/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.rs
+++ b/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.rs
@@ -1,8 +1,7 @@
 //@ compile-flags: -Z deduplicate-diagnostics=yes
 //@ edition:2024
 
-#![feature(fn_delegation)]
-#![feature(iter_advance_by)]
+#![feature(fn_delegation)]#![feature(iter_advance_by)]
 #![feature(iter_array_chunks)]
 #![feature(iterator_try_collect)]
 #![feature(iterator_try_reduce)]
@@ -15,7 +14,7 @@
 #![feature(iter_partition_in_place)]
 #![feature(trusted_random_access)]
 #![feature(try_find)]
-#![allow(incomplete_features)]
+
 
 impl Iterator {
 //~^ ERROR: expected a type, found a trait [E0782]

--- a/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.stderr
+++ b/tests/ui/delegation/generics/def-path-hash-collision-ice-153410.stderr
@@ -1,11 +1,11 @@
 error[E0575]: expected method or associated constant, found associated type `Iterator::Item`
-  --> $DIR/def-path-hash-collision-ice-153410.rs:22:10
+  --> $DIR/def-path-hash-collision-ice-153410.rs:21:10
    |
 LL |     reuse< < <for<'a> fn()>::Output>::Item as Iterator>::*;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a method or associated constant
 
 error[E0782]: expected a type, found a trait
-  --> $DIR/def-path-hash-collision-ice-153410.rs:20:6
+  --> $DIR/def-path-hash-collision-ice-153410.rs:19:6
    |
 LL | impl Iterator {
    |      ^^^^^^^^
@@ -20,7 +20,7 @@ LL | impl Iterator for /* Type */ {
    |               ++++++++++++++
 
 error[E0223]: ambiguous associated type
-  --> $DIR/def-path-hash-collision-ice-153410.rs:22:14
+  --> $DIR/def-path-hash-collision-ice-153410.rs:21:14
    |
 LL |     reuse< < <for<'a> fn()>::Output>::Item as Iterator>::*;
    |              ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/generics/free-fn-to-free-fn-pass.rs
+++ b/tests/ui/delegation/generics/free-fn-to-free-fn-pass.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn types<T, U>(x: U, y: T) -> (T, U) {

--- a/tests/ui/delegation/generics/free-fn-to-free-fn.rs
+++ b/tests/ui/delegation/generics/free-fn-to-free-fn.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn consts<const N: i32>() -> i32 {

--- a/tests/ui/delegation/generics/free-fn-to-free-fn.stderr
+++ b/tests/ui/delegation/generics/free-fn-to-free-fn.stderr
@@ -1,5 +1,5 @@
 error[E0107]: function takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/free-fn-to-free-fn.rs:19:5
+  --> $DIR/free-fn-to-free-fn.rs:18:5
    |
 LL |     late::<'static>(&0u8);
    |     ^^^^----------- help: remove the unnecessary generics
@@ -7,13 +7,13 @@ LL |     late::<'static>(&0u8);
    |     expected 0 lifetime arguments
    |
 note: function defined here, with 0 lifetime parameters
-  --> $DIR/free-fn-to-free-fn.rs:15:17
+  --> $DIR/free-fn-to-free-fn.rs:14:17
    |
 LL | reuse to_reuse::late;
    |                 ^^^^
 
 error[E0277]: the trait bound `S: Clone` is not satisfied
-  --> $DIR/free-fn-to-free-fn.rs:23:12
+  --> $DIR/free-fn-to-free-fn.rs:22:12
    |
 LL |     bounds(S);
    |     ------ ^ the trait `Clone` is not implemented for `S`
@@ -21,7 +21,7 @@ LL |     bounds(S);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `bounds`
-  --> $DIR/free-fn-to-free-fn.rs:11:22
+  --> $DIR/free-fn-to-free-fn.rs:10:22
    |
 LL |     pub fn bounds<T: Clone>(_: T) {}
    |                      ^^^^^ required by this bound in `bounds`

--- a/tests/ui/delegation/generics/free-fn-to-trait-infer.rs
+++ b/tests/ui/delegation/generics/free-fn-to-trait-infer.rs
@@ -13,8 +13,8 @@ reuse Trait::<_>::foo::<i32> as generic_arguments1;
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
 reuse <u8 as Trait<_>>::foo as generic_arguments2;
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
-//~| ERROR mismatched types
 reuse <_ as Trait<_>>::foo as generic_arguments3;
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+//~| ERROR the placeholder `_` is not allowed within types on item signatures for functions
 
 fn main() {}

--- a/tests/ui/delegation/generics/free-fn-to-trait-infer.rs
+++ b/tests/ui/delegation/generics/free-fn-to-trait-infer.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -Z deduplicate-diagnostics=yes
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait<T> {
     fn foo<U>(&self, _: U, _: T) {}

--- a/tests/ui/delegation/generics/free-fn-to-trait-infer.stderr
+++ b/tests/ui/delegation/generics/free-fn-to-trait-infer.stderr
@@ -1,23 +1,23 @@
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/free-fn-to-trait-infer.rs:12:15
+  --> $DIR/free-fn-to-trait-infer.rs:11:15
    |
 LL | reuse Trait::<_>::foo::<i32> as generic_arguments1;
    |               ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/free-fn-to-trait-infer.rs:14:20
+  --> $DIR/free-fn-to-trait-infer.rs:13:20
    |
 LL | reuse <u8 as Trait<_>>::foo as generic_arguments2;
    |                    ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/free-fn-to-trait-infer.rs:16:8
+  --> $DIR/free-fn-to-trait-infer.rs:15:8
    |
 LL | reuse <_ as Trait<_>>::foo as generic_arguments3;
    |        ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/free-fn-to-trait-infer.rs:16:19
+  --> $DIR/free-fn-to-trait-infer.rs:15:19
    |
 LL | reuse <_ as Trait<_>>::foo as generic_arguments3;
    |                   ^ not allowed in type signatures

--- a/tests/ui/delegation/generics/free-fn-to-trait-infer.stderr
+++ b/tests/ui/delegation/generics/free-fn-to-trait-infer.stderr
@@ -11,29 +11,17 @@ LL | reuse <u8 as Trait<_>>::foo as generic_arguments2;
    |                    ^ not allowed in type signatures
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/free-fn-to-trait-infer.rs:17:19
+  --> $DIR/free-fn-to-trait-infer.rs:16:8
+   |
+LL | reuse <_ as Trait<_>>::foo as generic_arguments3;
+   |        ^ not allowed in type signatures
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/free-fn-to-trait-infer.rs:16:19
    |
 LL | reuse <_ as Trait<_>>::foo as generic_arguments3;
    |                   ^ not allowed in type signatures
 
-error[E0308]: mismatched types
-  --> $DIR/free-fn-to-trait-infer.rs:14:25
-   |
-LL | reuse <u8 as Trait<_>>::foo as generic_arguments2;
-   |                         ^^^
-   |                         |
-   |                         expected `&u8`, found `&Self`
-   |                         arguments to this function are incorrect
-   |
-   = note: expected reference `&u8`
-              found reference `&Self`
-note: method defined here
-  --> $DIR/free-fn-to-trait-infer.rs:7:8
-   |
-LL |     fn foo<U>(&self, _: U, _: T) {}
-   |        ^^^    -----
-
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0121, E0308.
-For more information about an error, try `rustc --explain E0121`.
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/delegation/generics/free-fn-to-trait-method-pass.rs
+++ b/tests/ui/delegation/generics/free-fn-to-trait-method-pass.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod types {
     pub trait Trait<T> {

--- a/tests/ui/delegation/generics/free-fn-to-trait-method.rs
+++ b/tests/ui/delegation/generics/free-fn-to-trait-method.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod default_param {
     pub trait Trait<T = u32> {

--- a/tests/ui/delegation/generics/free-fn-to-trait-method.stderr
+++ b/tests/ui/delegation/generics/free-fn-to-trait-method.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `S: Copy` is not satisfied
-  --> $DIR/free-fn-to-trait-method.rs:39:18
+  --> $DIR/free-fn-to-trait-method.rs:38:18
    |
 LL |     bounds(&0u8, S, U);
    |     ------       ^ the trait `Copy` is not implemented for `S`
@@ -7,7 +7,7 @@ LL |     bounds(&0u8, S, U);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `bounds`
-  --> $DIR/free-fn-to-trait-method.rs:23:54
+  --> $DIR/free-fn-to-trait-method.rs:22:54
    |
 LL |         fn foo<U: Clone>(&self, t: T, u: U) where T: Copy {}
    |                                                      ^^^^ required by this bound in `bounds`
@@ -21,7 +21,7 @@ LL |     struct S;
    |
 
 error[E0277]: the trait bound `U: Clone` is not satisfied
-  --> $DIR/free-fn-to-trait-method.rs:39:21
+  --> $DIR/free-fn-to-trait-method.rs:38:21
    |
 LL |     bounds(&0u8, S, U);
    |     ------          ^ the trait `Clone` is not implemented for `U`
@@ -29,7 +29,7 @@ LL |     bounds(&0u8, S, U);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `bounds`
-  --> $DIR/free-fn-to-trait-method.rs:23:19
+  --> $DIR/free-fn-to-trait-method.rs:22:19
    |
 LL |         fn foo<U: Clone>(&self, t: T, u: U) where T: Copy {}
    |                   ^^^^^ required by this bound in `bounds`

--- a/tests/ui/delegation/generics/free-to-trait-self-reuse.rs
+++ b/tests/ui/delegation/generics/free-to-trait-self-reuse.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Bound<T> {}
 

--- a/tests/ui/delegation/generics/free-to-trait-self-reuse.rs
+++ b/tests/ui/delegation/generics/free-to-trait-self-reuse.rs
@@ -1,0 +1,56 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Bound<T> {}
+
+trait Trait<'a, T, const X: usize>
+where
+    Self: Bound<T> + Sized,
+{
+    fn method<U, const B: bool>(&self, x: U) {}
+    fn method2<U, const B: bool>(self, x: U) {}
+    fn method3<U, const B: bool>(&mut self, x: U) {}
+}
+
+impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+impl<T> Bound<T> for usize {}
+
+reuse <usize as Trait<'static, i32, 123>>::method as foo;
+reuse <usize as Trait<'static, i32, 123>>::method::<String, false> as foo2;
+reuse <usize as Trait>::method as bar;
+reuse <usize as Trait>::method::<Vec<i32>, false> as bar2;
+
+reuse Trait::<'static, i32, 123>::method as foo3;
+reuse Trait::<'static, i32, 123>::method2::<String, false> as foo4;
+reuse Trait::method3 as bar3;
+reuse Trait::method3::<Vec<i32>, false> as bar4;
+
+reuse <String as Trait>::method as error5;
+//~^ ERROR: the trait bound `String: Trait<'a, T, X>` is not satisfied
+
+struct Struct;
+impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+//~^ ERROR: the trait bound `Struct: Bound<T>` is not satisfied
+
+reuse <Struct as Trait>::method as error6;
+//~^ ERROR: the trait bound `Struct: Bound<T>` is not satisfied
+
+fn main() {
+    foo::<&'static str, true>(&123, "");
+    foo2(&123, "".to_string());
+    bar::<'static, i32, 123, String, false>(&123, "".to_string());
+    bar2::<'static, usize, 321>(&123, vec![213, 123]);
+
+    foo3::<String, true>(&123, "".to_string());
+    //~^ ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
+    foo4(123, "".to_string());
+    bar3::<'static, i32, 123, bool, false>(&mut 123, true);
+    //~^ ERROR: function takes 5 generic arguments but 4 generic arguments were supplied
+    bar4::<'static, usize, 321>(&mut 123, vec![123]);
+    //~^ ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
+
+    foo3::<usize, String, true>(&123, "".to_string());
+    foo4::<usize>(123, "".to_string());
+    bar3::<'static, usize, i32, 123, String, false>(&mut 123, "".to_string());
+    bar4::<'static, usize, usize, 321>(&mut 123, vec![123]);
+}

--- a/tests/ui/delegation/generics/free-to-trait-self-reuse.stderr
+++ b/tests/ui/delegation/generics/free-to-trait-self-reuse.stderr
@@ -1,21 +1,21 @@
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-self-reuse.rs:32:49
+  --> $DIR/free-to-trait-self-reuse.rs:31:49
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    |                                                 ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-self-reuse.rs:31:1
+  --> $DIR/free-to-trait-self-reuse.rs:30:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-self-reuse.rs:16:1
+  --> $DIR/free-to-trait-self-reuse.rs:15:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait`
-  --> $DIR/free-to-trait-self-reuse.rs:8:11
+  --> $DIR/free-to-trait-self-reuse.rs:7:11
    |
 LL | trait Trait<'a, T, const X: usize>
    |       ----- required by a bound in this trait
@@ -24,13 +24,13 @@ LL |     Self: Bound<T> + Sized,
    |           ^^^^^^^^ required by this bound in `Trait`
 
 error[E0277]: the trait bound `String: Trait<'a, T, X>` is not satisfied
-  --> $DIR/free-to-trait-self-reuse.rs:28:8
+  --> $DIR/free-to-trait-self-reuse.rs:27:8
    |
 LL | reuse <String as Trait>::method as error5;
    |        ^^^^^^ the trait `Trait<'a, T, X>` is not implemented for `String`
    |
 help: the following other types implement trait `Trait<'a, T, X>`
-  --> $DIR/free-to-trait-self-reuse.rs:15:1
+  --> $DIR/free-to-trait-self-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize`
@@ -39,23 +39,23 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Struct`
 
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-self-reuse.rs:35:8
+  --> $DIR/free-to-trait-self-reuse.rs:34:8
    |
 LL | reuse <Struct as Trait>::method as error6;
    |        ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-self-reuse.rs:31:1
+  --> $DIR/free-to-trait-self-reuse.rs:30:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-self-reuse.rs:16:1
+  --> $DIR/free-to-trait-self-reuse.rs:15:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait::method`
-  --> $DIR/free-to-trait-self-reuse.rs:8:11
+  --> $DIR/free-to-trait-self-reuse.rs:7:11
    |
 LL |     Self: Bound<T> + Sized,
    |           ^^^^^^^^ required by this bound in `Trait::method`
@@ -64,7 +64,7 @@ LL |     fn method<U, const B: bool>(&self, x: U) {}
    |        ------ required by a bound in this associated function
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/free-to-trait-self-reuse.rs:44:5
+  --> $DIR/free-to-trait-self-reuse.rs:43:5
    |
 LL |     foo3::<String, true>(&123, "".to_string());
    |     ^^^^   ------  ---- supplied 2 generic arguments
@@ -72,7 +72,7 @@ LL |     foo3::<String, true>(&123, "".to_string());
    |     expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `Self`, `U`, `B`
-  --> $DIR/free-to-trait-self-reuse.rs:23:45
+  --> $DIR/free-to-trait-self-reuse.rs:22:45
    |
 LL | reuse Trait::<'static, i32, 123>::method as foo3;
    |                                   ------    ^^^^
@@ -82,7 +82,7 @@ LL |     foo3::<String, true, B>(&123, "".to_string());
    |                        +++
 
 error[E0107]: function takes 5 generic arguments but 4 generic arguments were supplied
-  --> $DIR/free-to-trait-self-reuse.rs:47:5
+  --> $DIR/free-to-trait-self-reuse.rs:46:5
    |
 LL |     bar3::<'static, i32, 123, bool, false>(&mut 123, true);
    |     ^^^^            ---  ---  ----  ----- supplied 4 generic arguments
@@ -90,7 +90,7 @@ LL |     bar3::<'static, i32, 123, bool, false>(&mut 123, true);
    |     expected 5 generic arguments
    |
 note: function defined here, with 5 generic parameters: `Self`, `T`, `X`, `U`, `B`
-  --> $DIR/free-to-trait-self-reuse.rs:25:25
+  --> $DIR/free-to-trait-self-reuse.rs:24:25
    |
 LL | reuse Trait::method3 as bar3;
    |              -------    ^^^^
@@ -100,7 +100,7 @@ LL |     bar3::<'static, i32, 123, bool, false, B>(&mut 123, true);
    |                                          +++
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/free-to-trait-self-reuse.rs:49:5
+  --> $DIR/free-to-trait-self-reuse.rs:48:5
    |
 LL |     bar4::<'static, usize, 321>(&mut 123, vec![123]);
    |     ^^^^            -----  --- supplied 2 generic arguments
@@ -108,7 +108,7 @@ LL |     bar4::<'static, usize, 321>(&mut 123, vec![123]);
    |     expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `Self`, `T`, `X`
-  --> $DIR/free-to-trait-self-reuse.rs:26:44
+  --> $DIR/free-to-trait-self-reuse.rs:25:44
    |
 LL | reuse Trait::method3::<Vec<i32>, false> as bar4;
    |              -------                       ^^^^

--- a/tests/ui/delegation/generics/free-to-trait-self-reuse.stderr
+++ b/tests/ui/delegation/generics/free-to-trait-self-reuse.stderr
@@ -1,0 +1,123 @@
+error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
+  --> $DIR/free-to-trait-self-reuse.rs:32:49
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   |                                                 ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Bound<T>` is not implemented for `Struct`
+  --> $DIR/free-to-trait-self-reuse.rs:31:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+help: the trait `Bound<T>` is implemented for `usize`
+  --> $DIR/free-to-trait-self-reuse.rs:16:1
+   |
+LL | impl<T> Bound<T> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Trait`
+  --> $DIR/free-to-trait-self-reuse.rs:8:11
+   |
+LL | trait Trait<'a, T, const X: usize>
+   |       ----- required by a bound in this trait
+LL | where
+LL |     Self: Bound<T> + Sized,
+   |           ^^^^^^^^ required by this bound in `Trait`
+
+error[E0277]: the trait bound `String: Trait<'a, T, X>` is not satisfied
+  --> $DIR/free-to-trait-self-reuse.rs:28:8
+   |
+LL | reuse <String as Trait>::method as error5;
+   |        ^^^^^^ the trait `Trait<'a, T, X>` is not implemented for `String`
+   |
+help: the following other types implement trait `Trait<'a, T, X>`
+  --> $DIR/free-to-trait-self-reuse.rs:15:1
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize`
+...
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Struct`
+
+error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
+  --> $DIR/free-to-trait-self-reuse.rs:35:8
+   |
+LL | reuse <Struct as Trait>::method as error6;
+   |        ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Bound<T>` is not implemented for `Struct`
+  --> $DIR/free-to-trait-self-reuse.rs:31:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+help: the trait `Bound<T>` is implemented for `usize`
+  --> $DIR/free-to-trait-self-reuse.rs:16:1
+   |
+LL | impl<T> Bound<T> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Trait::method`
+  --> $DIR/free-to-trait-self-reuse.rs:8:11
+   |
+LL |     Self: Bound<T> + Sized,
+   |           ^^^^^^^^ required by this bound in `Trait::method`
+LL | {
+LL |     fn method<U, const B: bool>(&self, x: U) {}
+   |        ------ required by a bound in this associated function
+
+error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/free-to-trait-self-reuse.rs:44:5
+   |
+LL |     foo3::<String, true>(&123, "".to_string());
+   |     ^^^^   ------  ---- supplied 2 generic arguments
+   |     |
+   |     expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `Self`, `U`, `B`
+  --> $DIR/free-to-trait-self-reuse.rs:23:45
+   |
+LL | reuse Trait::<'static, i32, 123>::method as foo3;
+   |                                   ------    ^^^^
+help: add missing generic argument
+   |
+LL |     foo3::<String, true, B>(&123, "".to_string());
+   |                        +++
+
+error[E0107]: function takes 5 generic arguments but 4 generic arguments were supplied
+  --> $DIR/free-to-trait-self-reuse.rs:47:5
+   |
+LL |     bar3::<'static, i32, 123, bool, false>(&mut 123, true);
+   |     ^^^^            ---  ---  ----  ----- supplied 4 generic arguments
+   |     |
+   |     expected 5 generic arguments
+   |
+note: function defined here, with 5 generic parameters: `Self`, `T`, `X`, `U`, `B`
+  --> $DIR/free-to-trait-self-reuse.rs:25:25
+   |
+LL | reuse Trait::method3 as bar3;
+   |              -------    ^^^^
+help: add missing generic argument
+   |
+LL |     bar3::<'static, i32, 123, bool, false, B>(&mut 123, true);
+   |                                          +++
+
+error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
+  --> $DIR/free-to-trait-self-reuse.rs:49:5
+   |
+LL |     bar4::<'static, usize, 321>(&mut 123, vec![123]);
+   |     ^^^^            -----  --- supplied 2 generic arguments
+   |     |
+   |     expected 3 generic arguments
+   |
+note: function defined here, with 3 generic parameters: `Self`, `T`, `X`
+  --> $DIR/free-to-trait-self-reuse.rs:26:44
+   |
+LL | reuse Trait::method3::<Vec<i32>, false> as bar4;
+   |              -------                       ^^^^
+help: add missing generic argument
+   |
+LL |     bar4::<'static, usize, 321, X>(&mut 123, vec![123]);
+   |                               +++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0107, E0277.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
@@ -1,0 +1,46 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait Bound<T> {}
+
+trait Trait<'a, T, const X: usize>
+where
+    Self: Bound<T>,
+{
+    fn static_method<'c: 'c, U, const B: bool>(x: usize) {}
+}
+
+impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+impl<T> Bound<T> for usize {}
+
+reuse <usize as Trait<'static, i32, 123>>::static_method as foo { self + 2 }
+reuse <usize as Trait<'static, i32, 123>>::static_method::<'static, String, false> as foo2;
+reuse <usize as Trait>::static_method as bar { self + 1 }
+reuse <usize as Trait>::static_method::<'static, Vec<i32>, false> as bar2;
+
+reuse Trait::static_method as error { self - 123 }
+//~^ ERROR: type annotations needed
+reuse Trait::<'static, i32, 123>::static_method as error2;
+//~^ ERROR: type annotations needed
+reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
+//~^ ERROR: type annotations needed
+reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
+//~^ ERROR: type annotations needed
+
+reuse <String as Trait>::static_method as error5;
+//~^ ERROR: the trait bound `String: Trait<'a, T, X>` is not satisfied
+
+struct Struct;
+impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+//~^ ERROR: the trait bound `Struct: Bound<T>` is not satisfied
+
+reuse <Struct as Trait>::static_method as error6;
+//~^ ERROR: the trait bound `Struct: Bound<T>` is not satisfied
+
+fn main() {
+    foo::<'static, String, true>(123);
+    foo2(123);
+
+    bar::<'static, 'static, i32, 123, String, false>(123);
+    bar2::<'static, usize, 321>(123);
+}

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Bound<T> {}
 

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
@@ -1,21 +1,21 @@
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:34:49
+  --> $DIR/free-to-trait-static-reuse.rs:33:49
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    |                                                 ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-static-reuse.rs:33:1
+  --> $DIR/free-to-trait-static-reuse.rs:32:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-static-reuse.rs:14:1
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait`
-  --> $DIR/free-to-trait-static-reuse.rs:8:11
+  --> $DIR/free-to-trait-static-reuse.rs:7:11
    |
 LL | trait Trait<'a, T, const X: usize>
    |       ----- required by a bound in this trait
@@ -24,13 +24,13 @@ LL |     Self: Bound<T>,
    |           ^^^^^^^^ required by this bound in `Trait`
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:21:14
+  --> $DIR/free-to-trait-static-reuse.rs:20:14
    |
 LL | reuse Trait::static_method as error { self - 123 }
    |              ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:12:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:23:35
+  --> $DIR/free-to-trait-static-reuse.rs:22:35
    |
 LL | reuse Trait::<'static, i32, 123>::static_method as error2;
    |                                   ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:12:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:25:35
+  --> $DIR/free-to-trait-static-reuse.rs:24:35
    |
 LL | reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
    |                                   ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:12:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:27:14
+  --> $DIR/free-to-trait-static-reuse.rs:26:14
    |
 LL | reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
    |              ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:12:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `String: Trait<'a, T, X>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:30:8
+  --> $DIR/free-to-trait-static-reuse.rs:29:8
    |
 LL | reuse <String as Trait>::static_method as error5;
    |        ^^^^^^ the trait `Trait<'a, T, X>` is not implemented for `String`
    |
 help: the following other types implement trait `Trait<'a, T, X>`
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:12:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize`
@@ -99,23 +99,23 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Struct`
 
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:37:8
+  --> $DIR/free-to-trait-static-reuse.rs:36:8
    |
 LL | reuse <Struct as Trait>::static_method as error6;
    |        ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-static-reuse.rs:33:1
+  --> $DIR/free-to-trait-static-reuse.rs:32:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-static-reuse.rs:14:1
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait::static_method`
-  --> $DIR/free-to-trait-static-reuse.rs:8:11
+  --> $DIR/free-to-trait-static-reuse.rs:7:11
    |
 LL |     Self: Bound<T>,
    |           ^^^^^^^^ required by this bound in `Trait::static_method`

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
@@ -1,0 +1,129 @@
+error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
+  --> $DIR/free-to-trait-static-reuse.rs:34:49
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   |                                                 ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Bound<T>` is not implemented for `Struct`
+  --> $DIR/free-to-trait-static-reuse.rs:33:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+help: the trait `Bound<T>` is implemented for `usize`
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
+   |
+LL | impl<T> Bound<T> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Trait`
+  --> $DIR/free-to-trait-static-reuse.rs:8:11
+   |
+LL | trait Trait<'a, T, const X: usize>
+   |       ----- required by a bound in this trait
+LL | where
+LL |     Self: Bound<T>,
+   |           ^^^^^^^^ required by this bound in `Trait`
+
+error[E0283]: type annotations needed
+  --> $DIR/free-to-trait-static-reuse.rs:21:14
+   |
+LL | reuse Trait::static_method as error { self - 123 }
+   |              ^^^^^^^^^^^^^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0283]: type annotations needed
+  --> $DIR/free-to-trait-static-reuse.rs:23:35
+   |
+LL | reuse Trait::<'static, i32, 123>::static_method as error2;
+   |                                   ^^^^^^^^^^^^^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0283]: type annotations needed
+  --> $DIR/free-to-trait-static-reuse.rs:25:35
+   |
+LL | reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
+   |                                   ^^^^^^^^^^^^^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0283]: type annotations needed
+  --> $DIR/free-to-trait-static-reuse.rs:27:14
+   |
+LL | reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
+   |              ^^^^^^^^^^^^^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `String: Trait<'a, T, X>` is not satisfied
+  --> $DIR/free-to-trait-static-reuse.rs:30:8
+   |
+LL | reuse <String as Trait>::static_method as error5;
+   |        ^^^^^^ the trait `Trait<'a, T, X>` is not implemented for `String`
+   |
+help: the following other types implement trait `Trait<'a, T, X>`
+  --> $DIR/free-to-trait-static-reuse.rs:13:1
+   |
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize`
+...
+LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Struct`
+
+error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
+  --> $DIR/free-to-trait-static-reuse.rs:37:8
+   |
+LL | reuse <Struct as Trait>::static_method as error6;
+   |        ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `Bound<T>` is not implemented for `Struct`
+  --> $DIR/free-to-trait-static-reuse.rs:33:1
+   |
+LL | struct Struct;
+   | ^^^^^^^^^^^^^
+help: the trait `Bound<T>` is implemented for `usize`
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
+   |
+LL | impl<T> Bound<T> for usize {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `Trait::static_method`
+  --> $DIR/free-to-trait-static-reuse.rs:8:11
+   |
+LL |     Self: Bound<T>,
+   |           ^^^^^^^^ required by this bound in `Trait::static_method`
+LL | {
+LL |     fn static_method<'c: 'c, U, const B: bool>(x: usize) {}
+   |        ------------- required by a bound in this associated function
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0283.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/delegation/generics/generic-params-defaults.rs
+++ b/tests/ui/delegation/generics/generic-params-defaults.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait<'a, 'b, 'c, A = usize, B = u32, C = String, const N: usize = 123> {
     fn foo<T = usize>(&self) {

--- a/tests/ui/delegation/generics/generic-params-defaults.stderr
+++ b/tests/ui/delegation/generics/generic-params-defaults.stderr
@@ -1,5 +1,5 @@
 error: defaults for generic parameters are not allowed here
-  --> $DIR/generic-params-defaults.rs:5:12
+  --> $DIR/generic-params-defaults.rs:4:12
    |
 LL |     fn foo<T = usize>(&self) {
    |            ^^^^^^^^^
@@ -12,7 +12,7 @@ error: aborting due to 1 previous error
 
 Future incompatibility report: Future breakage diagnostic:
 error: defaults for generic parameters are not allowed here
-  --> $DIR/generic-params-defaults.rs:5:12
+  --> $DIR/generic-params-defaults.rs:4:12
    |
 LL |     fn foo<T = usize>(&self) {
    |            ^^^^^^^^^

--- a/tests/ui/delegation/generics/generic-params-same-names.rs
+++ b/tests/ui/delegation/generics/generic-params-same-names.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {

--- a/tests/ui/delegation/generics/generic-params-same-names.stderr
+++ b/tests/ui/delegation/generics/generic-params-same-names.stderr
@@ -1,5 +1,5 @@
 error[E0496]: lifetime name `'a` shadows a lifetime name that is already in scope
-  --> $DIR/generic-params-same-names.rs:5:12
+  --> $DIR/generic-params-same-names.rs:4:12
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |             -- first declared here
@@ -7,7 +7,7 @@ LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
    |            ^^ lifetime `'a` already in scope
 
 error[E0496]: lifetime name `'b` shadows a lifetime name that is already in scope
-  --> $DIR/generic-params-same-names.rs:5:16
+  --> $DIR/generic-params-same-names.rs:4:16
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |                 -- first declared here
@@ -15,7 +15,7 @@ LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
    |                ^^ lifetime `'b` already in scope
 
 error[E0496]: lifetime name `'c` shadows a lifetime name that is already in scope
-  --> $DIR/generic-params-same-names.rs:5:20
+  --> $DIR/generic-params-same-names.rs:4:20
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |                     -- first declared here
@@ -23,7 +23,7 @@ LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
    |                    ^^ lifetime `'c` already in scope
 
 error[E0403]: the name `A` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/generic-params-same-names.rs:5:24
+  --> $DIR/generic-params-same-names.rs:4:24
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |                         - first use of `A`
@@ -31,7 +31,7 @@ LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
    |                        ^ already used
 
 error[E0403]: the name `B` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/generic-params-same-names.rs:5:27
+  --> $DIR/generic-params-same-names.rs:4:27
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |                            - first use of `B`
@@ -39,7 +39,7 @@ LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
    |                           ^ already used
 
 error[E0403]: the name `C` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/generic-params-same-names.rs:5:30
+  --> $DIR/generic-params-same-names.rs:4:30
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |                               - first use of `C`
@@ -47,7 +47,7 @@ LL |     fn foo<'a, 'b, 'c, A, B, C, const N: usize>(&self) {
    |                              ^ already used
 
 error[E0403]: the name `N` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/generic-params-same-names.rs:5:39
+  --> $DIR/generic-params-same-names.rs:4:39
    |
 LL | trait Trait<'a, 'b, 'c, A, B, C, const N: usize> {
    |                                        - first use of `N`

--- a/tests/ui/delegation/generics/generics-aux-pass.rs
+++ b/tests/ui/delegation/generics/generics-aux-pass.rs
@@ -2,7 +2,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 reuse generics::foo as bar;
 reuse generics::Trait::foo as trait_foo;

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -Z deduplicate-diagnostics=yes
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod test_1 {
     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -1,5 +1,5 @@
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/generics-gen-args-errors.rs:34:21
+  --> $DIR/generics-gen-args-errors.rs:33:21
    |
 LL |     fn check<A, B, C>() {
    |              - type parameter from outer item
@@ -12,7 +12,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/generics-gen-args-errors.rs:34:24
+  --> $DIR/generics-gen-args-errors.rs:33:24
    |
 LL |     fn check<A, B, C>() {
    |                 - type parameter from outer item
@@ -25,7 +25,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/generics-gen-args-errors.rs:34:27
+  --> $DIR/generics-gen-args-errors.rs:33:27
    |
 LL |     fn check<A, B, C>() {
    |                    - type parameter from outer item
@@ -38,7 +38,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0261]: use of undeclared lifetime name `'asdasd`
-  --> $DIR/generics-gen-args-errors.rs:53:29
+  --> $DIR/generics-gen-args-errors.rs:52:29
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |                             ^^^^^^^ undeclared lifetime
@@ -49,7 +49,7 @@ LL |     reuse foo'asdasd, ::<'static, _, 'asdasd, 'static, 'static, 'static, _>
    |              ++++++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generics-gen-args-errors.rs:70:50
+  --> $DIR/generics-gen-args-errors.rs:69:50
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                                                  ^^ undeclared lifetime
@@ -60,7 +60,7 @@ LL |     reuse foo'a, ::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |              +++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/generics-gen-args-errors.rs:117:19
+  --> $DIR/generics-gen-args-errors.rs:116:19
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                   ^^^^^ expected 3 lifetime parameters
@@ -71,7 +71,7 @@ LL |     reuse Trait::<Trait<'a, 'a, 'a>, Clone, _, 'static, dyn Send, _>::foo'a
    |                        ++++++++++++                                      +++
 
 error[E0423]: expected value, found struct `String`
-  --> $DIR/generics-gen-args-errors.rs:14:33
+  --> $DIR/generics-gen-args-errors.rs:13:33
    |
 LL |         bar::<String, String, { String }>();
    |                                 ^^^^^^
@@ -81,7 +81,7 @@ LL |         bar::<String, String, { String }>();
    = note: `String` defined here
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:28:15
+  --> $DIR/generics-gen-args-errors.rs:27:15
    |
 LL |         bar::<asd, asd, asd>();
    |               ^^^ not found in this scope
@@ -92,7 +92,7 @@ LL |     fn check<A, B, C, asd>() {
    |                     +++++
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:28:20
+  --> $DIR/generics-gen-args-errors.rs:27:20
    |
 LL |         bar::<asd, asd, asd>();
    |                    ^^^ not found in this scope
@@ -103,7 +103,7 @@ LL |     fn check<A, B, C, asd>() {
    |                     +++++
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:28:25
+  --> $DIR/generics-gen-args-errors.rs:27:25
    |
 LL |         bar::<asd, asd, asd>();
    |                         ^^^ not found in this scope
@@ -114,73 +114,73 @@ LL |     fn check<A, B, C, asd>() {
    |                     +++++
 
 error[E0425]: cannot find type `asdasd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:57:39
+  --> $DIR/generics-gen-args-errors.rs:56:39
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |                                       ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:65:22
+  --> $DIR/generics-gen-args-errors.rs:64:22
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |                      ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:70:27
+  --> $DIR/generics-gen-args-errors.rs:69:27
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                           ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:85:19
+  --> $DIR/generics-gen-args-errors.rs:84:19
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                   ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:85:24
+  --> $DIR/generics-gen-args-errors.rs:84:24
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                        ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:85:29
+  --> $DIR/generics-gen-args-errors.rs:84:29
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                             ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:85:34
+  --> $DIR/generics-gen-args-errors.rs:84:34
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                  ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:85:39
+  --> $DIR/generics-gen-args-errors.rs:84:39
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                       ^^^ not found in this scope
 
 error[E0425]: cannot find type `asdasa` in this scope
-  --> $DIR/generics-gen-args-errors.rs:85:44
+  --> $DIR/generics-gen-args-errors.rs:84:44
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `DDDD` in this scope
-  --> $DIR/generics-gen-args-errors.rs:110:34
+  --> $DIR/generics-gen-args-errors.rs:109:34
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                  ^^^^ not found in this scope
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:34:15
+  --> $DIR/generics-gen-args-errors.rs:33:15
    |
 LL |         reuse foo::<A, B, C> as xd;
    |               ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:7:8
+  --> $DIR/generics-gen-args-errors.rs:6:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -190,19 +190,19 @@ LL |         reuse foo::<'a, 'b, A, B, C> as xd;
    |                     +++++++
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:46:11
+  --> $DIR/generics-gen-args-errors.rs:45:11
    |
 LL |     reuse foo::<> as bar1;
    |           ^^^ not allowed in type signatures
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:49:11
+  --> $DIR/generics-gen-args-errors.rs:48:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -212,7 +212,7 @@ LL |     reuse foo::<'a, 'b, String, String> as bar2;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:49:11
+  --> $DIR/generics-gen-args-errors.rs:48:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^   ------  ------ supplied 2 generic arguments
@@ -220,7 +220,7 @@ LL |     reuse foo::<String, String> as bar2;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
@@ -230,7 +230,7 @@ LL |     reuse foo::<String, String, N> as bar2;
    |                               +++
 
 error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:53:11
+  --> $DIR/generics-gen-args-errors.rs:52:11
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           ^^^                      --------------------------- help: remove the lifetime arguments
@@ -238,19 +238,19 @@ LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:53:11
+  --> $DIR/generics-gen-args-errors.rs:52:11
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           ^^^ expected 3 generic arguments             -------  - supplied 2 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
@@ -260,7 +260,7 @@ LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _, N> as ba
    |                                                                  +++
 
 error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:57:11
+  --> $DIR/generics-gen-args-errors.rs:56:11
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           ^^^   ------ supplied 1 lifetime argument
@@ -268,7 +268,7 @@ LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -278,13 +278,13 @@ LL |     reuse foo::<String, 'static, 'static, 123, asdasd> as bar4;
    |                       +++++++++
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:61:11
+  --> $DIR/generics-gen-args-errors.rs:60:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -294,7 +294,7 @@ LL |     reuse foo::<'a, 'b, 1, 2, _, 4, 5, _> as bar5;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:61:11
+  --> $DIR/generics-gen-args-errors.rs:60:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^          --------- help: remove the unnecessary generic arguments
@@ -302,19 +302,19 @@ LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:65:11
+  --> $DIR/generics-gen-args-errors.rs:64:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -324,7 +324,7 @@ LL |     reuse foo::<'a, 'b, 1, 2,asd,String, { let x = 0; }> as bar6;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:65:11
+  --> $DIR/generics-gen-args-errors.rs:64:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^           ----------------------- help: remove the unnecessary generic arguments
@@ -332,25 +332,25 @@ LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
 
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:70:17
+  --> $DIR/generics-gen-args-errors.rs:69:17
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                 ^^^^^^^^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:75:11
+  --> $DIR/generics-gen-args-errors.rs:74:11
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:44:8
+  --> $DIR/generics-gen-args-errors.rs:43:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -360,13 +360,13 @@ LL |     reuse foo::<'a, 'b, {}, {}, {}> as bar8;
    |                 +++++++
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:85:11
+  --> $DIR/generics-gen-args-errors.rs:84:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -376,7 +376,7 @@ LL |     reuse Trait::<'b, 'c, 'a, asd, asd, asd, asd, asd, asdasa>::foo as bar1
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:85:11
+  --> $DIR/generics-gen-args-errors.rs:84:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^           ----------------------- help: remove the unnecessary generic arguments
@@ -384,13 +384,13 @@ LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:95:11
+  --> $DIR/generics-gen-args-errors.rs:94:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^   -------  ------- supplied 2 lifetime arguments
@@ -398,7 +398,7 @@ LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -408,19 +408,19 @@ LL |     reuse Trait::<'static, 'static, 'static>::foo as bar2;
    |                                   +++++++++
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:95:11
+  --> $DIR/generics-gen-args-errors.rs:94:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^ not allowed in type signatures
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:98:11
+  --> $DIR/generics-gen-args-errors.rs:97:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -430,7 +430,7 @@ LL |     reuse Trait::<'b, 'c, 'a, 1, 2, 3, 4, 5>::foo as bar3;
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:98:11
+  --> $DIR/generics-gen-args-errors.rs:97:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^       --------- help: remove the unnecessary generic arguments
@@ -438,19 +438,19 @@ LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:102:11
+  --> $DIR/generics-gen-args-errors.rs:101:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -460,7 +460,7 @@ LL |     reuse Trait::<'b, 'c, 'a, 1, 2, true>::foo as bar4;
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:102:11
+  --> $DIR/generics-gen-args-errors.rs:101:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^       ------ help: remove the unnecessary generic argument
@@ -468,13 +468,13 @@ LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:106:11
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^   ------- supplied 1 lifetime argument
@@ -482,7 +482,7 @@ LL |     reuse Trait::<'static>::foo as bar5;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -492,13 +492,13 @@ LL |     reuse Trait::<'static, 'static, 'static>::foo as bar5;
    |                          ++++++++++++++++++
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:106:11
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^ not allowed in type signatures
 
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:110:11
+  --> $DIR/generics-gen-args-errors.rs:109:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^   - supplied 1 lifetime argument
@@ -506,7 +506,7 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -516,7 +516,7 @@ LL |     reuse Trait::<1, 'static, 'static, 2, 'static, DDDD>::foo::<1, 2, 3, 4,
    |                    ++++++++++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:110:11
+  --> $DIR/generics-gen-args-errors.rs:109:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^       --------------- help: remove the unnecessary generic argument
@@ -524,19 +524,19 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:110:41
+  --> $DIR/generics-gen-args-errors.rs:109:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^ expected 1 lifetime argument
    |
 note: method defined here, with 1 lifetime parameter: `'d`
-  --> $DIR/generics-gen-args-errors.rs:82:12
+  --> $DIR/generics-gen-args-errors.rs:81:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^ --
@@ -546,7 +546,7 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<'d, 1, 2, 3, 4, 5, 6> as bar6
    |                                               +++
 
 error[E0107]: method takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:110:41
+  --> $DIR/generics-gen-args-errors.rs:109:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^       ------------ help: remove the unnecessary generic arguments
@@ -554,13 +554,13 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         expected 2 generic arguments
    |
 note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:82:12
+  --> $DIR/generics-gen-args-errors.rs:81:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^         -  -------------
 
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:117:11
+  --> $DIR/generics-gen-args-errors.rs:116:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^   ----- supplied 1 lifetime argument
@@ -568,7 +568,7 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -578,7 +578,7 @@ LL |     reuse Trait::<Trait, 'static, 'static, Clone, _, 'static, dyn Send, _>:
    |                        ++++++++++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:117:11
+  --> $DIR/generics-gen-args-errors.rs:116:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^               --- help: remove the unnecessary generic argument
@@ -586,19 +586,19 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:81:11
+  --> $DIR/generics-gen-args-errors.rs:80:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
 error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:117:59
+  --> $DIR/generics-gen-args-errors.rs:116:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^ expected 1 lifetime argument
    |
 note: method defined here, with 1 lifetime parameter: `'d`
-  --> $DIR/generics-gen-args-errors.rs:82:12
+  --> $DIR/generics-gen-args-errors.rs:81:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^ --
@@ -608,7 +608,7 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<'d, 1, 2, 3
    |                                                                 +++
 
 error[E0107]: method takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:117:59
+  --> $DIR/generics-gen-args-errors.rs:116:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^       --------- help: remove the unnecessary generic arguments
@@ -616,13 +616,13 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |                                                           expected 2 generic arguments
    |
 note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:82:12
+  --> $DIR/generics-gen-args-errors.rs:81:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^         -  -------------
 
 error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:11:9
+  --> $DIR/generics-gen-args-errors.rs:10:9
    |
 LL |         bar::<1, 2, 3, 4, 5, 6>();
    |         ^^^          --------- help: remove the unnecessary generic arguments
@@ -630,13 +630,13 @@ LL |         bar::<1, 2, 3, 4, 5, 6>();
    |         expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:8:18
+  --> $DIR/generics-gen-args-errors.rs:7:18
    |
 LL |     reuse foo as bar;
    |           ---    ^^^
 
 error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:17:9
+  --> $DIR/generics-gen-args-errors.rs:16:9
    |
 LL |         bar::<'static, 'static, 'static, 'static, 'static>();
    |         ^^^                   --------------------------- help: remove the lifetime arguments
@@ -644,19 +644,19 @@ LL |         bar::<'static, 'static, 'static, 'static, 'static>();
    |         expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:8:18
+  --> $DIR/generics-gen-args-errors.rs:7:18
    |
 LL |     reuse foo as bar;
    |           ---    ^^^
 
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:20:23
+  --> $DIR/generics-gen-args-errors.rs:19:23
    |
 LL |         bar::<String, 1, 'static, i32, 'static>();
    |                       ^
 
 error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:25:9
+  --> $DIR/generics-gen-args-errors.rs:24:9
    |
 LL |         bar::<_, _, _, _, _>();
    |         ^^^          ------ help: remove the unnecessary generic arguments
@@ -664,13 +664,13 @@ LL |         bar::<_, _, _, _, _>();
    |         expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:8:18
+  --> $DIR/generics-gen-args-errors.rs:7:18
    |
 LL |     reuse foo as bar;
    |           ---    ^^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/generics-gen-args-errors.rs:28:25
+  --> $DIR/generics-gen-args-errors.rs:27:25
    |
 LL |         bar::<asd, asd, asd>();
    |                         ^^^
@@ -681,7 +681,7 @@ LL |         bar::<asd, asd, { asd }>();
    |                         +     +
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/generics-gen-args-errors.rs:34:27
+  --> $DIR/generics-gen-args-errors.rs:33:27
    |
 LL |         reuse foo::<A, B, C> as xd;
    |                           ^
@@ -692,7 +692,7 @@ LL |         reuse foo::<A, B, { C }> as xd;
    |                           +   +
 
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:75:17
+  --> $DIR/generics-gen-args-errors.rs:74:17
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |                 ^^

--- a/tests/ui/delegation/generics/impl-to-free-fn-pass.rs
+++ b/tests/ui/delegation/generics/impl-to-free-fn-pass.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn foo<T, U>(_: T, y: U) -> U { y }

--- a/tests/ui/delegation/generics/impl-to-trait-method.rs
+++ b/tests/ui/delegation/generics/impl-to-trait-method.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod bounds {
     trait Trait0 {}

--- a/tests/ui/delegation/generics/impl-to-trait-method.stderr
+++ b/tests/ui/delegation/generics/impl-to-trait-method.stderr
@@ -1,16 +1,16 @@
 error[E0277]: the trait bound `bounds::S: Trait0` is not satisfied
-  --> $DIR/impl-to-trait-method.rs:12:19
+  --> $DIR/impl-to-trait-method.rs:11:19
    |
 LL |             Self: Trait0,
    |                   ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Trait0` is not implemented for `bounds::S`
-  --> $DIR/impl-to-trait-method.rs:21:5
+  --> $DIR/impl-to-trait-method.rs:20:5
    |
 LL |     struct S(F);
    |     ^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/impl-to-trait-method.rs:5:5
+  --> $DIR/impl-to-trait-method.rs:4:5
    |
 LL |     trait Trait0 {}
    |     ^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL + #![feature(trivial_bounds)]
    |
 
 error[E0277]: the trait bound `bounds::F: Trait0` is not satisfied
-  --> $DIR/impl-to-trait-method.rs:24:34
+  --> $DIR/impl-to-trait-method.rs:23:34
    |
 LL |         reuse Trait1::<T>::foo { &self.0 }
    |                            ---   ^^^^^^^ unsatisfied trait bound
@@ -28,17 +28,17 @@ LL |         reuse Trait1::<T>::foo { &self.0 }
    |                            required by a bound introduced by this call
    |
 help: the trait `Trait0` is not implemented for `bounds::F`
-  --> $DIR/impl-to-trait-method.rs:18:5
+  --> $DIR/impl-to-trait-method.rs:17:5
    |
 LL |     struct F;
    |     ^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/impl-to-trait-method.rs:5:5
+  --> $DIR/impl-to-trait-method.rs:4:5
    |
 LL |     trait Trait0 {}
    |     ^^^^^^^^^^^^
 note: required by a bound in `Trait1::foo`
-  --> $DIR/impl-to-trait-method.rs:12:19
+  --> $DIR/impl-to-trait-method.rs:11:19
    |
 LL |         fn foo<U>(&self)
    |            --- required by a bound in this associated function
@@ -47,7 +47,7 @@ LL |             Self: Trait0,
    |                   ^^^^^^ required by this bound in `Trait1::foo`
 
 error[E0282]: type annotations needed
-  --> $DIR/impl-to-trait-method.rs:39:22
+  --> $DIR/impl-to-trait-method.rs:38:22
    |
 LL |         reuse Trait::foo { &self.0 }
    |                      ^^^ cannot infer type for type parameter `T` declared on the trait `Trait`

--- a/tests/ui/delegation/generics/impl-trait-to-trait-method-pass.rs
+++ b/tests/ui/delegation/generics/impl-trait-to-trait-method-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 use std::iter::{Iterator, Map};
 

--- a/tests/ui/delegation/generics/inherent-impl-to-trait-method-pass.rs
+++ b/tests/ui/delegation/generics/inherent-impl-to-trait-method-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait<T> {
     fn foo<U>(&self, x: T, y: U) -> (T, U) {

--- a/tests/ui/delegation/generics/mapping/free-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-free-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/free-to-trait-pass.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-trait-pass.rs
@@ -171,14 +171,14 @@ mod test_10 {
     pub fn check() {
         fn with_ctx<'a, 'b, 'c, A, B, C, const N: usize, const M: bool>() {
             reuse <u8 as Trait>::foo as bar;
-            bar::<'a, 'b, 'c, u8, C, A, M>();
-            bar::<'static, 'static, 'static, u8, i32, i32, false>();
+            bar::<'a, 'b, 'c, C, A, M>();
+            bar::<'static, 'static, 'static, i32, i32, false>();
 
             reuse <u8 as Trait::<'static, 'static, i32>>::foo as bar1;
-            bar1::<'static, u8, i32, true>();
+            bar1::<'static, i32, true>();
 
             reuse <u8 as Trait::<'static, 'static, i32>>::foo::<'static, u32, true> as bar2;
-            bar2::<u8>();
+            bar2();
         }
 
         with_ctx::<i32, i32, i32, 1, true>();
@@ -211,7 +211,7 @@ mod test_11 {
 
     pub fn check<'b>() {
         reuse <usize as Trait>::foo;
-        foo::<'static, 'b, usize, u32, Struct, String, false>();
+        foo::<'static, 'b, u32, Struct, String, false>();
     }
 }
 

--- a/tests/ui/delegation/generics/mapping/free-to-trait-pass.rs
+++ b/tests/ui/delegation/generics/mapping/free-to-trait-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/impl-trait-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/impl-trait-to-free-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child

--- a/tests/ui/delegation/generics/mapping/impl-trait-to-trait-pass.rs
+++ b/tests/ui/delegation/generics/mapping/impl-trait-to-trait-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-free-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/inherent-impl-to-trait-pass.rs
+++ b/tests/ui/delegation/generics/mapping/inherent-impl-to-trait-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child

--- a/tests/ui/delegation/generics/mapping/trait-to-free-pass.rs
+++ b/tests/ui/delegation/generics/mapping/trait-to-free-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child
 //! generic params, whose main goal is to create cases with

--- a/tests/ui/delegation/generics/mapping/trait-to-trait-pass.rs
+++ b/tests/ui/delegation/generics/mapping/trait-to-trait-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![allow(late_bound_lifetime_arguments)]
 
 //! This is one of the mapping tests, which tests mapping of delegee parent and child

--- a/tests/ui/delegation/generics/stability-implications-non-local-defid.rs
+++ b/tests/ui/delegation/generics/stability-implications-non-local-defid.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![feature(staged_api)]
 #![unstable(feature = "foo", issue = "none")]
 

--- a/tests/ui/delegation/generics/synth-params-ice-143498.rs
+++ b/tests/ui/delegation/generics/synth-params-ice-143498.rs
@@ -15,7 +15,6 @@
 #![feature(iter_partition_in_place)]
 #![feature(trusted_random_access)]
 #![feature(try_find)]
-#![allow(incomplete_features)]
 
 impl X {
 //~^ ERROR: cannot find type `X` in this scope

--- a/tests/ui/delegation/generics/synth-params-ice-143498.stderr
+++ b/tests/ui/delegation/generics/synth-params-ice-143498.stderr
@@ -1,17 +1,17 @@
 error[E0425]: cannot find type `X` in this scope
-  --> $DIR/synth-params-ice-143498.rs:20:6
+  --> $DIR/synth-params-ice-143498.rs:19:6
    |
 LL | impl X {
    |      ^ not found in this scope
 
 error[E0575]: expected method or associated constant, found associated type `Iterator::Item`
-  --> $DIR/synth-params-ice-143498.rs:22:10
+  --> $DIR/synth-params-ice-143498.rs:21:10
    |
 LL |     reuse< std::fmt::Debug as Iterator >::*;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a method or associated constant
 
 error[E0782]: expected a type, found a trait
-  --> $DIR/synth-params-ice-143498.rs:22:12
+  --> $DIR/synth-params-ice-143498.rs:21:12
    |
 LL |     reuse< std::fmt::Debug as Iterator >::*;
    |            ^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/generics/synth-params-ice-154780.rs
+++ b/tests/ui/delegation/generics/synth-params-ice-154780.rs
@@ -36,8 +36,8 @@ mod test_2 {
     reuse <X as Trait>::bar as bar2;
 
     pub fn check() {
-        assert_eq!(foo2::<'static, 'static, X, (), true, false, (), ()>(X, || 123), 123);
-        assert_eq!(bar2::<'static, X, (), true>(X, || 123), 123);
+        assert_eq!(foo2::<'static, 'static, (), true, false, (), ()>(X, || 123), 123);
+        assert_eq!(bar2::<'static, (), true>(X, || 123), 123);
     }
 }
 

--- a/tests/ui/delegation/generics/trait-impl-wrong-args-count.rs
+++ b/tests/ui/delegation/generics/trait-impl-wrong-args-count.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 // Testing delegation from trait impl to free functions.
 mod test_1 {

--- a/tests/ui/delegation/generics/trait-impl-wrong-args-count.stderr
+++ b/tests/ui/delegation/generics/trait-impl-wrong-args-count.stderr
@@ -1,5 +1,5 @@
 error[E0107]: function takes at most 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/trait-impl-wrong-args-count.rs:25:25
+  --> $DIR/trait-impl-wrong-args-count.rs:24:25
    |
 LL |         reuse to_reuse::bar;
    |                         ^^^
@@ -8,31 +8,31 @@ LL |         reuse to_reuse::bar;
    |                         help: remove the unnecessary generic argument
    |
 note: function defined here, with at most 2 generic parameters: `A`, `B`
-  --> $DIR/trait-impl-wrong-args-count.rs:7:16
+  --> $DIR/trait-impl-wrong-args-count.rs:6:16
    |
 LL |         pub fn bar<'a: 'a, 'b: 'b, A, B>(x: &super::XX) {}
    |                ^^^                 -  -
 
 error[E0107]: function takes 0 generic arguments but 3 generic arguments were supplied
-  --> $DIR/trait-impl-wrong-args-count.rs:28:25
+  --> $DIR/trait-impl-wrong-args-count.rs:27:25
    |
 LL |         reuse to_reuse::bar1;
    |                         ^^^^ expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
-  --> $DIR/trait-impl-wrong-args-count.rs:8:16
+  --> $DIR/trait-impl-wrong-args-count.rs:7:16
    |
 LL |         pub fn bar1(x: &super::XX) {}
    |                ^^^^
 
 error[E0284]: type annotations needed
-  --> $DIR/trait-impl-wrong-args-count.rs:31:25
+  --> $DIR/trait-impl-wrong-args-count.rs:30:25
    |
 LL |         reuse to_reuse::bar2;
    |                         ^^^^ cannot infer the value of the const parameter `X` declared on the function `bar2`
    |
 note: required by a const generic parameter in `bar2`
-  --> $DIR/trait-impl-wrong-args-count.rs:9:39
+  --> $DIR/trait-impl-wrong-args-count.rs:8:39
    |
 LL |         pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
    |                                       ^^^^^^^^^^^^^^ required by this const generic parameter in `bar2`
@@ -42,13 +42,13 @@ LL |         reuse to_reuse::bar2::<A, B, C, D, E, F, X, Y>;
    |                             ++++++++++++++++++++++++++
 
 error[E0284]: type annotations needed
-  --> $DIR/trait-impl-wrong-args-count.rs:31:25
+  --> $DIR/trait-impl-wrong-args-count.rs:30:25
    |
 LL |         reuse to_reuse::bar2;
    |                         ^^^^ cannot infer the value of the const parameter `Y` declared on the function `bar2`
    |
 note: required by a const generic parameter in `bar2`
-  --> $DIR/trait-impl-wrong-args-count.rs:9:55
+  --> $DIR/trait-impl-wrong-args-count.rs:8:55
    |
 LL |         pub fn bar2<A, B, C, D, E, F, const X: usize, const Y: bool>(x: &super::XX) {}
    |                                                       ^^^^^^^^^^^^^ required by this const generic parameter in `bar2`
@@ -58,13 +58,13 @@ LL |         reuse to_reuse::bar2::<A, B, C, D, E, F, X, Y>;
    |                             ++++++++++++++++++++++++++
 
 error[E0107]: missing generics for trait `test_2::Trait1`
-  --> $DIR/trait-impl-wrong-args-count.rs:61:21
+  --> $DIR/trait-impl-wrong-args-count.rs:60:21
    |
 LL |         reuse <X as Trait1>::bar;
    |                     ^^^^^^ expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/trait-impl-wrong-args-count.rs:52:11
+  --> $DIR/trait-impl-wrong-args-count.rs:51:11
    |
 LL |     trait Trait1<A, B> {
    |           ^^^^^^ -  -
@@ -74,13 +74,13 @@ LL |         reuse <X as Trait1<A, B>>::bar;
    |                           ++++++
 
 error[E0107]: missing generics for trait `test_2::Trait1`
-  --> $DIR/trait-impl-wrong-args-count.rs:68:21
+  --> $DIR/trait-impl-wrong-args-count.rs:67:21
    |
 LL |         reuse <X as Trait1>::bar::<'static, u32, u32, 1> as bar3;
    |                     ^^^^^^ expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/trait-impl-wrong-args-count.rs:52:11
+  --> $DIR/trait-impl-wrong-args-count.rs:51:11
    |
 LL |     trait Trait1<A, B> {
    |           ^^^^^^ -  -
@@ -90,13 +90,13 @@ LL |         reuse <X as Trait1<A, B>>::bar::<'static, u32, u32, 1> as bar3;
    |                           ++++++
 
 error[E0107]: missing generics for trait `test_2::Trait1`
-  --> $DIR/trait-impl-wrong-args-count.rs:71:21
+  --> $DIR/trait-impl-wrong-args-count.rs:70:21
    |
 LL |         reuse <X as Trait1>::bar as bar4;
    |                     ^^^^^^ expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/trait-impl-wrong-args-count.rs:52:11
+  --> $DIR/trait-impl-wrong-args-count.rs:51:11
    |
 LL |     trait Trait1<A, B> {
    |           ^^^^^^ -  -
@@ -106,37 +106,37 @@ LL |         reuse <X as Trait1<A, B>>::bar as bar4;
    |                           ++++++
 
 error[E0107]: associated function takes 0 generic arguments but 3 generic arguments were supplied
-  --> $DIR/trait-impl-wrong-args-count.rs:96:40
+  --> $DIR/trait-impl-wrong-args-count.rs:95:40
    |
 LL |         reuse <X as Trait1::<(), ()>>::bar;
    |                                        ^^^ expected 0 generic arguments
    |
 note: associated function defined here, with 0 generic parameters
-  --> $DIR/trait-impl-wrong-args-count.rs:87:12
+  --> $DIR/trait-impl-wrong-args-count.rs:86:12
    |
 LL |         fn bar() {}
    |            ^^^
 
 error[E0107]: associated function takes 0 generic arguments but 3 generic arguments were supplied
-  --> $DIR/trait-impl-wrong-args-count.rs:99:40
+  --> $DIR/trait-impl-wrong-args-count.rs:98:40
    |
 LL |         reuse <X as Trait1::<(), ()>>::bar as bar1;
    |                                        ^^^ expected 0 generic arguments
    |
 note: associated function defined here, with 0 generic parameters
-  --> $DIR/trait-impl-wrong-args-count.rs:87:12
+  --> $DIR/trait-impl-wrong-args-count.rs:86:12
    |
 LL |         fn bar() {}
    |            ^^^
 
 error[E0282]: type annotations needed
-  --> $DIR/trait-impl-wrong-args-count.rs:102:40
+  --> $DIR/trait-impl-wrong-args-count.rs:101:40
    |
 LL |         reuse <X as Trait1::<(), ()>>::foo as bar2;
    |                                        ^^^ cannot infer type of the type parameter `X` declared on the associated function `foo`
 
 error[E0107]: associated function takes at most 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/trait-impl-wrong-args-count.rs:105:40
+  --> $DIR/trait-impl-wrong-args-count.rs:104:40
    |
 LL |         reuse <X as Trait1::<(), ()>>::foo as bar3;
    |                                        ^^^
@@ -145,7 +145,7 @@ LL |         reuse <X as Trait1::<(), ()>>::foo as bar3;
    |                                        help: remove the unnecessary generic argument
    |
 note: associated function defined here, with at most 2 generic parameters: `X`, `Y`
-  --> $DIR/trait-impl-wrong-args-count.rs:88:12
+  --> $DIR/trait-impl-wrong-args-count.rs:87:12
    |
 LL |         fn foo<X, Y>() {}
    |            ^^^ -  -

--- a/tests/ui/delegation/generics/trait-method-to-other-pass.rs
+++ b/tests/ui/delegation/generics/trait-method-to-other-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn foo<T>(x: T) -> T { x }

--- a/tests/ui/delegation/generics/unresolved-segment-ice-153389.rs
+++ b/tests/ui/delegation/generics/unresolved-segment-ice-153389.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait{
     fn bar();

--- a/tests/ui/delegation/generics/unresolved-segment-ice-153389.stderr
+++ b/tests/ui/delegation/generics/unresolved-segment-ice-153389.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find function `missing` in this scope
-  --> $DIR/unresolved-segment-ice-153389.rs:9:11
+  --> $DIR/unresolved-segment-ice-153389.rs:8:11
    |
 LL |     reuse missing::<> as bar;
    |           ^^^^^^^ not found in this scope

--- a/tests/ui/delegation/glob-bad-path.rs
+++ b/tests/ui/delegation/glob-bad-path.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {}
 struct S;

--- a/tests/ui/delegation/glob-bad-path.stderr
+++ b/tests/ui/delegation/glob-bad-path.stderr
@@ -1,11 +1,11 @@
 error: expected trait, found struct `S`
-  --> $DIR/glob-bad-path.rs:9:11
+  --> $DIR/glob-bad-path.rs:8:11
    |
 LL |     reuse S::*;
    |           ^ not a trait
 
 error[E0433]: cannot find module or crate `unresolved` in this scope
-  --> $DIR/glob-bad-path.rs:8:11
+  --> $DIR/glob-bad-path.rs:7:11
    |
 LL |     reuse unresolved::*;
    |           ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`

--- a/tests/ui/delegation/glob-glob-conflict.rs
+++ b/tests/ui/delegation/glob-glob-conflict.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait1 {
     fn method(&self) -> u8;

--- a/tests/ui/delegation/glob-glob-conflict.stderr
+++ b/tests/ui/delegation/glob-glob-conflict.stderr
@@ -1,5 +1,5 @@
 error[E0201]: duplicate definitions with name `method`:
-  --> $DIR/glob-glob-conflict.rs:27:5
+  --> $DIR/glob-glob-conflict.rs:26:5
    |
 LL |     fn method(&self) -> u8;
    |     ----------------------- item in trait
@@ -10,7 +10,7 @@ LL |     reuse Trait2::*;
    |     ^^^^^^^^^^^^^^^^ duplicate definition
 
 error[E0201]: duplicate definitions with name `method`:
-  --> $DIR/glob-glob-conflict.rs:33:5
+  --> $DIR/glob-glob-conflict.rs:32:5
    |
 LL |     fn method(&self) -> u8;
    |     ----------------------- item in trait
@@ -21,13 +21,13 @@ LL |     reuse Trait1::*;
    |     ^^^^^^^^^^^^^^^^ duplicate definition
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> $DIR/glob-glob-conflict.rs:27:19
+  --> $DIR/glob-glob-conflict.rs:26:19
    |
 LL |     reuse Trait2::*;
    |                   ^ argument #1 of type `&_` is missing
    |
 note: method defined here
-  --> $DIR/glob-glob-conflict.rs:8:8
+  --> $DIR/glob-glob-conflict.rs:7:8
    |
 LL |     fn method(&self) -> u8;
    |        ^^^^^^  ----
@@ -37,7 +37,7 @@ LL |     reuse Trait2::*(/* value */);
    |                    +++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/glob-glob-conflict.rs:27:19
+  --> $DIR/glob-glob-conflict.rs:26:19
    |
 LL |     reuse Trait2::*;
    |                   ^- help: consider using a semicolon here: `;`
@@ -46,13 +46,13 @@ LL |     reuse Trait2::*;
    |                   expected `()` because of default return type
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> $DIR/glob-glob-conflict.rs:33:19
+  --> $DIR/glob-glob-conflict.rs:32:19
    |
 LL |     reuse Trait1::*;
    |                   ^ argument #1 of type `&_` is missing
    |
 note: method defined here
-  --> $DIR/glob-glob-conflict.rs:5:8
+  --> $DIR/glob-glob-conflict.rs:4:8
    |
 LL |     fn method(&self) -> u8;
    |        ^^^^^^  ----
@@ -62,7 +62,7 @@ LL |     reuse Trait1::*(/* value */);
    |                    +++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/glob-glob-conflict.rs:33:19
+  --> $DIR/glob-glob-conflict.rs:32:19
    |
 LL |     reuse Trait1::*;
    |                   ^- help: consider using a semicolon here: `;`

--- a/tests/ui/delegation/glob-glob.rs
+++ b/tests/ui/delegation/glob-glob.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod inner {
     pub trait TraitFoo {

--- a/tests/ui/delegation/glob-non-fn.rs
+++ b/tests/ui/delegation/glob-non-fn.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn method(&self);

--- a/tests/ui/delegation/glob-non-fn.stderr
+++ b/tests/ui/delegation/glob-non-fn.stderr
@@ -1,5 +1,5 @@
 error[E0324]: item `CONST` is an associated method, which doesn't match its trait `Trait`
-  --> $DIR/glob-non-fn.rs:30:5
+  --> $DIR/glob-non-fn.rs:29:5
    |
 LL |     const CONST: u8;
    |     ---------------- item in trait
@@ -8,7 +8,7 @@ LL |     reuse Trait::* { &self.0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0324]: item `Type` is an associated method, which doesn't match its trait `Trait`
-  --> $DIR/glob-non-fn.rs:30:5
+  --> $DIR/glob-non-fn.rs:29:5
    |
 LL |     type Type;
    |     ---------- item in trait
@@ -17,7 +17,7 @@ LL |     reuse Trait::* { &self.0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0201]: duplicate definitions with name `method`:
-  --> $DIR/glob-non-fn.rs:30:5
+  --> $DIR/glob-non-fn.rs:29:5
    |
 LL |     fn method(&self);
    |     ----------------- item in trait
@@ -29,19 +29,19 @@ LL |     reuse Trait::* { &self.0 }
    |     previous definition here
 
 error[E0423]: expected function, found associated constant `Trait::CONST`
-  --> $DIR/glob-non-fn.rs:30:11
+  --> $DIR/glob-non-fn.rs:29:11
    |
 LL |     reuse Trait::* { &self.0 }
    |           ^^^^^ not a function
 
 error[E0423]: expected function, found associated type `Trait::Type`
-  --> $DIR/glob-non-fn.rs:30:11
+  --> $DIR/glob-non-fn.rs:29:11
    |
 LL |     reuse Trait::* { &self.0 }
    |           ^^^^^ not a function
 
 error[E0046]: not all trait items implemented, missing: `CONST`, `Type`, `method`
-  --> $DIR/glob-non-fn.rs:29:1
+  --> $DIR/glob-non-fn.rs:28:1
    |
 LL |     const CONST: u8;
    |     --------------- `CONST` from trait

--- a/tests/ui/delegation/glob-non-impl.rs
+++ b/tests/ui/delegation/glob-non-impl.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn method() {}

--- a/tests/ui/delegation/glob-non-impl.stderr
+++ b/tests/ui/delegation/glob-non-impl.stderr
@@ -1,23 +1,23 @@
 error: delegation is not supported in `extern` blocks
-  --> $DIR/glob-non-impl.rs:15:5
+  --> $DIR/glob-non-impl.rs:14:5
    |
 LL |     reuse Trait::*;
    |     ^^^^^^^^^^^^^^^
 
 error: glob delegation is only supported in impls
-  --> $DIR/glob-non-impl.rs:8:1
+  --> $DIR/glob-non-impl.rs:7:1
    |
 LL | reuse Trait::*;
    | ^^^^^^^^^^^^^^^
 
 error: glob delegation is only supported in impls
-  --> $DIR/glob-non-impl.rs:11:5
+  --> $DIR/glob-non-impl.rs:10:5
    |
 LL |     reuse Trait::*;
    |     ^^^^^^^^^^^^^^^
 
 error: glob delegation is only supported in impls
-  --> $DIR/glob-non-impl.rs:19:5
+  --> $DIR/glob-non-impl.rs:18:5
    |
 LL |     reuse Trait::*;
    |     ^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/glob-override.rs
+++ b/tests/ui/delegation/glob-override.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) -> u8;

--- a/tests/ui/delegation/glob-traitless-qpath.rs
+++ b/tests/ui/delegation/glob-traitless-qpath.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 struct S;
 

--- a/tests/ui/delegation/glob-traitless-qpath.stderr
+++ b/tests/ui/delegation/glob-traitless-qpath.stderr
@@ -1,11 +1,11 @@
 error: qualified path without a trait in glob delegation
-  --> $DIR/glob-traitless-qpath.rs:7:5
+  --> $DIR/glob-traitless-qpath.rs:6:5
    |
 LL |     reuse <u8>::*;
    |     ^^^^^^^^^^^^^^
 
 error: qualified path without a trait in glob delegation
-  --> $DIR/glob-traitless-qpath.rs:8:5
+  --> $DIR/glob-traitless-qpath.rs:7:5
    |
 LL |     reuse <()>::*;
    |     ^^^^^^^^^^^^^^

--- a/tests/ui/delegation/glob.rs
+++ b/tests/ui/delegation/glob.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) -> u8;

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155125.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `foo` is defined multiple times
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:13:17
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:12:17
    |
 LL |                 fn foo() {}
    |                 -------- previous definition of the value `foo` here
@@ -9,7 +9,7 @@ LL |                 reuse foo;
    = note: `foo` must be defined only once in the value namespace of this block
 
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:11:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:10:13
    |
 LL | /             {
 LL | |                 fn foo() {}

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155127.stderr
@@ -1,5 +1,5 @@
 error: `#[deprecated]` attribute cannot be used on delegations
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:27:9
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:26:9
    |
 LL |         #[deprecated]
    |         ^^^^^^^^^^^^^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:37:11
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:36:11
    |
 LL |       reuse a as b {
    |  ___________^______-
@@ -9,7 +9,7 @@ LL | |     }
    | |_____- unexpected argument of type `fn() {foo::<_>}`
    |
 note: function defined here
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:35:8
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:34:8
    |
 LL |     fn a() {}
    |        ^

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
@@ -1,5 +1,5 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:47:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:46:13
    |
 LL | /             {
 LL | |

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find value `async` in this scope
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:65:13
    |
 LL |             async || {};
    |             ^^^^^ not found in this scope
 
 error[E0308]: mismatched types
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:22
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:65:22
    |
 LL |             async || {};
    |                      ^^ expected `bool`, found `()`

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -1,7 +1,6 @@
 //@ revisions: ice_155125 ice_155127 ice_155128 ice_155164 ice_155202
 
 #![feature(min_generic_const_args, fn_delegation)]
-#![allow(incomplete_features)]
 
 #[cfg(ice_155125)]
 mod ice_155125 {

--- a/tests/ui/delegation/ice-isssue-128190.rs
+++ b/tests/ui/delegation/ice-isssue-128190.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 fn a(&self) {}
 //~^ ERROR `self` parameter is only allowed in associated functions

--- a/tests/ui/delegation/ice-isssue-128190.stderr
+++ b/tests/ui/delegation/ice-isssue-128190.stderr
@@ -1,5 +1,5 @@
 error: `self` parameter is only allowed in associated functions
-  --> $DIR/ice-isssue-128190.rs:4:6
+  --> $DIR/ice-isssue-128190.rs:3:6
    |
 LL | fn a(&self) {}
    |      ^^^^^ not semantically valid as function parameter

--- a/tests/ui/delegation/ice-issue-122550.rs
+++ b/tests/ui/delegation/ice-issue-122550.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn description(&self) -> &str {}

--- a/tests/ui/delegation/ice-issue-122550.stderr
+++ b/tests/ui/delegation/ice-issue-122550.stderr
@@ -1,28 +1,28 @@
 error[E0308]: mismatched types
-  --> $DIR/ice-issue-122550.rs:5:35
+  --> $DIR/ice-issue-122550.rs:4:35
    |
 LL |     fn description(&self) -> &str {}
    |                                   ^^ expected `&str`, found `()`
 
 error[E0277]: the trait bound `S: Trait` is not satisfied
-  --> $DIR/ice-issue-122550.rs:13:12
+  --> $DIR/ice-issue-122550.rs:12:12
    |
 LL |     reuse <S as Trait>::description { &self.0 }
    |            ^ unsatisfied trait bound
    |
 help: the trait `Trait` is not implemented for `S`
-  --> $DIR/ice-issue-122550.rs:10:1
+  --> $DIR/ice-issue-122550.rs:9:1
    |
 LL | struct S(F);
    | ^^^^^^^^
 help: this trait has no implementations, consider adding one
-  --> $DIR/ice-issue-122550.rs:4:1
+  --> $DIR/ice-issue-122550.rs:3:1
    |
 LL | trait Trait {
    | ^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/ice-issue-122550.rs:13:39
+  --> $DIR/ice-issue-122550.rs:12:39
    |
 LL |     reuse <S as Trait>::description { &self.0 }
    |                         -----------   ^^^^^^^ expected `&S`, found `&F`
@@ -32,7 +32,7 @@ LL |     reuse <S as Trait>::description { &self.0 }
    = note: expected reference `&S`
               found reference `&F`
 note: method defined here
-  --> $DIR/ice-issue-122550.rs:5:8
+  --> $DIR/ice-issue-122550.rs:4:8
    |
 LL |     fn description(&self) -> &str {}
    |        ^^^^^^^^^^^ -----

--- a/tests/ui/delegation/ice-issue-124342.rs
+++ b/tests/ui/delegation/ice-issue-124342.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {}
 

--- a/tests/ui/delegation/ice-issue-124342.stderr
+++ b/tests/ui/delegation/ice-issue-124342.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find function `foo` in module `to_reuse`
-  --> $DIR/ice-issue-124342.rs:7:21
+  --> $DIR/ice-issue-124342.rs:6:21
    |
 LL |     reuse to_reuse::foo { foo }
    |                     ^^^ not found in `to_reuse`
 
 error[E0425]: cannot find value `foo` in this scope
-  --> $DIR/ice-issue-124342.rs:7:27
+  --> $DIR/ice-issue-124342.rs:6:27
    |
 LL |     reuse to_reuse::foo { foo }
    |                           ^^^

--- a/tests/ui/delegation/ice-issue-124347.rs
+++ b/tests/ui/delegation/ice-issue-124347.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     reuse Trait::foo { &self.0 }

--- a/tests/ui/delegation/ice-issue-124347.stderr
+++ b/tests/ui/delegation/ice-issue-124347.stderr
@@ -1,23 +1,23 @@
 error: failed to resolve delegation callee
-  --> $DIR/ice-issue-124347.rs:5:18
+  --> $DIR/ice-issue-124347.rs:4:18
    |
 LL |     reuse Trait::foo { &self.0 }
    |                  ^^^
 
 error: failed to resolve delegation callee
-  --> $DIR/ice-issue-124347.rs:10:7
+  --> $DIR/ice-issue-124347.rs:9:7
    |
 LL | reuse foo;
    |       ^^^
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/ice-issue-124347.rs:5:18
+  --> $DIR/ice-issue-124347.rs:4:18
    |
 LL |     reuse Trait::foo { &self.0 }
    |                  ^^^   ------- unexpected argument
    |
 note: associated function defined here
-  --> $DIR/ice-issue-124347.rs:5:18
+  --> $DIR/ice-issue-124347.rs:4:18
    |
 LL |     reuse Trait::foo { &self.0 }
    |                  ^^^
@@ -28,7 +28,7 @@ LL +     reuse Trait::fo&self.0 }
    |
 
 warning: function cannot return without recursing
-  --> $DIR/ice-issue-124347.rs:10:7
+  --> $DIR/ice-issue-124347.rs:9:7
    |
 LL | reuse foo;
    |       ^^^

--- a/tests/ui/delegation/ice-issue-138362.rs
+++ b/tests/ui/delegation/ice-issue-138362.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait HasSelf {
     fn method(self);

--- a/tests/ui/delegation/ice-issue-138362.stderr
+++ b/tests/ui/delegation/ice-issue-138362.stderr
@@ -1,11 +1,11 @@
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
-  --> $DIR/ice-issue-138362.rs:11:20
+  --> $DIR/ice-issue-138362.rs:10:20
    |
 LL |     reuse HasSelf::method;
    |                    ^^^^^^ argument #1 is missing
    |
 note: method defined here
-  --> $DIR/ice-issue-138362.rs:5:8
+  --> $DIR/ice-issue-138362.rs:4:8
    |
 LL |     fn method(self);
    |        ^^^^^^ ----

--- a/tests/ui/delegation/ice-issue-150673.rs
+++ b/tests/ui/delegation/ice-issue-150673.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn foo<T>() -> T {

--- a/tests/ui/delegation/ice-issue-150673.stderr
+++ b/tests/ui/delegation/ice-issue-150673.stderr
@@ -1,11 +1,11 @@
 error[E0107]: missing generics for struct `S`
-  --> $DIR/ice-issue-150673.rs:16:16
+  --> $DIR/ice-issue-150673.rs:15:16
    |
 LL | impl Trait for S {
    |                ^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-issue-150673.rs:10:8
+  --> $DIR/ice-issue-150673.rs:9:8
    |
 LL | struct S<T>(T);
    |        ^ -

--- a/tests/ui/delegation/ice-non-fn-target-in-trait-impl.rs
+++ b/tests/ui/delegation/ice-non-fn-target-in-trait-impl.rs
@@ -3,7 +3,6 @@
 // should emit a resolution error, not ICE.
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn bar();

--- a/tests/ui/delegation/ice-non-fn-target-in-trait-impl.stderr
+++ b/tests/ui/delegation/ice-non-fn-target-in-trait-impl.stderr
@@ -1,11 +1,11 @@
 error[E0423]: expected function, found module `std::path`
-  --> $DIR/ice-non-fn-target-in-trait-impl.rs:14:11
+  --> $DIR/ice-non-fn-target-in-trait-impl.rs:13:11
    |
 LL |     reuse std::path::<> as bar;
    |           ^^^^^^^^^^^^^ not a function
 
 error[E0423]: expected function, found crate `core`
-  --> $DIR/ice-non-fn-target-in-trait-impl.rs:16:11
+  --> $DIR/ice-non-fn-target-in-trait-impl.rs:15:11
    |
 LL |     reuse core::<> as bar2;
    |           ^^^^^^^^ not a function

--- a/tests/ui/delegation/impl-reuse-bad-path.rs
+++ b/tests/ui/delegation/impl-reuse-bad-path.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 mod unresolved {

--- a/tests/ui/delegation/impl-reuse-bad-path.stderr
+++ b/tests/ui/delegation/impl-reuse-bad-path.stderr
@@ -1,47 +1,47 @@
 error: empty glob delegation is not supported
-  --> $DIR/impl-reuse-bad-path.rs:11:5
+  --> $DIR/impl-reuse-bad-path.rs:10:5
    |
 LL |     reuse impl T for unresolved { self.0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected trait, found struct `Trait`
-  --> $DIR/impl-reuse-bad-path.rs:21:16
+  --> $DIR/impl-reuse-bad-path.rs:20:16
    |
 LL |     reuse impl Trait for S { self.0 }
    |                ^^^^^ not a trait
 
 error: expected trait, found module `TraitModule`
-  --> $DIR/impl-reuse-bad-path.rs:26:16
+  --> $DIR/impl-reuse-bad-path.rs:25:16
    |
 LL |     reuse impl TraitModule for S { self.0 }
    |                ^^^^^^^^^^^ not a trait
 
 error[E0433]: cannot find module or crate `unresolved` in this scope
-  --> $DIR/impl-reuse-bad-path.rs:6:16
+  --> $DIR/impl-reuse-bad-path.rs:5:16
    |
 LL |     reuse impl unresolved for S { self.0 }
    |                ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
 
 error[E0405]: cannot find trait `unresolved` in this scope
-  --> $DIR/impl-reuse-bad-path.rs:6:16
+  --> $DIR/impl-reuse-bad-path.rs:5:16
    |
 LL |     reuse impl unresolved for S { self.0 }
    |                ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `unresolved` in this scope
-  --> $DIR/impl-reuse-bad-path.rs:11:22
+  --> $DIR/impl-reuse-bad-path.rs:10:22
    |
 LL |     reuse impl T for unresolved { self.0 }
    |                      ^^^^^^^^^^ not found in this scope
 
 error[E0404]: expected trait, found struct `Trait`
-  --> $DIR/impl-reuse-bad-path.rs:21:16
+  --> $DIR/impl-reuse-bad-path.rs:20:16
    |
 LL |     reuse impl Trait for S { self.0 }
    |                ^^^^^ not a trait
 
 error[E0404]: expected trait, found module `TraitModule`
-  --> $DIR/impl-reuse-bad-path.rs:26:16
+  --> $DIR/impl-reuse-bad-path.rs:25:16
    |
 LL |     reuse impl TraitModule for S { self.0 }
    |                ^^^^^^^^^^^ not a trait

--- a/tests/ui/delegation/impl-reuse-empty-glob.rs
+++ b/tests/ui/delegation/impl-reuse-empty-glob.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 mod empty_glob {

--- a/tests/ui/delegation/impl-reuse-empty-glob.stderr
+++ b/tests/ui/delegation/impl-reuse-empty-glob.stderr
@@ -1,5 +1,5 @@
 error: empty glob delegation is not supported
-  --> $DIR/impl-reuse-empty-glob.rs:9:5
+  --> $DIR/impl-reuse-empty-glob.rs:8:5
    |
 LL |     reuse impl T for S { self.0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/impl-reuse-illegal-places.rs
+++ b/tests/ui/delegation/impl-reuse-illegal-places.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 trait T {

--- a/tests/ui/delegation/impl-reuse-illegal-places.stderr
+++ b/tests/ui/delegation/impl-reuse-illegal-places.stderr
@@ -1,5 +1,5 @@
 error: expected `:`, found keyword `impl`
-  --> $DIR/impl-reuse-illegal-places.rs:14:11
+  --> $DIR/impl-reuse-illegal-places.rs:13:11
    |
 LL | struct X {
    |        - while parsing this struct
@@ -7,7 +7,7 @@ LL |     reuse impl T for F { self.0 }
    |           ^^^^ expected `:`
 
 error: implementation is not supported in `trait`s or `impl`s
-  --> $DIR/impl-reuse-illegal-places.rs:19:5
+  --> $DIR/impl-reuse-illegal-places.rs:18:5
    |
 LL |     reuse impl T for F { self.0 }
    |     ^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     reuse impl T for F { self.0 }
    = help: consider moving the implementation out to a nearby module scope
 
 error: implementation is not supported in `trait`s or `impl`s
-  --> $DIR/impl-reuse-illegal-places.rs:24:5
+  --> $DIR/impl-reuse-illegal-places.rs:23:5
    |
 LL |     reuse impl T for F { self.0 }
    |     ^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     reuse impl T for F { self.0 }
    = help: consider moving the implementation out to a nearby module scope
 
 error: implementation is not supported in `extern` blocks
-  --> $DIR/impl-reuse-illegal-places.rs:29:5
+  --> $DIR/impl-reuse-illegal-places.rs:28:5
    |
 LL |     reuse impl T for F { self.0 }
    |     ^^^^^^^^^^^^^^^^^^
@@ -31,13 +31,13 @@ LL |     reuse impl T for F { self.0 }
    = help: consider moving the implementation out to a nearby module scope
 
 error: expected identifier, found keyword `impl`
-  --> $DIR/impl-reuse-illegal-places.rs:39:15
+  --> $DIR/impl-reuse-illegal-places.rs:38:15
    |
 LL |         reuse impl T for F { self.0 }
    |               ^^^^ expected identifier, found keyword
 
 error: expected one of `,`, `as`, or `}`, found keyword `impl`
-  --> $DIR/impl-reuse-illegal-places.rs:39:15
+  --> $DIR/impl-reuse-illegal-places.rs:38:15
    |
 LL |         reuse impl T for F { self.0 }
    |              -^^^^ expected one of `,`, `as`, or `}`
@@ -45,7 +45,7 @@ LL |         reuse impl T for F { self.0 }
    |              help: missing `,`
 
 error: expected one of `,`, `as`, or `}`, found `T`
-  --> $DIR/impl-reuse-illegal-places.rs:39:20
+  --> $DIR/impl-reuse-illegal-places.rs:38:20
    |
 LL |         reuse impl T for F { self.0 }
    |                   -^ expected one of `,`, `as`, or `}`
@@ -53,13 +53,13 @@ LL |         reuse impl T for F { self.0 }
    |                   help: missing `,`
 
 error: expected identifier, found keyword `for`
-  --> $DIR/impl-reuse-illegal-places.rs:39:22
+  --> $DIR/impl-reuse-illegal-places.rs:38:22
    |
 LL |         reuse impl T for F { self.0 }
    |                      ^^^ expected identifier, found keyword
 
 error: expected one of `,`, `as`, or `}`, found keyword `for`
-  --> $DIR/impl-reuse-illegal-places.rs:39:22
+  --> $DIR/impl-reuse-illegal-places.rs:38:22
    |
 LL |         reuse impl T for F { self.0 }
    |                     -^^^ expected one of `,`, `as`, or `}`
@@ -67,7 +67,7 @@ LL |         reuse impl T for F { self.0 }
    |                     help: missing `,`
 
 error: expected one of `,`, `as`, or `}`, found `F`
-  --> $DIR/impl-reuse-illegal-places.rs:39:26
+  --> $DIR/impl-reuse-illegal-places.rs:38:26
    |
 LL |         reuse impl T for F { self.0 }
    |                         -^ expected one of `,`, `as`, or `}`
@@ -75,13 +75,13 @@ LL |         reuse impl T for F { self.0 }
    |                         help: missing `,`
 
 error: expected one of `,`, `as`, or `}`, found `{`
-  --> $DIR/impl-reuse-illegal-places.rs:39:28
+  --> $DIR/impl-reuse-illegal-places.rs:38:28
    |
 LL |         reuse impl T for F { self.0 }
    |                            ^ expected one of `,`, `as`, or `}`
 
 error: expected item, found `}`
-  --> $DIR/impl-reuse-illegal-places.rs:48:1
+  --> $DIR/impl-reuse-illegal-places.rs:47:1
    |
 LL | }
    | ^ expected item

--- a/tests/ui/delegation/impl-reuse-negative-traits.rs
+++ b/tests/ui/delegation/impl-reuse-negative-traits.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 #![feature(negative_impls)]
 

--- a/tests/ui/delegation/impl-reuse-negative-traits.stderr
+++ b/tests/ui/delegation/impl-reuse-negative-traits.stderr
@@ -1,5 +1,5 @@
 error[E0749]: negative impls cannot have any items
-  --> $DIR/impl-reuse-negative-traits.rs:16:1
+  --> $DIR/impl-reuse-negative-traits.rs:15:1
    |
 LL | reuse impl !Trait for F { &self.0 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/impl-reuse-non-reuse-items.rs
+++ b/tests/ui/delegation/impl-reuse-non-reuse-items.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 mod non_delegatable_items {

--- a/tests/ui/delegation/impl-reuse-non-reuse-items.stderr
+++ b/tests/ui/delegation/impl-reuse-non-reuse-items.stderr
@@ -1,5 +1,5 @@
 error[E0324]: item `CONST` is an associated method, which doesn't match its trait `Trait`
-  --> $DIR/impl-reuse-non-reuse-items.rs:23:5
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:5
    |
 LL |         const CONST: u8;
    |         ---------------- item in trait
@@ -8,7 +8,7 @@ LL |     reuse impl Trait for S { &self.0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0324]: item `Type` is an associated method, which doesn't match its trait `Trait`
-  --> $DIR/impl-reuse-non-reuse-items.rs:23:5
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:5
    |
 LL |         type Type;
    |         ---------- item in trait
@@ -17,7 +17,7 @@ LL |     reuse impl Trait for S { &self.0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0201]: duplicate definitions with name `method`:
-  --> $DIR/impl-reuse-non-reuse-items.rs:23:5
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:5
    |
 LL |         fn method(&self);
    |         ----------------- item in trait
@@ -29,19 +29,19 @@ LL |     reuse impl Trait for S { &self.0 }
    |     previous definition here
 
 error[E0423]: expected function, found associated constant `Trait::CONST`
-  --> $DIR/impl-reuse-non-reuse-items.rs:23:16
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:16
    |
 LL |     reuse impl Trait for S { &self.0 }
    |                ^^^^^ not a function
 
 error[E0423]: expected function, found associated type `Trait::Type`
-  --> $DIR/impl-reuse-non-reuse-items.rs:23:16
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:16
    |
 LL |     reuse impl Trait for S { &self.0 }
    |                ^^^^^ not a function
 
 error[E0046]: not all trait items implemented, missing: `CONST`, `Type`, `method`
-  --> $DIR/impl-reuse-non-reuse-items.rs:23:5
+  --> $DIR/impl-reuse-non-reuse-items.rs:22:5
    |
 LL |         const CONST: u8;
    |         --------------- `CONST` from trait

--- a/tests/ui/delegation/impl-reuse-non-trait-impl-cfg-false.rs
+++ b/tests/ui/delegation/impl-reuse-non-trait-impl-cfg-false.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 struct Trait(usize);

--- a/tests/ui/delegation/impl-reuse-non-trait-impl-cfg-false.stderr
+++ b/tests/ui/delegation/impl-reuse-non-trait-impl-cfg-false.stderr
@@ -1,5 +1,5 @@
 error: only trait impls can be reused
-  --> $DIR/impl-reuse-non-trait-impl-cfg-false.rs:7:1
+  --> $DIR/impl-reuse-non-trait-impl-cfg-false.rs:6:1
    |
 LL | reuse impl Trait { self.0 }
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/impl-reuse-non-trait-impl.rs
+++ b/tests/ui/delegation/impl-reuse-non-trait-impl.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 struct Trait(usize);

--- a/tests/ui/delegation/impl-reuse-non-trait-impl.stderr
+++ b/tests/ui/delegation/impl-reuse-non-trait-impl.stderr
@@ -1,5 +1,5 @@
 error: only trait impls can be reused
-  --> $DIR/impl-reuse-non-trait-impl.rs:6:1
+  --> $DIR/impl-reuse-non-trait-impl.rs:5:1
    |
 LL | reuse impl Trait { self.0 }
    | ^^^^^^^^^^^^^^^^

--- a/tests/ui/delegation/impl-reuse-pass.rs
+++ b/tests/ui/delegation/impl-reuse-pass.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 #![feature(const_trait_impl)]
 #![allow(warnings)]

--- a/tests/ui/delegation/impl-reuse-self-hygiene.rs
+++ b/tests/ui/delegation/impl-reuse-self-hygiene.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 trait Trait {

--- a/tests/ui/delegation/impl-reuse-self-hygiene.stderr
+++ b/tests/ui/delegation/impl-reuse-self-hygiene.stderr
@@ -1,5 +1,5 @@
 error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:10:76
+  --> $DIR/impl-reuse-self-hygiene.rs:9:76
    |
 LL | macro_rules! one_line_reuse { ($self:ident) => { reuse impl Trait for S1 { $self.0 } } }
    |                                                  --------------------------^^^^^----
@@ -13,7 +13,7 @@ LL | one_line_reuse!(self);
    = note: this error originates in the macro `one_line_reuse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:10:76
+  --> $DIR/impl-reuse-self-hygiene.rs:9:76
    |
 LL | macro_rules! one_line_reuse { ($self:ident) => { reuse impl Trait for S1 { $self.0 } } }
    |                                                  --------------------------^^^^^----
@@ -28,7 +28,7 @@ LL | one_line_reuse!(self);
    = note: this error originates in the macro `one_line_reuse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:17:22
+  --> $DIR/impl-reuse-self-hygiene.rs:16:22
    |
 LL | macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 { $x } } }
    |                                                   ------------------------------ `self` not allowed in an implementation
@@ -36,7 +36,7 @@ LL | one_line_reuse_expr!(self.0);
    |                      ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:17:22
+  --> $DIR/impl-reuse-self-hygiene.rs:16:22
    |
 LL | macro_rules! one_line_reuse_expr { ($x:expr) => { reuse impl Trait for S2 { $x } } }
    |                                                   ------------------------------ `self` not allowed in an implementation
@@ -46,7 +46,7 @@ LL | one_line_reuse_expr!(self.0);
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:24:23
+  --> $DIR/impl-reuse-self-hygiene.rs:23:23
    |
 LL | macro_rules! one_line_reuse_expr2 { ($x:expr) => { reuse impl Trait for s3!() { $x } } }
    |                                                    --------------------------------- `self` not allowed in an implementation
@@ -54,7 +54,7 @@ LL | one_line_reuse_expr2!(self.0);
    |                       ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/impl-reuse-self-hygiene.rs:24:23
+  --> $DIR/impl-reuse-self-hygiene.rs:23:23
    |
 LL | macro_rules! one_line_reuse_expr2 { ($x:expr) => { reuse impl Trait for s3!() { $x } } }
    |                                                    --------------------------------- `self` not allowed in an implementation

--- a/tests/ui/delegation/impl-trait.rs
+++ b/tests/ui/delegation/impl-trait.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn foo() -> impl Clone { 0 }

--- a/tests/ui/delegation/inner-attr.rs
+++ b/tests/ui/delegation/inner-attr.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 fn a() {}
 

--- a/tests/ui/delegation/inner-attr.stderr
+++ b/tests/ui/delegation/inner-attr.stderr
@@ -1,5 +1,5 @@
 error: an inner attribute is not permitted in this context
-  --> $DIR/inner-attr.rs:6:16
+  --> $DIR/inner-attr.rs:5:16
    |
 LL | reuse a as b { #![rustc_dummy] self }
    |                ^^^^^^^^^^^^^^^
@@ -10,13 +10,13 @@ LL | fn main() {}
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/inner-attr.rs:6:7
+  --> $DIR/inner-attr.rs:5:7
    |
 LL | reuse a as b { #![rustc_dummy] self }
    |       ^                        ---- unexpected argument
    |
 note: function defined here
-  --> $DIR/inner-attr.rs:4:4
+  --> $DIR/inner-attr.rs:3:4
    |
 LL | fn a() {}
    |    ^

--- a/tests/ui/delegation/list.rs
+++ b/tests/ui/delegation/list.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) -> u8 { 0 }

--- a/tests/ui/delegation/macro-inside-glob.rs
+++ b/tests/ui/delegation/macro-inside-glob.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) -> u8 { 0 }

--- a/tests/ui/delegation/macro-inside-list.rs
+++ b/tests/ui/delegation/macro-inside-list.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) -> u8 { 0 }

--- a/tests/ui/delegation/method-call-choice.rs
+++ b/tests/ui/delegation/method-call-choice.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn foo(&self) {}

--- a/tests/ui/delegation/method-call-choice.stderr
+++ b/tests/ui/delegation/method-call-choice.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/method-call-choice.rs:21:27
+  --> $DIR/method-call-choice.rs:20:27
    |
 LL |     reuse to_reuse::foo { self.0 }
    |                     ---   ^^^^^^ expected `&F`, found `F`
@@ -7,7 +7,7 @@ LL |     reuse to_reuse::foo { self.0 }
    |                     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/method-call-choice.rs:15:12
+  --> $DIR/method-call-choice.rs:14:12
    |
 LL |     pub fn foo(_: &F) {}
    |            ^^^ -----

--- a/tests/ui/delegation/method-call-priority.rs
+++ b/tests/ui/delegation/method-call-priority.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![allow(dead_code)]
 
 trait Trait1 {

--- a/tests/ui/delegation/parse.rs
+++ b/tests/ui/delegation/parse.rs
@@ -2,7 +2,6 @@
 
 #![feature(decl_macro)]
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 macro_rules! reuse { {} => {} }
 

--- a/tests/ui/delegation/recursive-delegation-errors.rs
+++ b/tests/ui/delegation/recursive-delegation-errors.rs
@@ -1,6 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
-
 
 mod first_mod {
     reuse foo;

--- a/tests/ui/delegation/recursive-delegation-errors.stderr
+++ b/tests/ui/delegation/recursive-delegation-errors.stderr
@@ -1,101 +1,101 @@
 error: failed to resolve delegation callee
-  --> $DIR/recursive-delegation-errors.rs:6:11
+  --> $DIR/recursive-delegation-errors.rs:4:11
    |
 LL |     reuse foo;
    |           ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:12:11
+  --> $DIR/recursive-delegation-errors.rs:10:11
    |
 LL |     reuse foo as bar;
    |           ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:14:11
+  --> $DIR/recursive-delegation-errors.rs:12:11
    |
 LL |     reuse bar as foo;
    |           ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:19:11
+  --> $DIR/recursive-delegation-errors.rs:17:11
    |
 LL |     reuse foo as foo1;
    |           ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:21:11
+  --> $DIR/recursive-delegation-errors.rs:19:11
    |
 LL |     reuse foo1 as foo2;
    |           ^^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:23:11
+  --> $DIR/recursive-delegation-errors.rs:21:11
    |
 LL |     reuse foo2 as foo3;
    |           ^^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:25:11
+  --> $DIR/recursive-delegation-errors.rs:23:11
    |
 LL |     reuse foo3 as foo4;
    |           ^^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:27:11
+  --> $DIR/recursive-delegation-errors.rs:25:11
    |
 LL |     reuse foo4 as foo5;
    |           ^^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:29:11
+  --> $DIR/recursive-delegation-errors.rs:27:11
    |
 LL |     reuse foo5 as foo;
    |           ^^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:35:22
+  --> $DIR/recursive-delegation-errors.rs:33:22
    |
 LL |         reuse Trait::foo as bar;
    |                      ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:38:22
+  --> $DIR/recursive-delegation-errors.rs:36:22
    |
 LL |         reuse Trait::bar as foo;
    |                      ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:45:30
+  --> $DIR/recursive-delegation-errors.rs:43:30
    |
 LL |     reuse super::fifth_mod::{bar as foo, foo as bar};
    |                              ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:45:42
+  --> $DIR/recursive-delegation-errors.rs:43:42
    |
 LL |     reuse super::fifth_mod::{bar as foo, foo as bar};
    |                                          ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:50:27
+  --> $DIR/recursive-delegation-errors.rs:48:27
    |
 LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    |                           ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:50:39
+  --> $DIR/recursive-delegation-errors.rs:48:39
    |
 LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    |                                       ^^^
 
 error: encountered a cycle during delegation signature resolution
-  --> $DIR/recursive-delegation-errors.rs:50:51
+  --> $DIR/recursive-delegation-errors.rs:48:51
    |
 LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    |                                                   ^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/recursive-delegation-errors.rs:35:22
+  --> $DIR/recursive-delegation-errors.rs:33:22
    |
 LL |         reuse Trait::foo as bar;
    |                      ^^^ cannot infer type
@@ -103,7 +103,7 @@ LL |         reuse Trait::foo as bar;
    = note: the type must implement `fourth_mod::Trait`
 
 error[E0283]: type annotations needed
-  --> $DIR/recursive-delegation-errors.rs:38:22
+  --> $DIR/recursive-delegation-errors.rs:36:22
    |
 LL |         reuse Trait::bar as foo;
    |                      ^^^ cannot infer type
@@ -111,7 +111,7 @@ LL |         reuse Trait::bar as foo;
    = note: the type must implement `fourth_mod::Trait`
 
 error[E0283]: type annotations needed
-  --> $DIR/recursive-delegation-errors.rs:50:27
+  --> $DIR/recursive-delegation-errors.rs:48:27
    |
 LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    |                           ^^^ cannot infer type
@@ -119,7 +119,7 @@ LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    = note: the type must implement `GlobReuse`
 
 error[E0283]: type annotations needed
-  --> $DIR/recursive-delegation-errors.rs:50:39
+  --> $DIR/recursive-delegation-errors.rs:48:39
    |
 LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    |                                       ^^^ cannot infer type
@@ -127,7 +127,7 @@ LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    = note: the type must implement `GlobReuse`
 
 error[E0283]: type annotations needed
-  --> $DIR/recursive-delegation-errors.rs:50:51
+  --> $DIR/recursive-delegation-errors.rs:48:51
    |
 LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    |                                                   ^^^ cannot infer type
@@ -135,7 +135,7 @@ LL |         reuse GlobReuse::{foo as bar, bar as goo, goo as foo};
    = note: the type must implement `GlobReuse`
 
 warning: function cannot return without recursing
-  --> $DIR/recursive-delegation-errors.rs:6:11
+  --> $DIR/recursive-delegation-errors.rs:4:11
    |
 LL |     reuse foo;
    |           ^^^

--- a/tests/ui/delegation/recursive-delegation-ice-150152.rs
+++ b/tests/ui/delegation/recursive-delegation-ice-150152.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod first_example {
     mod to_reuse { pub fn foo() {} }

--- a/tests/ui/delegation/recursive-delegation-ice-150152.stderr
+++ b/tests/ui/delegation/recursive-delegation-ice-150152.stderr
@@ -1,29 +1,29 @@
 error[E0405]: cannot find trait `Item` in this scope
-  --> $DIR/recursive-delegation-ice-150152.rs:9:10
+  --> $DIR/recursive-delegation-ice-150152.rs:8:10
    |
 LL |     impl Item for S<S> {
    |          ^^^^ not found in this scope
 
 error[E0425]: cannot find type `S` in this scope
-  --> $DIR/recursive-delegation-ice-150152.rs:24:20
+  --> $DIR/recursive-delegation-ice-150152.rs:23:20
    |
 LL |     impl Trait for S {
    |                    ^ not found in this scope
    |
 note: struct `first_example::S` exists but is inaccessible
-  --> $DIR/recursive-delegation-ice-150152.rs:6:5
+  --> $DIR/recursive-delegation-ice-150152.rs:5:5
    |
 LL |     struct S< S >;
    |     ^^^^^^^^^^^^^^ not accessible
 
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/recursive-delegation-ice-150152.rs:26:15
+  --> $DIR/recursive-delegation-ice-150152.rs:25:15
    |
 LL |         reuse foo;
    |               ^^^ not found in this scope
    |
 note: these functions exist but are inaccessible
-  --> $DIR/recursive-delegation-ice-150152.rs:5:20
+  --> $DIR/recursive-delegation-ice-150152.rs:4:20
    |
 LL |     mod to_reuse { pub fn foo() {} }
    |                    ^^^^^^^^^^^^ `first_example::to_reuse::foo`: not accessible
@@ -32,19 +32,19 @@ LL |         fn foo() {}
    |         ^^^^^^^^ `second_example::to_reuse::foo`: not accessible
 
 error[E0603]: function `foo` is private
-  --> $DIR/recursive-delegation-ice-150152.rs:18:25
+  --> $DIR/recursive-delegation-ice-150152.rs:17:25
    |
 LL |         reuse to_reuse::foo;
    |                         ^^^ private function
    |
 note: the function `foo` is defined here
-  --> $DIR/recursive-delegation-ice-150152.rs:22:9
+  --> $DIR/recursive-delegation-ice-150152.rs:21:9
    |
 LL |         fn foo() {}
    |         ^^^^^^^^
 
 error[E0392]: type parameter `S` is never used
-  --> $DIR/recursive-delegation-ice-150152.rs:6:15
+  --> $DIR/recursive-delegation-ice-150152.rs:5:15
    |
 LL |     struct S< S >;
    |               ^ unused type parameter
@@ -53,13 +53,13 @@ LL |     struct S< S >;
    = help: if you intended `S` to be a const parameter, use `const S: /* Type */` instead
 
 error[E0107]: missing generics for struct `S`
-  --> $DIR/recursive-delegation-ice-150152.rs:9:21
+  --> $DIR/recursive-delegation-ice-150152.rs:8:21
    |
 LL |     impl Item for S<S> {
    |                     ^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `S`
-  --> $DIR/recursive-delegation-ice-150152.rs:6:12
+  --> $DIR/recursive-delegation-ice-150152.rs:5:12
    |
 LL |     struct S< S >;
    |            ^  -

--- a/tests/ui/delegation/recursive-delegation-pass.rs
+++ b/tests/ui/delegation/recursive-delegation-pass.rs
@@ -3,7 +3,6 @@
 //@ aux-crate:recursive_delegation_aux=recursive-delegation-aux.rs
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 #![allow(warnings)]
 
 mod first_mod {

--- a/tests/ui/delegation/rename.rs
+++ b/tests/ui/delegation/rename.rs
@@ -1,7 +1,6 @@
 //@ check-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn a() {}

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.rs
@@ -1,6 +1,5 @@
 //@ needs-rustc-debug-assertions
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn bar4();

--- a/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
+++ b/tests/ui/delegation/reuse-trait-path-with-empty-generics.stderr
@@ -1,5 +1,5 @@
 error[E0423]: expected function, found trait `Trait`
-  --> $DIR/reuse-trait-path-with-empty-generics.rs:10:11
+  --> $DIR/reuse-trait-path-with-empty-generics.rs:9:11
    |
 LL |     reuse Trait::<> as bar4;
    |           ^^^^^^^^^ not a function

--- a/tests/ui/delegation/self-coercion.rs
+++ b/tests/ui/delegation/self-coercion.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait : Sized {
     fn by_value(self) -> i32 { 1 }

--- a/tests/ui/delegation/self-hygiene.rs
+++ b/tests/ui/delegation/self-hygiene.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 macro_rules! emit_self { () => { self } }
 //~^ ERROR expected value, found module `self`

--- a/tests/ui/delegation/self-hygiene.stderr
+++ b/tests/ui/delegation/self-hygiene.stderr
@@ -1,5 +1,5 @@
 error[E0424]: expected value, found module `self`
-  --> $DIR/self-hygiene.rs:4:34
+  --> $DIR/self-hygiene.rs:3:34
    |
 LL |   macro_rules! emit_self { () => { self } }
    |                                    ^^^^ `self` value is a keyword only available in methods with a `self` parameter
@@ -13,7 +13,7 @@ LL | |     }
    = note: this error originates in the macro `emit_self` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/self-hygiene.rs:4:34
+  --> $DIR/self-hygiene.rs:3:34
    |
 LL |   macro_rules! emit_self { () => { self } }
    |                                    ^^^^ `self` value is a keyword only available in methods with a `self` parameter

--- a/tests/ui/delegation/target-expr-pass.rs
+++ b/tests/ui/delegation/target-expr-pass.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod to_reuse {
     pub fn foo(x: i32) -> i32 { x }

--- a/tests/ui/delegation/target-expr-pass.stderr
+++ b/tests/ui/delegation/target-expr-pass.stderr
@@ -1,5 +1,5 @@
 warning: trait `Trait` is never used
-  --> $DIR/target-expr-pass.rs:17:7
+  --> $DIR/target-expr-pass.rs:16:7
    |
 LL | trait Trait {
    |       ^^^^^
@@ -7,13 +7,13 @@ LL | trait Trait {
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: struct `F` is never constructed
-  --> $DIR/target-expr-pass.rs:21:8
+  --> $DIR/target-expr-pass.rs:20:8
    |
 LL | struct F;
    |        ^
 
 warning: struct `S` is never constructed
-  --> $DIR/target-expr-pass.rs:24:8
+  --> $DIR/target-expr-pass.rs:23:8
    |
 LL | struct S(F);
    |        ^

--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 trait Trait {
     fn static_method(x: i32) -> i32 { x }

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -1,5 +1,5 @@
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/target-expr.rs:18:17
+  --> $DIR/target-expr.rs:17:17
    |
 LL | fn bar<T: Default>(_: T) {
    |        - type parameter from outer item
@@ -12,7 +12,7 @@ LL |         let _ = T::Default();
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0434]: can't capture dynamic environment in a fn item
-  --> $DIR/target-expr.rs:26:17
+  --> $DIR/target-expr.rs:25:17
    |
 LL |         let x = y;
    |                 ^
@@ -20,7 +20,7 @@ LL |         let x = y;
    = help: use the `|| { ... }` closure form instead
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/target-expr.rs:33:5
+  --> $DIR/target-expr.rs:32:5
    |
 LL | fn main() {
    |    ---- this function can't have a `self` parameter
@@ -29,19 +29,19 @@ LL |     self.0;
    |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/target-expr.rs:35:13
+  --> $DIR/target-expr.rs:34:13
    |
 LL |     let z = x;
    |             ^
    |
 help: the binding `x` is available in a different scope in the same function
-  --> $DIR/target-expr.rs:26:13
+  --> $DIR/target-expr.rs:25:13
    |
 LL |         let x = y;
    |             ^
 
 error[E0308]: mismatched types
-  --> $DIR/target-expr.rs:16:32
+  --> $DIR/target-expr.rs:15:32
    |
 LL |       reuse Trait::static_method {
    |  ________________________________^

--- a/tests/ui/delegation/unlowered-path-ice-154820.rs
+++ b/tests/ui/delegation/unlowered-path-ice-154820.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 reuse foo:: < { //~ ERROR: failed to resolve delegation callee
   //~^ ERROR: function takes 0 generic arguments but 1 generic argument was supplied

--- a/tests/ui/delegation/unlowered-path-ice-154820.stderr
+++ b/tests/ui/delegation/unlowered-path-ice-154820.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `foo` is defined multiple times
-  --> $DIR/unlowered-path-ice-154820.rs:7:5
+  --> $DIR/unlowered-path-ice-154820.rs:6:5
    |
 LL |     fn foo() {}
    |     -------- previous definition of the value `foo` here
@@ -9,13 +9,13 @@ LL |     reuse foo;
    = note: `foo` must be defined only once in the value namespace of this block
 
 error: failed to resolve delegation callee
-  --> $DIR/unlowered-path-ice-154820.rs:4:7
+  --> $DIR/unlowered-path-ice-154820.rs:3:7
    |
 LL | reuse foo:: < {
    |       ^^^
 
 error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/unlowered-path-ice-154820.rs:4:7
+  --> $DIR/unlowered-path-ice-154820.rs:3:7
    |
 LL |   reuse foo:: < {
    |  _______^^^-
@@ -29,7 +29,7 @@ LL | |   >;
    | |___- help: remove the unnecessary generics
    |
 note: function defined here, with 0 generic parameters
-  --> $DIR/unlowered-path-ice-154820.rs:4:7
+  --> $DIR/unlowered-path-ice-154820.rs:3:7
    |
 LL | reuse foo:: < {
    |       ^^^

--- a/tests/ui/delegation/unreachable-label-ice-148889.rs
+++ b/tests/ui/delegation/unreachable-label-ice-148889.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 trait Trait {

--- a/tests/ui/delegation/unreachable-label-ice-148889.stderr
+++ b/tests/ui/delegation/unreachable-label-ice-148889.stderr
@@ -1,5 +1,5 @@
 error[E0767]: use of unreachable label `'foo`
-  --> $DIR/unreachable-label-ice-148889.rs:15:59
+  --> $DIR/unreachable-label-ice-148889.rs:14:59
    |
 LL |     'foo: loop {
    |     ---- unreachable label defined here

--- a/tests/ui/delegation/unresolved-delegation-ice-151356.rs
+++ b/tests/ui/delegation/unresolved-delegation-ice-151356.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 extern "C" {

--- a/tests/ui/delegation/unresolved-delegation-ice-151356.stderr
+++ b/tests/ui/delegation/unresolved-delegation-ice-151356.stderr
@@ -1,5 +1,5 @@
 error: incorrect function inside `extern` block
-  --> $DIR/unresolved-delegation-ice-151356.rs:5:8
+  --> $DIR/unresolved-delegation-ice-151356.rs:4:8
    |
 LL |   extern "C" {
    |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body

--- a/tests/ui/delegation/unsupported.current.stderr
+++ b/tests/ui/delegation/unsupported.current.stderr
@@ -1,36 +1,36 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:30:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:29:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:30:25
+  --> $DIR/unsupported.rs:29:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:30:25
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:29:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:33:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:32:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:33:24
+  --> $DIR/unsupported.rs:32:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:33:24
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:32:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^

--- a/tests/ui/delegation/unsupported.next.stderr
+++ b/tests/ui/delegation/unsupported.next.stderr
@@ -1,30 +1,30 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:30:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:29:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:30:25
+  --> $DIR/unsupported.rs:29:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
    = note: cycle used when computing implied outlives bounds for `<u8 as opaque::ToReuse>::opaque_ret::{anon_assoc#0}` (hack disabled = false)
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:33:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:32:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:33:24
+  --> $DIR/unsupported.rs:32:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
    = note: cycle used when computing implied outlives bounds for `<u16 as opaque::ToReuse>::opaque_ret::{anon_assoc#0}` (hack disabled = false)
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 

--- a/tests/ui/delegation/unsupported.rs
+++ b/tests/ui/delegation/unsupported.rs
@@ -9,7 +9,6 @@
 #![feature(const_trait_impl)]
 #![feature(c_variadic)]
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod opaque {
     trait Trait {}

--- a/tests/ui/delegation/unused-import-ice-144594.rs
+++ b/tests/ui/delegation/unused-import-ice-144594.rs
@@ -1,4 +1,3 @@
-#![allow(incomplete_features)]
 #![feature(fn_delegation)]
 
 reuse a as b {

--- a/tests/ui/delegation/unused-import-ice-144594.stderr
+++ b/tests/ui/delegation/unused-import-ice-144594.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find function `a` in this scope
-  --> $DIR/unused-import-ice-144594.rs:4:7
+  --> $DIR/unused-import-ice-144594.rs:3:7
    |
 LL | reuse a as b {
    |       ^ not found in this scope
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/unused-import-ice-144594.rs:8:9
+  --> $DIR/unused-import-ice-144594.rs:7:9
    |
 LL |         x.add
    |         ^ not found in this scope

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.rs
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.rs
@@ -1,5 +1,4 @@
 #![feature(fn_delegation)]
-#![allow(incomplete_features)]
 
 mod test_ice {
     fn a() {}

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/zero-args-delegations-ice-154332.rs:7:11
+  --> $DIR/zero-args-delegations-ice-154332.rs:6:11
    |
 LL |       reuse a as b {
    |  ___________^______-
@@ -11,7 +11,7 @@ LL | |     }
    | |_____- unexpected argument of type `()`
    |
 note: function defined here
-  --> $DIR/zero-args-delegations-ice-154332.rs:5:8
+  --> $DIR/zero-args-delegations-ice-154332.rs:4:8
    |
 LL |     fn a() {}
    |        ^
@@ -22,13 +22,13 @@ LL +     reuse {
    |
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/zero-args-delegations-ice-154332.rs:26:21
+  --> $DIR/zero-args-delegations-ice-154332.rs:25:21
    |
 LL |     reuse to_reuse::zero_args { self }
    |                     ^^^^^^^^^   ---- unexpected argument
    |
 note: function defined here
-  --> $DIR/zero-args-delegations-ice-154332.rs:21:16
+  --> $DIR/zero-args-delegations-ice-154332.rs:20:16
    |
 LL |         pub fn zero_args() -> i32 {
    |                ^^^^^^^^^


### PR DESCRIPTION
This PR adds support for self types specified in free to trait reuse. Up to this point we always generated `Self` despite the fact whether self type was specified or not. Now we use it in signature inheritance. Moreover we no more generate `Self` for static methods. Part of rust-lang/rust#118212.

```rust
trait Trait<T> {
  fn foo<const B: bool>(&self) {}
  fn bar() {}
}

impl<T> Trait<T> for usize {}

reuse <usize as Trait>::foo;

// Desugaring (no `Self` as usize is specified)
fn foo<T, const B: bool>(self: &usize) {
  <usize as Trait::<T>>::foo::<B>(self)
}

reuse Trait::bar;

// Desugaring (no `Self` as static method)
fn bar<T>() {
  Trait::<T>::bar(); //~ERROR: type annotations needed
}
```

r? @petrochenkov 