### PR TITLE
Update LLVM to 22.1.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/22.1-2026-01-27
+	branch = rustc/22.1-2026-03-22
 	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book

--- a/tests/ui/explicit-tail-calls/support/bystack.rs
+++ b/tests/ui/explicit-tail-calls/support/bystack.rs
@@ -36,11 +36,11 @@
 //@ revisions: loongarch32
 //@[loongarch32] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32] needs-llvm-components: loongarch
-//@[loongarch32] ignore-llvm-version: 23
+//@[loongarch32] ignore-llvm-version: 22 - 23
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
-//@[loongarch64] ignore-llvm-version: 23
+//@[loongarch64] ignore-llvm-version: 22 - 23
 //@ revisions: bpf
 //@[bpf] compile-flags: --target bpfeb-unknown-none
 //@[bpf] needs-llvm-components: bpf

--- a/tests/ui/explicit-tail-calls/support/byval.rs
+++ b/tests/ui/explicit-tail-calls/support/byval.rs
@@ -36,11 +36,11 @@
 //@ revisions: loongarch32
 //@[loongarch32] compile-flags: --target loongarch32-unknown-none
 //@[loongarch32] needs-llvm-components: loongarch
-//@[loongarch32] ignore-llvm-version: 23
+//@[loongarch32] ignore-llvm-version: 22 - 23
 //@ revisions: loongarch64
 //@[loongarch64] compile-flags: --target loongarch64-unknown-linux-gnu
 //@[loongarch64] needs-llvm-components: loongarch
-//@[loongarch64] ignore-llvm-version: 23
+//@[loongarch64] ignore-llvm-version: 22 - 23
 //@ revisions: bpf
 //@[bpf] compile-flags: --target bpfeb-unknown-none
 //@[bpf] needs-llvm-components: bpf


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155645)*
<!-- homu-ignore:end -->

Unlocks https://github.com/rust-lang/rust/pull/155249.

I made a new branch that removes CI checks for macOS and reverts https://github.com/rust-lang/llvm-project/commit/24b53fbc67d989ff0216c9b36369426828ac3b91.