### PR TITLE
`-Znext-solver` Propagate `stalled_on_coroutines` as a field in `Certainty::Maybe`

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -2099,7 +2099,7 @@ impl<'tcx> ProofTreeVisitor<'tcx> for CoerceVisitor<'_, 'tcx> {
                     ControlFlow::Break(())
                 }
             }
-            Ok(Certainty::Maybe { .. }) => {
+            Ok(Certainty::Maybe(_)) => {
                 // FIXME: structurally normalize?
                 if self.fcx.tcx.is_lang_item(pred.def_id(), LangItem::Unsize)
                     && let ty::Dynamic(..) = pred.skip_binder().trait_ref.args.type_at(1).kind()

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -9,7 +9,7 @@ use derive_where::derive_where;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::lang_items::SolverTraitLangItem;
 use rustc_type_ir::search_graph::CandidateHeadUsages;
-use rustc_type_ir::solve::{AliasBoundKind, SizedTraitKind};
+use rustc_type_ir::solve::{AliasBoundKind, MaybeInfo, SizedTraitKind, StalledOnCoroutines};
 use rustc_type_ir::{
     self as ty, AliasTy, Interner, TypeFlags, TypeFoldable, TypeFolder, TypeSuperFoldable,
     TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor, TypingMode, Unnormalized,
@@ -501,7 +501,7 @@ where
 
     pub(super) fn forced_ambiguity(
         &mut self,
-        cause: MaybeCause,
+        maybe: MaybeInfo,
     ) -> Result<Candidate<I>, NoSolution> {
         // This may fail if `try_evaluate_added_goals` overflows because it
         // fails to reach a fixpoint but ends up getting an error after
@@ -512,7 +512,7 @@ where
         // created a minimization for an ICE in typenum, but that one no
         // longer fails here. cc trait-system-refactor-initiative#105.
         let source = CandidateSource::BuiltinImpl(BuiltinImplSource::Misc);
-        let certainty = Certainty::Maybe { cause, opaque_types_jank: OpaqueTypesJank::AllGood };
+        let certainty = Certainty::Maybe(maybe);
         self.probe_trait_candidate(source)
             .enter(|this| this.evaluate_added_goals_and_make_canonical_response(certainty))
     }
@@ -1031,7 +1031,7 @@ where
         };
 
         if opaque_types.is_empty() {
-            candidates.extend(self.forced_ambiguity(MaybeCause::Ambiguity));
+            candidates.extend(self.forced_ambiguity(MaybeInfo::AMBIGUOUS));
             return;
         }
 
@@ -1122,10 +1122,11 @@ where
 
         if candidates.is_empty() {
             let source = CandidateSource::BuiltinImpl(BuiltinImplSource::Misc);
-            let certainty = Certainty::Maybe {
+            let certainty = Certainty::Maybe(MaybeInfo {
                 cause: MaybeCause::Ambiguity,
                 opaque_types_jank: OpaqueTypesJank::ErrorIfRigidSelfTy,
-            };
+                stalled_on_coroutines: StalledOnCoroutines::No,
+            });
             candidates
                 .extend(self.probe_trait_candidate(source).enter(|this| {
                     this.evaluate_added_goals_and_make_canonical_response(certainty)
@@ -1178,7 +1179,7 @@ where
             //
             // We use `forced_ambiguity` here over `make_ambiguous_response_no_constraints`
             // because the former will also record a built-in candidate in the inspector.
-            return self.forced_ambiguity(MaybeCause::Ambiguity).map(|cand| cand.result);
+            return self.forced_ambiguity(MaybeInfo::AMBIGUOUS).map(|cand| cand.result);
         };
 
         match proven_via {
@@ -1326,13 +1327,14 @@ where
             {
                 self.recursion_depth += 1;
                 if self.recursion_depth > self.ecx.cx().recursion_limit() {
-                    return ControlFlow::Break(Ok(Certainty::Maybe {
+                    return ControlFlow::Break(Ok(Certainty::Maybe(MaybeInfo {
                         cause: MaybeCause::Overflow {
                             suggest_increasing_limit: true,
                             keep_constraints: false,
                         },
                         opaque_types_jank: OpaqueTypesJank::AllGood,
-                    }));
+                        stalled_on_coroutines: StalledOnCoroutines::No,
+                    })));
                 }
                 let result = ty.super_visit_with(self);
                 self.recursion_depth -= 1;

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -8,7 +8,7 @@ use rustc_type_ir::inherent::*;
 use rustc_type_ir::relate::Relate;
 use rustc_type_ir::relate::solver_relating::RelateExt;
 use rustc_type_ir::search_graph::{CandidateHeadUsages, PathKind};
-use rustc_type_ir::solve::OpaqueTypesJank;
+use rustc_type_ir::solve::{MaybeInfo, OpaqueTypesJank};
 use rustc_type_ir::{
     self as ty, CanonicalVarValues, InferCtxtLike, Interner, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
@@ -217,7 +217,11 @@ where
             })
             .is_ok_and(|r| match r.certainty {
                 Certainty::Yes => true,
-                Certainty::Maybe { cause: _, opaque_types_jank } => match opaque_types_jank {
+                Certainty::Maybe(MaybeInfo {
+                    cause: _,
+                    opaque_types_jank,
+                    stalled_on_coroutines: _,
+                }) => match opaque_types_jank {
                     OpaqueTypesJank::AllGood => true,
                     OpaqueTypesJank::ErrorIfRigidSelfTy => false,
                 },
@@ -1268,10 +1272,13 @@ where
                 }
             };
 
-        if let Certainty::Maybe {
-            cause: cause @ MaybeCause::Overflow { keep_constraints: false, .. },
-            opaque_types_jank,
-        } = certainty
+        if let Certainty::Maybe(
+            maybe_info @ MaybeInfo {
+                cause: MaybeCause::Overflow { keep_constraints: false, .. },
+                opaque_types_jank: _,
+                stalled_on_coroutines: _,
+            },
+        ) = certainty
         {
             // If we have overflow, it's probable that we're substituting a type
             // into itself infinitely and any partial substitutions in the query
@@ -1284,7 +1291,7 @@ where
             //
             // Changing this to retain some constraints in the future
             // won't be a breaking change, so this is good enough for now.
-            return Ok(self.make_ambiguous_response_no_constraints(cause, opaque_types_jank));
+            return Ok(self.make_ambiguous_response_no_constraints(maybe_info));
         }
 
         let external_constraints =
@@ -1317,14 +1324,13 @@ where
     /// ambiguity but return constrained variables to guide inference.
     pub(in crate::solve) fn make_ambiguous_response_no_constraints(
         &self,
-        cause: MaybeCause,
-        opaque_types_jank: OpaqueTypesJank,
+        maybe: MaybeInfo,
     ) -> CanonicalResponse<I> {
         response_no_constraints_raw(
             self.cx(),
             self.max_input_universe,
             self.var_kinds,
-            Certainty::Maybe { cause, opaque_types_jank },
+            Certainty::Maybe(maybe),
         )
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -158,10 +158,7 @@ where
         if self.may_use_unstable_feature(param_env, symbol) {
             self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         } else {
-            self.evaluate_added_goals_and_make_canonical_response(Certainty::Maybe {
-                cause: MaybeCause::Ambiguity,
-                opaque_types_jank: OpaqueTypesJank::AllGood,
-            })
+            self.evaluate_added_goals_and_make_canonical_response(Certainty::AMBIGUOUS)
         }
     }
 
@@ -279,21 +276,16 @@ where
 
     fn bail_with_ambiguity(&mut self, candidates: &[Candidate<I>]) -> CanonicalResponse<I> {
         debug_assert!(candidates.len() > 1);
-        let (cause, opaque_types_jank) = candidates.iter().fold(
-            (MaybeCause::Ambiguity, OpaqueTypesJank::AllGood),
-            |(c, jank), candidates| {
-                // We pull down the certainty of `Certainty::Yes` to ambiguity when combining
-                // these responses, b/c we're combining more than one response and this we
-                // don't know which one applies.
-                match candidates.result.value.certainty {
-                    Certainty::Yes => (c, jank),
-                    Certainty::Maybe { cause, opaque_types_jank } => {
-                        (c.or(cause), jank.or(opaque_types_jank))
-                    }
-                }
-            },
-        );
-        self.make_ambiguous_response_no_constraints(cause, opaque_types_jank)
+        let maybe = candidates.iter().fold(MaybeInfo::AMBIGUOUS, |maybe, candidate| {
+            // We pull down the certainty of `Certainty::Yes` to ambiguity when combining
+            // these responses, b/c we're combining more than one response and this we
+            // don't know which one applies.
+            match candidate.result.value.certainty {
+                Certainty::Yes => maybe,
+                Certainty::Maybe(cand_maybe) => maybe.or(cand_maybe),
+            }
+        });
+        self.make_ambiguous_response_no_constraints(maybe)
     }
 
     /// If we fail to merge responses we flounder and return overflow or ambiguity.

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -6,7 +6,6 @@ mod opaque_types;
 use rustc_type_ir::fast_reject::DeepRejectCtxt;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
-use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::{
     self as ty, FieldInfo, Interner, NormalizesTo, PredicateKind, Unnormalized, Upcast as _,
 };
@@ -17,8 +16,8 @@ use crate::solve::assembly::structural_traits::{self, AsyncCallableRelevantTypes
 use crate::solve::assembly::{self, Candidate};
 use crate::solve::inspect::ProbeKind;
 use crate::solve::{
-    BuiltinImplSource, CandidateSource, Certainty, EvalCtxt, Goal, GoalSource, MaybeCause,
-    NoSolution, QueryResult,
+    BuiltinImplSource, CandidateSource, Certainty, EvalCtxt, Goal, GoalSource, MaybeInfo,
+    NoSolution, QueryResult, SizedTraitKind,
 };
 
 impl<D, I> EvalCtxt<'_, D>
@@ -460,7 +459,7 @@ where
                 goal_kind,
             )?
         else {
-            return ecx.forced_ambiguity(MaybeCause::Ambiguity);
+            return ecx.forced_ambiguity(MaybeInfo::AMBIGUOUS);
         };
         let (inputs, output) = ecx.instantiate_binder_with_infer(tupled_inputs_and_output);
 
@@ -588,7 +587,7 @@ where
 
         // Bail if the upvars haven't been constrained.
         if tupled_upvars_ty.expect_ty().is_ty_var() {
-            return ecx.forced_ambiguity(MaybeCause::Ambiguity);
+            return ecx.forced_ambiguity(MaybeInfo::AMBIGUOUS);
         }
 
         let Some(closure_kind) = closure_fn_kind_ty.expect_ty().to_opt_closure_kind() else {

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -5,7 +5,8 @@ use rustc_type_ir::fast_reject::DeepRejectCtxt;
 use rustc_type_ir::inherent::*;
 use rustc_type_ir::lang_items::SolverTraitLangItem;
 use rustc_type_ir::solve::{
-    AliasBoundKind, CandidatePreferenceMode, CanonicalResponse, SizedTraitKind,
+    AliasBoundKind, CandidatePreferenceMode, CanonicalResponse, MaybeInfo, OpaqueTypesJank,
+    SizedTraitKind,
 };
 use rustc_type_ir::{
     self as ty, FieldInfo, Interner, Movability, PredicatePolarity, TraitPredicate, TraitRef,
@@ -21,7 +22,8 @@ use crate::solve::assembly::{
 use crate::solve::inspect::ProbeKind;
 use crate::solve::{
     BuiltinImplSource, CandidateSource, Certainty, EvalCtxt, Goal, GoalSource, MaybeCause,
-    MergeCandidateInfo, NoSolution, ParamEnvSource, QueryResult, has_only_region_constraints,
+    MergeCandidateInfo, NoSolution, ParamEnvSource, QueryResult, StalledOnCoroutines,
+    has_only_region_constraints,
 };
 
 impl<D, I> assembly::GoalKind<D> for TraitPredicate<I>
@@ -372,7 +374,7 @@ where
                 goal_kind,
             )?
         else {
-            return ecx.forced_ambiguity(MaybeCause::Ambiguity);
+            return ecx.forced_ambiguity(MaybeInfo::AMBIGUOUS);
         };
         let (inputs, output) = ecx.instantiate_binder_with_infer(tupled_inputs_and_output);
 
@@ -671,7 +673,7 @@ where
         // Match the old solver by treating unresolved inference variables as
         // ambiguous until `rustc_transmute` can compute their layout.
         if goal.has_non_region_infer() {
-            return ecx.forced_ambiguity(MaybeCause::Ambiguity);
+            return ecx.forced_ambiguity(MaybeInfo::AMBIGUOUS);
         }
 
         ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {
@@ -823,7 +825,7 @@ where
                 (ty::Infer(ty::TyVar(..)), ..) => panic!("unexpected infer {a_ty:?} {b_ty:?}"),
 
                 (_, ty::Infer(ty::TyVar(..))) => {
-                    result_to_single(ecx.forced_ambiguity(MaybeCause::Ambiguity))
+                    result_to_single(ecx.forced_ambiguity(MaybeInfo::AMBIGUOUS))
                 }
 
                 // Trait upcasting, or `dyn Trait + Auto + 'a` -> `dyn Trait + 'b`.
@@ -1248,7 +1250,7 @@ where
             // we probably don't want to treat an `impl !AutoTrait for i32` as
             // disqualifying the built-in auto impl for `i64: AutoTrait` either.
             ty::Infer(ty::IntVar(_) | ty::FloatVar(_)) => {
-                Some(self.forced_ambiguity(MaybeCause::Ambiguity))
+                Some(self.forced_ambiguity(MaybeInfo::AMBIGUOUS))
             }
 
             // Backward compatibility for default auto traits.
@@ -1564,7 +1566,11 @@ where
                 } => {
                     if def_id.as_local().is_some_and(|def_id| stalled_generators.contains(&def_id))
                     {
-                        return Some(self.forced_ambiguity(MaybeCause::Ambiguity));
+                        return Some(self.forced_ambiguity(MaybeInfo {
+                            cause: MaybeCause::Ambiguity,
+                            opaque_types_jank: OpaqueTypesJank::AllGood,
+                            stalled_on_coroutines: StalledOnCoroutines::Yes,
+                        }));
                     }
                 }
                 TypingMode::Coherence

--- a/compiler/rustc_trait_selection/src/solve.rs
+++ b/compiler/rustc_trait_selection/src/solve.rs
@@ -7,7 +7,7 @@ mod normalize;
 mod select;
 
 pub(crate) use delegate::SolverDelegate;
-pub use fulfill::{FulfillmentCtxt, NextSolverError, StalledOnCoroutines};
+pub use fulfill::{FulfillmentCtxt, NextSolverError};
 pub(crate) use normalize::deeply_normalize_for_diagnostics;
 pub use normalize::{
     deeply_normalize, deeply_normalize_with_skipped_universes,

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -1,29 +1,23 @@
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::ControlFlow;
 
-use rustc_hir::def_id::LocalDefId;
 use rustc_infer::infer::InferCtxt;
 use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::{
     FromSolverError, PredicateObligation, PredicateObligations, TraitEngine,
 };
-use rustc_middle::ty::{
-    self, DelayedSet, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
-    TypingMode,
-};
+use rustc_middle::ty::{TyCtxt, TypeVisitableExt, TypingMode};
 use rustc_next_trait_solver::delegate::SolverDelegate as _;
 use rustc_next_trait_solver::solve::{
-    GoalEvaluation, GoalStalledOn, HasChanged, SolverDelegateEvalExt as _,
+    GoalEvaluation, GoalStalledOn, HasChanged, MaybeInfo, SolverDelegateEvalExt as _,
+    StalledOnCoroutines,
 };
-use rustc_span::Span;
 use thin_vec::ThinVec;
 use tracing::instrument;
 
 use self::derive_errors::*;
 use super::Certainty;
 use super::delegate::SolverDelegate;
-use super::inspect::{self, InferCtxtProofTreeExt};
 use crate::traits::{FulfillmentError, ScrubbedTraitError};
 
 mod derive_errors;
@@ -87,10 +81,10 @@ impl<'tcx> ObligationStorage<'tcx> {
 
     fn drain_pending(
         &mut self,
-        cond: impl Fn(&PredicateObligation<'tcx>) -> bool,
+        cond: impl Fn(&PredicateObligation<'tcx>, &Option<GoalStalledOn<TyCtxt<'tcx>>>) -> bool,
     ) -> PendingObligations<'tcx> {
         let (unstalled, pending) =
-            mem::take(&mut self.pending).into_iter().partition(|(o, _)| cond(o));
+            mem::take(&mut self.pending).into_iter().partition(|(o, s)| cond(o, s));
         self.pending = pending;
         unstalled
     }
@@ -183,7 +177,7 @@ where
         let mut errors = Vec::new();
         loop {
             let mut any_changed = false;
-            for (mut obligation, stalled_on) in self.obligations.drain_pending(|_| true) {
+            for (mut obligation, stalled_on) in self.obligations.drain_pending(|_, _| true) {
                 if !infcx.tcx.recursion_limit().value_within_limit(obligation.recursion_depth) {
                     self.obligations.on_fulfillment_overflow(infcx);
                     // Only return true errors that we have accumulated while processing.
@@ -203,7 +197,7 @@ where
                         //
                         // Only goals proven via the trait solver should be region dependent.
                         Certainty::Yes => {}
-                        Certainty::Maybe { .. } => {
+                        Certainty::Maybe(_) => {
                             self.obligations.register(obligation, None);
                         }
                     }
@@ -257,7 +251,7 @@ where
                             infcx.push_hir_typeck_potentially_region_dependent_goal(obligation);
                         }
                     }
-                    Certainty::Maybe { .. } => self.obligations.register(obligation, stalled_on),
+                    Certainty::Maybe(_) => self.obligations.register(obligation, stalled_on),
                 }
             }
 
@@ -296,75 +290,19 @@ where
         }
 
         self.obligations
-            .drain_pending(|obl| {
-                infcx.probe(|_| {
-                    infcx
-                        .visit_proof_tree(
-                            obl.as_goal(),
-                            &mut StalledOnCoroutines {
-                                stalled_coroutines,
-                                span: obl.cause.span,
-                                cache: Default::default(),
-                            },
-                        )
-                        .is_break()
+            .drain_pending(|_, stalled_on| {
+                stalled_on.as_ref().is_some_and(|s| match s.stalled_certainty {
+                    Certainty::Maybe(MaybeInfo {
+                        cause: _,
+                        opaque_types_jank: _,
+                        stalled_on_coroutines: StalledOnCoroutines::Yes,
+                    }) => true,
+                    Certainty::Maybe(_) | Certainty::Yes => false,
                 })
             })
             .into_iter()
             .map(|(o, _)| o)
             .collect()
-    }
-}
-
-/// Detect if a goal is stalled on a coroutine that is owned by the current typeck root.
-///
-/// This function can (erroneously) fail to detect a predicate, i.e. it doesn't need to
-/// be complete. However, this will lead to ambiguity errors, so we want to make it
-/// accurate.
-///
-/// This function can be also return false positives, which will lead to poor diagnostics
-/// so we want to keep this visitor *precise* too.
-pub struct StalledOnCoroutines<'tcx> {
-    pub stalled_coroutines: &'tcx ty::List<LocalDefId>,
-    pub span: Span,
-    pub cache: DelayedSet<Ty<'tcx>>,
-}
-
-impl<'tcx> inspect::ProofTreeVisitor<'tcx> for StalledOnCoroutines<'tcx> {
-    type Result = ControlFlow<()>;
-
-    fn span(&self) -> rustc_span::Span {
-        self.span
-    }
-
-    fn visit_goal(&mut self, inspect_goal: &super::inspect::InspectGoal<'_, 'tcx>) -> Self::Result {
-        inspect_goal.goal().predicate.visit_with(self)?;
-
-        if let Some(candidate) = inspect_goal.unique_applicable_candidate() {
-            candidate.visit_nested_no_probe(self)
-        } else {
-            ControlFlow::Continue(())
-        }
-    }
-}
-
-impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for StalledOnCoroutines<'tcx> {
-    type Result = ControlFlow<()>;
-
-    fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
-        if !self.cache.insert(ty) {
-            return ControlFlow::Continue(());
-        }
-
-        if let ty::Coroutine(def_id, _) = *ty.kind()
-            && def_id.as_local().is_some_and(|def_id| self.stalled_coroutines.contains(&def_id))
-        {
-            ControlFlow::Break(())
-        } else if ty.has_coroutines() {
-            ty.super_visit_with(self)
-        } else {
-            ControlFlow::Continue(())
-        }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -11,7 +11,7 @@ use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_middle::{bug, span_bug};
-use rustc_next_trait_solver::solve::{GoalEvaluation, SolverDelegateEvalExt as _};
+use rustc_next_trait_solver::solve::{GoalEvaluation, MaybeInfo, SolverDelegateEvalExt as _};
 use tracing::{instrument, trace};
 
 use crate::solve::delegate::SolverDelegate;
@@ -96,16 +96,22 @@ pub(super) fn fulfillment_error_for_stalled<'tcx>(
             None,
         ) {
             Ok(GoalEvaluation {
-                certainty: Certainty::Maybe { cause: MaybeCause::Ambiguity, .. },
+                certainty:
+                    Certainty::Maybe(MaybeInfo {
+                        cause: MaybeCause::Ambiguity,
+                        opaque_types_jank: _,
+                        stalled_on_coroutines: _,
+                    }),
                 ..
             }) => (FulfillmentErrorCode::Ambiguity { overflow: None }, true),
             Ok(GoalEvaluation {
                 certainty:
-                    Certainty::Maybe {
+                    Certainty::Maybe(MaybeInfo {
                         cause:
                             MaybeCause::Overflow { suggest_increasing_limit, keep_constraints: _ },
-                        ..
-                    },
+                        opaque_types_jank: _,
+                        stalled_on_coroutines: _,
+                    }),
                 ..
             }) => (
                 FulfillmentErrorCode::Ambiguity { overflow: Some(suggest_increasing_limit) },
@@ -271,7 +277,14 @@ impl<'tcx> BestObligation<'tcx> {
             );
             // Skip nested goals that aren't the *reason* for our goal's failure.
             match (self.consider_ambiguities, nested_goal.result()) {
-                (true, Ok(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. }))
+                (
+                    true,
+                    Ok(Certainty::Maybe(MaybeInfo {
+                        cause: MaybeCause::Ambiguity,
+                        opaque_types_jank: _,
+                        stalled_on_coroutines: _,
+                    })),
+                )
                 | (false, Err(_)) => {}
                 _ => continue,
             }
@@ -413,8 +426,15 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
         let tcx = goal.infcx().tcx;
         // Skip goals that aren't the *reason* for our goal's failure.
         match (self.consider_ambiguities, goal.result()) {
-            (true, Ok(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. })) | (false, Err(_)) => {
-            }
+            (
+                true,
+                Ok(Certainty::Maybe(MaybeInfo {
+                    cause: MaybeCause::Ambiguity,
+                    opaque_types_jank: _,
+                    stalled_on_coroutines: _,
+                })),
+            )
+            | (false, Err(_)) => {}
             _ => return ControlFlow::Continue(()),
         }
 

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -20,7 +20,7 @@ use rustc_middle::ty::{TyCtxt, VisitorResult, try_visit};
 use rustc_middle::{bug, ty};
 use rustc_next_trait_solver::canonical::instantiate_canonical_state;
 use rustc_next_trait_solver::resolve::eager_resolve_vars;
-use rustc_next_trait_solver::solve::{MaybeCause, SolverDelegateEvalExt as _, inspect};
+use rustc_next_trait_solver::solve::{MaybeCause, MaybeInfo, SolverDelegateEvalExt as _, inspect};
 use rustc_span::Span;
 use tracing::instrument;
 
@@ -332,7 +332,11 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
                 inspect::ProbeStep::MakeCanonicalResponse { shallow_certainty: c } => {
                     assert_matches!(
                         shallow_certainty.replace(c),
-                        None | Some(Certainty::Maybe { cause: MaybeCause::Ambiguity, .. })
+                        None | Some(Certainty::Maybe(MaybeInfo {
+                            cause: MaybeCause::Ambiguity,
+                            opaque_types_jank: _,
+                            stalled_on_coroutines: _,
+                        }))
                     );
                 }
                 inspect::ProbeStep::NestedProbe(ref probe) => {

--- a/compiler/rustc_trait_selection/src/solve/select.rs
+++ b/compiler/rustc_trait_selection/src/solve/select.rs
@@ -62,7 +62,7 @@ impl<'tcx> inspect::ProofTreeVisitor<'tcx> for Select {
 
         // Don't winnow until `Certainty::Yes` -- we don't need to winnow until
         // codegen, and only on the good path.
-        if matches!(goal.result().unwrap(), Certainty::Maybe { .. }) {
+        if matches!(goal.result().unwrap(), Certainty::Maybe(_)) {
             return ControlFlow::Break(Ok(None));
         }
 
@@ -95,7 +95,7 @@ fn candidate_should_be_dropped_in_favor_of<'tcx>(
 ) -> bool {
     // Don't winnow until `Certainty::Yes` -- we don't need to winnow until
     // codegen, and only on the good path.
-    if matches!(other.result().unwrap(), Certainty::Maybe { .. }) {
+    if matches!(other.result().unwrap(), Certainty::Maybe(_)) {
         return false;
     }
 
@@ -145,13 +145,13 @@ fn to_selection<'tcx>(
     span: Span,
     cand: inspect::InspectCandidate<'_, 'tcx>,
 ) -> Option<Selection<'tcx>> {
-    if let Certainty::Maybe { .. } = cand.shallow_certainty() {
+    if let Certainty::Maybe(_) = cand.shallow_certainty() {
         return None;
     }
 
     let nested = match cand.result().expect("expected positive result") {
         Certainty::Yes => thin_vec![],
-        Certainty::Maybe { .. } => cand
+        Certainty::Maybe(_) => cand
             .instantiate_nested_goals(span)
             .into_iter()
             .map(|nested| {

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -742,7 +742,7 @@ impl<'a, 'tcx> ProofTreeVisitor<'tcx> for AmbiguityCausesVisitor<'a, 'tcx> {
         // was irrelevant.
         match goal.result() {
             Ok(Certainty::Yes) | Err(NoSolution) => return,
-            Ok(Certainty::Maybe { .. }) => {}
+            Ok(Certainty::Maybe(_)) => {}
         }
 
         // For bound predicates we simply call `infcx.enter_forall`

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::ops::ControlFlow;
 
 use rustc_data_structures::obligation_forest::{
     Error, ForestObligation, ObligationForest, ObligationProcessor, Outcome, ProcessResult,
@@ -13,10 +14,9 @@ use rustc_middle::bug;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::{
-    self, Binder, Const, GenericArgsRef, TypeVisitable, TypeVisitableExt, TypingMode,
-    may_use_unstable_feature,
+    self, Binder, Const, DelayedSet, GenericArgsRef, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable,
+    TypeVisitableExt, TypeVisitor, TypingMode, may_use_unstable_feature,
 };
-use rustc_span::DUMMY_SP;
 use thin_vec::{ThinVec, thin_vec};
 use tracing::{debug, debug_span, instrument};
 
@@ -29,7 +29,6 @@ use super::{
 };
 use crate::error_reporting::InferCtxtErrorExt;
 use crate::infer::{InferCtxt, TyOrConstInferVar};
-use crate::solve::StalledOnCoroutines;
 use crate::traits::normalize::normalize_with_depth_to;
 use crate::traits::project::{PolyProjectionObligation, ProjectionCacheKeyExt as _};
 use crate::traits::query::evaluate_obligation::InferCtxtExt;
@@ -207,11 +206,37 @@ where
             type OUT = Outcome<Self::Obligation, Self::Error>;
 
             fn needs_process_obligation(&self, pending_obligation: &Self::Obligation) -> bool {
+                struct StalledOnCoroutines<'tcx> {
+                    pub stalled_coroutines: &'tcx ty::List<LocalDefId>,
+                    pub cache: DelayedSet<Ty<'tcx>>,
+                }
+
+                impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for StalledOnCoroutines<'tcx> {
+                    type Result = ControlFlow<()>;
+
+                    fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
+                        if !self.cache.insert(ty) {
+                            return ControlFlow::Continue(());
+                        }
+
+                        if let ty::Coroutine(def_id, _) = ty.kind()
+                            && def_id
+                                .as_local()
+                                .is_some_and(|def_id| self.stalled_coroutines.contains(&def_id))
+                        {
+                            ControlFlow::Break(())
+                        } else if ty.has_coroutines() {
+                            ty.super_visit_with(self)
+                        } else {
+                            ControlFlow::Continue(())
+                        }
+                    }
+                }
+
                 self.infcx
                     .resolve_vars_if_possible(pending_obligation.obligation.predicate)
                     .visit_with(&mut StalledOnCoroutines {
                         stalled_coroutines: self.stalled_coroutines,
-                        span: DUMMY_SP,
                         cache: Default::default(),
                     })
                     .is_break()

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -289,7 +289,39 @@ impl<I: Interner> NestedNormalizationGoals<I> {
 #[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
 pub enum Certainty {
     Yes,
-    Maybe { cause: MaybeCause, opaque_types_jank: OpaqueTypesJank },
+    Maybe(MaybeInfo),
+}
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+pub struct MaybeInfo {
+    pub cause: MaybeCause,
+    pub opaque_types_jank: OpaqueTypesJank,
+    pub stalled_on_coroutines: StalledOnCoroutines,
+}
+
+impl MaybeInfo {
+    pub const AMBIGUOUS: MaybeInfo = MaybeInfo {
+        cause: MaybeCause::Ambiguity,
+        opaque_types_jank: OpaqueTypesJank::AllGood,
+        stalled_on_coroutines: StalledOnCoroutines::No,
+    };
+
+    fn and(self, other: MaybeInfo) -> MaybeInfo {
+        MaybeInfo {
+            cause: self.cause.and(other.cause),
+            opaque_types_jank: self.opaque_types_jank.and(other.opaque_types_jank),
+            stalled_on_coroutines: self.stalled_on_coroutines.and(other.stalled_on_coroutines),
+        }
+    }
+
+    pub fn or(self, other: MaybeInfo) -> MaybeInfo {
+        MaybeInfo {
+            cause: self.cause.or(other.cause),
+            opaque_types_jank: self.opaque_types_jank.or(other.opaque_types_jank),
+            stalled_on_coroutines: self.stalled_on_coroutines.or(other.stalled_on_coroutines),
+        }
+    }
 }
 
 /// Supporting not-yet-defined opaque types in HIR typeck is somewhat
@@ -348,11 +380,33 @@ impl OpaqueTypesJank {
     }
 }
 
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "nightly", derive(HashStable_NoContext))]
+pub enum StalledOnCoroutines {
+    Yes,
+    No,
+}
+
+impl StalledOnCoroutines {
+    fn and(self, other: StalledOnCoroutines) -> StalledOnCoroutines {
+        match (self, other) {
+            (StalledOnCoroutines::No, StalledOnCoroutines::No) => StalledOnCoroutines::No,
+            (StalledOnCoroutines::Yes, _) | (_, StalledOnCoroutines::Yes) => {
+                StalledOnCoroutines::Yes
+            }
+        }
+    }
+
+    pub fn or(self, other: StalledOnCoroutines) -> StalledOnCoroutines {
+        // `StalledOnCoroutines::Yes` is contagious: obtaining `Certainty::Maybe`
+        // while a candidate is stalled on a coroutine might have been
+        // `Certainty::Yes` or `NoSolution` if it were not stalled.
+        StalledOnCoroutines::and(self, other)
+    }
+}
+
 impl Certainty {
-    pub const AMBIGUOUS: Certainty = Certainty::Maybe {
-        cause: MaybeCause::Ambiguity,
-        opaque_types_jank: OpaqueTypesJank::AllGood,
-    };
+    pub const AMBIGUOUS: Certainty = Certainty::Maybe(MaybeInfo::AMBIGUOUS);
 
     /// Use this function to merge the certainty of multiple nested subgoals.
     ///
@@ -371,21 +425,18 @@ impl Certainty {
             (Certainty::Yes, Certainty::Yes) => Certainty::Yes,
             (Certainty::Yes, Certainty::Maybe { .. }) => other,
             (Certainty::Maybe { .. }, Certainty::Yes) => self,
-            (
-                Certainty::Maybe { cause: a_cause, opaque_types_jank: a_jank },
-                Certainty::Maybe { cause: b_cause, opaque_types_jank: b_jank },
-            ) => Certainty::Maybe {
-                cause: a_cause.and(b_cause),
-                opaque_types_jank: a_jank.and(b_jank),
-            },
+            (Certainty::Maybe(a_maybe), Certainty::Maybe(b_maybe)) => {
+                Certainty::Maybe(a_maybe.and(b_maybe))
+            }
         }
     }
 
     pub const fn overflow(suggest_increasing_limit: bool) -> Certainty {
-        Certainty::Maybe {
+        Certainty::Maybe(MaybeInfo {
             cause: MaybeCause::Overflow { suggest_increasing_limit, keep_constraints: false },
             opaque_types_jank: OpaqueTypesJank::AllGood,
-        }
+            stalled_on_coroutines: StalledOnCoroutines::No,
+        })
     }
 }
 

--- a/tests/ui/async-await/async-closures/is-not-fn.next.stderr
+++ b/tests/ui/async-await/async-closures/is-not-fn.next.stderr
@@ -1,11 +1,13 @@
-error[E0271]: type mismatch resolving `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25} == ()`
+error[E0271]: expected `{async closure@is-not-fn.rs:8:14}` to return `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
   --> $DIR/is-not-fn.rs:8:14
    |
 LL |     needs_fn(async || {});
-   |     -------- ^^^^^^^^^^^ types differ
+   |     -------- ^^^^^^^^^^^ expected `()`, found `async` closure body
    |     |
    |     required by a bound introduced by this call
    |
+   = note:         expected unit type `()`
+           found `async` closure body `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
 note: required by a bound in `needs_fn`
   --> $DIR/is-not-fn.rs:7:25
    |

--- a/tests/ui/async-await/async-closures/is-not-fn.rs
+++ b/tests/ui/async-await/async-closures/is-not-fn.rs
@@ -6,6 +6,5 @@
 fn main() {
     fn needs_fn(x: impl FnOnce()) {}
     needs_fn(async || {});
-    //[current]~^ ERROR expected `{async closure@is-not-fn.rs:8:14}` to return `()`
-    //[next]~^^ ERROR type mismatch resolving `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25} == ()`
+    //~^ ERROR expected `{async closure@is-not-fn.rs:8:14}` to return `()`
 }

--- a/tests/ui/traits/next-solver/deeply-nested-stalled-on-coroutines.rs
+++ b/tests/ui/traits/next-solver/deeply-nested-stalled-on-coroutines.rs
@@ -1,0 +1,41 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+//@ edition: 2024
+
+// Regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/270
+
+struct Wrap<T>(T);
+
+impl<T> Wrap<T> {
+    fn nest(self) -> Wrap<Self> {
+        Wrap(self)
+    }
+}
+
+fn assert_send<S: Send>(s: S) -> S {
+    s
+}
+
+// We need an indirection so that the goal stalled on coroutine is not the root goal
+fn mk_opaque<F>(f: F) -> impl Future
+where
+    F: AsyncFnOnce(),
+{
+    f()
+}
+
+fn test() {
+    let coroutine = async || {};
+    let opaque = mk_opaque(coroutine);
+    // This `deep_nested: Send` is ambiguous because it contains nested obligation whose self_ty is
+    // coroutine.
+    // It should be collected into `stalled_coroutine_obligation` before report ambiguity errors.
+    // But it used to be not, because we were collecting them with a `ProofTreeVisitor`, which has
+    // a recursion limit.
+    let deep_nested =
+        Wrap(opaque).nest().nest().nest().nest().nest().nest().nest().nest().nest().nest().nest();
+
+    assert_send(deep_nested);
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155648)*
<!-- homu-ignore:end -->

..instead of collecting them with a `ProofTreeVisitor`

Fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/270