### PR TITLE
Add `Sender` diagnostic item for `std::sync::mpsc::Sender`

### DIFF
--- a/library/std/src/sync/mpsc.rs
+++ b/library/std/src/sync/mpsc.rs
@@ -330,6 +330,7 @@ pub struct IntoIter<T> {
 /// assert_eq!(3, msg + msg2);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "MpscSender")]
 pub struct Sender<T> {
     inner: mpmc::Sender<T>,
 }


### PR DESCRIPTION
Similar to the existing `Receiver` item, it will be used in Clippy to detect uses of `is_disconnected` that are racy.

Tracking issue: rust-lang/rust#153668
Suggested: https://github.com/rust-lang/libs-team/issues/748#issuecomment-4032790302