### PR TITLE
Const initialize `LOCK_LATCH` thread local

### DIFF
--- a/compiler/rustc_thread_pool/src/latch.rs
+++ b/compiler/rustc_thread_pool/src/latch.rs
@@ -220,7 +220,7 @@ pub(super) struct LockLatch {
 
 impl LockLatch {
     #[inline]
-    pub(super) fn new() -> LockLatch {
+    pub(super) const fn new() -> LockLatch {
         LockLatch { m: Mutex::new(false), v: Condvar::new() }
     }
 

--- a/compiler/rustc_thread_pool/src/registry.rs
+++ b/compiler/rustc_thread_pool/src/registry.rs
@@ -524,7 +524,7 @@ impl Registry {
         OP: FnOnce(&WorkerThread, bool) -> R + Send,
         R: Send,
     {
-        thread_local!(static LOCK_LATCH: LockLatch = LockLatch::new());
+        thread_local!(static LOCK_LATCH: LockLatch = const { LockLatch::new() });
 
         LOCK_LATCH.with(|l| {
             // This thread isn't a member of *any* thread pool, so just block.


### PR DESCRIPTION
A simple refactor to avoid runtime thread-local initialization.