### PR TITLE
Fix classify_union to return Union for regular unions

### DIFF
--- a/src/etc/rust_types.py
+++ b/src/etc/rust_types.py
@@ -130,4 +130,4 @@ def classify_union(fields: List) -> RustType:
         assert len(fields) == 1
         return RustType.CompressedEnum
     else:
-        return RustType.RegularEnum
+        return RustType.Union


### PR DESCRIPTION
Commit 623c7d7c4bc accidentally changed the return value from REGULAR_UNION to RegularEnum when converting string literals to enum values. Commit b17670d3de2 then renamed RegularUnion to Union, but the buggy return statement remained unchanged. This caused unions to be misclassified as enums, preventing LLDB from displaying union field contents.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
