### PR TITLE
Suggest enclosing format string with `""` under special cases

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -173,6 +173,16 @@ fn make_format_args(
         style: fmt_style,
         uncooked_symbol: uncooked_fmt_str,
     } = {
+        // Extract snippet so that we can check cases `{}`, `{:?}` and `{:#?}` and emit help for
+        // them later.
+        let snippet = if let ExprKind::Block(b, None) = &efmt.kind
+            && b.stmts.len() <= 1
+        {
+            Some(ecx.sess.source_map().span_to_snippet(unexpanded_fmt_span))
+        } else {
+            None
+        };
+
         let ExpandResult::Ready(mac) = expr_to_spanned_string(ecx, efmt.clone(), msg) else {
             return ExpandResult::Retry(());
         };
@@ -222,12 +232,26 @@ fn make_format_args(
                                     });
                                 }
                                 sugg_fmt = sugg_fmt.trim_end().to_string();
-                                err.span_suggestion(
+                                err.span_suggestion_verbose(
                                     unexpanded_fmt_span.shrink_to_lo(),
                                     "you might be missing a string literal to format with",
                                     format!("\"{sugg_fmt}\", "),
                                     Applicability::MaybeIncorrect,
                                 );
+
+                                if let Some(Ok(snippet)) = snippet.as_ref() {
+                                    match snippet.as_str() {
+                                        "{}" | "{:?}" | "{:#?}" => {
+                                            err.span_suggestion_verbose(
+                                                unexpanded_fmt_span,
+                                                format!("you might want to enclose `{snippet}` with `\"\"`"),
+                                                format!("\"{snippet}\""),
+                                                Applicability::MaybeIncorrect,
+                                            );
+                                        }
+                                        _ => {}
+                                    };
+                                }
                             }
                         }
                         err.emit()

--- a/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.fixed
+++ b/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.fixed
@@ -2,9 +2,9 @@
 
 fn main() {
     let s = "123";
-    println!("{:?} {} {}", {}, "sss", s);
+    println!("{:?} {} {}", "{}", "sss", s);
     //~^ ERROR format argument must be a string literal
-    println!("{:?}", {});
+    println!("{:?}", "{}");
     //~^ ERROR format argument must be a string literal
     println!("{} {} {} {:?}", s, "sss", s, {});
     //~^ ERROR format argument must be a string literal

--- a/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.stderr
+++ b/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.stderr
@@ -8,6 +8,11 @@ help: you might be missing a string literal to format with
    |
 LL |     println!("{:?} {} {}", {}, "sss", s);
    |              +++++++++++++
+help: you might want to enclose `{}` with `""`
+   |
+LL -     println!({}, "sss", s);
+LL +     println!("{}", "sss", s);
+   |
 
 error: format argument must be a string literal
   --> $DIR/format-empty-block-unit-tuple-suggestion-130170.rs:7:14
@@ -19,6 +24,11 @@ help: you might be missing a string literal to format with
    |
 LL |     println!("{:?}", {});
    |              +++++++
+help: you might want to enclose `{}` with `""`
+   |
+LL -     println!({});
+LL +     println!("{}");
+   |
 
 error: format argument must be a string literal
   --> $DIR/format-empty-block-unit-tuple-suggestion-130170.rs:9:14

--- a/tests/ui/macros/suggest-enclosing-format-string.rs
+++ b/tests/ui/macros/suggest-enclosing-format-string.rs
@@ -1,0 +1,27 @@
+// Suggest enclosing the format string with `""` when it is one of `{}`, `{:?}`, and `{:#?}`.
+
+#[derive(Debug)]
+enum UwU {
+    QwQ,
+    AwA,
+    QAQ,
+}
+
+fn main() {
+    println!({}, UwU::QwQ);
+    //~^ ERROR format argument must be a string literal
+    //~| HELP you might be missing a string literal to format with
+    //~| HELP you might want to enclose `{}` with `""`
+    println!({:?}, UwU::QwQ);
+    //~^ ERROR expected expression, found `:`
+    //~| ERROR format argument must be a string literal
+    //~| HELP you might be missing a string literal to format with
+    //~| HELP maybe write a path separator here
+    //~| HELP you might want to enclose `{:?}` with `""`
+    println!({:#?}, UwU::QwQ);
+    //~^ ERROR expected expression, found `:`
+    //~| ERROR format argument must be a string literal
+    //~| HELP you might be missing a string literal to format with
+    //~| HELP maybe write a path separator here
+    //~| HELP you might want to enclose `{:#?}` with `""`
+}

--- a/tests/ui/macros/suggest-enclosing-format-string.stderr
+++ b/tests/ui/macros/suggest-enclosing-format-string.stderr
@@ -1,0 +1,72 @@
+error: format argument must be a string literal
+  --> $DIR/suggest-enclosing-format-string.rs:11:14
+   |
+LL |     println!({}, UwU::QwQ);
+   |              ^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{:?} {}", {}, UwU::QwQ);
+   |              ++++++++++
+help: you might want to enclose `{}` with `""`
+   |
+LL -     println!({}, UwU::QwQ);
+LL +     println!("{}", UwU::QwQ);
+   |
+
+error: expected expression, found `:`
+  --> $DIR/suggest-enclosing-format-string.rs:15:15
+   |
+LL |     println!({:?}, UwU::QwQ);
+   |               ^ expected expression
+   |
+help: maybe write a path separator here
+   |
+LL |     println!({::?}, UwU::QwQ);
+   |                +
+
+error: format argument must be a string literal
+  --> $DIR/suggest-enclosing-format-string.rs:15:14
+   |
+LL |     println!({:?}, UwU::QwQ);
+   |              ^^^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{} {}", {:?}, UwU::QwQ);
+   |              ++++++++
+help: you might want to enclose `{:?}` with `""`
+   |
+LL -     println!({:?}, UwU::QwQ);
+LL +     println!("{:?}", UwU::QwQ);
+   |
+
+error: expected expression, found `:`
+  --> $DIR/suggest-enclosing-format-string.rs:21:15
+   |
+LL |     println!({:#?}, UwU::QwQ);
+   |               ^ expected expression
+   |
+help: maybe write a path separator here
+   |
+LL |     println!({::#?}, UwU::QwQ);
+   |                +
+
+error: format argument must be a string literal
+  --> $DIR/suggest-enclosing-format-string.rs:21:14
+   |
+LL |     println!({:#?}, UwU::QwQ);
+   |              ^^^^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{} {}", {:#?}, UwU::QwQ);
+   |              ++++++++
+help: you might want to enclose `{:#?}` with `""`
+   |
+LL -     println!({:#?}, UwU::QwQ);
+LL +     println!("{:#?}", UwU::QwQ);
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
This commit adds suggestions on enclosing format string with `""` when it falls into the following 3 cases: `{}`, `{:?}`, `{:#?}` as mentioned in rust-lang/rust#155508.  

Currently, this commit only recognizes the above 3 cases. I wonder if we should generalize this to more cases, for example, appying this suggestion to `Block`s with only 0 or 1 `Stmt`, such as `{:#x}`, `{:^10}`, `{abc}`.