### PR TITLE
Suppress invalid `.into_iter()` suggestion for borrowed projections

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -146,6 +146,18 @@ impl<'tcx, D: Delegate<'tcx>> Delegate<'tcx> for &mut D {
     }
 }
 
+impl<'tcx> Delegate<'tcx> for () {
+    fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
+
+    fn use_cloned(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
+
+    fn borrow(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId, _: ty::BorrowKind) {}
+
+    fn mutate(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
+
+    fn fake_read(&mut self, _: &PlaceWithHirId<'tcx>, _: FakeReadCause, _: HirId) {}
+}
+
 /// This trait makes `ExprUseVisitor` usable with both [`FnCtxt`]
 /// and [`LateContext`], depending on where in the compiler it is used.
 pub trait TypeInformationCtxt<'tcx> {
@@ -1854,4 +1866,11 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
             false
         }
     }
+}
+
+pub(crate) fn expr_place<'tcx>(
+    fcx: &FnCtxt<'_, 'tcx>,
+    expr: &hir::Expr<'_>,
+) -> Result<PlaceWithHirId<'tcx>, ErrorGuaranteed> {
+    ExprUseVisitor::new(fcx, ()).cat_expr(expr)
 }

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -48,6 +48,7 @@ use tracing::{debug, info, instrument};
 use super::probe::{AutorefOrPtrAdjustment, IsSuggestion, Mode, ProbeScope};
 use super::{CandidateSource, MethodError, NoMatchData};
 use crate::errors::{self, CandidateTraitNote, NoAssociatedItem};
+use crate::expr_use_visitor::expr_place;
 use crate::method::probe::UnsatisfiedPredicates;
 use crate::{Expectation, FnCtxt};
 
@@ -187,6 +188,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => return false,
         }
         false
+    }
+
+    fn allows_into_iter_suggestion(&self, source: SelfSource<'tcx>) -> bool {
+        let SelfSource::MethodCall(rcvr_expr) = source else {
+            return true;
+        };
+
+        let rcvr_expr = rcvr_expr.peel_drop_temps().peel_blocks();
+        let Ok(place_with_id) = expr_place(self, rcvr_expr) else {
+            return true;
+        };
+
+        !place_with_id.place.deref_tys().any(Ty::is_ref)
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -853,6 +867,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ));
             }
         } else if self.impl_into_iterator_should_be_iterator(rcvr_ty, span, unsatisfied_predicates)
+            && self.allows_into_iter_suggestion(source)
         {
             err.span_label(span, format!("`{rcvr_ty}` is not an iterator"));
             if !span.in_external_macro(self.tcx.sess.source_map()) {

--- a/tests/ui/did_you_mean/collect-without-into-iter-call.rs
+++ b/tests/ui/did_you_mean/collect-without-into-iter-call.rs
@@ -17,3 +17,30 @@ fn process(items: impl IntoIterator<Item = String>) -> Vec<String> {
     items.collect()
     //~^ ERROR no method named `collect` found for type parameter `impl IntoIterator<Item = String>` in the current scope
 }
+
+// Regression test for https://github.com/rust-lang/rust/issues/155365
+struct Demo {
+    contents: Vec<u32>,
+}
+
+impl Demo {
+    fn shared(&self) {
+        self.contents.filter(|v| *v % 2 == 1).count(); //~ ERROR `Vec<u32>` is not an iterator
+    }
+
+    fn mutable(&mut self) {
+        self.contents.filter(|v| *v % 2 == 1).count(); //~ ERROR `Vec<u32>` is not an iterator
+    }
+
+    fn owned(self) {
+        self.contents.filter(|v| *v % 2 == 1).count(); //~ ERROR no method named `filter` found
+    }
+}
+
+fn filter_param(contents: &Vec<u32>) {
+    contents.filter(|v| *v % 2 == 1).count(); //~ ERROR no method named `filter` found
+}
+
+fn filter_explicit_deref(contents: &Vec<u32>) {
+    (*contents).filter(|v| *v % 2 == 1).count(); //~ ERROR `Vec<u32>` is not an iterator
+}

--- a/tests/ui/did_you_mean/collect-without-into-iter-call.stderr
+++ b/tests/ui/did_you_mean/collect-without-into-iter-call.stderr
@@ -31,6 +31,64 @@ help: call `.into_iter()` first
 LL |     items.into_iter().collect()
    |           ++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0599]: `Vec<u32>` is not an iterator
+  --> $DIR/collect-without-into-iter-call.rs:28:23
+   |
+LL |         self.contents.filter(|v| *v % 2 == 1).count();
+   |                       ^^^^^^ `Vec<u32>` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `Vec<u32>: Iterator`
+           which is required by `&mut Vec<u32>: Iterator`
+           `[u32]: Iterator`
+           which is required by `&mut [u32]: Iterator`
+
+error[E0599]: `Vec<u32>` is not an iterator
+  --> $DIR/collect-without-into-iter-call.rs:32:23
+   |
+LL |         self.contents.filter(|v| *v % 2 == 1).count();
+   |                       ^^^^^^ `Vec<u32>` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `Vec<u32>: Iterator`
+           which is required by `&mut Vec<u32>: Iterator`
+           `[u32]: Iterator`
+           which is required by `&mut [u32]: Iterator`
+
+error[E0599]: no method named `filter` found for struct `Vec<u32>` in the current scope
+  --> $DIR/collect-without-into-iter-call.rs:36:23
+   |
+LL |         self.contents.filter(|v| *v % 2 == 1).count();
+   |                       ^^^^^^ `Vec<u32>` is not an iterator
+   |
+help: call `.into_iter()` first
+   |
+LL |         self.contents.into_iter().filter(|v| *v % 2 == 1).count();
+   |                       ++++++++++++
+
+error[E0599]: no method named `filter` found for reference `&Vec<u32>` in the current scope
+  --> $DIR/collect-without-into-iter-call.rs:41:14
+   |
+LL |     contents.filter(|v| *v % 2 == 1).count();
+   |              ^^^^^^ `&Vec<u32>` is not an iterator
+   |
+help: call `.into_iter()` first
+   |
+LL |     contents.into_iter().filter(|v| *v % 2 == 1).count();
+   |              ++++++++++++
+
+error[E0599]: `Vec<u32>` is not an iterator
+  --> $DIR/collect-without-into-iter-call.rs:45:17
+   |
+LL |     (*contents).filter(|v| *v % 2 == 1).count();
+   |                 ^^^^^^ `Vec<u32>` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `Vec<u32>: Iterator`
+           which is required by `&mut Vec<u32>: Iterator`
+           `[u32]: Iterator`
+           which is required by `&mut [u32]: Iterator`
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fixes rust-lang/rust#155365.