### PR TITLE
Change `ItemKind::Trait` to a field variant.

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -585,16 +585,16 @@ impl<'hir, R: ResolverAstLoweringExt<'hir>> LoweringContext<'_, 'hir, R> {
                         (safety, items, bounds)
                     },
                 );
-                hir::ItemKind::Trait(
+                hir::ItemKind::Trait {
                     impl_restriction,
                     constness,
-                    *is_auto,
+                    is_auto: *is_auto,
                     safety,
                     ident,
                     generics,
                     bounds,
                     items,
-                )
+                }
             }
             ItemKind::TraitAlias(box TraitAlias { constness, ident, generics, bounds }) => {
                 let constness = self.lower_constness(*constness);

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4466,7 +4466,7 @@ impl<'hir> Item<'hir> {
                 GenericBounds<'hir>,
                 &'hir [TraitItemId]
             ),
-            ItemKind::Trait(impl_restriction, constness, is_auto, safety, ident, generics, bounds, items),
+            ItemKind::Trait { impl_restriction, constness, is_auto, safety, ident, generics, bounds, items },
             (impl_restriction, *constness, *is_auto, *safety, *ident, generics, bounds, items);
 
         expect_trait_alias, (Constness, Ident, &'hir Generics<'hir>, GenericBounds<'hir>),
@@ -4658,16 +4658,16 @@ pub enum ItemKind<'hir> {
     /// A union definition, e.g., `union Foo<A, B> {x: A, y: B}`.
     Union(Ident, &'hir Generics<'hir>, VariantData<'hir>),
     /// A trait definition.
-    Trait(
-        &'hir ImplRestriction<'hir>,
-        Constness,
-        IsAuto,
-        Safety,
-        Ident,
-        &'hir Generics<'hir>,
-        GenericBounds<'hir>,
-        &'hir [TraitItemId],
-    ),
+    Trait {
+        impl_restriction: &'hir ImplRestriction<'hir>,
+        constness: Constness,
+        is_auto: IsAuto,
+        safety: Safety,
+        ident: Ident,
+        generics: &'hir Generics<'hir>,
+        bounds: GenericBounds<'hir>,
+        items: &'hir [TraitItemId],
+    },
     /// A trait alias.
     TraitAlias(Constness, Ident, &'hir Generics<'hir>, GenericBounds<'hir>),
 
@@ -4713,7 +4713,7 @@ impl ItemKind<'_> {
             | ItemKind::Enum(ident, ..)
             | ItemKind::Struct(ident, ..)
             | ItemKind::Union(ident, ..)
-            | ItemKind::Trait(_, _, _, _, ident, ..)
+            | ItemKind::Trait { ident, .. }
             | ItemKind::TraitAlias(_, ident, ..) => Some(ident),
 
             ItemKind::Use(_, UseKind::Glob | UseKind::ListStem)
@@ -4731,7 +4731,7 @@ impl ItemKind<'_> {
             | ItemKind::Enum(_, generics, _)
             | ItemKind::Struct(_, generics, _)
             | ItemKind::Union(_, generics, _)
-            | ItemKind::Trait(_, _, _, _, _, generics, _, _)
+            | ItemKind::Trait { generics, .. }
             | ItemKind::TraitAlias(_, _, generics, _)
             | ItemKind::Impl(Impl { generics, .. }) => generics,
             _ => return None,

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -618,16 +618,16 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item<'v>) -> V::
             try_visit!(visitor.visit_generics(generics));
             try_visit!(visitor.visit_variant_data(struct_definition));
         }
-        ItemKind::Trait(
-            ref impl_restriction,
-            _constness,
-            _is_auto,
-            _safety,
+        ItemKind::Trait {
+            impl_restriction,
+            constness: _,
+            is_auto: _,
+            safety: _,
             ident,
-            ref generics,
+            generics,
             bounds,
-            trait_item_refs,
-        ) => {
+            items: trait_item_refs,
+        } => {
             if let RestrictionKind::Restricted(path) = &impl_restriction.kind {
                 walk_list!(visitor, visit_path_segment, path.segments);
             }

--- a/compiler/rustc_hir/src/target.rs
+++ b/compiler/rustc_hir/src/target.rs
@@ -132,7 +132,7 @@ impl Target {
             ItemKind::Enum(..) => Target::Enum,
             ItemKind::Struct(..) => Target::Struct,
             ItemKind::Union(..) => Target::Union,
-            ItemKind::Trait(..) => Target::Trait,
+            ItemKind::Trait { .. } => Target::Trait,
             ItemKind::TraitAlias(..) => Target::TraitAlias,
             ItemKind::Impl(imp_) => Target::Impl { of_trait: imp_.of_trait.is_some() },
         }

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -326,7 +326,7 @@ pub(super) fn check_item<'tcx>(
         hir::ItemKind::Struct(..) => check_type_defn(tcx, item, false),
         hir::ItemKind::Union(..) => check_type_defn(tcx, item, true),
         hir::ItemKind::Enum(..) => check_type_defn(tcx, item, true),
-        hir::ItemKind::Trait(..) => check_trait(tcx, item),
+        hir::ItemKind::Trait { .. } => check_trait(tcx, item),
         hir::ItemKind::TraitAlias(..) => check_trait(tcx, item),
         _ => Ok(()),
     }
@@ -1188,7 +1188,7 @@ fn check_trait(tcx: TyCtxt<'_>, item: &hir::Item<'_>) -> Result<(), ErrorGuarant
     });
 
     // Only check traits, don't check trait aliases
-    if let hir::ItemKind::Trait(..) = item.kind {
+    if let hir::ItemKind::Trait { .. } = item.kind {
         check_gat_where_clauses(tcx, item.owner_id.def_id);
     }
     res

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -895,7 +895,7 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
     let item = tcx.hir_expect_item(def_id);
 
     let (constness, is_alias, is_auto, safety, impl_restriction) = match item.kind {
-        hir::ItemKind::Trait(impl_restriction, constness, is_auto, safety, ..) => (
+        hir::ItemKind::Trait { impl_restriction, constness, is_auto, safety, .. } => (
             constness,
             false,
             is_auto == hir::IsAuto::Yes,

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -221,7 +221,7 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
 
     // Add in the self type parameter.
     let opt_self = if let Node::Item(item) = node
-        && let ItemKind::Trait(..) | ItemKind::TraitAlias(..) = item.kind
+        && let ItemKind::Trait { .. } | ItemKind::TraitAlias(..) = item.kind
     {
         // Something of a hack: We reuse the node ID of the trait for the self type parameter.
         Some(ty::GenericParamDef {
@@ -402,7 +402,7 @@ fn param_default_policy(node: Node<'_>) -> Option<ParamDefaultPolicy> {
 
     Some(match node {
         Node::Item(item) => match item.kind {
-            ItemKind::Trait(..)
+            ItemKind::Trait { .. }
             | ItemKind::TraitAlias(..)
             | ItemKind::TyAlias(..)
             | ItemKind::Enum(..)

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -172,7 +172,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
                     ));
                 }
             }
-            ItemKind::Trait(_, _, _, _, _, _, self_bounds, ..)
+            ItemKind::Trait { bounds: self_bounds, .. }
             | ItemKind::TraitAlias(_, _, _, self_bounds) => {
                 is_trait = Some((self_bounds, item.span));
             }
@@ -669,7 +669,7 @@ pub(super) fn implied_predicates_with_filter<'tcx>(
     };
 
     let (generics, superbounds) = match item.kind {
-        hir::ItemKind::Trait(.., generics, supertraits, _) => (generics, supertraits),
+        hir::ItemKind::Trait { generics, bounds: supertraits, .. } => (generics, supertraits),
         hir::ItemKind::TraitAlias(_, _, generics, supertraits) => (generics, supertraits),
         _ => span_bug!(item.span, "super_predicates invoked on non-trait"),
     };
@@ -934,7 +934,7 @@ pub(super) fn type_param_predicates<'tcx>(
     };
 
     if let Node::Item(item) = hir_node
-        && let hir::ItemKind::Trait(..) = item.kind
+        && let hir::ItemKind::Trait { .. } = item.kind
         // Implied `Self: Trait` and supertrait bounds.
         && param_id == item_hir_id
     {
@@ -1073,7 +1073,7 @@ pub(super) fn const_conditions<'tcx>(
         Node::Item(item) => match item.kind {
             hir::ItemKind::Impl(impl_) => (impl_.generics, None, false),
             hir::ItemKind::Fn { generics, .. } => (generics, None, false),
-            hir::ItemKind::Trait(_, _, _, _, _, generics, supertraits, _) => {
+            hir::ItemKind::Trait { generics, bounds: supertraits, .. } => {
                 (generics, Some((Some(item.owner_id.def_id), supertraits)), false)
             }
             hir::ItemKind::TraitAlias(_, _, generics, supertraits) => {
@@ -1194,7 +1194,7 @@ pub(super) fn explicit_implied_const_bounds<'tcx>(
         }
         None => match tcx.hir_node_by_def_id(def_id) {
             Node::Item(hir::Item {
-                kind: hir::ItemKind::Trait(..) | hir::ItemKind::TraitAlias(..),
+                kind: hir::ItemKind::Trait { .. } | hir::ItemKind::TraitAlias(..),
                 ..
             }) => implied_predicates_with_filter(
                 tcx,

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -647,7 +647,7 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
             | hir::ItemKind::Enum(_, generics, _)
             | hir::ItemKind::Struct(_, generics, _)
             | hir::ItemKind::Union(_, generics, _)
-            | hir::ItemKind::Trait(_, _, _, _, _, generics, ..)
+            | hir::ItemKind::Trait { generics, .. }
             | hir::ItemKind::TraitAlias(_, _, generics, ..)
             | hir::ItemKind::Impl(hir::Impl { generics, .. }) => {
                 // These kinds of items have only early-bound lifetime parameters.
@@ -2258,7 +2258,7 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                     // we already do that in `BoundVarContext::supertrait_hrtb_vars`.
                     if let Res::SelfTyParam { trait_: _ } = expected_res
                         && let hir::Node::Item(item) = node
-                        && let hir::ItemKind::Trait(..) = item.kind
+                        && let hir::ItemKind::Trait { .. } = item.kind
                     {
                         // Yield the trait's def id. Supertraits will be
                         // elaborated from that.

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -171,7 +171,7 @@ pub(super) fn type_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_
                 Ty::new_adt(tcx, def, args)
             }
             ItemKind::GlobalAsm { .. } => tcx.typeck(def_id).node_type(hir_id),
-            ItemKind::Trait(..)
+            ItemKind::Trait { .. }
             | ItemKind::TraitAlias(..)
             | ItemKind::Macro(..)
             | ItemKind::Mod(..)

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -757,7 +757,7 @@ impl<'a> State<'a> {
                 }
                 self.bclose(item.span, cb);
             }
-            hir::ItemKind::Trait(
+            hir::ItemKind::Trait {
                 impl_restriction,
                 constness,
                 is_auto,
@@ -765,8 +765,8 @@ impl<'a> State<'a> {
                 ident,
                 generics,
                 bounds,
-                trait_items,
-            ) => {
+                items: trait_items,
+            } => {
                 let (cb, ib) = self.head("");
                 self.print_impl_restriction(impl_restriction);
                 self.print_constness(constness);

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1900,7 +1900,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     entry.1.insert((self_ty.span, String::new()));
                 }
                 Some(Node::Item(hir::Item {
-                    kind: hir::ItemKind::Trait(_, _, rustc_ast::ast::IsAuto::Yes, ..),
+                    kind: hir::ItemKind::Trait { is_auto:  rustc_ast::ast::IsAuto::Yes, .. },
                     span: item_span,
                     ..
                 })) => {
@@ -1912,7 +1912,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Some(
                     Node::Item(hir::Item {
                         kind:
-                            hir::ItemKind::Trait(_, _, _, _, ident, ..)
+                            hir::ItemKind::Trait { ident, .. }
                             | hir::ItemKind::TraitAlias(_, ident, ..),
                         ..
                     })
@@ -4571,7 +4571,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             return;
                         }
                         Node::Item(hir::Item {
-                            kind: hir::ItemKind::Trait(_, _, _, _, ident, _, bounds, _),
+                            kind: hir::ItemKind::Trait { ident, bounds, .. },
                             ..
                         }) => {
                             let (sp, sep, article) = if bounds.is_empty() {

--- a/compiler/rustc_incremental/src/persist/clean.rs
+++ b/compiler/rustc_incremental/src/persist/clean.rs
@@ -267,7 +267,7 @@ impl<'tcx> CleanVisitor<'tcx> {
                     HirItem::Union(..) => ("ItemUnion", LABELS_ADT),
 
                     // Represents a Trait Declaration
-                    HirItem::Trait(..) => ("ItemTrait", LABELS_TRAIT),
+                    HirItem::Trait { .. } => ("ItemTrait", LABELS_TRAIT),
 
                     // An implementation, eg `impl<A> Trait for Foo { .. }`
                     HirItem::Impl { .. } => ("ItemKind::Impl", LABELS_IMPL),

--- a/compiler/rustc_lint/src/multiple_supertrait_upcastable.rs
+++ b/compiler/rustc_lint/src/multiple_supertrait_upcastable.rs
@@ -40,7 +40,7 @@ impl<'tcx> LateLintPass<'tcx> for MultipleSupertraitUpcastable {
         let def_id = item.owner_id.to_def_id();
         // NOTE(nbdd0121): use `dyn_compatibility_violations` instead of `is_dyn_compatible` because
         // the latter will report `where_clause_object_safety` lint.
-        if let hir::ItemKind::Trait(_, _, _, _, ident, ..) = item.kind
+        if let hir::ItemKind::Trait { ident, .. } = item.kind
             && cx.tcx.is_dyn_compatible(def_id)
         {
             let direct_super_traits_iter = cx

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -1145,7 +1145,7 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesLint {
             // Doesn't define something that can contain a external type to be checked.
             hir::ItemKind::Impl(..)
             | hir::ItemKind::TraitAlias(..)
-            | hir::ItemKind::Trait(..)
+            | hir::ItemKind::Trait { .. }
             | hir::ItemKind::GlobalAsm { .. }
             | hir::ItemKind::ForeignMod { .. }
             | hir::ItemKind::Mod(..)

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -654,7 +654,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     | ItemKind::Enum(..)
                     | ItemKind::Struct(..)
                     | ItemKind::Union(..)
-                    | ItemKind::Trait(..)
+                    | ItemKind::Trait { .. }
                     | ItemKind::Impl { .. },
                 ..
             })
@@ -705,7 +705,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     ItemKind::Enum(..) => "enum",
                     ItemKind::Struct(..) => "struct",
                     ItemKind::Union(..) => "union",
-                    ItemKind::Trait(..) => "trait",
+                    ItemKind::Trait { .. } => "trait",
                     ItemKind::TraitAlias(..) => "trait alias",
                     ItemKind::Impl { .. } => "impl",
                 };
@@ -955,7 +955,7 @@ impl<'tcx> TyCtxt<'tcx> {
             }) => until_within(*outer_span, ty.span),
             // With generics and bounds.
             Node::Item(Item {
-                kind: ItemKind::Trait(_, _, _, _, _, generics, bounds, _),
+                kind: ItemKind::Trait { generics, bounds, .. },
                 span: outer_span,
                 ..
             })

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -497,7 +497,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     fn check_diagnostic_on_unimplemented(&self, hir_id: HirId, directive: Option<&Directive>) {
         if let Some(directive) = directive {
             if let Node::Item(Item {
-                kind: ItemKind::Trait(_, _, _, _, trait_name, generics, _, _),
+                kind: ItemKind::Trait { ident: trait_name, generics, .. },
                 ..
             }) = self.tcx.hir_node(hir_id)
             {
@@ -931,7 +931,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         match item.kind {
             ItemKind::Enum(_, generics, _) | ItemKind::Struct(_, generics, _)
                 if generics.params.len() != 0 => {}
-            ItemKind::Trait(_, _, _, _, _, generics, _, items)
+            ItemKind::Trait { generics, items, .. }
                 if generics.params.len() != 0
                     || items.iter().any(|item| {
                         matches!(self.tcx.def_kind(item.owner_id), DefKind::AssocTy)

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -486,7 +486,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                     intravisit::walk_item(self, item)
                 }
                 hir::ItemKind::ForeignMod { .. } => ControlFlow::Continue(()),
-                hir::ItemKind::Trait(.., trait_item_refs) => {
+                hir::ItemKind::Trait { items: trait_item_refs, .. } => {
                     // mark assoc ty live if the trait is live
                     for trait_item in trait_item_refs {
                         if self.tcx.def_kind(trait_item.owner_id) == DefKind::AssocTy {

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -256,7 +256,7 @@ impl<'tcx> ReachableContext<'tcx> {
                     | hir::ItemKind::Mod(..)
                     | hir::ItemKind::ForeignMod { .. }
                     | hir::ItemKind::Impl { .. }
-                    | hir::ItemKind::Trait(..)
+                    | hir::ItemKind::Trait { .. }
                     | hir::ItemKind::TraitAlias(..)
                     | hir::ItemKind::Struct(..)
                     | hir::ItemKind::Enum(..)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -577,8 +577,9 @@ pub fn report_dyn_incompatibility<'tcx>(
     let trait_str = tcx.def_path_str(trait_def_id);
     let trait_span = tcx.hir_get_if_local(trait_def_id).and_then(|node| match node {
         hir::Node::Item(item) => match item.kind {
-            hir::ItemKind::Trait(_, _, _, _, ident, ..)
-            | hir::ItemKind::TraitAlias(_, ident, _, _) => Some(ident.span),
+            hir::ItemKind::Trait { ident, .. } | hir::ItemKind::TraitAlias(_, ident, _, _) => {
+                Some(ident.span)
+            }
             _ => unreachable!(),
         },
         _ => None,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -494,7 +494,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let node = self.tcx.hir_node_by_def_id(body_id);
             match node {
                 hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Trait(_, _, _, _, ident, generics, bounds, _),
+                    kind: hir::ItemKind::Trait { ident, generics, bounds, .. },
                     ..
                 }) if self_ty == self.tcx.types.self_param => {
                     assert!(param_ty);
@@ -557,7 +557,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }
                 hir::Node::Item(hir::Item {
                     kind:
-                        hir::ItemKind::Trait(_, _, _, _, _, generics, ..)
+                        hir::ItemKind::Trait { generics, .. }
                         | hir::ItemKind::Impl(hir::Impl { generics, .. }),
                     ..
                 }) if projection.is_some() => {
@@ -581,7 +581,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         hir::ItemKind::Struct(_, generics, _)
                         | hir::ItemKind::Enum(_, generics, _)
                         | hir::ItemKind::Union(_, generics, _)
-                        | hir::ItemKind::Trait(_, _, _, _, _, generics, ..)
+                        | hir::ItemKind::Trait { generics, .. }
                         | hir::ItemKind::Impl(hir::Impl { generics, .. })
                         | hir::ItemKind::Fn { generics, .. }
                         | hir::ItemKind::TyAlias(_, generics, _)
@@ -661,7 +661,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         hir::ItemKind::Struct(_, generics, _)
                         | hir::ItemKind::Enum(_, generics, _)
                         | hir::ItemKind::Union(_, generics, _)
-                        | hir::ItemKind::Trait(_, _, _, _, _, generics, ..)
+                        | hir::ItemKind::Trait { generics, .. }
                         | hir::ItemKind::Impl(hir::Impl { generics, .. })
                         | hir::ItemKind::Fn { generics, .. }
                         | hir::ItemKind::TyAlias(_, generics, _)
@@ -4142,7 +4142,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let mut is_auto_trait = false;
                 match tcx.hir_get_if_local(data.impl_or_alias_def_id) {
                     Some(Node::Item(hir::Item {
-                        kind: hir::ItemKind::Trait(_, _, is_auto, _, ident, _, _, _),
+                        kind: hir::ItemKind::Trait { is_auto, ident, .. },
                         ..
                     })) => {
                         // FIXME: we should do something else so that it works even on crate foreign

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -623,7 +623,7 @@ impl Subdiagnostic for AddLifetimeParamsSuggestion<'_> {
                     match self.tcx.parent_hir_node(self.tcx.local_def_id_to_hir_id(anon_reg.scope))
                     {
                         hir::Node::Item(hir::Item {
-                            kind: hir::ItemKind::Trait(_, _, _, _, _, generics, ..),
+                            kind: hir::ItemKind::Trait { generics, .. },
                             ..
                         })
                         | hir::Node::Item(hir::Item {

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -141,7 +141,7 @@ fn get_sized_bounds(tcx: TyCtxt<'_>, trait_def_id: DefId) -> SmallVec<[Span; 1]>
     tcx.hir_get_if_local(trait_def_id)
         .and_then(|node| match node {
             hir::Node::Item(hir::Item {
-                kind: hir::ItemKind::Trait(.., generics, bounds, _),
+                kind: hir::ItemKind::Trait { generics, bounds, .. },
                 ..
             }) => Some(
                 generics

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -25,7 +25,7 @@ pub(crate) fn provide(providers: &mut Providers) {
 fn associated_item_def_ids(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &[DefId] {
     let item = tcx.hir_expect_item(def_id);
     match item.kind {
-        hir::ItemKind::Trait(.., trait_item_refs) => {
+        hir::ItemKind::Trait { items: trait_item_refs, .. } => {
             // We collect RPITITs for each trait method's return type and create a corresponding
             // associated item using the associated_types_for_impl_traits_in_trait_or_impl
             // query.
@@ -153,7 +153,7 @@ fn associated_types_for_impl_traits_in_trait_or_impl<'tcx>(
     let item = tcx.hir_expect_item(def_id);
     let disambiguators = &mut Default::default();
     match item.kind {
-        ItemKind::Trait(.., trait_item_refs) => trait_item_refs
+        ItemKind::Trait { items: trait_item_refs, .. } => trait_item_refs
             .iter()
             .filter_map(move |item| {
                 if !matches!(tcx.def_kind(item.owner_id), DefKind::AssocFn) {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2942,7 +2942,7 @@ fn clean_maybe_renamed_item<'tcx>(
                 clean_fn_or_proc_macro(item, sig, generics, body_id, &mut name, cx)
             }
             // FIXME: rustdoc will need to handle `impl` restrictions at some point
-            ItemKind::Trait(_impl_restriction, _, _, _, _, generics, bounds, item_ids) => {
+            ItemKind::Trait { generics, bounds, items: item_ids, .. } => {
                 let items = item_ids
                     .iter()
                     .map(|&ti| clean_trait_item(cx.tcx.hir_trait_item(ti), cx))

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -349,7 +349,7 @@ impl<'tcx> Visitor<'tcx> for SpanMapVisitor<'tcx> {
             | ItemKind::Enum(..)
             | ItemKind::Struct(..)
             | ItemKind::Union(..)
-            | ItemKind::Trait(..)
+            | ItemKind::Trait { .. }
             | ItemKind::TraitAlias(..) => self.extract_info_from_hir_id(item.hir_id()),
             ItemKind::Impl(_)
             | ItemKind::Use(..)

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -537,7 +537,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             | hir::ItemKind::Union(..)
             | hir::ItemKind::TyAlias(..)
             | hir::ItemKind::Static(..)
-            | hir::ItemKind::Trait(..)
+            | hir::ItemKind::Trait { .. }
             | hir::ItemKind::TraitAlias(..) => {
                 self.add_to_current_mod(item, renamed, import_id);
             }
@@ -607,7 +607,7 @@ impl<'tcx> Visitor<'tcx> for RustdocVisitor<'_, 'tcx> {
                 hir::ItemKind::Mod(..)
                     | hir::ItemKind::ForeignMod { .. }
                     | hir::ItemKind::Impl(..)
-                    | hir::ItemKind::Trait(..)
+                    | hir::ItemKind::Trait { .. }
             );
         let prev = mem::replace(&mut self.is_importable_from_parent, new_value);
         walk_item(self, i);

--- a/src/tools/clippy/clippy_lints/src/arbitrary_source_item_ordering.rs
+++ b/src/tools/clippy/clippy_lints/src/arbitrary_source_item_ordering.rs
@@ -306,16 +306,16 @@ impl<'tcx> LateLintPass<'tcx> for ArbitrarySourceItemOrdering {
                     cur_f = Some(field);
                 }
             },
-            ItemKind::Trait(
-                _impl_restriction,
-                _constness,
+            ItemKind::Trait {
+                impl_restriction:_,
+                constness:_,
                 is_auto,
-                _safety,
-                _ident,
-                _generics,
-                _generic_bounds,
-                item_ref,
-            ) if self.enable_ordering_for_trait && *is_auto == IsAuto::No => {
+                safety:_,
+                ident:_,
+                generics: _,
+                bounds: _,
+                items: item_ref}
+             if self.enable_ordering_for_trait && *is_auto == IsAuto::No => {
                 let mut cur_t: Option<(TraitItemId, Ident)> = None;
 
                 for &item in *item_ref {
@@ -510,7 +510,7 @@ fn convert_module_item_kind(value: &ItemKind<'_>) -> SourceItemOrderingModuleIte
         ItemKind::Enum(..) => Enum,
         ItemKind::Struct(..) => Struct,
         ItemKind::Union(..) => Union,
-        ItemKind::Trait(..) => Trait,
+        ItemKind::Trait { .. } => Trait,
         ItemKind::TraitAlias(..) => TraitAlias,
         ItemKind::Impl(..) => Impl,
     }

--- a/src/tools/clippy/clippy_lints/src/doc/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/doc/mod.rs
@@ -769,7 +769,7 @@ impl<'tcx> LateLintPass<'tcx> for Documentation {
                     {
                         missing_headers::check(cx, item.owner_id, sig, headers, Some(body), self.check_private_items);
                     },
-                    ItemKind::Trait(_, _, _, unsafety, ..) => match (headers.safety, unsafety) {
+                    ItemKind::Trait { safety, .. } => match (headers.safety, safety) {
                         (false, Safety::Unsafe) => span_lint(
                             cx,
                             MISSING_SAFETY_DOC,

--- a/src/tools/clippy/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
+++ b/src/tools/clippy/clippy_lints/src/doc/too_long_first_doc_paragraph.rs
@@ -33,7 +33,7 @@ pub(super) fn check(
                 | ItemKind::Enum(..)
                 | ItemKind::Struct(..)
                 | ItemKind::Union(..)
-                | ItemKind::Trait(..)
+                | ItemKind::Trait { .. }
                 | ItemKind::TraitAlias(..)
         )
     {

--- a/src/tools/clippy/clippy_lints/src/item_name_repetitions.rs
+++ b/src/tools/clippy/clippy_lints/src/item_name_repetitions.rs
@@ -528,7 +528,7 @@ impl LateLintPass<'_> for ItemNameRepetitions {
             | ItemKind::Fn { ident, .. }
             | ItemKind::Macro(ident, ..)
             | ItemKind::Static(_, ident, ..)
-            | ItemKind::Trait(_, _, _, _, ident, ..)
+            | ItemKind::Trait { ident, ..}
             | ItemKind::TraitAlias(_, ident, ..)
             | ItemKind::TyAlias(ident, ..)
             | ItemKind::Union(ident, ..)

--- a/src/tools/clippy/clippy_lints/src/len_without_is_empty.rs
+++ b/src/tools/clippy/clippy_lints/src/len_without_is_empty.rs
@@ -44,7 +44,7 @@ declare_lint_pass!(LenWithoutIsEmpty => [LEN_WITHOUT_IS_EMPTY]);
 
 impl<'tcx> LateLintPass<'tcx> for LenWithoutIsEmpty {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx Item<'_>) {
-        if let ItemKind::Trait(_, _, _, _, ident, _, _, trait_items) = item.kind
+        if let ItemKind::Trait { ident, items: trait_items, .. } = item.kind
             && !item.span.from_expansion()
         {
             check_trait_items(cx, item, ident, trait_items);

--- a/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_const_for_fn.rs
@@ -141,7 +141,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingConstForFn {
             let parent = cx.tcx.hir_get_parent_item(hir_id).def_id;
             if parent != CRATE_DEF_ID
                 && let hir::Node::Item(item) = cx.tcx.hir_node_by_def_id(parent)
-                && let hir::ItemKind::Trait(..) = &item.kind
+                && let hir::ItemKind::Trait { .. } = &item.kind
             {
                 return;
             }

--- a/src/tools/clippy/clippy_lints/src/missing_doc.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_doc.rs
@@ -159,7 +159,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingDoc {
             | ItemKind::Macro(ident, ..)
             | ItemKind::Static(_, ident, ..)
             | ItemKind::Struct(ident, ..)
-            | ItemKind::Trait(_, _, _, _, ident, ..)
+            | ItemKind::Trait { ident, .. }
             | ItemKind::TraitAlias(_, ident, ..)
             | ItemKind::TyAlias(ident, ..)
             | ItemKind::Union(ident, ..) => ident.span,

--- a/src/tools/clippy/clippy_lints/src/missing_inline.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_inline.rs
@@ -111,7 +111,7 @@ impl<'tcx> LateLintPass<'tcx> for MissingInline {
                 let attrs = cx.tcx.hir_attrs(it.hir_id());
                 check_missing_inline_attrs(cx, attrs, it.span, desc, None);
             },
-            hir::ItemKind::Trait(.., trait_items) => {
+            hir::ItemKind::Trait { items: trait_items, .. } => {
                 // note: we need to check if the trait is exported so we can't use
                 // `LateLintPass::check_trait_item` here.
                 for &tit in trait_items {

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -167,7 +167,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByRefMut<'tcx> {
         if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id)
             && matches!(
                 item.kind,
-                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
+                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait { .. }
             )
         {
             return;

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -103,7 +103,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
         if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id)
             && matches!(
                 item.kind,
-                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
+                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait { .. }
             )
         {
             return;

--- a/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
+++ b/src/tools/clippy/clippy_lints/src/pass_by_ref_or_value.rs
@@ -292,7 +292,7 @@ impl<'tcx> LateLintPass<'tcx> for PassByRefOrValue {
         if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id)
             && matches!(
                 item.kind,
-                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
+                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait { .. }
             )
         {
             return;

--- a/src/tools/clippy/clippy_lints/src/trait_bounds.rs
+++ b/src/tools/clippy/clippy_lints/src/trait_bounds.rs
@@ -115,7 +115,7 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
         // special handling for self trait bounds as these are not considered generics
         // i.e. trait Foo: Display {}
         if let Item {
-            kind: ItemKind::Trait(_, _, _, _, _, _, bounds, ..),
+            kind: ItemKind::Trait { bounds, .. },
             ..
         } = item
         {
@@ -136,7 +136,7 @@ impl<'tcx> LateLintPass<'tcx> for TraitBounds {
                     ..
                 }) = segments.first()
                 && let Some(Node::Item(Item {
-                    kind: ItemKind::Trait(_, _, _, _, _, _, self_bounds, _),
+                    kind: ItemKind::Trait {bounds: self_bounds,..},
                     ..
                 })) = cx.tcx.hir_get_if_local(*def_id)
             {

--- a/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
+++ b/src/tools/clippy/clippy_lints/src/unnecessary_wraps.rs
@@ -99,7 +99,7 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryWraps {
         if let Node::Item(item) = cx.tcx.parent_hir_node(hir_id)
             && matches!(
                 item.kind,
-                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait(..)
+                ItemKind::Impl(Impl { of_trait: Some(_), .. }) | ItemKind::Trait { .. }
             )
         {
             return;

--- a/src/tools/clippy/clippy_lints/src/upper_case_acronyms.rs
+++ b/src/tools/clippy/clippy_lints/src/upper_case_acronyms.rs
@@ -131,7 +131,7 @@ impl LateLintPass<'_> for UpperCaseAcronyms {
             return;
         }
         match it.kind {
-            ItemKind::TyAlias(ident, ..) | ItemKind::Struct(ident, ..) | ItemKind::Trait(_, _, _, _, ident, ..) => {
+            ItemKind::TyAlias(ident, ..) | ItemKind::Struct(ident, ..) | ItemKind::Trait { ident, .. }=> {
                 check_ident(cx, &ident, it.hir_id(), self.upper_case_acronyms_aggressive);
             },
             ItemKind::Enum(ident, _, ref enumdef) => {

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -265,15 +265,15 @@ fn item_search_pat(item: &Item<'_>) -> (Pat, Pat) {
         ItemKind::Struct(_, _, VariantData::Struct { .. }) => (Pat::Str("struct"), Pat::Str("}")),
         ItemKind::Struct(..) => (Pat::Str("struct"), Pat::Str(";")),
         ItemKind::Union(..) => (Pat::Str("union"), Pat::Str("}")),
-        ItemKind::Trait(_, _, _, Safety::Unsafe, ..)
+        ItemKind::Trait { safety: Safety::Unsafe, .. }
         | ItemKind::Impl(Impl {
             of_trait: Some(TraitImplHeader {
                 safety: Safety::Unsafe, ..
             }),
             ..
         }) => (Pat::Str("unsafe"), Pat::Str("}")),
-        ItemKind::Trait(_, _, IsAuto::Yes, ..) => (Pat::Str("auto"), Pat::Str("}")),
-        ItemKind::Trait(..) => (Pat::Str("trait"), Pat::Str("}")),
+        ItemKind::Trait { is_auto: IsAuto::Yes, .. } => (Pat::Str("auto"), Pat::Str("}")),
+        ItemKind::Trait { .. } => (Pat::Str("trait"), Pat::Str("}")),
         ItemKind::Impl(_) => (Pat::Str("impl"), Pat::Str("}")),
         ItemKind::Mod(..) => (Pat::Str("mod"), Pat::Str("")),
         ItemKind::Macro(_, def, _) => (

--- a/src/tools/clippy/clippy_utils/src/paths.rs
+++ b/src/tools/clippy/clippy_utils/src/paths.rs
@@ -332,7 +332,7 @@ fn local_item_child_by_name(tcx: TyCtxt<'_>, local_id: LocalDefId, ns: PathNS, n
                 None
             }
         }),
-        ItemKind::Impl(..) | ItemKind::Trait(..) => tcx
+        ItemKind::Impl(..) | ItemKind::Trait { .. } => tcx
             .associated_items(local_id)
             .filter_by_name_unhygienic(name)
             .find(|assoc_item| ns.matches(Some(assoc_item.namespace())))


### PR DESCRIPTION
This changes `ItemKind::Trait` from an octuple(!!) to an enum variant with fields. Their names were chosen to match up with existing usage and minimize renaming.

I'm leaning towards renaming `ident` to `name` as well; let me know if that's desired.