### PR TITLE
Remove myself as a maintainer of `wasm32-wasip1-threads`

### DIFF
--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -19,7 +19,6 @@ with native multi threading capabilities.
 ## Target maintainers
 
 [@g0djan](https://github.com/g0djan)
-[@alexcrichton](https://github.com/alexcrichton)
 [@abrown](https://github.com/abrown)
 [@loganek](https://github.com/loganek)
 


### PR DESCRIPTION
Over time the landscape for myself has changed, and I no longer would like to be officially listed as a maintainer of this target in Rust, so I'm going to step down. There are still a number of others listed on this target, however, so I'm sure they can address issues should they come up.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
