### PR TITLE
Remove `AttributeLintKind` variants - part 7

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -20,7 +20,8 @@ use thin_vec::{ThinVec, thin_vec};
 use crate::context::{AcceptContext, Stage};
 use crate::errors::{
     DisallowedPlaceholder, DisallowedPositionalArgument, IgnoredDiagnosticOption,
-    InvalidFormatSpecifier, MalFormedDiagnosticAttributeLint, WrappedParserError,
+    InvalidFormatSpecifier, MalFormedDiagnosticAttributeLint, MissingOptionsForDiagnosticAttribute,
+    WrappedParserError,
 };
 use crate::parser::{ArgParser, MetaItemListParser, MetaItemOrLitParser, MetaItemParser};
 
@@ -151,11 +152,14 @@ fn parse_list<'p, S: Stage>(
             );
         }
         ArgParser::NoArgs => {
-            cx.emit_lint(
+            cx.emit_dyn_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                AttributeLintKind::MissingOptionsForDiagnosticAttribute {
-                    attribute: mode.as_str(),
-                    options: mode.expected_options(),
+                move |dcx, level| {
+                    MissingOptionsForDiagnosticAttribute {
+                        attribute: mode.as_str(),
+                        options: mode.expected_options(),
+                    }
+                    .into_diag(dcx, level)
                 },
                 span,
             );

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -6,7 +6,7 @@ use rustc_hir::attrs::diagnostic::{
     Directive, FilterFormatString, Flag, FormatArg, FormatString, LitOrArg, Name, NameValue,
     OnUnimplementedCondition, Piece, Predicate,
 };
-use rustc_hir::lints::{AttributeLintKind, FormatWarning};
+use rustc_hir::lints::FormatWarning;
 use rustc_macros::Diagnostic;
 use rustc_parse_format::{
     Argument, FormatSpec, ParseError, ParseMode, Parser, Piece as RpfPiece, Position,
@@ -21,7 +21,7 @@ use crate::context::{AcceptContext, Stage};
 use crate::errors::{
     DisallowedPlaceholder, DisallowedPositionalArgument, IgnoredDiagnosticOption,
     InvalidFormatSpecifier, MalFormedDiagnosticAttributeLint, MissingOptionsForDiagnosticAttribute,
-    WrappedParserError,
+    NonMetaItemDiagnosticAttribute, WrappedParserError,
 };
 use crate::parser::{ArgParser, MetaItemListParser, MetaItemOrLitParser, MetaItemParser};
 
@@ -145,9 +145,9 @@ fn parse_list<'p, S: Stage>(
             // We're dealing with `#[diagnostic::attr()]`.
             // This can be because that is what the user typed, but that's also what we'd see
             // if the user used non-metaitem syntax. See `ArgParser::from_attr_args`.
-            cx.emit_lint(
+            cx.emit_dyn_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                AttributeLintKind::NonMetaItemDiagnosticAttribute,
+                move |dcx, level| NonMetaItemDiagnosticAttribute.into_diag(dcx, level),
                 list.span,
             );
         }

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -400,3 +400,10 @@ pub(crate) struct MissingOptionsForDiagnosticAttribute {
     pub attribute: &'static str,
     pub options: &'static str,
 }
+
+#[derive(Diagnostic)]
+#[diag("expected a literal or missing delimiter")]
+#[help(
+    "only literals are allowed as values for the `message`, `note` and `label` options. These options must be separated by a comma"
+)]
+pub(crate) struct NonMetaItemDiagnosticAttribute;

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -392,3 +392,11 @@ pub(crate) struct IgnoredDiagnosticOption {
     #[label("`{$option_name}` is later redundantly declared here")]
     pub later_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("missing options for `{$attribute}` attribute")]
+#[help("{$options}")]
+pub(crate) struct MissingOptionsForDiagnosticAttribute {
+    pub attribute: &'static str,
+    pub options: &'static str,
+}

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -6,8 +6,6 @@ use rustc_hir::lints::AttributeLintKind;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 
-use crate::lints;
-
 mod check_cfg;
 
 pub struct DiagAndSess<'sess> {
@@ -41,10 +39,6 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
             &AttributeLintKind::UnexpectedCfgValue(name, value) => {
                 check_cfg::unexpected_cfg_value(self.sess, self.tcx, name, value)
                     .into_diag(dcx, level)
-            }
-
-            &AttributeLintKind::NonMetaItemDiagnosticAttribute => {
-                lints::NonMetaItemDiagnosticAttribute.into_diag(dcx, level)
             }
         }
     }

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -43,10 +43,6 @@ impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
                     .into_diag(dcx, level)
             }
 
-            &AttributeLintKind::MissingOptionsForDiagnosticAttribute { attribute, options } => {
-                lints::MissingOptionsForDiagnosticAttribute { attribute, options }
-                    .into_diag(dcx, level)
-            }
             &AttributeLintKind::NonMetaItemDiagnosticAttribute => {
                 lints::NonMetaItemDiagnosticAttribute.into_diag(dcx, level)
             }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3283,14 +3283,6 @@ impl Subdiagnostic for MismatchedLifetimeSyntaxesSuggestion {
 }
 
 #[derive(Diagnostic)]
-#[diag("missing options for `{$attribute}` attribute")]
-#[help("{$options}")]
-pub(crate) struct MissingOptionsForDiagnosticAttribute {
-    pub attribute: &'static str,
-    pub options: &'static str,
-}
-
-#[derive(Diagnostic)]
 #[diag("`Eq::assert_receiver_is_total_eq` should never be implemented by hand")]
 #[note("this method was used to add checks to the `Eq` derive macro")]
 pub(crate) struct EqInternalMethodImplemented;

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3286,10 +3286,3 @@ impl Subdiagnostic for MismatchedLifetimeSyntaxesSuggestion {
 #[diag("`Eq::assert_receiver_is_total_eq` should never be implemented by hand")]
 #[note("this method was used to add checks to the `Eq` derive macro")]
 pub(crate) struct EqInternalMethodImplemented;
-
-#[derive(Diagnostic)]
-#[diag("expected a literal or missing delimiter")]
-#[help(
-    "only literals are allowed as values for the `message`, `note` and `label` options. These options must be separated by a comma"
-)]
-pub(crate) struct NonMetaItemDiagnosticAttribute;

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -656,7 +656,6 @@ pub enum DeprecatedSinceKind {
 pub enum AttributeLintKind {
     UnexpectedCfgName((Symbol, Span), Option<(Symbol, Span)>),
     UnexpectedCfgValue((Symbol, Span), Option<(Symbol, Span)>),
-    NonMetaItemDiagnosticAttribute,
 }
 
 #[derive(Debug, Clone, HashStable_Generic)]

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -656,7 +656,6 @@ pub enum DeprecatedSinceKind {
 pub enum AttributeLintKind {
     UnexpectedCfgName((Symbol, Span), Option<(Symbol, Span)>),
     UnexpectedCfgValue((Symbol, Span), Option<(Symbol, Span)>),
-    MissingOptionsForDiagnosticAttribute { attribute: &'static str, options: &'static str },
     NonMetaItemDiagnosticAttribute,
 }
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/153099.

It's the last easy one. Next one will require to get the crate name and to pass `Session` to the remaining lints. Fun times ahead. :)

r? @JonathanBrouwer