### PR TITLE
bump curl-sys and openssl-sys to support OpenSSL 4.0.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.87+curl-8.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
 dependencies = [
  "cc",
  "libc",
@@ -2728,9 +2728,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
The previously pinned versions of openssl-sys and curl-sys are not
compatible with OpenSSL 4.0.x.

- `curl-sys`: 0.4.84+curl-8.17.0 -> 0.4.87+curl-8.19.0
- `openssl-sys`: 0.9.111 -> 0.9.114

r? @mati865

@rustbot label +beta-nominated +stable-nominated