### PR TITLE
Forbid `*-pass` and `*-fail` directives in tests/crashes

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -70,17 +70,17 @@ See [Controlling pass/fail expectations](ui.md#controlling-passfail-expectations
 
 | Directive                   | Explanation                                 | Supported test suites                     | Possible values |
 |-----------------------------|---------------------------------------------|-------------------------------------------|-----------------|
-| `check-pass`                | Building (no codegen) should pass           | `ui`, `crashes`                           | N/A             |
-| `check-fail`                | Building (no codegen) should fail           | `ui`, `crashes`                           | N/A             |
-| `build-pass`                | Building should pass                        | `ui`, `crashes`, `codegen`                | N/A             |
-| `build-fail`                | Building should fail                        | `ui`, `crashes`                           | N/A             |
-| `run-pass`                  | Program must exit with code `0`             | `ui`, `crashes`                           | N/A             |
-| `run-fail`                  | Program must exit with code `1..=127`       | `ui`, `crashes`                           | N/A             |
+| `check-pass`                | Building (no codegen) should pass           | `ui`                                      | N/A             |
+| `check-fail`                | Building (no codegen) should fail           | `ui`                                      | N/A             |
+| `build-pass`                | Building should pass                        | `ui`                                      | N/A             |
+| `build-fail`                | Building should fail                        | `ui`                                      | N/A             |
+| `run-pass`                  | Program must exit with code `0`             | `ui`                                      | N/A             |
+| `run-fail`                  | Program must exit with code `1..=127`       | `ui`                                      | N/A             |
 | `run-crash`                 | Program must crash                          | `ui`                                      | N/A             |
 | `run-fail-or-crash`         | Program must `run-fail` or `run-crash`      | `ui`                                      | N/A             |
-| `ignore-pass`               | Ignore `--pass` flag                        | `ui`, `crashes`, `codegen`, `incremental` | N/A             |
+| `ignore-pass`               | Ignore `--pass` flag                        | `ui`                                      | N/A             |
 | `dont-check-failure-status` | Don't check exact failure status (i.e. `1`) | `ui`, `incremental`                       | N/A             |
-| `failure-status`            | On failure, the compiler must exit with this status code. To expect an ICE, use `//@ failure-status: 101`. | `ui`, `crashes`, `incremental`            | Any `u16`       |
+| `failure-status`            | On failure, the compiler must exit with this status code. To expect an ICE, use `//@ failure-status: 101`. | `ui`, `incremental` | Any `u16` |
 | `should-fail`               | Compiletest self-test                       | All                                       | N/A             |
 
 ### Controlling output snapshots and normalizations

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -408,8 +408,7 @@ impl TestProps {
 
     fn update_fail_mode(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
         let check_ui = |mode: &str| {
-            // Mode::Crashes may need build-fail in order to trigger llvm errors or stack overflows
-            if config.mode != TestMode::Ui && config.mode != TestMode::Crashes {
+            if config.mode != TestMode::Ui {
                 panic!("`{}-fail` directive is only supported in UI tests", mode);
             }
         };
@@ -441,7 +440,6 @@ impl TestProps {
     fn update_pass_mode(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
         let check_no_run = |s| match (config.mode, s) {
             (TestMode::Ui, _) => (),
-            (TestMode::Crashes, _) => (),
             (mode, _) => panic!("`{s}` directive is not supported in `{mode}` tests"),
         };
         let pass_mode = if config.parse_name_directive(ln, "check-pass") {

--- a/src/tools/compiletest/src/runtest/crashes.rs
+++ b/src/tools/compiletest/src/runtest/crashes.rs
@@ -1,9 +1,8 @@
-use super::{TestCx, WillExecute};
+use super::{Emit, TestCx, WillExecute};
 
 impl TestCx<'_> {
     pub(super) fn run_crash_test(&self) {
-        let pm = self.pass_mode();
-        let proc_res = self.compile_test(WillExecute::No, self.should_emit_metadata(pm));
+        let proc_res = self.compile_test(WillExecute::No, Emit::None);
 
         if std::env::var("COMPILETEST_VERBOSE_CRASHES").is_ok() {
             writeln!(self.stderr, "{}", proc_res.status);


### PR DESCRIPTION
Crash tests are always expected to crash during compilation, so there is no sensible meaning for specifying a pass expectation or a run-fail expectation in a crash test.

It could conceivably be useful to use failure expectations to specify whether a crash test requires codegen in order to crash, but currently none of the crash tests try to do that. If that functionality is desired in the future, we can always look into re-adding it after the internals of pass/fail expectations have been cleaned up a bit.

---

After this change, pass/fail directives are only allowed in UI tests, which should make it easier to overhaul and simplify their implementation.

r? jieyouxu