### PR TITLE
arm64e: set ptrauth ABI subtype on lib.rmeta Mach-O objects

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -216,7 +216,9 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
     file.set_sub_architecture(sub_architecture);
     if sess.target.is_like_darwin {
         if macho_is_arm64e(&sess.target) {
-            file.set_macho_cpu_subtype(object::macho::CPU_SUBTYPE_ARM64E);
+            file.set_macho_cpu_subtype(
+                object::macho::CPU_SUBTYPE_ARM64E | object::macho::CPU_SUBTYPE_PTRAUTH_ABI,
+            );
         }
 
         file.set_macho_build_version(macho_object_build_version_for_target(sess))


### PR DESCRIPTION
Set `CPU_SUBTYPE_PTRAUTH_ABI` (as well as the existing `CPU_SUBTYPE_ARM64E`) on ARM64e object files that `rustc` creates, to match Clang/LLVM-generated ARM64e objects.

This corresponds to `cpusubtype == 0x80000002`. Before this change, rustc emitted the bare `CPU_SUBTYPE_ARM64E` subtype for the metadata wrapper objects / `symbols.o` file, producing `0x00000002`, which can be reported by Apple's linker as `arm64e.old`.

Fixes [rust-lang/rust#130085](https://github.com/rust-lang/rust/issues/130085).
Fixes [rust-lang/rust#143844](https://github.com/rust-lang/rust/issues/143844).
Fixes [rust-lang/rust#150046](https://github.com/rust-lang/rust/issues/150046).
Fixes [rust-lang/rust#139218](https://github.com/rust-lang/rust/issues/139218).