### PR TITLE
Add regression test for dbg! early drop of temporaries

### DIFF
--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-temp-borrow.rs
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-temp-borrow.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/153850>
+// `dbg!` must not drop arguments' temporaries early in multi-arg form.
+
+fn id() -> i32 {
+    42
+}
+
+fn main() {
+    assert_eq!(*dbg!(&id()), 42);
+
+    assert_eq!(dbg!(0, &id()).0, 0);
+    assert_eq!(*dbg!(&id(), 1).0, 42);
+    assert_eq!(*dbg!(0, &id(), 2).1, 42);
+
+    let f = || *dbg!(0, &id()).1;
+    assert_eq!(f(), 42);
+}


### PR DESCRIPTION
Add a compiletest regression for the dbg! temporary-lifetime bug fixed in rust-lang/rust#154074

rust-lang/rust#149869 rewrote multi-argument `dbg!` expansion to avoid print tearing, but
accidentally caused borrowed temporaries to be dropped too early, triggering
E0716 on valid code (rust-lang/rust#153850). rust-lang/rust#154074 fixed the macro expansion and added a
library test, but that test only runs under `./x test library/std` - there
was no tests/ui/ coverage.