### PR TITLE
Fix typo by removing extra 'to'

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -11,7 +11,7 @@
 //! - The [`TryFrom`] and [`TryInto`] traits behave like [`From`] and [`Into`],
 //!   but should be implemented when the conversion can fail.
 //!
-//! The traits in this module are often used as trait bounds for generic functions such that to
+//! The traits in this module are often used as trait bounds for generic functions such that
 //! arguments of multiple types are supported. See the documentation of each trait for examples.
 //!
 //! As a library author, you should always prefer implementing [`From<T>`][`From`] or


### PR DESCRIPTION
Fixes rust-lang/rust#155695

Fix a typo in the `std::convert` module documentation by removing an extra "to" in the module-level docs.