### PR TITLE
Remove `AllVariants` workaround for rust-analyzer

### DIFF
--- a/compiler/rustc_session/src/config/print_request.rs
+++ b/compiler/rustc_session/src/config/print_request.rs
@@ -50,11 +50,6 @@ pub enum PrintKind {
 }
 
 impl PrintKind {
-    /// FIXME: rust-analyzer doesn't support `#![feature(macro_derive)]` yet
-    /// (<https://github.com/rust-lang/rust-analyzer/issues/21043>), which breaks autocomplete.
-    /// Work around that by aliasing the trait constant to a regular constant.
-    const ALL_VARIANTS: &[Self] = <Self as AllVariants>::ALL_VARIANTS;
-
     fn name(self) -> &'static str {
         use PrintKind::*;
         match self {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/155677

Removes the `ALL_VARIANTS` alias added to work around rust-analyzer not supporting `#![feature(macro_derive)]`, which has since been fixed (rust-lang/rust-analyzer/issues/21043).