### PR TITLE
std: Refactor BufWriter::flush to use the `?` operator

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -641,7 +641,8 @@ impl<W: ?Sized + Write> Write for BufWriter<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.flush_buf().and_then(|()| self.get_mut().flush())
+        self.flush_buf()?;
+        self.get_mut().flush()
     }
 }
 


### PR DESCRIPTION
Functionally, this is equivalent and may     be slightly more amenable to inlining.