### PR TITLE
Fix build issues

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -486,13 +486,17 @@ fn main() {
     // C++ runtime library
     if !target.contains("msvc") {
         if let Some(s) = llvm_static_stdcpp {
-            assert!(cxxflags.into_iter().all(|flag| flag != "-stdlib=libc++"));
-            let path = PathBuf::from(s);
-            println!("cargo:rustc-link-search=native={}", path.parent().unwrap().display());
+            let path = PathBuf::from(s).parent().unwrap().display().to_string();
+            if !path.is_empty() {
+                println!("cargo:rustc-link-search=native={path}");
+            }
             if target.contains("windows") {
                 println!("cargo:rustc-link-lib=static:-bundle={stdcppname}");
             } else {
                 println!("cargo:rustc-link-lib=static={stdcppname}");
+                if stdcppname == "c++" {
+                    println!("cargo:rustc-link-lib=static=c++abi");
+                }
             }
         } else if cxxflags.into_iter().any(|flag| flag == "-stdlib=libc++") {
             println!("cargo:rustc-link-lib=c++");

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -940,10 +940,10 @@ class RustBuild(object):
             if section_match is not None:
                 cur_section = section_match.group(1)
 
-            match = re.match(r"^{}\s*=(.*)$".format(key), line)
+            match = re.match(r"^({}\.)?{}\s*=(.*)$".format(section, key), line)
             if match is not None:
-                value = match.group(1)
-                if section is None or section == cur_section:
+                value = match.group(2)
+                if section is None or section == cur_section or match.group(1) is not None:
                     return RustBuild.get_string(value) or value.strip()
         return None
 

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1484,8 +1484,12 @@ fn rustc_llvm_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelect
         && !target.contains("apple")
         && !target.contains("solaris")
     {
-        let libstdcxx_name =
-            if target.contains("windows-gnullvm") { "libc++.a" } else { "libstdc++.a" };
+        let libstdcxx_name = if target.contains("windows-gnullvm") || builder.config.llvm_use_libcxx
+        {
+            "libc++.a"
+        } else {
+            "libstdc++.a"
+        };
         let file = compiler_file(
             builder,
             &builder.cxx(target).unwrap(),

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -878,6 +878,8 @@ fn configure_cmake(
     {
         if target.contains("apple") || target.is_windows() {
             ldflags.push_all("-static-libstdc++");
+        } else if builder.config.llvm_use_libcxx {
+            ldflags.push_all("-Wl,-Bsymbolic -static-libstdc++ -Wl,-Bstatic -lc++abi -Wl,-Bdynamic");
         } else {
             ldflags.push_all("-Wl,-Bsymbolic -static-libstdc++");
         }

--- a/src/tools/opt-dist/src/bolt.rs
+++ b/src/tools/opt-dist/src/bolt.rs
@@ -11,6 +11,7 @@ use crate::utils::io::copy_file;
 pub fn with_bolt_instrumented<F: FnOnce(&Utf8Path) -> anyhow::Result<R>, R>(
     env: &Environment,
     path: &Utf8Path,
+    prof_root: &Utf8Path,
     func: F,
 ) -> anyhow::Result<R> {
     // Back up the original file.
@@ -21,8 +22,8 @@ pub fn with_bolt_instrumented<F: FnOnce(&Utf8Path) -> anyhow::Result<R>, R>(
 
     let instrumented_path = tempfile::NamedTempFile::new()?.into_temp_path();
 
-    let profile_dir =
-        tempfile::TempDir::new().context("Could not create directory for BOLT profiles")?;
+    let profile_dir = tempfile::TempDir::new_in(prof_root)
+        .context("Could not create directory for BOLT profiles")?;
     let profile_prefix = profile_dir.path().join("prof.fdata");
     let profile_prefix = Utf8Path::from_path(&profile_prefix).unwrap();
 

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -329,11 +329,21 @@ fn execute_pipeline(
 
                 // FIXME(kobzol): try gather profiles together, at once for LLVM and rustc
                 // Instrument the libraries and gather profiles
-                let llvm_profile = with_bolt_instrumented(env, &llvm_lib, |llvm_profile_dir| {
-                    stage.section("Gather profiles", |_| {
-                        gather_bolt_profiles(env, "LLVM", llvm_benchmarks(env), llvm_profile_dir)
-                    })
-                })?;
+                let llvm_profile = with_bolt_instrumented(
+                    env,
+                    &llvm_lib,
+                    &env.artifact_dir(),
+                    |llvm_profile_dir| {
+                        stage.section("Gather profiles", |_| {
+                            gather_bolt_profiles(
+                                env,
+                                "LLVM",
+                                llvm_benchmarks(env),
+                                llvm_profile_dir,
+                            )
+                        })
+                    },
+                )?;
                 print_free_disk_space()?;
 
                 // Now optimize the library with BOLT. The `libLLVM-XXX.so` library is actually hard-linked
@@ -354,11 +364,16 @@ fn execute_pipeline(
             log::info!("Optimizing {rustc_lib} with BOLT");
 
             // Instrument it and gather profiles
-            let rustc_profile = with_bolt_instrumented(env, &rustc_lib, |rustc_profile_dir| {
-                stage.section("Gather profiles", |_| {
-                    gather_bolt_profiles(env, "rustc", rustc_benchmarks(env), rustc_profile_dir)
-                })
-            })?;
+            let rustc_profile = with_bolt_instrumented(
+                env,
+                &rustc_lib,
+                &env.artifact_dir(),
+                |rustc_profile_dir| {
+                    stage.section("Gather profiles", |_| {
+                        gather_bolt_profiles(env, "rustc", rustc_benchmarks(env), rustc_profile_dir)
+                    })
+                },
+            )?;
             print_free_disk_space()?;
 
             // Now optimize the library with BOLT.


### PR DESCRIPTION
Building Rust and LLVM using a statically linked Clang libc++ doesn't work because of libc++abi.a not being linked. This case also appears to be explicitly unsupported, judging from an `assert()`.

This PR addresses that limitation and also fixes some blockers for running `opt-dist` successfully in an environment with a limited /tmp storage.