### PR TITLE
make the `core::ffi::va_list` module private

### DIFF
--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -23,19 +23,13 @@ use crate::fmt;
 #[stable(feature = "c_str_module", since = "1.88.0")]
 pub mod c_str;
 
+mod va_list;
 #[unstable(
     feature = "c_variadic",
     issue = "44930",
     reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
 )]
 pub use self::va_list::{VaArgSafe, VaList};
-
-#[unstable(
-    feature = "c_variadic",
-    issue = "44930",
-    reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
-)]
-pub mod va_list;
 
 mod primitives;
 #[stable(feature = "core_ffi_c", since = "1.64.0")]

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -2,6 +2,12 @@
 //!
 //! Better known as "varargs".
 
+#![unstable(
+    feature = "c_variadic",
+    issue = "44930",
+    reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
+)]
+
 #[cfg(not(target_arch = "xtensa"))]
 use crate::ffi::c_void;
 use crate::fmt;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -53,7 +53,7 @@
     issue = "none"
 )]
 
-use crate::ffi::va_list::{VaArgSafe, VaList};
+use crate::ffi::{VaArgSafe, VaList};
 use crate::marker::{ConstParamTy, DiscriminantKind, PointeeSized, Tuple};
 use crate::{mem, ptr};
 


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/44930

the types are exported from `core::ffi` itself.

T-libs-api decided that we should only export the types from `core::ffi`, and should not make `core::ffi::va_list` public, see https://github.com/rust-lang/rust/issues/44930#issuecomment-4289951633.

r? tgross35


