### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -23,19 +23,13 @@ use crate::fmt;
 #[stable(feature = "c_str_module", since = "1.88.0")]
 pub mod c_str;
 
+mod va_list;
 #[unstable(
     feature = "c_variadic",
     issue = "44930",
     reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
 )]
 pub use self::va_list::{VaArgSafe, VaList};
-
-#[unstable(
-    feature = "c_variadic",
-    issue = "44930",
-    reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
-)]
-pub mod va_list;
 
 mod primitives;
 #[stable(feature = "core_ffi_c", since = "1.64.0")]

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -2,6 +2,12 @@
 //!
 //! Better known as "varargs".
 
+#![unstable(
+    feature = "c_variadic",
+    issue = "44930",
+    reason = "the `c_variadic` feature has not been properly tested on all supported platforms"
+)]
+
 #[cfg(not(target_arch = "xtensa"))]
 use crate::ffi::c_void;
 use crate::fmt;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -53,7 +53,7 @@
     issue = "none"
 )]
 
-use crate::ffi::va_list::{VaArgSafe, VaList};
+use crate::ffi::{VaArgSafe, VaList};
 use crate::marker::{ConstParamTy, DiscriminantKind, PointeeSized, Tuple};
 use crate::{mem, ptr};
 

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -641,7 +641,8 @@ impl<W: ?Sized + Write> Write for BufWriter<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.flush_buf().and_then(|()| self.get_mut().flush())
+        self.flush_buf()?;
+        self.get_mut().flush()
     }
 }
 

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -27,6 +27,7 @@
     decl_macro,
     f16,
     f128,
+    transparent_unions,
     asm_experimental_arch,
     unboxed_closures
 )]
@@ -126,6 +127,25 @@ pub struct ManuallyDrop<T: PointeeSized> {
     value: T,
 }
 impl<T: Copy + PointeeSized> Copy for ManuallyDrop<T> {}
+
+#[lang = "maybe_uninit"]
+#[repr(transparent)]
+pub union MaybeUninit<T> {
+    uninit: (),
+    value: ManuallyDrop<T>,
+}
+
+impl<T: Copy + PointeeSized> Copy for MaybeUninit<T> {}
+
+impl<T> MaybeUninit<T> {
+    pub const fn uninit() -> Self {
+        Self { uninit: () }
+    }
+
+    pub const fn new(value: T) -> Self {
+        Self { value: ManuallyDrop { value } }
+    }
+}
 
 #[repr(transparent)]
 #[rustc_nonnull_optimization_guaranteed]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
@@ -42,13 +42,13 @@ struct Test {
     i128: extern "cmse-nonsecure-call" fn() -> i128, //~ ERROR [E0798]
 }
 
-#[repr(C)]
-pub union ReprCUnionU64 {
+#[repr(Rust)]
+pub union ReprRustUnionU64 {
     _unused: u64,
 }
 
-#[repr(Rust)]
-pub union ReprRustUnionU64 {
+#[repr(C)]
+pub union ReprCUnionU64 {
     _unused: u64,
 }
 
@@ -56,5 +56,11 @@ pub union ReprRustUnionU64 {
 pub fn test_union(
     f1: extern "cmse-nonsecure-call" fn() -> ReprRustUnionU64, //~ ERROR [E0798]
     f2: extern "cmse-nonsecure-call" fn() -> ReprCUnionU64,    //~ ERROR [E0798]
+
+    // MaybeUninit is a transparent union, and hence MaybeUninit<u64> is abi-compatible with u64,
+    // and thus allowed as a return type.
+    f3: extern "cmse-nonsecure-call" fn() -> MaybeUninit<u32>,
+    f4: extern "cmse-nonsecure-call" fn() -> MaybeUninit<u64>,
+    f5: extern "cmse-nonsecure-call" fn() -> MaybeUninit<f64>,
 ) {
 }

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
@@ -45,3 +45,26 @@ pub extern "cmse-nonsecure-entry" fn four(_: Four) {}
 
 #[no_mangle]
 pub extern "cmse-nonsecure-entry" fn five(_: Five) {} //~ ERROR [E0798]
+
+#[repr(Rust)]
+pub union ReprRustUnionU64 {
+    _unused: u64,
+}
+
+#[repr(C)]
+pub union ReprCUnionU64 {
+    _unused: u64,
+}
+
+#[no_mangle]
+#[allow(improper_ctypes_definitions)]
+pub extern "cmse-nonsecure-entry" fn union_rust(_: ReprRustUnionU64) {}
+
+#[no_mangle]
+pub extern "cmse-nonsecure-entry" fn union_c(_: ReprCUnionU64) {}
+
+#[no_mangle]
+pub extern "cmse-nonsecure-entry" fn maybe_uninit_32bit(_: MaybeUninit<u32>) {}
+
+#[no_mangle]
+pub extern "cmse-nonsecure-entry" fn maybe_uninit_64bit(_: MaybeUninit<f64>) {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155754 (make the `core::ffi::va_list` module private)
 - rust-lang/rust#155522 (cmse: test returning `MaybeUninit<T>`)
 - rust-lang/rust#155741 (std: Refactor BufWriter::flush to use the `?` operator)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155754,155522,155741)
<!-- homu-ignore:end -->

