### PR TITLE
Promotes 5 Thumb-mode bare-metal Arm targets to Tier 2

### DIFF
--- a/compiler/rustc_target/src/spec/targets/thumbv7a_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_none_eabi.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "thumbv7a-none-eabi".into(),
         metadata: TargetMetadata {
             description: Some("Thumb-mode Bare Armv7-A".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/compiler/rustc_target/src/spec/targets/thumbv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7a_none_eabihf.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "thumbv7a-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Thumb-mode Bare Armv7-A, hardfloat".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/compiler/rustc_target/src/spec/targets/thumbv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7r_none_eabi.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "thumbv7r-none-eabi".into(),
         metadata: TargetMetadata {
             description: Some("Thumb-mode Bare Armv7-R".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/compiler/rustc_target/src/spec/targets/thumbv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv7r_none_eabihf.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "thumbv7r-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Thumb-mode Bare Armv7-R, hardfloat".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/compiler/rustc_target/src/spec/targets/thumbv8r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/thumbv8r_none_eabihf.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "thumbv8r-none-eabihf".into(),
         metadata: TargetMetadata {
             description: Some("Thumb-mode Bare Armv8-R, hardfloat".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -114,11 +114,16 @@ ENV TARGETS=$TARGETS,riscv32imafc-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv64imac-unknown-none-elf
 ENV TARGETS=$TARGETS,riscv64gc-unknown-none-elf
 ENV TARGETS=$TARGETS,armv7r-none-eabi
+ENV TARGETS=$TARGETS,thumbv7r-none-eabi
 ENV TARGETS=$TARGETS,armv7r-none-eabihf
+ENV TARGETS=$TARGETS,thumbv7r-none-eabihf
 ENV TARGETS=$TARGETS,armv8r-none-eabihf
+ENV TARGETS=$TARGETS,thumbv8r-none-eabihf
 ENV TARGETS=$TARGETS,thumbv7neon-unknown-linux-gnueabihf
 ENV TARGETS=$TARGETS,armv7a-none-eabi
+ENV TARGETS=$TARGETS,thumbv7a-none-eabi
 ENV TARGETS=$TARGETS,armv7a-none-eabihf
+ENV TARGETS=$TARGETS,thumbv7a-none-eabihf
 
 ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft" \
     CFLAGS_arm_unknown_linux_musleabi="-march=armv6 -marm" \
@@ -133,8 +138,18 @@ ENV CFLAGS_armv5te_unknown_linux_musleabi="-march=armv5te -marm -mfloat-abi=soft
     CC_armv7a_none_eabihf=arm-none-eabi-gcc \
     CFLAGS_armv7a_none_eabi=-march=armv7-a \
     CFLAGS_armv7a_none_eabihf=-march=armv7-a+fp \
+    CC_thumbv7a_none_eabi=arm-none-eabi-gcc \
+    CC_thumbv7a_none_eabihf=arm-none-eabi-gcc \
+    CFLAGS_thumbv7a_none_eabi=-march=armv7-a \
+    CFLAGS_thumbv7a_none_eabihf="-march=armv7-a+fp -mfpu=vfpv3-d16" \
+    CC_thumbv7r_none_eabi=arm-none-eabi-gcc \
+    CC_thumbv7r_none_eabihf=arm-none-eabi-gcc \
+    CFLAGS_thumbv7r_none_eabi=-march=armv7-r \
+    CFLAGS_thumbv7r_none_eabihf="-march=armv7-r+fp -mfpu=vfpv3-d16" \
     CC_armv8r_none_eabihf=arm-none-eabi-gcc \
     CFLAGS_armv8r_none_eabihf="-march=armv8-r+fp.sp -mfpu=fp-armv8" \
+    CC_thumbv8r_none_eabihf=arm-none-eabi-gcc \
+    CFLAGS_thumbv8r_none_eabihf="-march=armv8-r+fp.sp -mfpu=fp-armv8" \
     CC_aarch64_unknown_none_softfloat=aarch64-none-elf-gcc \
     CFLAGS_aarch64_unknown_none_softfloat=-mstrict-align -march=armv8-a+nofp+nosimd \
     CC_aarch64_unknown_none=aarch64-none-elf-gcc \

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -174,6 +174,11 @@ target | std | notes
 [`armv7r-none-eabi`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R
 [`armv7r-none-eabihf`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R, hardfloat
 [`armv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * | Bare Armv8-R, hardfloat
+[`thumbv7a-none-eabi`](platform-support/armv7a-none-eabi.md) | * | Thumb-mode Bare Armv7-A
+[`thumbv7a-none-eabihf`](platform-support/armv7a-none-eabi.md) | * | Thumb-mode Bare Armv7-A, hardfloat
+[`thumbv7r-none-eabi`](platform-support/armv7r-none-eabi.md) | * | Thumb-mode Bare Armv7-R
+[`thumbv7r-none-eabihf`](platform-support/armv7r-none-eabi.md) | * | Thumb-mode Bare Armv7-R, hardfloat
+[`thumbv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * | Thumb-mode Bare Armv8-R, hardfloat
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux (kernel 3.2+, glibc 2.17, original Pentium) [^x86_32-floats-x87]
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux (musl 1.2.5, original Pentium) [^x86_32-floats-x87]
 [`i686-linux-android`](platform-support/android.md) | ✓ | 32-bit x86 Android ([Pentium 4 plus various extensions](https://developer.android.com/ndk/guides/abis.html#x86)) [^x86_32-floats-return-ABI]
@@ -419,8 +424,6 @@ target | std | host | notes
 [`thumbv5te-none-eabi`](platform-support/armv5te-none-eabi.md) | * |  | Thumb-mode Bare Armv5TE
 [`thumbv6-none-eabi`](platform-support/armv6-none-eabi.md) | * | | Thumb-mode Bare Armv6
 [`thumbv6m-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv6M with NuttX
-[`thumbv7a-none-eabi`](platform-support/armv7a-none-eabi.md) | * |  | Thumb-mode Bare Armv7-A
-[`thumbv7a-none-eabihf`](platform-support/armv7a-none-eabi.md) | * |  | Thumb-mode Bare Armv7-A, hardfloat
 [`thumbv7a-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX
 [`thumbv7a-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX, hardfloat
 `thumbv7a-pc-windows-msvc` |  |  |
@@ -429,12 +432,9 @@ target | std | host | notes
 [`thumbv7em-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv7EM with NuttX, hardfloat
 [`thumbv7m-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv7M with NuttX
 `thumbv7neon-unknown-linux-musleabihf` | ? |  | Thumb2-mode Armv7-A Linux with NEON, musl 1.2.5
-[`thumbv7r-none-eabi`](platform-support/armv7r-none-eabi.md) | * |  | Thumb-mode Bare Armv7-R
-[`thumbv7r-none-eabihf`](platform-support/armv7r-none-eabi.md) | * |  | Thumb-mode Bare Armv7-R, hardfloat
 [`thumbv8m.base-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv8M Baseline with NuttX
 [`thumbv8m.main-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX
 [`thumbv8m.main-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv8M Mainline with NuttX, hardfloat
-[`thumbv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * |  | Thumb-mode Bare Armv8-R, hardfloat
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`wasm32-wali-linux-musl`](platform-support/wasm32-wali-linux.md) | ? |  | WebAssembly with [WALI](https://github.com/arjunr2/WALI)
 [`wasm32-wasip3`](platform-support/wasm32-wasip3.md) | ✓ |  | WebAssembly with WASIp3

--- a/src/doc/rustc/src/platform-support/arm-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/arm-none-eabi.md
@@ -13,10 +13,13 @@ their own document.
 
 - Arm A-Profile Architectures
   - [`armv7a-none-eabi`](armv7a-none-eabi.md)
+  - [`thumbv7a-none-eabi` and `thumbv7a-none-eabihf`](armv7a-none-eabi.md)
 - Arm R-Profile Architectures
   - [`armv7r-none-eabi` and `armv7r-none-eabihf`](armv7r-none-eabi.md)
   - [`armebv7r-none-eabi` and `armebv7r-none-eabihf`](armebv7r-none-eabi.md)
   - [`armv8r-none-eabihf`](armv8r-none-eabihf.md)
+  - [`thumbv7r-none-eabi` and `thumbv7r-none-eabihf`](armv7r-none-eabi.md)
+  - [`thumbv8r-none-eabihf`](armv8r-none-eabihf.md)
 - Arm M-Profile Architectures
   - [`thumbv6m-none-eabi`](thumbv6m-none-eabi.md)
   - [`thumbv7m-none-eabi`](thumbv7m-none-eabi.md)

--- a/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7a-none-eabi.md
@@ -1,7 +1,6 @@
 # `armv7a-none-eabi*` and `thumbv7a-none-eabi*`
 
-* **Tier: 2** (`armv7a-none-eabi` and `armv7a-none-eabihf`)
-* **Tier: 3** (`thumbv7a-none-eabi` and `thumbv7a-none-eabihf`)
+* **Tier: 2**
 * **Library Support:** core and alloc (bare-metal, `#![no_std]`)
 
 Bare-metal target for CPUs in the Armv7-A architecture family, supporting dual

--- a/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
@@ -1,7 +1,6 @@
 # `armv7r-none-eabi*` and `thumbv7r-none-eabi*`
 
-* **Tier: 2** (`armv7r-none-eabi` and `armv7r-none-eabihf`)
-* **Tier: 3** (`thumbv7r-none-eabi` and `thumbv7r-none-eabihf`)
+* **Tier: 2**
 * **Library Support:** core and alloc (bare-metal, `#![no_std]`)
 
 Bare-metal target for CPUs in the Armv7-R architecture family, supporting dual

--- a/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
+++ b/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
@@ -1,7 +1,6 @@
 # `armv8r-none-eabihf` and `thumbv8r-none-eabihf`
 
-* **Tier: 2**: `armv8r-none-eabihf`
-* **Tier: 3**: `thumbv8r-none-eabihf`
+* **Tier: 2**
 * **Library Support:** core and alloc (bare-metal, `#![no_std]`)
 
 Bare-metal target for CPUs in the Armv8-R architecture family, supporting dual


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155763)*
<!-- homu-ignore:end -->

This PR promotes five Thumb-mode bare-metal Arm targets to Tier 2, joining their Arm-mode counterparts which are already Tier 2:

| Thumb-mode target (Tier 3 → Tier 2) | Arm-mode counterpart (already Tier 2) |
|:---|:---|
| `thumbv7a-none-eabi` | `armv7a-none-eabi` |
| `thumbv7a-none-eabihf` | `armv7a-none-eabihf` |
| `thumbv7r-none-eabi` | `armv7r-none-eabi` |
| `thumbv7r-none-eabihf` | `armv7r-none-eabihf` |
| `thumbv8r-none-eabihf` | `armv8r-none-eabihf` |

Note: There is no `thumbv8r-none-eabi` target because the Cortex-R52 processor always includes an FPU, making a soft-float ABI variant unnecessary.

These Thumb-mode targets generate T32 code by default while their Arm-mode counterparts generate A32 code. They share the same LLVM backend, ABI, and data layout — the only spec differences are the `llvm_target` string and the description.

See rust-lang/compiler-team#985