### PR TITLE
triagebot.toml: Ping Enselic when tests/debuginfo/basic-stepping.rs changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1345,6 +1345,9 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."tests/codegen-llvm/stack-protector.rs"]
 cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 
+[mentions."tests/debuginfo/basic-stepping.rs"]
+cc = ["@Enselic"]
+
 [mentions."tests/ui/sanitizer"]
 cc = ["@rcvalle"]
 


### PR DESCRIPTION
The test `tests/debuginfo/basic-stepping.rs` has a history of [regressing for subtle reasons](https://github.com/rust-lang/rust/issues/33013#issuecomment-3121579216) ([retroactively](https://github.com/rust-lang/rust/pull/144497)), and has [expected behavior](https://github.com/rust-lang/rust/pull/153941) that is [not obvious](https://github.com/rust-lang/rust/pull/155377). So I'd like to keep an extra eye one it.