### PR TITLE
Avoid misleading closure return type note

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -2009,6 +2009,9 @@ impl<'tcx> CoerceMany<'tcx> {
             // note in this case, since it would be incorrect.
             && let Some(fn_sig) = fcx.body_fn_sig()
             && fn_sig.output().is_ty_var()
+            && fcx.ret_coercion.as_ref().is_some_and(|ret_coercion| {
+                fcx.resolve_vars_if_possible(ret_coercion.borrow().expected_ty()) == expected
+            })
         {
             err.span_note(sp, format!("return type inferred to be `{expected}` here"));
         }

--- a/tests/ui/closures/closure-return-block-note-issue-155670.rs
+++ b/tests/ui/closures/closure-return-block-note-issue-155670.rs
@@ -1,0 +1,14 @@
+struct SmolStr;
+
+const _: fn() = || {
+    match Some(()) {
+        Some(()) => (),
+        None => return,
+    };
+    let _: String = {
+        SmolStr
+        //~^ ERROR mismatched types
+    };
+};
+
+fn main() {}

--- a/tests/ui/closures/closure-return-block-note-issue-155670.stderr
+++ b/tests/ui/closures/closure-return-block-note-issue-155670.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/closure-return-block-note-issue-155670.rs:9:9
+   |
+LL |         SmolStr
+   |         ^^^^^^^ expected `String`, found `SmolStr`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#155670