### PR TITLE
Remove attribute parsing `Stage`

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 use rustc_ast::node_id::NodeMap;
 use rustc_ast::visit::Visitor;
 use rustc_ast::{self as ast, *};
-use rustc_attr_parsing::{AttributeParser, Late, OmitDoc};
+use rustc_attr_parsing::{AttributeParser, OmitDoc, Recovery, ShouldEmit};
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::sorted_map::SortedMap;
@@ -221,7 +221,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 tcx.sess,
                 tcx.features(),
                 registered_tools,
-                Late,
+                ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed },
             ),
             delayed_lints: Vec::new(),
         }

--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 use crate::session_diagnostics;
 
 pub(crate) struct AllowInternalUnstableParser;
-impl<S: Stage> CombineAttributeParser<S> for AllowInternalUnstableParser {
+impl CombineAttributeParser for AllowInternalUnstableParser {
     const PATH: &[Symbol] = &[sym::allow_internal_unstable];
     type Item = (Symbol, Span);
     const CONVERT: ConvertFn<Self::Item> =
@@ -18,17 +18,17 @@ impl<S: Stage> CombineAttributeParser<S> for AllowInternalUnstableParser {
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
-        parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
+        parse_unstable(cx, args, <Self as CombineAttributeParser>::PATH[0])
             .into_iter()
             .zip(iter::repeat(cx.attr_span))
     }
 }
 
 pub(crate) struct UnstableFeatureBoundParser;
-impl<S: Stage> CombineAttributeParser<S> for UnstableFeatureBoundParser {
+impl CombineAttributeParser for UnstableFeatureBoundParser {
     const PATH: &[rustc_span::Symbol] = &[sym::unstable_feature_bound];
     type Item = (Symbol, Span);
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::UnstableFeatureBound(items);
@@ -40,20 +40,20 @@ impl<S: Stage> CombineAttributeParser<S> for UnstableFeatureBoundParser {
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         if !cx.features().staged_api() {
             cx.emit_err(session_diagnostics::StabilityOutsideStd { span: cx.attr_span });
         }
-        parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
+        parse_unstable(cx, args, <Self as CombineAttributeParser>::PATH[0])
             .into_iter()
             .zip(iter::repeat(cx.attr_span))
     }
 }
 
 pub(crate) struct RustcAllowConstFnUnstableParser;
-impl<S: Stage> CombineAttributeParser<S> for RustcAllowConstFnUnstableParser {
+impl CombineAttributeParser for RustcAllowConstFnUnstableParser {
     const PATH: &[Symbol] = &[sym::rustc_allow_const_fn_unstable];
     type Item = Symbol;
     const CONVERT: ConvertFn<Self::Item> =
@@ -67,15 +67,15 @@ impl<S: Stage> CombineAttributeParser<S> for RustcAllowConstFnUnstableParser {
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
-        parse_unstable(cx, args, <Self as CombineAttributeParser<S>>::PATH[0])
+        parse_unstable(cx, args, <Self as CombineAttributeParser>::PATH[0])
     }
 }
 
-fn parse_unstable<S: Stage>(
-    cx: &AcceptContext<'_, '_, S>,
+fn parse_unstable(
+    cx: &AcceptContext<'_, '_>,
     args: &ArgParser,
     symbol: Symbol,
 ) -> impl IntoIterator<Item = Symbol> {

--- a/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
@@ -10,13 +10,13 @@ use thin_vec::ThinVec;
 
 use crate::attributes::SingleAttributeParser;
 use crate::attributes::prelude::Allow;
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::parser::{ArgParser, MetaItemOrLitParser};
 use crate::target_checking::AllowedTargets;
 
 pub(crate) struct RustcAutodiffParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcAutodiffParser {
+impl SingleAttributeParser for RustcAutodiffParser {
     const PATH: &[Symbol] = &[sym::rustc_autodiff];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -30,7 +30,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAutodiffParser {
         "https://doc.rust-lang.org/std/autodiff/index.html"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = match args {
             ArgParser::NoArgs => return Some(AttributeKind::RustcAutodiff(None)),
             ArgParser::List(list) => list,

--- a/compiler/rustc_attr_parsing/src/attributes/body.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/body.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 
 pub(crate) struct CoroutineParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for CoroutineParser {
+impl NoArgsAttributeParser for CoroutineParser {
     const PATH: &[Symbol] = &[sym::coroutine];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Closure)]);
     const CREATE: fn(rustc_span::Span) -> AttributeKind = |span| AttributeKind::Coroutine(span);

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -20,7 +20,7 @@ use thin_vec::ThinVec;
 
 use crate::attributes::AttributeSafety;
 use crate::attributes::diagnostic::check_cfg;
-use crate::context::{AcceptContext, ShouldEmit, Stage};
+use crate::context::{AcceptContext, ShouldEmit};
 use crate::parser::{
     AllowExprMetavar, ArgParser, MetaItemListParser, MetaItemOrLitParser, NameValueParser,
 };
@@ -40,10 +40,7 @@ const CFG_ATTR_TEMPLATE: AttributeTemplate = template!(
     "https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute"
 );
 
-pub fn parse_cfg<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
-    args: &ArgParser,
-) -> Option<CfgEntry> {
+pub fn parse_cfg(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<CfgEntry> {
     let list = cx.expect_list(args, cx.attr_span)?;
 
     let Some(single) = list.as_single() else {
@@ -81,8 +78,8 @@ pub fn parse_cfg<S: Stage>(
     parse_cfg_entry(cx, single).ok()
 }
 
-pub fn parse_cfg_entry<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+pub fn parse_cfg_entry(
+    cx: &mut AcceptContext<'_, '_>,
     item: &MetaItemOrLitParser,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
     Ok(match item {
@@ -126,8 +123,8 @@ pub fn parse_cfg_entry<S: Stage>(
     })
 }
 
-fn parse_cfg_entry_version<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_cfg_entry_version(
+    cx: &mut AcceptContext<'_, '_>,
     list: &MetaItemListParser,
     meta_span: Span,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
@@ -158,8 +155,8 @@ fn parse_cfg_entry_version<S: Stage>(
     Ok(CfgEntry::Version(min_version, list.span))
 }
 
-fn parse_cfg_entry_target<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_cfg_entry_target(
+    cx: &mut AcceptContext<'_, '_>,
     list: &MetaItemListParser,
     meta_span: Span,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
@@ -201,12 +198,12 @@ fn parse_cfg_entry_target<S: Stage>(
     Ok(CfgEntry::All(result, list.span))
 }
 
-pub(crate) fn parse_name_value<S: Stage>(
+pub(crate) fn parse_name_value(
     name: Symbol,
     name_span: Span,
     value: Option<&NameValueParser>,
     span: Span,
-    cx: &mut AcceptContext<'_, '_, S>,
+    cx: &mut AcceptContext<'_, '_>,
 ) -> Result<CfgEntry, ErrorGuaranteed> {
     try_gate_cfg(name, span, cx.sess(), cx.features_option());
 

--- a/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 pub(crate) struct CfiEncodingParser;
-impl<S: Stage> SingleAttributeParser<S> for CfiEncodingParser {
+impl SingleAttributeParser for CfiEncodingParser {
     const PATH: &[Symbol] = &[sym::cfi_encoding];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Struct),
@@ -10,7 +10,7 @@ impl<S: Stage> SingleAttributeParser<S> for CfiEncodingParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "encoding");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(name_value) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, Some(sym::cfi_encoding));

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -12,7 +12,7 @@ use crate::target_checking::Policy::AllowSilent;
 
 pub(crate) struct OptimizeParser;
 
-impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
+impl SingleAttributeParser for OptimizeParser {
     const PATH: &[Symbol] = &[sym::optimize];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -23,7 +23,7 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &["size", "speed", "none"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
 
         let res = match single.meta_item().and_then(|i| i.path().word().map(|i| i.name)) {
@@ -43,9 +43,9 @@ impl<S: Stage> SingleAttributeParser<S> for OptimizeParser {
 
 pub(crate) struct ColdParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for ColdParser {
+impl NoArgsAttributeParser for ColdParser {
     const PATH: &[Symbol] = &[sym::cold];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -59,7 +59,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for ColdParser {
 
 pub(crate) struct CoverageParser;
 
-impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
+impl SingleAttributeParser for CoverageParser {
     const PATH: &[Symbol] = &[sym::coverage];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -74,7 +74,7 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::off, sym::on]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let arg = cx.expect_single_element_list(args, cx.attr_span)?;
 
         let mut fail_incorrect_argument =
@@ -100,9 +100,9 @@ impl<S: Stage> SingleAttributeParser<S> for CoverageParser {
 
 pub(crate) struct ExportNameParser;
 
-impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
+impl SingleAttributeParser for ExportNameParser {
     const PATH: &[rustc_span::Symbol] = &[sym::export_name];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: Some(Edition2024) };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Static),
@@ -117,7 +117,7 @@ impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -139,13 +139,13 @@ impl<S: Stage> SingleAttributeParser<S> for ExportNameParser {
 
 pub(crate) struct RustcObjcClassParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcObjcClassParser {
+impl SingleAttributeParser for RustcObjcClassParser {
     const PATH: &[rustc_span::Symbol] = &[sym::rustc_objc_class];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "ClassName");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -170,13 +170,13 @@ impl<S: Stage> SingleAttributeParser<S> for RustcObjcClassParser {
 
 pub(crate) struct RustcObjcSelectorParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcObjcSelectorParser {
+impl SingleAttributeParser for RustcObjcSelectorParser {
     const PATH: &[rustc_span::Symbol] = &[sym::rustc_objc_selector];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "methodName");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -204,8 +204,8 @@ pub(crate) struct NakedParser {
     span: Option<Span>,
 }
 
-impl<S: Stage> AttributeParser<S> for NakedParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> =
+impl AttributeParser for NakedParser {
+    const ATTRIBUTES: AcceptMapping<Self> =
         &[(&[sym::naked], template!(Word), |this, cx, args| {
             if let Err(span) = args.no_args() {
                 cx.adcx().expected_no_args(span);
@@ -228,7 +228,7 @@ impl<S: Stage> AttributeParser<S> for NakedParser {
         Warn(Target::MacroCall),
     ]);
 
-    fn finalize(self, cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         // FIXME(jdonszelmann): upgrade this list to *parsed* attributes
         // once all of these have parsed forms. That'd make the check much nicer...
         //
@@ -317,9 +317,9 @@ impl<S: Stage> AttributeParser<S> for NakedParser {
 }
 
 pub(crate) struct TrackCallerParser;
-impl<S: Stage> NoArgsAttributeParser<S> for TrackCallerParser {
+impl NoArgsAttributeParser for TrackCallerParser {
     const PATH: &[Symbol] = &[sym::track_caller];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -337,9 +337,9 @@ impl<S: Stage> NoArgsAttributeParser<S> for TrackCallerParser {
 }
 
 pub(crate) struct NoMangleParser;
-impl<S: Stage> NoArgsAttributeParser<S> for NoMangleParser {
+impl NoArgsAttributeParser for NoMangleParser {
     const PATH: &[Symbol] = &[sym::no_mangle];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: Some(Edition2024) };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
@@ -363,8 +363,8 @@ pub(crate) struct UsedParser {
 // - Specifying two `#[used]` attributes is a warning (but will be an error in the future)
 // - But specifying two conflicting attributes: `#[used(compiler)]` and `#[used(linker)]` is already an error today
 // We can change this to a Simple parser once the warning becomes an error
-impl<S: Stage> AttributeParser<S> for UsedParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for UsedParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::used],
         template!(Word, List: &["compiler", "linker"]),
         |group: &mut Self, cx, args| {
@@ -445,7 +445,7 @@ impl<S: Stage> AttributeParser<S> for UsedParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Static), Warn(Target::MacroCall)]);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         // If a specific form of `used` is specified, it takes precedence over generic `#[used]`.
         // If both `linker` and `compiler` are specified, use `linker`.
         Some(match (self.first_compiler, self.first_linker, self.first_default) {
@@ -457,8 +457,8 @@ impl<S: Stage> AttributeParser<S> for UsedParser {
     }
 }
 
-fn parse_tf_attribute<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_tf_attribute(
+    cx: &mut AcceptContext<'_, '_>,
     args: &ArgParser,
 ) -> impl IntoIterator<Item = (Symbol, Span)> {
     let mut features = Vec::new();
@@ -505,7 +505,7 @@ fn parse_tf_attribute<S: Stage>(
 
 pub(crate) struct TargetFeatureParser;
 
-impl<S: Stage> CombineAttributeParser<S> for TargetFeatureParser {
+impl CombineAttributeParser for TargetFeatureParser {
     type Item = (Symbol, Span);
     const PATH: &[Symbol] = &[sym::target_feature];
     const CONVERT: ConvertFn<Self::Item> = |items, span| AttributeKind::TargetFeature {
@@ -516,7 +516,7 @@ impl<S: Stage> CombineAttributeParser<S> for TargetFeatureParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["enable = \"feat1, feat2\""]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         parse_tf_attribute(cx, args)
@@ -537,7 +537,7 @@ impl<S: Stage> CombineAttributeParser<S> for TargetFeatureParser {
 
 pub(crate) struct ForceTargetFeatureParser;
 
-impl<S: Stage> CombineAttributeParser<S> for ForceTargetFeatureParser {
+impl CombineAttributeParser for ForceTargetFeatureParser {
     type Item = (Symbol, Span);
     const PATH: &[Symbol] = &[sym::force_target_feature];
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: None };
@@ -555,7 +555,7 @@ impl<S: Stage> CombineAttributeParser<S> for ForceTargetFeatureParser {
     ]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         parse_tf_attribute(cx, args)
@@ -564,7 +564,7 @@ impl<S: Stage> CombineAttributeParser<S> for ForceTargetFeatureParser {
 
 pub(crate) struct SanitizeParser;
 
-impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
+impl SingleAttributeParser for SanitizeParser {
     const PATH: &[Symbol] = &[sym::sanitize];
 
     // FIXME: still checked in check_attrs.rs
@@ -584,7 +584,7 @@ impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
         r#"realtime = "nonblocking|blocking|caller""#,
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
 
         let mut on_set = SanitizerSet::empty();
@@ -680,7 +680,7 @@ impl<S: Stage> SingleAttributeParser<S> for SanitizeParser {
 
 pub(crate) struct ThreadLocalParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for ThreadLocalParser {
+impl NoArgsAttributeParser for ThreadLocalParser {
     const PATH: &[Symbol] = &[sym::thread_local];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Static), Allow(Target::ForeignStatic)]);
@@ -689,7 +689,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for ThreadLocalParser {
 
 pub(crate) struct RustcPassIndirectlyInNonRusticAbisParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcPassIndirectlyInNonRusticAbisParser {
+impl NoArgsAttributeParser for RustcPassIndirectlyInNonRusticAbisParser {
     const PATH: &[Symbol] = &[sym::rustc_pass_indirectly_in_non_rustic_abis];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcPassIndirectlyInNonRusticAbis;
@@ -697,7 +697,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcPassIndirectlyInNonRusticAbisPa
 
 pub(crate) struct RustcEiiForeignItemParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcEiiForeignItemParser {
+impl NoArgsAttributeParser for RustcEiiForeignItemParser {
     const PATH: &[Symbol] = &[sym::rustc_eii_foreign_item];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignFn), Allow(Target::ForeignStatic)]);
@@ -706,12 +706,12 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcEiiForeignItemParser {
 
 pub(crate) struct PatchableFunctionEntryParser;
 
-impl<S: Stage> SingleAttributeParser<S> for PatchableFunctionEntryParser {
+impl SingleAttributeParser for PatchableFunctionEntryParser {
     const PATH: &[Symbol] = &[sym::patchable_function_entry];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["prefix_nops = m, entry_nops = n"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let meta_item_list = cx.expect_list(args, cx.attr_span)?;
 
         let mut prefix = None;

--- a/compiler/rustc_attr_parsing/src/attributes/confusables.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/confusables.rs
@@ -7,8 +7,8 @@ pub(crate) struct ConfusablesParser {
     first_span: Option<Span>,
 }
 
-impl<S: Stage> AttributeParser<S> for ConfusablesParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for ConfusablesParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::rustc_confusables],
         template!(List: &[r#""name1", "name2", ..."#]),
         |this, cx, args| {
@@ -35,7 +35,7 @@ impl<S: Stage> AttributeParser<S> for ConfusablesParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Method(MethodKind::Inherent))]);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if self.confusables.is_empty() {
             return None;
         }

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -9,13 +9,13 @@ use crate::errors::{UnknownCrateTypes, UnknownCrateTypesSuggestion};
 
 pub(crate) struct CrateNameParser;
 
-impl<S: Stage> SingleAttributeParser<S> for CrateNameParser {
+impl SingleAttributeParser for CrateNameParser {
     const PATH: &[Symbol] = &[sym::crate_name];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(n) = args else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -33,7 +33,7 @@ impl<S: Stage> SingleAttributeParser<S> for CrateNameParser {
 
 pub(crate) struct CrateTypeParser;
 
-impl<S: Stage> CombineAttributeParser<S> for CrateTypeParser {
+impl CombineAttributeParser for CrateTypeParser {
     const PATH: &[Symbol] = &[sym::crate_type];
     type Item = CrateType;
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::CrateType(items);
@@ -44,7 +44,7 @@ impl<S: Stage> CombineAttributeParser<S> for CrateTypeParser {
         template!(NameValueStr: "crate type", "https://doc.rust-lang.org/reference/linkage.html");
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let ArgParser::NameValue(n) = args else {
@@ -88,13 +88,13 @@ impl<S: Stage> CombineAttributeParser<S> for CrateTypeParser {
 
 pub(crate) struct RecursionLimitParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RecursionLimitParser {
+impl SingleAttributeParser for RecursionLimitParser {
     const PATH: &[Symbol] = &[sym::recursion_limit];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -111,12 +111,12 @@ impl<S: Stage> SingleAttributeParser<S> for RecursionLimitParser {
 
 pub(crate) struct MoveSizeLimitParser;
 
-impl<S: Stage> SingleAttributeParser<S> for MoveSizeLimitParser {
+impl SingleAttributeParser for MoveSizeLimitParser {
     const PATH: &[Symbol] = &[sym::move_size_limit];
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -133,13 +133,13 @@ impl<S: Stage> SingleAttributeParser<S> for MoveSizeLimitParser {
 
 pub(crate) struct TypeLengthLimitParser;
 
-impl<S: Stage> SingleAttributeParser<S> for TypeLengthLimitParser {
+impl SingleAttributeParser for TypeLengthLimitParser {
     const PATH: &[Symbol] = &[sym::type_length_limit];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -156,12 +156,12 @@ impl<S: Stage> SingleAttributeParser<S> for TypeLengthLimitParser {
 
 pub(crate) struct PatternComplexityLimitParser;
 
-impl<S: Stage> SingleAttributeParser<S> for PatternComplexityLimitParser {
+impl SingleAttributeParser for PatternComplexityLimitParser {
     const PATH: &[Symbol] = &[sym::pattern_complexity_limit];
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -178,7 +178,7 @@ impl<S: Stage> SingleAttributeParser<S> for PatternComplexityLimitParser {
 
 pub(crate) struct NoCoreParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NoCoreParser {
+impl NoArgsAttributeParser for NoCoreParser {
     const PATH: &[Symbol] = &[sym::no_core];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoCore;
@@ -186,25 +186,25 @@ impl<S: Stage> NoArgsAttributeParser<S> for NoCoreParser {
 
 pub(crate) struct NoStdParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NoStdParser {
+impl NoArgsAttributeParser for NoStdParser {
     const PATH: &[Symbol] = &[sym::no_std];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoStd;
 }
 
 pub(crate) struct NoMainParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NoMainParser {
+impl NoArgsAttributeParser for NoMainParser {
     const PATH: &[Symbol] = &[sym::no_main];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoMain;
 }
 
 pub(crate) struct RustcCoherenceIsCoreParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcCoherenceIsCoreParser {
+impl NoArgsAttributeParser for RustcCoherenceIsCoreParser {
     const PATH: &[Symbol] = &[sym::rustc_coherence_is_core];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcCoherenceIsCore;
@@ -212,13 +212,13 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcCoherenceIsCoreParser {
 
 pub(crate) struct WindowsSubsystemParser;
 
-impl<S: Stage> SingleAttributeParser<S> for WindowsSubsystemParser {
+impl SingleAttributeParser for WindowsSubsystemParser {
     const PATH: &[Symbol] = &[sym::windows_subsystem];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let inner_span = cx.inner_span;
             cx.adcx().expected_name_value(
@@ -246,7 +246,7 @@ impl<S: Stage> SingleAttributeParser<S> for WindowsSubsystemParser {
 
 pub(crate) struct PanicRuntimeParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for PanicRuntimeParser {
+impl NoArgsAttributeParser for PanicRuntimeParser {
     const PATH: &[Symbol] = &[sym::panic_runtime];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PanicRuntime;
@@ -254,7 +254,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for PanicRuntimeParser {
 
 pub(crate) struct NeedsPanicRuntimeParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NeedsPanicRuntimeParser {
+impl NoArgsAttributeParser for NeedsPanicRuntimeParser {
     const PATH: &[Symbol] = &[sym::needs_panic_runtime];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NeedsPanicRuntime;
@@ -262,7 +262,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for NeedsPanicRuntimeParser {
 
 pub(crate) struct ProfilerRuntimeParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for ProfilerRuntimeParser {
+impl NoArgsAttributeParser for ProfilerRuntimeParser {
     const PATH: &[Symbol] = &[sym::profiler_runtime];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProfilerRuntime;
@@ -270,16 +270,16 @@ impl<S: Stage> NoArgsAttributeParser<S> for ProfilerRuntimeParser {
 
 pub(crate) struct NoBuiltinsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NoBuiltinsParser {
+impl NoArgsAttributeParser for NoBuiltinsParser {
     const PATH: &[Symbol] = &[sym::no_builtins];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoBuiltins;
 }
 
 pub(crate) struct RustcPreserveUbChecksParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcPreserveUbChecksParser {
+impl NoArgsAttributeParser for RustcPreserveUbChecksParser {
     const PATH: &[Symbol] = &[sym::rustc_preserve_ub_checks];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcPreserveUbChecks;
@@ -287,7 +287,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcPreserveUbChecksParser {
 
 pub(crate) struct RustcNoImplicitBoundsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNoImplicitBoundsParser {
+impl NoArgsAttributeParser for RustcNoImplicitBoundsParser {
     const PATH: &[Symbol] = &[sym::rustc_no_implicit_bounds];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoImplicitBounds;
@@ -295,7 +295,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNoImplicitBoundsParser {
 
 pub(crate) struct DefaultLibAllocatorParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for DefaultLibAllocatorParser {
+impl NoArgsAttributeParser for DefaultLibAllocatorParser {
     const PATH: &[Symbol] = &[sym::default_lib_allocator];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::DefaultLibAllocator;
@@ -303,7 +303,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for DefaultLibAllocatorParser {
 
 pub(crate) struct FeatureParser;
 
-impl<S: Stage> CombineAttributeParser<S> for FeatureParser {
+impl CombineAttributeParser for FeatureParser {
     const PATH: &[Symbol] = &[sym::feature];
     type Item = Ident;
     const CONVERT: ConvertFn<Self::Item> = AttributeKind::Feature;
@@ -311,7 +311,7 @@ impl<S: Stage> CombineAttributeParser<S> for FeatureParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["feature1, feature2, ..."]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let Some(list) = cx.expect_list(args, cx.attr_span) else {
@@ -349,7 +349,7 @@ impl<S: Stage> CombineAttributeParser<S> for FeatureParser {
 
 pub(crate) struct RegisterToolParser;
 
-impl<S: Stage> CombineAttributeParser<S> for RegisterToolParser {
+impl CombineAttributeParser for RegisterToolParser {
     const PATH: &[Symbol] = &[sym::register_tool];
     type Item = Ident;
     const CONVERT: ConvertFn<Self::Item> = AttributeKind::RegisterTool;
@@ -357,7 +357,7 @@ impl<S: Stage> CombineAttributeParser<S> for RegisterToolParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["tool1, tool2, ..."]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let Some(list) = cx.expect_list(args, cx.attr_span) else {

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 
 pub(crate) struct DebuggerViualizerParser;
 
-impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
+impl CombineAttributeParser for DebuggerViualizerParser {
     const PATH: &[Symbol] = &[sym::debugger_visualizer];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Mod), Allow(Target::Crate)]);
@@ -17,7 +17,7 @@ impl<S: Stage> CombineAttributeParser<S> for DebuggerViualizerParser {
     const CONVERT: ConvertFn<Self::Item> = |v, _| AttributeKind::DebuggerVisualizer(v);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -7,8 +7,8 @@ use crate::session_diagnostics::{
     DeprecatedItemSuggestion, InvalidSince, MissingNote, MissingSince,
 };
 
-fn get<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn get(
+    cx: &mut AcceptContext<'_, '_>,
     name: Symbol,
     param_span: Span,
     arg: &ArgParser,
@@ -32,7 +32,7 @@ fn get<S: Stage>(
 }
 
 pub(crate) struct DeprecatedParser;
-impl<S: Stage> SingleAttributeParser<S> for DeprecatedParser {
+impl SingleAttributeParser for DeprecatedParser {
     const PATH: &[Symbol] = &[sym::deprecated];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
@@ -66,7 +66,7 @@ impl<S: Stage> SingleAttributeParser<S> for DeprecatedParser {
         NameValueStr: "reason"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let features = cx.features();
 
         let mut since = None;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -8,20 +8,20 @@ use rustc_session::lint::builtin::{
 use rustc_span::{Symbol, sym};
 
 use crate::attributes::{OnDuplicate, SingleAttributeParser};
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::errors::IncorrectDoNotRecommendLocation;
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 
 pub(crate) struct DoNotRecommendParser;
-impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
+impl SingleAttributeParser for DoNotRecommendParser {
     const PATH: &[Symbol] = &[sym::diagnostic, sym::do_not_recommend];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     // "Allowed" on any target, noop on all but trait impls
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word /*doesn't matter */);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let attr_span = cx.attr_span;
         if !matches!(args, ArgParser::NoArgs) {
             cx.emit_lint(

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -16,7 +16,7 @@ use rustc_session::lint::builtin::{
 use rustc_span::{Ident, InnerSpan, Span, Symbol, kw, sym};
 use thin_vec::{ThinVec, thin_vec};
 
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::errors::{
     FormatWarning, IgnoredDiagnosticOption, MalFormedDiagnosticAttributeLint,
     MissingOptionsForDiagnosticAttribute, NonMetaItemDiagnosticAttribute, WrappedParserError,
@@ -112,8 +112,8 @@ impl Mode {
     }
 }
 
-fn merge_directives<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn merge_directives(
+    cx: &mut AcceptContext<'_, '_>,
     first: &mut Option<(Span, Directive)>,
     later: (Span, Directive),
 ) {
@@ -130,8 +130,8 @@ fn merge_directives<S: Stage>(
     }
 }
 
-fn merge<T, S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn merge<T>(
+    cx: &mut AcceptContext<'_, '_>,
     first: &mut Option<(Span, T)>,
     later: Option<(Span, T)>,
     option_name: Symbol,
@@ -155,8 +155,8 @@ fn merge<T, S: Stage>(
     }
 }
 
-fn parse_list<'p, S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_list<'p>(
+    cx: &mut AcceptContext<'_, '_>,
     args: &'p ArgParser,
     mode: Mode,
 ) -> Option<&'p MetaItemListParser> {
@@ -204,8 +204,8 @@ fn parse_list<'p, S: Stage>(
     None
 }
 
-fn parse_directive_items<'p, S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_directive_items<'p>(
+    cx: &mut AcceptContext<'_, '_>,
     mode: Mode,
     items: impl Iterator<Item = &'p MetaItemOrLitParser>,
     is_root: bool,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -11,8 +11,8 @@ pub(crate) struct OnConstParser {
     directive: Option<(Span, Directive)>,
 }
 
-impl<S: Stage> AttributeParser<S> for OnConstParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for OnConstParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_const],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
         |this, cx, args| {
@@ -53,7 +53,7 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
     // this linted on in parser.
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {
             Some(AttributeKind::OnConst { span, directive: self.directive.map(|d| Box::new(d.1)) })
         } else {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -6,7 +6,7 @@ use rustc_span::sym;
 
 use crate::attributes::diagnostic::*;
 use crate::attributes::prelude::*;
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::errors::DiagnosticOnMoveOnlyForAdt;
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
@@ -18,12 +18,7 @@ pub(crate) struct OnMoveParser {
 }
 
 impl OnMoveParser {
-    fn parse<'sess, S: Stage>(
-        &mut self,
-        cx: &mut AcceptContext<'_, 'sess, S>,
-        args: &ArgParser,
-        mode: Mode,
-    ) {
+    fn parse<'sess>(&mut self, cx: &mut AcceptContext<'_, 'sess>, args: &ArgParser, mode: Mode) {
         if !cx.features().diagnostic_on_move() {
             // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs
             return;
@@ -48,8 +43,8 @@ impl OnMoveParser {
         }
     }
 }
-impl<S: Stage> AttributeParser<S> for OnMoveParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for OnMoveParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_move],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
         |this, cx, args| {
@@ -60,7 +55,7 @@ impl<S: Stage> AttributeParser<S> for OnMoveParser {
     // "Allowed" for all targets but noop if used on not-adt.
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {
             Some(AttributeKind::OnMove { span, directive: self.directive.map(|d| Box::new(d.1)) })
         } else {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -13,12 +13,7 @@ pub(crate) struct OnUnimplementedParser {
 }
 
 impl OnUnimplementedParser {
-    fn parse<'sess, S: Stage>(
-        &mut self,
-        cx: &mut AcceptContext<'_, 'sess, S>,
-        args: &ArgParser,
-        mode: Mode,
-    ) {
+    fn parse<'sess>(&mut self, cx: &mut AcceptContext<'_, 'sess>, args: &ArgParser, mode: Mode) {
         let span = cx.attr_span;
         self.span = Some(span);
 
@@ -39,8 +34,8 @@ impl OnUnimplementedParser {
     }
 }
 
-impl<S: Stage> AttributeParser<S> for OnUnimplementedParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[
+impl AttributeParser for OnUnimplementedParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[
         (
             &[sym::diagnostic, sym::on_unimplemented],
             template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
@@ -59,7 +54,7 @@ impl<S: Stage> AttributeParser<S> for OnUnimplementedParser {
     //FIXME attribute is not parsed for non-traits but diagnostics are issued in `check_attr.rs`
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {
             Some(AttributeKind::OnUnimplemented {
                 span,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -31,7 +31,7 @@ impl OnUnknownParser {
 
         // At early parsing we get passed `Target::Crate` regardless of the item we're on.
         // Only do target checking if we're late.
-        let early = matches!(cx.stage.should_emit(), ShouldEmit::Nothing);
+        let early = matches!(cx.should_emit, ShouldEmit::Nothing);
 
         if !early && !matches!(cx.target, Target::Use) {
             let target_span = cx.target_span;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -14,12 +14,7 @@ pub(crate) struct OnUnknownParser {
 }
 
 impl OnUnknownParser {
-    fn parse<'sess, S: Stage>(
-        &mut self,
-        cx: &mut AcceptContext<'_, 'sess, S>,
-        args: &ArgParser,
-        mode: Mode,
-    ) {
+    fn parse<'sess>(&mut self, cx: &mut AcceptContext<'_, 'sess>, args: &ArgParser, mode: Mode) {
         if let Some(features) = cx.features
             && !features.diagnostic_on_unknown()
         {
@@ -53,8 +48,8 @@ impl OnUnknownParser {
     }
 }
 
-impl<S: Stage> AttributeParser<S> for OnUnknownParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for OnUnknownParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_unknown],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
         |this, cx, args| {
@@ -64,7 +59,7 @@ impl<S: Stage> AttributeParser<S> for OnUnknownParser {
     // "Allowed" for all targets, but noop for all but use statements.
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {
             Some(AttributeKind::OnUnknown {
                 span,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -25,7 +25,7 @@ impl OnUnknownParser {
         self.span = Some(span);
 
         // At early parsing we get passed `Target::Crate` regardless of the item we're on.
-        // Only do target checking if we're late.
+        // Therefore, only do target checking if we can emit.
         let early = matches!(cx.should_emit, ShouldEmit::Nothing);
 
         if !early && !matches!(cx.target, Target::Use) {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
@@ -12,8 +12,8 @@ pub(crate) struct OnUnmatchArgsParser {
     directive: Option<(Span, Directive)>,
 }
 
-impl<S: Stage> AttributeParser<S> for OnUnmatchArgsParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for OnUnmatchArgsParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_unmatch_args],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
         |this, cx, args| {
@@ -45,7 +45,7 @@ impl<S: Stage> AttributeParser<S> for OnUnmatchArgsParser {
 
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(span) = self.span {
             Some(AttributeKind::OnUnmatchArgs {
                 span,

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -11,7 +11,7 @@ use thin_vec::ThinVec;
 
 use super::prelude::{ALL_TARGETS, AllowedTargets};
 use super::{AcceptMapping, AttributeParser};
-use crate::context::{AcceptContext, FinalizeContext, Stage};
+use crate::context::{AcceptContext, FinalizeContext};
 use crate::errors::{
     AttrCrateLevelOnly, DocAliasDuplicated, DocAutoCfgExpectsHideOrShow,
     DocAutoCfgHideShowExpectsList, DocAutoCfgHideShowUnexpectedItem, DocAutoCfgWrongLiteral,
@@ -25,7 +25,7 @@ use crate::session_diagnostics::{
     DocAttributeNotAttribute, DocKeywordNotKeyword,
 };
 
-fn check_keyword<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, keyword: Symbol, span: Span) -> bool {
+fn check_keyword(cx: &mut AcceptContext<'_, '_>, keyword: Symbol, span: Span) -> bool {
     // FIXME: Once rustdoc can handle URL conflicts on case insensitive file systems, we
     // can remove the `SelfTy` case here, remove `sym::SelfTy`, and update the
     // `#[doc(keyword = "SelfTy")` attribute in `library/std/src/keyword_docs.rs`.
@@ -39,11 +39,7 @@ fn check_keyword<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, keyword: Symbol, s
     false
 }
 
-fn check_attribute<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
-    attribute: Symbol,
-    span: Span,
-) -> bool {
+fn check_attribute(cx: &mut AcceptContext<'_, '_>, attribute: Symbol, span: Span) -> bool {
     // FIXME: This should support attributes with namespace like `diagnostic::do_not_recommend`.
     if rustc_feature::BUILTIN_ATTRIBUTE_MAP.contains_key(&attribute) {
         return true;
@@ -53,8 +49,8 @@ fn check_attribute<S: Stage>(
 }
 
 /// Checks that an attribute is *not* used at the crate level. Returns `true` if valid.
-fn check_attr_not_crate_level<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn check_attr_not_crate_level(
+    cx: &mut AcceptContext<'_, '_>,
     span: Span,
     attr_name: Symbol,
 ) -> bool {
@@ -66,7 +62,7 @@ fn check_attr_not_crate_level<S: Stage>(
 }
 
 /// Checks that an attribute is used at the crate level. Returns `true` if valid.
-fn check_attr_crate_level<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Span) -> bool {
+fn check_attr_crate_level(cx: &mut AcceptContext<'_, '_>, span: Span) -> bool {
     if cx.shared.target != Target::Crate {
         cx.emit_lint(
             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
@@ -79,11 +75,7 @@ fn check_attr_crate_level<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Spa
 }
 
 // FIXME: To be removed once merged and replace with `cx.expected_name_value(span, _name)`.
-fn expected_name_value<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
-    span: Span,
-    _name: Option<Symbol>,
-) {
+fn expected_name_value(cx: &mut AcceptContext<'_, '_>, span: Span, _name: Option<Symbol>) {
     cx.emit_lint(
         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
         |dcx, level| ExpectedNameValue.into_diag(dcx, level),
@@ -92,7 +84,7 @@ fn expected_name_value<S: Stage>(
 }
 
 // FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
-fn expected_no_args<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Span) {
+fn expected_no_args(cx: &mut AcceptContext<'_, '_>, span: Span) {
     cx.emit_lint(
         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
         |dcx, level| ExpectedNoArgs.into_diag(dcx, level),
@@ -102,8 +94,8 @@ fn expected_no_args<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Span) {
 
 // FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
 // cx.expected_string_literal(span, _actual_literal);
-fn expected_string_literal<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn expected_string_literal(
+    cx: &mut AcceptContext<'_, '_>,
     span: Span,
     _actual_literal: Option<&MetaItemLit>,
 ) {
@@ -114,8 +106,8 @@ fn expected_string_literal<S: Stage>(
     );
 }
 
-fn parse_keyword_and_attribute<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_keyword_and_attribute(
+    cx: &mut AcceptContext<'_, '_>,
     path: &OwnedPathParser,
     args: &ArgParser,
     attr_value: &mut Option<(Symbol, Span)>,
@@ -160,9 +152,9 @@ pub(crate) struct DocParser {
 }
 
 impl DocParser {
-    fn parse_single_test_doc_attr_item<S: Stage>(
+    fn parse_single_test_doc_attr_item(
         &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         mip: &MetaItemParser,
     ) {
         let path = mip.path();
@@ -233,12 +225,7 @@ impl DocParser {
         }
     }
 
-    fn add_alias<S: Stage>(
-        &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
-        alias: Symbol,
-        span: Span,
-    ) {
+    fn add_alias(&mut self, cx: &mut AcceptContext<'_, '_>, alias: Symbol, span: Span) {
         let attr_str = "`#[doc(alias = \"...\")]`";
         if alias == sym::empty {
             cx.emit_err(DocAliasEmpty { span, attr_str });
@@ -271,9 +258,9 @@ impl DocParser {
         self.attribute.aliases.insert(alias, span);
     }
 
-    fn parse_alias<S: Stage>(
+    fn parse_alias(
         &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         path: &OwnedPathParser,
         args: &ArgParser,
     ) {
@@ -301,9 +288,9 @@ impl DocParser {
         }
     }
 
-    fn parse_inline<S: Stage>(
+    fn parse_inline(
         &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         path: &OwnedPathParser,
         args: &ArgParser,
         inline: DocInline,
@@ -316,7 +303,7 @@ impl DocParser {
         self.attribute.inline.push((inline, path.span()));
     }
 
-    fn parse_cfg<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
+    fn parse_cfg(&mut self, cx: &mut AcceptContext<'_, '_>, args: &ArgParser) {
         // This function replaces cases like `cfg(all())` with `true`.
         fn simplify_cfg(cfg_entry: &mut CfgEntry) {
             match cfg_entry {
@@ -336,9 +323,9 @@ impl DocParser {
         }
     }
 
-    fn parse_auto_cfg<S: Stage>(
+    fn parse_auto_cfg(
         &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         path: &OwnedPathParser,
         args: &ArgParser,
     ) {
@@ -456,11 +443,7 @@ impl DocParser {
         }
     }
 
-    fn parse_single_doc_attr_item<S: Stage>(
-        &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
-        mip: &MetaItemParser,
-    ) {
+    fn parse_single_doc_attr_item(&mut self, cx: &mut AcceptContext<'_, '_>, mip: &MetaItemParser) {
         let path = mip.path();
         let args = mip.args();
 
@@ -680,11 +663,7 @@ impl DocParser {
         }
     }
 
-    fn accept_single_doc_attr<S: Stage>(
-        &mut self,
-        cx: &mut AcceptContext<'_, '_, S>,
-        args: &ArgParser,
-    ) {
+    fn accept_single_doc_attr(&mut self, cx: &mut AcceptContext<'_, '_>, args: &ArgParser) {
         match args {
             ArgParser::NoArgs => {
                 let suggestions = cx.adcx().suggestions();
@@ -726,8 +705,8 @@ impl DocParser {
     }
 }
 
-impl<S: Stage> AttributeParser<S> for DocParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for DocParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::doc],
         template!(
             List: &[
@@ -797,7 +776,7 @@ impl<S: Stage> AttributeParser<S> for DocParser {
     //     Error(Target::WherePredicate),
     // ]);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if self.nb_doc_attrs != 0 {
             Some(AttributeKind::Doc(Box::new(self.attribute)))
         } else {

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -3,18 +3,18 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Symbol, sym};
 
 use crate::attributes::{OnDuplicate, SingleAttributeParser};
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
 
 pub(crate) struct RustcDummyParser;
-impl<S: Stage> SingleAttributeParser<S> for RustcDummyParser {
+impl SingleAttributeParser for RustcDummyParser {
     const PATH: &[Symbol] = &[sym::rustc_dummy];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Ignore;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
 
-    fn convert(_: &mut AcceptContext<'_, '_, S>, _: &ArgParser) -> Option<AttributeKind> {
+    fn convert(_: &mut AcceptContext<'_, '_>, _: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::RustcDummy)
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -9,9 +9,9 @@ use super::prelude::*;
 
 pub(crate) struct InlineParser;
 
-impl<S: Stage> SingleAttributeParser<S> for InlineParser {
+impl SingleAttributeParser for InlineParser {
     const PATH: &[Symbol] = &[sym::inline];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -33,7 +33,7 @@ impl<S: Stage> SingleAttributeParser<S> for InlineParser {
         "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         match args {
             ArgParser::NoArgs => Some(AttributeKind::Inline(InlineAttr::Hint, cx.attr_span)),
             ArgParser::List(list) => {
@@ -62,7 +62,7 @@ impl<S: Stage> SingleAttributeParser<S> for InlineParser {
 
 pub(crate) struct RustcForceInlineParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcForceInlineParser {
+impl SingleAttributeParser for RustcForceInlineParser {
     const PATH: &[Symbol] = &[sym::rustc_force_inline];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -71,7 +71,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcForceInlineParser {
 
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["reason"], NameValueStr: "reason");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let reason = match args {
             ArgParser::NoArgs => None,
             ArgParser::List(list) => {

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -5,7 +5,7 @@ use crate::session_diagnostics;
 
 pub(crate) struct InstructionSetParser;
 
-impl<S: Stage> SingleAttributeParser<S> for InstructionSetParser {
+impl SingleAttributeParser for InstructionSetParser {
     const PATH: &[Symbol] = &[sym::instruction_set];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
@@ -16,7 +16,7 @@ impl<S: Stage> SingleAttributeParser<S> for InstructionSetParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         const POSSIBLE_SYMBOLS: &[Symbol] = &[sym::arm_a32, sym::arm_t32];
         const POSSIBLE_ARM_SYMBOLS: &[Symbol] = &[sym::a32, sym::t32];
         let maybe_meta_item = cx.expect_single_element_list(args, cx.attr_span)?;

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -23,9 +23,9 @@ use crate::session_diagnostics::{
 
 pub(crate) struct LinkNameParser;
 
-impl<S: Stage> SingleAttributeParser<S> for LinkNameParser {
+impl SingleAttributeParser for LinkNameParser {
     const PATH: &[Symbol] = &[sym::link_name];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::ForeignFn),
         Allow(Target::ForeignStatic),
@@ -35,7 +35,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkNameParser {
         "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -52,7 +52,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkNameParser {
 
 pub(crate) struct LinkParser;
 
-impl<S: Stage> CombineAttributeParser<S> for LinkParser {
+impl CombineAttributeParser for LinkParser {
     type Item = LinkEntry;
     const PATH: &[Symbol] = &[sym::link];
     const CONVERT: ConvertFn<Self::Item> = AttributeKind::Link;
@@ -66,7 +66,7 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let items = match args {
@@ -252,10 +252,10 @@ impl<S: Stage> CombineAttributeParser<S> for LinkParser {
 }
 
 impl LinkParser {
-    fn parse_link_name<S: Stage>(
+    fn parse_link_name(
         item: &MetaItemParser,
         name: &mut Option<(Symbol, Span)>,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
     ) -> bool {
         if name.is_some() {
             cx.adcx().duplicate_key(item.span(), sym::name);
@@ -277,10 +277,10 @@ impl LinkParser {
         true
     }
 
-    fn parse_link_kind<S: Stage>(
+    fn parse_link_kind(
         item: &MetaItemParser,
         kind: &mut Option<NativeLibKind>,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         sess: &Session,
         features: &Features,
     ) -> bool {
@@ -359,10 +359,10 @@ impl LinkParser {
         true
     }
 
-    fn parse_link_modifiers<S: Stage>(
+    fn parse_link_modifiers(
         item: &MetaItemParser,
         modifiers: &mut Option<(Symbol, Span)>,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
     ) -> bool {
         if modifiers.is_some() {
             cx.adcx().duplicate_key(item.span(), sym::modifiers);
@@ -380,10 +380,10 @@ impl LinkParser {
         true
     }
 
-    fn parse_link_cfg<S: Stage>(
+    fn parse_link_cfg(
         item: &MetaItemParser,
         cfg: &mut Option<CfgEntry>,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         sess: &Session,
         features: &Features,
     ) -> bool {
@@ -401,10 +401,10 @@ impl LinkParser {
         true
     }
 
-    fn parse_link_wasm_import_module<S: Stage>(
+    fn parse_link_wasm_import_module(
         item: &MetaItemParser,
         wasm_import_module: &mut Option<(Symbol, Span)>,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
     ) -> bool {
         if wasm_import_module.is_some() {
             cx.adcx().duplicate_key(item.span(), sym::wasm_import_module);
@@ -422,10 +422,10 @@ impl LinkParser {
         true
     }
 
-    fn parse_link_import_name_type<S: Stage>(
+    fn parse_link_import_name_type(
         item: &MetaItemParser,
         import_name_type: &mut Option<(PeImportNameType, Span)>,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
     ) -> bool {
         if import_name_type.is_some() {
             cx.adcx().duplicate_key(item.span(), sym::import_name_type);
@@ -486,9 +486,9 @@ fn check_link_section_macho(name: Symbol) -> Result<(), InvalidMachoSectionReaso
     Ok(())
 }
 
-impl<S: Stage> SingleAttributeParser<S> for LinkSectionParser {
+impl SingleAttributeParser for LinkSectionParser {
     const PATH: &[Symbol] = &[sym::link_section];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: Some(Edition2024) };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Static),
@@ -502,7 +502,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkSectionParser {
         "https://doc.rust-lang.org/reference/abi.html#the-link_section-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -536,14 +536,14 @@ impl<S: Stage> SingleAttributeParser<S> for LinkSectionParser {
 }
 
 pub(crate) struct ExportStableParser;
-impl<S: Stage> NoArgsAttributeParser<S> for ExportStableParser {
+impl NoArgsAttributeParser for ExportStableParser {
     const PATH: &[Symbol] = &[sym::export_stable];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ExportStable;
 }
 
 pub(crate) struct FfiConstParser;
-impl<S: Stage> NoArgsAttributeParser<S> for FfiConstParser {
+impl NoArgsAttributeParser for FfiConstParser {
     const PATH: &[Symbol] = &[sym::ffi_const];
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: None };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
@@ -551,7 +551,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for FfiConstParser {
 }
 
 pub(crate) struct FfiPureParser;
-impl<S: Stage> NoArgsAttributeParser<S> for FfiPureParser {
+impl NoArgsAttributeParser for FfiPureParser {
     const PATH: &[Symbol] = &[sym::ffi_pure];
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: None };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
@@ -559,7 +559,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for FfiPureParser {
 }
 
 pub(crate) struct RustcStdInternalSymbolParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcStdInternalSymbolParser {
+impl NoArgsAttributeParser for RustcStdInternalSymbolParser {
     const PATH: &[Symbol] = &[sym::rustc_std_internal_symbol];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -572,7 +572,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcStdInternalSymbolParser {
 
 pub(crate) struct LinkOrdinalParser;
 
-impl<S: Stage> SingleAttributeParser<S> for LinkOrdinalParser {
+impl SingleAttributeParser for LinkOrdinalParser {
     const PATH: &[Symbol] = &[sym::link_ordinal];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::ForeignFn),
@@ -584,7 +584,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkOrdinalParser {
         "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ordinal = parse_single_integer(cx, args)?;
 
         // According to the table at
@@ -611,7 +611,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkOrdinalParser {
 
 pub(crate) struct LinkageParser;
 
-impl<S: Stage> SingleAttributeParser<S> for LinkageParser {
+impl SingleAttributeParser for LinkageParser {
     const PATH: &[Symbol] = &[sym::linkage];
 
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
@@ -637,7 +637,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkageParser {
         "weak_odr",
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(name_value) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, Some(sym::linkage));
@@ -694,7 +694,7 @@ impl<S: Stage> SingleAttributeParser<S> for LinkageParser {
 
 pub(crate) struct NeedsAllocatorParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NeedsAllocatorParser {
+impl NoArgsAttributeParser for NeedsAllocatorParser {
     const PATH: &[Symbol] = &[sym::needs_allocator];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NeedsAllocator;
@@ -702,7 +702,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for NeedsAllocatorParser {
 
 pub(crate) struct CompilerBuiltinsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for CompilerBuiltinsParser {
+impl NoArgsAttributeParser for CompilerBuiltinsParser {
     const PATH: &[Symbol] = &[sym::compiler_builtins];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::CompilerBuiltins;

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 
 pub(crate) struct RustcAsPtrParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcAsPtrParser {
+impl NoArgsAttributeParser for RustcAsPtrParser {
     const PATH: &[Symbol] = &[sym::rustc_as_ptr];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -14,7 +14,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcAsPtrParser {
 }
 
 pub(crate) struct RustcPubTransparentParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcPubTransparentParser {
+impl NoArgsAttributeParser for RustcPubTransparentParser {
     const PATH: &[Symbol] = &[sym::rustc_pub_transparent];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
@@ -25,7 +25,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcPubTransparentParser {
 }
 
 pub(crate) struct RustcPassByValueParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcPassByValueParser {
+impl NoArgsAttributeParser for RustcPassByValueParser {
     const PATH: &[Symbol] = &[sym::rustc_pass_by_value];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
@@ -36,7 +36,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcPassByValueParser {
 }
 
 pub(crate) struct RustcShouldNotBeCalledOnConstItemsParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcShouldNotBeCalledOnConstItemsParser {
+impl NoArgsAttributeParser for RustcShouldNotBeCalledOnConstItemsParser {
     const PATH: &[Symbol] = &[sym::rustc_should_not_be_called_on_const_items];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Inherent)),
@@ -46,9 +46,9 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcShouldNotBeCalledOnConstItemsPa
 }
 
 pub(crate) struct AutomaticallyDerivedParser;
-impl<S: Stage> NoArgsAttributeParser<S> for AutomaticallyDerivedParser {
+impl NoArgsAttributeParser for AutomaticallyDerivedParser {
     const PATH: &[Symbol] = &[sym::automatically_derived];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Impl { of_trait: true }),
         Error(Target::Crate),

--- a/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
@@ -1,14 +1,14 @@
 use super::prelude::*;
 
 pub(crate) struct LoopMatchParser;
-impl<S: Stage> NoArgsAttributeParser<S> for LoopMatchParser {
+impl NoArgsAttributeParser for LoopMatchParser {
     const PATH: &[Symbol] = &[sym::loop_match];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Expression)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::LoopMatch;
 }
 
 pub(crate) struct ConstContinueParser;
-impl<S: Stage> NoArgsAttributeParser<S> for ConstContinueParser {
+impl NoArgsAttributeParser for ConstContinueParser {
     const PATH: &[Symbol] = &[sym::const_continue];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Expression)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::ConstContinue;

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -4,9 +4,9 @@ use rustc_session::lint::builtin::INVALID_MACRO_EXPORT_ARGUMENTS;
 use super::prelude::*;
 
 pub(crate) struct MacroEscapeParser;
-impl<S: Stage> NoArgsAttributeParser<S> for MacroEscapeParser {
+impl NoArgsAttributeParser for MacroEscapeParser {
     const PATH: &[Symbol] = &[sym::macro_escape];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = MACRO_USE_ALLOWED_TARGETS;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::MacroEscape;
 }
@@ -37,11 +37,11 @@ const MACRO_USE_ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnR
     Error(Target::WherePredicate),
 ]);
 
-impl<S: Stage> AttributeParser<S> for MacroUseParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for MacroUseParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::macro_use],
         MACRO_USE_TEMPLATE,
-        |group: &mut Self, cx: &mut AcceptContext<'_, '_, S>, args| {
+        |group: &mut Self, cx: &mut AcceptContext<'_, '_>, args| {
             let span = cx.attr_span;
             group.first_span.get_or_insert(span);
             match args {
@@ -107,16 +107,16 @@ impl<S: Stage> AttributeParser<S> for MacroUseParser {
     )];
     const ALLOWED_TARGETS: AllowedTargets = MACRO_USE_ALLOWED_TARGETS;
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         Some(AttributeKind::MacroUse { span: self.first_span?, arguments: self.state })
     }
 }
 
 pub(crate) struct AllowInternalUnsafeParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for AllowInternalUnsafeParser {
+impl NoArgsAttributeParser for AllowInternalUnsafeParser {
     const PATH: &[Symbol] = &[sym::allow_internal_unsafe];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Ignore;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::MacroDef),
@@ -128,9 +128,9 @@ impl<S: Stage> NoArgsAttributeParser<S> for AllowInternalUnsafeParser {
 
 pub(crate) struct MacroExportParser;
 
-impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
+impl SingleAttributeParser for MacroExportParser {
     const PATH: &[Symbol] = &[sym::macro_export];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["local_inner_macros"]);
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::MacroDef),
@@ -138,7 +138,7 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
         Error(Target::Crate),
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let local_inner_macros = match args {
             ArgParser::NoArgs => false,
             ArgParser::List(list) => {
@@ -165,7 +165,7 @@ impl<S: Stage> SingleAttributeParser<S> for MacroExportParser {
 
 pub(crate) struct CollapseDebugInfoParser;
 
-impl<S: Stage> SingleAttributeParser<S> for CollapseDebugInfoParser {
+impl SingleAttributeParser for CollapseDebugInfoParser {
     const PATH: &[Symbol] = &[sym::collapse_debuginfo];
     const TEMPLATE: AttributeTemplate = template!(
         List: &["no", "external", "yes"],
@@ -173,7 +173,7 @@ impl<S: Stage> SingleAttributeParser<S> for CollapseDebugInfoParser {
     );
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
         let Some(mi) = single.meta_item() else {
             cx.adcx().expected_not_literal(single.span());
@@ -200,7 +200,7 @@ impl<S: Stage> SingleAttributeParser<S> for CollapseDebugInfoParser {
 
 pub(crate) struct RustcProcMacroDeclsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcProcMacroDeclsParser {
+impl NoArgsAttributeParser for RustcProcMacroDeclsParser {
     const PATH: &[Symbol] = &[sym::rustc_proc_macro_decls];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Static)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcProcMacroDecls;

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -22,7 +22,7 @@ use rustc_span::edition::Edition;
 use rustc_span::{Span, Symbol};
 use thin_vec::ThinVec;
 
-use crate::context::{AcceptContext, FinalizeContext, Stage};
+use crate::context::{AcceptContext, FinalizeContext};
 use crate::parser::ArgParser;
 use crate::session_diagnostics::UnusedMultiple;
 use crate::target_checking::AllowedTargets;
@@ -70,8 +70,8 @@ pub(crate) mod traits;
 pub(crate) mod transparency;
 pub(crate) mod util;
 
-type AcceptFn<T, S> = for<'sess> fn(&mut T, &mut AcceptContext<'_, 'sess, S>, &ArgParser);
-type AcceptMapping<T, S> = &'static [(&'static [Symbol], AttributeTemplate, AcceptFn<T, S>)];
+type AcceptFn<T> = for<'sess> fn(&mut T, &mut AcceptContext<'_, 'sess>, &ArgParser);
+type AcceptMapping<T> = &'static [(&'static [Symbol], AttributeTemplate, AcceptFn<T>)];
 
 /// An [`AttributeParser`] is a type which searches for syntactic attributes.
 ///
@@ -92,11 +92,11 @@ type AcceptMapping<T, S> = &'static [(&'static [Symbol], AttributeTemplate, Acce
 ///
 /// For a simpler attribute parsing interface, consider using [`SingleAttributeParser`]
 /// or [`CombineAttributeParser`] instead.
-pub(crate) trait AttributeParser<S: Stage>: Default + 'static {
+pub(crate) trait AttributeParser: Default + 'static {
     /// The symbols for the attributes that this parser is interested in.
     ///
     /// If an attribute has this symbol, the `accept` function will be called on it.
-    const ATTRIBUTES: AcceptMapping<Self, S>;
+    const ATTRIBUTES: AcceptMapping<Self>;
     const ALLOWED_TARGETS: AllowedTargets;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
 
@@ -108,7 +108,7 @@ pub(crate) trait AttributeParser<S: Stage>: Default + 'static {
     /// that'd be equivalent to unconditionally applying an attribute to
     /// every single syntax item that could have attributes applied to it.
     /// Your accept mappings should determine whether this returns something.
-    fn finalize(self, cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind>;
+    fn finalize(self, cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind>;
 }
 
 /// Alternative to [`AttributeParser`] that automatically handles state management.
@@ -120,7 +120,7 @@ pub(crate) trait AttributeParser<S: Stage>: Default + 'static {
 ///
 /// [`SingleAttributeParser`] can only convert attributes one-to-one, and cannot combine multiple
 /// attributes together like is necessary for `#[stable()]` and `#[unstable()]` for example.
-pub(crate) trait SingleAttributeParser<S: Stage>: 'static {
+pub(crate) trait SingleAttributeParser: 'static {
     /// The single path of the attribute this parser accepts.
     ///
     /// If you need the parser to accept more than one path, use [`AttributeParser`] instead
@@ -128,7 +128,7 @@ pub(crate) trait SingleAttributeParser<S: Stage>: 'static {
 
     /// Configures what to do when when the same attribute is
     /// applied more than once on the same syntax node.
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
 
     const ALLOWED_TARGETS: AllowedTargets;
@@ -137,27 +137,22 @@ pub(crate) trait SingleAttributeParser<S: Stage>: 'static {
     const TEMPLATE: AttributeTemplate;
 
     /// Converts a single syntactical attribute to a single semantic attribute, or [`AttributeKind`]
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind>;
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind>;
 }
 
 /// Use in combination with [`SingleAttributeParser`].
 /// `Single<T: SingleAttributeParser>` implements [`AttributeParser`].
-pub(crate) struct Single<T: SingleAttributeParser<S>, S: Stage>(
-    PhantomData<(S, T)>,
-    Option<(AttributeKind, Span)>,
-);
+pub(crate) struct Single<T: SingleAttributeParser>(PhantomData<T>, Option<(AttributeKind, Span)>);
 
-impl<T: SingleAttributeParser<S>, S: Stage> Default for Single<T, S> {
+impl<T: SingleAttributeParser> Default for Single<T> {
     fn default() -> Self {
         Self(Default::default(), Default::default())
     }
 }
 
-impl<T: SingleAttributeParser<S>, S: Stage> AttributeParser<S> for Single<T, S> {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
-        T::PATH,
-        <T as SingleAttributeParser<S>>::TEMPLATE,
-        |group: &mut Single<T, S>, cx, args| {
+impl<T: SingleAttributeParser> AttributeParser for Single<T> {
+    const ATTRIBUTES: AcceptMapping<Self> =
+        &[(T::PATH, <T as SingleAttributeParser>::TEMPLATE, |group: &mut Single<T>, cx, args| {
             if let Some(pa) = T::convert(cx, args) {
                 if let Some((_, used)) = group.1 {
                     T::ON_DUPLICATE.exec::<T>(cx, used, cx.attr_span);
@@ -165,17 +160,16 @@ impl<T: SingleAttributeParser<S>, S: Stage> AttributeParser<S> for Single<T, S> 
                     group.1 = Some((pa, cx.attr_span));
                 }
             }
-        },
-    )];
+        })];
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const SAFETY: AttributeSafety = T::SAFETY;
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         Some(self.1?.0)
     }
 }
 
-pub(crate) enum OnDuplicate<S: Stage> {
+pub(crate) enum OnDuplicate {
     /// Give a default warning
     Warn,
 
@@ -193,13 +187,13 @@ pub(crate) enum OnDuplicate<S: Stage> {
     /// - `unused` is the span of the attribute that was unused or bad because of some
     ///   duplicate reason
     /// - `used` is the span of the attribute that was used in favor of the unused attribute
-    Custom(fn(cx: &AcceptContext<'_, '_, S>, used: Span, unused: Span)),
+    Custom(fn(cx: &AcceptContext<'_, '_>, used: Span, unused: Span)),
 }
 
-impl<S: Stage> OnDuplicate<S> {
-    fn exec<P: SingleAttributeParser<S>>(
+impl OnDuplicate {
+    fn exec<P: SingleAttributeParser>(
         &self,
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         used: Span,
         unused: Span,
     ) {
@@ -238,9 +232,9 @@ pub enum AttributeSafety {
 ///
 /// [`WithoutArgs<T> where T: NoArgsAttributeParser`](WithoutArgs) implements [`SingleAttributeParser`].
 //
-pub(crate) trait NoArgsAttributeParser<S: Stage>: 'static {
+pub(crate) trait NoArgsAttributeParser: 'static {
     const PATH: &[Symbol];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
 
@@ -248,22 +242,22 @@ pub(crate) trait NoArgsAttributeParser<S: Stage>: 'static {
     const CREATE: fn(Span) -> AttributeKind;
 }
 
-pub(crate) struct WithoutArgs<T: NoArgsAttributeParser<S>, S: Stage>(PhantomData<(S, T)>);
+pub(crate) struct WithoutArgs<T: NoArgsAttributeParser>(PhantomData<T>);
 
-impl<T: NoArgsAttributeParser<S>, S: Stage> Default for WithoutArgs<T, S> {
+impl<T: NoArgsAttributeParser> Default for WithoutArgs<T> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<T: NoArgsAttributeParser<S>, S: Stage> SingleAttributeParser<S> for WithoutArgs<T, S> {
+impl<T: NoArgsAttributeParser> SingleAttributeParser for WithoutArgs<T> {
     const PATH: &[Symbol] = T::PATH;
-    const ON_DUPLICATE: OnDuplicate<S> = T::ON_DUPLICATE;
+    const ON_DUPLICATE: OnDuplicate = T::ON_DUPLICATE;
     const SAFETY: AttributeSafety = T::SAFETY;
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(Word);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
             cx.adcx().expected_no_args(span);
         }
@@ -280,7 +274,7 @@ type ConvertFn<E> = fn(ThinVec<E>, Span) -> AttributeKind;
 ///
 /// [`CombineAttributeParser`] can only convert a single kind of attribute, and cannot combine multiple
 /// attributes together like is necessary for `#[stable()]` and `#[unstable()]` for example.
-pub(crate) trait CombineAttributeParser<S: Stage>: 'static {
+pub(crate) trait CombineAttributeParser: 'static {
     const PATH: &[rustc_span::Symbol];
 
     type Item;
@@ -298,22 +292,22 @@ pub(crate) trait CombineAttributeParser<S: Stage>: 'static {
 
     /// Converts a single syntactical attribute to a number of elements of the semantic attribute, or [`AttributeKind`]
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item>;
 }
 
 /// Use in combination with [`CombineAttributeParser`].
 /// `Combine<T: CombineAttributeParser>` implements [`AttributeParser`].
-pub(crate) struct Combine<T: CombineAttributeParser<S>, S: Stage> {
-    phantom: PhantomData<(S, T)>,
+pub(crate) struct Combine<T: CombineAttributeParser> {
+    phantom: PhantomData<T>,
     /// A list of all items produced by parsing attributes so far. One attribute can produce any amount of items.
-    items: ThinVec<<T as CombineAttributeParser<S>>::Item>,
+    items: ThinVec<<T as CombineAttributeParser>::Item>,
     /// The full span of the first attribute that was encountered.
     first_span: Option<Span>,
 }
 
-impl<T: CombineAttributeParser<S>, S: Stage> Default for Combine<T, S> {
+impl<T: CombineAttributeParser> Default for Combine<T> {
     fn default() -> Self {
         Self {
             phantom: Default::default(),
@@ -323,9 +317,9 @@ impl<T: CombineAttributeParser<S>, S: Stage> Default for Combine<T, S> {
     }
 }
 
-impl<T: CombineAttributeParser<S>, S: Stage> AttributeParser<S> for Combine<T, S> {
-    const ATTRIBUTES: AcceptMapping<Self, S> =
-        &[(T::PATH, T::TEMPLATE, |group: &mut Combine<T, S>, cx, args| {
+impl<T: CombineAttributeParser> AttributeParser for Combine<T> {
+    const ATTRIBUTES: AcceptMapping<Self> =
+        &[(T::PATH, T::TEMPLATE, |group: &mut Combine<T>, cx, args| {
             // Keep track of the span of the first attribute, for diagnostics
             group.first_span.get_or_insert(cx.attr_span);
             group.items.extend(T::extend(cx, args))
@@ -333,7 +327,7 @@ impl<T: CombineAttributeParser<S>, S: Stage> AttributeParser<S> for Combine<T, S
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const SAFETY: AttributeSafety = T::SAFETY;
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(first_span) = self.first_span {
             Some(T::CONVERT(self.items, first_span))
         } else {

--- a/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 pub(crate) struct MustNotSuspendParser;
 
-impl<S: Stage> SingleAttributeParser<S> for MustNotSuspendParser {
+impl SingleAttributeParser for MustNotSuspendParser {
     const PATH: &[rustc_span::Symbol] = &[sym::must_not_suspend];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
@@ -12,7 +12,7 @@ impl<S: Stage> SingleAttributeParser<S> for MustNotSuspendParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let reason = match args {
             ArgParser::NameValue(reason) => match reason.value_as_str() {
                 Some(val) => Some(val),

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 pub(crate) struct MustUseParser;
 
-impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
+impl SingleAttributeParser for MustUseParser {
     const PATH: &[Symbol] = &[sym::must_use];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Fn),
         Allow(Target::Enum),
@@ -25,7 +25,7 @@ impl<S: Stage> SingleAttributeParser<S> for MustUseParser {
         "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::MustUse {
             span: cx.attr_span,
             reason: match args {

--- a/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 pub(crate) struct NoImplicitPreludeParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NoImplicitPreludeParser {
+impl NoArgsAttributeParser for NoImplicitPreludeParser {
     const PATH: &[rustc_span::Symbol] = &[sym::no_implicit_prelude];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Mod), Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoImplicitPrelude;

--- a/compiler/rustc_attr_parsing/src/attributes/no_link.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_link.rs
@@ -1,9 +1,9 @@
 use super::prelude::*;
 
 pub(crate) struct NoLinkParser;
-impl<S: Stage> NoArgsAttributeParser<S> for NoLinkParser {
+impl NoArgsAttributeParser for NoLinkParser {
     const PATH: &[Symbol] = &[sym::no_link];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::ExternCrate),
         Warn(Target::Field),

--- a/compiler/rustc_attr_parsing/src/attributes/non_exhaustive.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/non_exhaustive.rs
@@ -3,15 +3,14 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Span, Symbol, sym};
 
 use crate::attributes::{NoArgsAttributeParser, OnDuplicate};
-use crate::context::Stage;
 use crate::target_checking::AllowedTargets;
 use crate::target_checking::Policy::{Allow, Warn};
 
 pub(crate) struct NonExhaustiveParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for NonExhaustiveParser {
+impl NoArgsAttributeParser for NonExhaustiveParser {
     const PATH: &[Symbol] = &[sym::non_exhaustive];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
         Allow(Target::Struct),

--- a/compiler/rustc_attr_parsing/src/attributes/path.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/path.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 pub(crate) struct PathParser;
 
-impl<S: Stage> SingleAttributeParser<S> for PathParser {
+impl SingleAttributeParser for PathParser {
     const PATH: &[Symbol] = &[sym::path];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Mod), Error(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(
@@ -12,7 +12,7 @@ impl<S: Stage> SingleAttributeParser<S> for PathParser {
         "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);

--- a/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
@@ -3,13 +3,12 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Span, Symbol, sym};
 
 use crate::attributes::NoArgsAttributeParser;
-use crate::context::Stage;
 use crate::target_checking::AllowedTargets;
 use crate::target_checking::Policy::Allow;
 
 pub(crate) struct PinV2Parser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for PinV2Parser {
+impl NoArgsAttributeParser for PinV2Parser {
     const PATH: &[Symbol] = &[sym::pin_v2];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Enum),

--- a/compiler/rustc_attr_parsing/src/attributes/prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prelude.rs
@@ -17,7 +17,7 @@ pub(super) use crate::attributes::{
 };
 // contexts
 #[doc(hidden)]
-pub(super) use crate::context::{AcceptContext, FinalizeContext, Stage};
+pub(super) use crate::context::{AcceptContext, FinalizeContext};
 #[doc(hidden)]
 pub(super) use crate::parser::*;
 // target checking

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -7,21 +7,21 @@ const PROC_MACRO_ALLOWED_TARGETS: AllowedTargets =
     AllowedTargets::AllowList(&[Allow(Target::Fn), Warn(Target::Crate), Warn(Target::MacroCall)]);
 
 pub(crate) struct ProcMacroParser;
-impl<S: Stage> NoArgsAttributeParser<S> for ProcMacroParser {
+impl NoArgsAttributeParser for ProcMacroParser {
     const PATH: &[Symbol] = &[sym::proc_macro];
     const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::ProcMacro;
 }
 
 pub(crate) struct ProcMacroAttributeParser;
-impl<S: Stage> NoArgsAttributeParser<S> for ProcMacroAttributeParser {
+impl NoArgsAttributeParser for ProcMacroAttributeParser {
     const PATH: &[Symbol] = &[sym::proc_macro_attribute];
     const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::ProcMacroAttribute;
 }
 
 pub(crate) struct ProcMacroDeriveParser;
-impl<S: Stage> SingleAttributeParser<S> for ProcMacroDeriveParser {
+impl SingleAttributeParser for ProcMacroDeriveParser {
     const PATH: &[Symbol] = &[sym::proc_macro_derive];
     const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(
@@ -29,7 +29,7 @@ impl<S: Stage> SingleAttributeParser<S> for ProcMacroDeriveParser {
         "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let (trait_name, helper_attrs) = parse_derive_like(cx, args, true)?;
         Some(AttributeKind::ProcMacroDerive {
             trait_name: trait_name.expect("Trait name is mandatory, so it is present"),
@@ -40,20 +40,20 @@ impl<S: Stage> SingleAttributeParser<S> for ProcMacroDeriveParser {
 }
 
 pub(crate) struct RustcBuiltinMacroParser;
-impl<S: Stage> SingleAttributeParser<S> for RustcBuiltinMacroParser {
+impl SingleAttributeParser for RustcBuiltinMacroParser {
     const PATH: &[Symbol] = &[sym::rustc_builtin_macro];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
         template!(List: &["TraitName", "TraitName, attributes(name1, name2, ...)"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let (builtin_name, helper_attrs) = parse_derive_like(cx, args, false)?;
         Some(AttributeKind::RustcBuiltinMacro { builtin_name, helper_attrs, span: cx.attr_span })
     }
 }
 
-fn parse_derive_like<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_derive_like(
+    cx: &mut AcceptContext<'_, '_>,
     args: &ArgParser,
     trait_name_mandatory: bool,
 ) -> Option<(Option<Symbol>, ThinVec<Symbol>)> {

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -6,7 +6,7 @@ use rustc_hir::attrs::{AttributeKind, MirDialect, MirPhase};
 use rustc_span::{Span, Symbol, sym};
 
 use crate::attributes::SingleAttributeParser;
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::parser::ArgParser;
 use crate::session_diagnostics;
 use crate::target_checking::AllowedTargets;
@@ -14,14 +14,14 @@ use crate::target_checking::Policy::Allow;
 
 pub(crate) struct CustomMirParser;
 
-impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
+impl SingleAttributeParser for CustomMirParser {
     const PATH: &[rustc_span::Symbol] = &[sym::custom_mir];
 
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
 
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"dialect = "...", phase = "...""#]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
 
         let mut dialect = None;
@@ -60,8 +60,8 @@ impl<S: Stage> SingleAttributeParser<S> for CustomMirParser {
     }
 }
 
-fn extract_value<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn extract_value(
+    cx: &mut AcceptContext<'_, '_>,
     key: Symbol,
     arg: &ArgParser,
     span: Span,
@@ -89,8 +89,8 @@ fn extract_value<S: Stage>(
     *out_val = Some((value_sym, val.value_span));
 }
 
-fn parse_dialect<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_dialect(
+    cx: &mut AcceptContext<'_, '_>,
     dialect: Option<(Symbol, Span)>,
     failed: &mut bool,
 ) -> Option<(MirDialect, Span)> {
@@ -111,8 +111,8 @@ fn parse_dialect<S: Stage>(
     Some((dialect, span))
 }
 
-fn parse_phase<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_phase(
+    cx: &mut AcceptContext<'_, '_>,
     phase: Option<(Symbol, Span)>,
     failed: &mut bool,
 ) -> Option<(MirPhase, Span)> {
@@ -136,8 +136,8 @@ fn parse_phase<S: Stage>(
     Some((phase, span))
 }
 
-fn check_custom_mir<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn check_custom_mir(
+    cx: &mut AcceptContext<'_, '_>,
     dialect: Option<(MirDialect, Span)>,
     phase: Option<(MirPhase, Span)>,
     failed: &mut bool,

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -15,7 +15,7 @@ use crate::session_diagnostics::{self, IncorrectReprFormatGenericCause};
 // FIXME(jdonszelmann): is a vec the right representation here even? isn't it just a struct?
 pub(crate) struct ReprParser;
 
-impl<S: Stage> CombineAttributeParser<S> for ReprParser {
+impl CombineAttributeParser for ReprParser {
     type Item = (ReprAttr, Span);
     const PATH: &[Symbol] = &[sym::repr];
     const CONVERT: ConvertFn<Self::Item> =
@@ -27,7 +27,7 @@ impl<S: Stage> CombineAttributeParser<S> for ReprParser {
     );
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let mut reprs = Vec::new();
@@ -98,7 +98,7 @@ fn int_type_of_word(s: Symbol) -> Option<IntType> {
     }
 }
 
-fn parse_repr<S: Stage>(cx: &AcceptContext<'_, '_, S>, param: &MetaItemParser) -> Option<ReprAttr> {
+fn parse_repr(cx: &AcceptContext<'_, '_>, param: &MetaItemParser) -> Option<ReprAttr> {
     use ReprAttr::*;
 
     // FIXME(jdonszelmann): invert the parsing here to match on the word first and then the
@@ -187,8 +187,8 @@ enum AlignKind {
     Align,
 }
 
-fn parse_repr_align<S: Stage>(
-    cx: &AcceptContext<'_, '_, S>,
+fn parse_repr_align(
+    cx: &AcceptContext<'_, '_>,
     list: &MetaItemListParser,
     param_span: Span,
     align_kind: AlignKind,
@@ -248,10 +248,7 @@ fn parse_repr_align<S: Stage>(
     }
 }
 
-fn parse_alignment<S: Stage>(
-    node: &LitKind,
-    cx: &AcceptContext<'_, '_, S>,
-) -> Result<Align, String> {
+fn parse_alignment(node: &LitKind, cx: &AcceptContext<'_, '_>) -> Result<Align, String> {
     let LitKind::Int(literal, LitIntType::Unsuffixed) = node else {
         return Err("not an unsuffixed integer".to_string());
     };
@@ -287,7 +284,7 @@ impl RustcAlignParser {
     const PATH: &[Symbol] = &[sym::rustc_align];
     const TEMPLATE: AttributeTemplate = template!(List: &["<alignment in bytes>"]);
 
-    fn parse<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
+    fn parse(&mut self, cx: &mut AcceptContext<'_, '_>, args: &ArgParser) {
         match args {
             ArgParser::NoArgs | ArgParser::NameValue(_) => {
                 let attr_span = cx.attr_span;
@@ -320,8 +317,8 @@ impl RustcAlignParser {
     }
 }
 
-impl<S: Stage> AttributeParser<S> for RustcAlignParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(Self::PATH, Self::TEMPLATE, Self::parse)];
+impl AttributeParser for RustcAlignParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(Self::PATH, Self::TEMPLATE, Self::parse)];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -331,7 +328,7 @@ impl<S: Stage> AttributeParser<S> for RustcAlignParser {
         Allow(Target::ForeignFn),
     ]);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         let (align, span) = self.0?;
         Some(AttributeKind::RustcAlign { align, span })
     }
@@ -344,17 +341,17 @@ impl RustcAlignStaticParser {
     const PATH: &[Symbol] = &[sym::rustc_align_static];
     const TEMPLATE: AttributeTemplate = RustcAlignParser::TEMPLATE;
 
-    fn parse<S: Stage>(&mut self, cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) {
+    fn parse(&mut self, cx: &mut AcceptContext<'_, '_>, args: &ArgParser) {
         self.0.parse(cx, args)
     }
 }
 
-impl<S: Stage> AttributeParser<S> for RustcAlignStaticParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(Self::PATH, Self::TEMPLATE, Self::parse)];
+impl AttributeParser for RustcAlignStaticParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(Self::PATH, Self::TEMPLATE, Self::parse)];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Static), Allow(Target::ForeignStatic)]);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         let (align, span) = self.0.0?;
         Some(AttributeKind::RustcAlign { align, span })
     }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
@@ -2,7 +2,7 @@ use super::prelude::*;
 
 pub(crate) struct RustcAllocatorParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcAllocatorParser {
+impl NoArgsAttributeParser for RustcAllocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
@@ -11,7 +11,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcAllocatorParser {
 
 pub(crate) struct RustcAllocatorZeroedParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcAllocatorZeroedParser {
+impl NoArgsAttributeParser for RustcAllocatorZeroedParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator_zeroed];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
@@ -20,12 +20,12 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcAllocatorZeroedParser {
 
 pub(crate) struct RustcAllocatorZeroedVariantParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcAllocatorZeroedVariantParser {
+impl SingleAttributeParser for RustcAllocatorZeroedVariantParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator_zeroed_variant];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "function");
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(name) = args.name_value().and_then(NameValueParser::value_as_str) else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -38,7 +38,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAllocatorZeroedVariantParser {
 
 pub(crate) struct RustcDeallocatorParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDeallocatorParser {
+impl NoArgsAttributeParser for RustcDeallocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_deallocator];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
@@ -47,7 +47,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDeallocatorParser {
 
 pub(crate) struct RustcReallocatorParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcReallocatorParser {
+impl NoArgsAttributeParser for RustcReallocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_reallocator];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -3,12 +3,11 @@ use rustc_hir::{MethodKind, Target};
 use rustc_span::{Span, Symbol, sym};
 
 use super::prelude::*;
-use crate::context::Stage;
 use crate::target_checking::AllowedTargets;
 
 pub(crate) struct RustcDumpUserArgsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpUserArgsParser {
+impl NoArgsAttributeParser for RustcDumpUserArgsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_user_args];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpUserArgs;
@@ -16,7 +15,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpUserArgsParser {
 
 pub(crate) struct RustcDumpDefParentsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpDefParentsParser {
+impl NoArgsAttributeParser for RustcDumpDefParentsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_def_parents];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpDefParents;
@@ -24,7 +23,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpDefParentsParser {
 
 pub(crate) struct RustcDumpDefPathParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcDumpDefPathParser {
+impl SingleAttributeParser for RustcDumpDefPathParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_def_path];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -36,7 +35,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDumpDefPathParser {
         Allow(Target::Impl { of_trait: false }),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word);
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
             cx.adcx().expected_no_args(span);
             return None;
@@ -47,7 +46,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDumpDefPathParser {
 
 pub(crate) struct RustcDumpHiddenTypeOfOpaquesParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpHiddenTypeOfOpaquesParser {
+impl NoArgsAttributeParser for RustcDumpHiddenTypeOfOpaquesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_hidden_type_of_opaques];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpHiddenTypeOfOpaques;
@@ -55,7 +54,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpHiddenTypeOfOpaquesParser {
 
 pub(crate) struct RustcDumpInferredOutlivesParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpInferredOutlivesParser {
+impl NoArgsAttributeParser for RustcDumpInferredOutlivesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_inferred_outlives];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Struct),
@@ -68,7 +67,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpInferredOutlivesParser {
 
 pub(crate) struct RustcDumpItemBoundsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpItemBoundsParser {
+impl NoArgsAttributeParser for RustcDumpItemBoundsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_item_bounds];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::AssocTy)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpItemBounds;
@@ -76,7 +75,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpItemBoundsParser {
 
 pub(crate) struct RustcDumpLayoutParser;
 
-impl<S: Stage> CombineAttributeParser<S> for RustcDumpLayoutParser {
+impl CombineAttributeParser for RustcDumpLayoutParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_layout];
 
     type Item = RustcDumpLayoutKind;
@@ -93,7 +92,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcDumpLayoutParser {
     const TEMPLATE: AttributeTemplate =
         template!(List: &["abi", "align", "size", "homogenous_aggregate", "debug"]);
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let Some(items) = cx.expect_list(args, cx.attr_span) else {
@@ -138,7 +137,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcDumpLayoutParser {
 
 pub(crate) struct RustcDumpObjectLifetimeDefaultsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpObjectLifetimeDefaultsParser {
+impl NoArgsAttributeParser for RustcDumpObjectLifetimeDefaultsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_object_lifetime_defaults];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::AssocConst),
@@ -164,7 +163,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpObjectLifetimeDefaultsParse
 
 pub(crate) struct RustcDumpPredicatesParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpPredicatesParser {
+impl NoArgsAttributeParser for RustcDumpPredicatesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_predicates];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::AssocConst),
@@ -191,7 +190,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpPredicatesParser {
 
 pub(crate) struct RustcDumpSymbolNameParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcDumpSymbolNameParser {
+impl SingleAttributeParser for RustcDumpSymbolNameParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_symbol_name];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -203,7 +202,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDumpSymbolNameParser {
         Allow(Target::Impl { of_trait: false }),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word);
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if let Err(span) = args.no_args() {
             cx.adcx().expected_no_args(span);
             return None;
@@ -214,7 +213,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDumpSymbolNameParser {
 
 pub(crate) struct RustcDumpVariancesParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpVariancesParser {
+impl NoArgsAttributeParser for RustcDumpVariancesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_variances];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
@@ -231,7 +230,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpVariancesParser {
 
 pub(crate) struct RustcDumpVariancesOfOpaquesParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpVariancesOfOpaquesParser {
+impl NoArgsAttributeParser for RustcDumpVariancesOfOpaquesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_variances_of_opaques];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpVariancesOfOpaques;
@@ -239,7 +238,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpVariancesOfOpaquesParser {
 
 pub(crate) struct RustcDumpVtableParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDumpVtableParser {
+impl NoArgsAttributeParser for RustcDumpVtableParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_vtable];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Impl { of_trait: true }),

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -17,7 +17,7 @@ use crate::session_diagnostics::{
 
 pub(crate) struct RustcMainParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcMainParser {
+impl NoArgsAttributeParser for RustcMainParser {
     const PATH: &[Symbol] = &[sym::rustc_main];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcMain;
@@ -25,11 +25,11 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcMainParser {
 
 pub(crate) struct RustcMustImplementOneOfParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcMustImplementOneOfParser {
+impl SingleAttributeParser for RustcMustImplementOneOfParser {
     const PATH: &[Symbol] = &[sym::rustc_must_implement_one_of];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["function1, function2, ..."]);
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
 
         let mut fn_names = ThinVec::new();
@@ -66,7 +66,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcMustImplementOneOfParser {
 
 pub(crate) struct RustcNeverReturnsNullPtrParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNeverReturnsNullPtrParser {
+impl NoArgsAttributeParser for RustcNeverReturnsNullPtrParser {
     const PATH: &[Symbol] = &[sym::rustc_never_returns_null_ptr];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -79,7 +79,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNeverReturnsNullPtrParser {
 }
 pub(crate) struct RustcNoImplicitAutorefsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNoImplicitAutorefsParser {
+impl NoArgsAttributeParser for RustcNoImplicitAutorefsParser {
     const PATH: &[Symbol] = &[sym::rustc_no_implicit_autorefs];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -94,12 +94,12 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNoImplicitAutorefsParser {
 
 pub(crate) struct RustcLayoutScalarValidRangeStartParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStartParser {
+impl SingleAttributeParser for RustcLayoutScalarValidRangeStartParser {
     const PATH: &[Symbol] = &[sym::rustc_layout_scalar_valid_range_start];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["start"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         parse_single_integer(cx, args)
             .map(|n| AttributeKind::RustcLayoutScalarValidRangeStart(Box::new(n), cx.attr_span))
     }
@@ -107,12 +107,12 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeStartPars
 
 pub(crate) struct RustcLayoutScalarValidRangeEndParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEndParser {
+impl SingleAttributeParser for RustcLayoutScalarValidRangeEndParser {
     const PATH: &[Symbol] = &[sym::rustc_layout_scalar_valid_range_end];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["end"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         parse_single_integer(cx, args)
             .map(|n| AttributeKind::RustcLayoutScalarValidRangeEnd(Box::new(n), cx.attr_span))
     }
@@ -120,12 +120,12 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLayoutScalarValidRangeEndParser
 
 pub(crate) struct RustcLegacyConstGenericsParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcLegacyConstGenericsParser {
+impl SingleAttributeParser for RustcLegacyConstGenericsParser {
     const PATH: &[Symbol] = &[sym::rustc_legacy_const_generics];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["N"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let meta_items = cx.expect_list(args, cx.attr_span)?;
 
         let mut parsed_indexes = ThinVec::new();
@@ -159,7 +159,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLegacyConstGenericsParser {
 
 pub(crate) struct RustcInheritOverflowChecksParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcInheritOverflowChecksParser {
+impl NoArgsAttributeParser for RustcInheritOverflowChecksParser {
     const PATH: &[Symbol] = &[sym::rustc_inherit_overflow_checks];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -172,11 +172,11 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcInheritOverflowChecksParser {
 
 pub(crate) struct RustcLintOptDenyFieldAccessParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcLintOptDenyFieldAccessParser {
+impl SingleAttributeParser for RustcLintOptDenyFieldAccessParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_deny_field_access];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Field)]);
     const TEMPLATE: AttributeTemplate = template!(Word);
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let arg = cx.expect_single_element_list(args, cx.attr_span)?;
 
         let MetaItemOrLitParser::Lit(MetaItemLit { kind: LitKind::Str(lint_message, _), .. }) = arg
@@ -191,14 +191,14 @@ impl<S: Stage> SingleAttributeParser<S> for RustcLintOptDenyFieldAccessParser {
 
 pub(crate) struct RustcLintOptTyParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcLintOptTyParser {
+impl NoArgsAttributeParser for RustcLintOptTyParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_ty];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcLintOptTy;
 }
 
-fn parse_cgu_fields<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn parse_cgu_fields(
+    cx: &mut AcceptContext<'_, '_>,
     args: &ArgParser,
     accepts_kind: bool,
 ) -> Option<(Symbol, Symbol, Option<CguKind>)> {
@@ -293,8 +293,8 @@ pub(crate) struct RustcCguTestAttributeParser {
     items: ThinVec<(Span, CguFields)>,
 }
 
-impl<S: Stage> AttributeParser<S> for RustcCguTestAttributeParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[
+impl AttributeParser for RustcCguTestAttributeParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[
         (
             &[sym::rustc_partition_reused],
             template!(List: &[r#"cfg = "...", module = "...""#]),
@@ -328,14 +328,14 @@ impl<S: Stage> AttributeParser<S> for RustcCguTestAttributeParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Mod), Allow(Target::Crate)]);
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         Some(AttributeKind::RustcCguTestAttr(self.items))
     }
 }
 
 pub(crate) struct RustcDeprecatedSafe2024Parser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcDeprecatedSafe2024Parser {
+impl SingleAttributeParser for RustcDeprecatedSafe2024Parser {
     const PATH: &[Symbol] = &[sym::rustc_deprecated_safe_2024];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -346,7 +346,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDeprecatedSafe2024Parser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"audit_that = "...""#]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
 
         let Some(arg) = single.meta_item() else {
@@ -375,7 +375,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDeprecatedSafe2024Parser {
 
 pub(crate) struct RustcConversionSuggestionParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcConversionSuggestionParser {
+impl NoArgsAttributeParser for RustcConversionSuggestionParser {
     const PATH: &[Symbol] = &[sym::rustc_conversion_suggestion];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -389,7 +389,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcConversionSuggestionParser {
 
 pub(crate) struct RustcCaptureAnalysisParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcCaptureAnalysisParser {
+impl NoArgsAttributeParser for RustcCaptureAnalysisParser {
     const PATH: &[Symbol] = &[sym::rustc_capture_analysis];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Closure)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCaptureAnalysis;
@@ -397,7 +397,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcCaptureAnalysisParser {
 
 pub(crate) struct RustcNeverTypeOptionsParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcNeverTypeOptionsParser {
+impl SingleAttributeParser for RustcNeverTypeOptionsParser {
     const PATH: &[Symbol] = &[sym::rustc_never_type_options];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &[
@@ -405,7 +405,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcNeverTypeOptionsParser {
         r#"diverging_block_default = "unit", "never""#,
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
 
         let mut fallback = None::<Ident>;
@@ -475,7 +475,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcNeverTypeOptionsParser {
 
 pub(crate) struct RustcTrivialFieldReadsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcTrivialFieldReadsParser {
+impl NoArgsAttributeParser for RustcTrivialFieldReadsParser {
     const PATH: &[Symbol] = &[sym::rustc_trivial_field_reads];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcTrivialFieldReads;
@@ -483,7 +483,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcTrivialFieldReadsParser {
 
 pub(crate) struct RustcNoMirInlineParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNoMirInlineParser {
+impl NoArgsAttributeParser for RustcNoMirInlineParser {
     const PATH: &[Symbol] = &[sym::rustc_no_mir_inline];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -497,9 +497,9 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNoMirInlineParser {
 
 pub(crate) struct RustcNoWritableParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNoWritableParser {
+impl NoArgsAttributeParser for RustcNoWritableParser {
     const PATH: &[Symbol] = &[sym::rustc_no_writable];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Closure),
@@ -512,7 +512,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNoWritableParser {
 
 pub(crate) struct RustcLintQueryInstabilityParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcLintQueryInstabilityParser {
+impl NoArgsAttributeParser for RustcLintQueryInstabilityParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_query_instability];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -526,7 +526,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcLintQueryInstabilityParser {
 
 pub(crate) struct RustcRegionsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcRegionsParser {
+impl NoArgsAttributeParser for RustcRegionsParser {
     const PATH: &[Symbol] = &[sym::rustc_regions];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -541,7 +541,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcRegionsParser {
 
 pub(crate) struct RustcLintUntrackedQueryInformationParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcLintUntrackedQueryInformationParser {
+impl NoArgsAttributeParser for RustcLintUntrackedQueryInformationParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_untracked_query_information];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -556,12 +556,12 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcLintUntrackedQueryInformationPa
 
 pub(crate) struct RustcSimdMonomorphizeLaneLimitParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcSimdMonomorphizeLaneLimitParser {
+impl SingleAttributeParser for RustcSimdMonomorphizeLaneLimitParser {
     const PATH: &[Symbol] = &[sym::rustc_simd_monomorphize_lane_limit];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ArgParser::NameValue(nv) = args else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -573,12 +573,12 @@ impl<S: Stage> SingleAttributeParser<S> for RustcSimdMonomorphizeLaneLimitParser
 
 pub(crate) struct RustcScalableVectorParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcScalableVectorParser {
+impl SingleAttributeParser for RustcScalableVectorParser {
     const PATH: &[Symbol] = &[sym::rustc_scalable_vector];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if args.no_args().is_ok() {
             return Some(AttributeKind::RustcScalableVector {
                 element_count: None,
@@ -597,12 +597,12 @@ impl<S: Stage> SingleAttributeParser<S> for RustcScalableVectorParser {
 
 pub(crate) struct LangParser;
 
-impl<S: Stage> SingleAttributeParser<S> for LangParser {
+impl SingleAttributeParser for LangParser {
     const PATH: &[Symbol] = &[sym::lang];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -622,7 +622,7 @@ impl<S: Stage> SingleAttributeParser<S> for LangParser {
 
 pub(crate) struct RustcHasIncoherentInherentImplsParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcHasIncoherentInherentImplsParser {
+impl NoArgsAttributeParser for RustcHasIncoherentInherentImplsParser {
     const PATH: &[Symbol] = &[sym::rustc_has_incoherent_inherent_impls];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
@@ -636,7 +636,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcHasIncoherentInherentImplsParse
 
 pub(crate) struct PanicHandlerParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for PanicHandlerParser {
+impl NoArgsAttributeParser for PanicHandlerParser {
     const PATH: &[Symbol] = &[sym::panic_handler];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
     const CREATE: fn(Span) -> AttributeKind = |span| AttributeKind::Lang(LangItem::PanicImpl, span);
@@ -644,7 +644,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for PanicHandlerParser {
 
 pub(crate) struct RustcNounwindParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNounwindParser {
+impl NoArgsAttributeParser for RustcNounwindParser {
     const PATH: &[Symbol] = &[sym::rustc_nounwind];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -658,7 +658,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNounwindParser {
 
 pub(crate) struct RustcOffloadKernelParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcOffloadKernelParser {
+impl NoArgsAttributeParser for RustcOffloadKernelParser {
     const PATH: &[Symbol] = &[sym::rustc_offload_kernel];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcOffloadKernel;
@@ -666,7 +666,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcOffloadKernelParser {
 
 pub(crate) struct RustcMirParser;
 
-impl<S: Stage> CombineAttributeParser<S> for RustcMirParser {
+impl CombineAttributeParser for RustcMirParser {
     const PATH: &[Symbol] = &[sym::rustc_mir];
 
     type Item = RustcMirKind;
@@ -684,7 +684,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcMirParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["arg1, arg2, ..."]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let Some(list) = cx.expect_list(args, cx.attr_span) else {
@@ -754,7 +754,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcMirParser {
 }
 pub(crate) struct RustcNonConstTraitMethodParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNonConstTraitMethodParser {
+impl NoArgsAttributeParser for RustcNonConstTraitMethodParser {
     const PATH: &[Symbol] = &[sym::rustc_non_const_trait_method];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Method(MethodKind::Trait { body: true })),
@@ -765,7 +765,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNonConstTraitMethodParser {
 
 pub(crate) struct RustcCleanParser;
 
-impl<S: Stage> CombineAttributeParser<S> for RustcCleanParser {
+impl CombineAttributeParser for RustcCleanParser {
     const PATH: &[Symbol] = &[sym::rustc_clean];
 
     type Item = RustcCleanAttribute;
@@ -801,7 +801,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcCleanParser {
         template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         if !cx.cx.sess.opts.unstable_opts.query_dep_graph {
@@ -868,7 +868,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcCleanParser {
 
 pub(crate) struct RustcIfThisChangedParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcIfThisChangedParser {
+impl SingleAttributeParser for RustcIfThisChangedParser {
     const PATH: &[Symbol] = &[sym::rustc_if_this_changed];
 
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
@@ -898,7 +898,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcIfThisChangedParser {
 
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["DepNode"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if !cx.cx.sess.opts.unstable_opts.query_dep_graph {
             cx.emit_err(AttributeRequiresOpt { span: cx.attr_span, opt: "-Z query-dep-graph" });
         }
@@ -923,7 +923,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcIfThisChangedParser {
 
 pub(crate) struct RustcThenThisWouldNeedParser;
 
-impl<S: Stage> CombineAttributeParser<S> for RustcThenThisWouldNeedParser {
+impl CombineAttributeParser for RustcThenThisWouldNeedParser {
     const PATH: &[Symbol] = &[sym::rustc_then_this_would_need];
     type Item = Ident;
 
@@ -957,7 +957,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcThenThisWouldNeedParser {
     const TEMPLATE: AttributeTemplate = template!(List: &["DepNode"]);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         if !cx.cx.sess.opts.unstable_opts.query_dep_graph {
@@ -974,7 +974,7 @@ impl<S: Stage> CombineAttributeParser<S> for RustcThenThisWouldNeedParser {
 
 pub(crate) struct RustcInsignificantDtorParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcInsignificantDtorParser {
+impl NoArgsAttributeParser for RustcInsignificantDtorParser {
     const PATH: &[Symbol] = &[sym::rustc_insignificant_dtor];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Enum),
@@ -986,7 +986,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcInsignificantDtorParser {
 
 pub(crate) struct RustcEffectiveVisibilityParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcEffectiveVisibilityParser {
+impl NoArgsAttributeParser for RustcEffectiveVisibilityParser {
     const PATH: &[Symbol] = &[sym::rustc_effective_visibility];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Use),
@@ -1024,7 +1024,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcEffectiveVisibilityParser {
 
 pub(crate) struct RustcDiagnosticItemParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcDiagnosticItemParser {
+impl SingleAttributeParser for RustcDiagnosticItemParser {
     const PATH: &[Symbol] = &[sym::rustc_diagnostic_item];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
@@ -1046,7 +1046,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDiagnosticItemParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);
@@ -1062,7 +1062,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDiagnosticItemParser {
 
 pub(crate) struct RustcDoNotConstCheckParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDoNotConstCheckParser {
+impl NoArgsAttributeParser for RustcDoNotConstCheckParser {
     const PATH: &[Symbol] = &[sym::rustc_do_not_const_check];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -1076,7 +1076,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDoNotConstCheckParser {
 
 pub(crate) struct RustcNonnullOptimizationGuaranteedParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcNonnullOptimizationGuaranteedParser {
+impl NoArgsAttributeParser for RustcNonnullOptimizationGuaranteedParser {
     const PATH: &[Symbol] = &[sym::rustc_nonnull_optimization_guaranteed];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNonnullOptimizationGuaranteed;
@@ -1084,7 +1084,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcNonnullOptimizationGuaranteedPa
 
 pub(crate) struct RustcStrictCoherenceParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcStrictCoherenceParser {
+impl NoArgsAttributeParser for RustcStrictCoherenceParser {
     const PATH: &[Symbol] = &[sym::rustc_strict_coherence];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
@@ -1098,14 +1098,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcStrictCoherenceParser {
 
 pub(crate) struct RustcReservationImplParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcReservationImplParser {
+impl SingleAttributeParser for RustcReservationImplParser {
     const PATH: &[Symbol] = &[sym::rustc_reservation_impl];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Impl { of_trait: true })]);
 
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "reservation message");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(args.span().unwrap_or(attr_span), None);
@@ -1123,7 +1123,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcReservationImplParser {
 
 pub(crate) struct PreludeImportParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for PreludeImportParser {
+impl NoArgsAttributeParser for PreludeImportParser {
     const PATH: &[Symbol] = &[sym::prelude_import];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Use)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PreludeImport;
@@ -1131,12 +1131,12 @@ impl<S: Stage> NoArgsAttributeParser<S> for PreludeImportParser {
 
 pub(crate) struct RustcDocPrimitiveParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcDocPrimitiveParser {
+impl SingleAttributeParser for RustcDocPrimitiveParser {
     const PATH: &[Symbol] = &[sym::rustc_doc_primitive];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Mod)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "primitive name");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let span = cx.attr_span;
             cx.adcx().expected_name_value(args.span().unwrap_or(span), None);
@@ -1154,7 +1154,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcDocPrimitiveParser {
 
 pub(crate) struct RustcIntrinsicParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcIntrinsicParser {
+impl NoArgsAttributeParser for RustcIntrinsicParser {
     const PATH: &[Symbol] = &[sym::rustc_intrinsic];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcIntrinsic;
@@ -1162,7 +1162,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcIntrinsicParser {
 
 pub(crate) struct RustcIntrinsicConstStableIndirectParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcIntrinsicConstStableIndirectParser {
+impl NoArgsAttributeParser for RustcIntrinsicConstStableIndirectParser {
     const PATH: &'static [Symbol] = &[sym::rustc_intrinsic_const_stable_indirect];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcIntrinsicConstStableIndirect;
@@ -1170,7 +1170,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcIntrinsicConstStableIndirectPar
 
 pub(crate) struct RustcExhaustiveParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcExhaustiveParser {
+impl NoArgsAttributeParser for RustcExhaustiveParser {
     const PATH: &'static [Symbol] = &[sym::rustc_must_match_exhaustively];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Enum)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcMustMatchExhaustively;

--- a/compiler/rustc_attr_parsing/src/attributes/semantics.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/semantics.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 
 pub(crate) struct MayDangleParser;
-impl<S: Stage> NoArgsAttributeParser<S> for MayDangleParser {
+impl NoArgsAttributeParser for MayDangleParser {
     const PATH: &[Symbol] = &[sym::may_dangle];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
     const CREATE: fn(span: Span) -> AttributeKind = AttributeKind::MayDangle;

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -61,7 +61,7 @@ pub(crate) struct StabilityParser {
 
 impl StabilityParser {
     /// Checks, and emits an error when a stability (or unstability) was already set, which would be a duplicate.
-    fn check_duplicate<S: Stage>(&self, cx: &AcceptContext<'_, '_, S>) -> bool {
+    fn check_duplicate(&self, cx: &AcceptContext<'_, '_>) -> bool {
         if let Some((_, _)) = self.stability {
             cx.emit_err(session_diagnostics::MultipleStabilityLevels { span: cx.attr_span });
             true
@@ -71,8 +71,8 @@ impl StabilityParser {
     }
 }
 
-impl<S: Stage> AttributeParser<S> for StabilityParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[
+impl AttributeParser for StabilityParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[
         (
             &[sym::stable],
             template!(List: &[r#"feature = "name", since = "version""#]),
@@ -117,7 +117,7 @@ impl<S: Stage> AttributeParser<S> for StabilityParser {
     ];
     const ALLOWED_TARGETS: AllowedTargets = ALLOWED_TARGETS;
 
-    fn finalize(mut self, cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(mut self, cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if let Some(atum) = self.allowed_through_unstable_modules {
             if let Some((
                 Stability {
@@ -157,8 +157,8 @@ pub(crate) struct BodyStabilityParser {
     stability: Option<(DefaultBodyStability, Span)>,
 }
 
-impl<S: Stage> AttributeParser<S> for BodyStabilityParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[(
+impl AttributeParser for BodyStabilityParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::rustc_default_body_unstable],
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
         |this, cx, args| {
@@ -173,7 +173,7 @@ impl<S: Stage> AttributeParser<S> for BodyStabilityParser {
     )];
     const ALLOWED_TARGETS: AllowedTargets = ALLOWED_TARGETS;
 
-    fn finalize(self, _cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(self, _cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         let (stability, span) = self.stability?;
 
         Some(AttributeKind::RustcBodyStability { stability, span })
@@ -181,9 +181,9 @@ impl<S: Stage> AttributeParser<S> for BodyStabilityParser {
 }
 
 pub(crate) struct RustcConstStableIndirectParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcConstStableIndirectParser {
+impl NoArgsAttributeParser for RustcConstStableIndirectParser {
     const PATH: &[Symbol] = &[sym::rustc_const_stable_indirect];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Ignore;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -199,7 +199,7 @@ pub(crate) struct ConstStabilityParser {
 
 impl ConstStabilityParser {
     /// Checks, and emits an error when a stability (or unstability) was already set, which would be a duplicate.
-    fn check_duplicate<S: Stage>(&self, cx: &AcceptContext<'_, '_, S>) -> bool {
+    fn check_duplicate(&self, cx: &AcceptContext<'_, '_>) -> bool {
         if let Some((_, _)) = self.stability {
             cx.emit_err(session_diagnostics::MultipleStabilityLevels { span: cx.attr_span });
             true
@@ -209,8 +209,8 @@ impl ConstStabilityParser {
     }
 }
 
-impl<S: Stage> AttributeParser<S> for ConstStabilityParser {
-    const ATTRIBUTES: AcceptMapping<Self, S> = &[
+impl AttributeParser for ConstStabilityParser {
+    const ATTRIBUTES: AcceptMapping<Self> = &[
         (
             &[sym::rustc_const_stable],
             template!(List: &[r#"feature = "name""#]),
@@ -262,7 +262,7 @@ impl<S: Stage> AttributeParser<S> for ConstStabilityParser {
         Allow(Target::Crate),
     ]);
 
-    fn finalize(mut self, cx: &FinalizeContext<'_, '_, S>) -> Option<AttributeKind> {
+    fn finalize(mut self, cx: &FinalizeContext<'_, '_>) -> Option<AttributeKind> {
         if self.promotable {
             if let Some((ref mut stab, _)) = self.stability {
                 stab.promotable = true;
@@ -282,8 +282,8 @@ impl<S: Stage> AttributeParser<S> for ConstStabilityParser {
 ///
 /// Emits an error when either the option was already Some, or the arguments weren't of form
 /// `name = value`
-fn insert_value_into_option_or_error<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+fn insert_value_into_option_or_error(
+    cx: &mut AcceptContext<'_, '_>,
     param: &MetaItemParser,
     item: &mut Option<Symbol>,
     name: Ident,
@@ -304,8 +304,8 @@ fn insert_value_into_option_or_error<S: Stage>(
 
 /// Read the content of a `stable`/`rustc_const_stable` attribute, and return the feature name and
 /// its stability information.
-pub(crate) fn parse_stability<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+pub(crate) fn parse_stability(
+    cx: &mut AcceptContext<'_, '_>,
     args: &ArgParser,
 ) -> Option<(Symbol, StabilityLevel)> {
     let mut feature = None;
@@ -368,8 +368,8 @@ pub(crate) fn parse_stability<S: Stage>(
 
 /// Read the content of a `unstable`/`rustc_const_unstable`/`rustc_default_body_unstable`
 /// attribute, and return the feature name and its stability information.
-pub(crate) fn parse_unstability<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+pub(crate) fn parse_unstability(
+    cx: &mut AcceptContext<'_, '_>,
     args: &ArgParser,
 ) -> Option<(Symbol, StabilityLevel)> {
     let mut feature = None;
@@ -472,7 +472,7 @@ pub(crate) fn parse_unstability<S: Stage>(
 
 pub(crate) struct UnstableRemovedParser;
 
-impl<S: Stage> CombineAttributeParser<S> for UnstableRemovedParser {
+impl CombineAttributeParser for UnstableRemovedParser {
     type Item = UnstableRemovedFeature;
     const PATH: &[Symbol] = &[sym::unstable_removed];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
@@ -482,7 +482,7 @@ impl<S: Stage> CombineAttributeParser<S> for UnstableRemovedParser {
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::UnstableRemoved(items);
 
     fn extend(
-        cx: &mut AcceptContext<'_, '_, S>,
+        cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
         let mut feature = None;

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -5,9 +5,9 @@ use super::prelude::*;
 
 pub(crate) struct IgnoreParser;
 
-impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
+impl SingleAttributeParser for IgnoreParser {
     const PATH: &[Symbol] = &[sym::ignore];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Warn;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Fn), Error(Target::WherePredicate)]);
     const TEMPLATE: AttributeTemplate = template!(
@@ -15,7 +15,7 @@ impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
         "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::Ignore {
             span: cx.attr_span,
             reason: match args {
@@ -46,9 +46,9 @@ impl<S: Stage> SingleAttributeParser<S> for IgnoreParser {
 
 pub(crate) struct ShouldPanicParser;
 
-impl<S: Stage> SingleAttributeParser<S> for ShouldPanicParser {
+impl SingleAttributeParser for ShouldPanicParser {
     const PATH: &[Symbol] = &[sym::should_panic];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::WarnButFutureError;
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Fn), Error(Target::WherePredicate)]);
     const TEMPLATE: AttributeTemplate = template!(
@@ -56,7 +56,7 @@ impl<S: Stage> SingleAttributeParser<S> for ShouldPanicParser {
         "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
     );
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::ShouldPanic {
             span: cx.attr_span,
             reason: match args {
@@ -98,12 +98,12 @@ impl<S: Stage> SingleAttributeParser<S> for ShouldPanicParser {
 
 pub(crate) struct ReexportTestHarnessMainParser;
 
-impl<S: Stage> SingleAttributeParser<S> for ReexportTestHarnessMainParser {
+impl SingleAttributeParser for ReexportTestHarnessMainParser {
     const PATH: &[Symbol] = &[sym::reexport_test_harness_main];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let inner_span = cx.inner_span;
             cx.adcx().expected_name_value(
@@ -124,7 +124,7 @@ impl<S: Stage> SingleAttributeParser<S> for ReexportTestHarnessMainParser {
 
 pub(crate) struct RustcAbiParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcAbiParser {
+impl SingleAttributeParser for RustcAbiParser {
     const PATH: &[Symbol] = &[sym::rustc_abi];
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::debug, sym::assert_eq]);
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
@@ -137,7 +137,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAbiParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(args) = args.as_list() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_specific_argument_and_list(attr_span, &[sym::assert_eq, sym::debug]);
@@ -169,7 +169,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcAbiParser {
 
 pub(crate) struct RustcDelayedBugFromInsideQueryParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDelayedBugFromInsideQueryParser {
+impl NoArgsAttributeParser for RustcDelayedBugFromInsideQueryParser {
     const PATH: &[Symbol] = &[sym::rustc_delayed_bug_from_inside_query];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDelayedBugFromInsideQuery;
@@ -177,7 +177,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDelayedBugFromInsideQueryParser
 
 pub(crate) struct RustcEvaluateWhereClausesParser;
 
-impl<S: Stage> NoArgsAttributeParser<S> for RustcEvaluateWhereClausesParser {
+impl NoArgsAttributeParser for RustcEvaluateWhereClausesParser {
     const PATH: &[Symbol] = &[sym::rustc_evaluate_where_clauses];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
@@ -191,12 +191,12 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcEvaluateWhereClausesParser {
 
 pub(crate) struct TestRunnerParser;
 
-impl<S: Stage> SingleAttributeParser<S> for TestRunnerParser {
+impl SingleAttributeParser for TestRunnerParser {
     const PATH: &[Symbol] = &[sym::test_runner];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["path"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
 
         let Some(meta) = single.meta_item() else {
@@ -210,7 +210,7 @@ impl<S: Stage> SingleAttributeParser<S> for TestRunnerParser {
 
 pub(crate) struct RustcTestMarkerParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcTestMarkerParser {
+impl SingleAttributeParser for RustcTestMarkerParser {
     const PATH: &[Symbol] = &[sym::rustc_test_marker];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Const),
@@ -219,7 +219,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcTestMarkerParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "test_path");
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(name_value) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, Some(sym::rustc_test_marker));

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -2,19 +2,19 @@ use std::mem;
 
 use super::prelude::*;
 use crate::attributes::{NoArgsAttributeParser, SingleAttributeParser};
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::parser::ArgParser;
 use crate::target_checking::AllowedTargets;
 use crate::target_checking::Policy::{Allow, Warn};
 
 pub(crate) struct RustcSkipDuringMethodDispatchParser;
-impl<S: Stage> SingleAttributeParser<S> for RustcSkipDuringMethodDispatchParser {
+impl SingleAttributeParser for RustcSkipDuringMethodDispatchParser {
     const PATH: &[Symbol] = &[sym::rustc_skip_during_method_dispatch];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
 
     const TEMPLATE: AttributeTemplate = template!(List: &["array, boxed_slice"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let mut array = false;
         let mut boxed_slice = false;
         let args = cx.expect_list(args, cx.attr_span)?;
@@ -53,7 +53,7 @@ impl<S: Stage> SingleAttributeParser<S> for RustcSkipDuringMethodDispatchParser 
 }
 
 pub(crate) struct RustcParenSugarParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcParenSugarParser {
+impl NoArgsAttributeParser for RustcParenSugarParser {
     const PATH: &[Symbol] = &[sym::rustc_paren_sugar];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcParenSugar;
@@ -62,7 +62,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcParenSugarParser {
 // Markers
 
 pub(crate) struct MarkerParser;
-impl<S: Stage> NoArgsAttributeParser<S> for MarkerParser {
+impl NoArgsAttributeParser for MarkerParser {
     const PATH: &[Symbol] = &[sym::marker];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Trait),
@@ -74,14 +74,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for MarkerParser {
 }
 
 pub(crate) struct RustcDenyExplicitImplParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDenyExplicitImplParser {
+impl NoArgsAttributeParser for RustcDenyExplicitImplParser {
     const PATH: &[Symbol] = &[sym::rustc_deny_explicit_impl];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcDenyExplicitImpl;
 }
 
 pub(crate) struct RustcDynIncompatibleTraitParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcDynIncompatibleTraitParser {
+impl NoArgsAttributeParser for RustcDynIncompatibleTraitParser {
     const PATH: &[Symbol] = &[sym::rustc_dyn_incompatible_trait];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcDynIncompatibleTrait;
@@ -90,14 +90,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcDynIncompatibleTraitParser {
 // Specialization
 
 pub(crate) struct RustcSpecializationTraitParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcSpecializationTraitParser {
+impl NoArgsAttributeParser for RustcSpecializationTraitParser {
     const PATH: &[Symbol] = &[sym::rustc_specialization_trait];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcSpecializationTrait;
 }
 
 pub(crate) struct RustcUnsafeSpecializationMarkerParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcUnsafeSpecializationMarkerParser {
+impl NoArgsAttributeParser for RustcUnsafeSpecializationMarkerParser {
     const PATH: &[Symbol] = &[sym::rustc_unsafe_specialization_marker];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcUnsafeSpecializationMarker;
@@ -106,14 +106,14 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcUnsafeSpecializationMarkerParse
 // Coherence
 
 pub(crate) struct RustcCoinductiveParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcCoinductiveParser {
+impl NoArgsAttributeParser for RustcCoinductiveParser {
     const PATH: &[Symbol] = &[sym::rustc_coinductive];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcCoinductive;
 }
 
 pub(crate) struct RustcAllowIncoherentImplParser;
-impl<S: Stage> NoArgsAttributeParser<S> for RustcAllowIncoherentImplParser {
+impl NoArgsAttributeParser for RustcAllowIncoherentImplParser {
     const PATH: &[Symbol] = &[sym::rustc_allow_incoherent_impl];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Method(MethodKind::Inherent))]);
@@ -121,7 +121,7 @@ impl<S: Stage> NoArgsAttributeParser<S> for RustcAllowIncoherentImplParser {
 }
 
 pub(crate) struct FundamentalParser;
-impl<S: Stage> NoArgsAttributeParser<S> for FundamentalParser {
+impl NoArgsAttributeParser for FundamentalParser {
     const PATH: &[Symbol] = &[sym::fundamental];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Struct), Allow(Target::Trait)]);

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -4,16 +4,16 @@ use super::prelude::*;
 
 pub(crate) struct RustcMacroTransparencyParser;
 
-impl<S: Stage> SingleAttributeParser<S> for RustcMacroTransparencyParser {
+impl SingleAttributeParser for RustcMacroTransparencyParser {
     const PATH: &[Symbol] = &[sym::rustc_macro_transparency];
-    const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Custom(|cx, used, unused| {
+    const ON_DUPLICATE: OnDuplicate = OnDuplicate::Custom(|cx, used, unused| {
         cx.dcx().span_err(vec![used, unused], "multiple macro transparency attributes");
     });
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
         template!(NameValueStr: ["transparent", "semiopaque", "opaque"]);
 
-    fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
+    fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(nv) = args.name_value() else {
             let attr_span = cx.attr_span;
             cx.adcx().expected_name_value(attr_span, None);

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -6,7 +6,7 @@ use rustc_hir::RustcVersion;
 use rustc_hir::limit::Limit;
 use rustc_span::Symbol;
 
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::parser::{ArgParser, NameValueParser};
 use crate::session_diagnostics::LimitInvalid;
 
@@ -36,8 +36,8 @@ pub fn is_builtin_attr(attr: &ast::Attribute) -> bool {
 /// `#[link_ordinal]` and `#[rustc_layout_scalar_valid_range_start]`.
 /// `cx` is the context given to the attribute.
 /// `args` is the parser for the attribute arguments.
-pub(crate) fn parse_single_integer<S: Stage>(
-    cx: &mut AcceptContext<'_, '_, S>,
+pub(crate) fn parse_single_integer(
+    cx: &mut AcceptContext<'_, '_>,
     args: &ArgParser,
 ) -> Option<u128> {
     let single = cx.expect_single_element_list(args, cx.attr_span)?;
@@ -52,7 +52,7 @@ pub(crate) fn parse_single_integer<S: Stage>(
     Some(num.0)
 }
 
-impl<S: Stage> AcceptContext<'_, '_, S> {
+impl AcceptContext<'_, '_> {
     pub(crate) fn parse_limit_int(&mut self, nv: &NameValueParser) -> Option<Limit> {
         let Some(limit) = nv.value_as_str() else {
             self.adcx().expected_string_literal(nv.value_span, Some(nv.value_as_lit()));

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -353,8 +353,6 @@ pub trait Stage: Sized + 'static + Sealed {
     type Id: Copy;
 
     fn parsers() -> &'static GroupType<Self>;
-
-    fn should_emit(&self) -> ShouldEmit;
 }
 
 // allow because it's a sealed trait
@@ -364,10 +362,6 @@ impl Stage for Early {
 
     fn parsers() -> &'static GroupType<Self> {
         &early::ATTRIBUTE_PARSERS
-    }
-
-    fn should_emit(&self) -> ShouldEmit {
-        self.emit_errors
     }
 }
 
@@ -379,19 +373,11 @@ impl Stage for Late {
     fn parsers() -> &'static GroupType<Self> {
         &late::ATTRIBUTE_PARSERS
     }
-
-    fn should_emit(&self) -> ShouldEmit {
-        ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed }
-    }
 }
 
 /// Used when parsing attributes for miscellaneous things *before* ast lowering
-pub struct Early {
-    /// Whether to emit errors or delay them as a bug.
-    /// For most attributes, the attribute will be parsed again in the `Late` stage and in this case the errors should be delayed.
-    /// But for some, such as `cfg`, the attribute will be removed before the `Late` stage so errors must be emitted.
-    pub emit_errors: ShouldEmit,
-}
+pub struct Early;
+
 /// used when parsing attributes during ast lowering
 pub struct Late;
 
@@ -477,7 +463,7 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
         span: impl Into<MultiSpan>,
     ) {
         if !matches!(
-            self.stage.should_emit(),
+            self.should_emit,
             ShouldEmit::ErrorsAndLints { .. } | ShouldEmit::EarlyFatal { also_emit_lints: true }
         ) {
             return;

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -5,14 +5,14 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::LazyLock;
 
-use rustc_ast::{AttrStyle, MetaItemLit, NodeId};
+use rustc_ast::{AttrStyle, MetaItemLit};
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
 use rustc_feature::{AttrSuggestionStyle, AttributeTemplate};
 use rustc_hir::AttrPath;
 use rustc_hir::attrs::AttributeKind;
-use rustc_hir::{AttrPath, HirId};
 use rustc_parse::parser::Recovery;
+use rustc_session::Session;
 use rustc_session::lint::{Lint, LintId};
 use rustc_span::{ErrorGuaranteed, Span, Symbol};
 
@@ -66,7 +66,6 @@ use crate::session_diagnostics::{
 };
 use crate::target_checking::AllowedTargets;
 use crate::{AttributeParser, EmitAttribute};
-use crate::context::private::Sealed;
 
 type GroupType = LazyLock<GroupTypeInner>;
 
@@ -89,20 +88,6 @@ pub(crate) type FinalizeFn = fn(&mut FinalizeContext<'_, '_>) -> Option<Attribut
 macro_rules! attribute_parsers {
     (
         pub(crate) static $name: ident = [$($names: ty),* $(,)?];
-    ) => {
-        mod early {
-            use super::*;
-
-            attribute_parsers!(@[Early] pub(crate) static $name = [$($names),*];);
-        }
-        mod late {
-            use super::*;
-
-            attribute_parsers!(@[Late] pub(crate) static $name = [$($names),*];);
-        }
-    };
-    (
-        @[$stage: ty] pub(crate) static $name: ident = [$($names: ty),* $(,)?];
     ) => {
         pub(crate) static $name: GroupType = LazyLock::new(|| {
             let mut accepters = BTreeMap::<_, GroupTypeInnerAccept>::new();
@@ -337,46 +322,6 @@ attribute_parsers!(
     ];
 );
 
-mod private {
-    pub trait Sealed {}
-    impl Sealed for super::Early {}
-    impl Sealed for super::Late {}
-}
-
-// allow because it's a sealed trait
-#[allow(private_interfaces)]
-pub trait Stage: Sized + 'static + Sealed {
-    type Id: Copy;
-
-    fn parsers() -> &'static GroupType;
-}
-
-// allow because it's a sealed trait
-#[allow(private_interfaces)]
-impl Stage for Early {
-    type Id = NodeId;
-
-    fn parsers() -> &'static GroupType {
-        &early::ATTRIBUTE_PARSERS
-    }
-}
-
-// allow because it's a sealed trait
-#[allow(private_interfaces)]
-impl Stage for Late {
-    type Id = HirId;
-
-    fn parsers() -> &'static GroupType {
-        &late::ATTRIBUTE_PARSERS
-    }
-}
-
-/// Used when parsing attributes for miscellaneous things *before* ast lowering
-pub struct Early;
-
-/// used when parsing attributes during ast lowering
-pub struct Late;
-
 /// Context given to every attribute parser when accepting
 ///
 /// Gives [`AttributeParser`]s enough information to create errors, for example.
@@ -610,8 +555,6 @@ pub struct SharedContext<'p, 'sess> {
     pub(crate) target_span: Span,
     pub(crate) target: rustc_hir::Target,
 
-    /// The second argument of the closure is a [`NodeId`] if `S` is `Early` and a [`HirId`] if `S`
-    /// is `Late` and is the ID of the syntactical component this attribute was applied to.
     pub(crate) emit_lint: &'p mut dyn FnMut(LintId, MultiSpan, EmitAttribute),
 }
 

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -5,11 +5,11 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::LazyLock;
 
-use private::Sealed;
 use rustc_ast::{AttrStyle, MetaItemLit, NodeId};
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
 use rustc_feature::{AttrSuggestionStyle, AttributeTemplate};
+use rustc_hir::AttrPath;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::{AttrPath, HirId};
 use rustc_parse::parser::Recovery;
@@ -66,23 +66,25 @@ use crate::session_diagnostics::{
 };
 use crate::target_checking::AllowedTargets;
 use crate::{AttributeParser, EmitAttribute};
-type GroupType<S> = LazyLock<GroupTypeInner<S>>;
+use crate::context::private::Sealed;
 
-pub(super) struct GroupTypeInner<S: Stage> {
-    pub(super) accepters: BTreeMap<&'static [Symbol], GroupTypeInnerAccept<S>>,
+type GroupType = LazyLock<GroupTypeInner>;
+
+pub(super) struct GroupTypeInner {
+    pub(super) accepters: BTreeMap<&'static [Symbol], GroupTypeInnerAccept>,
 }
 
-pub(super) struct GroupTypeInnerAccept<S: Stage> {
+pub(super) struct GroupTypeInnerAccept {
     pub(super) template: AttributeTemplate,
-    pub(super) accept_fn: AcceptFn<S>,
+    pub(super) accept_fn: AcceptFn,
     pub(super) allowed_targets: AllowedTargets,
     pub(super) safety: AttributeSafety,
-    pub(super) finalizer: FinalizeFn<S>,
+    pub(super) finalizer: FinalizeFn,
 }
 
-pub(crate) type AcceptFn<S> =
-    Box<dyn for<'sess, 'a> Fn(&mut AcceptContext<'_, 'sess, S>, &ArgParser) + Send + Sync>;
-pub(crate) type FinalizeFn<S> = fn(&mut FinalizeContext<'_, '_, S>) -> Option<AttributeKind>;
+pub(crate) type AcceptFn =
+    Box<dyn for<'sess, 'a> Fn(&mut AcceptContext<'_, 'sess>, &ArgParser) + Send + Sync>;
+pub(crate) type FinalizeFn = fn(&mut FinalizeContext<'_, '_>) -> Option<AttributeKind>;
 
 macro_rules! attribute_parsers {
     (
@@ -90,17 +92,11 @@ macro_rules! attribute_parsers {
     ) => {
         mod early {
             use super::*;
-            type Combine<T> = super::Combine<T, Early>;
-            type Single<T> = super::Single<T, Early>;
-            type WithoutArgs<T> = super::WithoutArgs<T, Early>;
 
             attribute_parsers!(@[Early] pub(crate) static $name = [$($names),*];);
         }
         mod late {
             use super::*;
-            type Combine<T> = super::Combine<T, Late>;
-            type Single<T> = super::Single<T, Late>;
-            type WithoutArgs<T> = super::WithoutArgs<T, Late>;
 
             attribute_parsers!(@[Late] pub(crate) static $name = [$($names),*];);
         }
@@ -108,8 +104,8 @@ macro_rules! attribute_parsers {
     (
         @[$stage: ty] pub(crate) static $name: ident = [$($names: ty),* $(,)?];
     ) => {
-        pub(crate) static $name: GroupType<$stage> = LazyLock::new(|| {
-            let mut accepters = BTreeMap::<_, GroupTypeInnerAccept<$stage>>::new();
+        pub(crate) static $name: GroupType = LazyLock::new(|| {
+            let mut accepters = BTreeMap::<_, GroupTypeInnerAccept>::new();
             $(
                 {
                     thread_local! {
@@ -126,8 +122,8 @@ macro_rules! attribute_parsers {
                                             accept_fn(s, cx, args)
                                         })
                                     }),
-                                    safety: <$names as crate::attributes::AttributeParser<$stage>>::SAFETY,
-                                    allowed_targets: <$names as crate::attributes::AttributeParser<$stage>>::ALLOWED_TARGETS,
+                                    safety: <$names as crate::attributes::AttributeParser>::SAFETY,
+                                    allowed_targets: <$names as crate::attributes::AttributeParser>::ALLOWED_TARGETS,
                                     finalizer: |cx| {
                                         let state = STATE_OBJECT.take();
                                         state.finalize(cx)
@@ -352,7 +348,7 @@ mod private {
 pub trait Stage: Sized + 'static + Sealed {
     type Id: Copy;
 
-    fn parsers() -> &'static GroupType<Self>;
+    fn parsers() -> &'static GroupType;
 }
 
 // allow because it's a sealed trait
@@ -360,7 +356,7 @@ pub trait Stage: Sized + 'static + Sealed {
 impl Stage for Early {
     type Id = NodeId;
 
-    fn parsers() -> &'static GroupType<Self> {
+    fn parsers() -> &'static GroupType {
         &early::ATTRIBUTE_PARSERS
     }
 }
@@ -370,7 +366,7 @@ impl Stage for Early {
 impl Stage for Late {
     type Id = HirId;
 
-    fn parsers() -> &'static GroupType<Self> {
+    fn parsers() -> &'static GroupType {
         &late::ATTRIBUTE_PARSERS
     }
 }
@@ -384,8 +380,8 @@ pub struct Late;
 /// Context given to every attribute parser when accepting
 ///
 /// Gives [`AttributeParser`]s enough information to create errors, for example.
-pub struct AcceptContext<'f, 'sess, S: Stage> {
-    pub(crate) shared: SharedContext<'f, 'sess, S>,
+pub struct AcceptContext<'f, 'sess> {
+    pub(crate) shared: SharedContext<'f, 'sess>,
 
     /// The outer span of the attribute currently being parsed
     ///
@@ -419,7 +415,7 @@ pub struct AcceptContext<'f, 'sess, S: Stage> {
     pub(crate) attr_path: AttrPath,
 }
 
-impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
+impl<'f, 'sess: 'f> SharedContext<'f, 'sess> {
     pub(crate) fn emit_err(&self, diag: impl for<'x> Diagnostic<'x>) -> ErrorGuaranteed {
         self.cx.emit_err(diag)
     }
@@ -506,8 +502,8 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
     }
 }
 
-impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
-    pub(crate) fn adcx(&mut self) -> AttributeDiagnosticContext<'_, 'f, 'sess, S> {
+impl<'f, 'sess: 'f> AcceptContext<'f, 'sess> {
+    pub(crate) fn adcx(&mut self) -> AttributeDiagnosticContext<'_, 'f, 'sess> {
         AttributeDiagnosticContext { ctx: self, custom_suggestions: Vec::new() }
     }
 
@@ -588,15 +584,15 @@ impl<'f, 'sess: 'f, S: Stage> AcceptContext<'f, 'sess, S> {
     }
 }
 
-impl<'f, 'sess, S: Stage> Deref for AcceptContext<'f, 'sess, S> {
-    type Target = SharedContext<'f, 'sess, S>;
+impl<'f, 'sess> Deref for AcceptContext<'f, 'sess> {
+    type Target = SharedContext<'f, 'sess>;
 
     fn deref(&self) -> &Self::Target {
         &self.shared
     }
 }
 
-impl<'f, 'sess, S: Stage> DerefMut for AcceptContext<'f, 'sess, S> {
+impl<'f, 'sess> DerefMut for AcceptContext<'f, 'sess> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.shared
     }
@@ -606,10 +602,10 @@ impl<'f, 'sess, S: Stage> DerefMut for AcceptContext<'f, 'sess, S> {
 ///
 /// Gives [`AttributeParser`](crate::attributes::AttributeParser)s enough information to create
 /// errors, for example.
-pub struct SharedContext<'p, 'sess, S: Stage> {
+pub struct SharedContext<'p, 'sess> {
     /// The parse context, gives access to the session and the
     /// diagnostics context.
-    pub(crate) cx: &'p mut AttributeParser<'sess, S>,
+    pub(crate) cx: &'p mut AttributeParser<'sess>,
     /// The span of the syntactical component this attribute was applied to
     pub(crate) target_span: Span,
     pub(crate) target: rustc_hir::Target,
@@ -623,8 +619,8 @@ pub struct SharedContext<'p, 'sess, S: Stage> {
 ///
 /// Gives [`AttributeParser`](crate::attributes::AttributeParser)s enough information to create
 /// errors, for example.
-pub(crate) struct FinalizeContext<'p, 'sess, S: Stage> {
-    pub(crate) shared: SharedContext<'p, 'sess, S>,
+pub(crate) struct FinalizeContext<'p, 'sess> {
+    pub(crate) shared: SharedContext<'p, 'sess>,
 
     /// A list of all attribute on this syntax node.
     ///
@@ -635,29 +631,29 @@ pub(crate) struct FinalizeContext<'p, 'sess, S: Stage> {
     pub(crate) all_attrs: &'p [RefPathParser<'p>],
 }
 
-impl<'p, 'sess: 'p, S: Stage> Deref for FinalizeContext<'p, 'sess, S> {
-    type Target = SharedContext<'p, 'sess, S>;
+impl<'p, 'sess: 'p> Deref for FinalizeContext<'p, 'sess> {
+    type Target = SharedContext<'p, 'sess>;
 
     fn deref(&self) -> &Self::Target {
         &self.shared
     }
 }
 
-impl<'p, 'sess: 'p, S: Stage> DerefMut for FinalizeContext<'p, 'sess, S> {
+impl<'p, 'sess: 'p> DerefMut for FinalizeContext<'p, 'sess> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.shared
     }
 }
 
-impl<'p, 'sess: 'p, S: Stage> Deref for SharedContext<'p, 'sess, S> {
-    type Target = AttributeParser<'sess, S>;
+impl<'p, 'sess: 'p> Deref for SharedContext<'p, 'sess> {
+    type Target = AttributeParser<'sess>;
 
     fn deref(&self) -> &Self::Target {
         self.cx
     }
 }
 
-impl<'p, 'sess: 'p, S: Stage> DerefMut for SharedContext<'p, 'sess, S> {
+impl<'p, 'sess: 'p> DerefMut for SharedContext<'p, 'sess> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.cx
     }
@@ -704,15 +700,12 @@ impl ShouldEmit {
     }
 }
 
-pub(crate) struct AttributeDiagnosticContext<'a, 'f, 'sess, S: Stage> {
-    ctx: &'a mut AcceptContext<'f, 'sess, S>,
+pub(crate) struct AttributeDiagnosticContext<'a, 'f, 'sess> {
+    ctx: &'a mut AcceptContext<'f, 'sess>,
     custom_suggestions: Vec<Suggestion>,
 }
 
-impl<'a, 'f, 'sess: 'f, S> AttributeDiagnosticContext<'a, 'f, 'sess, S>
-where
-    S: Stage,
-{
+impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
     fn emit_parse_error(
         &mut self,
         span: Span,
@@ -757,10 +750,7 @@ where
 }
 
 /// Helpers that can be used to generate errors during attribute parsing.
-impl<'a, 'f, 'sess: 'f, S> AttributeDiagnosticContext<'a, 'f, 'sess, S>
-where
-    S: Stage,
-{
+impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
     pub(crate) fn expected_integer_literal_in_range(
         &mut self,
         span: Span,
@@ -991,21 +981,15 @@ where
     }
 }
 
-impl<'a, 'f, 'sess: 'f, S> Deref for AttributeDiagnosticContext<'a, 'f, 'sess, S>
-where
-    S: Stage,
-{
-    type Target = AcceptContext<'f, 'sess, S>;
+impl<'a, 'f, 'sess: 'f> Deref for AttributeDiagnosticContext<'a, 'f, 'sess> {
+    type Target = AcceptContext<'f, 'sess>;
 
     fn deref(&self) -> &Self::Target {
         self.ctx
     }
 }
 
-impl<'a, 'f, 'sess: 'f, S> DerefMut for AttributeDiagnosticContext<'a, 'f, 'sess, S>
-where
-    S: Stage,
-{
+impl<'a, 'f, 'sess: 'f> DerefMut for AttributeDiagnosticContext<'a, 'f, 'sess> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.ctx
     }

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -13,7 +13,6 @@ use rustc_feature::{AttrSuggestionStyle, AttributeTemplate};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::{AttrPath, HirId};
 use rustc_parse::parser::Recovery;
-use rustc_session::Session;
 use rustc_session::lint::{Lint, LintId};
 use rustc_span::{ErrorGuaranteed, Span, Symbol};
 
@@ -355,12 +354,6 @@ pub trait Stage: Sized + 'static + Sealed {
 
     fn parsers() -> &'static GroupType<Self>;
 
-    fn emit_err<'sess>(
-        &self,
-        sess: &'sess Session,
-        diag: impl for<'x> Diagnostic<'x>,
-    ) -> ErrorGuaranteed;
-
     fn should_emit(&self) -> ShouldEmit;
 }
 
@@ -371,13 +364,6 @@ impl Stage for Early {
 
     fn parsers() -> &'static GroupType<Self> {
         &early::ATTRIBUTE_PARSERS
-    }
-    fn emit_err<'sess>(
-        &self,
-        sess: &'sess Session,
-        diag: impl for<'x> Diagnostic<'x>,
-    ) -> ErrorGuaranteed {
-        self.should_emit().emit_err(sess.dcx().create_err(diag))
     }
 
     fn should_emit(&self) -> ShouldEmit {
@@ -392,13 +378,6 @@ impl Stage for Late {
 
     fn parsers() -> &'static GroupType<Self> {
         &late::ATTRIBUTE_PARSERS
-    }
-    fn emit_err<'sess>(
-        &self,
-        tcx: &'sess Session,
-        diag: impl for<'x> Diagnostic<'x>,
-    ) -> ErrorGuaranteed {
-        tcx.dcx().emit_err(diag)
     }
 
     fn should_emit(&self) -> ShouldEmit {
@@ -456,7 +435,7 @@ pub struct AcceptContext<'f, 'sess, S: Stage> {
 
 impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
     pub(crate) fn emit_err(&self, diag: impl for<'x> Diagnostic<'x>) -> ErrorGuaranteed {
-        self.stage.emit_err(&self.sess, diag)
+        self.cx.emit_err(diag)
     }
 
     /// Emit a lint. This method is somewhat special, since lints emitted during attribute parsing

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -1,4 +1,5 @@
 use std::convert::identity;
+use std::marker::PhantomData;
 
 use rustc_ast as ast;
 use rustc_ast::token::DocFragmentKind;
@@ -10,7 +11,7 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_hir::{AttrArgs, AttrItem, AttrPath, Attribute, HashIgnoredAttrId, Target};
 use rustc_session::Session;
 use rustc_session::lint::LintId;
-use rustc_span::{DUMMY_SP, Span, Symbol, sym, ErrorGuaranteed};
+use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Symbol, sym};
 
 use crate::attributes::AttributeSafety;
 use crate::context::{AcceptContext, FinalizeContext, FinalizeFn, SharedContext, Stage};
@@ -34,7 +35,8 @@ pub struct AttributeParser<'sess, S: Stage = Late> {
     pub(crate) tools: Vec<Symbol>,
     pub(crate) features: Option<&'sess Features>,
     pub(crate) sess: &'sess Session,
-    pub(crate) stage: S,
+    pub(crate) stage: PhantomData<S>,
+    pub(crate) should_emit: ShouldEmit,
 
     /// *Only* parse attributes with this symbol.
     ///
@@ -116,10 +118,10 @@ impl<'sess> AttributeParser<'sess, Early> {
         target_span: Span,
         target_node_id: NodeId,
         features: Option<&'sess Features>,
-        emit_errors: ShouldEmit,
+        should_emit: ShouldEmit,
     ) -> Vec<Attribute> {
         let mut p =
-            Self { features, tools: Vec::new(), parse_only, sess, stage: Early { emit_errors } };
+            Self { features, tools: Vec::new(), parse_only, sess, stage: PhantomData, should_emit };
         p.parse_attribute_list(
             attrs,
             target_span,
@@ -196,7 +198,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         target_node_id: NodeId,
         target: Target,
         features: Option<&'sess Features>,
-        emit_errors: ShouldEmit,
+        should_emit: ShouldEmit,
         args: &I,
         parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &I) -> T,
         template: &AttributeTemplate,
@@ -206,7 +208,8 @@ impl<'sess> AttributeParser<'sess, Early> {
             tools: Vec::new(),
             parse_only: None,
             sess,
-            stage: Early { emit_errors },
+            stage: PhantomData,
+            should_emit,
         };
         let mut emit_lint = |lint_id: LintId, span: MultiSpan, kind: EmitAttribute| {
             sess.psess.dyn_buffer_lint_sess(lint_id.lint, span, target_node_id, kind.0)
@@ -243,9 +246,16 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         sess: &'sess Session,
         features: &'sess Features,
         tools: Vec<Symbol>,
-        stage: S,
+        should_emit: ShouldEmit,
     ) -> Self {
-        Self { features: Some(features), tools, parse_only: None, sess, stage }
+        Self {
+            features: Some(features),
+            tools,
+            parse_only: None,
+            sess,
+            should_emit,
+            stage: PhantomData,
+        }
     }
 
     pub(crate) fn sess(&self) -> &'sess Session {
@@ -265,7 +275,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
     }
 
     pub(crate) fn emit_err(&self, diag: impl for<'x> Diagnostic<'x>) -> ErrorGuaranteed {
-        self.stage.should_emit().emit_err(self.sess.dcx().create_err(diag))
+        self.should_emit.emit_err(self.sess.dcx().create_err(diag))
     }
 
     /// Parse a list of attributes.
@@ -353,7 +363,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             args,
                             &parts,
                             &self.sess.psess,
-                            self.stage.should_emit(),
+                            self.should_emit,
                             AllowExprMetavar::No,
                         ) else {
                             continue;
@@ -408,7 +418,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                         (accept.accept_fn)(&mut cx, &args);
                         finalizers.push(accept.finalizer);
 
-                        if !matches!(cx.stage.should_emit(), ShouldEmit::Nothing) {
+                        if !matches!(cx.should_emit, ShouldEmit::Nothing) {
                             Self::check_target(&accept.allowed_targets, target, &mut cx);
                         }
                     } else {
@@ -429,7 +439,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             &mut emit_lint,
                         );
 
-                        if !matches!(self.stage.should_emit(), ShouldEmit::Nothing)
+                        if !matches!(self.should_emit, ShouldEmit::Nothing)
                             && target == Target::Crate
                         {
                             self.check_invalid_crate_level_attr_item(&attr, n.item.span());
@@ -462,9 +472,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
             }
         }
 
-        if !matches!(self.stage.should_emit(), ShouldEmit::Nothing)
-            && target == Target::WherePredicate
-        {
+        if !matches!(self.should_emit, ShouldEmit::Nothing) && target == Target::WherePredicate {
             self.check_invalid_where_predicate_attrs(attributes.iter().chain(&dropped_attributes));
         }
 

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -1,5 +1,4 @@
 use std::convert::identity;
-use std::marker::PhantomData;
 
 use rustc_ast as ast;
 use rustc_ast::token::DocFragmentKind;
@@ -18,7 +17,7 @@ use crate::context::{AcceptContext, FinalizeContext, FinalizeFn, SharedContext, 
 use crate::early_parsed::{EARLY_PARSED_ATTRIBUTES, EarlyParsedState};
 use crate::parser::{AllowExprMetavar, ArgParser, PathParser, RefPathParser};
 use crate::session_diagnostics::ParsedDescription;
-use crate::{Early, Late, OmitDoc, ShouldEmit};
+use crate::{Late, OmitDoc, ShouldEmit};
 
 pub struct EmitAttribute(
     pub  Box<
@@ -31,11 +30,10 @@ pub struct EmitAttribute(
 
 /// Context created once, for example as part of the ast lowering
 /// context, through which all attributes can be lowered.
-pub struct AttributeParser<'sess, S: Stage = Late> {
+pub struct AttributeParser<'sess> {
     pub(crate) tools: Vec<Symbol>,
     pub(crate) features: Option<&'sess Features>,
     pub(crate) sess: &'sess Session,
-    pub(crate) stage: PhantomData<S>,
     pub(crate) should_emit: ShouldEmit,
 
     /// *Only* parse attributes with this symbol.
@@ -44,7 +42,7 @@ pub struct AttributeParser<'sess, S: Stage = Late> {
     parse_only: Option<&'static [Symbol]>,
 }
 
-impl<'sess> AttributeParser<'sess, Early> {
+impl<'sess> AttributeParser<'sess> {
     /// This method allows you to parse attributes *before* you have access to features or tools.
     /// One example where this is necessary, is to parse `feature` attributes themselves for
     /// example.
@@ -120,8 +118,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         features: Option<&'sess Features>,
         should_emit: ShouldEmit,
     ) -> Vec<Attribute> {
-        let mut p =
-            Self { features, tools: Vec::new(), parse_only, sess, stage: PhantomData, should_emit };
+        let mut p = Self { features, tools: Vec::new(), parse_only, sess, should_emit };
         p.parse_attribute_list(
             attrs,
             target_span,
@@ -144,7 +141,7 @@ impl<'sess> AttributeParser<'sess, Early> {
         target: Target,
         features: Option<&'sess Features>,
         emit_errors: ShouldEmit,
-        parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &ArgParser) -> Option<T>,
+        parse_fn: fn(cx: &mut AcceptContext<'_, '_>, item: &ArgParser) -> Option<T>,
         template: &AttributeTemplate,
         allow_expr_metavar: AllowExprMetavar,
         expected_safety: AttributeSafety,
@@ -200,17 +197,10 @@ impl<'sess> AttributeParser<'sess, Early> {
         features: Option<&'sess Features>,
         should_emit: ShouldEmit,
         args: &I,
-        parse_fn: fn(cx: &mut AcceptContext<'_, '_, Early>, item: &I) -> T,
+        parse_fn: fn(cx: &mut AcceptContext<'_, '_>, item: &I) -> T,
         template: &AttributeTemplate,
     ) -> T {
-        let mut parser = Self {
-            features,
-            tools: Vec::new(),
-            parse_only: None,
-            sess,
-            stage: PhantomData,
-            should_emit,
-        };
+        let mut parser = Self { features, tools: Vec::new(), parse_only: None, sess, should_emit };
         let mut emit_lint = |lint_id: LintId, span: MultiSpan, kind: EmitAttribute| {
             sess.psess.dyn_buffer_lint_sess(lint_id.lint, span, target_node_id, kind.0)
         };
@@ -223,7 +213,7 @@ impl<'sess> AttributeParser<'sess, Early> {
                 &mut emit_lint,
             );
         }
-        let mut cx: AcceptContext<'_, 'sess, Early> = AcceptContext {
+        let mut cx: AcceptContext<'_, 'sess> = AcceptContext {
             shared: SharedContext {
                 cx: &mut parser,
                 target_span,
@@ -241,21 +231,14 @@ impl<'sess> AttributeParser<'sess, Early> {
     }
 }
 
-impl<'sess, S: Stage> AttributeParser<'sess, S> {
+impl<'sess> AttributeParser<'sess> {
     pub fn new(
         sess: &'sess Session,
         features: &'sess Features,
         tools: Vec<Symbol>,
         should_emit: ShouldEmit,
     ) -> Self {
-        Self {
-            features: Some(features),
-            tools,
-            parse_only: None,
-            sess,
-            should_emit,
-            stage: PhantomData,
-        }
+        Self { features: Some(features), tools, parse_only: None, sess, should_emit }
     }
 
     pub(crate) fn sess(&self) -> &'sess Session {
@@ -300,7 +283,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         let mut attr_paths: Vec<RefPathParser<'_>> = Vec::new();
         let mut early_parsed_state = EarlyParsedState::default();
 
-        let mut finalizers: Vec<FinalizeFn<S>> = Vec::with_capacity(attrs.len());
+        let mut finalizers: Vec<FinalizeFn> = Vec::with_capacity(attrs.len());
 
         for attr in attrs {
             // If we're only looking for a single attribute, skip all the ones we don't care about.
@@ -350,7 +333,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                     let parts =
                         n.item.path.segments.iter().map(|seg| seg.ident.name).collect::<Vec<_>>();
 
-                    if let Some(accept) = S::parsers().accepters.get(parts.as_slice()) {
+                    if let Some(accept) = Late::parsers().accepters.get(parts.as_slice()) {
                         self.check_attribute_safety(
                             &attr_path,
                             lower_span(n.item.span()),
@@ -400,7 +383,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                             continue;
                         }
 
-                        let mut cx: AcceptContext<'_, 'sess, S> = AcceptContext {
+                        let mut cx: AcceptContext<'_, 'sess> = AcceptContext {
                             shared: SharedContext {
                                 cx: self,
                                 target_span,

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -4,13 +4,13 @@ use rustc_ast as ast;
 use rustc_ast::token::DocFragmentKind;
 use rustc_ast::{AttrItemKind, AttrStyle, CRATE_NODE_ID, NodeId, Safety};
 use rustc_data_structures::sync::{DynSend, DynSync};
-use rustc_errors::{Diag, DiagCtxtHandle, Level, MultiSpan};
+use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
 use rustc_feature::{AttributeTemplate, Features};
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::{AttrArgs, AttrItem, AttrPath, Attribute, HashIgnoredAttrId, Target};
 use rustc_session::Session;
 use rustc_session::lint::LintId;
-use rustc_span::{DUMMY_SP, Span, Symbol, sym};
+use rustc_span::{DUMMY_SP, Span, Symbol, sym, ErrorGuaranteed};
 
 use crate::attributes::AttributeSafety;
 use crate::context::{AcceptContext, FinalizeContext, FinalizeFn, SharedContext, Stage};
@@ -262,6 +262,10 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
 
     pub(crate) fn dcx(&self) -> DiagCtxtHandle<'sess> {
         self.sess().dcx()
+    }
+
+    pub(crate) fn emit_err(&self, diag: impl for<'x> Diagnostic<'x>) -> ErrorGuaranteed {
+        self.stage.should_emit().emit_err(self.sess.dcx().create_err(diag))
     }
 
     /// Parse a list of attributes.

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -13,11 +13,13 @@ use rustc_session::lint::LintId;
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Symbol, sym};
 
 use crate::attributes::AttributeSafety;
-use crate::context::{AcceptContext, FinalizeContext, FinalizeFn, SharedContext, Stage};
+use crate::context::{
+    ATTRIBUTE_PARSERS, AcceptContext, FinalizeContext, FinalizeFn, SharedContext,
+};
 use crate::early_parsed::{EARLY_PARSED_ATTRIBUTES, EarlyParsedState};
 use crate::parser::{AllowExprMetavar, ArgParser, PathParser, RefPathParser};
 use crate::session_diagnostics::ParsedDescription;
-use crate::{Late, OmitDoc, ShouldEmit};
+use crate::{OmitDoc, ShouldEmit};
 
 pub struct EmitAttribute(
     pub  Box<
@@ -333,7 +335,7 @@ impl<'sess> AttributeParser<'sess> {
                     let parts =
                         n.item.path.segments.iter().map(|seg| seg.ident.name).collect::<Vec<_>>();
 
-                    if let Some(accept) = Late::parsers().accepters.get(parts.as_slice()) {
+                    if let Some(accept) = ATTRIBUTE_PARSERS.accepters.get(parts.as_slice()) {
                         self.check_attribute_safety(
                             &attr_path,
                             lower_span(n.item.span()),
@@ -472,7 +474,7 @@ impl<'sess> AttributeParser<'sess> {
             &[sym::cfg_attr],
         ];
 
-        Late::parsers().accepters.contains_key(path)
+        ATTRIBUTE_PARSERS.accepters.contains_key(path)
             || EARLY_PARSED_ATTRIBUTES.contains(&path)
             || SPECIAL_ATTRIBUTES.contains(&path)
     }

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -114,4 +114,5 @@ pub use attributes::cfg_select::*;
 pub use attributes::util::{is_builtin_attr, parse_version};
 pub use context::{Early, Late, OmitDoc, ShouldEmit};
 pub use interface::{AttributeParser, EmitAttribute};
+pub use rustc_parse::parser::Recovery;
 pub use session_diagnostics::ParsedDescription;

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -112,7 +112,7 @@ pub use attributes::cfg::{
 };
 pub use attributes::cfg_select::*;
 pub use attributes::util::{is_builtin_attr, parse_version};
-pub use context::{Early, Late, OmitDoc, ShouldEmit};
+pub use context::{OmitDoc, ShouldEmit};
 pub use interface::{AttributeParser, EmitAttribute};
 pub use rustc_parse::parser::Recovery;
 pub use session_diagnostics::ParsedDescription;

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -75,6 +75,13 @@
 //!
 //! This is equivalent to `#[repr(C, packed)]` and results in a single `AttributeKind::Repr`
 //! containing both `C` and `packed` annotations.
+//!
+//! ## Early attribute parsing
+//!
+//! While lowering to the HIR, all attributes are parsed using the attribute parsers.
+//! However, sometimes an attributes' parsed form is needed before the HIR is constructed.
+//! This is referred to as "early" attribute parsing,
+//! and is performed using the `parse_limited_*` family of functions on `AttributeParser`.
 
 // tidy-alphabetical-start
 #![feature(decl_macro)]

--- a/compiler/rustc_attr_parsing/src/safety.rs
+++ b/compiler/rustc_attr_parsing/src/safety.rs
@@ -63,18 +63,15 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                 }
 
                 if emit_error {
-                    self.stage.emit_err(
-                        self.sess,
-                        crate::session_diagnostics::UnsafeAttrOutsideUnsafe {
-                            span: path_span,
-                            suggestion: not_from_proc_macro.then(|| {
-                                crate::session_diagnostics::UnsafeAttrOutsideUnsafeSuggestion {
-                                    left: diag_span.shrink_to_lo(),
-                                    right: diag_span.shrink_to_hi(),
-                                }
-                            }),
-                        },
-                    );
+                    self.emit_err(crate::session_diagnostics::UnsafeAttrOutsideUnsafe {
+                        span: path_span,
+                        suggestion: not_from_proc_macro.then(|| {
+                            crate::session_diagnostics::UnsafeAttrOutsideUnsafeSuggestion {
+                                left: diag_span.shrink_to_lo(),
+                                right: diag_span.shrink_to_hi(),
+                            }
+                        }),
+                    });
                 } else {
                     emit_lint(
                         LintId::of(UNSAFE_ATTR_OUTSIDE_UNSAFE),
@@ -97,13 +94,10 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
             // - Normal builtin attribute
             // - Writing `#[unsafe(..)]` is not permitted on normal builtin attributes
             (AttributeSafety::Normal, Safety::Unsafe(unsafe_span)) => {
-                self.stage.emit_err(
-                    self.sess,
-                    crate::session_diagnostics::InvalidAttrUnsafe {
-                        span: unsafe_span,
-                        name: attr_path.clone(),
-                    },
-                );
+                self.emit_err(crate::session_diagnostics::InvalidAttrUnsafe {
+                    span: unsafe_span,
+                    name: attr_path.clone(),
+                });
             }
 
             // - Normal builtin attribute

--- a/compiler/rustc_attr_parsing/src/safety.rs
+++ b/compiler/rustc_attr_parsing/src/safety.rs
@@ -6,10 +6,9 @@ use rustc_session::lint::builtin::UNSAFE_ATTR_OUTSIDE_UNSAFE;
 use rustc_span::Span;
 
 use crate::attributes::AttributeSafety;
-use crate::context::Stage;
 use crate::{AttributeParser, EmitAttribute, ShouldEmit, errors};
 
-impl<'sess, S: Stage> AttributeParser<'sess, S> {
+impl<'sess> AttributeParser<'sess> {
     pub fn check_attribute_safety(
         &mut self,
         attr_path: &AttrPath,

--- a/compiler/rustc_attr_parsing/src/safety.rs
+++ b/compiler/rustc_attr_parsing/src/safety.rs
@@ -18,7 +18,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         expected_safety: AttributeSafety,
         emit_lint: &mut impl FnMut(LintId, MultiSpan, EmitAttribute),
     ) {
-        if matches!(self.stage.should_emit(), ShouldEmit::Nothing) {
+        if matches!(self.should_emit, ShouldEmit::Nothing) {
             return;
         }
 

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -8,7 +8,7 @@ use rustc_hir::{AttrItem, Attribute, MethodKind, Target};
 use rustc_span::{BytePos, Span, Symbol, sym};
 
 use crate::AttributeParser;
-use crate::context::{AcceptContext, Stage};
+use crate::context::AcceptContext;
 use crate::errors::{
     InvalidAttrAtCrateLevel, InvalidTargetLint, ItemFollowingInnerAttr,
     UnsupportedAttributesInWhere,
@@ -87,11 +87,11 @@ pub(crate) enum Policy {
     Error(Target),
 }
 
-impl<'sess, S: Stage> AttributeParser<'sess, S> {
+impl<'sess> AttributeParser<'sess> {
     pub(crate) fn check_target(
         allowed_targets: &AllowedTargets,
         target: Target,
-        cx: &mut AcceptContext<'_, 'sess, S>,
+        cx: &mut AcceptContext<'_, 'sess>,
     ) {
         // For crate-level attributes we emit a specific set of lints to warn
         // people about accidentally not using them on the crate.
@@ -176,7 +176,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         }
     }
 
-    pub(crate) fn check_crate_level(target: Target, cx: &mut AcceptContext<'_, 'sess, S>) {
+    pub(crate) fn check_crate_level(target: Target, cx: &mut AcceptContext<'_, 'sess>) {
         if target == Target::Crate {
             return;
         }

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -17,7 +17,7 @@ use rustc_session::lint::builtin::ILL_FORMED_ATTRIBUTE_INPUT;
 use rustc_session::parse::ParseSess;
 use rustc_span::{Span, Symbol, sym};
 
-use crate::{AttributeParser, Late, session_diagnostics as errors};
+use crate::{AttributeParser, session_diagnostics as errors};
 
 pub fn check_attr(psess: &ParseSess, attr: &Attribute) {
     if attr.is_doc_comment() || attr.has_name(sym::cfg_trace) || attr.has_name(sym::cfg_attr_trace)
@@ -30,7 +30,7 @@ pub fn check_attr(psess: &ParseSess, attr: &Attribute) {
     // Check input tokens for built-in and key-value attributes.
     match builtin_attr_info {
         Some(BuiltinAttribute { name, .. }) => {
-            if AttributeParser::<Late>::is_parsed_attribute(slice::from_ref(&name)) {
+            if AttributeParser::is_parsed_attribute(slice::from_ref(&name)) {
                 return;
             }
             match parse_meta(psess, attr) {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -15,7 +15,7 @@ use rustc_ast::{
 use rustc_ast_pretty::pprust;
 use rustc_attr_parsing::parser::AllowExprMetavar;
 use rustc_attr_parsing::{
-    AttributeParser, AttributeSafety, CFG_TEMPLATE, Early, EvalConfigResult, ShouldEmit,
+    AttributeParser, AttributeSafety, CFG_TEMPLATE, EvalConfigResult, ShouldEmit,
     eval_config_entry, parse_cfg, validate_attr,
 };
 use rustc_data_structures::flat_map_in_place::FlatMapInPlace;
@@ -2296,7 +2296,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     crate::errors::MacroCallUnusedDocComment { span: attr.span },
                 );
             } else if rustc_attr_parsing::is_builtin_attr(attr)
-                && !AttributeParser::<Early>::is_parsed_attribute(&attr.path())
+                && !AttributeParser::is_parsed_attribute(&attr.path())
             {
                 let attr_name = attr.name().unwrap();
                 self.cx.sess.psess.buffer_lint(

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, LazyLock, OnceLock};
 use std::{env, fs, iter};
 
 use rustc_ast::{self as ast, CRATE_NODE_ID};
-use rustc_attr_parsing::{AttributeParser, Early, ShouldEmit};
+use rustc_attr_parsing::{AttributeParser, ShouldEmit};
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CompiledModules, CrateInfo};
 use rustc_data_structures::indexmap::IndexMap;
@@ -1419,7 +1419,7 @@ pub fn collect_crate_types(
     let mut base = session.opts.crate_types.clone();
     if base.is_empty() {
         if let Some(Attribute::Parsed(AttributeKind::CrateType(crate_type))) =
-            AttributeParser::<Early>::parse_limited_should_emit(
+            AttributeParser::parse_limited_should_emit(
                 session,
                 attrs,
                 &[sym::crate_type],

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -10,7 +10,7 @@ use std::slice;
 
 use rustc_abi::ExternAbi;
 use rustc_ast::{AttrStyle, MetaItemKind, ast};
-use rustc_attr_parsing::{AttributeParser, Late};
+use rustc_attr_parsing::AttributeParser;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unord::UnordMap;
 use rustc_errors::{DiagCtxtHandle, IntoDiagArg, MultiSpan, msg};
@@ -381,7 +381,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         [name, rest@..] => {
                             match BUILTIN_ATTRIBUTE_MAP.get(name) {
                                 Some(_) => {
-                                    if rest.len() > 0 && AttributeParser::<Late>::is_parsed_attribute(slice::from_ref(name)) {
+                                    if rest.len() > 0 && AttributeParser::is_parsed_attribute(slice::from_ref(name)) {
                                         // Check if we tried to use a builtin attribute as an attribute namespace, like `#[must_use::skip]`.
                                         // This check is here to solve https://github.com/rust-lang/rust/issues/137590
                                         // An error is already produced for this case elsewhere

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -3,7 +3,7 @@ use std::mem;
 use rustc_ast::visit::FnKind;
 use rustc_ast::*;
 use rustc_attr_parsing as attr;
-use rustc_attr_parsing::{AttributeParser, Early, OmitDoc, ShouldEmit};
+use rustc_attr_parsing::{AttributeParser, OmitDoc, ShouldEmit};
 use rustc_expand::expand::AstFragment;
 use rustc_hir as hir;
 use rustc_hir::Target;
@@ -146,7 +146,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 // FIXME(jdonszelmann) make one of these in the resolver?
                 // FIXME(jdonszelmann) don't care about tools here maybe? Just parse what we can.
                 // Does that prevents errors from happening? maybe
-                let mut parser = AttributeParser::<'_, Early>::new(
+                let mut parser = AttributeParser::new(
                     &self.r.tcx.sess,
                     self.r.tcx.features(),
                     Vec::new(),

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -150,7 +150,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     &self.r.tcx.sess,
                     self.r.tcx.features(),
                     Vec::new(),
-                    Early { emit_errors: ShouldEmit::Nothing },
+                    ShouldEmit::Nothing,
                 );
                 let attrs = parser.parse_attribute_list(
                     &i.attrs,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155775)*
<!-- homu-ignore:end -->

I discovered that it is surprisingly easy to remove the concept of `Stage` in the attribute parsers, imo this makes the code a lot cleaner.

r? @jdonszelmann 
cc @mejrs @Bryntet 
