### PR TITLE
Error when an arg to `#[allow_internal_unstable]` is a key-value

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -91,14 +91,29 @@ fn parse_unstable<S: Stage>(
 
     for param in list.mixed() {
         let param_span = param.span();
-        if let Some(ident) = param.meta_item().and_then(|i| i.path().word()) {
-            res.push(ident.name);
-        } else {
+        let fail = || {
             cx.emit_err(session_diagnostics::ExpectsFeatures {
                 span: param_span,
                 name: symbol.to_ident_string(),
-            });
-        }
+            })
+        };
+
+        let Some(meta_item) = param.meta_item() else {
+            fail();
+            continue;
+        };
+
+        let Ok(()) = meta_item.args().no_args() else {
+            fail();
+            continue;
+        };
+
+        let Some(ident) = meta_item.path().word() else {
+            fail();
+            continue;
+        };
+
+        res.push(ident.name);
     }
 
     res

--- a/tests/ui/attributes/allow-internal-unstable-name-value.rs
+++ b/tests/ui/attributes/allow-internal-unstable-name-value.rs
@@ -1,9 +1,7 @@
-//@ check-pass
-
 #![feature(allow_internal_unstable)]
 #![allow(internal_features)]
 
-#[allow_internal_unstable(cat = "meow")]
+#[allow_internal_unstable(cat = "meow")] //~ ERROR `allow_internal_unstable` expects feature names
 macro_rules! foo {
     () => {}
 }

--- a/tests/ui/attributes/allow-internal-unstable-name-value.rs
+++ b/tests/ui/attributes/allow-internal-unstable-name-value.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![feature(allow_internal_unstable)]
+#![allow(internal_features)]
+
+#[allow_internal_unstable(cat = "meow")]
+macro_rules! foo {
+    () => {}
+}
+
+fn main() {}

--- a/tests/ui/attributes/allow-internal-unstable-name-value.stderr
+++ b/tests/ui/attributes/allow-internal-unstable-name-value.stderr
@@ -1,0 +1,8 @@
+error: `allow_internal_unstable` expects feature names
+  --> $DIR/allow-internal-unstable-name-value.rs:4:27
+   |
+LL | #[allow_internal_unstable(cat = "meow")]
+   |                           ^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
It looks like we don't check that the features passed to `#[allow_internal_unstable]` are "just features" (as in, with no arguments). This means the following compiles:

```rust
#![feature(allow_internal_unstable)]

#[allow_internal_unstable(cat = "meow")]
macro_rules! foo {
    () => {};
}
```

###### [Playground link](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=e3552a79c6b75e0d06b487c7adcc66ce)

This PR makes it an error to pass anything other than an identifier as argument to `#[allow_internal_unstable]`. I believe it is ok to make it an error (and technically breaking some code) because `allow_internal_unstable` is an internal feature, which (quoting `rustc`'s output) *is internal to the compiler or standard library*. Happy to change to a warning if my assumption is wrong though :)

Discovered while writing the followup of rust-lang/rust#155696.

<!-- homu-ignore:end -->
