### PR TITLE
de-non_const (DoubleEnded)Iterator advance(_back)_by

### DIFF
--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -137,13 +137,18 @@ pub const trait DoubleEndedIterator: [const] Iterator {
     /// [`Err(k)`]: Err
     #[inline]
     #[unstable(feature = "iter_advance_by", issue = "77404")]
-    #[rustc_non_const_trait_method]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        for i in 0..n {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>>
+    where
+        Self::Item: [const] Destruct,
+    {
+        //FIXME(const-hack): revert this to `for i in 0..n` when possible
+        let mut i: usize = 0;
+        while i < n {
             if self.next_back().is_none() {
                 // SAFETY: `i` is always less than `n`.
                 return Err(unsafe { NonZero::new_unchecked(n - i) });
             }
+            i += 1;
         }
         Ok(())
     }
@@ -191,8 +196,10 @@ pub const trait DoubleEndedIterator: [const] Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iter_nth_back", since = "1.37.0")]
-    #[rustc_non_const_trait_method]
-    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item>
+    where
+        Self::Item: [const] Destruct,
+    {
         if self.advance_back_by(n).is_err() {
             return None;
         }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -308,32 +308,54 @@ pub const trait Iterator {
     /// ```
     #[inline]
     #[unstable(feature = "iter_advance_by", issue = "77404")]
-    #[rustc_non_const_trait_method]
-    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>>
+    where
+        Self::Item: [const] Destruct,
+    {
         /// Helper trait to specialize `advance_by` via `try_fold` for `Sized` iterators.
-        trait SpecAdvanceBy {
+        const trait SpecAdvanceBy {
             fn spec_advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>>;
         }
 
-        impl<I: Iterator + ?Sized> SpecAdvanceBy for I {
+        #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+        impl<I: [const] Iterator + ?Sized> const SpecAdvanceBy for I
+        where
+            I::Item: [const] Destruct,
+        {
             default fn spec_advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-                for i in 0..n {
+                //FIXME(const-hack): revert this to `for i in 0..n` when possible
+                let mut i: usize = 0;
+                while i < n {
                     if self.next().is_none() {
                         // SAFETY: `i` is always less than `n`.
                         return Err(unsafe { NonZero::new_unchecked(n - i) });
                     }
+                    i += 1;
                 }
                 Ok(())
             }
         }
 
-        impl<I: Iterator> SpecAdvanceBy for I {
+        #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+        impl<I: [const] Iterator> const SpecAdvanceBy for I
+        where
+            I::Item: [const] Destruct,
+        {
             fn spec_advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+                //FIXME(const-hack): revert this to a const closure when they are fine to use
+                #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+                const fn try_minus_one<T: [const] Destruct>(
+                    n: NonZero<usize>,
+                    _: T,
+                ) -> Option<NonZero<usize>> {
+                    NonZero::new(n.get() - 1)
+                }
+
                 let Some(n) = NonZero::new(n) else {
                     return Ok(());
                 };
 
-                let res = self.try_fold(n, |n, _| NonZero::new(n.get() - 1));
+                let res = self.try_fold(n, try_minus_one);
 
                 match res {
                     None => Ok(()),
@@ -386,8 +408,10 @@ pub const trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_non_const_trait_method]
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+    fn nth(&mut self, n: usize) -> Option<Self::Item>
+    where
+        Self::Item: [const] Destruct,
+    {
         self.advance_by(n).ok()?;
         self.next()
     }

--- a/tests/codegen-units/item-collection/opaque-return-impls.rs
+++ b/tests/codegen-units/item-collection/opaque-return-impls.rs
@@ -73,12 +73,13 @@ pub fn foo3() -> Box<dyn Iterator<Item = usize>> {
 }
 
 //~ MONO_ITEM fn <Counter as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by
-//~ MONO_ITEM fn <Counter as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}
+//~ MONO_ITEM fn <I as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::try_minus_one::<usize>
 //~ MONO_ITEM fn <Counter as std::iter::Iterator>::advance_by
 //~ MONO_ITEM fn <Counter as std::iter::Iterator>::next
 //~ MONO_ITEM fn <Counter as std::iter::Iterator>::nth
 //~ MONO_ITEM fn <Counter as std::iter::Iterator>::size_hint
-//~ MONO_ITEM fn <Counter as std::iter::Iterator>::try_fold::<std::num::NonZero<usize>, {closure@<Counter as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::{closure#0}}, std::option::Option<std::num::NonZero<usize>>>
+//~ MONO_ITEM fn <Counter as std::iter::Iterator>::try_fold::<std::num::NonZero<usize>, fn(std::num::NonZero<usize>, usize) -> std::option::Option<std::num::NonZero<usize>> {<I as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::try_minus_one::<usize>}, std::option::Option<std::num::NonZero<usize>>>
+//~ MONO_ITEM fn <fn(std::num::NonZero<usize>, usize) -> std::option::Option<std::num::NonZero<usize>> {<I as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::try_minus_one::<usize>} as std::ops::FnMut<(std::num::NonZero<usize>, usize)>>::call_mut - shim(fn(std::num::NonZero<usize>, usize) -> std::option::Option<std::num::NonZero<usize>> {<I as std::iter::Iterator::advance_by::SpecAdvanceBy>::spec_advance_by::try_minus_one::<usize>})
 //~ MONO_ITEM fn <std::option::Option<std::num::NonZero<usize>> as std::ops::FromResidual<std::option::Option<std::convert::Infallible>>>::from_residual
 //~ MONO_ITEM fn <std::option::Option<std::num::NonZero<usize>> as std::ops::Try>::branch
 //~ MONO_ITEM fn <std::option::Option<std::num::NonZero<usize>> as std::ops::Try>::from_output


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/92476

de-non_const `advance_by`, `nth` for `Iterator`, and `advance_back_by`, `nth_back` for `DoubleEndedIterator`

