### PR TITLE
Mention `DEPRECATED_LLVM_INTRINSIC` lint for internal use

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -5639,7 +5639,12 @@ declare_lint! {
     /// LLVM periodically updates its list of intrinsics. Deprecated intrinsics are unlikely
     /// to be removed, but they may optimize less well than their new versions, so it's
     /// best to use the new version. Also, some deprecated intrinsics might have buggy
-    /// behavior
+    /// behavior.
+    ///
+    /// This `link_llvm_intrinsics` lint is intended to be used internally only, and requires the
+    /// `#![feature(link_llvm_intrinsics)]` internal feature gate. For more information, see [its chapter in
+    /// the Unstable Book](https://doc.rust-lang.org/unstable-book/language-features/link-llvm-intrinsics.html)
+    /// and [its tracking issue](https://github.com/rust-lang/rust/issues/29602).
     pub DEPRECATED_LLVM_INTRINSIC,
     Allow,
     "detects uses of deprecated LLVM intrinsics",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Since `link_llvm_intrinsics` is an internal feature, having `deprecated_llvm_intrinsic` lint appearing in https://doc.rust-lang.org/nightly/rustc/lints/listing/allowed-by-default.html#deprecated-llvm-intrinsic without mentioning its internal nature is quite confusing to the end users.

This PR improves the documentation of recently merged PR https://github.com/rust-lang/rust/pull/140763 that implemented `deprecated_llvm_intrinsic` lint by mentioning the internal nature of `deprecated_llvm_intrinsic` lint and `link_llvm_intrinsics` feature.

Tracking issue of unstable `link_llvm_intrinsics` feature: https://github.com/rust-lang/rust/issues/29602