### PR TITLE
Remove the incomplete marker from `impl` restrictions

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -549,7 +549,7 @@ declare_features! (
     /// Target features on hexagon.
     (unstable, hexagon_target_feature, "1.27.0", Some(150250)),
     /// Allows `impl(crate) trait Foo` restrictions.
-    (incomplete, impl_restriction, "1.96.0", Some(105077)),
+    (unstable, impl_restriction, "CURRENT_RUSTC_VERSION", Some(105077)),
     /// Allows `impl Trait` to be used inside associated types (RFC 2515).
     (unstable, impl_trait_in_assoc_type, "1.70.0", Some(63063)),
     /// Allows `impl Trait` in bindings (`let`).

--- a/tests/ui/impl-restriction/auxiliary/external-impl-restriction.rs
+++ b/tests/ui/impl-restriction/auxiliary/external-impl-restriction.rs
@@ -1,5 +1,4 @@
 #![feature(impl_restriction)]
-#![expect(incomplete_features)]
 
 pub impl(crate) trait TopLevel {}
 

--- a/tests/ui/impl-restriction/feature-gate-impl-restriction.rs
+++ b/tests/ui/impl-restriction/feature-gate-impl-restriction.rs
@@ -3,7 +3,6 @@
 //@[with_gate] check-pass
 
 #![cfg_attr(with_gate, feature(impl_restriction))]
-#![cfg_attr(with_gate, allow(incomplete_features))]
 #![feature(auto_traits, const_trait_impl)]
 
 pub impl(crate) trait Bar {} //[without_gate]~ ERROR `impl` restrictions are experimental

--- a/tests/ui/impl-restriction/feature-gate-impl-restriction.without_gate.stderr
+++ b/tests/ui/impl-restriction/feature-gate-impl-restriction.without_gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:9:5
+  --> $DIR/feature-gate-impl-restriction.rs:8:5
    |
 LL | pub impl(crate) trait Bar {}
    |     ^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | pub impl(crate) trait Bar {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:10:5
+  --> $DIR/feature-gate-impl-restriction.rs:9:5
    |
 LL | pub impl(in crate) trait BarInCrate {}
    |     ^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | pub impl(in crate) trait BarInCrate {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:13:9
+  --> $DIR/feature-gate-impl-restriction.rs:12:9
    |
 LL |     pub impl(in crate::foo) trait Baz {}
    |         ^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     pub impl(in crate::foo) trait Baz {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:14:9
+  --> $DIR/feature-gate-impl-restriction.rs:13:9
    |
 LL |     pub impl(super) unsafe trait BazUnsafeSuper {}
    |         ^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     pub impl(super) unsafe trait BazUnsafeSuper {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:15:9
+  --> $DIR/feature-gate-impl-restriction.rs:14:9
    |
 LL |     pub impl(self) auto trait BazAutoSelf {}
    |         ^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     pub impl(self) auto trait BazAutoSelf {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:16:9
+  --> $DIR/feature-gate-impl-restriction.rs:15:9
    |
 LL |     pub impl(in self) const trait BazConst {}
    |         ^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     pub impl(in self) const trait BazConst {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:19:13
+  --> $DIR/feature-gate-impl-restriction.rs:18:13
    |
 LL |         pub impl(in crate::foo::foo_inner) trait Qux {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |         pub impl(in crate::foo::foo_inner) trait Qux {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:20:13
+  --> $DIR/feature-gate-impl-restriction.rs:19:13
    |
 LL | ...   pub impl(in crate::foo::foo_inner) unsafe auto trait QuxAutoUnsafe {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL | ...   pub impl(in crate::foo::foo_inner) unsafe auto trait QuxAutoUnsafe {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:21:13
+  --> $DIR/feature-gate-impl-restriction.rs:20:13
    |
 LL | ...   pub impl(in crate::foo::foo_inner) const unsafe trait QuxConstUnsafe {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL | ...   pub impl(in crate::foo::foo_inner) const unsafe trait QuxConstUnsafe 
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:25:9
+  --> $DIR/feature-gate-impl-restriction.rs:24:9
    |
 LL |     pub impl(crate) trait Bar {}
    |         ^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     pub impl(crate) trait Bar {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:27:9
+  --> $DIR/feature-gate-impl-restriction.rs:26:9
    |
 LL |     pub impl(in crate) trait BarInCrate {}
    |         ^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     pub impl(in crate) trait BarInCrate {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:29:9
+  --> $DIR/feature-gate-impl-restriction.rs:28:9
    |
 LL |     pub impl(self) unsafe trait BazUnsafeSelf {}
    |         ^^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     pub impl(self) unsafe trait BazUnsafeSelf {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:31:9
+  --> $DIR/feature-gate-impl-restriction.rs:30:9
    |
 LL |     pub impl(in super) auto trait BazAutoSuper {}
    |         ^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     pub impl(in super) auto trait BazAutoSuper {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:33:9
+  --> $DIR/feature-gate-impl-restriction.rs:32:9
    |
 LL |     pub impl(super) const trait BazConstSuper {}
    |         ^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL |     pub impl(super) const trait BazConstSuper {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:37:13
+  --> $DIR/feature-gate-impl-restriction.rs:36:13
    |
 LL |         pub impl(in crate::foo::cfged_out_foo) trait CfgedOutQux {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |         pub impl(in crate::foo::cfged_out_foo) trait CfgedOutQux {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:38:13
+  --> $DIR/feature-gate-impl-restriction.rs:37:13
    |
 LL | ...   pub impl(in crate::foo::cfged_out_foo) unsafe auto trait CfgedOutQuxUnsafeAuto {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +159,7 @@ LL | ...   pub impl(in crate::foo::cfged_out_foo) unsafe auto trait CfgedOutQuxU
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:39:13
+  --> $DIR/feature-gate-impl-restriction.rs:38:13
    |
 LL | ...   pub impl(in crate::foo::cfged_out_foo) const unsafe trait CfgedOutQuxConstUnsafe {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-restriction/impl-restriction-check.e2015.stderr
+++ b/tests/ui/impl-restriction/impl-restriction-check.e2015.stderr
@@ -1,95 +1,95 @@
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:12:1
+  --> $DIR/impl-restriction-check.rs:11:1
    |
 LL | impl external::TopLevel for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:4:5
+  --> $DIR/auxiliary/external-impl-restriction.rs:3:5
    |
 LL | pub impl(crate) trait TopLevel {}
    |     ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:13:1
+  --> $DIR/impl-restriction-check.rs:12:1
    |
 LL | impl external::inner::Inner for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:7:9
+  --> $DIR/auxiliary/external-impl-restriction.rs:6:9
    |
 LL |     pub impl(self) trait Inner {}
    |         ^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:30:5
+  --> $DIR/impl-restriction-check.rs:29:5
    |
 LL |     impl bar::Foo for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:39:1
+  --> $DIR/impl-restriction-check.rs:38:1
    |
 LL | impl foo::bar::Foo for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo`
-  --> $DIR/impl-restriction-check.rs:41:1
+  --> $DIR/impl-restriction-check.rs:40:1
    |
 LL | impl foo::bar::Bar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:18:20
+  --> $DIR/impl-restriction-check.rs:17:20
    |
 LL |         pub(crate) impl(super) trait Bar {}
    |                    ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:34:5
+  --> $DIR/impl-restriction-check.rs:33:5
    |
 LL |     impl bar::Qux for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:44:1
+  --> $DIR/impl-restriction-check.rs:43:1
    |
 LL | impl foo::bar::Qux for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo`
-  --> $DIR/impl-restriction-check.rs:46:1
+  --> $DIR/impl-restriction-check.rs:45:1
    |
 LL | impl foo::bar::FooBar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:21:20
+  --> $DIR/impl-restriction-check.rs:20:20
    |
 LL |         pub(crate) impl(in crate::foo) trait FooBar {}
    |                    ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-restriction/impl-restriction-check.e2018.stderr
+++ b/tests/ui/impl-restriction/impl-restriction-check.e2018.stderr
@@ -1,95 +1,95 @@
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:12:1
+  --> $DIR/impl-restriction-check.rs:11:1
    |
 LL | impl external::TopLevel for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:4:5
+  --> $DIR/auxiliary/external-impl-restriction.rs:3:5
    |
 LL | pub impl(crate) trait TopLevel {}
    |     ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:13:1
+  --> $DIR/impl-restriction-check.rs:12:1
    |
 LL | impl external::inner::Inner for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:7:9
+  --> $DIR/auxiliary/external-impl-restriction.rs:6:9
    |
 LL |     pub impl(self) trait Inner {}
    |         ^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:30:5
+  --> $DIR/impl-restriction-check.rs:29:5
    |
 LL |     impl bar::Foo for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:39:1
+  --> $DIR/impl-restriction-check.rs:38:1
    |
 LL | impl foo::bar::Foo for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo`
-  --> $DIR/impl-restriction-check.rs:41:1
+  --> $DIR/impl-restriction-check.rs:40:1
    |
 LL | impl foo::bar::Bar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:18:20
+  --> $DIR/impl-restriction-check.rs:17:20
    |
 LL |         pub(crate) impl(super) trait Bar {}
    |                    ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:34:5
+  --> $DIR/impl-restriction-check.rs:33:5
    |
 LL |     impl bar::Qux for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:44:1
+  --> $DIR/impl-restriction-check.rs:43:1
    |
 LL | impl foo::bar::Qux for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo`
-  --> $DIR/impl-restriction-check.rs:46:1
+  --> $DIR/impl-restriction-check.rs:45:1
    |
 LL | impl foo::bar::FooBar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:21:20
+  --> $DIR/impl-restriction-check.rs:20:20
    |
 LL |         pub(crate) impl(in crate::foo) trait FooBar {}
    |                    ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-restriction/impl-restriction-check.rs
+++ b/tests/ui/impl-restriction/impl-restriction-check.rs
@@ -3,7 +3,6 @@
 //@ [e2015] edition: 2015
 //@ [e2018] edition: 2018..
 #![feature(impl_restriction)]
-#![expect(incomplete_features)]
 
 extern crate external_impl_restriction as external;
 

--- a/tests/ui/impl-restriction/recover-incorrect-impl-restriction.rs
+++ b/tests/ui/impl-restriction/recover-incorrect-impl-restriction.rs
@@ -1,5 +1,4 @@
 #![feature(impl_restriction, auto_traits, const_trait_impl)]
-#![expect(incomplete_features)]
 
 mod foo {
     pub impl(crate::foo) trait Baz {} //~ ERROR incorrect `impl` restriction

--- a/tests/ui/impl-restriction/recover-incorrect-impl-restriction.stderr
+++ b/tests/ui/impl-restriction/recover-incorrect-impl-restriction.stderr
@@ -1,5 +1,5 @@
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:5:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:4:14
    |
 LL |     pub impl(crate::foo) trait Baz {}
    |              ^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     pub impl(in crate::foo) trait Baz {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:6:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:5:14
    |
 LL |     pub impl(crate::foo) unsafe trait BazUnsafe {}
    |              ^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     pub impl(in crate::foo) unsafe trait BazUnsafe {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:7:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:6:14
    |
 LL |     pub impl(crate::foo) auto trait BazAuto {}
    |              ^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     pub impl(in crate::foo) auto trait BazAuto {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:8:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:7:14
    |
 LL |     pub impl(crate::foo) const trait BazConst {}
    |              ^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     pub impl(in crate::foo) const trait BazConst {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:9:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:8:14
    |
 LL |     pub impl(crate::foo) const unsafe trait BazConstUnsafe {}
    |              ^^^^^^^^^^
@@ -79,7 +79,7 @@ LL |     pub impl(in crate::foo) const unsafe trait BazConstUnsafe {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:10:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:9:14
    |
 LL |     pub impl(crate::foo) unsafe auto trait BazUnsafeAuto {}
    |              ^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     pub impl(in crate::foo) unsafe auto trait BazUnsafeAuto {}
    |              ++
 
 error: expected one of `for`, `where`, or `{`, found keyword `trait`
-  --> $DIR/recover-incorrect-impl-restriction.rs:17:33
+  --> $DIR/recover-incorrect-impl-restriction.rs:16:33
    |
 LL |     pub unsafe impl(crate::foo) trait BadOrder1 {}
    |                                 ^^^^^ expected one of `for`, `where`, or `{`

--- a/tests/ui/impl-restriction/restriction_resolution_errors.rs
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.rs
@@ -1,6 +1,5 @@
 //@ aux-build: external-impl-restriction.rs
 #![feature(impl_restriction)]
-#![expect(incomplete_features)]
 
 extern crate external_impl_restriction as external;
 

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -1,77 +1,77 @@
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:17:21
+  --> $DIR/restriction_resolution_errors.rs:16:21
    |
 LL |         pub impl(in ::std) trait T2 {}
    |                     ^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:19:21
+  --> $DIR/restriction_resolution_errors.rs:18:21
    |
 LL |         pub impl(in self::c) trait T3 {}
    |                     ^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:21:21
+  --> $DIR/restriction_resolution_errors.rs:20:21
    |
 LL |         pub impl(in super::d) trait T4 {}
    |                     ^^^^^^^^
 
 error[E0433]: too many leading `super` keywords
-  --> $DIR/restriction_resolution_errors.rs:27:35
+  --> $DIR/restriction_resolution_errors.rs:26:35
    |
 LL |         pub impl(in super::super::super) trait T7 {}
    |                                   ^^^^^ there are too many leading `super` keywords
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:37:21
+  --> $DIR/restriction_resolution_errors.rs:36:21
    |
 LL |         pub impl(in self::f) trait L1 {}
    |                     ^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:41:21
+  --> $DIR/restriction_resolution_errors.rs:40:21
    |
 LL |         pub impl(in super::h) trait L3 {}
    |                     ^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:50:13
+  --> $DIR/restriction_resolution_errors.rs:49:13
    |
 LL | pub impl(in crate::a) trait T13 {}
    |             ^^^^^^^^
 
 error[E0433]: too many leading `super` keywords
-  --> $DIR/restriction_resolution_errors.rs:57:10
+  --> $DIR/restriction_resolution_errors.rs:56:10
    |
 LL | pub impl(super) trait T17 {}
    |          ^^^^^ there are too many leading `super` keywords
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:59:13
+  --> $DIR/restriction_resolution_errors.rs:58:13
    |
 LL | pub impl(in external) trait T18 {}
    |             ^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:62:13
+  --> $DIR/restriction_resolution_errors.rs:61:13
    |
 LL | pub impl(in crate::j) trait L4 {}
    |             ^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:78:21
+  --> $DIR/restriction_resolution_errors.rs:77:21
    |
 LL |         pub impl(in crate::m2) trait U2 {}
    |                     ^^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:80:21
+  --> $DIR/restriction_resolution_errors.rs:79:21
    |
 LL |         pub impl(in m6::m5) trait U4 {}
    |                     ^^^^^^
 
 error[E0433]: cannot find module or crate `a` in this scope
-  --> $DIR/restriction_resolution_errors.rs:15:21
+  --> $DIR/restriction_resolution_errors.rs:14:21
    |
 LL |         pub impl(in a::b) trait T1 {}
    |                     ^ use of unresolved module or unlinked crate `a`
@@ -87,25 +87,25 @@ LL +         use a;
    |
 
 error[E0433]: cannot find module `c` in the crate root
-  --> $DIR/restriction_resolution_errors.rs:23:28
+  --> $DIR/restriction_resolution_errors.rs:22:28
    |
 LL |         pub impl(in crate::c) trait T5 {}
    |                            ^ not found in the crate root
 
 error[E0577]: expected module, found enum `super::E`
-  --> $DIR/restriction_resolution_errors.rs:25:21
+  --> $DIR/restriction_resolution_errors.rs:24:21
    |
 LL |         pub impl(in super::E) trait T6 {}
    |                     ^^^^^^^^ not a module
 
 error[E0577]: expected module, found enum `super::G`
-  --> $DIR/restriction_resolution_errors.rs:39:21
+  --> $DIR/restriction_resolution_errors.rs:38:21
    |
 LL |         pub impl(in super::G) trait L2 {}
    |                     ^^^^^^^^ not a module
 
 error[E0577]: expected module, found enum `crate::a::E`
-  --> $DIR/restriction_resolution_errors.rs:52:13
+  --> $DIR/restriction_resolution_errors.rs:51:13
    |
 LL |     pub mod b {
    |     --------- similarly named module `b` defined here
@@ -120,7 +120,7 @@ LL + pub impl(in crate::a::b) trait T14 {}
    |
 
 error[E0577]: expected module, found enum `crate::I`
-  --> $DIR/restriction_resolution_errors.rs:64:13
+  --> $DIR/restriction_resolution_errors.rs:63:13
    |
 LL | pub mod a {
    | --------- similarly named module `a` defined here
@@ -135,7 +135,7 @@ LL + pub impl(in crate::a) trait L5 {}
    |
 
 error[E0577]: expected module, found enum `m7`
-  --> $DIR/restriction_resolution_errors.rs:81:21
+  --> $DIR/restriction_resolution_errors.rs:80:21
    |
 LL |         pub impl(in m7) trait U5 {}
    |                     ^^ not a module

--- a/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.rs
+++ b/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.rs
@@ -1,5 +1,4 @@
 #![feature(impl_restriction, auto_traits, const_trait_impl, trait_alias)]
-#![expect(incomplete_features)]
 
 impl(crate) trait Alias = Copy; //~ ERROR trait aliases cannot be `impl`-restricted
 impl(in crate) auto trait AutoAlias = Copy; //~ ERROR trait aliases cannot be `impl`-restricted

--- a/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.stderr
+++ b/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.stderr
@@ -1,71 +1,71 @@
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:4:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:3:1
    |
 LL | impl(crate) trait Alias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `auto`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:5:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:4:1
    |
 LL | impl(in crate) auto trait AutoAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `auto`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:5:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:4:1
    |
 LL | impl(in crate) auto trait AutoAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `unsafe`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:7:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:6:1
    |
 LL | impl(self) unsafe trait UnsafeAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `unsafe`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:7:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:6:1
    |
 LL | impl(self) unsafe trait UnsafeAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:9:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:8:1
    |
 LL | impl(in self) const trait ConstAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:12:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:11:5
    |
 LL |     impl(super) trait InnerAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `unsafe`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:13:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:12:5
    |
 LL |     impl(in crate::foo) const unsafe trait InnerConstUnsafeAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `unsafe`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:13:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:12:5
    |
 LL |     impl(in crate::foo) const unsafe trait InnerConstUnsafeAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `auto`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:15:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:14:5
    |
 LL |     impl(in crate::foo) unsafe auto trait InnerUnsafeAutoAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `auto`
 
 error: trait aliases cannot be `unsafe`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:15:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:14:5
    |
 LL |     impl(in crate::foo) unsafe auto trait InnerUnsafeAutoAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `unsafe`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:15:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:14:5
    |
 LL |     impl(in crate::foo) unsafe auto trait InnerUnsafeAutoAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Following the discussion on Zulip ([#gsoc > Idea: Implementing impl and mut restrictions @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Idea.3A.20Implementing.20impl.20and.20mut.20restrictions/near/590562763)),this PR removes the incomplete marker from `#[feature(impl_restriction)]`.
Tracking issue for restrictions: rust-lang/rust#105077.

r? @Urgau
cc @jhpratt 