### PR TITLE
Always use `ConstFn` context for `const` closures

### DIFF
--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -317,11 +317,9 @@ impl<'tcx> TyCtxt<'tcx> {
             BodyOwnerKind::Static(mutability) => ConstContext::Static(mutability),
 
             BodyOwnerKind::Fn if self.is_constructor(def_id) => return None,
-            // Const closures use their parent's const context
-            BodyOwnerKind::Closure if self.is_const_fn(def_id) => {
-                return self.hir_body_const_context(self.local_parent(local_def_id));
+            BodyOwnerKind::Fn | BodyOwnerKind::Closure if self.is_const_fn(def_id) => {
+                ConstContext::ConstFn
             }
-            BodyOwnerKind::Fn if self.is_const_fn(def_id) => ConstContext::ConstFn,
             BodyOwnerKind::Fn | BodyOwnerKind::Closure | BodyOwnerKind::GlobalAsm => return None,
         };
 

--- a/tests/ui/traits/const-traits/call-const-closure.next.stderr
+++ b/tests/ui/traits/const-traits/call-const-closure.next.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `(): const Bar` is not satisfied
+error[E0277]: the trait bound `(): [const] Bar` is not satisfied
   --> $DIR/call-const-closure.rs:16:18
    |
 LL |     (const || ().foo())();

--- a/tests/ui/traits/const-traits/call-const-closure.old.stderr
+++ b/tests/ui/traits/const-traits/call-const-closure.old.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `(): const Bar` is not satisfied
+error[E0277]: the trait bound `(): [const] Bar` is not satisfied
   --> $DIR/call-const-closure.rs:16:18
    |
 LL |     (const || ().foo())();

--- a/tests/ui/traits/const-traits/call-const-closure.rs
+++ b/tests/ui/traits/const-traits/call-const-closure.rs
@@ -14,7 +14,7 @@ impl Bar for () {
 
 const FOO: () = {
     (const || ().foo())();
-    //~^ ERROR the trait bound `(): const Bar` is not satisfied
+    //~^ ERROR the trait bound `(): [const] Bar` is not satisfied
 };
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-closure-fn-ptr-const-item.rs
+++ b/tests/ui/traits/const-traits/const-closure-fn-ptr-const-item.rs
@@ -1,0 +1,11 @@
+//@ run-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/155803
+
+#![feature(const_closures, const_trait_impl)]
+
+const F: fn() -> i32 = const || 42;
+
+fn main() {
+    assert_eq!(F(), 42);
+}

--- a/tests/ui/traits/const-traits/const-closure-link-dead-code.rs
+++ b/tests/ui/traits/const-traits/const-closure-link-dead-code.rs
@@ -1,0 +1,12 @@
+//@ build-pass
+//@ compile-flags: -Clink-dead-code=true
+
+// Regression test for https://github.com/rust-lang/rust/issues/155803
+
+#![feature(const_closures, const_trait_impl)]
+
+const _: () = {
+    assert!((const || true)());
+};
+
+fn main() {}


### PR DESCRIPTION
fixes rust-lang/rust#155803

Since https://github.com/rust-lang/rust/commit/e8a46117795f82f35e2f4087516a8743e28ba174, `hir_body_const_context()` returned the parent's const context for a `const` closure. But a `const` closure can escape its enclosing body via a `fn`-pointer-typed const item or an opaque return type and be invoked at runtime, so it must be const-checked under the most restrictive `ConstFn` context like a regular `const fn`.

r? oli-obk (since you authored the commit mentioned above, feel free to reroll)