### PR TITLE
Expand the initialism UCRT in rustc book

### DIFF
--- a/src/doc/rustc/src/platform-support/windows-gnullvm.md
+++ b/src/doc/rustc/src/platform-support/windows-gnullvm.md
@@ -2,7 +2,7 @@
 
 **Tier: 2 (with host tools)**
 
-Windows targets similar to `*-windows-gnu` but using UCRT as the runtime and various LLVM tools/libraries instead of
+Windows targets similar to `*-windows-gnu` but using Universal C Runtime (UCRT) as the runtime and various LLVM tools/libraries instead of
 GCC/Binutils.
 
 Target triples available so far:


### PR DESCRIPTION
This PR adds a commit expanding the initialism UCRT on first use in the rusct book chapter on the [*-windows-gnullvm platform support](https://doc.rust-lang.org/nightly/rustc/platform-support/windows-gnullvm.html), making the chapter easier to understand. Microsoft, the originator of this technology (and thus, the canonical source for the acronym) in Windows, expands it to _Universal C Runtime_[^1][^2][^3]. The same expansion is added to the chapter.

[^1]: https://learn.microsoft.com/en-us/cpp/porting/upgrade-your-code-to-the-universal-crt
[^2]: https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment
[^3]: https://devblogs.microsoft.com/cppblog/introducing-the-universal-crt/

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
