### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/library/std/src/sys/process/unix/common/cstring_array.rs
+++ b/library/std/src/sys/process/unix/common/cstring_array.rs
@@ -35,10 +35,12 @@ impl CStringArray {
     /// Push an additional string to the array.
     pub fn push(&mut self, item: CString) {
         let argc = self.ptrs.len() - 1;
-        // Replace the null pointer at the end of the array...
-        self.ptrs[argc] = item.into_raw();
-        // ... and recreate it to restore the data structure invariant.
+        // Amend the array by another null pointer first, to ensure that the
+        // array is null-terminated even when the `push` panics, in which case
+        // the array will be left undisturbed (see #155748).
         self.ptrs.push(ptr::null());
+        // Now, replace the previous null pointer.
+        self.ptrs[argc] = item.into_raw();
     }
 
     /// Returns a pointer to the C-string array managed by this type.

--- a/src/doc/rustc/src/platform-support/windows-gnullvm.md
+++ b/src/doc/rustc/src/platform-support/windows-gnullvm.md
@@ -2,7 +2,7 @@
 
 **Tier: 2 (with host tools)**
 
-Windows targets similar to `*-windows-gnu` but using UCRT as the runtime and various LLVM tools/libraries instead of
+Windows targets similar to `*-windows-gnu` but using Universal C Runtime (UCRT) as the runtime and various LLVM tools/libraries instead of
 GCC/Binutils.
 
 Target triples available so far:


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155774 (std: maintain `CStringArray` null-termination even if `Vec::push` panics)
 - rust-lang/rust#155810 (Expand the initialism UCRT in rustc book)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155774,155810)
<!-- homu-ignore:end -->

