### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -235,34 +235,6 @@ impl AttributeExt for Attribute {
         }
     }
 
-    fn deprecation_note(&self) -> Option<Ident> {
-        match &self.kind {
-            AttrKind::Normal(normal) if normal.item.path == sym::deprecated => {
-                let meta = &normal.item;
-
-                // #[deprecated = "..."]
-                if let Some(s) = meta.value_str() {
-                    return Some(Ident { name: s, span: meta.span() });
-                }
-
-                // #[deprecated(note = "...")]
-                if let Some(list) = meta.meta_item_list() {
-                    for nested in list {
-                        if let Some(mi) = nested.meta_item()
-                            && mi.path == sym::note
-                            && let Some(s) = mi.value_str()
-                        {
-                            return Some(Ident { name: s, span: mi.span });
-                        }
-                    }
-                }
-
-                None
-            }
-            _ => None,
-        }
-    }
-
     fn doc_resolution_scope(&self) -> Option<AttrStyle> {
         match &self.kind {
             AttrKind::DocComment(..) => Some(self.style),

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -341,6 +341,34 @@ impl Attribute {
             )],
         }
     }
+
+    pub fn deprecation_note(&self) -> Option<Ident> {
+        match &self.kind {
+            AttrKind::Normal(normal) if normal.item.path == sym::deprecated => {
+                let meta = &normal.item;
+
+                // #[deprecated = "..."]
+                if let Some(s) = meta.value_str() {
+                    return Some(Ident { name: s, span: meta.span() });
+                }
+
+                // #[deprecated(note = "...")]
+                if let Some(list) = meta.meta_item_list() {
+                    for nested in list {
+                        if let Some(mi) = nested.meta_item()
+                            && mi.path == sym::note
+                            && let Some(s) = mi.value_str()
+                        {
+                            return Some(Ident { name: s, span: mi.span });
+                        }
+                    }
+                }
+
+                None
+            }
+            _ => None,
+        }
+    }
 }
 
 impl AttrItem {
@@ -824,19 +852,19 @@ pub fn mk_attr_name_value_str(
     mk_attr(g, style, unsafety, path, args, span)
 }
 
-pub fn filter_by_name<A: AttributeExt>(attrs: &[A], name: Symbol) -> impl Iterator<Item = &A> {
+pub fn filter_by_name(attrs: &[Attribute], name: Symbol) -> impl Iterator<Item = &Attribute> {
     attrs.iter().filter(move |attr| attr.has_name(name))
 }
 
-pub fn find_by_name<A: AttributeExt>(attrs: &[A], name: Symbol) -> Option<&A> {
+pub fn find_by_name(attrs: &[Attribute], name: Symbol) -> Option<&Attribute> {
     filter_by_name(attrs, name).next()
 }
 
-pub fn first_attr_value_str_by_name(attrs: &[impl AttributeExt], name: Symbol) -> Option<Symbol> {
+pub fn first_attr_value_str_by_name(attrs: &[Attribute], name: Symbol) -> Option<Symbol> {
     find_by_name(attrs, name).and_then(|attr| attr.value_str())
 }
 
-pub fn contains_name(attrs: &[impl AttributeExt], name: Symbol) -> bool {
+pub fn contains_name(attrs: &[Attribute], name: Symbol) -> bool {
     find_by_name(attrs, name).is_some()
 }
 
@@ -910,11 +938,6 @@ pub trait AttributeExt: Debug {
     /// * `#[doc = "doc"]` returns `Some("doc")`.
     /// * `#[doc(...)]` returns `None`.
     fn doc_str(&self) -> Option<Symbol>;
-
-    /// Returns the deprecation note if this is deprecation attribute.
-    /// * `#[deprecated = "note"]` returns `Some("note")`.
-    /// * `#[deprecated(note = "note", ...)]` returns `Some("note")`.
-    fn deprecation_note(&self) -> Option<Ident>;
 
     /// Returns whether this attribute is any of the proc macro attributes.
     /// i.e. `proc_macro`, `proc_macro_attribute` or `proc_macro_derive`.

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -1,7 +1,6 @@
 use std::num::IntErrorKind;
 
-use rustc_ast::LitKind;
-use rustc_ast::attr::AttributeExt;
+use rustc_ast::{LitKind, ast};
 use rustc_feature::is_builtin_attr_name;
 use rustc_hir::RustcVersion;
 use rustc_hir::limit::Limit;
@@ -27,8 +26,8 @@ pub fn parse_version(s: Symbol) -> Option<RustcVersion> {
     Some(RustcVersion { major, minor, patch })
 }
 
-pub fn is_builtin_attr(attr: &impl AttributeExt) -> bool {
-    attr.is_doc_comment().is_some() || attr.name().is_some_and(|name| is_builtin_attr_name(name))
+pub fn is_builtin_attr(attr: &ast::Attribute) -> bool {
+    attr.is_doc_comment() || attr.name().is_some_and(|name| is_builtin_attr_name(name))
 }
 
 /// Parse a single integer.

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -545,6 +545,49 @@ mod metavar_exprs {
         pub span: Span,
         pub key: MacroRulesNormalizedIdent,
     }
+
+    #[derive(Diagnostic)]
+    #[diag(r#"`${"{"}concat(..){"}"}` is not generating a valid identifier"#)]
+    pub(crate) struct ConcatInvalidIdent {
+        #[primary_span]
+        pub span: Span,
+        #[subdiagnostic]
+        pub reason: InvalidIdentReason,
+    }
+
+    #[derive(Subdiagnostic)]
+    pub(crate) enum InvalidIdentReason {
+        #[note(r#"this `${"{"}concat(..){"}"}` invocation generated an empty ident"#)]
+        Empty,
+        #[note(r#"this `${"{"}concat(..){"}"}` invocation generated `{$symbol}`, but {$start} is neither '_' nor XID_Start"#)]
+        #[note(
+            "see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers"
+        )]
+        InvalidStart { symbol: Symbol, start: char },
+        #[note(r#"this `${"{"}concat(..){"}"}` invocation generated `{$symbol}`, but {$not_continue} is not XID_Continue"#)]
+        #[note(
+            "see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers"
+        )]
+        InvalidContinue { symbol: Symbol, not_continue: char },
+    }
+
+    impl InvalidIdentReason {
+        pub(crate) fn new(symbol: Symbol) -> Self {
+            let mut chars = symbol.as_str().chars();
+            if let Some(start) = chars.next() {
+                if rustc_lexer::is_id_start(start) {
+                    let not_continue = chars
+                        .find(|c| !rustc_lexer::is_id_continue(*c))
+                        .expect("InvalidIdentReason: cannot find invalid ident reason");
+                    InvalidIdentReason::InvalidContinue { symbol, not_continue }
+                } else {
+                    InvalidIdentReason::InvalidStart { symbol, start }
+                }
+            } else {
+                InvalidIdentReason::Empty
+            }
+        }
+    }
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -18,9 +18,10 @@ use rustc_span::{
 use smallvec::{SmallVec, smallvec};
 
 use crate::errors::{
-    CountRepetitionMisplaced, MacroVarStillRepeating, MetaVarsDifSeqMatchers, MustRepeatOnce,
-    MveUnrecognizedVar, NoRepeatableVar, NoSyntaxVarsExprRepeat, VarNoTypo,
-    VarTypoSuggestionRepeatable, VarTypoSuggestionUnrepeatable, VarTypoSuggestionUnrepeatableLabel,
+    ConcatInvalidIdent, CountRepetitionMisplaced, InvalidIdentReason, MacroVarStillRepeating,
+    MetaVarsDifSeqMatchers, MustRepeatOnce, MveUnrecognizedVar, NoRepeatableVar,
+    NoSyntaxVarsExprRepeat, VarNoTypo, VarTypoSuggestionRepeatable, VarTypoSuggestionUnrepeatable,
+    VarTypoSuggestionUnrepeatableLabel,
 };
 use crate::mbe::macro_parser::NamedMatch;
 use crate::mbe::macro_parser::NamedMatch::*;
@@ -656,10 +657,10 @@ fn metavar_expr_concat<'tx>(
     let symbol = nfc_normalize(&concatenated);
     let concatenated_span = tscx.visited_dspan(dspan);
     if !rustc_lexer::is_ident(symbol.as_str()) {
-        return Err(dcx.struct_span_err(
-            concatenated_span,
-            "`${concat(..)}` is not generating a valid identifier",
-        ));
+        return Err(dcx.create_err(ConcatInvalidIdent {
+            span: concatenated_span,
+            reason: InvalidIdentReason::new(symbol),
+        }));
     }
     tscx.psess.symbol_gallery.insert(symbol, concatenated_span);
 

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -549,7 +549,7 @@ declare_features! (
     /// Target features on hexagon.
     (unstable, hexagon_target_feature, "1.27.0", Some(150250)),
     /// Allows `impl(crate) trait Foo` restrictions.
-    (incomplete, impl_restriction, "1.96.0", Some(105077)),
+    (unstable, impl_restriction, "CURRENT_RUSTC_VERSION", Some(105077)),
     /// Allows `impl Trait` to be used inside associated types (RFC 2515).
     (unstable, impl_trait_in_assoc_type, "1.70.0", Some(63063)),
     /// Allows `impl Trait` in bindings (`let`).

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1415,14 +1415,6 @@ impl AttributeExt for Attribute {
         }
     }
 
-    #[inline]
-    fn deprecation_note(&self) -> Option<Ident> {
-        match &self {
-            Attribute::Parsed(AttributeKind::Deprecated { deprecation, .. }) => deprecation.note,
-            _ => None,
-        }
-    }
-
     fn is_automatically_derived_attr(&self) -> bool {
         matches!(self, Attribute::Parsed(AttributeKind::AutomaticallyDerived(..)))
     }

--- a/compiler/rustc_mir_transform/src/ssa_range_prop.rs
+++ b/compiler/rustc_mir_transform/src/ssa_range_prop.rs
@@ -143,14 +143,13 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
     fn visit_statement(&mut self, statement: &mut Statement<'tcx>, location: Location) {
         self.super_statement(statement, location);
         match &statement.kind {
-            StatementKind::Intrinsic(box NonDivergingIntrinsic::Assume(operand)) => {
+            StatementKind::Intrinsic(box NonDivergingIntrinsic::Assume(operand))
                 if let Some(place) = operand.place()
-                    && self.is_ssa(place)
-                {
-                    let successor = location.successor_within_block();
-                    let range = WrappingRange { start: 1, end: 1 };
-                    self.insert_range(place, successor, range);
-                }
+                    && self.is_ssa(place) =>
+            {
+                let successor = location.successor_within_block();
+                let range = WrappingRange { start: 1, end: 1 };
+                self.insert_range(place, successor, range);
             }
             _ => {}
         }
@@ -159,58 +158,56 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
     fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
         self.super_terminator(terminator, location);
         match &terminator.kind {
-            TerminatorKind::Assert { cond, expected, target, .. } => {
+            TerminatorKind::Assert { cond, expected, target, .. }
                 if let Some(place) = cond.place()
+                    && self.is_ssa(place) =>
+            {
+                let successor = Location { block: *target, statement_index: 0 };
+                if location.dominates(successor, &self.dominators) {
+                    assert_ne!(location.block, successor.block);
+                    let val = *expected as u128;
+                    let range = WrappingRange { start: val, end: val };
+                    self.insert_range(place, successor, range);
+                }
+            }
+            TerminatorKind::SwitchInt { discr, targets }
+                if let Some(place) = discr.place()
                     && self.is_ssa(place)
-                {
-                    let successor = Location { block: *target, statement_index: 0 };
-                    if location.dominates(successor, &self.dominators) {
+                    // Reduce the potential compile-time overhead.
+                    && targets.all_targets().len() < 16 =>
+            {
+                let mut distinct_targets: FxHashMap<BasicBlock, u64> = FxHashMap::default();
+                for (_, target) in targets.iter() {
+                    let targets = distinct_targets.entry(target).or_default();
+                    *targets += 1;
+                }
+                for (val, target) in targets.iter() {
+                    if distinct_targets[&target] != 1 {
+                        // FIXME: For multiple targets, the range can be the union of their values.
+                        continue;
+                    }
+                    let successor = Location { block: target, statement_index: 0 };
+                    if self.unique_predecessors.contains(successor.block) {
                         assert_ne!(location.block, successor.block);
-                        let val = *expected as u128;
                         let range = WrappingRange { start: val, end: val };
                         self.insert_range(place, successor, range);
                     }
                 }
-            }
-            TerminatorKind::SwitchInt { discr, targets } => {
-                if let Some(place) = discr.place()
-                    && self.is_ssa(place)
-                    // Reduce the potential compile-time overhead.
-                    && targets.all_targets().len() < 16
-                {
-                    let mut distinct_targets: FxHashMap<BasicBlock, u64> = FxHashMap::default();
-                    for (_, target) in targets.iter() {
-                        let targets = distinct_targets.entry(target).or_default();
-                        *targets += 1;
-                    }
-                    for (val, target) in targets.iter() {
-                        if distinct_targets[&target] != 1 {
-                            // FIXME: For multiple targets, the range can be the union of their values.
-                            continue;
-                        }
-                        let successor = Location { block: target, statement_index: 0 };
-                        if self.unique_predecessors.contains(successor.block) {
-                            assert_ne!(location.block, successor.block);
-                            let range = WrappingRange { start: val, end: val };
-                            self.insert_range(place, successor, range);
-                        }
-                    }
 
-                    // FIXME: The range for the otherwise target be extend to more types.
-                    // For instance, `val` is within the range [4, 1) at the otherwise target of `matches!(val, 1 | 2 | 3)`.
-                    let otherwise = Location { block: targets.otherwise(), statement_index: 0 };
-                    if place.ty(self.local_decls, self.tcx).ty.is_bool()
-                        && let [val] = targets.all_values()
-                        && self.unique_predecessors.contains(otherwise.block)
-                    {
-                        assert_ne!(location.block, otherwise.block);
-                        let range = if val.get() == 0 {
-                            WrappingRange { start: 1, end: 1 }
-                        } else {
-                            WrappingRange { start: 0, end: 0 }
-                        };
-                        self.insert_range(place, otherwise, range);
-                    }
+                // FIXME: The range for the otherwise target be extend to more types.
+                // For instance, `val` is within the range [4, 1) at the otherwise target of `matches!(val, 1 | 2 | 3)`.
+                let otherwise = Location { block: targets.otherwise(), statement_index: 0 };
+                if place.ty(self.local_decls, self.tcx).ty.is_bool()
+                    && let [val] = targets.all_values()
+                    && self.unique_predecessors.contains(otherwise.block)
+                {
+                    assert_ne!(location.block, otherwise.block);
+                    let range = if val.get() == 0 {
+                        WrappingRange { start: 1, end: 1 }
+                    } else {
+                        WrappingRange { start: 0, end: 0 }
+                    };
+                    self.insert_range(place, otherwise, range);
                 }
             }
             _ => {}

--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -409,7 +409,7 @@ pub fn may_be_doc_link(link_type: LinkType) -> bool {
 
 /// Simplified version of `preprocessed_markdown_links` from rustdoc.
 /// Must return at least the same links as it, but may add some more links on top of that.
-pub(crate) fn attrs_to_preprocessed_links<A: AttributeExt + Clone>(attrs: &[A]) -> Vec<Box<str>> {
+pub(crate) fn attrs_to_preprocessed_links(attrs: &[ast::Attribute]) -> Vec<Box<str>> {
     let (doc_fragments, other_attrs) =
         attrs_to_doc_fragments(attrs.iter().map(|attr| (attr, None)), false);
     let mut doc =

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -8,7 +8,6 @@ use arrayvec::ArrayVec;
 use itertools::Either;
 use rustc_abi::{ExternAbi, VariantIdx};
 use rustc_ast as ast;
-use rustc_ast::attr::AttributeExt;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir as hir;
@@ -501,11 +500,7 @@ impl Item {
     }
 
     pub(crate) fn attr_span(&self, tcx: TyCtxt<'_>) -> rustc_span::Span {
-        let deprecation_notes = self
-            .attrs
-            .other_attrs
-            .iter()
-            .filter_map(|attr| attr.deprecation_note().map(|note| note.span));
+        let deprecation_notes = find_attr!(&self.attrs.other_attrs, Deprecated { deprecation, .. } => deprecation.note.map(|note| note.span)).flatten();
 
         span_of_fragments(&self.attrs.doc_strings)
             .into_iter()

--- a/tests/ui/impl-restriction/auxiliary/external-impl-restriction.rs
+++ b/tests/ui/impl-restriction/auxiliary/external-impl-restriction.rs
@@ -1,5 +1,4 @@
 #![feature(impl_restriction)]
-#![expect(incomplete_features)]
 
 pub impl(crate) trait TopLevel {}
 

--- a/tests/ui/impl-restriction/feature-gate-impl-restriction.rs
+++ b/tests/ui/impl-restriction/feature-gate-impl-restriction.rs
@@ -3,7 +3,6 @@
 //@[with_gate] check-pass
 
 #![cfg_attr(with_gate, feature(impl_restriction))]
-#![cfg_attr(with_gate, allow(incomplete_features))]
 #![feature(auto_traits, const_trait_impl)]
 
 pub impl(crate) trait Bar {} //[without_gate]~ ERROR `impl` restrictions are experimental

--- a/tests/ui/impl-restriction/feature-gate-impl-restriction.without_gate.stderr
+++ b/tests/ui/impl-restriction/feature-gate-impl-restriction.without_gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:9:5
+  --> $DIR/feature-gate-impl-restriction.rs:8:5
    |
 LL | pub impl(crate) trait Bar {}
    |     ^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | pub impl(crate) trait Bar {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:10:5
+  --> $DIR/feature-gate-impl-restriction.rs:9:5
    |
 LL | pub impl(in crate) trait BarInCrate {}
    |     ^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | pub impl(in crate) trait BarInCrate {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:13:9
+  --> $DIR/feature-gate-impl-restriction.rs:12:9
    |
 LL |     pub impl(in crate::foo) trait Baz {}
    |         ^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     pub impl(in crate::foo) trait Baz {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:14:9
+  --> $DIR/feature-gate-impl-restriction.rs:13:9
    |
 LL |     pub impl(super) unsafe trait BazUnsafeSuper {}
    |         ^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     pub impl(super) unsafe trait BazUnsafeSuper {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:15:9
+  --> $DIR/feature-gate-impl-restriction.rs:14:9
    |
 LL |     pub impl(self) auto trait BazAutoSelf {}
    |         ^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     pub impl(self) auto trait BazAutoSelf {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:16:9
+  --> $DIR/feature-gate-impl-restriction.rs:15:9
    |
 LL |     pub impl(in self) const trait BazConst {}
    |         ^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     pub impl(in self) const trait BazConst {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:19:13
+  --> $DIR/feature-gate-impl-restriction.rs:18:13
    |
 LL |         pub impl(in crate::foo::foo_inner) trait Qux {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |         pub impl(in crate::foo::foo_inner) trait Qux {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:20:13
+  --> $DIR/feature-gate-impl-restriction.rs:19:13
    |
 LL | ...   pub impl(in crate::foo::foo_inner) unsafe auto trait QuxAutoUnsafe {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL | ...   pub impl(in crate::foo::foo_inner) unsafe auto trait QuxAutoUnsafe {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:21:13
+  --> $DIR/feature-gate-impl-restriction.rs:20:13
    |
 LL | ...   pub impl(in crate::foo::foo_inner) const unsafe trait QuxConstUnsafe {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL | ...   pub impl(in crate::foo::foo_inner) const unsafe trait QuxConstUnsafe 
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:25:9
+  --> $DIR/feature-gate-impl-restriction.rs:24:9
    |
 LL |     pub impl(crate) trait Bar {}
    |         ^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     pub impl(crate) trait Bar {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:27:9
+  --> $DIR/feature-gate-impl-restriction.rs:26:9
    |
 LL |     pub impl(in crate) trait BarInCrate {}
    |         ^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     pub impl(in crate) trait BarInCrate {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:29:9
+  --> $DIR/feature-gate-impl-restriction.rs:28:9
    |
 LL |     pub impl(self) unsafe trait BazUnsafeSelf {}
    |         ^^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     pub impl(self) unsafe trait BazUnsafeSelf {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:31:9
+  --> $DIR/feature-gate-impl-restriction.rs:30:9
    |
 LL |     pub impl(in super) auto trait BazAutoSuper {}
    |         ^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     pub impl(in super) auto trait BazAutoSuper {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:33:9
+  --> $DIR/feature-gate-impl-restriction.rs:32:9
    |
 LL |     pub impl(super) const trait BazConstSuper {}
    |         ^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL |     pub impl(super) const trait BazConstSuper {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:37:13
+  --> $DIR/feature-gate-impl-restriction.rs:36:13
    |
 LL |         pub impl(in crate::foo::cfged_out_foo) trait CfgedOutQux {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |         pub impl(in crate::foo::cfged_out_foo) trait CfgedOutQux {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:38:13
+  --> $DIR/feature-gate-impl-restriction.rs:37:13
    |
 LL | ...   pub impl(in crate::foo::cfged_out_foo) unsafe auto trait CfgedOutQuxUnsafeAuto {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +159,7 @@ LL | ...   pub impl(in crate::foo::cfged_out_foo) unsafe auto trait CfgedOutQuxU
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: `impl` restrictions are experimental
-  --> $DIR/feature-gate-impl-restriction.rs:39:13
+  --> $DIR/feature-gate-impl-restriction.rs:38:13
    |
 LL | ...   pub impl(in crate::foo::cfged_out_foo) const unsafe trait CfgedOutQuxConstUnsafe {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-restriction/impl-restriction-check.e2015.stderr
+++ b/tests/ui/impl-restriction/impl-restriction-check.e2015.stderr
@@ -1,95 +1,95 @@
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:12:1
+  --> $DIR/impl-restriction-check.rs:11:1
    |
 LL | impl external::TopLevel for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:4:5
+  --> $DIR/auxiliary/external-impl-restriction.rs:3:5
    |
 LL | pub impl(crate) trait TopLevel {}
    |     ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:13:1
+  --> $DIR/impl-restriction-check.rs:12:1
    |
 LL | impl external::inner::Inner for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:7:9
+  --> $DIR/auxiliary/external-impl-restriction.rs:6:9
    |
 LL |     pub impl(self) trait Inner {}
    |         ^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:30:5
+  --> $DIR/impl-restriction-check.rs:29:5
    |
 LL |     impl bar::Foo for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:39:1
+  --> $DIR/impl-restriction-check.rs:38:1
    |
 LL | impl foo::bar::Foo for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo`
-  --> $DIR/impl-restriction-check.rs:41:1
+  --> $DIR/impl-restriction-check.rs:40:1
    |
 LL | impl foo::bar::Bar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:18:20
+  --> $DIR/impl-restriction-check.rs:17:20
    |
 LL |         pub(crate) impl(super) trait Bar {}
    |                    ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:34:5
+  --> $DIR/impl-restriction-check.rs:33:5
    |
 LL |     impl bar::Qux for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo::bar`
-  --> $DIR/impl-restriction-check.rs:44:1
+  --> $DIR/impl-restriction-check.rs:43:1
    |
 LL | impl foo::bar::Qux for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `foo`
-  --> $DIR/impl-restriction-check.rs:46:1
+  --> $DIR/impl-restriction-check.rs:45:1
    |
 LL | impl foo::bar::FooBar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:21:20
+  --> $DIR/impl-restriction-check.rs:20:20
    |
 LL |         pub(crate) impl(in crate::foo) trait FooBar {}
    |                    ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-restriction/impl-restriction-check.e2018.stderr
+++ b/tests/ui/impl-restriction/impl-restriction-check.e2018.stderr
@@ -1,95 +1,95 @@
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:12:1
+  --> $DIR/impl-restriction-check.rs:11:1
    |
 LL | impl external::TopLevel for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:4:5
+  --> $DIR/auxiliary/external-impl-restriction.rs:3:5
    |
 LL | pub impl(crate) trait TopLevel {}
    |     ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `external`
-  --> $DIR/impl-restriction-check.rs:13:1
+  --> $DIR/impl-restriction-check.rs:12:1
    |
 LL | impl external::inner::Inner for LocalType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/auxiliary/external-impl-restriction.rs:7:9
+  --> $DIR/auxiliary/external-impl-restriction.rs:6:9
    |
 LL |     pub impl(self) trait Inner {}
    |         ^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:30:5
+  --> $DIR/impl-restriction-check.rs:29:5
    |
 LL |     impl bar::Foo for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:39:1
+  --> $DIR/impl-restriction-check.rs:38:1
    |
 LL | impl foo::bar::Foo for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:17:20
+  --> $DIR/impl-restriction-check.rs:16:20
    |
 LL |         pub(crate) impl(self) trait Foo {}
    |                    ^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo`
-  --> $DIR/impl-restriction-check.rs:41:1
+  --> $DIR/impl-restriction-check.rs:40:1
    |
 LL | impl foo::bar::Bar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:18:20
+  --> $DIR/impl-restriction-check.rs:17:20
    |
 LL |         pub(crate) impl(super) trait Bar {}
    |                    ^^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:34:5
+  --> $DIR/impl-restriction-check.rs:33:5
    |
 LL |     impl bar::Qux for i8 {}
    |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo::bar`
-  --> $DIR/impl-restriction-check.rs:44:1
+  --> $DIR/impl-restriction-check.rs:43:1
    |
 LL | impl foo::bar::Qux for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:20:20
+  --> $DIR/impl-restriction-check.rs:19:20
    |
 LL |         pub(crate) impl(in crate::foo::bar) trait Qux {}
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait cannot be implemented outside `crate::foo`
-  --> $DIR/impl-restriction-check.rs:46:1
+  --> $DIR/impl-restriction-check.rs:45:1
    |
 LL | impl foo::bar::FooBar for u8 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: trait restricted here
-  --> $DIR/impl-restriction-check.rs:21:20
+  --> $DIR/impl-restriction-check.rs:20:20
    |
 LL |         pub(crate) impl(in crate::foo) trait FooBar {}
    |                    ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-restriction/impl-restriction-check.rs
+++ b/tests/ui/impl-restriction/impl-restriction-check.rs
@@ -3,7 +3,6 @@
 //@ [e2015] edition: 2015
 //@ [e2018] edition: 2018..
 #![feature(impl_restriction)]
-#![expect(incomplete_features)]
 
 extern crate external_impl_restriction as external;
 

--- a/tests/ui/impl-restriction/recover-incorrect-impl-restriction.rs
+++ b/tests/ui/impl-restriction/recover-incorrect-impl-restriction.rs
@@ -1,5 +1,4 @@
 #![feature(impl_restriction, auto_traits, const_trait_impl)]
-#![expect(incomplete_features)]
 
 mod foo {
     pub impl(crate::foo) trait Baz {} //~ ERROR incorrect `impl` restriction

--- a/tests/ui/impl-restriction/recover-incorrect-impl-restriction.stderr
+++ b/tests/ui/impl-restriction/recover-incorrect-impl-restriction.stderr
@@ -1,5 +1,5 @@
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:5:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:4:14
    |
 LL |     pub impl(crate::foo) trait Baz {}
    |              ^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     pub impl(in crate::foo) trait Baz {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:6:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:5:14
    |
 LL |     pub impl(crate::foo) unsafe trait BazUnsafe {}
    |              ^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     pub impl(in crate::foo) unsafe trait BazUnsafe {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:7:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:6:14
    |
 LL |     pub impl(crate::foo) auto trait BazAuto {}
    |              ^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     pub impl(in crate::foo) auto trait BazAuto {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:8:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:7:14
    |
 LL |     pub impl(crate::foo) const trait BazConst {}
    |              ^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     pub impl(in crate::foo) const trait BazConst {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:9:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:8:14
    |
 LL |     pub impl(crate::foo) const unsafe trait BazConstUnsafe {}
    |              ^^^^^^^^^^
@@ -79,7 +79,7 @@ LL |     pub impl(in crate::foo) const unsafe trait BazConstUnsafe {}
    |              ++
 
 error: incorrect `impl` restriction
-  --> $DIR/recover-incorrect-impl-restriction.rs:10:14
+  --> $DIR/recover-incorrect-impl-restriction.rs:9:14
    |
 LL |     pub impl(crate::foo) unsafe auto trait BazUnsafeAuto {}
    |              ^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     pub impl(in crate::foo) unsafe auto trait BazUnsafeAuto {}
    |              ++
 
 error: expected one of `for`, `where`, or `{`, found keyword `trait`
-  --> $DIR/recover-incorrect-impl-restriction.rs:17:33
+  --> $DIR/recover-incorrect-impl-restriction.rs:16:33
    |
 LL |     pub unsafe impl(crate::foo) trait BadOrder1 {}
    |                                 ^^^^^ expected one of `for`, `where`, or `{`

--- a/tests/ui/impl-restriction/restriction_resolution_errors.rs
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.rs
@@ -1,6 +1,5 @@
 //@ aux-build: external-impl-restriction.rs
 #![feature(impl_restriction)]
-#![expect(incomplete_features)]
 
 extern crate external_impl_restriction as external;
 

--- a/tests/ui/impl-restriction/restriction_resolution_errors.stderr
+++ b/tests/ui/impl-restriction/restriction_resolution_errors.stderr
@@ -1,77 +1,77 @@
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:17:21
+  --> $DIR/restriction_resolution_errors.rs:16:21
    |
 LL |         pub impl(in ::std) trait T2 {}
    |                     ^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:19:21
+  --> $DIR/restriction_resolution_errors.rs:18:21
    |
 LL |         pub impl(in self::c) trait T3 {}
    |                     ^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:21:21
+  --> $DIR/restriction_resolution_errors.rs:20:21
    |
 LL |         pub impl(in super::d) trait T4 {}
    |                     ^^^^^^^^
 
 error[E0433]: too many leading `super` keywords
-  --> $DIR/restriction_resolution_errors.rs:27:35
+  --> $DIR/restriction_resolution_errors.rs:26:35
    |
 LL |         pub impl(in super::super::super) trait T7 {}
    |                                   ^^^^^ there are too many leading `super` keywords
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:37:21
+  --> $DIR/restriction_resolution_errors.rs:36:21
    |
 LL |         pub impl(in self::f) trait L1 {}
    |                     ^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:41:21
+  --> $DIR/restriction_resolution_errors.rs:40:21
    |
 LL |         pub impl(in super::h) trait L3 {}
    |                     ^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:50:13
+  --> $DIR/restriction_resolution_errors.rs:49:13
    |
 LL | pub impl(in crate::a) trait T13 {}
    |             ^^^^^^^^
 
 error[E0433]: too many leading `super` keywords
-  --> $DIR/restriction_resolution_errors.rs:57:10
+  --> $DIR/restriction_resolution_errors.rs:56:10
    |
 LL | pub impl(super) trait T17 {}
    |          ^^^^^ there are too many leading `super` keywords
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:59:13
+  --> $DIR/restriction_resolution_errors.rs:58:13
    |
 LL | pub impl(in external) trait T18 {}
    |             ^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:62:13
+  --> $DIR/restriction_resolution_errors.rs:61:13
    |
 LL | pub impl(in crate::j) trait L4 {}
    |             ^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:78:21
+  --> $DIR/restriction_resolution_errors.rs:77:21
    |
 LL |         pub impl(in crate::m2) trait U2 {}
    |                     ^^^^^^^^^
 
 error: trait implementation can only be restricted to ancestor modules
-  --> $DIR/restriction_resolution_errors.rs:80:21
+  --> $DIR/restriction_resolution_errors.rs:79:21
    |
 LL |         pub impl(in m6::m5) trait U4 {}
    |                     ^^^^^^
 
 error[E0433]: cannot find module or crate `a` in this scope
-  --> $DIR/restriction_resolution_errors.rs:15:21
+  --> $DIR/restriction_resolution_errors.rs:14:21
    |
 LL |         pub impl(in a::b) trait T1 {}
    |                     ^ use of unresolved module or unlinked crate `a`
@@ -87,25 +87,25 @@ LL +         use a;
    |
 
 error[E0433]: cannot find module `c` in the crate root
-  --> $DIR/restriction_resolution_errors.rs:23:28
+  --> $DIR/restriction_resolution_errors.rs:22:28
    |
 LL |         pub impl(in crate::c) trait T5 {}
    |                            ^ not found in the crate root
 
 error[E0577]: expected module, found enum `super::E`
-  --> $DIR/restriction_resolution_errors.rs:25:21
+  --> $DIR/restriction_resolution_errors.rs:24:21
    |
 LL |         pub impl(in super::E) trait T6 {}
    |                     ^^^^^^^^ not a module
 
 error[E0577]: expected module, found enum `super::G`
-  --> $DIR/restriction_resolution_errors.rs:39:21
+  --> $DIR/restriction_resolution_errors.rs:38:21
    |
 LL |         pub impl(in super::G) trait L2 {}
    |                     ^^^^^^^^ not a module
 
 error[E0577]: expected module, found enum `crate::a::E`
-  --> $DIR/restriction_resolution_errors.rs:52:13
+  --> $DIR/restriction_resolution_errors.rs:51:13
    |
 LL |     pub mod b {
    |     --------- similarly named module `b` defined here
@@ -120,7 +120,7 @@ LL + pub impl(in crate::a::b) trait T14 {}
    |
 
 error[E0577]: expected module, found enum `crate::I`
-  --> $DIR/restriction_resolution_errors.rs:64:13
+  --> $DIR/restriction_resolution_errors.rs:63:13
    |
 LL | pub mod a {
    | --------- similarly named module `a` defined here
@@ -135,7 +135,7 @@ LL + pub impl(in crate::a) trait L5 {}
    |
 
 error[E0577]: expected module, found enum `m7`
-  --> $DIR/restriction_resolution_errors.rs:81:21
+  --> $DIR/restriction_resolution_errors.rs:80:21
    |
 LL |         pub impl(in m7) trait U5 {}
    |                     ^^ not a module

--- a/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.rs
+++ b/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.rs
@@ -1,5 +1,4 @@
 #![feature(impl_restriction, auto_traits, const_trait_impl, trait_alias)]
-#![expect(incomplete_features)]
 
 impl(crate) trait Alias = Copy; //~ ERROR trait aliases cannot be `impl`-restricted
 impl(in crate) auto trait AutoAlias = Copy; //~ ERROR trait aliases cannot be `impl`-restricted

--- a/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.stderr
+++ b/tests/ui/impl-restriction/trait-alias-cannot-be-impl-restricted.stderr
@@ -1,71 +1,71 @@
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:4:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:3:1
    |
 LL | impl(crate) trait Alias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `auto`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:5:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:4:1
    |
 LL | impl(in crate) auto trait AutoAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `auto`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:5:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:4:1
    |
 LL | impl(in crate) auto trait AutoAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `unsafe`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:7:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:6:1
    |
 LL | impl(self) unsafe trait UnsafeAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `unsafe`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:7:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:6:1
    |
 LL | impl(self) unsafe trait UnsafeAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:9:1
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:8:1
    |
 LL | impl(in self) const trait ConstAlias = Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:12:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:11:5
    |
 LL |     impl(super) trait InnerAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `unsafe`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:13:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:12:5
    |
 LL |     impl(in crate::foo) const unsafe trait InnerConstUnsafeAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `unsafe`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:13:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:12:5
    |
 LL |     impl(in crate::foo) const unsafe trait InnerConstUnsafeAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted
 
 error: trait aliases cannot be `auto`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:15:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:14:5
    |
 LL |     impl(in crate::foo) unsafe auto trait InnerUnsafeAutoAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `auto`
 
 error: trait aliases cannot be `unsafe`
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:15:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:14:5
    |
 LL |     impl(in crate::foo) unsafe auto trait InnerUnsafeAutoAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `unsafe`
 
 error: trait aliases cannot be `impl`-restricted
-  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:15:5
+  --> $DIR/trait-alias-cannot-be-impl-restricted.rs:14:5
    |
 LL |     impl(in crate::foo) unsafe auto trait InnerUnsafeAutoAlias = Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait aliases cannot be `impl`-restricted

--- a/tests/ui/macros/metavar-expressions/concat-trace-errors.rs
+++ b/tests/ui/macros/metavar-expressions/concat-trace-errors.rs
@@ -16,18 +16,28 @@ macro_rules! post_expansion {
     ($a:literal) => {
         const _: () = ${concat("hi", $a, "bye")};
         //~^ ERROR is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated `hi!bye`, but '!' is not XID_Continue
+        //~| NOTE see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
     }
 }
 
 post_expansion!("!");
+//~^ NOTE in this expansion of post_expansion!
+//~| NOTE in this expansion of post_expansion!
+//~| NOTE in this expansion of post_expansion!
 
 macro_rules! post_expansion_many {
     ($a:ident, $b:ident, $c:ident, $d:literal, $e:ident) => {
         const _: () = ${concat($a, $b, $c, $d, $e)};
         //~^ ERROR is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated `abc.de`, but '.' is not XID_Continue
+        //~| NOTE see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
     }
 }
 
 post_expansion_many!(a, b, c, ".d", e);
+//~^ NOTE in this expansion of post_expansion_many!
+//~| NOTE in this expansion of post_expansion_many!
+//~| NOTE in this expansion of post_expansion_many!
 
 fn main() {}

--- a/tests/ui/macros/metavar-expressions/concat-trace-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-trace-errors.stderr
@@ -7,10 +7,12 @@ LL |         const _: () = ${concat("hi", $a, "bye")};
 LL | post_expansion!("!");
    | -------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `hi!bye`, but '!' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `post_expansion` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-trace-errors.rs:26:24
+  --> $DIR/concat-trace-errors.rs:31:24
    |
 LL |         const _: () = ${concat($a, $b, $c, $d, $e)};
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,6 +20,8 @@ LL |         const _: () = ${concat($a, $b, $c, $d, $e)};
 LL | post_expansion_many!(a, b, c, ".d", e);
    | -------------------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `abc.de`, but '.' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `post_expansion_many` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/macros/metavar-expressions/concat-usage-errors.rs
+++ b/tests/ui/macros/metavar-expressions/concat-usage-errors.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ dont-require-annotations: NOTE
 
 #![feature(macro_metavar_expr_concat)]
 
@@ -43,6 +44,7 @@ macro_rules! starting_number {
     ($ident:ident) => {{
         let ${concat("1", $ident)}: () = ();
         //~^ ERROR `${concat(..)}` is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated `1_abc`, but '1' is neither '_' nor XID_Start
     }};
 }
 
@@ -56,6 +58,8 @@ macro_rules! starting_invalid_unicode {
     ($ident:ident) => {{
         let ${concat("\u{00BD}", $ident)}: () = ();
         //~^ ERROR `${concat(..)}` is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated `\u{00BD}_abc`, but '\' is neither '_' nor XID_Start
+        //~| NOTE see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
     }};
 }
 
@@ -75,6 +79,7 @@ macro_rules! ending_invalid_unicode {
     ($ident:ident) => {{
         let ${concat($ident, "\u{00BD}")}: () = ();
         //~^ ERROR `${concat(..)}` is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated `_abc\u{00BD}`, but '\' is not XID_Continue
     }};
 }
 
@@ -82,6 +87,7 @@ macro_rules! empty {
     () => {{
         let ${concat("", "")}: () = ();
         //~^ ERROR `${concat(..)}` is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated an empty ident
     }};
 }
 
@@ -130,6 +136,8 @@ macro_rules! bad_literal_string {
         //~| ERROR `${concat(..)}` is not generating a valid identifier
         //~| ERROR `${concat(..)}` is not generating a valid identifier
         //~| ERROR `${concat(..)}` is not generating a valid identifier
+        //~| NOTE this `${concat(..)}` invocation generated `_foo🤷`, but '🤷' is not XID_Continue
+        //~| NOTE this `${concat(..)}` invocation generated `_foo-1`, but '-' is not XID_Continue
     }
 }
 

--- a/tests/ui/macros/metavar-expressions/concat-usage-errors.stderr
+++ b/tests/ui/macros/metavar-expressions/concat-usage-errors.stderr
@@ -1,131 +1,131 @@
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:7:10
+  --> $DIR/concat-usage-errors.rs:8:10
    |
 LL |         ${concat()}
    |          ^^^^^^^^^^
 
 error: `concat` must have at least two elements
-  --> $DIR/concat-usage-errors.rs:10:11
+  --> $DIR/concat-usage-errors.rs:11:11
    |
 LL |         ${concat(aaaa)}
    |           ^^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:13:10
+  --> $DIR/concat-usage-errors.rs:14:10
    |
 LL |         ${concat(aaaa,)}
    |          ^^^^^^^^^^^^^^^
 
 error: expected comma
-  --> $DIR/concat-usage-errors.rs:18:10
+  --> $DIR/concat-usage-errors.rs:19:10
    |
 LL |         ${concat(aaaa aaaa)}
    |          ^^^^^^^^^^^^^^^^^^^
 
 error: `concat` must have at least two elements
-  --> $DIR/concat-usage-errors.rs:21:11
+  --> $DIR/concat-usage-errors.rs:22:11
    |
 LL |         ${concat($ex)}
    |           ^^^^^^
 
 error: expected comma
-  --> $DIR/concat-usage-errors.rs:27:10
+  --> $DIR/concat-usage-errors.rs:28:10
    |
 LL |         ${concat($ex, aaaa 123)}
    |          ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:30:10
+  --> $DIR/concat-usage-errors.rs:31:10
    |
 LL |         ${concat($ex, aaaa,)}
    |          ^^^^^^^^^^^^^^^^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:90:26
+  --> $DIR/concat-usage-errors.rs:96:26
    |
 LL |         let ${concat(_a, 'b')}: () = ();
    |                          ^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:93:26
+  --> $DIR/concat-usage-errors.rs:99:26
    |
 LL |         let ${concat(_a, 1)}: () = ();
    |                          ^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:95:26
+  --> $DIR/concat-usage-errors.rs:101:26
    |
 LL |         let ${concat(_a, 1.5)}: () = ();
    |                          ^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:97:26
+  --> $DIR/concat-usage-errors.rs:103:26
    |
 LL |         let ${concat(_a, c"hi")}: () = ();
    |                          ^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:99:26
+  --> $DIR/concat-usage-errors.rs:105:26
    |
 LL |         let ${concat(_a, b"hi")}: () = ();
    |                          ^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:101:26
+  --> $DIR/concat-usage-errors.rs:107:26
    |
 LL |         let ${concat(_a, b'b')}: () = ();
    |                          ^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:103:26
+  --> $DIR/concat-usage-errors.rs:109:26
    |
 LL |         let ${concat(_a, b'b')}: () = ();
    |                          ^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:106:30
+  --> $DIR/concat-usage-errors.rs:112:30
    |
 LL |         let ${concat($ident, 'b')}: () = ();
    |                              ^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:108:30
+  --> $DIR/concat-usage-errors.rs:114:30
    |
 LL |         let ${concat($ident, 1)}: () = ();
    |                              ^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:110:30
+  --> $DIR/concat-usage-errors.rs:116:30
    |
 LL |         let ${concat($ident, 1.5)}: () = ();
    |                              ^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:112:30
+  --> $DIR/concat-usage-errors.rs:118:30
    |
 LL |         let ${concat($ident, c"hi")}: () = ();
    |                              ^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:114:30
+  --> $DIR/concat-usage-errors.rs:120:30
    |
 LL |         let ${concat($ident, b"hi")}: () = ();
    |                              ^^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:116:30
+  --> $DIR/concat-usage-errors.rs:122:30
    |
 LL |         let ${concat($ident, b'b')}: () = ();
    |                              ^^^^
 
 error: expected identifier or string literal
-  --> $DIR/concat-usage-errors.rs:118:30
+  --> $DIR/concat-usage-errors.rs:124:30
    |
 LL |         let ${concat($ident, b'b')}: () = ();
    |                              ^^^^
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:24:19
+  --> $DIR/concat-usage-errors.rs:25:19
    |
 LL |         ${concat($ex, aaaa)}
    |                   ^^
@@ -133,13 +133,13 @@ LL |         ${concat($ex, aaaa)}
    = note: currently only string and integer literals are supported
 
 error: variable `foo` is not recognized in meta-variable expression
-  --> $DIR/concat-usage-errors.rs:37:30
+  --> $DIR/concat-usage-errors.rs:38:30
    |
 LL |         const ${concat(FOO, $foo)}: i32 = 2;
    |                              ^^^
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:44:14
+  --> $DIR/concat-usage-errors.rs:45:14
    |
 LL |         let ${concat("1", $ident)}: () = ();
    |              ^^^^^^^^^^^^^^^^^^^^^
@@ -147,10 +147,12 @@ LL |         let ${concat("1", $ident)}: () = ();
 LL |     starting_number!(_abc);
    |     ---------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `1_abc`, but '1' is neither '_' nor XID_Start
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `starting_number` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:57:14
+  --> $DIR/concat-usage-errors.rs:59:14
    |
 LL |         let ${concat("\u{00BD}", $ident)}: () = ();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,10 +160,12 @@ LL |         let ${concat("\u{00BD}", $ident)}: () = ();
 LL |     starting_invalid_unicode!(_abc);
    |     ------------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `\u{00BD}_abc`, but '\' is neither '_' nor XID_Start
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `starting_invalid_unicode` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:76:14
+  --> $DIR/concat-usage-errors.rs:80:14
    |
 LL |         let ${concat($ident, "\u{00BD}")}: () = ();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,10 +173,12 @@ LL |         let ${concat($ident, "\u{00BD}")}: () = ();
 LL |     ending_invalid_unicode!(_abc);
    |     ----------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_abc\u{00BD}`, but '\' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `ending_invalid_unicode` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected pattern, found `$`
-  --> $DIR/concat-usage-errors.rs:90:13
+  --> $DIR/concat-usage-errors.rs:96:13
    |
 LL |         let ${concat(_a, 'b')}: () = ();
    |             ^ expected pattern
@@ -183,7 +189,7 @@ LL |     unsupported_literals!(_abc);
    = note: this error originates in the macro `unsupported_literals` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:83:14
+  --> $DIR/concat-usage-errors.rs:88:14
    |
 LL |         let ${concat("", "")}: () = ();
    |              ^^^^^^^^^^^^^^^^
@@ -191,10 +197,11 @@ LL |         let ${concat("", "")}: () = ();
 LL |     empty!();
    |     -------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated an empty ident
    = note: this error originates in the macro `empty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -202,10 +209,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("\u{00BD}");
    |     ------------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_foo\u{00BD}`, but '\' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -213,10 +222,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("\x41");
    |     --------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_foo\x41`, but '\' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,10 +235,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("🤷");
    |     ------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_foo🤷`, but '🤷' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -235,10 +248,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("d[-_-]b");
    |     ------------------------------ in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_food[-_-]b`, but '[' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -246,10 +261,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("-1");
    |     ------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_foo-1`, but '-' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -257,10 +274,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("1.0");
    |     -------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_foo1.0`, but '.' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `${concat(..)}` is not generating a valid identifier
-  --> $DIR/concat-usage-errors.rs:125:16
+  --> $DIR/concat-usage-errors.rs:131:16
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -268,10 +287,12 @@ LL |         const ${concat(_foo, $literal)}: () = ();
 LL |     bad_literal_string!("'1'");
    |     -------------------------- in this macro invocation
    |
+   = note: this `${concat(..)}` invocation generated `_foo'1'`, but '\'' is not XID_Continue
+   = note: see <https://doc.rust-lang.org/reference/identifiers.html> for the definition of valid identifiers
    = note: this error originates in the macro `bad_literal_string` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:146:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -279,16 +300,7 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: currently only string and integer literals are supported
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
-   |
-LL |         const ${concat(_foo, $literal)}: () = ();
-   |                               ^^^^^^^
-   |
-   = note: currently only string and integer literals are supported
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:146:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -297,7 +309,16 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:146:31
+   |
+LL |         const ${concat(_foo, $literal)}: () = ();
+   |                               ^^^^^^^
+   |
+   = note: currently only string and integer literals are supported
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
+  --> $DIR/concat-usage-errors.rs:146:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -306,19 +327,19 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: floats are not supported as metavariables of `${concat(..)}`
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:146:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
 
 error: integer metavariables of `${concat(..)}` must not be suffixed
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:146:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
 
 error: integer metavariables of `${concat(..)}` must not be suffixed
-  --> $DIR/concat-usage-errors.rs:138:31
+  --> $DIR/concat-usage-errors.rs:146:31
    |
 LL |         const ${concat(_foo, $literal)}: () = ();
    |                               ^^^^^^^
@@ -326,7 +347,7 @@ LL |         const ${concat(_foo, $literal)}: () = ();
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:151:31
+  --> $DIR/concat-usage-errors.rs:159:31
    |
 LL |         const ${concat(_foo, $tt)}: () = ();
    |                               ^^
@@ -334,7 +355,7 @@ LL |         const ${concat(_foo, $tt)}: () = ();
    = note: currently only string and integer literals are supported
 
 error: metavariables of `${concat(..)}` must be of type `ident`, `literal` or `tt`
-  --> $DIR/concat-usage-errors.rs:151:31
+  --> $DIR/concat-usage-errors.rs:159:31
    |
 LL |         const ${concat(_foo, $tt)}: () = ();
    |                               ^^


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155757 (macro_metavar_expr_concat: explain why idents are invalid)
 - rust-lang/rust#155779 (ssa_range_prop: use `if let` guards)
 - rust-lang/rust#155789 (Cleanups to `AttributeExt`)
 - rust-lang/rust#155806 (Remove the incomplete marker from `impl` restrictions)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155757,155779,155789,155806)
<!-- homu-ignore:end -->

