### PR TITLE
Add Swift function call ABI

### DIFF
--- a/compiler/rustc_abi/src/canon_abi.rs
+++ b/compiler/rustc_abi/src/canon_abi.rs
@@ -32,6 +32,10 @@ pub enum CanonAbi {
     /// An ABI that rustc does not know how to call or define.
     Custom,
 
+    /// Swift calling convention, exposed via LLVM's `swiftcc`. Cross-platform
+    /// and not tied to a specific target architecture.
+    Swift,
+
     /// ABIs relevant to 32-bit Arm targets
     Arm(ArmCall),
     /// ABI relevant to GPUs: the entry point for a GPU kernel
@@ -58,6 +62,7 @@ impl CanonAbi {
             CanonAbi::Rust | CanonAbi::RustCold | CanonAbi::RustPreserveNone => true,
             CanonAbi::C
             | CanonAbi::Custom
+            | CanonAbi::Swift
             | CanonAbi::Arm(_)
             | CanonAbi::GpuKernel
             | CanonAbi::Interrupt(_)
@@ -77,6 +82,7 @@ impl fmt::Display for CanonAbi {
             CanonAbi::RustCold => ExternAbi::RustCold,
             CanonAbi::RustPreserveNone => ExternAbi::RustPreserveNone,
             CanonAbi::Custom => ExternAbi::Custom,
+            CanonAbi::Swift => ExternAbi::Swift,
             CanonAbi::Arm(arm_call) => match arm_call {
                 ArmCall::Aapcs => ExternAbi::Aapcs { unwind: false },
                 ArmCall::CCmseNonSecureCall => ExternAbi::CmseNonSecureCall,

--- a/compiler/rustc_abi/src/extern_abi.rs
+++ b/compiler/rustc_abi/src/extern_abi.rs
@@ -62,6 +62,10 @@ pub enum ExternAbi {
     /// and only valid on platforms that have a UEFI standard
     EfiApi,
 
+    /// Swift's calling convention, used to interoperate with Swift code without
+    /// going through C as an intermediary.
+    Swift,
+
     /* arm */
     /// Arm Architecture Procedure Call Standard, sometimes `ExternAbi::C` is an alias for this
     Aapcs {
@@ -173,6 +177,7 @@ abi_impls! {
             C { unwind: false } =><= "C",
             C { unwind: true } =><= "C-unwind",
             Rust =><= "Rust",
+            Swift =><= "Swift",
             Aapcs { unwind: false } =><= "aapcs",
             Aapcs { unwind: true } =><= "aapcs-unwind",
             AvrInterrupt =><= "avr-interrupt",
@@ -348,7 +353,8 @@ impl ExternAbi {
             | Self::Vectorcall { .. }
             | Self::SysV64 { .. }
             | Self::Win64 { .. }
-            | Self::RustPreserveNone => true,
+            | Self::RustPreserveNone
+            | Self::Swift => true,
         }
     }
 }

--- a/compiler/rustc_ast_lowering/src/stability.rs
+++ b/compiler/rustc_ast_lowering/src/stability.rs
@@ -144,5 +144,8 @@ pub fn extern_abi_stability(abi: ExternAbi) -> Result<(), UnstableAbi> {
         ExternAbi::Custom => {
             Err(UnstableAbi { abi, feature: sym::abi_custom, explain: GateReason::Experimental })
         }
+        ExternAbi::Swift => {
+            Err(UnstableAbi { abi, feature: sym::abi_swift, explain: GateReason::Experimental })
+        }
     }
 }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -424,6 +424,7 @@ impl<'a> AstValidator<'a> {
                     | CanonAbi::Rust
                     | CanonAbi::RustCold
                     | CanonAbi::RustPreserveNone
+                    | CanonAbi::Swift
                     | CanonAbi::Arm(_)
                     | CanonAbi::X86(_) => { /* nothing to check */ }
 

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -70,7 +70,7 @@ pub(crate) fn conv_to_call_conv(
             _ => default_call_conv,
         },
 
-        CanonAbi::Interrupt(_) | CanonAbi::Arm(_) => {
+        CanonAbi::Interrupt(_) | CanonAbi::Arm(_) | CanonAbi::Swift => {
             sess.dcx().fatal("call conv {c:?} is not yet implemented")
         }
         CanonAbi::GpuKernel => {

--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -245,6 +245,8 @@ pub fn conv_to_fn_attribute<'gcc>(conv: CanonAbi, arch: &Arch) -> Option<FnAttri
         // possible to declare an `extern "custom"` block, so the backend still needs a calling
         // convention for declaring foreign functions.
         CanonAbi::Custom => return None,
+        // gcc/gccjit does not have anything for Swift's calling convention.
+        CanonAbi::Swift => panic!("gcc/gccjit backend does not support Swift calling convention"),
         CanonAbi::Arm(arm_call) => match arm_call {
             ArmCall::CCmseNonSecureCall => FnAttribute::ArmCmseNonsecureCall,
             ArmCall::CCmseNonSecureEntry => FnAttribute::ArmCmseNonsecureEntry,

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -722,6 +722,7 @@ pub(crate) fn to_llvm_calling_convention(sess: &Session, abi: CanonAbi) -> llvm:
         // possible to declare an `extern "custom"` block, so the backend still needs a calling
         // convention for declaring foreign functions.
         CanonAbi::Custom => llvm::CCallConv,
+        CanonAbi::Swift => llvm::SwiftCallConv,
         CanonAbi::GpuKernel => match &sess.target.arch {
             Arch::AmdGpu => llvm::AmdgpuKernel,
             Arch::Nvptx64 => llvm::PtxKernel,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -166,6 +166,7 @@ pub(crate) enum CallConv {
     ColdCallConv = 9,
     PreserveMost = 14,
     PreserveAll = 15,
+    SwiftCallConv = 16,
     Tail = 18,
     PreserveNone = 21,
     X86StdcallCallConv = 64,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -380,6 +380,8 @@ declare_features! (
     (unstable, abi_ptx, "1.15.0", Some(38788)),
     /// Allows `extern "riscv-interrupt-m" fn()` and `extern "riscv-interrupt-s" fn()`.
     (unstable, abi_riscv_interrupt, "1.73.0", Some(111889)),
+    /// Allows `extern "Swift" fn()`.
+    (unstable, abi_swift, "CURRENT_RUSTC_VERSION", Some(156481)),
     /// Allows `extern "x86-interrupt" fn()`.
     (unstable, abi_x86_interrupt, "1.17.0", Some(40180)),
     /// Allows additional const parameter types, such as `[u8; 10]` or user defined types

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -202,6 +202,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | CanonAbi::Rust
             | CanonAbi::RustCold
             | CanonAbi::RustPreserveNone
+            | CanonAbi::Swift
             | CanonAbi::Arm(_)
             | CanonAbi::X86(_) => {}
         }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1291,6 +1291,7 @@ pub fn fn_can_unwind(tcx: TyCtxt<'_>, fn_def_id: Option<DefId>, abi: ExternAbi) 
         | RiscvInterruptM
         | RiscvInterruptS
         | RustInvalid
+        | Swift
         | Unadjusted => false,
         Rust | RustCall | RustCold | RustPreserveNone => tcx.sess.panic_strategy().unwinds(),
     }

--- a/compiler/rustc_public/src/abi.rs
+++ b/compiler/rustc_public/src/abi.rs
@@ -458,6 +458,8 @@ pub enum CallConvention {
 
     Custom,
 
+    Swift,
+
     // Target-specific calling conventions.
     ArmAapcs,
     CCmseNonSecureCall,

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -1169,6 +1169,7 @@ pub enum Abi {
     RustPreserveNone,
     RustInvalid,
     Custom,
+    Swift,
 }
 
 /// A binder represents a possibly generic type and its bound vars.

--- a/compiler/rustc_public/src/unstable/convert/internal.rs
+++ b/compiler/rustc_public/src/unstable/convert/internal.rs
@@ -619,6 +619,7 @@ impl RustcInternal for Abi {
             Abi::RiscvInterruptS => rustc_abi::ExternAbi::RiscvInterruptS,
             Abi::RustPreserveNone => rustc_abi::ExternAbi::RustPreserveNone,
             Abi::Custom => rustc_abi::ExternAbi::Custom,
+            Abi::Swift => rustc_abi::ExternAbi::Swift,
         }
     }
 }

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -126,6 +126,7 @@ impl<'tcx> Stable<'tcx> for CanonAbi {
             CanonAbi::RustCold => CallConvention::Cold,
             CanonAbi::RustPreserveNone => CallConvention::PreserveNone,
             CanonAbi::Custom => CallConvention::Custom,
+            CanonAbi::Swift => CallConvention::Swift,
             CanonAbi::Arm(arm_call) => match arm_call {
                 ArmCall::Aapcs => CallConvention::ArmAapcs,
                 ArmCall::CCmseNonSecureCall => CallConvention::CCmseNonSecureCall,

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -1050,6 +1050,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::ExternAbi {
             ExternAbi::RiscvInterruptM => Abi::RiscvInterruptM,
             ExternAbi::RiscvInterruptS => Abi::RiscvInterruptS,
             ExternAbi::Custom => Abi::Custom,
+            ExternAbi::Swift => Abi::Swift,
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -355,6 +355,7 @@ symbols! {
         abi_msp430_interrupt,
         abi_ptx,
         abi_riscv_interrupt,
+        abi_swift,
         abi_sysv64,
         abi_thiscall,
         abi_unadjusted,

--- a/compiler/rustc_target/src/spec/abi_map.rs
+++ b/compiler/rustc_target/src/spec/abi_map.rs
@@ -65,7 +65,9 @@ impl AbiMap {
             _ => ArchKind::Other,
         };
 
-        let os = if target.is_like_windows {
+        let os = if target.is_like_darwin {
+            OsKind::Apple
+        } else if target.is_like_windows {
             OsKind::Windows
         } else if target.is_like_vexos {
             OsKind::VEXos
@@ -80,6 +82,15 @@ impl AbiMap {
     pub fn canonize_abi(&self, extern_abi: ExternAbi, has_c_varargs: bool) -> AbiMapping {
         let AbiMap { os, arch } = *self;
 
+        if extern_abi == ExternAbi::Swift {
+            // Per https://www.swift.org/blog/abi-stability-and-more/, Swift's ABI
+            // is only stable on Apple platforms, so we reject it elsewhere.
+            match os {
+                OsKind::Apple => {}
+                _ => return AbiMapping::Invalid,
+            }
+        }
+
         let canon_abi = match (extern_abi, arch) {
             // infallible lowerings
             (ExternAbi::C { .. }, _) => CanonAbi::C,
@@ -91,6 +102,8 @@ impl AbiMap {
             (ExternAbi::RustPreserveNone, _) => CanonAbi::RustPreserveNone,
 
             (ExternAbi::Custom, _) => CanonAbi::Custom,
+
+            (ExternAbi::Swift, _) => CanonAbi::Swift,
 
             (ExternAbi::System { .. }, ArchKind::X86)
                 if os == OsKind::Windows && !has_c_varargs =>
@@ -213,6 +226,7 @@ enum ArchKind {
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 enum OsKind {
+    Apple,
     Windows,
     VEXos,
     Other,

--- a/tests/ui/abi/swift-abi-non-apple.rs
+++ b/tests/ui/abi/swift-abi-non-apple.rs
@@ -1,0 +1,33 @@
+//@ add-minicore
+//@ needs-llvm-components: x86
+//@ compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
+//@ ignore-backends: gcc
+#![no_core]
+#![feature(no_core, lang_items, abi_swift)]
+
+extern crate minicore;
+use minicore::*;
+
+// The Swift ABI is only stable on Apple platforms, so it must be rejected
+// on other targets even when the `abi_swift` feature gate is enabled.
+
+extern "Swift" fn f() {} //~ ERROR is not a supported ABI
+
+trait T {
+    extern "Swift" fn m(); //~ ERROR is not a supported ABI
+
+    extern "Swift" fn dm() {} //~ ERROR is not a supported ABI
+}
+
+struct S;
+impl T for S {
+    extern "Swift" fn m() {} //~ ERROR is not a supported ABI
+}
+
+impl S {
+    extern "Swift" fn im() {} //~ ERROR is not a supported ABI
+}
+
+type TA = extern "Swift" fn(); //~ ERROR is not a supported ABI
+
+extern "Swift" {} //~ ERROR is not a supported ABI

--- a/tests/ui/abi/swift-abi-non-apple.stderr
+++ b/tests/ui/abi/swift-abi-non-apple.stderr
@@ -1,0 +1,45 @@
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:14:8
+   |
+LL | extern "Swift" fn f() {}
+   |        ^^^^^^^
+
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:17:12
+   |
+LL |     extern "Swift" fn m();
+   |            ^^^^^^^
+
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:19:12
+   |
+LL |     extern "Swift" fn dm() {}
+   |            ^^^^^^^
+
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:24:12
+   |
+LL |     extern "Swift" fn m() {}
+   |            ^^^^^^^
+
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:28:12
+   |
+LL |     extern "Swift" fn im() {}
+   |            ^^^^^^^
+
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:31:18
+   |
+LL | type TA = extern "Swift" fn();
+   |                  ^^^^^^^
+
+error[E0570]: "Swift" is not a supported ABI for the current target
+  --> $DIR/swift-abi-non-apple.rs:33:8
+   |
+LL | extern "Swift" {}
+   |        ^^^^^^^
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/feature-gates/feature-gate-abi_swift.rs
+++ b/tests/ui/feature-gates/feature-gate-abi_swift.rs
@@ -1,0 +1,33 @@
+//@ add-minicore
+//@ needs-llvm-components: aarch64
+//@ compile-flags: --target=aarch64-apple-darwin --crate-type=rlib
+//@ ignore-backends: gcc
+#![no_core]
+#![feature(no_core, lang_items)]
+
+extern crate minicore;
+use minicore::*;
+
+// Test that the "Swift" ABI is feature-gated, and cannot be used when
+// the `abi_swift` feature gate is not used.
+
+extern "Swift" fn f() {} //~ ERROR "Swift" ABI is experimental
+
+trait T {
+    extern "Swift" fn m(); //~ ERROR "Swift" ABI is experimental
+
+    extern "Swift" fn dm() {} //~ ERROR "Swift" ABI is experimental
+}
+
+struct S;
+impl T for S {
+    extern "Swift" fn m() {} //~ ERROR "Swift" ABI is experimental
+}
+
+impl S {
+    extern "Swift" fn im() {} //~ ERROR "Swift" ABI is experimental
+}
+
+type TA = extern "Swift" fn(); //~ ERROR "Swift" ABI is experimental
+
+extern "Swift" {} //~ ERROR "Swift" ABI is experimental

--- a/tests/ui/feature-gates/feature-gate-abi_swift.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_swift.stderr
@@ -1,0 +1,73 @@
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:14:8
+   |
+LL | extern "Swift" fn f() {}
+   |        ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:17:12
+   |
+LL |     extern "Swift" fn m();
+   |            ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:19:12
+   |
+LL |     extern "Swift" fn dm() {}
+   |            ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:24:12
+   |
+LL |     extern "Swift" fn m() {}
+   |            ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:28:12
+   |
+LL |     extern "Swift" fn im() {}
+   |            ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:31:18
+   |
+LL | type TA = extern "Swift" fn();
+   |                  ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "Swift" ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi_swift.rs:33:8
+   |
+LL | extern "Swift" {}
+   |        ^^^^^^^
+   |
+   = note: see issue #156481 <https://github.com/rust-lang/rust/issues/156481> for more information
+   = help: add `#![feature(abi_swift)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/print-request/print-calling-conventions.stdout
+++ b/tests/ui/print-request/print-calling-conventions.stdout
@@ -1,6 +1,7 @@
 C
 C-unwind
 Rust
+Swift
 aapcs
 aapcs-unwind
 avr-interrupt


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155815)*
<!-- homu-ignore:end -->

Adds an unstable `extern "Swift"` ABI behind the `abi_swift` feature gate, mapping to LLVM's `swiftcc` calling convention. This is only allowed (a) for `is_darwin_like` targets, since the [ABI is only stable for those platforms](https://www.swift.org/blog/abi-stability-and-more/) and (b) with the LLVM backend, since the other backends don't support it.

Current approaches to interoperability with Swift lower to Objective-C (or require a Swift stub exposing a C ABI), but that is an optional mapping on the Swift side that some newer Apple frameworks omit. It would be great to be able to more directly/natively be able to call into Swift code directly via its stable API (on Apple platforms at least).

Reimplements rust-lang/rust#64582 on top of current main. The main objection to the previous PR seemed to be that it needed an RFC, but there was pushback (which seems sensible to me) that an RFC could be deferred until stabilization.

I think this needs a tracking issue? Would be happy to write one up if/when there is a consensus that this will be merged.