### PR TITLE
Avoid improper spans when `...` or `..=` is recovered from non-ASCII

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1140,14 +1140,13 @@ pub(crate) struct InclusiveRangeMatchArrow {
     #[primary_span]
     pub arrow: Span,
     #[label("this is parsed as an inclusive range `..=`")]
-    pub span: Span,
     #[suggestion(
         "add a space between the pattern and `=>`",
         style = "verbose",
-        code = " ",
+        code = ".. =",
         applicability = "machine-applicable"
     )]
-    pub after_pat: Span,
+    pub span: Span,
 }
 
 #[derive(Diagnostic)]
@@ -1155,14 +1154,13 @@ pub(crate) struct InclusiveRangeMatchArrow {
 #[note("inclusive ranges must be bounded at the end (`..=b` or `a..=b`)")]
 pub(crate) struct InclusiveRangeNoEnd {
     #[primary_span]
-    pub span: Span,
     #[suggestion(
         "use `..` instead",
-        code = "",
+        code = "..",
         applicability = "machine-applicable",
         style = "verbose"
     )]
-    pub suggestion: Span,
+    pub span: Span,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1225,7 +1225,7 @@ impl<'a> Parser<'a> {
     pub(super) fn inclusive_range_with_incorrect_end(&mut self) -> ErrorGuaranteed {
         let tok = &self.token;
         let span = self.prev_token.span;
-        // If the user typed "..==" instead of "..=", we want to give them
+        // If the user typed "..==" or "...=" instead of "..=", we want to give them
         // a specific error message telling them to use "..=".
         // If they typed "..=>", suggest they use ".. =>".
         // Otherwise, we assume that they meant to type a half open exclusive
@@ -1243,14 +1243,10 @@ impl<'a> Parser<'a> {
 
                 self.dcx().emit_err(InclusiveRangeExtraEquals { span: span_with_eq })
             }
-            token::Gt if no_space => {
-                let after_pat = span.with_hi(span.hi() - BytePos(1)).shrink_to_hi();
-                self.dcx().emit_err(InclusiveRangeMatchArrow { span, arrow: tok.span, after_pat })
+            token::Gt if self.prev_token.kind == token::DotDotEq && no_space => {
+                self.dcx().emit_err(InclusiveRangeMatchArrow { span, arrow: tok.span })
             }
-            _ => self.dcx().emit_err(InclusiveRangeNoEnd {
-                span,
-                suggestion: span.with_lo(span.hi() - BytePos(1)),
-            }),
+            _ => self.dcx().emit_err(InclusiveRangeNoEnd { span }),
         }
     }
 

--- a/tests/ui/parser/range-inclusive-suggestion-span.rs
+++ b/tests/ui/parser/range-inclusive-suggestion-span.rs
@@ -6,9 +6,41 @@
 //
 // Regression test for <https://github.com/rust-lang/rust/issues/155799>.
 
-// FIXME: The ICE is fixed in a subsequent commit.
-//@ known-bug: #155799
-//@ failure-status: 101
-
 // These dots are U+00B7 MIDDLE DOT, not an ASCII period.
 fn dot_dot_dot() { ··· }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unexpected token: `...`
+//~| ERROR inclusive range with no end
+
+fn dot_dot_dot_eq() { ···= }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unexpected token: `...`
+//~| ERROR unexpected `=` after inclusive range
+
+fn dot_dot_dot_gt() { ···> }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unexpected token: `...`
+//~| ERROR inclusive range with no end
+//~| ERROR expected one of `;` or `}`, found `>`
+
+fn dot_dot_eq() { ··= }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR inclusive range with no end
+
+fn dot_dot_eq_eq() { ··== }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unexpected `=` after inclusive range
+
+fn dot_dot_eq_gt() { ··=> }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unexpected `>` after inclusive range
+//~| ERROR expected one of `;` or `}`, found `>`

--- a/tests/ui/parser/range-inclusive-suggestion-span.rs
+++ b/tests/ui/parser/range-inclusive-suggestion-span.rs
@@ -1,0 +1,14 @@
+#![crate_type = "rlib"]
+
+// Suggestions for range patterns should not perform span manipulations that
+// assume the range token is ASCII, because it could have been recovered from
+// similar-looking Unicode characters.
+//
+// Regression test for <https://github.com/rust-lang/rust/issues/155799>.
+
+// FIXME: The ICE is fixed in a subsequent commit.
+//@ known-bug: #155799
+//@ failure-status: 101
+
+// These dots are U+00B7 MIDDLE DOT, not an ASCII period.
+fn dot_dot_dot() { ··· }

--- a/tests/ui/parser/range-inclusive-suggestion-span.stderr
+++ b/tests/ui/parser/range-inclusive-suggestion-span.stderr
@@ -1,0 +1,334 @@
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:10:20
+   |
+LL | fn dot_dot_dot() { ··· }
+   |                    ^^^
+   |
+   = note: character appears 2 more times
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot() { ··· }
+LL + fn dot_dot_dot() { ... }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:10:21
+   |
+LL | fn dot_dot_dot() { ··· }
+   |                     ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot() { ··· }
+LL + fn dot_dot_dot() { ·.. }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:10:22
+   |
+LL | fn dot_dot_dot() { ··· }
+   |                      ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot() { ··· }
+LL + fn dot_dot_dot() { ··. }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:17:23
+   |
+LL | fn dot_dot_dot_eq() { ···= }
+   |                       ^^^
+   |
+   = note: character appears 2 more times
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot_eq() { ···= }
+LL + fn dot_dot_dot_eq() { ...= }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:17:24
+   |
+LL | fn dot_dot_dot_eq() { ···= }
+   |                        ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot_eq() { ···= }
+LL + fn dot_dot_dot_eq() { ·..= }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:17:25
+   |
+LL | fn dot_dot_dot_eq() { ···= }
+   |                         ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot_eq() { ···= }
+LL + fn dot_dot_dot_eq() { ··.= }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:24:23
+   |
+LL | fn dot_dot_dot_gt() { ···> }
+   |                       ^^^
+   |
+   = note: character appears 2 more times
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot_gt() { ···> }
+LL + fn dot_dot_dot_gt() { ...> }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:24:24
+   |
+LL | fn dot_dot_dot_gt() { ···> }
+   |                        ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot_gt() { ···> }
+LL + fn dot_dot_dot_gt() { ·..> }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:24:25
+   |
+LL | fn dot_dot_dot_gt() { ···> }
+   |                         ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_dot_gt() { ···> }
+LL + fn dot_dot_dot_gt() { ··.> }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:32:19
+   |
+LL | fn dot_dot_eq() { ··= }
+   |                   ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_eq() { ··= }
+LL + fn dot_dot_eq() { ..= }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:32:20
+   |
+LL | fn dot_dot_eq() { ··= }
+   |                    ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_eq() { ··= }
+LL + fn dot_dot_eq() { ·.= }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:37:22
+   |
+LL | fn dot_dot_eq_eq() { ··== }
+   |                      ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_eq_eq() { ··== }
+LL + fn dot_dot_eq_eq() { ..== }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:37:23
+   |
+LL | fn dot_dot_eq_eq() { ··== }
+   |                       ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_eq_eq() { ··== }
+LL + fn dot_dot_eq_eq() { ·.== }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:42:22
+   |
+LL | fn dot_dot_eq_gt() { ··=> }
+   |                      ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_eq_gt() { ··=> }
+LL + fn dot_dot_eq_gt() { ..=> }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/range-inclusive-suggestion-span.rs:42:23
+   |
+LL | fn dot_dot_eq_gt() { ··=> }
+   |                       ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - fn dot_dot_eq_gt() { ··=> }
+LL + fn dot_dot_eq_gt() { ·.=> }
+   |
+
+error: unexpected token: `...`
+  --> $DIR/range-inclusive-suggestion-span.rs:10:20
+   |
+LL | fn dot_dot_dot() { ··· }
+   |                    ^^^
+   |
+help: use `..` for an exclusive range
+   |
+LL - fn dot_dot_dot() { ··· }
+LL + fn dot_dot_dot() { .. }
+   |
+help: or `..=` for an inclusive range
+   |
+LL - fn dot_dot_dot() { ··· }
+LL + fn dot_dot_dot() { ..= }
+   |
+
+error[E0586]: inclusive range with no end
+  --> $DIR/range-inclusive-suggestion-span.rs:10:20
+   |
+LL | fn dot_dot_dot() { ··· }
+   |                    ^^^
+   |
+   = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - fn dot_dot_dot() { ··· }
+LL + fn dot_dot_dot() { .. }
+   |
+
+error: unexpected token: `...`
+  --> $DIR/range-inclusive-suggestion-span.rs:17:23
+   |
+LL | fn dot_dot_dot_eq() { ···= }
+   |                       ^^^
+   |
+help: use `..` for an exclusive range
+   |
+LL - fn dot_dot_dot_eq() { ···= }
+LL + fn dot_dot_dot_eq() { ..= }
+   |
+help: or `..=` for an inclusive range
+   |
+LL - fn dot_dot_dot_eq() { ···= }
+LL + fn dot_dot_dot_eq() { ..== }
+   |
+
+error: unexpected `=` after inclusive range
+  --> $DIR/range-inclusive-suggestion-span.rs:17:23
+   |
+LL | fn dot_dot_dot_eq() { ···= }
+   |                       ^^^^
+   |
+   = note: inclusive ranges end with a single equals sign (`..=`)
+help: use `..=` instead
+   |
+LL - fn dot_dot_dot_eq() { ···= }
+LL + fn dot_dot_dot_eq() { ..= }
+   |
+
+error: unexpected token: `...`
+  --> $DIR/range-inclusive-suggestion-span.rs:24:23
+   |
+LL | fn dot_dot_dot_gt() { ···> }
+   |                       ^^^
+   |
+help: use `..` for an exclusive range
+   |
+LL - fn dot_dot_dot_gt() { ···> }
+LL + fn dot_dot_dot_gt() { ..> }
+   |
+help: or `..=` for an inclusive range
+   |
+LL - fn dot_dot_dot_gt() { ···> }
+LL + fn dot_dot_dot_gt() { ..=> }
+   |
+
+error[E0586]: inclusive range with no end
+  --> $DIR/range-inclusive-suggestion-span.rs:24:23
+   |
+LL | fn dot_dot_dot_gt() { ···> }
+   |                       ^^^
+   |
+   = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - fn dot_dot_dot_gt() { ···> }
+LL + fn dot_dot_dot_gt() { ..> }
+   |
+
+error: expected one of `;` or `}`, found `>`
+  --> $DIR/range-inclusive-suggestion-span.rs:24:26
+   |
+LL | fn dot_dot_dot_gt() { ···> }
+   |                          ^ expected one of `;` or `}`
+
+error[E0586]: inclusive range with no end
+  --> $DIR/range-inclusive-suggestion-span.rs:32:19
+   |
+LL | fn dot_dot_eq() { ··= }
+   |                   ^^^
+   |
+   = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
+help: use `..` instead
+   |
+LL - fn dot_dot_eq() { ··= }
+LL + fn dot_dot_eq() { .. }
+   |
+
+error: unexpected `=` after inclusive range
+  --> $DIR/range-inclusive-suggestion-span.rs:37:22
+   |
+LL | fn dot_dot_eq_eq() { ··== }
+   |                      ^^^^
+   |
+   = note: inclusive ranges end with a single equals sign (`..=`)
+help: use `..=` instead
+   |
+LL - fn dot_dot_eq_eq() { ··== }
+LL + fn dot_dot_eq_eq() { ..= }
+   |
+
+error: unexpected `>` after inclusive range
+  --> $DIR/range-inclusive-suggestion-span.rs:42:25
+   |
+LL | fn dot_dot_eq_gt() { ··=> }
+   |                      ---^
+   |                      |
+   |                      this is parsed as an inclusive range `..=`
+   |
+help: add a space between the pattern and `=>`
+   |
+LL - fn dot_dot_eq_gt() { ··=> }
+LL + fn dot_dot_eq_gt() { .. => }
+   |
+
+error: expected one of `;` or `}`, found `>`
+  --> $DIR/range-inclusive-suggestion-span.rs:42:25
+   |
+LL | fn dot_dot_eq_gt() { ··=> }
+   |                         ^ expected one of `;` or `}`
+
+error: aborting due to 26 previous errors
+
+For more information about this error, try `rustc --explain E0586`.


### PR DESCRIPTION
- Fixes https://github.com/rust-lang/rust/issues/155799

Adjusting span endpoints by `BytePos(1)` is almost always bad news.

In this case, the code assumed that it was skipping over a single ASCII character. But in the presence of parser recovery from other non-ASCII characters this resulted in an ICE due to bad string indexing when emitting suggestions.