### PR TITLE
std::process: uefi: avoid panicking in Stdio From impls.

### DIFF
--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -27,11 +27,13 @@ pub struct Command {
     env: CommandEnv,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 pub enum Stdio {
     Inherit,
     Null,
     MakePipe,
+    #[allow(dead_code)] // This variant exists only for the Debug impl
+    InheritFile(File),
 }
 
 impl Command {
@@ -116,6 +118,7 @@ impl Command {
                 )
             }
             .map(Some),
+            Stdio::InheritFile(_) => Err(unsupported()?),
             Stdio::Inherit => Ok(None),
         }
     }
@@ -131,6 +134,7 @@ impl Command {
                 )
             }
             .map(Some),
+            Stdio::InheritFile(_) => Err(unsupported()?),
             Stdio::Inherit => Ok(None),
             Stdio::MakePipe => unsupported(),
         }
@@ -147,7 +151,7 @@ pub fn output(command: &mut Command) -> io::Result<(ExitStatus, Vec<u8>, Vec<u8>
     }
 
     // Setup Stdout
-    let stdout = command.stdout.unwrap_or(Stdio::MakePipe);
+    let stdout = command.stdout.take().unwrap_or(Stdio::MakePipe);
     let stdout = Command::create_pipe(stdout)?;
     if let Some(con) = stdout {
         cmd.stdout_init(con)
@@ -156,7 +160,7 @@ pub fn output(command: &mut Command) -> io::Result<(ExitStatus, Vec<u8>, Vec<u8>
     };
 
     // Setup Stderr
-    let stderr = command.stderr.unwrap_or(Stdio::MakePipe);
+    let stderr = command.stderr.take().unwrap_or(Stdio::MakePipe);
     let stderr = Command::create_pipe(stderr)?;
     if let Some(con) = stderr {
         cmd.stderr_init(con)
@@ -165,7 +169,7 @@ pub fn output(command: &mut Command) -> io::Result<(ExitStatus, Vec<u8>, Vec<u8>
     };
 
     // Setup Stdin
-    let stdin = command.stdin.unwrap_or(Stdio::Null);
+    let stdin = command.stdin.take().unwrap_or(Stdio::Null);
     let stdin = Command::create_stdin(stdin)?;
     if let Some(con) = stdin {
         cmd.stdin_init(con)
@@ -211,25 +215,19 @@ impl From<ChildPipe> for Stdio {
 
 impl From<io::Stdout> for Stdio {
     fn from(_: io::Stdout) -> Stdio {
-        // FIXME: This is wrong.
-        // Instead, the Stdio we have here should be a unit struct.
-        panic!("unsupported")
+        Stdio::Inherit
     }
 }
 
 impl From<io::Stderr> for Stdio {
     fn from(_: io::Stderr) -> Stdio {
-        // FIXME: This is wrong.
-        // Instead, the Stdio we have here should be a unit struct.
-        panic!("unsupported")
+        Stdio::Inherit
     }
 }
 
 impl From<File> for Stdio {
-    fn from(_file: File) -> Stdio {
-        // FIXME: This is wrong.
-        // Instead, the Stdio we have here should be a unit struct.
-        panic!("unsupported")
+    fn from(file: File) -> Stdio {
+        Stdio::InheritFile(file)
     }
 }
 


### PR DESCRIPTION
map io::Stdout/Stderr to Stdio::Inherit and File to a new InheritFile variant returning io::Error from output() instead of aborting.