### PR TITLE
rustc_attr_parsing: use a `try {}` in `or_malformed`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -236,9 +236,11 @@ fn parse_directive_items<'p, S: Stage>(
         }}
 
         macro or_malformed($($code:tt)*) {{
-            let Some(ret) = (||{
-                Some($($code)*)
-            })() else {
+            let Some(ret) = (
+                try {
+                    $($code)*
+                }
+            ) else {
                 malformed!()
             };
             ret


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This replace the `(|| { Some($($code)*) })()` with a nice and clean `try { $($code)* }` block. `try {}` is unstable but widely used within the compiler (and in a few places in `rustc_attr_parsing`), so I would argue it's ok to use it here too?

To the best of my knowledge, there is no instance of IIFE (aka the poor man's `try {}`) in `rustc_attribute_parsing`. Happy to be proven wrong though :)

r? mejrs 
<!-- homu-ignore:end -->
