### PR TITLE
Refactor crate name handling; pass a TyCtxt into macro expansion

### DIFF
--- a/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
+++ b/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
@@ -10,7 +10,7 @@ use crate::errors;
 use crate::util::check_builtin_macro_attribute;
 
 pub(crate) fn expand(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     _span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -59,7 +59,7 @@ pub(crate) fn expand(
 // unsafe fn __rust_alloc_error_handler(size: usize, align: usize) -> ! {
 //     handler(core::alloc::Layout::from_size_align_unchecked(size, align))
 // }
-fn generate_handler(cx: &ExtCtxt<'_>, handler: Ident, span: Span, sig_span: Span) -> Stmt {
+fn generate_handler(cx: &ExtCtxt<'_, '_>, handler: Ident, span: Span, sig_span: Span) -> Stmt {
     let usize = cx.path_ident(span, Ident::new(sym::usize, span));
     let ty_usize = cx.ty_path(usize);
     let size = Ident::new(sym::size, span);

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -27,7 +27,7 @@ struct ValidatedAsmArgs {
 }
 
 fn parse_args<'a>(
-    ecx: &ExtCtxt<'a>,
+    ecx: &ExtCtxt<'a, '_>,
     sp: Span,
     tts: TokenStream,
     asm_macro: AsmMacro,
@@ -37,7 +37,7 @@ fn parse_args<'a>(
 }
 
 fn validate_asm_args<'a>(
-    ecx: &ExtCtxt<'a>,
+    ecx: &ExtCtxt<'a, '_>,
     asm_macro: AsmMacro,
     args: Vec<AsmArg>,
 ) -> PResult<'a, ValidatedAsmArgs> {
@@ -263,7 +263,7 @@ fn validate_asm_args<'a>(
 }
 
 fn expand_preparsed_asm(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     asm_macro: AsmMacro,
     args: ValidatedAsmArgs,
 ) -> ExpandResult<Result<ast::InlineAsm, ErrorGuaranteed>, ()> {
@@ -580,7 +580,7 @@ fn expand_preparsed_asm(
 }
 
 pub(super) fn expand_asm<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -609,7 +609,7 @@ pub(super) fn expand_asm<'cx>(
 }
 
 pub(super) fn expand_naked_asm<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -639,7 +639,7 @@ pub(super) fn expand_naked_asm<'cx>(
 }
 
 pub(super) fn expand_global_asm<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -15,7 +15,7 @@ use crate::edition_panic::use_panic_2021;
 use crate::errors;
 
 pub(crate) fn expand_assert<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     span: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -101,7 +101,7 @@ struct Assert {
 
 // if !{ ... } { ... } else { ... }
 fn expr_if_not(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     cond: Box<Expr>,
     then: Box<Expr>,
@@ -110,7 +110,7 @@ fn expr_if_not(
     cx.expr_if(span, cx.expr(span, ExprKind::Unary(UnOp::Not, cond)), then, els)
 }
 
-fn parse_assert<'a>(cx: &ExtCtxt<'a>, sp: Span, stream: TokenStream) -> PResult<'a, Assert> {
+fn parse_assert<'a>(cx: &ExtCtxt<'a, '_>, sp: Span, stream: TokenStream) -> PResult<'a, Assert> {
     let mut parser = cx.new_parser_from_tts(stream);
 
     if parser.token == token::Eof {

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -10,7 +10,7 @@ use rustc_expand::base::ExtCtxt;
 use rustc_span::{Ident, Span, Symbol, sym};
 use thin_vec::{ThinVec, thin_vec};
 
-pub(super) struct Context<'cx, 'a> {
+pub(super) struct Context<'cx, 'a, 'tcx> {
     // An optimization.
     //
     // Elements that aren't consumed (PartialEq, PartialOrd, ...) can be copied **after** the
@@ -18,7 +18,7 @@ pub(super) struct Context<'cx, 'a> {
     best_case_captures: Vec<Stmt>,
     // Top-level `let captureN = Capture::new()` statements
     capture_decls: Vec<Capture>,
-    cx: &'cx ExtCtxt<'a>,
+    cx: &'cx ExtCtxt<'a, 'tcx>,
     // Formatting string used for debugging
     fmt_string: String,
     // If the current expression being visited consumes itself. Used to construct
@@ -36,8 +36,8 @@ pub(super) struct Context<'cx, 'a> {
     span: Span,
 }
 
-impl<'cx, 'a> Context<'cx, 'a> {
-    pub(super) fn new(cx: &'cx ExtCtxt<'a>, span: Span) -> Self {
+impl<'cx, 'a, 'tcx> Context<'cx, 'a, 'tcx> {
+    pub(super) fn new(cx: &'cx ExtCtxt<'a, 'tcx>, span: Span) -> Self {
         Self {
             best_case_captures: <_>::default(),
             capture_decls: <_>::default(),
@@ -443,12 +443,12 @@ fn escape_to_fmt(s: &str) -> String {
     rslt
 }
 
-fn expr_addr_of_mut(cx: &ExtCtxt<'_>, sp: Span, e: Box<Expr>) -> Box<Expr> {
+fn expr_addr_of_mut(cx: &ExtCtxt<'_, '_>, sp: Span, e: Box<Expr>) -> Box<Expr> {
     cx.expr(sp, ExprKind::AddrOf(BorrowKind::Ref, Mutability::Mut, e))
 }
 
 fn expr_method_call(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     seg: PathSegment,
     receiver: Box<Expr>,
     args: ThinVec<Box<Expr>>,
@@ -457,6 +457,6 @@ fn expr_method_call(
     cx.expr(span, ExprKind::MethodCall(Box::new(MethodCall { seg, receiver, args, span })))
 }
 
-fn expr_paren(cx: &ExtCtxt<'_>, sp: Span, e: Box<Expr>) -> Box<Expr> {
+fn expr_paren(cx: &ExtCtxt<'_, '_>, sp: Span, e: Box<Expr>) -> Box<Expr> {
     cx.expr(sp, ExprKind::Paren(e))
 }

--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -83,7 +83,7 @@ mod llvm_enzyme {
     }
 
     pub(crate) fn from_ast(
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         meta_item: &ThinVec<MetaItemInner>,
         has_ret: bool,
         mode: DiffMode,
@@ -162,7 +162,7 @@ mod llvm_enzyme {
     }
 
     pub(crate) fn expand_forward(
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         expand_span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,
@@ -171,7 +171,7 @@ mod llvm_enzyme {
     }
 
     pub(crate) fn expand_reverse(
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         expand_span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,
@@ -203,7 +203,7 @@ mod llvm_enzyme {
     /// FIXME(ZuseZ4): Once autodiff is enabled by default, make this a doc comment which is checked
     /// in CI.
     pub(crate) fn expand_with_mode(
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         expand_span: Span,
         meta_item: &ast::MetaItem,
         mut item: Annotatable,
@@ -502,7 +502,7 @@ mod llvm_enzyme {
     // std::intrinsics::autodiff(source as fn(..) -> .., diff, (args))
     // ```
     fn call_autodiff(
-        ecx: &ExtCtxt<'_>,
+        ecx: &ExtCtxt<'_, '_>,
         primal: Ident,
         diff: Ident,
         span: Span,
@@ -586,7 +586,7 @@ mod llvm_enzyme {
     // Given `foo` and `<A, B, C>` params, gen `foo::<A, B, C>`
     // We use this expression when passing primal and diff function to the autodiff intrinsic
     fn gen_turbofish_expr(
-        ecx: &ExtCtxt<'_>,
+        ecx: &ExtCtxt<'_, '_>,
         ident: Ident,
         generics: &Generics,
         span: Span,
@@ -648,7 +648,7 @@ mod llvm_enzyme {
     // FIXME(Sa4dUs): make individual activities' span available so errors
     // can point to only the activity instead of the entire attribute
     fn gen_enzyme_decl(
-        ecx: &ExtCtxt<'_>,
+        ecx: &ExtCtxt<'_, '_>,
         sig: &ast::FnSig,
         x: &RustcAutodiff,
         span: Span,

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -19,7 +19,7 @@ use rustc_span::{ErrorGuaranteed, Span, sym};
 use crate::errors;
 
 pub(crate) fn expand_cfg(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -35,7 +35,11 @@ pub(crate) fn expand_cfg(
     })
 }
 
-fn parse_cfg(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream) -> Result<CfgEntry, ErrorGuaranteed> {
+fn parse_cfg(
+    cx: &ExtCtxt<'_, '_>,
+    span: Span,
+    tts: TokenStream,
+) -> Result<CfgEntry, ErrorGuaranteed> {
     let mut parser = cx.new_parser_from_tts(tts);
     if parser.token == token::Eof {
         return Err(cx.dcx().emit_err(errors::RequiresCfgPattern { span }));

--- a/compiler/rustc_builtin_macros/src/cfg_accessible.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_accessible.rs
@@ -10,7 +10,7 @@ use crate::errors;
 
 pub(crate) struct Expander;
 
-fn validate_input<'a>(ecx: &ExtCtxt<'_>, mi: &'a ast::MetaItem) -> Option<&'a ast::Path> {
+fn validate_input<'a>(ecx: &ExtCtxt<'_, '_>, mi: &'a ast::MetaItem) -> Option<&'a ast::Path> {
     use errors::CfgAccessibleInvalid::*;
     match mi.meta_item_list() {
         None => {}
@@ -38,7 +38,7 @@ fn validate_input<'a>(ecx: &ExtCtxt<'_>, mi: &'a ast::MetaItem) -> Option<&'a as
 impl MultiItemModifier for Expander {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 use crate::util::{check_builtin_macro_attribute, warn_on_duplicate_attribute};
 
 pub(crate) fn expand(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     _span: Span,
     meta_item: &ast::MetaItem,
     annotatable: Annotatable,

--- a/compiler/rustc_builtin_macros/src/cfg_select.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_select.rs
@@ -11,8 +11,8 @@ use crate::errors::CfgSelectNoMatches;
 /// This intermediate structure is used to emit parse errors for the branches that are not chosen.
 /// The `MacResult` instance below parses all branches, emitting any errors it encounters, but only
 /// keeps the parse result for the selected branch.
-struct CfgSelectResult<'cx, 'sess> {
-    ecx: &'cx mut ExtCtxt<'sess>,
+struct CfgSelectResult<'cx, 'sess, 'tcx> {
+    ecx: &'cx mut ExtCtxt<'sess, 'tcx>,
     site_span: Span,
     selected_tts: TokenStream,
     selected_span: Span,
@@ -20,7 +20,7 @@ struct CfgSelectResult<'cx, 'sess> {
 }
 
 fn tts_to_mac_result<'cx, 'sess>(
-    ecx: &'cx mut ExtCtxt<'sess>,
+    ecx: &'cx mut ExtCtxt<'sess, '_>,
     site_span: Span,
     tts: TokenStream,
     span: Span,
@@ -46,7 +46,7 @@ macro_rules! forward_to_parser_any_macro {
     };
 }
 
-impl<'cx, 'sess> MacResult for CfgSelectResult<'cx, 'sess> {
+impl<'cx, 'sess> MacResult for CfgSelectResult<'cx, 'sess, '_> {
     forward_to_parser_any_macro!(make_expr, Box<Expr>);
     forward_to_parser_any_macro!(make_stmts, SmallVec<[ast::Stmt; 1]>);
     forward_to_parser_any_macro!(make_items, SmallVec<[Box<ast::Item>; 1]>);
@@ -61,7 +61,7 @@ impl<'cx, 'sess> MacResult for CfgSelectResult<'cx, 'sess> {
 }
 
 pub(super) fn expand_cfg_select<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/compile_error.rs
+++ b/compiler/rustc_builtin_macros/src/compile_error.rs
@@ -7,7 +7,7 @@ use rustc_span::Span;
 use crate::util::get_single_str_from_tts;
 
 pub(crate) fn expand_compile_error<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/concat.rs
+++ b/compiler/rustc_builtin_macros/src/concat.rs
@@ -8,7 +8,7 @@ use crate::errors;
 use crate::util::get_exprs_from_tts;
 
 pub(crate) fn expand_concat(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: rustc_span::Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {

--- a/compiler/rustc_builtin_macros/src/concat_bytes.rs
+++ b/compiler/rustc_builtin_macros/src/concat_bytes.rs
@@ -9,7 +9,7 @@ use crate::util::get_exprs_from_tts;
 
 /// Emits errors for literal expressions that are invalid inside and outside of an array.
 fn invalid_type_err(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     token_lit: token::Lit,
     span: Span,
     is_nested: bool,
@@ -86,7 +86,7 @@ fn invalid_type_err(
 /// Otherwise, returns `None`, and either pushes the `expr`'s span to `missing_literals` or
 /// updates `guar` accordingly.
 fn handle_array_element(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     guar: &mut Option<ErrorGuaranteed>,
     missing_literals: &mut Vec<rustc_span::Span>,
     expr: &Box<rustc_ast::Expr>,
@@ -130,7 +130,7 @@ fn handle_array_element(
 }
 
 pub(crate) fn expand_concat_bytes(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {

--- a/compiler/rustc_builtin_macros/src/contracts.rs
+++ b/compiler/rustc_builtin_macros/src/contracts.rs
@@ -12,7 +12,7 @@ pub(crate) struct ExpandEnsures;
 impl AttrProcMacro for ExpandRequires {
     fn expand<'cx>(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
@@ -24,7 +24,7 @@ impl AttrProcMacro for ExpandRequires {
 impl AttrProcMacro for ExpandEnsures {
     fn expand<'cx>(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
@@ -45,7 +45,7 @@ impl AttrProcMacro for ExpandEnsures {
 // our attribute infrastructure does not yet support mixing a token-tree annotation with an AST
 // annotated, we end up doing token tree manipulation.
 fn expand_contract_clause(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     attr_span: Span,
     annotated: TokenStream,
     inject: impl FnOnce(&mut TokenStream) -> Result<(), ErrorGuaranteed>,
@@ -131,7 +131,7 @@ fn expand_contract_clause(
 }
 
 fn expand_contract_clause_tts(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     attr_span: Span,
     annotation: TokenStream,
     annotated: TokenStream,

--- a/compiler/rustc_builtin_macros/src/define_opaque.rs
+++ b/compiler/rustc_builtin_macros/src/define_opaque.rs
@@ -3,7 +3,7 @@ use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::Span;
 
 pub(crate) fn expand(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     _expand_span: Span,
     meta_item: &ast::MetaItem,
     mut item: Annotatable,

--- a/compiler/rustc_builtin_macros/src/derive.rs
+++ b/compiler/rustc_builtin_macros/src/derive.rs
@@ -18,7 +18,7 @@ pub(crate) struct Expander {
 impl MultiItemModifier for Expander {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,

--- a/compiler/rustc_builtin_macros/src/deriving/bounds.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/bounds.rs
@@ -6,7 +6,7 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_copy(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -32,7 +32,7 @@ pub(crate) fn expand_deriving_copy(
 }
 
 pub(crate) fn expand_deriving_const_param_ty(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -9,7 +9,7 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_clone(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -120,7 +120,7 @@ pub(crate) fn expand_deriving_clone(
 
 fn cs_clone_simple(
     name: &str,
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     trait_span: Span,
     substr: &Substructure<'_>,
     is_union: bool,
@@ -183,14 +183,14 @@ fn cs_clone_simple(
 
 fn cs_clone(
     name: &str,
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     trait_span: Span,
     substr: &Substructure<'_>,
 ) -> BlockOrExpr {
     let ctor_path;
     let all_fields;
     let fn_path = cx.std_path(&[sym::clone, sym::Clone, sym::clone]);
-    let subcall = |cx: &ExtCtxt<'_>, field: &FieldInfo| {
+    let subcall = |cx: &ExtCtxt<'_, '_>, field: &FieldInfo| {
         let args = thin_vec![field.self_expr.clone()];
         cx.expr_call_global(field.span, fn_path.clone(), args)
     };

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -9,7 +9,7 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_eq(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -53,7 +53,7 @@ pub(crate) fn expand_deriving_eq(
 }
 
 fn cs_total_eq_assert(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     trait_span: Span,
     substr: &Substructure<'_>,
 ) -> BlockOrExpr {

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -8,7 +8,7 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_ord(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -42,7 +42,7 @@ pub(crate) fn expand_deriving_ord(
     trait_def.expand(cx, mitem, item, push)
 }
 
-pub(crate) fn cs_cmp(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> BlockOrExpr {
+pub(crate) fn cs_cmp(cx: &ExtCtxt<'_, '_>, span: Span, substr: &Substructure<'_>) -> BlockOrExpr {
     let test_id = Ident::new(sym::cmp, span);
     let equal_path = cx.path_global(span, cx.std_path(&[sym::cmp, sym::Ordering, sym::Equal]));
     let cmp_path = cx.std_path(&[sym::cmp, sym::Ord, sym::cmp]);

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
@@ -10,7 +10,7 @@ use crate::deriving::{path_local, path_std};
 /// Expands a `#[derive(PartialEq)]` attribute into an implementation for the
 /// target item.
 pub(crate) fn expand_deriving_partial_eq(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -119,7 +119,7 @@ pub(crate) fn expand_deriving_partial_eq(
 /// If called on static or all-fieldless enums/structs, which should not occur
 /// during derive expansion.
 fn get_substructure_equality_expr(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     substructure: &Substructure<'_>,
 ) -> Box<Expr> {
@@ -183,7 +183,7 @@ fn get_substructure_equality_expr(
 ///
 /// Panics if there are not exactly two arguments to compare (should be `self`
 /// and `other`).
-fn get_field_equality_expr(cx: &ExtCtxt<'_>, field: &FieldInfo) -> Box<Expr> {
+fn get_field_equality_expr(cx: &ExtCtxt<'_, '_>, field: &FieldInfo) -> Box<Expr> {
     let [rhs] = &field.other_selflike_exprs[..] else {
         cx.dcx().span_bug(field.span, "not exactly 2 arguments in `derive(PartialEq)`");
     };
@@ -213,7 +213,7 @@ fn peel_refs(mut expr: &Box<Expr>) -> Box<Expr> {
 ///
 /// If the given expression is a block, it is wrapped in parentheses; otherwise,
 /// it is returned unchanged.
-fn wrap_block_expr(cx: &ExtCtxt<'_>, expr: Box<Expr>) -> Box<Expr> {
+fn wrap_block_expr(cx: &ExtCtxt<'_, '_>, expr: Box<Expr>) -> Box<Expr> {
     if matches!(&expr.kind, ExprKind::Block(..)) {
         return cx.expr_paren(expr.span, expr);
     }

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -8,7 +8,7 @@ use crate::deriving::generic::*;
 use crate::deriving::{path_std, pathvec_std};
 
 pub(crate) fn expand_deriving_partial_ord(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -72,7 +72,7 @@ pub(crate) fn expand_deriving_partial_ord(
 }
 
 fn cs_partial_cmp(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     substr: &Substructure<'_>,
     discr_then_data: bool,

--- a/compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/coerce_pointee.rs
@@ -19,7 +19,7 @@ macro_rules! path {
 }
 
 pub(crate) fn expand_deriving_coerce_pointee(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     _mitem: &MetaItem,
     item: &Annotatable,
@@ -402,11 +402,11 @@ impl<'a> ast::mut_visit::MutVisitor for TypeSubstitution<'a> {
     }
 }
 
-struct DetectNonGenericPointeeAttr<'a, 'b> {
-    cx: &'a ExtCtxt<'b>,
+struct DetectNonGenericPointeeAttr<'a, 'b, 'tcx> {
+    cx: &'a ExtCtxt<'b, 'tcx>,
 }
 
-impl<'a, 'b> rustc_ast::visit::Visitor<'a> for DetectNonGenericPointeeAttr<'a, 'b> {
+impl<'a, 'b> rustc_ast::visit::Visitor<'a> for DetectNonGenericPointeeAttr<'a, 'b, '_> {
     fn visit_attribute(&mut self, attr: &'a rustc_ast::Attribute) -> Self::Result {
         if attr.has_name(sym::pointee) {
             self.cx.dcx().emit_err(errors::NonGenericPointee { span: attr.span });
@@ -450,11 +450,11 @@ impl<'a, 'b> rustc_ast::visit::Visitor<'a> for DetectNonGenericPointeeAttr<'a, '
     }
 }
 
-struct AlwaysErrorOnGenericParam<'a, 'b> {
-    cx: &'a ExtCtxt<'b>,
+struct AlwaysErrorOnGenericParam<'a, 'b, 'tcx> {
+    cx: &'a ExtCtxt<'b, 'tcx>,
 }
 
-impl<'a, 'b> rustc_ast::visit::Visitor<'a> for AlwaysErrorOnGenericParam<'a, 'b> {
+impl<'a, 'b> rustc_ast::visit::Visitor<'a> for AlwaysErrorOnGenericParam<'a, 'b, '_> {
     fn visit_attribute(&mut self, attr: &'a rustc_ast::Attribute) -> Self::Result {
         if attr.has_name(sym::pointee) {
             self.cx.dcx().emit_err(errors::NonGenericPointee { span: attr.span });

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -9,7 +9,7 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 pub(crate) fn expand_deriving_debug(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -48,7 +48,7 @@ pub(crate) fn expand_deriving_debug(
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn show_substructure(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> BlockOrExpr {
+fn show_substructure(cx: &ExtCtxt<'_, '_>, span: Span, substr: &Substructure<'_>) -> BlockOrExpr {
     // We want to make sure we have the ctxt set so that we can use unstable methods
     let span = cx.with_def_site_ctxt(span);
 
@@ -92,7 +92,7 @@ fn show_substructure(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) ->
     const CUTOFF: usize = 5;
 
     fn expr_for_field(
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         field: &FieldInfo,
         index: usize,
         len: usize,
@@ -224,7 +224,7 @@ fn show_substructure(cx: &ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) ->
 /// }
 /// ```
 fn show_fieldless_enum(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     def: &EnumDef,
     substr: &Substructure<'_>,

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -12,7 +12,7 @@ use crate::deriving::generic::*;
 use crate::errors;
 
 pub(crate) fn expand_deriving_default(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &ast::MetaItem,
     item: &Annotatable,
@@ -57,14 +57,14 @@ pub(crate) fn expand_deriving_default(
     trait_def.expand(cx, mitem, item, push)
 }
 
-fn default_call(cx: &ExtCtxt<'_>, span: Span) -> Box<ast::Expr> {
+fn default_call(cx: &ExtCtxt<'_, '_>, span: Span) -> Box<ast::Expr> {
     // Note that `kw::Default` is "default" and `sym::Default` is "Default"!
     let default_ident = cx.std_path(&[kw::Default, sym::Default, kw::Default]);
     cx.expr_call_global(span, default_ident, ThinVec::new())
 }
 
 fn default_struct_substructure(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     trait_span: Span,
     substr: &Substructure<'_>,
     summary: &StaticFields<'_>,
@@ -97,7 +97,7 @@ fn default_struct_substructure(
 }
 
 fn default_enum_substructure(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     trait_span: Span,
     enum_def: &EnumDef,
     item_span: Span,
@@ -156,7 +156,7 @@ fn default_enum_substructure(
 }
 
 fn extract_default_variant<'a>(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     enum_def: &'a EnumDef,
     trait_span: Span,
     item_span: Span,
@@ -240,7 +240,7 @@ fn extract_default_variant<'a>(
 }
 
 fn validate_default_attribute(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     default_variant: &rustc_ast::Variant,
 ) -> Result<(), ErrorGuaranteed> {
     let attrs: SmallVec<[_; 1]> =
@@ -275,11 +275,11 @@ fn validate_default_attribute(
     Ok(())
 }
 
-struct DetectNonVariantDefaultAttr<'a, 'b> {
-    cx: &'a ExtCtxt<'b>,
+struct DetectNonVariantDefaultAttr<'a, 'b, 'tcx> {
+    cx: &'a ExtCtxt<'b, 'tcx>,
 }
 
-impl<'a, 'b> rustc_ast::visit::Visitor<'a> for DetectNonVariantDefaultAttr<'a, 'b> {
+impl<'a, 'b> rustc_ast::visit::Visitor<'a> for DetectNonVariantDefaultAttr<'a, 'b, '_> {
     fn visit_attribute(&mut self, attr: &'a rustc_ast::Attribute) {
         if attr.has_name(kw::Default) {
             let post = if self.cx.ecfg.features.default_field_values() {

--- a/compiler/rustc_builtin_macros/src/deriving/from.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/from.rs
@@ -16,7 +16,7 @@ use crate::errors;
 /// Generate an implementation of the `From` trait, provided that `item`
 /// is a struct or a tuple struct with exactly one field.
 pub(crate) fn expand_deriving_from(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &ast::MetaItem,
     annotatable: &Annotatable,

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -340,7 +340,7 @@ pub(crate) enum SubstructureFields<'a> {
 /// Combine the values of all the fields together. The last argument is
 /// all the fields of all the structures.
 pub(crate) type CombineSubstructureFunc<'a> =
-    Box<dyn FnMut(&ExtCtxt<'_>, Span, &Substructure<'_>) -> BlockOrExpr + 'a>;
+    Box<dyn FnMut(&ExtCtxt<'_, '_>, Span, &Substructure<'_>) -> BlockOrExpr + 'a>;
 
 pub(crate) fn combine_substructure(
     f: CombineSubstructureFunc<'_>,
@@ -375,7 +375,7 @@ impl BlockOrExpr {
     }
 
     // Converts it into a block.
-    fn into_block(mut self, cx: &ExtCtxt<'_>, span: Span) -> Box<ast::Block> {
+    fn into_block(mut self, cx: &ExtCtxt<'_, '_>, span: Span) -> Box<ast::Block> {
         if let Some(expr) = self.1 {
             self.0.push(cx.stmt_expr(expr));
         }
@@ -383,7 +383,7 @@ impl BlockOrExpr {
     }
 
     // Converts it into an expression.
-    fn into_expr(self, cx: &ExtCtxt<'_>, span: Span) -> Box<Expr> {
+    fn into_expr(self, cx: &ExtCtxt<'_, '_>, span: Span) -> Box<Expr> {
         if self.0.is_empty() {
             match self.1 {
                 None => cx.expr_block(cx.block(span, ThinVec::new())),
@@ -409,18 +409,18 @@ impl BlockOrExpr {
 fn find_type_parameters(
     ty: &ast::Ty,
     ty_param_names: &[Symbol],
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
 ) -> Vec<TypeParameter> {
     use rustc_ast::visit;
 
-    struct Visitor<'a, 'b> {
-        cx: &'a ExtCtxt<'b>,
+    struct Visitor<'a, 'b, 'tcx> {
+        cx: &'a ExtCtxt<'b, 'tcx>,
         ty_param_names: &'a [Symbol],
         bound_generic_params_stack: ThinVec<ast::GenericParam>,
         type_params: Vec<TypeParameter>,
     }
 
-    impl<'a, 'b> visit::Visitor<'a> for Visitor<'a, 'b> {
+    impl<'a, 'b> visit::Visitor<'a> for Visitor<'a, 'b, '_> {
         fn visit_ty(&mut self, ty: &'a ast::Ty) {
             let stack_len = self.bound_generic_params_stack.len();
             if let ast::TyKind::FnPtr(fn_ptr) = &ty.kind
@@ -474,7 +474,7 @@ fn find_type_parameters(
 impl<'a> TraitDef<'a> {
     pub(crate) fn expand(
         self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         mitem: &ast::MetaItem,
         item: &'a Annotatable,
         push: &mut dyn FnMut(Annotatable),
@@ -484,7 +484,7 @@ impl<'a> TraitDef<'a> {
 
     pub(crate) fn expand_ext(
         self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         mitem: &ast::MetaItem,
         item: &'a Annotatable,
         push: &mut dyn FnMut(Annotatable),
@@ -592,7 +592,7 @@ impl<'a> TraitDef<'a> {
     /// therefore does not get bound by the derived trait.
     fn create_derived_impl(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         type_ident: Ident,
         generics: &Generics,
         field_tys: Vec<&ast::Ty>,
@@ -862,7 +862,7 @@ impl<'a> TraitDef<'a> {
 
     fn expand_struct_def(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         struct_def: &'a VariantData,
         type_ident: Ident,
         generics: &Generics,
@@ -915,7 +915,7 @@ impl<'a> TraitDef<'a> {
 
     fn expand_enum_def(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         enum_def: &'a EnumDef,
         type_ident: Ident,
         generics: &Generics,
@@ -975,7 +975,7 @@ impl<'a> TraitDef<'a> {
 impl<'a> MethodDef<'a> {
     fn call_substructure_method(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'_>,
         type_ident: Ident,
         nonselflike_args: &[Box<Expr>],
@@ -1001,7 +1001,7 @@ impl<'a> MethodDef<'a> {
     //   `&self`.
     fn extract_arg_details(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'_>,
         type_ident: Ident,
         generics: &Generics,
@@ -1038,7 +1038,7 @@ impl<'a> MethodDef<'a> {
 
     fn create_method(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'_>,
         type_ident: Ident,
         generics: &Generics,
@@ -1136,7 +1136,7 @@ impl<'a> MethodDef<'a> {
     /// ```
     fn expand_struct_method_body<'b>(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'b>,
         struct_def: &'b VariantData,
         type_ident: Ident,
@@ -1159,7 +1159,7 @@ impl<'a> MethodDef<'a> {
 
     fn expand_static_struct_method_body(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'a>,
         struct_def: &'a VariantData,
         type_ident: Ident,
@@ -1213,7 +1213,7 @@ impl<'a> MethodDef<'a> {
     /// `Unify`), and possibly a default arm.
     fn expand_enum_method_body<'b>(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'b>,
         enum_def: &'b EnumDef,
         type_ident: Ident,
@@ -1261,7 +1261,7 @@ impl<'a> MethodDef<'a> {
         // let __self_discr = ::core::intrinsics::discriminant_value(self);
         // let __arg1_discr = ::core::intrinsics::discriminant_value(other);
         // ```
-        let get_discr_pieces = |cx: &ExtCtxt<'_>| {
+        let get_discr_pieces = |cx: &ExtCtxt<'_, '_>| {
             let discr_idents: Vec<_> = prefixes
                 .iter()
                 .map(|name| Ident::from_str_and_span(&format!("{name}_discr"), span))
@@ -1462,7 +1462,7 @@ impl<'a> MethodDef<'a> {
 
     fn expand_static_enum_method_body(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         trait_: &TraitDef<'_>,
         enum_def: &EnumDef,
         type_ident: Ident,
@@ -1480,7 +1480,11 @@ impl<'a> MethodDef<'a> {
 
 // general helper methods.
 impl<'a> TraitDef<'a> {
-    fn summarise_struct(&self, cx: &ExtCtxt<'_>, struct_def: &'a VariantData) -> StaticFields<'a> {
+    fn summarise_struct(
+        &self,
+        cx: &ExtCtxt<'_, '_>,
+        struct_def: &'a VariantData,
+    ) -> StaticFields<'a> {
         let mut named_idents = Vec::new();
         let mut just_spans = Vec::new();
         for field in struct_def.fields() {
@@ -1510,7 +1514,7 @@ impl<'a> TraitDef<'a> {
 
     fn create_struct_patterns(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         struct_path: ast::Path,
         struct_def: &'a VariantData,
         prefixes: &[String],
@@ -1600,7 +1604,7 @@ impl<'a> TraitDef<'a> {
 
     fn create_struct_pattern_fields(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         struct_def: &'a VariantData,
         prefixes: &[String],
     ) -> Vec<FieldInfo> {
@@ -1617,7 +1621,7 @@ impl<'a> TraitDef<'a> {
 
     fn create_struct_field_access_fields(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         selflike_args: &[Box<Expr>],
         struct_def: &'a VariantData,
         is_packed: bool,
@@ -1673,13 +1677,13 @@ pub(crate) enum CsFold<'a> {
 /// Statics may not be folded over.
 pub(crate) fn cs_fold<F>(
     use_foldl: bool,
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     trait_span: Span,
     substructure: &Substructure<'_>,
     mut f: F,
 ) -> Box<Expr>
 where
-    F: FnMut(&ExtCtxt<'_>, CsFold<'_>) -> Box<Expr>,
+    F: FnMut(&ExtCtxt<'_, '_>, CsFold<'_>) -> Box<Expr>,
 {
     match substructure.fields {
         EnumMatching(.., all_fields) | Struct(_, all_fields) => {

--- a/compiler/rustc_builtin_macros/src/deriving/generic/ty.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/ty.rs
@@ -35,7 +35,7 @@ impl Path {
 
     pub(crate) fn to_ty(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         span: Span,
         self_ty: Ident,
         self_generics: &Generics,
@@ -44,7 +44,7 @@ impl Path {
     }
     pub(crate) fn to_path(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         span: Span,
         self_ty: Ident,
         self_generics: &Generics,
@@ -86,7 +86,7 @@ pub(crate) fn self_ref() -> Ty {
 impl Ty {
     pub(crate) fn to_ty(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         span: Span,
         self_ty: Ident,
         self_generics: &Generics,
@@ -108,7 +108,7 @@ impl Ty {
 
     pub(crate) fn to_path(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         span: Span,
         self_ty: Ident,
         generics: &Generics,
@@ -145,7 +145,7 @@ impl Ty {
 }
 
 fn mk_ty_param(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     name: Symbol,
     bounds: &[Path],
@@ -174,7 +174,7 @@ impl Bounds {
     }
     pub(crate) fn to_generics(
         &self,
-        cx: &ExtCtxt<'_>,
+        cx: &ExtCtxt<'_, '_>,
         span: Span,
         self_ty: Ident,
         self_generics: &Generics,
@@ -197,7 +197,10 @@ impl Bounds {
     }
 }
 
-pub(crate) fn get_explicit_self(cx: &ExtCtxt<'_>, span: Span) -> (Box<Expr>, ast::ExplicitSelf) {
+pub(crate) fn get_explicit_self(
+    cx: &ExtCtxt<'_, '_>,
+    span: Span,
+) -> (Box<Expr>, ast::ExplicitSelf) {
     // This constructs a fresh `self` path.
     let self_path = cx.expr_self(span);
     let self_ty = respan(span, SelfKind::Region(None, ast::Mutability::Not));

--- a/compiler/rustc_builtin_macros/src/deriving/hash.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/hash.rs
@@ -8,7 +8,7 @@ use crate::deriving::generic::*;
 use crate::deriving::{path_std, pathvec_std};
 
 pub(crate) fn expand_deriving_hash(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     mitem: &MetaItem,
     item: &Annotatable,
@@ -49,7 +49,11 @@ pub(crate) fn expand_deriving_hash(
     hash_trait_def.expand(cx, mitem, item, push);
 }
 
-fn hash_substructure(cx: &ExtCtxt<'_>, trait_span: Span, substr: &Substructure<'_>) -> BlockOrExpr {
+fn hash_substructure(
+    cx: &ExtCtxt<'_, '_>,
+    trait_span: Span,
+    substr: &Substructure<'_>,
+) -> BlockOrExpr {
     let [state_expr] = substr.nonselflike_args else {
         cx.dcx().span_bug(trait_span, "incorrect number of arguments in `derive(Hash)`");
     };

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -38,14 +38,14 @@ pub(crate) mod partial_ord;
 pub(crate) mod generic;
 
 pub(crate) type BuiltinDeriveFn =
-    fn(&ExtCtxt<'_>, Span, &MetaItem, &Annotatable, &mut dyn FnMut(Annotatable), bool);
+    fn(&ExtCtxt<'_, '_>, Span, &MetaItem, &Annotatable, &mut dyn FnMut(Annotatable), bool);
 
 pub(crate) struct BuiltinDerive(pub(crate) BuiltinDeriveFn);
 
 impl MultiItemModifier for BuiltinDerive {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         meta_item: &MetaItem,
         item: Annotatable,
@@ -88,7 +88,7 @@ impl MultiItemModifier for BuiltinDerive {
 
 /// Constructs an expression that calls an intrinsic
 fn call_intrinsic(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     span: Span,
     intrinsic: Symbol,
     args: ThinVec<Box<ast::Expr>>,
@@ -99,7 +99,7 @@ fn call_intrinsic(
 }
 
 /// Constructs an expression that calls the `unreachable` intrinsic.
-fn call_unreachable(cx: &ExtCtxt<'_>, span: Span) -> Box<ast::Expr> {
+fn call_unreachable(cx: &ExtCtxt<'_, '_>, span: Span) -> Box<ast::Expr> {
     let span = cx.with_def_site_ctxt(span);
     let path = cx.std_path(&[sym::intrinsics, sym::unreachable]);
     let call = cx.expr_call_global(span, path, ThinVec::new());
@@ -114,7 +114,7 @@ fn call_unreachable(cx: &ExtCtxt<'_>, span: Span) -> Box<ast::Expr> {
 }
 
 fn assert_ty_bounds(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     stmts: &mut ThinVec<ast::Stmt>,
     ty: Box<ast::Ty>,
     span: Span,

--- a/compiler/rustc_builtin_macros/src/edition_panic.rs
+++ b/compiler/rustc_builtin_macros/src/edition_panic.rs
@@ -15,7 +15,7 @@ use rustc_span::{Span, sym};
 /// `$crate` will refer to either the `std` or `core` crate depending on which
 /// one we're expanding from.
 pub(crate) fn expand_panic<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -28,7 +28,7 @@ pub(crate) fn expand_panic<'cx>(
 /// - `$crate::panic::unreachable_2021!(...)`
 /// depending on the edition.
 pub(crate) fn expand_unreachable<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -38,7 +38,7 @@ pub(crate) fn expand_unreachable<'cx>(
 
 fn expand<'cx>(
     mac: rustc_span::Symbol,
-    cx: &'cx ExtCtxt<'_>,
+    cx: &'cx ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -36,7 +36,7 @@ use crate::errors::{
 /// macro panic_handler() {}
 /// ```
 pub(crate) fn eii(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -45,7 +45,7 @@ pub(crate) fn eii(
 }
 
 pub(crate) fn unsafe_eii(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -54,7 +54,7 @@ pub(crate) fn unsafe_eii(
 }
 
 fn eii_(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     eii_attr_span: Span,
     meta_item: &ast::MetaItem,
     orig_item: Annotatable,
@@ -177,7 +177,7 @@ fn eii_(
 /// This is either an explicitly given name, or the name of the item in the
 /// declaration of the EII.
 fn name_for_impl_macro(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     item_ident: Ident,
     meta_item: &MetaItem,
 ) -> Result<Ident, ErrorGuaranteed> {
@@ -198,7 +198,7 @@ fn name_for_impl_macro(
 
 /// Ensure that in the list of attrs, there's only a single `eii` attribute.
 fn filter_attrs_for_multiple_eii_attr(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     attrs: ThinVec<Attribute>,
     eii_attr_span: Span,
     eii_attr_path: &Path,
@@ -221,7 +221,7 @@ fn filter_attrs_for_multiple_eii_attr(
 }
 
 fn generate_default_func_impl(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     func: &ast::Fn,
     impl_unsafe: bool,
     macro_name: Ident,
@@ -284,7 +284,7 @@ fn generate_default_func_impl(
 /// extern "…" { safe fn item(); }
 /// ```
 fn generate_foreign_item(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     eii_attr_span: Span,
     item_span: Span,
     item_kind: &ItemKind,
@@ -376,7 +376,7 @@ fn generate_foreign_static(mut stat: Box<ast::StaticItem>) -> ast::ForeignItemKi
 /// macro macro_name { () => {} }
 /// ```
 fn generate_attribute_macro_to_implement(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     span: Span,
     macro_name: Ident,
     foreign_item_name: Ident,
@@ -439,7 +439,7 @@ fn generate_attribute_macro_to_implement(
 }
 
 pub(crate) fn eii_declaration(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     span: Span,
     meta_item: &ast::MetaItem,
     mut item: Annotatable,
@@ -495,7 +495,7 @@ pub(crate) fn eii_declaration(
 
 /// all Eiis share this function as the implementation for their attribute.
 pub(crate) fn eii_shared_macro(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     span: Span,
     meta_item: &ast::MetaItem,
     mut item: Annotatable,

--- a/compiler/rustc_builtin_macros/src/env.rs
+++ b/compiler/rustc_builtin_macros/src/env.rs
@@ -17,7 +17,7 @@ use thin_vec::thin_vec;
 use crate::errors;
 use crate::util::{expr_to_string, get_exprs_from_tts, get_single_expr_from_tts};
 
-fn lookup_env<'cx>(cx: &'cx ExtCtxt<'_>, var: Symbol) -> Result<Symbol, VarError> {
+fn lookup_env<'cx>(cx: &'cx ExtCtxt<'_, '_>, var: Symbol) -> Result<Symbol, VarError> {
     let var = var.as_str();
     if let Some(value) = cx.sess.opts.logical_env.get(var) {
         return Ok(Symbol::intern(value));
@@ -28,7 +28,7 @@ fn lookup_env<'cx>(cx: &'cx ExtCtxt<'_>, var: Symbol) -> Result<Symbol, VarError
 }
 
 pub(crate) fn expand_option_env<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -88,7 +88,7 @@ pub(crate) fn expand_option_env<'cx>(
 }
 
 pub(crate) fn expand_env<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -68,7 +68,7 @@ struct MacroInput {
 /// ```text
 /// Ok((fmtstr, parsed arguments))
 /// ```
-fn parse_args<'a>(ecx: &ExtCtxt<'a>, sp: Span, tts: TokenStream) -> PResult<'a, MacroInput> {
+fn parse_args<'a>(ecx: &ExtCtxt<'a, '_>, sp: Span, tts: TokenStream) -> PResult<'a, MacroInput> {
     let mut p = ecx.new_parser_from_tts(tts);
 
     // parse the format string
@@ -157,7 +157,7 @@ fn parse_args<'a>(ecx: &ExtCtxt<'a>, sp: Span, tts: TokenStream) -> PResult<'a, 
 }
 
 fn make_format_args(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     input: MacroInput,
     append_newline: bool,
     macro_span: Span,
@@ -658,7 +658,7 @@ fn make_format_args(
 }
 
 fn invalid_placeholder_type_error(
-    ecx: &ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_, '_>,
     ty: &str,
     ty_span: Option<Range<usize>>,
     fmt_span: Span,
@@ -686,7 +686,7 @@ fn invalid_placeholder_type_error(
 }
 
 fn report_missing_placeholders(
-    ecx: &ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_, '_>,
     unused: Vec<(Span, bool)>,
     used: &[bool],
     args: &FormatArguments,
@@ -845,7 +845,7 @@ fn report_missing_placeholders(
 /// This function detects and reports unused format!() arguments that are
 /// redundant due to implicit captures (e.g. `format!("{x}", x)`).
 fn report_redundant_format_arguments<'a>(
-    ecx: &ExtCtxt<'a>,
+    ecx: &ExtCtxt<'a, '_>,
     args: &FormatArguments,
     used: &[bool],
     placeholders: Vec<(Span, &str)>,
@@ -917,7 +917,7 @@ fn report_redundant_format_arguments<'a>(
 /// there are named arguments or numbered positional arguments in the
 /// format string.
 fn report_invalid_references(
-    ecx: &ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_, '_>,
     invalid_refs: &[(usize, Option<Span>, PositionUsedAs, FormatArgPositionKind)],
     template: &[FormatArgsPiece],
     fmt_span: Span,
@@ -1083,7 +1083,7 @@ fn report_invalid_references(
 }
 
 fn expand_format_args_impl<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     mut sp: Span,
     tts: TokenStream,
     nl: bool,
@@ -1109,7 +1109,7 @@ fn expand_format_args_impl<'cx>(
 }
 
 pub(crate) fn expand_format_args<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -1117,7 +1117,7 @@ pub(crate) fn expand_format_args<'cx>(
 }
 
 pub(crate) fn expand_format_args_nl<'cx>(
-    ecx: &'cx mut ExtCtxt<'_>,
+    ecx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -13,7 +13,7 @@ use crate::errors;
 use crate::util::check_builtin_macro_attribute;
 
 pub(crate) fn expand(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     _span: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -65,14 +65,14 @@ pub(crate) fn expand(
     vec![orig_item, const_item]
 }
 
-struct AllocFnFactory<'a, 'b> {
+struct AllocFnFactory<'a, 'b, 'tcx> {
     span: Span,
     ty_span: Span,
     global: Ident,
-    cx: &'a ExtCtxt<'b>,
+    cx: &'a ExtCtxt<'b, 'tcx>,
 }
 
-impl AllocFnFactory<'_, '_> {
+impl AllocFnFactory<'_, '_, '_> {
     fn allocator_fn(&self, method: &AllocatorMethod) -> Stmt {
         let mut abi_args = ThinVec::new();
         let args = method.inputs.iter().map(|input| self.arg_ty(input, &mut abi_args)).collect();

--- a/compiler/rustc_builtin_macros/src/iter.rs
+++ b/compiler/rustc_builtin_macros/src/iter.rs
@@ -5,7 +5,7 @@ use rustc_expand::base::{self, DummyResult, ExpandResult, ExtCtxt, MacroExpander
 use rustc_span::Span;
 
 pub(crate) fn expand<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -20,7 +20,7 @@ pub(crate) fn expand<'cx>(
 }
 
 fn parse_closure<'a>(
-    cx: &mut ExtCtxt<'a>,
+    cx: &mut ExtCtxt<'a, '_>,
     span: Span,
     stream: TokenStream,
 ) -> PResult<'a, Box<Expr>> {

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -55,7 +55,7 @@ pub mod standard_library_imports;
 pub mod test_harness;
 pub mod util;
 
-pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
+pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand<'_>) {
     let mut register = |name, kind| resolver.register_builtin_macro(name, kind);
     macro register_bang($($name:ident: $f:expr,)*) {
         $(register(sym::$name, SyntaxExtensionKind::LegacyBang(Arc::new($f as MacroExpanderFn)));)*

--- a/compiler/rustc_builtin_macros/src/log_syntax.rs
+++ b/compiler/rustc_builtin_macros/src/log_syntax.rs
@@ -3,7 +3,7 @@ use rustc_ast_pretty::pprust;
 use rustc_expand::base::{DummyResult, ExpandResult, ExtCtxt, MacroExpanderResult};
 
 pub(crate) fn expand_log_syntax<'cx>(
-    _cx: &'cx mut ExtCtxt<'_>,
+    _cx: &'cx mut ExtCtxt<'_, '_>,
     sp: rustc_span::Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {

--- a/compiler/rustc_builtin_macros/src/pattern_type.rs
+++ b/compiler/rustc_builtin_macros/src/pattern_type.rs
@@ -7,7 +7,7 @@ use rustc_parse::parser::{CommaRecoveryMode, RecoverColon, RecoverComma};
 use rustc_span::Span;
 
 pub(crate) fn expand<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -22,7 +22,7 @@ pub(crate) fn expand<'cx>(
 }
 
 fn parse_pat_ty<'a>(
-    cx: &mut ExtCtxt<'a>,
+    cx: &mut ExtCtxt<'a, '_>,
     stream: TokenStream,
 ) -> PResult<'a, (Box<Ty>, Box<TyPat>)> {
     let mut parser = cx.new_parser_from_tts(stream);
@@ -57,7 +57,7 @@ fn ty_pat(kind: TyPatKind, span: Span) -> TyPat {
     TyPat { id: DUMMY_NODE_ID, kind, span, tokens: None }
 }
 
-fn pat_to_ty_pat(cx: &mut ExtCtxt<'_>, pat: ast::Pat) -> TyPat {
+fn pat_to_ty_pat(cx: &mut ExtCtxt<'_, '_>, pat: ast::Pat) -> TyPat {
     let kind = match pat.kind {
         ast::PatKind::Range(start, end, include_end) => TyPatKind::Range(
             start.map(|value| {

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -52,7 +52,7 @@ pub fn inject(
     krate: &mut ast::Crate,
     sess: &Session,
     features: &Features,
-    resolver: &mut dyn ResolverExpand,
+    resolver: &mut dyn ResolverExpand<'_>,
     is_proc_macro_crate: bool,
     has_proc_macro_decls: bool,
     is_test_crate: bool,
@@ -277,7 +277,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
 //              // ...
 //          ];
 //      }
-fn mk_decls(cx: &mut ExtCtxt<'_>, macros: &[ProcMacro]) -> Box<ast::Item> {
+fn mk_decls(cx: &mut ExtCtxt<'_, '_>, macros: &[ProcMacro]) -> Box<ast::Item> {
     let expn_id = cx.resolver.expansion_for_ast_pass(
         DUMMY_SP,
         AstPass::ProcMacroHarness,
@@ -308,8 +308,8 @@ fn mk_decls(cx: &mut ExtCtxt<'_>, macros: &[ProcMacro]) -> Box<ast::Item> {
                 ProcMacro::Derive(m) => m.span,
                 ProcMacro::Attr(m) | ProcMacro::Bang(m) => m.span,
             };
-            let local_path = |cx: &ExtCtxt<'_>, ident| cx.expr_path(cx.path(span, vec![ident]));
-            let proc_macro_ty_method_path = |cx: &ExtCtxt<'_>, method| {
+            let local_path = |cx: &ExtCtxt<'_, '_>, ident| cx.expr_path(cx.path(span, vec![ident]));
+            let proc_macro_ty_method_path = |cx: &ExtCtxt<'_, '_>, method| {
                 cx.expr_path(cx.path(
                     span.with_ctxt(harness_span.ctxt()),
                     vec![proc_macro, bridge, client, proc_macro_ty, method],

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -28,7 +28,7 @@ use crate::util::{
 
 /// Expand `line!()` to the current line number.
 pub(crate) fn expand_line(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -43,7 +43,7 @@ pub(crate) fn expand_line(
 
 /// Expand `column!()` to the current column number.
 pub(crate) fn expand_column(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -58,7 +58,7 @@ pub(crate) fn expand_column(
 
 /// Expand `file!()` to the current filename.
 pub(crate) fn expand_file(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -77,7 +77,7 @@ pub(crate) fn expand_file(
 
 /// Expand `stringify!($input)`.
 pub(crate) fn expand_stringify(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -88,7 +88,7 @@ pub(crate) fn expand_stringify(
 
 /// Expand `module_path!()` to (a textual representation of) the current module path.
 pub(crate) fn expand_mod(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -104,7 +104,7 @@ pub(crate) fn expand_mod(
 ///
 /// This works in item and expression position. Notably, it doesn't work in pattern position.
 pub(crate) fn expand_include<'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
@@ -202,7 +202,7 @@ pub(crate) fn expand_include<'cx>(
 ///
 /// This works in expression, pattern and statement position.
 pub(crate) fn expand_include_str(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -236,7 +236,7 @@ pub(crate) fn expand_include_str(
 ///
 /// This works in expression, pattern and statement position.
 pub(crate) fn expand_include_bytes(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'static> {
@@ -262,7 +262,7 @@ pub(crate) fn expand_include_bytes(
 }
 
 fn load_binary_file(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     original_path: &Path,
     macro_span: Span,
     path_span: Span,

--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -11,7 +11,7 @@ use thin_vec::thin_vec;
 pub fn inject(
     krate: &mut ast::Crate,
     pre_configured_attrs: &[ast::Attribute],
-    resolver: &mut dyn ResolverExpand,
+    resolver: &mut dyn ResolverExpand<'_>,
     sess: &Session,
     features: &Features,
 ) -> usize {

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -25,7 +25,7 @@ use crate::util::{check_builtin_macro_attribute, warn_on_duplicate_attribute};
 /// We mark item with an inert attribute "rustc_test_marker" which the test generation
 /// logic will pick up on.
 pub(crate) fn expand_test_case(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     attr_sp: Span,
     meta_item: &ast::MetaItem,
     anno_item: Annotatable,
@@ -85,7 +85,7 @@ pub(crate) fn expand_test_case(
 }
 
 pub(crate) fn expand_test(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     attr_sp: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -96,7 +96,7 @@ pub(crate) fn expand_test(
 }
 
 pub(crate) fn expand_bench(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     attr_sp: Span,
     meta_item: &ast::MetaItem,
     item: Annotatable,
@@ -107,7 +107,7 @@ pub(crate) fn expand_bench(
 }
 
 pub(crate) fn expand_test_or_bench(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     attr_sp: Span,
     item: Annotatable,
     is_bench: bool,
@@ -404,7 +404,12 @@ pub(crate) fn expand_test_or_bench(
     }
 }
 
-fn not_testable_error(cx: &ExtCtxt<'_>, is_bench: bool, attr_sp: Span, item: Option<&ast::Item>) {
+fn not_testable_error(
+    cx: &ExtCtxt<'_, '_>,
+    is_bench: bool,
+    attr_sp: Span,
+    item: Option<&ast::Item>,
+) {
     let dcx = cx.dcx();
     let name = if is_bench { "bench" } else { "test" };
     let msg = format!("the `#[{name}]` attribute may only be used on a free function");
@@ -438,7 +443,7 @@ fn not_testable_error(cx: &ExtCtxt<'_>, is_bench: bool, attr_sp: Span, item: Opt
     }
 }
 
-fn get_location_info(cx: &ExtCtxt<'_>, fn_: &ast::Fn) -> (Symbol, usize, usize, usize, usize) {
+fn get_location_info(cx: &ExtCtxt<'_, '_>, fn_: &ast::Fn) -> (Symbol, usize, usize, usize, usize) {
     let span = fn_.ident.span;
     let (source_file, lo_line, lo_col, hi_line, hi_col) =
         cx.sess.source_map().span_to_location_info(span);
@@ -478,7 +483,7 @@ fn should_ignore_message(i: &ast::Item) -> Option<Symbol> {
     }
 }
 
-fn should_panic(cx: &ExtCtxt<'_>, i: &ast::Item) -> ShouldPanic {
+fn should_panic(cx: &ExtCtxt<'_, '_>, i: &ast::Item) -> ShouldPanic {
     if let Some(Attribute::Parsed(AttributeKind::ShouldPanic { reason, .. })) =
         AttributeParser::parse_limited(cx.sess, &i.attrs, &[sym::should_panic])
     {
@@ -497,7 +502,7 @@ enum TestType {
 /// Attempts to determine the type of test.
 /// Since doctests are created without macro expanding, only possible variants here
 /// are `UnitTest`, `IntegrationTest` or `Unknown`.
-fn test_type(cx: &ExtCtxt<'_>) -> TestType {
+fn test_type(cx: &ExtCtxt<'_, '_>) -> TestType {
     // Root path from context contains the topmost sources directory of the crate.
     // I.e., for `project` with sources in `src` and tests in `tests` folders
     // (no matter how many nested folders lie inside),
@@ -517,7 +522,7 @@ fn test_type(cx: &ExtCtxt<'_>) -> TestType {
 }
 
 fn check_test_signature(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     i: &ast::Item,
     f: &ast::Fn,
 ) -> Result<(), ErrorGuaranteed> {
@@ -581,7 +586,7 @@ fn check_test_signature(
 }
 
 fn check_bench_signature(
-    cx: &ExtCtxt<'_>,
+    cx: &ExtCtxt<'_, '_>,
     i: &ast::Item,
     f: &ast::Fn,
 ) -> Result<(), ErrorGuaranteed> {

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -31,8 +31,8 @@ struct Test {
     name: Symbol,
 }
 
-struct TestCtxt<'a> {
-    ext_cx: ExtCtxt<'a>,
+struct TestCtxt<'a, 'tcx> {
+    ext_cx: ExtCtxt<'a, 'tcx>,
     panic_strategy: PanicStrategy,
     def_site: Span,
     test_cases: Vec<Test>,
@@ -46,7 +46,7 @@ pub fn inject(
     krate: &mut ast::Crate,
     sess: &Session,
     features: &Features,
-    resolver: &mut dyn ResolverExpand,
+    resolver: &mut dyn ResolverExpand<'_>,
 ) {
     let dcx = sess.dcx();
     let panic_strategy = sess.panic_strategy();
@@ -89,12 +89,12 @@ pub fn inject(
     }
 }
 
-struct TestHarnessGenerator<'a> {
-    cx: TestCtxt<'a>,
+struct TestHarnessGenerator<'a, 'tcx> {
+    cx: TestCtxt<'a, 'tcx>,
     tests: Vec<Test>,
 }
 
-impl TestHarnessGenerator<'_> {
+impl TestHarnessGenerator<'_, '_> {
     fn add_test_cases(&mut self, node_id: ast::NodeId, span: Span, prev_tests: Vec<Test>) {
         let mut tests = mem::replace(&mut self.tests, prev_tests);
 
@@ -118,7 +118,7 @@ impl TestHarnessGenerator<'_> {
     }
 }
 
-impl<'a> MutVisitor for TestHarnessGenerator<'a> {
+impl<'a> MutVisitor for TestHarnessGenerator<'a, '_> {
     fn visit_crate(&mut self, c: &mut ast::Crate) {
         let prev_tests = mem::take(&mut self.tests);
         walk_crate(self, c);
@@ -222,7 +222,7 @@ impl<'a> MutVisitor for EntryPointCleaner<'a> {
 /// Crawl over the crate, inserting test reexports and the test main function
 fn generate_test_harness(
     sess: &Session,
-    resolver: &mut dyn ResolverExpand,
+    resolver: &mut dyn ResolverExpand<'_>,
     reexport_test_harness_main: Option<Symbol>,
     krate: &mut ast::Crate,
     features: &Features,
@@ -286,7 +286,7 @@ fn generate_test_harness(
 /// [`TestCtxt::reexport_test_harness_main`] provides a different name for the `main`
 /// function and [`TestCtxt::test_runner`] provides a path that replaces
 /// `test::test_main_static`.
-fn mk_main(cx: &mut TestCtxt<'_>) -> Box<ast::Item> {
+fn mk_main(cx: &mut TestCtxt<'_, '_>) -> Box<ast::Item> {
     let sp = cx.def_site;
     let ecx = &cx.ext_cx;
     let test_ident = Ident::new(sym::test, sp);
@@ -365,7 +365,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> Box<ast::Item> {
 
 /// Creates a slice containing every test like so:
 /// &[&test1, &test2]
-fn mk_tests_slice(cx: &TestCtxt<'_>, sp: Span) -> Box<ast::Expr> {
+fn mk_tests_slice(cx: &TestCtxt<'_, '_>, sp: Span) -> Box<ast::Expr> {
     debug!("building test vector from {} tests", cx.test_cases.len());
     let ecx = &cx.ext_cx;
 

--- a/compiler/rustc_builtin_macros/src/trace_macros.rs
+++ b/compiler/rustc_builtin_macros/src/trace_macros.rs
@@ -5,7 +5,7 @@ use rustc_span::{Span, kw};
 use crate::errors;
 
 pub(crate) fn expand_trace_macros(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     tt: TokenStream,
 ) -> MacroExpanderResult<'static> {

--- a/compiler/rustc_builtin_macros/src/util.rs
+++ b/compiler/rustc_builtin_macros/src/util.rs
@@ -12,7 +12,11 @@ use rustc_span::{BytePos, Span, Symbol};
 
 use crate::errors;
 
-pub(crate) fn check_builtin_macro_attribute(ecx: &ExtCtxt<'_>, meta_item: &MetaItem, name: Symbol) {
+pub(crate) fn check_builtin_macro_attribute(
+    ecx: &ExtCtxt<'_, '_>,
+    meta_item: &MetaItem,
+    name: Symbol,
+) {
     // All the built-in macro attributes are "words" at the moment.
     let template = AttributeTemplate { word: true, ..Default::default() };
     validate_attr::check_builtin_meta_item(
@@ -27,7 +31,7 @@ pub(crate) fn check_builtin_macro_attribute(ecx: &ExtCtxt<'_>, meta_item: &MetaI
 
 /// Emit a warning if the item is annotated with the given attribute. This is used to diagnose when
 /// an attribute may have been mistakenly duplicated.
-pub(crate) fn warn_on_duplicate_attribute(ecx: &ExtCtxt<'_>, item: &Annotatable, name: Symbol) {
+pub(crate) fn warn_on_duplicate_attribute(ecx: &ExtCtxt<'_, '_>, item: &Annotatable, name: Symbol) {
     let attrs: Option<&[Attribute]> = match item {
         Annotatable::Item(item) => Some(&item.attrs),
         Annotatable::AssocItem(item, _) => Some(&item.attrs),
@@ -79,7 +83,7 @@ type UnexpectedExprKind<'a> = Result<(Diag<'a>, bool /* has_suggestions */), Err
 /// added to the diagnostic to avoid emitting multiple suggestions. `Err(Err(ErrorGuaranteed))`
 /// indicates that an ast error was encountered.
 pub(crate) fn expr_to_spanned_string<'a>(
-    cx: &'a mut ExtCtxt<'_>,
+    cx: &'a mut ExtCtxt<'_, '_>,
     expr: Box<ast::Expr>,
     err_msg: &'static str,
 ) -> ExpandResult<ExprToSpannedStringResult<'a>, ()> {
@@ -131,7 +135,7 @@ pub(crate) fn expr_to_spanned_string<'a>(
 /// emitting `err_msg` if `expr` is not a string literal. This does not stop
 /// compilation on error, merely emits a non-fatal error and returns `Err`.
 pub(crate) fn expr_to_string(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     expr: Box<ast::Expr>,
     err_msg: &'static str,
 ) -> ExpandResult<Result<(Symbol, ast::StrStyle), ErrorGuaranteed>, ()> {
@@ -148,7 +152,7 @@ pub(crate) fn expr_to_string(
 /// returns even when `tts` is non-empty, macros that *need* to stop
 /// compilation should call `cx.diagnostic().abort_if_errors()`
 /// (this should be done as rarely as possible).
-pub(crate) fn check_zero_tts(cx: &ExtCtxt<'_>, span: Span, tts: TokenStream, name: &str) {
+pub(crate) fn check_zero_tts(cx: &ExtCtxt<'_, '_>, span: Span, tts: TokenStream, name: &str) {
     if !tts.is_empty() {
         cx.dcx().emit_err(errors::TakesNoArguments { span, name });
     }
@@ -169,7 +173,7 @@ pub(crate) fn parse_expr(p: &mut parser::Parser<'_>) -> Result<Box<ast::Expr>, E
 /// Interpreting `tts` as a comma-separated sequence of expressions,
 /// expect exactly one string literal, or emit an error and return `Err`.
 pub(crate) fn get_single_str_from_tts(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     span: Span,
     tts: TokenStream,
     name: &str,
@@ -178,7 +182,7 @@ pub(crate) fn get_single_str_from_tts(
 }
 
 pub(crate) fn get_single_str_spanned_from_tts(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     span: Span,
     tts: TokenStream,
     name: &str,
@@ -202,7 +206,7 @@ pub(crate) fn get_single_str_spanned_from_tts(
 /// Interpreting `tts` as a comma-separated sequence of expressions,
 /// expect exactly one expression, or emit an error and return `Err`.
 pub(crate) fn get_single_expr_from_tts(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     span: Span,
     tts: TokenStream,
     name: &str,
@@ -227,7 +231,7 @@ pub(crate) fn get_single_expr_from_tts(
 /// Extracts comma-separated expressions from `tts`.
 /// On error, emit it, and return `Err`.
 pub(crate) fn get_exprs_from_tts(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     tts: TokenStream,
 ) -> ExpandResult<Result<Vec<Box<ast::Expr>>, ErrorGuaranteed>, ()> {
     let mut p = cx.new_parser_from_tts(tts);

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -681,8 +681,8 @@ fn print_crate_info(
                     // no crate attributes, print out an error and exit
                     return Compilation::Continue;
                 };
-                let t_outputs = rustc_interface::util::build_output_filenames(attrs, sess);
                 let crate_name = passes::get_crate_name(sess, attrs);
+                let t_outputs = rustc_interface::util::build_output_filenames(sess, crate_name);
                 let crate_types = collect_crate_types(
                     sess,
                     &codegen_backend.supported_crate_types(sess),
@@ -692,7 +692,10 @@ fn print_crate_info(
                 );
                 for &style in &crate_types {
                     let fname = rustc_session::output::filename_for_input(
-                        sess, style, crate_name, &t_outputs,
+                        sess,
+                        style,
+                        crate_name.normalized,
+                        &t_outputs,
                     );
                     println_info!("{}", fname.as_path().file_name().unwrap().to_string_lossy());
                 }
@@ -702,7 +705,7 @@ fn print_crate_info(
                     // no crate attributes, print out an error and exit
                     return Compilation::Continue;
                 };
-                println_info!("{}", passes::get_crate_name(sess, attrs));
+                println_info!("{}", passes::get_crate_name(sess, attrs).normalized);
             }
             CrateRootLintLevels => {
                 let Some(attrs) = attrs.as_ref() else {
@@ -711,7 +714,7 @@ fn print_crate_info(
                 };
                 let crate_name = passes::get_crate_name(sess, attrs);
                 let lint_store = crate::unerased_lint_store(sess);
-                let features = rustc_expand::config::features(sess, attrs, crate_name);
+                let features = rustc_expand::config::features(sess, attrs, crate_name.normalized);
                 let registered_tools = rustc_resolve::registered_tools_ast(sess.dcx(), attrs, sess);
                 let lint_levels = rustc_lint::LintLevelsBuilder::crate_root(
                     sess,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -13,7 +13,6 @@ use rustc_ast::{self as ast, AttrVec, Attribute, HasAttrs, Item, NodeId, PatKind
 use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
 use rustc_data_structures::sync;
 use rustc_errors::{BufferedEarlyLint, DiagCtxtHandle, ErrorGuaranteed, PResult};
-use rustc_feature::Features;
 use rustc_hir as hir;
 use rustc_hir::attrs::{CfgEntry, CollapseMacroDebuginfo, Deprecation};
 use rustc_hir::def::MacroKinds;
@@ -1187,10 +1186,7 @@ pub trait ResolverExpand<'tcx> {
 pub trait LintStoreExpand {
     fn pre_expansion_lint(
         &self,
-        sess: &Session,
         tcx: TyCtxt<'_>,
-        features: &Features,
-        registered_tools: &RegisteredTools,
         node_id: NodeId,
         attrs: &[Attribute],
         items: &[Box<Item>],

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -20,6 +20,7 @@ use rustc_hir::def::MacroKinds;
 use rustc_hir::limit::Limit;
 use rustc_hir::{Stability, find_attr};
 use rustc_lint_defs::RegisteredTools;
+use rustc_middle::ty::TyCtxt;
 use rustc_parse::MACRO_ARGUMENTS;
 use rustc_parse::parser::Parser;
 use rustc_session::Session;
@@ -268,7 +269,7 @@ impl<'cx> MacroExpanderResult<'cx> {
     ///
     /// The `TokenStream` is forwarded without any expansion.
     pub fn from_tts(
-        cx: &'cx mut ExtCtxt<'_>,
+        cx: &'cx mut ExtCtxt<'_, '_>,
         tts: TokenStream,
         site_span: Span,
         arm_span: Span,
@@ -287,7 +288,7 @@ pub trait MultiItemModifier {
     /// `meta_item` is the attribute, and `item` is the item being modified.
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,
@@ -297,11 +298,11 @@ pub trait MultiItemModifier {
 
 impl<F> MultiItemModifier for F
 where
-    F: Fn(&mut ExtCtxt<'_>, Span, &ast::MetaItem, Annotatable) -> Vec<Annotatable>,
+    F: Fn(&mut ExtCtxt<'_, '_>, Span, &ast::MetaItem, Annotatable) -> Vec<Annotatable>,
 {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         meta_item: &ast::MetaItem,
         item: Annotatable,
@@ -314,7 +315,7 @@ where
 pub trait BangProcMacro {
     fn expand<'cx>(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         ts: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed>;
@@ -322,11 +323,11 @@ pub trait BangProcMacro {
 
 impl<F> BangProcMacro for F
 where
-    F: Fn(&mut ExtCtxt<'_>, Span, TokenStream) -> Result<TokenStream, ErrorGuaranteed>,
+    F: Fn(&mut ExtCtxt<'_, '_>, Span, TokenStream) -> Result<TokenStream, ErrorGuaranteed>,
 {
     fn expand<'cx>(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         ts: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
@@ -338,7 +339,7 @@ where
 pub trait AttrProcMacro {
     fn expand<'cx>(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
@@ -347,7 +348,7 @@ pub trait AttrProcMacro {
     // Default implementation for safe attributes; override if the attribute can be unsafe.
     fn expand_with_safety<'cx>(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         safety: Safety,
         span: Span,
         annotation: TokenStream,
@@ -366,7 +367,7 @@ where
 {
     fn expand<'cx>(
         &self,
-        _ecx: &'cx mut ExtCtxt<'_>,
+        _ecx: &'cx mut ExtCtxt<'_, '_>,
         _span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
@@ -380,7 +381,7 @@ where
 pub trait TTMacroExpander: Any {
     fn expand<'cx, 'a: 'cx>(
         &'a self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         input: TokenStream,
     ) -> MacroExpanderResult<'cx>;
@@ -389,15 +390,15 @@ pub trait TTMacroExpander: Any {
 pub type MacroExpanderResult<'cx> = ExpandResult<Box<dyn MacResult + 'cx>, ()>;
 
 pub type MacroExpanderFn =
-    for<'cx> fn(&'cx mut ExtCtxt<'_>, Span, TokenStream) -> MacroExpanderResult<'cx>;
+    for<'cx> fn(&'cx mut ExtCtxt<'_, '_>, Span, TokenStream) -> MacroExpanderResult<'cx>;
 
 impl<F: 'static> TTMacroExpander for F
 where
-    F: for<'cx> Fn(&'cx mut ExtCtxt<'_>, Span, TokenStream) -> MacroExpanderResult<'cx>,
+    F: for<'cx> Fn(&'cx mut ExtCtxt<'_, '_>, Span, TokenStream) -> MacroExpanderResult<'cx>,
 {
     fn expand<'cx, 'a: 'cx>(
         &'a self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &'cx mut ExtCtxt<'_, '_>,
         span: Span,
         input: TokenStream,
     ) -> MacroExpanderResult<'cx> {
@@ -406,7 +407,7 @@ where
 }
 
 pub trait GlobDelegationExpander {
-    fn expand(&self, ecx: &mut ExtCtxt<'_>) -> ExpandResult<Vec<(Ident, Option<Ident>)>, ()>;
+    fn expand(&self, ecx: &mut ExtCtxt<'_, '_>) -> ExpandResult<Vec<(Ident, Option<Ident>)>, ()>;
 }
 
 fn make_stmts_default(expr: Option<Box<ast::Expr>>) -> Option<SmallVec<[ast::Stmt; 1]>> {
@@ -984,7 +985,7 @@ impl SyntaxExtension {
     /// A dummy bang macro `foo!()`.
     pub fn dummy_bang(edition: Edition) -> SyntaxExtension {
         fn expand(
-            ecx: &mut ExtCtxt<'_>,
+            ecx: &mut ExtCtxt<'_, '_>,
             span: Span,
             _ts: TokenStream,
         ) -> Result<TokenStream, ErrorGuaranteed> {
@@ -996,7 +997,7 @@ impl SyntaxExtension {
     /// A dummy derive macro `#[derive(Foo)]`.
     pub fn dummy_derive(edition: Edition) -> SyntaxExtension {
         fn expander(
-            _: &mut ExtCtxt<'_>,
+            _: &mut ExtCtxt<'_, '_>,
             _: Span,
             _: &ast::MetaItem,
             _: Annotatable,
@@ -1024,7 +1025,7 @@ impl SyntaxExtension {
         impl GlobDelegationExpander for GlobDelegationExpanderImpl {
             fn expand(
                 &self,
-                ecx: &mut ExtCtxt<'_>,
+                ecx: &mut ExtCtxt<'_, '_>,
             ) -> ExpandResult<Vec<(Ident, Option<Ident>)>, ()> {
                 match ecx.resolver.glob_delegation_suffixes(
                     self.trait_def_id,
@@ -1081,7 +1082,8 @@ pub struct DeriveResolution {
     pub is_const: bool,
 }
 
-pub trait ResolverExpand {
+pub trait ResolverExpand<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx>;
     fn next_node_id(&mut self) -> NodeId;
     fn invocation_parent(&self, id: LocalExpnId) -> LocalDefId;
 
@@ -1233,13 +1235,13 @@ pub struct ExpansionData {
 /// One of these is made during expansion and incrementally updated as we go;
 /// when a macro expansion occurs, the resulting nodes have the `backtrace()
 /// -> expn_data` of their expansion context stored into their span.
-pub struct ExtCtxt<'a> {
+pub struct ExtCtxt<'a, 'tcx> {
     pub sess: &'a Session,
     pub ecfg: expand::ExpansionConfig<'a>,
     pub num_standard_library_imports: usize,
     pub reduced_recursion_limit: Option<(Limit, ErrorGuaranteed)>,
     pub root_path: PathBuf,
-    pub resolver: &'a mut dyn ResolverExpand,
+    pub resolver: &'a mut dyn ResolverExpand<'tcx>,
     pub current_expansion: ExpansionData,
     /// Error recovery mode entered when expansion is stuck
     /// (or during eager expansion, but that's a hack).
@@ -1258,13 +1260,13 @@ pub struct ExtCtxt<'a> {
     pub nb_macro_errors: usize,
 }
 
-impl<'a> ExtCtxt<'a> {
+impl<'a, 'tcx> ExtCtxt<'a, 'tcx> {
     pub fn new(
         sess: &'a Session,
         ecfg: expand::ExpansionConfig<'a>,
-        resolver: &'a mut dyn ResolverExpand,
+        resolver: &'a mut dyn ResolverExpand<'tcx>,
         lint_store: LintStoreExpandDyn<'a>,
-    ) -> ExtCtxt<'a> {
+    ) -> ExtCtxt<'a, 'tcx> {
         ExtCtxt {
             sess,
             ecfg,
@@ -1295,13 +1297,13 @@ impl<'a> ExtCtxt<'a> {
     }
 
     /// Returns a `Folder` for deeply expanding all macros in an AST node.
-    pub fn expander<'b>(&'b mut self) -> expand::MacroExpander<'b, 'a> {
+    pub fn expander<'b>(&'b mut self) -> expand::MacroExpander<'b, 'a, 'tcx> {
         expand::MacroExpander::new(self, false)
     }
 
     /// Returns a `Folder` that deeply expands all macros and assigns all `NodeId`s in an AST node.
     /// Once `NodeId`s are assigned, the node may not be expanded, removed, or otherwise modified.
-    pub fn monotonic_expander<'b>(&'b mut self) -> expand::MacroExpander<'b, 'a> {
+    pub fn monotonic_expander<'b>(&'b mut self) -> expand::MacroExpander<'b, 'a, 'tcx> {
         expand::MacroExpander::new(self, true)
     }
     pub fn new_parser_from_tts(&self, stream: TokenStream) -> Parser<'a> {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1188,6 +1188,7 @@ pub trait LintStoreExpand {
     fn pre_expansion_lint(
         &self,
         sess: &Session,
+        tcx: TyCtxt<'_>,
         features: &Features,
         registered_tools: &RegisteredTools,
         node_id: NodeId,

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -10,7 +10,7 @@ use thin_vec::{ThinVec, thin_vec};
 
 use crate::base::ExtCtxt;
 
-impl<'a> ExtCtxt<'a> {
+impl<'a, 'tcx> ExtCtxt<'a, 'tcx> {
     pub fn path(&self, span: Span, strs: Vec<Ident>) -> ast::Path {
         self.path_all(span, false, strs, vec![])
     }

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1421,6 +1421,7 @@ impl InvocationCollectorNode for Box<ast::Item> {
                 if let Some(lint_store) = ecx.lint_store {
                     lint_store.pre_expansion_lint(
                         ecx.sess,
+                        ecx.resolver.tcx(),
                         ecx.ecfg.features,
                         ecx.resolver.registered_tools(),
                         ecx.current_expansion.lint_node_id,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1420,10 +1420,7 @@ impl InvocationCollectorNode for Box<ast::Item> {
 
                 if let Some(lint_store) = ecx.lint_store {
                     lint_store.pre_expansion_lint(
-                        ecx.sess,
                         ecx.resolver.tcx(),
-                        ecx.ecfg.features,
-                        ecx.resolver.registered_tools(),
                         ecx.current_expansion.lint_node_id,
                         &attrs,
                         &items,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -459,13 +459,13 @@ impl Invocation {
     }
 }
 
-pub struct MacroExpander<'a, 'b> {
-    pub cx: &'a mut ExtCtxt<'b>,
+pub struct MacroExpander<'a, 'b, 'tcx> {
+    pub cx: &'a mut ExtCtxt<'b, 'tcx>,
     monotonic: bool, // cf. `cx.monotonic_expander()`
 }
 
-impl<'a, 'b> MacroExpander<'a, 'b> {
-    pub fn new(cx: &'a mut ExtCtxt<'b>, monotonic: bool) -> Self {
+impl<'a, 'b, 'tcx> MacroExpander<'a, 'b, 'tcx> {
+    pub fn new(cx: &'a mut ExtCtxt<'b, 'tcx>, monotonic: bool) -> Self {
         MacroExpander { cx, monotonic }
     }
 
@@ -1279,10 +1279,10 @@ trait InvocationCollectorNode: HasAttrs + HasNodeId + Sized {
     fn descr() -> &'static str {
         unreachable!()
     }
-    fn walk_flat_map(self, _collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, _collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         unreachable!()
     }
-    fn walk(&mut self, _collector: &mut InvocationCollector<'_, '_>) {
+    fn walk(&mut self, _collector: &mut InvocationCollector<'_, '_, '_>) {
         unreachable!()
     }
     fn is_mac_call(&self) -> bool {
@@ -1308,14 +1308,14 @@ trait InvocationCollectorNode: HasAttrs + HasNodeId + Sized {
     }
     fn wrap_flat_map_node_walk_flat_map(
         node: Self,
-        collector: &mut InvocationCollector<'_, '_>,
-        walk_flat_map: impl FnOnce(Self, &mut InvocationCollector<'_, '_>) -> Self::OutputTy,
+        collector: &mut InvocationCollector<'_, '_, '_>,
+        walk_flat_map: impl FnOnce(Self, &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy,
     ) -> Result<Self::OutputTy, Self> {
         Ok(walk_flat_map(node, collector))
     }
     fn expand_cfg_false(
         &mut self,
-        collector: &mut InvocationCollector<'_, '_>,
+        collector: &mut InvocationCollector<'_, '_, '_>,
         _pos: usize,
         span: Span,
     ) {
@@ -1339,7 +1339,7 @@ impl InvocationCollectorNode for Box<ast::Item> {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_items()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_item(collector, self)
     }
     fn is_mac_call(&self) -> bool {
@@ -1368,8 +1368,8 @@ impl InvocationCollectorNode for Box<ast::Item> {
     }
     fn wrap_flat_map_node_walk_flat_map(
         mut node: Self,
-        collector: &mut InvocationCollector<'_, '_>,
-        walk_flat_map: impl FnOnce(Self, &mut InvocationCollector<'_, '_>) -> Self::OutputTy,
+        collector: &mut InvocationCollector<'_, '_, '_>,
+        walk_flat_map: impl FnOnce(Self, &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy,
     ) -> Result<Self::OutputTy, Self> {
         if !matches!(node.kind, ItemKind::Mod(..)) {
             return Ok(walk_flat_map(node, collector));
@@ -1497,7 +1497,7 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::AssocItem>, TraitItemTa
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_trait_items()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_assoc_item(collector, self.wrapped, AssocCtxt::Trait)
     }
     fn is_mac_call(&self) -> bool {
@@ -1541,7 +1541,7 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::AssocItem>, ImplItemTag
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_impl_items()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_assoc_item(collector, self.wrapped, AssocCtxt::Impl { of_trait: false })
     }
     fn is_mac_call(&self) -> bool {
@@ -1585,7 +1585,7 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::AssocItem>, TraitImplIt
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_trait_impl_items()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_assoc_item(collector, self.wrapped, AssocCtxt::Impl { of_trait: true })
     }
     fn is_mac_call(&self) -> bool {
@@ -1626,7 +1626,7 @@ impl InvocationCollectorNode for Box<ast::ForeignItem> {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_foreign_items()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_foreign_item(collector, self)
     }
     fn is_mac_call(&self) -> bool {
@@ -1656,7 +1656,7 @@ impl InvocationCollectorNode for ast::Variant {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_variants()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_variant(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1672,7 +1672,7 @@ impl InvocationCollectorNode for ast::WherePredicate {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_where_predicates()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_where_predicate(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1688,7 +1688,7 @@ impl InvocationCollectorNode for ast::FieldDef {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_field_defs()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_field_def(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1704,7 +1704,7 @@ impl InvocationCollectorNode for ast::PatField {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_pat_fields()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_pat_field(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1720,7 +1720,7 @@ impl InvocationCollectorNode for ast::ExprField {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_expr_fields()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_expr_field(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1736,7 +1736,7 @@ impl InvocationCollectorNode for ast::Param {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_params()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_param(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1752,7 +1752,7 @@ impl InvocationCollectorNode for ast::GenericParam {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_generic_params()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_generic_param(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1784,7 +1784,7 @@ impl InvocationCollectorNode for ast::Arm {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_arms()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_arm(collector, self)
     }
     fn as_target(&self) -> Target {
@@ -1800,7 +1800,7 @@ impl InvocationCollectorNode for ast::Stmt {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_stmts()
     }
-    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_flat_map_stmt(collector, self)
     }
     fn is_mac_call(&self) -> bool {
@@ -1877,12 +1877,12 @@ impl InvocationCollectorNode for ast::Crate {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_crate()
     }
-    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_>) {
+    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_, '_>) {
         walk_crate(collector, self)
     }
     fn expand_cfg_false(
         &mut self,
-        collector: &mut InvocationCollector<'_, '_>,
+        collector: &mut InvocationCollector<'_, '_, '_>,
         pos: usize,
         _span: Span,
     ) {
@@ -1906,7 +1906,7 @@ impl InvocationCollectorNode for ast::Ty {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_ty()
     }
-    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_>) {
+    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_, '_>) {
         // Save the pre-expanded name of this `ImplTrait`, so that later when defining
         // an APIT we use a name that doesn't have any placeholder fragments in it.
         if let ast::TyKind::ImplTrait(..) = self.kind {
@@ -1943,7 +1943,7 @@ impl InvocationCollectorNode for ast::Pat {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_pat()
     }
-    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_>) {
+    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_, '_>) {
         walk_pat(collector, self)
     }
     fn is_mac_call(&self) -> bool {
@@ -1972,7 +1972,7 @@ impl InvocationCollectorNode for ast::Expr {
     fn descr() -> &'static str {
         "an expression"
     }
-    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_>) {
+    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_, '_>) {
         walk_expr(collector, self)
     }
     fn is_mac_call(&self) -> bool {
@@ -1999,7 +1999,7 @@ impl InvocationCollectorNode for AstNodeWrapper<Box<ast::Expr>, OptExprTag> {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         fragment.make_opt_expr()
     }
-    fn walk_flat_map(mut self, collector: &mut InvocationCollector<'_, '_>) -> Self::OutputTy {
+    fn walk_flat_map(mut self, collector: &mut InvocationCollector<'_, '_, '_>) -> Self::OutputTy {
         walk_expr(collector, &mut self.wrapped);
         Some(self.wrapped)
     }
@@ -2037,7 +2037,7 @@ impl InvocationCollectorNode for AstNodeWrapper<ast::Expr, MethodReceiverTag> {
     fn fragment_to_output(fragment: AstFragment) -> Self::OutputTy {
         AstNodeWrapper::new(fragment.make_method_receiver_expr(), MethodReceiverTag)
     }
-    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_>) {
+    fn walk(&mut self, collector: &mut InvocationCollector<'_, '_, '_>) {
         walk_expr(collector, &mut self.wrapped)
     }
     fn is_mac_call(&self) -> bool {
@@ -2056,7 +2056,7 @@ impl InvocationCollectorNode for AstNodeWrapper<ast::Expr, MethodReceiverTag> {
 }
 
 fn build_single_delegations<'a, Node: InvocationCollectorNode>(
-    ecx: &ExtCtxt<'_>,
+    ecx: &ExtCtxt<'_, '_>,
     deleg: &'a ast::DelegationMac,
     item: &'a ast::Item<Node::ItemKind>,
     suffixes: &'a [(Ident, Option<Ident>)],
@@ -2144,13 +2144,13 @@ impl DummyAstNode for AstNodeWrapper<ast::Expr, MethodReceiverTag> {
     }
 }
 
-struct InvocationCollector<'a, 'b> {
-    cx: &'a mut ExtCtxt<'b>,
+struct InvocationCollector<'a, 'b, 'tcx> {
+    cx: &'a mut ExtCtxt<'b, 'tcx>,
     invocations: Vec<(Invocation, Option<Arc<SyntaxExtension>>)>,
     monotonic: bool,
 }
 
-impl<'a, 'b> InvocationCollector<'a, 'b> {
+impl<'a, 'b, 'tcx> InvocationCollector<'a, 'b, 'tcx> {
     fn cfg(&self) -> StripUnconfigured<'_> {
         StripUnconfigured {
             sess: self.cx.sess,
@@ -2495,7 +2495,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
     }
 }
 
-impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
+impl<'a, 'b, 'tcx> MutVisitor for InvocationCollector<'a, 'b, 'tcx> {
     fn flat_map_item(&mut self, node: Box<ast::Item>) -> SmallVec<[Box<ast::Item>; 1]> {
         self.flat_map_node(node)
     }

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -117,7 +117,7 @@ impl<'a, 'b> ParserAnyMacro<'a, 'b> {
 
     #[instrument(skip(cx, tts, bindings, matched_rule_bindings))]
     pub(crate) fn from_tts<'cx>(
-        cx: &'cx mut ExtCtxt<'a>,
+        cx: &'cx mut ExtCtxt<'a, '_>,
         tts: TokenStream,
         site_span: Span,
         arm_span: Span,
@@ -190,7 +190,7 @@ impl MacroRulesMacroExpander {
 
     pub fn expand_derive(
         &self,
-        cx: &mut ExtCtxt<'_>,
+        cx: &mut ExtCtxt<'_, '_>,
         sp: Span,
         body: &TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
@@ -251,7 +251,7 @@ impl MacroRulesMacroExpander {
 impl TTMacroExpander for MacroRulesMacroExpander {
     fn expand<'cx, 'a: 'cx>(
         &'a self,
-        cx: &'cx mut ExtCtxt<'_>,
+        cx: &'cx mut ExtCtxt<'_, '_>,
         sp: Span,
         input: TokenStream,
     ) -> MacroExpanderResult<'cx> {
@@ -272,7 +272,7 @@ impl TTMacroExpander for MacroRulesMacroExpander {
 impl AttrProcMacro for MacroRulesMacroExpander {
     fn expand(
         &self,
-        _cx: &mut ExtCtxt<'_>,
+        _cx: &mut ExtCtxt<'_, '_>,
         _sp: Span,
         _args: TokenStream,
         _body: TokenStream,
@@ -282,7 +282,7 @@ impl AttrProcMacro for MacroRulesMacroExpander {
 
     fn expand_with_safety(
         &self,
-        cx: &mut ExtCtxt<'_>,
+        cx: &mut ExtCtxt<'_, '_>,
         safety: Safety,
         sp: Span,
         args: TokenStream,
@@ -309,7 +309,7 @@ struct DummyBang(ErrorGuaranteed);
 impl BangProcMacro for DummyBang {
     fn expand<'cx>(
         &self,
-        _: &'cx mut ExtCtxt<'_>,
+        _: &'cx mut ExtCtxt<'_, '_>,
         _: Span,
         _: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
@@ -363,7 +363,7 @@ impl<'matcher> Tracker<'matcher> for NoopTracker {
 /// Expands the rules based macro defined by `rules` for a given input `arg`.
 #[instrument(skip(cx, transparency, arg, rules, on_unmatch_args))]
 fn expand_macro<'cx, 'a: 'cx>(
-    cx: &'cx mut ExtCtxt<'_>,
+    cx: &'cx mut ExtCtxt<'_, '_>,
     sp: Span,
     def_span: Span,
     node_id: NodeId,
@@ -441,7 +441,7 @@ fn expand_macro<'cx, 'a: 'cx>(
 /// Expands the rules based macro defined by `rules` for a given attribute `args` and `body`.
 #[instrument(skip(cx, transparency, args, body, rules, on_unmatch_args))]
 fn expand_macro_attr(
-    cx: &mut ExtCtxt<'_>,
+    cx: &mut ExtCtxt<'_, '_>,
     sp: Span,
     def_span: Span,
     node_id: NodeId,

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -21,7 +21,7 @@ fn exec_strategy(sess: &Session) -> impl pm::bridge::server::ExecutionStrategy +
 }
 
 fn record_expand_proc_macro<'a>(
-    ecx: &ExtCtxt<'a>,
+    ecx: &ExtCtxt<'a, '_>,
     name: &'static str,
     span: Span,
 ) -> TimingGuard<'a> {
@@ -37,7 +37,7 @@ pub struct BangProcMacro {
 impl base::BangProcMacro for BangProcMacro {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         input: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
@@ -62,7 +62,7 @@ pub struct AttrProcMacro {
 impl base::AttrProcMacro for AttrProcMacro {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         annotation: TokenStream,
         annotated: TokenStream,
@@ -92,7 +92,7 @@ pub struct DeriveProcMacro {
 impl MultiItemModifier for DeriveProcMacro {
     fn expand(
         &self,
-        ecx: &mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_, '_>,
         span: Span,
         _meta_item: &ast::MetaItem,
         item: Annotatable,
@@ -181,7 +181,7 @@ type DeriveClient = pm::bridge::client::Client<pm::TokenStream, pm::TokenStream>
 fn expand_derive_macro(
     invoc_id: LocalExpnId,
     input: TokenStream,
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     client: DeriveClient,
 ) -> Result<TokenStream, ()> {
     let _timer =
@@ -224,7 +224,7 @@ struct QueryDeriveExpandCtx {
 impl QueryDeriveExpandCtx {
     /// Store the extension context and the client into the thread local value.
     /// It will be accessible via the `with` method while `f` is active.
-    fn enter<F, R>(ecx: &mut ExtCtxt<'_>, client: DeriveClient, f: F) -> R
+    fn enter<F, R>(ecx: &mut ExtCtxt<'_, '_>, client: DeriveClient, f: F) -> R
     where
         F: FnOnce() -> R,
     {
@@ -237,11 +237,11 @@ impl QueryDeriveExpandCtx {
     /// Must be called while the `enter` function is active.
     fn with<F, R>(f: F) -> R
     where
-        F: for<'a, 'b> FnOnce(&'b mut ExtCtxt<'a>, DeriveClient) -> R,
+        F: for<'a, 'b> FnOnce(&'b mut ExtCtxt<'a, '_>, DeriveClient) -> R,
     {
         DERIVE_EXPAND_CTX.with(|ctx| {
             let ectx = {
-                let casted = ctx.expansion_ctx.cast::<ExtCtxt<'_>>();
+                let casted = ctx.expansion_ctx.cast::<ExtCtxt<'_, '_>>();
                 // SAFETY: We can only get the value from `with` while the `enter` function
                 // is active (on the callstack), and that function's signature ensures that the
                 // lifetime is valid.

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -304,7 +304,7 @@ impl FromInternal<TokenStream> for Vec<TokenTree<TokenStream, Span, Symbol>> {
 
 // We use a `SmallVec` because the output size is always one or two `TokenTree`s.
 impl ToInternal<SmallVec<[tokenstream::TokenTree; 2]>>
-    for (TokenTree<TokenStream, Span, Symbol>, &mut Rustc<'_, '_>)
+    for (TokenTree<TokenStream, Span, Symbol>, &mut Rustc<'_, '_, '_>)
 {
     fn to_internal(self) -> SmallVec<[tokenstream::TokenTree; 2]> {
         use rustc_ast::token::*;
@@ -418,8 +418,8 @@ fn cancel_diags_into_string(diags: Vec<Diag<'_>>) -> String {
     msg
 }
 
-pub(crate) struct Rustc<'a, 'b> {
-    ecx: &'a mut ExtCtxt<'b>,
+pub(crate) struct Rustc<'a, 'b, 'tcx> {
+    ecx: &'a mut ExtCtxt<'b, 'tcx>,
     def_site: Span,
     call_site: Span,
     mixed_site: Span,
@@ -427,8 +427,8 @@ pub(crate) struct Rustc<'a, 'b> {
     rebased_spans: FxHashMap<usize, Span>,
 }
 
-impl<'a, 'b> Rustc<'a, 'b> {
-    pub(crate) fn new(ecx: &'a mut ExtCtxt<'b>) -> Self {
+impl<'a, 'b, 'tcx> Rustc<'a, 'b, 'tcx> {
+    pub(crate) fn new(ecx: &'a mut ExtCtxt<'b, 'tcx>) -> Self {
         let expn_data = ecx.current_expansion.id.expn_data();
         Rustc {
             def_site: ecx.with_def_site_ctxt(expn_data.def_site),
@@ -445,7 +445,7 @@ impl<'a, 'b> Rustc<'a, 'b> {
     }
 }
 
-impl server::Server for Rustc<'_, '_> {
+impl server::Server for Rustc<'_, '_, '_> {
     type TokenStream = TokenStream;
     type Span = Span;
     type Symbol = Symbol;

--- a/compiler/rustc_expand/src/stats.rs
+++ b/compiler/rustc_expand/src/stats.rs
@@ -37,7 +37,7 @@ pub(crate) fn unreachable_to_string<T>(_: &T) -> String {
 }
 
 pub(crate) fn update_bang_macro_stats(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     fragment_kind: AstFragmentKind,
     span: Span,
     mac: Box<ast::MacCall>,
@@ -75,7 +75,7 @@ pub(crate) fn update_bang_macro_stats(
 }
 
 pub(crate) fn update_attr_macro_stats(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     fragment_kind: AstFragmentKind,
     span: Span,
     path: &ast::Path,
@@ -104,7 +104,7 @@ pub(crate) fn update_attr_macro_stats(
 }
 
 pub(crate) fn update_derive_macro_stats(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     fragment_kind: AstFragmentKind,
     span: Span,
     path: &ast::Path,
@@ -118,7 +118,7 @@ pub(crate) fn update_derive_macro_stats(
 }
 
 pub(crate) fn update_macro_stats(
-    ecx: &mut ExtCtxt<'_>,
+    ecx: &mut ExtCtxt<'_, '_>,
     macro_kind: MacroKind,
     fragment_kind: AstFragmentKind,
     span: Span,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -87,6 +87,7 @@ pub fn parse<'a>(sess: &'a Session) -> ast::Crate {
 
 fn pre_expansion_lint<'a>(
     sess: &Session,
+    tcx: TyCtxt<'_>,
     features: &Features,
     lint_store: &LintStore,
     registered_tools: &RegisteredTools,
@@ -97,7 +98,7 @@ fn pre_expansion_lint<'a>(
         || {
             rustc_lint::check_ast_node(
                 sess,
-                None,
+                Some(tcx),
                 features,
                 true,
                 lint_store,
@@ -117,6 +118,7 @@ impl LintStoreExpand for LintStoreExpandImpl<'_> {
     fn pre_expansion_lint(
         &self,
         sess: &Session,
+        tcx: TyCtxt<'_>,
         features: &Features,
         registered_tools: &RegisteredTools,
         node_id: ast::NodeId,
@@ -124,7 +126,15 @@ impl LintStoreExpand for LintStoreExpandImpl<'_> {
         items: &[Box<ast::Item>],
         name: Symbol,
     ) {
-        pre_expansion_lint(sess, features, self.0, registered_tools, (node_id, attrs, items), name);
+        pre_expansion_lint(
+            sess,
+            tcx,
+            features,
+            self.0,
+            registered_tools,
+            (node_id, attrs, items),
+            name,
+        );
     }
 }
 
@@ -146,6 +156,7 @@ fn configure_and_expand(
     let lint_check_node = (&krate, pre_configured_attrs);
     pre_expansion_lint(
         sess,
+        tcx,
         features,
         lint_store,
         tcx.registered_tools(()),

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -37,7 +37,7 @@ use rustc_resolve::{Resolver, ResolverOutputs};
 use rustc_session::Session;
 use rustc_session::config::{CrateType, Input, OutFileName, OutputFilenames, OutputType};
 use rustc_session::cstore::Untracked;
-use rustc_session::output::{filename_for_input, invalid_output_for_target};
+use rustc_session::output::{filename_for_input, invalid_output_for_target, validate_crate_name};
 use rustc_session::parse::feature_err;
 use rustc_session::search_paths::PathKind;
 use rustc_span::{
@@ -295,7 +295,7 @@ fn print_macro_stats(ecx: &ExtCtxt<'_, '_>) {
             std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "<unknown crate>".to_string());
         format!("{pkg_name} build script")
     } else {
-        ecx.resolver.tcx().local_crate_name()
+        ecx.resolver.tcx().crate_name(LOCAL_CRATE).as_str().to_string()
     };
 
     // No instability because we immediately sort the produced vector.
@@ -907,15 +907,15 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
         krate.spans.inner_span,
     );
     let stable_crate_id = StableCrateId::new(
-        crate_name,
+        crate_name.normalized,
         crate_types.contains(&CrateType::Executable),
         sess.opts.cg.metadata.clone(),
         sess.cfg_version,
     );
 
-    let outputs = util::build_output_filenames(&pre_configured_attrs, sess);
+    let outputs = util::build_output_filenames(sess, crate_name);
 
-    let dep_graph = setup_dep_graph(sess, crate_name, stable_crate_id);
+    let dep_graph = setup_dep_graph(sess, crate_name.normalized, stable_crate_id);
 
     let cstore =
         FreezeLock::new(Box::new(CStore::new(compiler.codegen_backend.metadata_loader())) as _);
@@ -979,13 +979,13 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
         |tcx| {
             let feed = tcx.create_crate_num(stable_crate_id).unwrap();
             assert_eq!(feed.key(), LOCAL_CRATE);
-            feed.crate_name(crate_name);
+            feed.crate_name(crate_name.normalized);
 
             let feed = tcx.feed_unit_query();
             feed.features_query(tcx.arena.alloc(rustc_expand::config::features(
                 tcx.sess,
                 &pre_configured_attrs,
-                crate_name,
+                crate_name.normalized,
             )));
             feed.crate_for_resolver(tcx.arena.alloc(Steal::new((krate, pre_configured_attrs))));
             feed.output_filenames(Arc::new(outputs));
@@ -1286,8 +1286,53 @@ pub(crate) fn start_codegen<'tcx>(
     (codegen, crate_info, metadata)
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CrateName {
+    /// The normalized final crate name.
+    ///
+    /// Crate name precedence is as follows:
+    /// - `#![crate_name]` must match `--crate-name` if both are present.
+    /// - Both `#![crate_name]` and `--crate-name` are validated.
+    /// - If neither are present, the input comes from an on-disk file, and the file is valid
+    /// UTF-8, the normalized filename. The normalized filename is not validated.
+    /// - Otherwise, `rust_out`.
+    ///
+    /// If you don't want the crate name to be normalized, use [`TyCtxt::filestem`].
+    ///
+    /// Note that `#![cfg_attr(..., crate_name = "...")]` is a hard error.
+    /// Note that the normalization applied to input filestem is very incomplete and cannot be
+    /// relied upon to produce a valid Rust identifier.
+    ///
+    /// See [`get_crate_name`] for more info.
+    pub normalized: Symbol,
+    /// The unnormalized crate name, as suitable for an [`OutFileName`].
+    /// If no crate name was present, fall back to the filestem of the input.
+    ///
+    /// Note that no normalization is applied and the stem may be an invalid Rust identifier.
+    ///
+    /// Usually you don't want this and should use [`local_crate_name`](CrateName::normalized) instead.
+    /// See its docs for more information.
+    ///
+    /// I don't know why some existing code depends on this behavior but it does.
+    pub unnormalized: Symbol,
+}
+
+impl CrateName {
+    pub fn from_normalized(sess: &Session, name: Symbol, span: Option<Span>) -> Self {
+        validate_crate_name(sess, name, span);
+        CrateName { normalized: name, unnormalized: name }
+    }
+
+    pub fn from_unnormalized(sess: &Session, unnormalized: &str, span: Option<Span>) -> Self {
+        let normalized = Symbol::intern(&unnormalized.replace('-', "_"));
+        validate_crate_name(sess, normalized, span);
+
+        CrateName { normalized, unnormalized: Symbol::intern(unnormalized) }
+    }
+}
+
 /// Compute and validate the crate name.
-pub fn get_crate_name(sess: &Session, krate_attrs: &[ast::Attribute]) -> Symbol {
+pub fn get_crate_name(sess: &Session, krate_attrs: &[ast::Attribute]) -> CrateName {
     // We validate *all* occurrences of `#![crate_name]`, pick the first find and
     // if a crate name was passed on the command line via `--crate-name` we enforce
     // that they match.
@@ -1298,10 +1343,7 @@ pub fn get_crate_name(sess: &Session, krate_attrs: &[ast::Attribute]) -> Symbol 
     let attr_crate_name =
         parse_crate_name(sess, krate_attrs, ShouldEmit::EarlyFatal { also_emit_lints: true });
 
-    let validate = |name, span| {
-        rustc_session::output::validate_crate_name(sess, name, span);
-        name
-    };
+    let validate = |name, span| CrateName::from_normalized(sess, name, span);
 
     if let Some(crate_name) = &sess.opts.crate_name {
         let crate_name = Symbol::intern(crate_name);
@@ -1327,11 +1369,11 @@ pub fn get_crate_name(sess: &Session, krate_attrs: &[ast::Attribute]) -> Symbol 
         if file_stem.starts_with('-') {
             sess.dcx().emit_err(errors::CrateNameInvalid { crate_name: file_stem });
         } else {
-            return validate(Symbol::intern(&file_stem.replace('-', "_")), None);
+            return CrateName::from_unnormalized(sess, file_stem, None);
         }
     }
 
-    sym::rust_out
+    validate(sym::rust_out, None)
 }
 
 pub(crate) fn parse_crate_name(

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1345,6 +1345,7 @@ pub fn get_crate_name(sess: &Session, krate_attrs: &[ast::Attribute]) -> CrateNa
 
     let validate = |name, span| CrateName::from_normalized(sess, name, span);
 
+    #[expect(rustc::bad_opt_access, reason = "Can't use crate_name(). We are crate_name().")]
     if let Some(crate_name) = &sess.opts.crate_name {
         let crate_name = Symbol::intern(crate_name);
         if let Some((attr_crate_name, span)) = attr_crate_name

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -289,14 +289,13 @@ fn configure_and_expand(
 fn print_macro_stats(ecx: &ExtCtxt<'_, '_>) {
     use std::fmt::Write;
 
-    let crate_name = ecx.ecfg.crate_name.as_str();
-    let crate_name = if crate_name == "build_script_build" {
-        // This is a build script. Get the package name from the environment.
+    let crate_name = if ecx.resolver.tcx().is_build_script() {
+        // Get the package name from the environment.
         let pkg_name =
             std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| "<unknown crate>".to_string());
         format!("{pkg_name} build script")
     } else {
-        crate_name.to_string()
+        ecx.resolver.tcx().local_crate_name()
     };
 
     // No instability because we immediately sort the produced vector.

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -16,7 +16,6 @@ use rustc_data_structures::thousands;
 use rustc_errors::DiagCallback;
 use rustc_errors::timings::TimingSection;
 use rustc_expand::base::{ExtCtxt, LintStoreExpand};
-use rustc_feature::Features;
 use rustc_fs_util::try_canonicalize;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::def_id::{LOCAL_CRATE, StableCrateId, StableCrateIdMap};
@@ -31,7 +30,7 @@ use rustc_lint::{
 use rustc_metadata::EncodedMetadata;
 use rustc_metadata::creader::CStore;
 use rustc_middle::arena::Arena;
-use rustc_middle::ty::{self, RegisteredTools, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::util::Providers;
 use rustc_parse::lexer::StripTokens;
 use rustc_parse::{new_parser_from_file, new_parser_from_source_str, unwrap_or_emit_fatal};
@@ -86,29 +85,24 @@ pub fn parse<'a>(sess: &'a Session) -> ast::Crate {
 }
 
 fn pre_expansion_lint<'a>(
-    sess: &Session,
     tcx: TyCtxt<'_>,
-    features: &Features,
     lint_store: &LintStore,
-    registered_tools: &RegisteredTools,
     check_node: impl EarlyCheckNode<'a>,
     node_name: Symbol,
 ) {
-    sess.prof.generic_activity_with_arg("pre_AST_expansion_lint_checks", node_name.as_str()).run(
-        || {
+    tcx.sess
+        .prof
+        .generic_activity_with_arg("pre_AST_expansion_lint_checks", node_name.as_str())
+        .run(|| {
             rustc_lint::check_ast_node(
-                sess,
                 tcx,
-                features,
                 true,
                 lint_store,
-                registered_tools,
                 None,
                 rustc_lint::BuiltinCombinedPreExpansionLintPass::new(),
                 check_node,
             );
-        },
-    );
+        });
 }
 
 // Cannot implement directly for `LintStore` due to trait coherence.
@@ -117,24 +111,13 @@ struct LintStoreExpandImpl<'a>(&'a LintStore);
 impl LintStoreExpand for LintStoreExpandImpl<'_> {
     fn pre_expansion_lint(
         &self,
-        sess: &Session,
         tcx: TyCtxt<'_>,
-        features: &Features,
-        registered_tools: &RegisteredTools,
         node_id: ast::NodeId,
         attrs: &[ast::Attribute],
         items: &[Box<ast::Item>],
         name: Symbol,
     ) {
-        pre_expansion_lint(
-            sess,
-            tcx,
-            features,
-            self.0,
-            registered_tools,
-            (node_id, attrs, items),
-            name,
-        );
+        pre_expansion_lint(tcx, self.0, (node_id, attrs, items), name);
     }
 }
 
@@ -154,15 +137,7 @@ fn configure_and_expand(
     let lint_store = unerased_lint_store(tcx.sess);
     let crate_name = tcx.crate_name(LOCAL_CRATE);
     let lint_check_node = (&krate, pre_configured_attrs);
-    pre_expansion_lint(
-        sess,
-        tcx,
-        features,
-        lint_store,
-        tcx.registered_tools(()),
-        lint_check_node,
-        crate_name,
-    );
+    pre_expansion_lint(tcx, lint_store, lint_check_node, crate_name);
     rustc_builtin_macros::register_builtin_macros(resolver);
 
     let num_standard_library_imports = sess.time("crate_injection", || {
@@ -480,12 +455,9 @@ fn early_lint_checks(tcx: TyCtxt<'_>, (): ()) {
 
     let lint_store = unerased_lint_store(tcx.sess);
     rustc_lint::check_ast_node(
-        sess,
         tcx,
-        tcx.features(),
         false,
         lint_store,
-        tcx.registered_tools(()),
         Some(lint_buffer),
         rustc_lint::BuiltinCombinedEarlyLintPass::new(),
         (&**krate, &*krate.attrs),
@@ -1049,11 +1021,7 @@ pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
                             attribute_lint.lint_id.lint,
                             attribute_lint.id,
                             attribute_lint.span.clone(),
-                            DecorateAttrLint {
-                                sess: tcx.sess,
-                                tcx,
-                                diagnostic: &attribute_lint.kind,
-                            },
+                            DecorateAttrLint { tcx, diagnostic: &attribute_lint.kind },
                         );
                     }
                     DelayedLint::Dynamic(attribute_lint) => tcx.emit_node_span_lint(

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -309,7 +309,7 @@ fn configure_and_expand(
     krate
 }
 
-fn print_macro_stats(ecx: &ExtCtxt<'_>) {
+fn print_macro_stats(ecx: &ExtCtxt<'_, '_>) {
     use std::fmt::Write;
 
     let crate_name = ecx.ecfg.crate_name.as_str();

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -98,7 +98,7 @@ fn pre_expansion_lint<'a>(
         || {
             rustc_lint::check_ast_node(
                 sess,
-                Some(tcx),
+                tcx,
                 features,
                 true,
                 lint_store,
@@ -481,7 +481,7 @@ fn early_lint_checks(tcx: TyCtxt<'_>, (): ()) {
     let lint_store = unerased_lint_store(tcx.sess);
     rustc_lint::check_ast_node(
         sess,
-        Some(tcx),
+        tcx,
         tcx.features(),
         false,
         lint_store,
@@ -1051,7 +1051,7 @@ pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
                             attribute_lint.span.clone(),
                             DecorateAttrLint {
                                 sess: tcx.sess,
-                                tcx: Some(tcx),
+                                tcx,
                                 diagnostic: &attribute_lint.kind,
                             },
                         );

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -24,9 +24,7 @@ use rustc_hir::limit::Limit;
 use rustc_hir::lints::DelayedLint;
 use rustc_hir::{Attribute, MaybeOwner, Target, find_attr};
 use rustc_incremental::setup_dep_graph;
-use rustc_lint::{
-    BufferedEarlyLint, DecorateAttrLint, EarlyCheckNode, LintStore, unerased_lint_store,
-};
+use rustc_lint::{BufferedEarlyLint, DecorateAttrLint, EarlyCheckNode};
 use rustc_metadata::EncodedMetadata;
 use rustc_metadata::creader::CStore;
 use rustc_middle::arena::Arena;
@@ -84,12 +82,7 @@ pub fn parse<'a>(sess: &'a Session) -> ast::Crate {
     krate
 }
 
-fn pre_expansion_lint<'a>(
-    tcx: TyCtxt<'_>,
-    lint_store: &LintStore,
-    check_node: impl EarlyCheckNode<'a>,
-    node_name: Symbol,
-) {
+fn pre_expansion_lint<'a>(tcx: TyCtxt<'_>, check_node: impl EarlyCheckNode<'a>, node_name: Symbol) {
     tcx.sess
         .prof
         .generic_activity_with_arg("pre_AST_expansion_lint_checks", node_name.as_str())
@@ -97,7 +90,6 @@ fn pre_expansion_lint<'a>(
             rustc_lint::check_ast_node(
                 tcx,
                 true,
-                lint_store,
                 None,
                 rustc_lint::BuiltinCombinedPreExpansionLintPass::new(),
                 check_node,
@@ -105,10 +97,10 @@ fn pre_expansion_lint<'a>(
         });
 }
 
-// Cannot implement directly for `LintStore` due to trait coherence.
-struct LintStoreExpandImpl<'a>(&'a LintStore);
+// Can't move this into rustc_expand because it doesn't depend on rustc_lint.
+struct LintStoreExpandImpl;
 
-impl LintStoreExpand for LintStoreExpandImpl<'_> {
+impl LintStoreExpand for LintStoreExpandImpl {
     fn pre_expansion_lint(
         &self,
         tcx: TyCtxt<'_>,
@@ -117,7 +109,7 @@ impl LintStoreExpand for LintStoreExpandImpl<'_> {
         items: &[Box<ast::Item>],
         name: Symbol,
     ) {
-        pre_expansion_lint(tcx, self.0, (node_id, attrs, items), name);
+        pre_expansion_lint(tcx, (node_id, attrs, items), name);
     }
 }
 
@@ -134,10 +126,9 @@ fn configure_and_expand(
     let tcx = resolver.tcx();
     let sess = tcx.sess;
     let features = tcx.features();
-    let lint_store = unerased_lint_store(tcx.sess);
     let crate_name = tcx.crate_name(LOCAL_CRATE);
     let lint_check_node = (&krate, pre_configured_attrs);
-    pre_expansion_lint(tcx, lint_store, lint_check_node, crate_name);
+    pre_expansion_lint(tcx, lint_check_node, crate_name);
     rustc_builtin_macros::register_builtin_macros(resolver);
 
     let num_standard_library_imports = sess.time("crate_injection", || {
@@ -199,7 +190,7 @@ fn configure_and_expand(
             proc_macro_backtrace: sess.opts.unstable_opts.proc_macro_backtrace,
         };
 
-        let lint_store = LintStoreExpandImpl(lint_store);
+        let lint_store = LintStoreExpandImpl;
         let mut ecx = ExtCtxt::new(sess, cfg, resolver, Some(&lint_store));
         ecx.num_standard_library_imports = num_standard_library_imports;
         // Expand macros now!
@@ -453,11 +444,9 @@ fn early_lint_checks(tcx: TyCtxt<'_>, (): ()) {
         }
     });
 
-    let lint_store = unerased_lint_store(tcx.sess);
     rustc_lint::check_ast_node(
         tcx,
         false,
-        lint_store,
         Some(lint_buffer),
         rustc_lint::BuiltinCombinedEarlyLintPass::new(),
         (&**krate, &*krate.attrs),

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -5,8 +5,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::{env, thread};
 
-use rustc_ast as ast;
-use rustc_attr_parsing::ShouldEmit;
 use rustc_codegen_ssa::back::archive::{ArArchiveBuilderBuilder, ArchiveBuilderBuilder};
 use rustc_codegen_ssa::back::link::link_binary;
 use rustc_codegen_ssa::target_features::cfg_target_feature;
@@ -30,7 +28,7 @@ use rustc_target::spec::Target;
 use tracing::info;
 
 use crate::errors;
-use crate::passes::parse_crate_name;
+use crate::passes::CrateName;
 
 /// Function pointer type that constructs a new CodegenBackend.
 type MakeBackendFn = fn() -> Box<dyn CodegenBackend>;
@@ -602,18 +600,13 @@ fn multiple_output_types_to_stdout(
     }
 }
 
-pub fn build_output_filenames(attrs: &[ast::Attribute], sess: &Session) -> OutputFilenames {
+pub fn build_output_filenames(sess: &Session, crate_name: CrateName) -> OutputFilenames {
     if multiple_output_types_to_stdout(
         &sess.opts.output_types,
         sess.io.output_file == Some(OutFileName::Stdout),
     ) {
         sess.dcx().emit_fatal(errors::MultipleOutputTypesToStdout);
     }
-
-    let crate_name =
-        sess.opts.crate_name.clone().or_else(|| {
-            parse_crate_name(sess, attrs, ShouldEmit::Nothing).map(|i| i.0.to_string())
-        });
 
     match sess.io.output_file {
         None => {
@@ -622,13 +615,10 @@ pub fn build_output_filenames(attrs: &[ast::Attribute], sess: &Session) -> Outpu
             // We want to toss everything after the final '.'
             let dirpath = sess.io.output_dir.clone().unwrap_or_default();
 
-            // If a crate name is present, we use it as the link name
-            let stem = crate_name.clone().unwrap_or_else(|| sess.io.input.filestem().to_owned());
-
             OutputFilenames::new(
                 dirpath,
-                crate_name.unwrap_or_else(|| stem.replace('-', "_")),
-                stem,
+                crate_name.normalized.to_string(),
+                crate_name.unnormalized.to_string(),
                 None,
                 sess.io.temps_dir.clone(),
                 sess.opts.unstable_opts.split_dwarf_out_dir.clone(),
@@ -657,7 +647,7 @@ pub fn build_output_filenames(attrs: &[ast::Attribute], sess: &Session) -> Outpu
                 out_file.filestem().unwrap_or_default().to_str().unwrap().to_string();
             OutputFilenames::new(
                 out_file.parent().unwrap_or_else(|| Path::new("")).to_path_buf(),
-                crate_name.unwrap_or_else(|| out_filestem.replace('-', "_")),
+                crate_name.normalized.to_string(),
                 out_filestem,
                 ofile,
                 sess.io.temps_dir.clone(),

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -29,7 +29,7 @@ macro_rules! lint_callback { ($cx:expr, $f:ident, $($args:expr),*) => ({
 /// `check_*` methods.
 pub struct EarlyContextAndPass<'ecx, 'tcx, T: EarlyLintPass> {
     context: EarlyContext<'ecx>,
-    tcx: Option<TyCtxt<'tcx>>,
+    tcx: TyCtxt<'tcx>,
     pass: T,
 }
 
@@ -329,7 +329,7 @@ impl<'a> EarlyCheckNode<'a> for (ast::NodeId, &'a [ast::Attribute], &'a [Box<ast
 
 pub fn check_ast_node<'a>(
     sess: &Session,
-    tcx: Option<TyCtxt<'_>>,
+    tcx: TyCtxt<'_>,
     features: &Features,
     pre_expansion: bool,
     lint_store: &LintStore,
@@ -364,7 +364,7 @@ pub fn check_ast_node<'a>(
 
 fn check_ast_node_inner<'a, T: EarlyLintPass>(
     sess: &Session,
-    tcx: Option<TyCtxt<'_>>,
+    tcx: TyCtxt<'_>,
     check_node: impl EarlyCheckNode<'a>,
     context: EarlyContext<'_>,
     pass: T,

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -8,9 +8,7 @@ use rustc_ast::visit::{self as ast_visit, Visitor, walk_list};
 use rustc_ast::{self as ast, AttrVec, HasAttrs};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::{BufferedEarlyLint, DecorateDiagCompat, LintBuffer};
-use rustc_feature::Features;
-use rustc_middle::ty::{RegisteredTools, TyCtxt};
-use rustc_session::Session;
+use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::LintPass;
 use rustc_span::{Ident, Span};
 use tracing::debug;
@@ -42,11 +40,7 @@ impl<'ecx, 'tcx, T: EarlyLintPass> EarlyContextAndPass<'ecx, 'tcx, T> {
                     self.context.opt_span_lint(
                         lint_id.lint,
                         span,
-                        DecorateAttrLint {
-                            sess: self.context.sess(),
-                            tcx: self.tcx,
-                            diagnostic: &b,
-                        },
+                        DecorateAttrLint { tcx: self.tcx, diagnostic: &b },
                     );
                 }
                 DecorateDiagCompat::Dynamic(callback) => {
@@ -328,22 +322,19 @@ impl<'a> EarlyCheckNode<'a> for (ast::NodeId, &'a [ast::Attribute], &'a [Box<ast
 }
 
 pub fn check_ast_node<'a>(
-    sess: &Session,
     tcx: TyCtxt<'_>,
-    features: &Features,
     pre_expansion: bool,
     lint_store: &LintStore,
-    registered_tools: &RegisteredTools,
     lint_buffer: Option<LintBuffer>,
     builtin_lints: impl EarlyLintPass + 'static,
     check_node: impl EarlyCheckNode<'a>,
 ) {
     let context = EarlyContext::new(
-        sess,
-        features,
+        tcx.sess,
+        tcx.features(),
         !pre_expansion,
         lint_store,
-        registered_tools,
+        tcx.registered_tools(()),
         lint_buffer.unwrap_or_default(),
     );
 
@@ -353,17 +344,16 @@ pub fn check_ast_node<'a>(
     let passes =
         if pre_expansion { &lint_store.pre_expansion_passes } else { &lint_store.early_passes };
     if passes.is_empty() {
-        check_ast_node_inner(sess, tcx, check_node, context, builtin_lints);
+        check_ast_node_inner(tcx, check_node, context, builtin_lints);
     } else {
         let mut passes: Vec<_> = passes.iter().map(|mk_pass| (mk_pass)()).collect();
         passes.push(Box::new(builtin_lints));
         let pass = RuntimeCombinedEarlyLintPass { passes: &mut passes[..] };
-        check_ast_node_inner(sess, tcx, check_node, context, pass);
+        check_ast_node_inner(tcx, check_node, context, pass);
     }
 }
 
 fn check_ast_node_inner<'a, T: EarlyLintPass>(
-    sess: &Session,
     tcx: TyCtxt<'_>,
     check_node: impl EarlyCheckNode<'a>,
     context: EarlyContext<'_>,
@@ -379,7 +369,7 @@ fn check_ast_node_inner<'a, T: EarlyLintPass>(
     for (id, lints) in cx.context.buffered.map {
         if !lints.is_empty() {
             assert!(
-                sess.dcx().has_errors().is_some(),
+                tcx.sess.dcx().has_errors().is_some(),
                 "failed to process buffered lint here (dummy = {})",
                 id == ast::DUMMY_NODE_ID
             );

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -13,9 +13,9 @@ use rustc_session::lint::LintPass;
 use rustc_span::{Ident, Span};
 use tracing::debug;
 
-use crate::context::{EarlyContext, LintContext, LintStore};
+use crate::context::{EarlyContext, LintContext};
 use crate::passes::{EarlyLintPass, EarlyLintPassObject};
-use crate::{DecorateAttrLint, DiagAndSess};
+use crate::{DecorateAttrLint, DiagAndSess, unerased_lint_store};
 
 pub(super) mod diagnostics;
 
@@ -324,11 +324,11 @@ impl<'a> EarlyCheckNode<'a> for (ast::NodeId, &'a [ast::Attribute], &'a [Box<ast
 pub fn check_ast_node<'a>(
     tcx: TyCtxt<'_>,
     pre_expansion: bool,
-    lint_store: &LintStore,
     lint_buffer: Option<LintBuffer>,
     builtin_lints: impl EarlyLintPass + 'static,
     check_node: impl EarlyCheckNode<'a>,
 ) {
+    let lint_store = unerased_lint_store(tcx.sess);
     let context = EarlyContext::new(
         tcx.sess,
         tcx.features(),

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -25,7 +25,7 @@ impl<'a> Diagnostic<'a, ()> for DiagAndSess<'_> {
 /// Directly creating the lint structs is expensive, using this will only decorate the lint structs when needed.
 pub struct DecorateAttrLint<'a, 'sess, 'tcx> {
     pub sess: &'sess Session,
-    pub tcx: Option<TyCtxt<'tcx>>,
+    pub tcx: TyCtxt<'tcx>,
     pub diagnostic: &'a AttributeLintKind,
 }
 

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -23,22 +23,19 @@ impl<'a> Diagnostic<'a, ()> for DiagAndSess<'_> {
 
 /// This is a diagnostic struct that will decorate a `AttributeLintKind`
 /// Directly creating the lint structs is expensive, using this will only decorate the lint structs when needed.
-pub struct DecorateAttrLint<'a, 'sess, 'tcx> {
-    pub sess: &'sess Session,
+pub struct DecorateAttrLint<'a, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub diagnostic: &'a AttributeLintKind,
 }
 
-impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_, '_> {
+impl<'a> Diagnostic<'a, ()> for DecorateAttrLint<'_, '_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
         match self.diagnostic {
             &AttributeLintKind::UnexpectedCfgName(name, value) => {
-                check_cfg::unexpected_cfg_name(self.sess, self.tcx, name, value)
-                    .into_diag(dcx, level)
+                check_cfg::unexpected_cfg_name(self.tcx, name, value).into_diag(dcx, level)
             }
             &AttributeLintKind::UnexpectedCfgValue(name, value) => {
-                check_cfg::unexpected_cfg_value(self.sess, self.tcx, name, value)
-                    .into_diag(dcx, level)
+                check_cfg::unexpected_cfg_value(self.tcx, name, value).into_diag(dcx, level)
             }
         }
     }

--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -62,7 +62,7 @@ fn to_check_cfg_arg(name: Ident, value: Option<Symbol>, quotes: EscapeQuotes) ->
 }
 
 fn cargo_help_sub(
-    sess: &Session,
+    tcx: TyCtxt<'_>,
     inst: &impl Fn(EscapeQuotes) -> String,
 ) -> lints::UnexpectedCfgCargoHelp {
     // We don't want to suggest the `build.rs` way to expected cfgs if we are already in a
@@ -70,7 +70,7 @@ fn cargo_help_sub(
     // `build_script_build`) to try to figure out if we are building a Cargo build script
 
     let unescaped = &inst(EscapeQuotes::No);
-    if let Some("build_script_build") = sess.opts.crate_name.as_deref() {
+    if let Some("build_script_build") = tcx.sess.opts.crate_name.as_deref() {
         lints::UnexpectedCfgCargoHelp::lint_cfg(unescaped)
     } else {
         lints::UnexpectedCfgCargoHelp::lint_cfg_and_build_rs(unescaped, &inst(EscapeQuotes::Yes))
@@ -106,11 +106,12 @@ fn cargo_macro_help(tcx: TyCtxt<'_>, span: Span) -> Option<lints::UnexpectedCfgC
 }
 
 pub(super) fn unexpected_cfg_name(
-    sess: &Session,
     tcx: TyCtxt<'_>,
     (name, name_span): (Symbol, Span),
     value: Option<(Symbol, Span)>,
 ) -> lints::UnexpectedCfgName {
+    let sess = tcx.sess;
+
     #[allow(rustc::potential_query_instability)]
     let possibilities: Vec<Symbol> = sess.psess.check_config.expecteds.keys().copied().collect();
 
@@ -268,7 +269,7 @@ pub(super) fn unexpected_cfg_name(
 
     let invocation_help = if is_from_cargo {
         let help = if !is_feature_cfg && !is_from_external_macro {
-            Some(cargo_help_sub(sess, &inst))
+            Some(cargo_help_sub(tcx, &inst))
         } else {
             None
         };
@@ -288,11 +289,12 @@ pub(super) fn unexpected_cfg_name(
 }
 
 pub(super) fn unexpected_cfg_value(
-    sess: &Session,
     tcx: TyCtxt<'_>,
     (name, name_span): (Symbol, Span),
     value: Option<(Symbol, Span)>,
 ) -> lints::UnexpectedCfgValue {
+    let sess = tcx.sess;
+
     let Some(ExpectedValues::Some(values)) = &sess.psess.check_config.expecteds.get(&name) else {
         bug!(
             "it shouldn't be possible to have a diagnostic on a value whose name is not in values"
@@ -406,7 +408,7 @@ pub(super) fn unexpected_cfg_value(
                 Some(lints::unexpected_cfg_value::CargoHelp::DefineFeatures)
             }
         } else if can_suggest_adding_value && !is_from_external_macro {
-            Some(lints::unexpected_cfg_value::CargoHelp::Other(cargo_help_sub(sess, &inst)))
+            Some(lints::unexpected_cfg_value::CargoHelp::Other(cargo_help_sub(tcx, &inst)))
         } else {
             None
         };

--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -65,12 +65,10 @@ fn cargo_help_sub(
     tcx: TyCtxt<'_>,
     inst: &impl Fn(EscapeQuotes) -> String,
 ) -> lints::UnexpectedCfgCargoHelp {
-    // We don't want to suggest the `build.rs` way to expected cfgs if we are already in a
-    // `build.rs`. We therefor do a best effort check (looking if the `--crate-name` is
-    // `build_script_build`) to try to figure out if we are building a Cargo build script
+    // Don't suggest the `build.rs` way to expected cfgs if we are already in a `build.rs`.
 
     let unescaped = &inst(EscapeQuotes::No);
-    if let Some("build_script_build") = tcx.sess.opts.crate_name.as_deref() {
+    if tcx.is_build_script() {
         lints::UnexpectedCfgCargoHelp::lint_cfg(unescaped)
     } else {
         lints::UnexpectedCfgCargoHelp::lint_cfg_and_build_rs(unescaped, &inst(EscapeQuotes::Yes))

--- a/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
+++ b/compiler/rustc_lint/src/early/diagnostics/check_cfg.rs
@@ -89,15 +89,11 @@ fn rustc_macro_help(span: Span) -> Option<lints::UnexpectedCfgRustcMacroHelp> {
     }
 }
 
-fn cargo_macro_help(
-    tcx: Option<TyCtxt<'_>>,
-    span: Span,
-) -> Option<lints::UnexpectedCfgCargoMacroHelp> {
+fn cargo_macro_help(tcx: TyCtxt<'_>, span: Span) -> Option<lints::UnexpectedCfgCargoMacroHelp> {
     let oexpn = span.ctxt().outer_expn_data();
     if let Some(def_id) = oexpn.macro_def_id
         && let ExpnKind::Macro(macro_kind, macro_name) = oexpn.kind
         && def_id.krate != LOCAL_CRATE
-        && let Some(tcx) = tcx
     {
         Some(lints::UnexpectedCfgCargoMacroHelp {
             macro_kind: macro_kind.descr(),
@@ -111,7 +107,7 @@ fn cargo_macro_help(
 
 pub(super) fn unexpected_cfg_name(
     sess: &Session,
-    tcx: Option<TyCtxt<'_>>,
+    tcx: TyCtxt<'_>,
     (name, name_span): (Symbol, Span),
     value: Option<(Symbol, Span)>,
 ) -> lints::UnexpectedCfgName {
@@ -293,7 +289,7 @@ pub(super) fn unexpected_cfg_name(
 
 pub(super) fn unexpected_cfg_value(
     sess: &Session,
-    tcx: Option<TyCtxt<'_>>,
+    tcx: TyCtxt<'_>,
     (name, name_span): (Symbol, Span),
     value: Option<(Symbol, Span)>,
 ) -> lints::UnexpectedCfgValue {

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -342,6 +342,7 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
             return;
         }
 
+        #[expect(rustc::bad_opt_access, reason = "We explicitly handle #![crate_name] below")]
         let crate_ident = if let Some(name) = &cx.tcx.sess.opts.crate_name {
             Some(Ident::from_str(name))
         } else {

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -771,7 +771,7 @@ impl CStore {
                         CrateOrigin::Extern,
                     )
                     .is_err();
-                err.report(tcx.sess, span, missing_core);
+                err.report(tcx, span, missing_core);
                 None
             }
         }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -224,6 +224,7 @@ use rustc_data_structures::owned_slice::{OwnedSlice, slice_owned};
 use rustc_data_structures::svh::Svh;
 use rustc_errors::{DiagArgValue, IntoDiagArg};
 use rustc_fs_util::try_canonicalize;
+use rustc_middle::ty::TyCtxt;
 use rustc_session::cstore::CrateSource;
 use rustc_session::filesearch::FileSearch;
 use rustc_session::search_paths::PathKind;
@@ -1051,7 +1052,8 @@ impl fmt::Display for MetadataError<'_> {
 }
 
 impl CrateError {
-    pub(crate) fn report(self, sess: &Session, span: Span, missing_core: bool) {
+    pub(crate) fn report(self, tcx: TyCtxt<'_>, span: Span, missing_core: bool) {
+        let sess = tcx.sess;
         let dcx = sess.dcx();
         match self {
             CrateError::NonAsciiName(crate_name) => {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1188,11 +1188,7 @@ impl CrateError {
                         crate_name,
                         add_info,
                         missing_core,
-                        current_crate: sess
-                            .opts
-                            .crate_name
-                            .clone()
-                            .unwrap_or_else(|| "<unknown>".to_string()),
+                        current_crate: tcx.local_crate_name().to_string(),
                         is_nightly_build: sess.is_nightly_build(),
                         profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                         locator_triple: locator.triple,
@@ -1214,11 +1210,7 @@ impl CrateError {
                     crate_name,
                     add_info: String::new(),
                     missing_core,
-                    current_crate: sess
-                        .opts
-                        .crate_name
-                        .clone()
-                        .unwrap_or_else(|| "<unknown>".to_string()),
+                    current_crate: tcx.local_crate_name().to_string(),
                     is_nightly_build: sess.is_nightly_build(),
                     profiler_runtime: Symbol::intern(&sess.opts.unstable_opts.profiler_runtime),
                     locator_triple: sess.opts.target_triple.clone(),

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -143,7 +143,7 @@ pub(crate) struct Reentrant;
 #[note(
     "an ideal reproduction consists of the code before and some patch that then triggers the bug when applied and compiled again"
 )]
-#[note("as a workaround, you can run {$run_cmd} to allow your project to compile")]
+#[note("as a workaround, you can {$run_cmd} to allow your project to compile")]
 pub(crate) struct IncrementCompilation {
     pub run_cmd: String,
     pub dep_node: String,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -43,6 +43,7 @@ use rustc_session::Session;
 use rustc_session::config::CrateType;
 use rustc_session::cstore::{CrateStoreDyn, Untracked};
 use rustc_session::lint::Lint;
+use rustc_session::utils::was_invoked_from_cargo;
 use rustc_span::def_id::{CRATE_DEF_ID, DefPathHash, StableCrateId};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_type_ir::TyKind::*;
@@ -1423,6 +1424,14 @@ impl<'tcx> TyCtxtAt<'tcx> {
 
         feed.def_span(self.span);
         feed
+    }
+}
+
+/// Operations on the crate name.
+impl<'tcx> TyCtxt<'tcx> {
+    /// Check if this crate is a Cargo build script.
+    pub fn is_build_script(self) -> bool {
+        self.crate_name(LOCAL_CRATE) == sym::build_script_build && was_invoked_from_cargo()
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1429,10 +1429,14 @@ impl<'tcx> TyCtxtAt<'tcx> {
 
 /// Operations on the crate name.
 impl<'tcx> TyCtxt<'tcx> {
+    pub fn local_crate_name(self) -> Symbol {
+        self.crate_name(LOCAL_CRATE)
+    }
+
     /// Check if this crate is a Cargo build script.
     /// Should only be used for diagnostics.
     pub fn is_build_script(self) -> bool {
-        self.crate_name(LOCAL_CRATE) == sym::build_script_build && was_invoked_from_cargo()
+        self.local_crate_name() == sym::build_script_build && was_invoked_from_cargo()
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1430,6 +1430,7 @@ impl<'tcx> TyCtxtAt<'tcx> {
 /// Operations on the crate name.
 impl<'tcx> TyCtxt<'tcx> {
     /// Check if this crate is a Cargo build script.
+    /// Should only be used for diagnostics.
     pub fn is_build_script(self) -> bool {
         self.crate_name(LOCAL_CRATE) == sym::build_script_build && was_invoked_from_cargo()
     }

--- a/compiler/rustc_middle/src/verify_ich.rs
+++ b/compiler/rustc_middle/src/verify_ich.rs
@@ -1,6 +1,8 @@
 use std::cell::Cell;
 
 use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_session::utils::was_invoked_from_cargo;
 use tracing::instrument;
 
 use crate::dep_graph::{DepGraphData, SerializedDepNodeIndex};
@@ -66,10 +68,10 @@ fn incremental_verify_ich_failed<'tcx>(
     if old_in_panic {
         tcx.dcx().emit_err(crate::error::Reentrant);
     } else {
-        let run_cmd = if let Some(crate_name) = &tcx.sess.opts.crate_name {
-            format!("`cargo clean -p {crate_name}` or `cargo clean`")
+        let run_cmd = if was_invoked_from_cargo() {
+            format!("run `cargo clean -p {}` or `cargo clean`", tcx.crate_name(LOCAL_CRATE))
         } else {
-            "`cargo clean`".to_string()
+            "clean your build cache".to_owned()
         };
 
         let dep_node = tcx.dep_graph.data().unwrap().prev_node_of(prev_index);

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -155,7 +155,11 @@ pub fn registered_tools_ast(
     registered_tools
 }
 
-impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
+impl<'ra, 'tcx> ResolverExpand<'tcx> for Resolver<'ra, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn next_node_id(&mut self) -> NodeId {
         self.next_node_id()
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1205,6 +1205,7 @@ impl OutputFilenames {
     }
 
     pub fn interface_path(&self) -> PathBuf {
+        debug!("using crate_name={} for interface_path", self.crate_stem);
         self.out_directory.join(format!("lib{}.rs", self.crate_stem))
     }
 
@@ -1214,6 +1215,7 @@ impl OutputFilenames {
         let extension = flavor.extension();
         match flavor {
             OutputType::Metadata => {
+                debug!("using crate_name={} for {extension}", self.crate_stem);
                 self.out_directory.join(format!("lib{}.{}", self.crate_stem, extension))
             }
             _ => self.with_directory_and_extension(&self.out_directory, extension),
@@ -1288,6 +1290,7 @@ impl OutputFilenames {
     }
 
     pub fn with_directory_and_extension(&self, directory: &Path, extension: &str) -> PathBuf {
+        debug!("using filestem={} for {extension}", self.filestem);
         let mut path = directory.join(&self.filestem);
         path.set_extension(extension);
         path

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1136,6 +1136,8 @@ pub struct OutputFilenames {
     /// Crate name. Never contains '-'.
     crate_stem: String,
     /// Typically based on `.rs` input file name. Any '-' is preserved.
+    ///
+    /// See also `rustc_interface::passes::CrateName`.
     filestem: String,
     pub single_output_file: Option<OutFileName>,
     temps_directory: Option<PathBuf>,

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1013,17 +1013,6 @@ pub enum Input {
 }
 
 impl Input {
-    pub fn filestem(&self) -> &str {
-        if let Input::File(ifile) = self {
-            // If for some reason getting the file stem as a UTF-8 string fails,
-            // then fallback to a fixed name.
-            if let Some(name) = ifile.file_stem().and_then(OsStr::to_str) {
-                return name;
-            }
-        }
-        "rust_out"
-    }
-
     pub fn file_name(&self, session: &Session) -> FileName {
         match *self {
             Input::File(ref ifile) => FileName::Real(

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -337,6 +337,7 @@ top_level_options!(
         prints: Vec<PrintRequest> [UNTRACKED],
         cg: CodegenOptions [SUBSTRUCT] { TARGET_MODIFIER: CodegenOptions(CodegenOptionsTargetModifiers) },
         externs: Externs [UNTRACKED],
+        #[rustc_lint_opt_deny_field_access("use `tcx.local_crate_name()` instead of this field")]
         crate_name: Option<String> [TRACKED],
         /// Indicates how the compiler should treat unstable features.
         unstable_features: UnstableFeatures [TRACKED],

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -541,6 +541,7 @@ symbols! {
         breakpoint,
         bridge,
         bswap,
+        build_script_build,
         built,
         builtin_syntax,
         bundle,

--- a/src/librustdoc/doctest/markdown.rs
+++ b/src/librustdoc/doctest/markdown.rs
@@ -1,5 +1,6 @@
 //! Doctest functionality used only for doctests in `.md` Markdown files.
 
+use std::ffi::OsStr;
 use std::fs::read_to_string;
 use std::sync::{Arc, Mutex};
 
@@ -79,6 +80,20 @@ impl DocTestVisitor for MdCollector {
     }
 }
 
+/// Obviously not a real crate name, but close enough for purposes of doctests.
+///
+/// We don't have a `Session` when parsing markdown files so we can't do any better here.
+pub fn filestem(input: &Input) -> &str {
+    if let Input::File(ifile) = input {
+        // If for some reason getting the file stem as a UTF-8 string fails,
+        // then fallback to a fixed name.
+        if let Some(name) = ifile.file_stem().and_then(OsStr::to_str) {
+            return name;
+        }
+    }
+    "rust_out"
+}
+
 /// Runs any tests/code examples in the markdown file `options.input`.
 pub(crate) fn test(input: &Input, options: Options, dcx: DiagCtxtHandle<'_>) -> Result<(), String> {
     let input_str = match input {
@@ -88,8 +103,7 @@ pub(crate) fn test(input: &Input, options: Options, dcx: DiagCtxtHandle<'_>) -> 
         Input::Str { name: _, input } => input.clone(),
     };
 
-    // Obviously not a real crate name, but close enough for purposes of doctests.
-    let crate_name = input.filestem().to_string();
+    let crate_name = filestem(input).to_string();
     let temp_dir =
         tempdir().map_err(|error| format!("failed to create temporary directory: {error:?}"))?;
     let args_file = temp_dir.path().join("rustdoc-cfgs");

--- a/src/tools/clippy/clippy_lints/src/write/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/write/mod.rs
@@ -3,7 +3,7 @@ use clippy_utils::diagnostics::span_lint;
 use clippy_utils::macros::{FormatArgsStorage, root_macro_call_first_node};
 use clippy_utils::{is_in_test, sym};
 use rustc_hir::{Expr, Impl, Item, ItemKind, OwnerId};
-use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::impl_lint_pass;
 
 mod empty_string;
@@ -294,17 +294,10 @@ impl<'tcx> LateLintPass<'tcx> for Write {
             return;
         };
 
-        let is_build_script = cx
-            .sess()
-            .opts
-            .crate_name
-            .as_ref()
-            .is_some_and(|crate_name| crate_name == "build_script_build");
-
         let allowed_in_tests = self.allow_print_in_tests && is_in_test(cx.tcx, expr.hir_id);
         match diag_name {
             sym::print_macro | sym::println_macro if !allowed_in_tests => {
-                if !is_build_script {
+                if !cx.tcx.is_build_script() {
                     span_lint(cx, PRINT_STDOUT, macro_call.span, format!("use of `{name}!`"));
                 }
             },

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -62,7 +62,7 @@ use rustc_middle::middle::exported_symbols::{
 use rustc_middle::query::LocalCrate;
 use rustc_middle::traits::{ObligationCause, ObligationCauseCode};
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_session::config::{CrateType, ErrorOutputType, OptLevel};
+use rustc_session::config::{CrateType, ErrorOutputType, OptLevel, OutputType};
 use rustc_session::{EarlyDiagCtxt, Session};
 use rustc_span::def_id::DefId;
 
@@ -219,7 +219,9 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
         // Obtain and complete the Miri configuration.
         let mut config = self.miri_config.take().expect("after_analysis must only be called once");
         // Add filename to `miri` arguments.
-        config.args.insert(0, tcx.sess.io.input.filestem().to_string());
+        let exe_path = tcx.output_filenames(()).path(OutputType::Exe);
+        let exe_stem = exe_path.filestem().unwrap().to_string_lossy();
+        config.args.insert(0, exe_stem.to_string());
 
         // Adjust working directory for interpretation.
         if let Some(cwd) = env::var_os("MIRI_CWD") {

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -27,7 +27,7 @@ use rustc_middle::ty::layout::{
 };
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_session::config::InliningThreshold;
-use rustc_span::def_id::{CrateNum, DefId};
+use rustc_span::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_span::{Span, SpanData, Symbol};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::callconv::FnAbi;
@@ -676,8 +676,7 @@ impl<'tcx> MiriMachine<'tcx> {
         let layouts =
             PrimitiveLayouts::new(layout_cx).expect("Couldn't get layouts of primitive types");
         let profiler = config.measureme_out.as_ref().map(|out| {
-            let crate_name =
-                tcx.sess.opts.crate_name.clone().unwrap_or_else(|| "unknown-crate".to_string());
+            let crate_name = tcx.crate_name(LOCAL_CRATE);
             let pid = process::id();
             // We adopt the same naming scheme for the profiler output that rustc uses. In rustc,
             // the PID is padded so that the nondeterministic value of the PID does not spread

--- a/tests/ui-fulldeps/internal-lints/bad_opt_access.rs
+++ b/tests/ui-fulldeps/internal-lints/bad_opt_access.rs
@@ -17,6 +17,6 @@ pub fn access_bad_option(sess: Session) {
     let _ = sess.opts.crate_types;
     //~^ ERROR use `TyCtxt::crate_types` instead of this field
 
-    let _ = sess.opts.crate_name;
+    let _ = sess.opts.prints;
     // okay!
 }


### PR DESCRIPTION
Modified version of https://github.com/rust-lang/rust/pull/153924/ that doesn't try to change any dataflow, just clarify the existing behavior.

- The first two commits are https://github.com/rust-lang/rust/pull/155835, which has already been approved.
- The next five commits pass a `TyCtxt` into macro expansion, and make some easy cleanups that are possible as a result. https://github.com/rust-lang/rust/commit/b84658a2888a27b80723a48ccc1970801b314c11 should be the only commit that changes behavior (in diagnostics), I kept it intentionally small.
- The next three commits are minor cleanups related to crate name handling.
- https://github.com/rust-lang/rust/commit/b59aeac10979b26dff9a314b81492d736ce347fd introduces a new `CrateName` struct that documents the difference between the filestem and crate name. Previously the compiler confused the two (unsure if this was intentional, the code was quite complicated). I have preserved the behavior even though I'm not sure it's correct; a bunch of run-make tests depend on it.
- Now that all the hard bits are taken care of, d0d19671e8677a40486d3ba03ac11d57a097f5e1 lints on `opts.crate_name` and mops up a last couple places that shouldn't have been using it.
- The last commit removes the temptation to use `filestem()` instead of `CrateName`.

---
I promise that I tried very hard not to change any behavior in this PR. Here is a transcript of some existing behavior on nightly:
```
$ cat x-y.rs
fn main() {}
$ rustc x-y.rs --print=file-names --crate-type=lib --crate-type=bin --crate-type=cdylib --crate-type=staticlib --crate-type=cdylib --crate-type=proc-macro  --print=crate-name
libx_y.rlib
x-y
libx_y.dylib
libx_y.a
libx_y.dylib
x_y
$ echo "fn main() {}" | rustc - --print=file-names --crate-type=bin --print=crate-name
rust_out
rust_out
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
