### PR TITLE
tests/ui/tuple: add annotations for reference rules

### DIFF
--- a/tests/ui/tuple/add-tuple-within-arguments.rs
+++ b/tests/ui/tuple/add-tuple-within-arguments.rs
@@ -1,3 +1,6 @@
+//@ reference: expr.tuple.unary-tuple-restriction
+//@ reference: type.tuple.intro
+//@ reference: type.tuple.restriction
 fn foo(s: &str, a: (i32, i32), s2: &str) {}
 
 fn bar(s: &str, a: (&str,), s2: &str) {}
@@ -5,6 +8,8 @@ fn bar(s: &str, a: (&str,), s2: &str) {}
 fn main() {
     foo("hi", 1, 2, "hi");
     //~^ ERROR function takes 3 arguments but 4 arguments were supplied
+    //~| HELP: wrap these arguments in parentheses to construct a tuple
     bar("hi", "hi", "hi");
     //~^ ERROR mismatched types
+    //~| HELP: use a trailing comma to create a tuple with one element
 }

--- a/tests/ui/tuple/add-tuple-within-arguments.rs
+++ b/tests/ui/tuple/add-tuple-within-arguments.rs
@@ -1,3 +1,6 @@
+//@ reference: expr.tuple.unary-tuple-restriction
+//@ reference: type.tuple.syntax
+//@ reference: type.tuple.restriction
 fn foo(s: &str, a: (i32, i32), s2: &str) {}
 
 fn bar(s: &str, a: (&str,), s2: &str) {}
@@ -5,6 +8,8 @@ fn bar(s: &str, a: (&str,), s2: &str) {}
 fn main() {
     foo("hi", 1, 2, "hi");
     //~^ ERROR function takes 3 arguments but 4 arguments were supplied
+    //~| HELP: wrap these arguments in parentheses to construct a tuple
     bar("hi", "hi", "hi");
     //~^ ERROR mismatched types
+    //~| HELP: use a trailing comma to create a tuple with one element
 }

--- a/tests/ui/tuple/add-tuple-within-arguments.stderr
+++ b/tests/ui/tuple/add-tuple-within-arguments.stderr
@@ -1,11 +1,11 @@
 error[E0061]: function takes 3 arguments but 4 arguments were supplied
-  --> $DIR/add-tuple-within-arguments.rs:6:5
+  --> $DIR/add-tuple-within-arguments.rs:9:5
    |
 LL |     foo("hi", 1, 2, "hi");
    |     ^^^
    |
 note: function defined here
-  --> $DIR/add-tuple-within-arguments.rs:1:4
+  --> $DIR/add-tuple-within-arguments.rs:4:4
    |
 LL | fn foo(s: &str, a: (i32, i32), s2: &str) {}
    |    ^^^          -------------
@@ -15,7 +15,7 @@ LL |     foo("hi", (1, 2), "hi");
    |               +    +
 
 error[E0308]: mismatched types
-  --> $DIR/add-tuple-within-arguments.rs:8:15
+  --> $DIR/add-tuple-within-arguments.rs:12:15
    |
 LL |     bar("hi", "hi", "hi");
    |     ---       ^^^^ expected `(&str,)`, found `&str`
@@ -25,7 +25,7 @@ LL |     bar("hi", "hi", "hi");
    = note:  expected tuple `(&str,)`
            found reference `&'static str`
 note: function defined here
-  --> $DIR/add-tuple-within-arguments.rs:3:4
+  --> $DIR/add-tuple-within-arguments.rs:6:4
    |
 LL | fn bar(s: &str, a: (&str,), s2: &str) {}
    |    ^^^          ----------

--- a/tests/ui/tuple/coercion-never.rs
+++ b/tests/ui/tuple/coercion-never.rs
@@ -5,6 +5,7 @@
 // See also coercion-slice.rs
 //
 //@ check-pass
+//@ reference: coerce.site.tuple
 
 fn main() {
     let _: ((),) = (loop {},);

--- a/tests/ui/tuple/coercion-never.rs
+++ b/tests/ui/tuple/coercion-never.rs
@@ -5,6 +5,8 @@
 // See also coercion-slice.rs
 //
 //@ check-pass
+//@ reference: coerce.site.tuple
+//@ reference: coerce.types.never
 
 fn main() {
     let _: ((),) = (loop {},);

--- a/tests/ui/tuple/coercion-slice.rs
+++ b/tests/ui/tuple/coercion-slice.rs
@@ -3,6 +3,7 @@
 // unifying match arms, for example.
 //
 // See also: coercion-never.rs
+//@ reference: coerce.site.tuple
 
 fn main() {
     let _: (&[u8],) = (&[],);

--- a/tests/ui/tuple/coercion-slice.rs
+++ b/tests/ui/tuple/coercion-slice.rs
@@ -3,6 +3,9 @@
 // unifying match arms, for example.
 //
 // See also: coercion-never.rs
+//@ reference: coerce.site.tuple
+//@ reference: coerce.types.unsize
+//@ reference: coerce.unsize.slice
 
 fn main() {
     let _: (&[u8],) = (&[],);

--- a/tests/ui/tuple/coercion-slice.stderr
+++ b/tests/ui/tuple/coercion-slice.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coercion-slice.rs:11:23
+  --> $DIR/coercion-slice.rs:12:23
    |
 LL |     let _: (&[u8],) = y;
    |            --------   ^ expected `(&[u8],)`, found `(&[_; 0],)`

--- a/tests/ui/tuple/coercion-slice.stderr
+++ b/tests/ui/tuple/coercion-slice.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coercion-slice.rs:11:23
+  --> $DIR/coercion-slice.rs:14:23
    |
 LL |     let _: (&[u8],) = y;
    |            --------   ^ expected `(&[u8],)`, found `(&[_; 0],)`

--- a/tests/ui/tuple/index-float.rs
+++ b/tests/ui/tuple/index-float.rs
@@ -1,4 +1,6 @@
 //@ check-pass
+//@ reference: expr.tuple-index.intro
+//@ reference: expr.tuple-index.syntax
 
 fn main() {
     let tuple = (((),),);

--- a/tests/ui/tuple/index-float.rs
+++ b/tests/ui/tuple/index-float.rs
@@ -1,4 +1,6 @@
 //@ check-pass
+//@ reference: expr.tuple-index.syntax
+//@ reference: comments.normal.tokenization
 
 fn main() {
     let tuple = (((),),);

--- a/tests/ui/tuple/index-invalid.rs
+++ b/tests/ui/tuple/index-invalid.rs
@@ -1,3 +1,4 @@
+//@ reference: type.tuple.field-name
 fn main() {
     let _ = (((),),).1.0; //~ ERROR no field `1` on type `(((),),)`
 

--- a/tests/ui/tuple/index-invalid.rs
+++ b/tests/ui/tuple/index-invalid.rs
@@ -1,3 +1,7 @@
+//@ reference: expr.tuple-index.index-name-operand
+//@ reference: expr.tuple-index.index-syntax
+//@ reference: lex.token.literal.int.tuple-field.eq
+//@ reference: type.tuple.field-name
 fn main() {
     let _ = (((),),).1.0; //~ ERROR no field `1` on type `(((),),)`
 

--- a/tests/ui/tuple/index-invalid.stderr
+++ b/tests/ui/tuple/index-invalid.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `1` on type `(((),),)`
-  --> $DIR/index-invalid.rs:2:22
+  --> $DIR/index-invalid.rs:3:22
    |
 LL |     let _ = (((),),).1.0;
    |                      ^ unknown field
@@ -7,7 +7,7 @@ LL |     let _ = (((),),).1.0;
    = note: available field is: `0`
 
 error[E0609]: no field `1` on type `((),)`
-  --> $DIR/index-invalid.rs:4:24
+  --> $DIR/index-invalid.rs:5:24
    |
 LL |     let _ = (((),),).0.1;
    |                        ^ unknown field
@@ -15,7 +15,7 @@ LL |     let _ = (((),),).0.1;
    = note: available field is: `0`
 
 error[E0609]: no field `000` on type `(((),),)`
-  --> $DIR/index-invalid.rs:6:22
+  --> $DIR/index-invalid.rs:7:22
    |
 LL |     let _ = (((),),).000.000;
    |                      ^^^ unknown field

--- a/tests/ui/tuple/index-invalid.stderr
+++ b/tests/ui/tuple/index-invalid.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `1` on type `(((),),)`
-  --> $DIR/index-invalid.rs:2:22
+  --> $DIR/index-invalid.rs:6:22
    |
 LL |     let _ = (((),),).1.0;
    |                      ^ unknown field
@@ -7,7 +7,7 @@ LL |     let _ = (((),),).1.0;
    = note: available field is: `0`
 
 error[E0609]: no field `1` on type `((),)`
-  --> $DIR/index-invalid.rs:4:24
+  --> $DIR/index-invalid.rs:8:24
    |
 LL |     let _ = (((),),).0.1;
    |                        ^ unknown field
@@ -15,7 +15,7 @@ LL |     let _ = (((),),).0.1;
    = note: available field is: `0`
 
 error[E0609]: no field `000` on type `(((),),)`
-  --> $DIR/index-invalid.rs:6:22
+  --> $DIR/index-invalid.rs:10:22
    |
 LL |     let _ = (((),),).000.000;
    |                      ^^^ unknown field

--- a/tests/ui/tuple/never-to-any-coercion-in-collection-issue-100727.rs
+++ b/tests/ui/tuple/never-to-any-coercion-in-collection-issue-100727.rs
@@ -3,6 +3,8 @@
 
 //@ check-pass
 //@ edition: 2021
+//@ reference: coerce.site.tuple
+//@ reference: coerce.types.never
 
 #![allow(unreachable_code)]
 

--- a/tests/ui/tuple/one-tuple.rs
+++ b/tests/ui/tuple/one-tuple.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ reference: type.tuple.restriction
 // Why one-tuples? Because macros.
 
 

--- a/tests/ui/tuple/one-tuple.rs
+++ b/tests/ui/tuple/one-tuple.rs
@@ -1,4 +1,8 @@
 //@ run-pass
+//@ reference: expr.tuple.unary-tuple-restriction
+//@ reference: patterns.tuple.syntax
+//@ reference: statement.let.syntax
+//@ reference: type.tuple.restriction
 // Why one-tuples? Because macros.
 
 

--- a/tests/ui/tuple/tup.rs
+++ b/tests/ui/tuple/tup.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ reference: patterns.tuple.intro
+//@ reference: type.tuple.constructor
 
 #![allow(non_camel_case_types)]
 

--- a/tests/ui/tuple/tup.rs
+++ b/tests/ui/tuple/tup.rs
@@ -1,4 +1,6 @@
 //@ run-pass
+//@ reference: patterns.tuple.syntax
+//@ reference: type.tuple.constructor
 
 #![allow(non_camel_case_types)]
 

--- a/tests/ui/tuple/tuple-arity-mismatch.rs
+++ b/tests/ui/tuple/tuple-arity-mismatch.rs
@@ -1,5 +1,6 @@
 // Issue #6155
-
+//@ reference: expr.tuple.type
+//@ reference: type.tuple.field-number
 //@ dont-require-annotations: NOTE
 
 fn first((value, _): (isize, f64)) -> isize { value }

--- a/tests/ui/tuple/tuple-arity-mismatch.stderr
+++ b/tests/ui/tuple/tuple-arity-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/tuple-arity-mismatch.rs:8:20
+  --> $DIR/tuple-arity-mismatch.rs:9:20
    |
 LL |     let y = first ((1,2.0,3));
    |             -----  ^^^^^^^^^ expected a tuple with 2 elements, found one with 3 elements
@@ -9,13 +9,13 @@ LL |     let y = first ((1,2.0,3));
    = note: expected tuple `(isize, f64)`
               found tuple `(isize, f64, {integer})`
 note: function defined here
-  --> $DIR/tuple-arity-mismatch.rs:5:4
+  --> $DIR/tuple-arity-mismatch.rs:6:4
    |
 LL | fn first((value, _): (isize, f64)) -> isize { value }
    |    ^^^^^ ------------------------
 
 error[E0308]: mismatched types
-  --> $DIR/tuple-arity-mismatch.rs:14:20
+  --> $DIR/tuple-arity-mismatch.rs:15:20
    |
 LL |     let y = first ((1,));
    |             -----  ^^^^ expected a tuple with 2 elements, found one with 1 element
@@ -25,7 +25,7 @@ LL |     let y = first ((1,));
    = note: expected tuple `(isize, f64)`
               found tuple `(isize,)`
 note: function defined here
-  --> $DIR/tuple-arity-mismatch.rs:5:4
+  --> $DIR/tuple-arity-mismatch.rs:6:4
    |
 LL | fn first((value, _): (isize, f64)) -> isize { value }
    |    ^^^^^ ------------------------

--- a/tests/ui/tuple/tuple-index-not-tuple.rs
+++ b/tests/ui/tuple/tuple-index-not-tuple.rs
@@ -1,3 +1,4 @@
+//@ reference: expr.tuple-index.required-type
 struct Point { x: isize, y: isize }
 struct Empty;
 

--- a/tests/ui/tuple/tuple-index-not-tuple.stderr
+++ b/tests/ui/tuple/tuple-index-not-tuple.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `0` on type `Point`
-  --> $DIR/tuple-index-not-tuple.rs:6:12
+  --> $DIR/tuple-index-not-tuple.rs:7:12
    |
 LL |     origin.0;
    |            ^ unknown field
@@ -11,7 +11,7 @@ LL +     origin.x;
    |
 
 error[E0609]: no field `0` on type `Empty`
-  --> $DIR/tuple-index-not-tuple.rs:8:11
+  --> $DIR/tuple-index-not-tuple.rs:9:11
    |
 LL |     Empty.0;
    |           ^ unknown field

--- a/tests/ui/tuple/tuple-index-out-of-bounds.rs
+++ b/tests/ui/tuple/tuple-index-out-of-bounds.rs
@@ -1,3 +1,5 @@
+//@ reference: expr.tuple-index.index-name-operand
+//@ reference: type.tuple.field-number
 struct Point(i32, i32);
 
 fn main() {

--- a/tests/ui/tuple/tuple-index-out-of-bounds.rs
+++ b/tests/ui/tuple/tuple-index-out-of-bounds.rs
@@ -1,3 +1,7 @@
+//@ reference: expr.tuple-index.index-name-operand
+//@ reference: type.struct.tuple
+//@ reference: type.tuple.field-name
+//@ reference: type.tuple.field-number
 struct Point(i32, i32);
 
 fn main() {

--- a/tests/ui/tuple/tuple-index-out-of-bounds.stderr
+++ b/tests/ui/tuple/tuple-index-out-of-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `2` on type `Point`
-  --> $DIR/tuple-index-out-of-bounds.rs:7:12
+  --> $DIR/tuple-index-out-of-bounds.rs:9:12
    |
 LL |     origin.2;
    |            ^ unknown field
@@ -7,7 +7,7 @@ LL |     origin.2;
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `2` on type `({integer}, {integer})`
-  --> $DIR/tuple-index-out-of-bounds.rs:12:11
+  --> $DIR/tuple-index-out-of-bounds.rs:14:11
    |
 LL |     tuple.2;
    |           ^ unknown field

--- a/tests/ui/tuple/tuple-index-out-of-bounds.stderr
+++ b/tests/ui/tuple/tuple-index-out-of-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `2` on type `Point`
-  --> $DIR/tuple-index-out-of-bounds.rs:7:12
+  --> $DIR/tuple-index-out-of-bounds.rs:11:12
    |
 LL |     origin.2;
    |            ^ unknown field
@@ -7,7 +7,7 @@ LL |     origin.2;
    = note: available fields are: `0`, `1`
 
 error[E0609]: no field `2` on type `({integer}, {integer})`
-  --> $DIR/tuple-index-out-of-bounds.rs:12:11
+  --> $DIR/tuple-index-out-of-bounds.rs:16:11
    |
 LL |     tuple.2;
    |           ^ unknown field

--- a/tests/ui/tuple/tuple-index.rs
+++ b/tests/ui/tuple/tuple-index.rs
@@ -1,4 +1,9 @@
 //@ run-pass
+//@ reference: expr.tuple.fields
+//@ reference: expr.tuple-index.result
+//@ reference: type.struct.tuple
+//@ reference: type.tuple.access
+//@ reference: type.tuple.field-name
 
 struct Point(isize, isize);
 


### PR DESCRIPTION
Also includes `HELP` checks for add-tuple-within-arguments.rs to make it clear that the referenced rules are being tested

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

r? ehuss
@rustbot label +A-docs
<!-- homu-ignore:end -->
