### PR TITLE
Don't reload length in String::push

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1420,7 +1420,7 @@ impl String {
 
         // SAFETY: Just reserved capacity for at least the length needed to encode `ch`.
         unsafe {
-            core::char::encode_utf8_raw_unchecked(ch as u32, self.vec.as_mut_ptr().add(self.len()));
+            core::char::encode_utf8_raw_unchecked(ch as u32, self.vec.as_mut_ptr().add(len));
             self.vec.set_len(len + ch_len);
         }
     }


### PR DESCRIPTION
Same as in `Vec::push_mut`, we get `.len()` once at the start since it won't change in the `reserve()` call.

Saves reloading the length after the allocation: https://godbolt.org/z/W3G165Gd7