### PR TITLE
[doc]: Revert `core::io::ErrorKind` doc changes

### DIFF
--- a/library/core/src/io/error.rs
+++ b/library/core/src/io/error.rs
@@ -7,6 +7,10 @@ use crate::fmt;
 /// This list is intended to grow over time and it is not recommended to
 /// exhaustively match against it.
 ///
+/// It is used with the [`io::Error`][error] type.
+///
+/// [error]: ../../std/io/struct.Error.html
+///
 /// # Handling errors and matching on `ErrorKind`
 ///
 /// In application code, use `match` for the `ErrorKind` values you are
@@ -121,12 +125,13 @@ pub enum ErrorKind {
     #[stable(feature = "rust1", since = "1.0.0")]
     TimedOut,
     /// An error returned when an operation could not be completed because a
-    /// call to an underlying writer returned [`Ok(0)`].
+    /// call to [`write`][write] returned [`Ok(0)`].
     ///
     /// This typically means that an operation could only succeed if it wrote a
     /// particular number of bytes but only a smaller number of bytes could be
     /// written.
     ///
+    /// [write]: ../../std/io/trait.Write.html#tymethod.write
     /// [`Ok(0)`]: Ok
     #[stable(feature = "rust1", since = "1.0.0")]
     WriteZero,
@@ -225,7 +230,7 @@ pub enum ErrorKind {
     //
     /// A custom error that does not fall under any other I/O error kind.
     ///
-    /// This can be used to construct your own errors that do not match any
+    /// This can be used to construct your own [`Error`][error]s that do not match any
     /// [`ErrorKind`].
     ///
     /// This [`ErrorKind`] is not used by the standard library.
@@ -233,6 +238,8 @@ pub enum ErrorKind {
     /// Errors from the standard library that do not fall under any of the I/O
     /// error kinds cannot be `match`ed on, and will only match a wildcard (`_`) pattern.
     /// New [`ErrorKind`]s might be added in the future for some of those.
+    ///
+    /// [error]: ../../std/io/struct.Error.html
     #[stable(feature = "rust1", since = "1.0.0")]
     Other,
 
@@ -365,7 +372,15 @@ impl ErrorKind {
 
 #[stable(feature = "io_errorkind_display", since = "1.60.0")]
 impl fmt::Display for ErrorKind {
-    /// Shows a human-readable description of the `ErrorKind`.
+    /// Shows a human-readable description of the [`ErrorKind`].
+    ///
+    /// This is similar to `impl Display for Error`, but doesn't require first converting to Error.
+    ///
+    /// # Examples
+    /// ```
+    /// use core::io::ErrorKind;
+    /// assert_eq!("entity not found", ErrorKind::NotFound.to_string());
+    /// ```
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.write_str(self.as_str())
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/152918)*
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Related: https://github.com/rust-lang/rust/pull/154654

## Description

rust-lang/rust#154654 changed the documentation for `ErrorKind` to remove links to `std` items. These changes were made falsely assuming documentation links from `core` to `std` were not possible. Since it is possible, we can restore the documentation to its original form prior to the `core::io` move.

## Notes

* No AI tooling of any kind was used in the creation of this PR.

