### PR TITLE
Only exclude the #155473 change for 1-byte bool-likes

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -2084,7 +2084,8 @@ impl Niche {
         let distance_end_zero = max_value - v.end;
         // FIXME: this ought to work for `bool` too, but that seems to be hitting a miscompilation
         // <https://github.com/rust-lang/rust/pull/155473#issuecomment-4302036343>
-        if count == 1 && v != (WrappingRange { start: 0, end: 1 }) {
+        let is_bool = size.bytes() == 1 && v == WrappingRange { start: 0, end: 1 };
+        if count == 1 && !is_bool {
             // We only need one, so just pick the one closest to zero.
             // Not only does that obviously use zero if it's possible, but it also
             // simplifies testing things like `Option<char>`, since looking for `-1`

--- a/tests/codegen-llvm/function-arguments.rs
+++ b/tests/codegen-llvm/function-arguments.rs
@@ -297,7 +297,7 @@ pub fn return_slice(x: &[u16]) -> &[u16] {
     x
 }
 
-// CHECK: { i16, i16 } @enum_id_1(i16 noundef{{( range\(i16 0, 3\))?}} %x.0, i16 %x.1)
+// CHECK: { i16, i16 } @enum_id_1(i16 noundef{{( range\(i16 -1, 2\))?}} %x.0, i16 %x.1)
 #[no_mangle]
 pub fn enum_id_1(x: Option<Result<u16, u16>>) -> Option<Result<u16, u16>> {
     x


### PR DESCRIPTION
That's the thing we handle differently in codegen (see `to_immediate_scalar`) so if the other ones are fine, that helps narrow it down further.

cc https://github.com/rust-lang/rust/pull/155473