### PR TITLE
Use `_mcount` as the mcount symbol name on RISC-V Linux GNU targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32gc_unknown_linux_gnu.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             llvm_abiname: LlvmAbi::Ilp32d,
             max_atomic_width: Some(32),
             supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
+            mcount: "\u{1}_mcount".into(),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64a23_unknown_linux_gnu.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
             supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
+            mcount: "\u{1}_mcount".into(),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_linux_gnu.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
             llvm_abiname: LlvmAbi::Lp64d,
             max_atomic_width: Some(64),
             supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
+            mcount: "\u{1}_mcount".into(),
             ..base::linux_gnu::opts()
         },
     }


### PR DESCRIPTION
Fixes rust-lang/rust#155830

glibc on RISC-V exports `_mcount`, not `mcount`. https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/riscv/machine-gmon.h;hb=HEAD

r? mati865 (I think you're well-suited to review this area, but feel free to reroll)