### PR TITLE
Suggest `[const] Trait` bounds in more places

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/always_applicable.rs
+++ b/compiler/rustc_hir_analysis/src/check/always_applicable.rs
@@ -217,16 +217,26 @@ fn ensure_all_fields_are_const_destruct<'tcx>(
                 unreachable!()
             };
             let field_ty = eff.trait_ref.self_ty();
-            let diag = struct_span_code_err!(
+            let mut diag = struct_span_code_err!(
                 tcx.dcx(),
                 error.root_obligation.cause.span,
                 E0367,
                 "`{field_ty}` does not implement `[const] Destruct`",
             )
             .with_span_note(impl_span, "required for this `Drop` impl");
-            if field_ty.has_param() {
-                // FIXME: suggest adding `[const] Destruct` by teaching
-                // `suggest_restricting_param_bound` about const traits.
+            if field_ty.has_param()
+                && let Some(generics) = tcx.hir_node_by_def_id(impl_def_id).generics()
+            {
+                let destruct_def_id = tcx.lang_items().destruct_trait();
+                ty::suggest_constraining_type_param(
+                    tcx,
+                    generics,
+                    &mut diag,
+                    &field_ty.to_string(),
+                    "[const] Destruct",
+                    destruct_def_id,
+                    None,
+                );
             }
             Err(diag.emit())
         })

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -25,8 +25,8 @@ use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::print::{
-    PrintPolyTraitPredicateExt, PrintTraitPredicateExt as _, PrintTraitRefExt as _,
-    with_forced_trimmed_paths,
+    PrintPolyTraitPredicateExt, PrintPolyTraitRefExt as _, PrintTraitPredicateExt as _,
+    PrintTraitRefExt as _, with_forced_trimmed_paths,
 };
 use rustc_middle::ty::{
     self, GenericArgKind, TraitRef, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
@@ -886,6 +886,23 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     );
                 }
             }
+        } else if let ty::Param(param) = trait_ref.self_ty().skip_binder().kind()
+            && let Some(generics) =
+                self.tcx.hir_node_by_def_id(main_obligation.cause.body_id).generics()
+        {
+            let constraint = ty::print::with_no_trimmed_paths!(format!(
+                "[const] {}",
+                trait_ref.map_bound(|tr| tr.trait_ref).print_trait_sugared(),
+            ));
+            ty::suggest_constraining_type_param(
+                self.tcx,
+                generics,
+                &mut diag,
+                param.name.as_str(),
+                &constraint,
+                Some(trait_ref.def_id()),
+                None,
+            );
         }
         diag
     }
@@ -2708,7 +2725,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     fn predicate_can_apply(
         &self,
         param_env: ty::ParamEnv<'tcx>,
-        pred: ty::PolyTraitPredicate<'tcx>,
+        pred: impl Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>> + TypeFoldable<TyCtxt<'tcx>>,
     ) -> bool {
         struct ParamToVarFolder<'a, 'tcx> {
             infcx: &'a InferCtxt<'tcx>,

--- a/tests/ui/consts/drop-impl-nonconst-drop-field.stderr
+++ b/tests/ui/consts/drop-impl-nonconst-drop-field.stderr
@@ -21,6 +21,10 @@ note: required for this `Drop` impl
    |
 LL | impl<T> const Drop for ConstDrop2<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider restricting type parameter `T` with unstable trait `Destruct`
+   |
+LL | impl<T: [const] Destruct> const Drop for ConstDrop2<T> {
+   |       ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/trait_alias.fail.stderr
+++ b/tests/ui/consts/trait_alias.fail.stderr
@@ -3,6 +3,11 @@ error[E0277]: the trait bound `T: [const] Baz` is not satisfied
    |
 LL |         x.baz();
    |           ^^^
+   |
+help: consider further restricting type parameter `T` with trait `Baz`
+   |
+LL | const fn foo<T: [const] Foo + [const] Baz>(x: &T) {
+   |                             +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/trait_alias.next_fail.stderr
+++ b/tests/ui/consts/trait_alias.next_fail.stderr
@@ -3,6 +3,11 @@ error[E0277]: the trait bound `T: [const] Baz` is not satisfied
    |
 LL |         x.baz();
    |           ^^^
+   |
+help: consider further restricting type parameter `T` with trait `Baz`
+   |
+LL | const fn foo<T: [const] Foo + [const] Baz>(x: &T) {
+   |                             +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
@@ -15,6 +15,11 @@ error[E0277]: the trait bound `T: [const] Foo` is not satisfied
    |
 LL |     x.a();
    |       ^
+   |
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL | const fn foo<T: Bar + [const] Foo>(x: &T) {
+   |                     +++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yy.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yy.stderr
@@ -3,6 +3,11 @@ error[E0277]: the trait bound `T: [const] Foo` is not satisfied
    |
 LL |     x.a();
    |       ^
+   |
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL | const fn foo<T: Bar + [const] Foo>(x: &T) {
+   |                     +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yyn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yyn.stderr
@@ -38,6 +38,11 @@ error[E0277]: the trait bound `T: [const] Foo` is not satisfied
    |
 LL |     x.a();
    |       ^
+   |
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL | const fn foo<T: [const] Bar + [const] Foo>(x: &T) {
+   |                             +++++++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Right now we have some special logic in the const checker for emitting `[const] Trait` suggestions, but I'm trying to handle that similarly to how it is handled for normal `Trait` clauses. This is just a small step in how it will look on the UX side, which should make my follow-up PRs affect tests less and just be a refactoring
