### PR TITLE
fix: avoid panic in SSA range propagation when assert target is self-dominating

### DIFF
--- a/compiler/rustc_mir_transform/src/ssa_range_prop.rs
+++ b/compiler/rustc_mir_transform/src/ssa_range_prop.rs
@@ -163,8 +163,7 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
                     && self.is_ssa(place) =>
             {
                 let successor = Location { block: *target, statement_index: 0 };
-                if location.dominates(successor, &self.dominators) {
-                    assert_ne!(location.block, successor.block);
+                if location.dominates(successor, &self.dominators) && location.block != successor.block {
                     let val = *expected as u128;
                     let range = WrappingRange { start: val, end: val };
                     self.insert_range(place, successor, range);
@@ -187,8 +186,7 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
                         continue;
                     }
                     let successor = Location { block: target, statement_index: 0 };
-                    if self.unique_predecessors.contains(successor.block) {
-                        assert_ne!(location.block, successor.block);
+                    if self.unique_predecessors.contains(successor.block) && location.block != successor.block {
                         let range = WrappingRange { start: val, end: val };
                         self.insert_range(place, successor, range);
                     }


### PR DESCRIPTION
Fixes rust-lang/rust#155836

## Summary
ICE (compiler panic) in rustc_mir_transform SSA range propagation when an Assert terminator's target is the same BasicBlock as the current location (self-dominating).

**Panic:** assertion `left != right` failed: left: bb7, right: bb7

## Fix
**File:** `compiler/rustc_mir_transform/src/ssa_range_prop.rs`

Replace the two-part check (dominates + panicking assert) with a single guard combining both conditions:
```rust
// Before
if location.dominates(successor, &self.dominators) {
    assert_ne!(location.block, successor.block);

// After  
if location.dominates(successor, &self.dominators) && location.block != successor.block {
```

Same fix applied for SwitchInt handling (line ~188).