### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -701,6 +701,9 @@ impl DocParser {
                 for i in items.mixed() {
                     match i {
                         MetaItemOrLitParser::MetaItemParser(mip) => {
+                            if self.nb_doc_attrs == 0 {
+                                self.attribute.first_span = cx.attr_span;
+                            }
                             self.nb_doc_attrs += 1;
                             self.parse_single_doc_attr_item(cx, mip);
                         }

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -292,15 +292,16 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         // in where clauses. After that, this function would become useless.
         let spans = attrs
             .into_iter()
-            // FIXME: We shouldn't need to special-case `doc`!
-            .filter(|attr| {
-                matches!(
-                    attr,
-                    Attribute::Parsed(AttributeKind::DocComment { .. } | AttributeKind::Doc(_))
-                        | Attribute::Unparsed(_)
-                )
+            .filter_map(|attr| {
+                match attr {
+                    Attribute::Parsed(AttributeKind::DocComment { span, .. }) => Some(*span),
+                    // FIXME: We shouldn't need to special-case `doc`!
+                    Attribute::Parsed(AttributeKind::Doc(attr)) => Some(attr.first_span),
+                    // Checked during attribute parsing target checking
+                    Attribute::Parsed(_) => None,
+                    Attribute::Unparsed(attr) => Some(attr.span),
+                }
             })
-            .map(|attr| attr.span())
             .collect::<Vec<_>>();
         if !spans.is_empty() {
             self.dcx()

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -544,6 +544,8 @@ pub struct CfgHideShow {
 
 #[derive(Clone, Debug, Default, HashStable_Generic, Decodable, PrintAttribute)]
 pub struct DocAttribute {
+    pub first_span: Span,
+
     pub aliases: FxIndexMap<Symbol, Span>,
     pub hidden: Option<Span>,
     // Because we need to emit the error if there is more than one `inline` attribute on an item
@@ -581,6 +583,7 @@ pub struct DocAttribute {
 impl<E: rustc_span::SpanEncoder> rustc_serialize::Encodable<E> for DocAttribute {
     fn encode(&self, encoder: &mut E) {
         let DocAttribute {
+            first_span,
             aliases,
             hidden,
             inline,
@@ -603,6 +606,7 @@ impl<E: rustc_span::SpanEncoder> rustc_serialize::Encodable<E> for DocAttribute 
             test_attrs,
             no_crate_inject,
         } = self;
+        rustc_serialize::Encodable::<E>::encode(first_span, encoder);
         rustc_serialize::Encodable::<E>::encode(aliases, encoder);
         rustc_serialize::Encodable::<E>::encode(hidden, encoder);
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1027,6 +1027,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// [`check_doc_inline`]: Self::check_doc_inline
     fn check_doc_attrs(&self, attr: &DocAttribute, hir_id: HirId, target: Target) {
         let DocAttribute {
+            first_span: _,
             aliases,
             // valid pretty much anywhere, not checked here?
             // FIXME: should we?

--- a/library/core/src/array/drain.rs
+++ b/library/core/src/array/drain.rs
@@ -1,8 +1,8 @@
 use crate::marker::{Destruct, PhantomData};
-use crate::mem::{ManuallyDrop, SizedTypeProperties, conjure_zst};
-use crate::ptr::{NonNull, drop_in_place, from_raw_parts_mut, null_mut};
+use crate::mem::{ManuallyDrop, SizedTypeProperties, conjure_zst, transmute};
+use crate::ptr::{NonNull, drop_in_place, from_raw_parts_mut, without_provenance_mut};
 
-impl<'l, 'f, T, U, const N: usize, F: FnMut(T) -> U> Drain<'l, 'f, T, N, F> {
+impl<'l, 'f, T, U, F: FnMut(T) -> U> Drain<'l, 'f, T, F> {
     /// This function returns a function that lets you index the given array in const.
     /// As implemented it can optimize better than iterators, and can be constified.
     /// It acts like a sort of guard (owns the array) and iterator combined, which can be implemented
@@ -14,9 +14,11 @@ impl<'l, 'f, T, U, const N: usize, F: FnMut(T) -> U> Drain<'l, 'f, T, N, F> {
     /// This will also not actually store the array.
     ///
     /// SAFETY: must only be called `N` times. Thou shalt not drop the array either.
-    // FIXME(const-hack): this is a hack for `let guard = Guard(array); |i| f(guard[i])`.
     #[rustc_const_unstable(feature = "array_try_map", issue = "79711")]
-    pub(super) const unsafe fn new(array: &'l mut ManuallyDrop<[T; N]>, f: &'f mut F) -> Self {
+    pub(super) const unsafe fn new<const N: usize>(
+        array: &'l mut ManuallyDrop<[T; N]>,
+        f: &'f mut F,
+    ) -> Self {
         // dont drop the array, transfers "ownership" to Self
         let ptr: NonNull<T> = NonNull::from_mut(array).cast();
         // SAFETY:
@@ -24,8 +26,9 @@ impl<'l, 'f, T, U, const N: usize, F: FnMut(T) -> U> Drain<'l, 'f, T, N, F> {
         // at the end of `slice`. `end` will never be dereferenced, only checked
         // for direct pointer equality with `ptr` to check if the drainer is done.
         unsafe {
-            let end = if T::IS_ZST { null_mut() } else { ptr.as_ptr().add(N) };
-            Self { ptr, end, f, l: PhantomData }
+            let end_or_len =
+                if T::IS_ZST { without_provenance_mut(N) } else { ptr.as_ptr().add(N) };
+            Self { ptr, end_or_len, f, l: PhantomData }
         }
     }
 }
@@ -33,8 +36,8 @@ impl<'l, 'f, T, U, const N: usize, F: FnMut(T) -> U> Drain<'l, 'f, T, N, F> {
 /// See [`Drain::new`]; this is our fake iterator.
 #[rustc_const_unstable(feature = "array_try_map", issue = "79711")]
 #[unstable(feature = "array_try_map", issue = "79711")]
-pub(super) struct Drain<'l, 'f, T, const N: usize, F> {
-    // FIXME(const-hack): This is essentially a slice::IterMut<'static>, replace when possible.
+pub(super) struct Drain<'l, 'f, T, F> {
+    // FIXME(const-hack): This is a slice::IterMut<'l>, replace when possible.
     /// The pointer to the next element to return, or the past-the-end location
     /// if the drainer is empty.
     ///
@@ -42,16 +45,16 @@ pub(super) struct Drain<'l, 'f, T, const N: usize, F> {
     /// As we "own" this array, we dont need to store any lifetime.
     ptr: NonNull<T>,
     /// For non-ZSTs, the non-null pointer to the past-the-end element.
-    /// For ZSTs, this is null.
-    end: *mut T,
+    /// For ZSTs, this is the number of unprocessed items.
+    end_or_len: *mut T,
 
     f: &'f mut F,
-    l: PhantomData<&'l mut [T; N]>,
+    l: PhantomData<&'l mut [T]>,
 }
 
 #[rustc_const_unstable(feature = "array_try_map", issue = "79711")]
 #[unstable(feature = "array_try_map", issue = "79711")]
-impl<T, U, const N: usize, F> const FnOnce<(usize,)> for &mut Drain<'_, '_, T, N, F>
+impl<T, U, F> const FnOnce<(usize,)> for &mut Drain<'_, '_, T, F>
 where
     F: [const] FnMut(T) -> U,
 {
@@ -64,7 +67,7 @@ where
 }
 #[rustc_const_unstable(feature = "array_try_map", issue = "79711")]
 #[unstable(feature = "array_try_map", issue = "79711")]
-impl<T, U, const N: usize, F> const FnMut<(usize,)> for &mut Drain<'_, '_, T, N, F>
+impl<T, U, F> const FnMut<(usize,)> for &mut Drain<'_, '_, T, F>
 where
     F: [const] FnMut(T) -> U,
 {
@@ -74,6 +77,16 @@ where
         (_ /* ignore argument */,): (usize,),
     ) -> Self::Output {
         if T::IS_ZST {
+            #[expect(ptr_to_integer_transmute_in_consts)]
+            // SAFETY:
+            // This is equivalent to `self.end_or_len.addr`, but that's not
+            // available in `const`. `self.end_or_len` doesn't have provenance,
+            // so transmuting is fine.
+            let len = unsafe { transmute::<*mut T, usize>(self.end_or_len) };
+            // SAFETY:
+            // The caller guarantees that this is never called more than N times
+            // (see `Drain::new`), hence this cannot underflow.
+            self.end_or_len = without_provenance_mut(unsafe { len.unchecked_sub(1) });
             // its UB to call this more than N times, so returning more ZSTs is valid.
             // SAFETY: its a ZST? we conjur.
             (self.f)(unsafe { conjure_zst::<T>() })
@@ -89,20 +102,32 @@ where
 }
 #[rustc_const_unstable(feature = "array_try_map", issue = "79711")]
 #[unstable(feature = "array_try_map", issue = "79711")]
-impl<T: [const] Destruct, const N: usize, F> const Drop for Drain<'_, '_, T, N, F> {
+impl<T: [const] Destruct, F> const Drop for Drain<'_, '_, T, F> {
     fn drop(&mut self) {
-        if !T::IS_ZST {
+        let slice = if T::IS_ZST {
+            from_raw_parts_mut::<[T]>(
+                self.ptr.as_ptr(),
+                #[expect(ptr_to_integer_transmute_in_consts)]
+                // SAFETY:
+                // This is equivalent to `self.end_or_len.addr`, but that's not
+                // available in `const`. `self.end_or_len` doesn't have provenance,
+                // so transmuting is fine.
+                unsafe {
+                    transmute::<*mut T, usize>(self.end_or_len)
+                },
+            )
+        } else {
             // SAFETY: we cant read more than N elements
-            let slice = unsafe {
+            unsafe {
                 from_raw_parts_mut::<[T]>(
                     self.ptr.as_ptr(),
                     // SAFETY: `start <= end`
-                    self.end.offset_from_unsigned(self.ptr.as_ptr()),
+                    self.end_or_len.offset_from_unsigned(self.ptr.as_ptr()),
                 )
-            };
+            }
+        };
 
-            // SAFETY: By the type invariant, we're allowed to drop all these. (we own it, after all)
-            unsafe { drop_in_place(slice) }
-        }
+        // SAFETY: By the type invariant, we're allowed to drop all these. (we own it, after all)
+        unsafe { drop_in_place(slice) }
     }
 }

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -1,6 +1,8 @@
+use core::cell::Cell;
 use core::num::NonZero;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{array, assert_eq};
+use std::sync::ReentrantLock;
 
 #[test]
 fn array_from_ref() {
@@ -716,6 +718,31 @@ fn array_map_drops_unmapped_elements_on_panic() {
         assert!(success.is_err());
         assert_eq!(counter.load(Ordering::SeqCst), MAX);
     }
+}
+
+#[cfg(not(panic = "abort"))]
+#[test]
+fn array_map_drops_unmapped_zst_elements_on_panic() {
+    static DROPPED: ReentrantLock<Cell<usize>> = ReentrantLock::new(Cell::new(0));
+
+    struct ZstDrop;
+    impl Drop for ZstDrop {
+        fn drop(&mut self) {
+            DROPPED.lock().update(|x| x + 1);
+        }
+    }
+
+    let dropped = DROPPED.lock();
+    dropped.set(0);
+    let array = [const { ZstDrop }; 5];
+    let success = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _ = array.map(|x| {
+            drop(x);
+            assert_eq!(dropped.get(), 1);
+        });
+    }));
+    assert!(success.is_err());
+    assert_eq!(dropped.get(), 5);
 }
 
 // This covers the `PartialEq::<[T]>::eq` impl for `[T; N]` when it returns false.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -99,6 +99,7 @@
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]
 #![feature(ptr_metadata)]
+#![feature(reentrant_lock)]
 #![feature(result_option_map_or_default)]
 #![feature(signed_bigint_helpers)]
 #![feature(slice_from_ptr_range)]

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2780,6 +2780,7 @@ fn add_without_unwanted_attributes<'hir>(
             hir::Attribute::Parsed(AttributeKind::Doc(box d)) => {
                 // Remove attributes from `normal` that should not be inherited by `use` re-export.
                 let DocAttribute {
+                    first_span: _,
                     aliases,
                     hidden,
                     inline,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -960,6 +960,7 @@ fn maybe_from_hir_attr(attr: &hir::Attribute, item_id: ItemId, tcx: TyCtxt<'_>) 
             }
 
             let DocAttribute {
+                first_span: _,
                 aliases,
                 hidden,
                 inline,

--- a/tests/ui/attributes/where-doc.rs
+++ b/tests/ui/attributes/where-doc.rs
@@ -16,6 +16,19 @@ where
 //~^ ERROR most attributes are not supported in `where` clauses
 ():,
 
+// == That the doc attributes below don't trigger the error is a bug
+#[doc()]
+():,
+
+#[doc(5)]
+():,
+
+#[doc]
+():,
+
+#[doc = 5]
+():,
+
 { }
 
 fn main() {}

--- a/tests/ui/attributes/where-doc.rs
+++ b/tests/ui/attributes/where-doc.rs
@@ -1,0 +1,21 @@
+#![feature(where_clause_attrs)]
+#![allow(invalid_doc_attributes)]
+
+fn test()
+where
+#[doc(alias = ":(")]
+//~^ ERROR most attributes are not supported in `where` clauses
+//~| ERROR `#[doc(alias = "...")]` isn't allowed on where predicate
+():,
+
+#[doc(hidden)]
+//~^ ERROR most attributes are not supported in `where` clauses
+():,
+
+#[doc = ""]
+//~^ ERROR most attributes are not supported in `where` clauses
+():,
+
+{ }
+
+fn main() {}

--- a/tests/ui/attributes/where-doc.stderr
+++ b/tests/ui/attributes/where-doc.stderr
@@ -1,0 +1,32 @@
+error: most attributes are not supported in `where` clauses
+  --> $DIR/where-doc.rs:6:1
+   |
+LL | #[doc(alias = ":(")]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/where-doc.rs:11:1
+   |
+LL | #[doc(hidden)]
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/where-doc.rs:15:1
+   |
+LL | #[doc = ""]
+   | ^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: `#[doc(alias = "...")]` isn't allowed on where predicate
+  --> $DIR/where-doc.rs:6:15
+   |
+LL | #[doc(alias = ":(")]
+   |               ^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/traits/next-solver/normalization-shadowing/is-global-norm-binius_field-regression.rs
+++ b/tests/ui/traits/next-solver/normalization-shadowing/is-global-norm-binius_field-regression.rs
@@ -1,0 +1,51 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// One of the minimizations from trait-system-refactor-initiative#257 which ended up
+// getting fixed by #153614. It seems somewhat likely that this is somewhat
+// accidental by changing the exact shape of the cycle, causing us to avoid the
+// underlying issue of trait-system-refactor-initiative#257.
+
+pub trait Field: Sized + HasUnderlier<Underlier: PackScalar<Self>> {}
+pub trait PackScalar<F>: 'static + UnderlierType {
+    type Packed;
+}
+trait PackedField {
+    type Scalar;
+}
+pub trait UnderlierType {}
+pub trait HasUnderlier {
+    type Underlier;
+}
+impl<U: UnderlierType> HasUnderlier for U {
+    type Underlier = U;
+}
+impl UnderlierType for u8 {}
+struct MyField;
+impl Field for MyField {}
+impl HasUnderlier for MyField {
+    type Underlier = u8;
+}
+impl<F> PackScalar<F> for u8
+where
+    F: Field,
+{
+    type Packed = PackedPrimitiveType<F>;
+}
+pub struct PackedPrimitiveType<Scalar: Field>(Scalar);
+impl<Scalar> PackedField for PackedPrimitiveType<Scalar>
+where
+    Scalar: Field,
+{
+    type Scalar = Scalar;
+}
+
+pub trait PackedTransformationFactory<OP> {}
+trait TaggedPackedTransformationFactory<OP>: PackedField<Scalar: Field> {}
+impl<OP> PackedTransformationFactory<OP> for PackedPrimitiveType<MyField> where
+    Self: TaggedPackedTransformationFactory<OP>
+{
+}
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#152487 (core: drop unmapped ZSTs in array `map`)
 - rust-lang/rust#155864 (Fix panic for doc attributes on where predicates)
 - rust-lang/rust#155865 (add test for accidentally fixed `binius_field` issue)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=152487,155864,155865)
<!-- homu-ignore:end -->

