### PR TITLE
Fix cross-compiling `macos-deployment-target-warning` test

### DIFF
--- a/tests/run-make/macos-deployment-target-warning/rmake.rs
+++ b/tests/run-make/macos-deployment-target-warning/rmake.rs
@@ -1,19 +1,16 @@
-//@ only-apple
 //! Tests that deployment target linker warnings are shown as `linker-info`, not `linker-messages`
+
+//@ only-macos
 
 use run_make_support::external_deps::c_cxx_compiler::cc;
 use run_make_support::external_deps::llvm::llvm_ar;
-use run_make_support::{bare_rustc, diff};
+use run_make_support::{diff, rustc};
 
 fn main() {
-    let cwd = std::env::current_dir().unwrap().to_str().unwrap().to_owned();
-
     cc().arg("-c").arg("-mmacosx-version-min=15.5").output("foo.o").input("foo.c").run();
     llvm_ar().obj_to_ar().output_input("libfoo.a", "foo.o").run();
 
-    let warnings = bare_rustc()
-        .arg("-L")
-        .arg(format!("native={cwd}"))
+    let warnings = rustc()
         .arg("-lstatic=foo")
         .link_arg("-mmacosx-version-min=11.2")
         .input("main.rs")


### PR DESCRIPTION
`cc()` gets target flags, which won't match with the host triple used by `bare_rustc()`.

Follow-up to https://github.com/rust-lang/rust/pull/155716, with both of these, `./x test --target arm64e-apple-darwin tests` now succeeds.

r? compiler