### PR TITLE
CI: rfl: move job forward to Linux v7.1-rc1

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-LINUX_VERSION=v7.0
+LINUX_VERSION=v7.1-rc1
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
Linux v7.1 will have our new MSRVs: Rust 1.85.0 and `bindgen` 0.71.1.

r? @lqd @Kobzol
try-job: x86_64-rust-for-linux
@rustbot label A-rust-for-linux
@bors try