### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -701,6 +701,9 @@ impl DocParser {
                 for i in items.mixed() {
                     match i {
                         MetaItemOrLitParser::MetaItemParser(mip) => {
+                            if self.nb_doc_attrs == 0 {
+                                self.attribute.first_span = cx.attr_span;
+                            }
                             self.nb_doc_attrs += 1;
                             self.parse_single_doc_attr_item(cx, mip);
                         }

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -292,15 +292,16 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         // in where clauses. After that, this function would become useless.
         let spans = attrs
             .into_iter()
-            // FIXME: We shouldn't need to special-case `doc`!
-            .filter(|attr| {
-                matches!(
-                    attr,
-                    Attribute::Parsed(AttributeKind::DocComment { .. } | AttributeKind::Doc(_))
-                        | Attribute::Unparsed(_)
-                )
+            .filter_map(|attr| {
+                match attr {
+                    Attribute::Parsed(AttributeKind::DocComment { span, .. }) => Some(*span),
+                    // FIXME: We shouldn't need to special-case `doc`!
+                    Attribute::Parsed(AttributeKind::Doc(attr)) => Some(attr.first_span),
+                    // Checked during attribute parsing target checking
+                    Attribute::Parsed(_) => None,
+                    Attribute::Unparsed(attr) => Some(attr.span),
+                }
             })
-            .map(|attr| attr.span())
             .collect::<Vec<_>>();
         if !spans.is_empty() {
             self.dcx()

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -216,7 +216,9 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
     file.set_sub_architecture(sub_architecture);
     if sess.target.is_like_darwin {
         if macho_is_arm64e(&sess.target) {
-            file.set_macho_cpu_subtype(object::macho::CPU_SUBTYPE_ARM64E);
+            file.set_macho_cpu_subtype(
+                object::macho::CPU_SUBTYPE_ARM64E | object::macho::CPU_SUBTYPE_PTRAUTH_ABI,
+            );
         }
 
         file.set_macho_build_version(macho_object_build_version_for_target(sess))

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -139,14 +139,7 @@ pub(crate) struct PanicNonStrErr {
 }
 
 #[derive(Diagnostic)]
-#[diag(
-    r#"function pointer calls are not allowed in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
-)]
+#[diag(r#"function pointer calls are not allowed in {$kind}s"#)]
 pub(crate) struct UnallowedFnPointerCall {
     #[primary_span]
     pub span: Span,
@@ -224,12 +217,7 @@ pub(crate) struct MutableBorrowEscaping {
 
 #[derive(Diagnostic)]
 #[diag(
-    r#"cannot call {$non_or_conditionally}-const formatting macro in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#,
+    r#"cannot call {$non_or_conditionally}-const formatting macro in {$kind}s"#,
     code = E0015,
 )]
 pub(crate) struct NonConstFmtMacroCall {
@@ -240,12 +228,7 @@ pub(crate) struct NonConstFmtMacroCall {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"cannot call {$non_or_conditionally}-const {$def_descr} `{$def_path_str}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"cannot call {$non_or_conditionally}-const {$def_descr} `{$def_path_str}` in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstFnCall {
     #[primary_span]
     pub span: Span,
@@ -256,14 +239,7 @@ pub(crate) struct NonConstFnCall {
 }
 
 #[derive(Diagnostic)]
-#[diag(
-    r#"cannot call non-const intrinsic `{$name}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
-)]
+#[diag(r#"cannot call non-const intrinsic `{$name}` in {$kind}s"#)]
 pub(crate) struct NonConstIntrinsic {
     #[primary_span]
     pub span: Span,
@@ -280,12 +256,7 @@ pub(crate) struct UnallowedOpInConstContext {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"inline assembly is not allowed in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"inline assembly is not allowed in {$kind}s"#, code = E0015)]
 pub(crate) struct UnallowedInlineAsm {
     #[primary_span]
     pub span: Span,
@@ -384,14 +355,7 @@ pub(crate) struct RawBytesNote {
 }
 
 #[derive(Diagnostic)]
-#[diag(
-    r#"cannot match on `{$ty}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#
-)]
+#[diag(r#"cannot match on `{$ty}` in {$kind}s"#)]
 #[note("`{$ty}` cannot be compared in compile-time, and therefore cannot be used in `match`es")]
 pub(crate) struct NonConstMatchEq<'tcx> {
     #[primary_span]
@@ -402,12 +366,7 @@ pub(crate) struct NonConstMatchEq<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"cannot use `for` loop on `{$ty}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"cannot use `for` loop on `{$ty}` in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstForLoopIntoIter<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -417,12 +376,7 @@ pub(crate) struct NonConstForLoopIntoIter<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"`?` is not allowed on `{$ty}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"`?` is not allowed on `{$ty}` in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstQuestionBranch<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -432,12 +386,7 @@ pub(crate) struct NonConstQuestionBranch<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"`?` is not allowed on `{$ty}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"`?` is not allowed on `{$ty}` in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstQuestionFromResidual<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -447,12 +396,7 @@ pub(crate) struct NonConstQuestionFromResidual<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"`try` block cannot convert `{$ty}` to the result in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"`try` block cannot convert `{$ty}` to the result in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstTryBlockFromOutput<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -462,12 +406,7 @@ pub(crate) struct NonConstTryBlockFromOutput<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"cannot convert `{$ty}` into a future in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"cannot convert `{$ty}` into a future in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstAwait<'tcx> {
     #[primary_span]
     pub span: Span,
@@ -477,12 +416,7 @@ pub(crate) struct NonConstAwait<'tcx> {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"cannot call {$non_or_conditionally}-const closure in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"cannot call {$non_or_conditionally}-const closure in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstClosure {
     #[primary_span]
     pub span: Span,
@@ -493,12 +427,7 @@ pub(crate) struct NonConstClosure {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"calling const c-variadic functions is unstable in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"calling const c-variadic functions is unstable in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstCVariadicCall {
     #[primary_span]
     pub span: Span,
@@ -512,23 +441,9 @@ pub(crate) enum NonConstClosureNote {
         #[primary_span]
         span: Span,
     },
-    #[note(
-        r#"function pointers need an RFC before allowed to be called in {$kind ->
-            [const] constant
-            [static] static
-            [const_fn] constant function
-            *[other] {""}
-        }s"#
-    )]
+    #[note(r#"function pointers need an RFC before allowed to be called in {$kind}s"#)]
     FnPtr { kind: ConstContext },
-    #[note(
-        r#"closures need an RFC before allowed to be called in {$kind ->
-            [const] constant
-            [static] static
-            [const_fn] constant function
-            *[other] {""}
-        }s"#
-    )]
+    #[note(r#"closures need an RFC before allowed to be called in {$kind}s"#)]
     Closure { kind: ConstContext },
 }
 
@@ -543,12 +458,7 @@ pub(crate) struct ConsiderDereferencing {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"cannot call {$non_or_conditionally}-const operator in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"cannot call {$non_or_conditionally}-const operator in {$kind}s"#, code = E0015)]
 pub(crate) struct NonConstOperator {
     #[primary_span]
     pub span: Span,
@@ -559,12 +469,7 @@ pub(crate) struct NonConstOperator {
 }
 
 #[derive(Diagnostic)]
-#[diag(r#"cannot perform {$non_or_conditionally}-const deref coercion on `{$ty}` in {$kind ->
-    [const] constant
-    [static] static
-    [const_fn] constant function
-    *[other] {""}
-}s"#, code = E0015)]
+#[diag(r#"cannot perform {$non_or_conditionally}-const deref coercion on `{$ty}` in {$kind}s"#, code = E0015)]
 #[note("attempting to deref into `{$target_ty}`")]
 pub(crate) struct NonConstDerefCoercion<'tcx> {
     #[primary_span]
@@ -581,14 +486,7 @@ pub(crate) struct NonConstDerefCoercion<'tcx> {
 #[diag("destructor of `{$dropped_ty}` cannot be evaluated at compile-time", code = E0493)]
 pub(crate) struct LiveDrop<'tcx> {
     #[primary_span]
-    #[label(
-        r#"the destructor for this type cannot be evaluated in {$kind ->
-            [const] constant
-            [static] static
-            [const_fn] constant function
-            *[other] {""}
-        }s"#
-    )]
+    #[label(r#"the destructor for this type cannot be evaluated in {$kind}s"#)]
     pub span: Span,
     pub kind: ConstContext,
     pub dropped_ty: Ty<'tcx>,

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -544,6 +544,8 @@ pub struct CfgHideShow {
 
 #[derive(Clone, Debug, Default, HashStable_Generic, Decodable, PrintAttribute)]
 pub struct DocAttribute {
+    pub first_span: Span,
+
     pub aliases: FxIndexMap<Symbol, Span>,
     pub hidden: Option<Span>,
     // Because we need to emit the error if there is more than one `inline` attribute on an item
@@ -581,6 +583,7 @@ pub struct DocAttribute {
 impl<E: rustc_span::SpanEncoder> rustc_serialize::Encodable<E> for DocAttribute {
     fn encode(&self, encoder: &mut E) {
         let DocAttribute {
+            first_span,
             aliases,
             hidden,
             inline,
@@ -603,6 +606,7 @@ impl<E: rustc_span::SpanEncoder> rustc_serialize::Encodable<E> for DocAttribute 
             test_attrs,
             no_crate_inject,
         } = self;
+        rustc_serialize::Encodable::<E>::encode(first_span, encoder);
         rustc_serialize::Encodable::<E>::encode(aliases, encoder);
         rustc_serialize::Encodable::<E>::encode(hidden, encoder);
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2389,9 +2389,9 @@ impl fmt::Display for ConstContext {
 impl IntoDiagArg for ConstContext {
     fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
         DiagArgValue::Str(Cow::Borrowed(match self {
-            ConstContext::ConstFn => "const_fn",
+            ConstContext::ConstFn => "constant function",
             ConstContext::Static(_) => "static",
-            ConstContext::Const { .. } => "const",
+            ConstContext::Const { .. } => "constant",
         }))
     }
 }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1027,6 +1027,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     /// [`check_doc_inline`]: Self::check_doc_inline
     fn check_doc_attrs(&self, attr: &DocAttribute, hir_id: HirId, target: Target) {
         let DocAttribute {
+            first_span: _,
             aliases,
             // valid pretty much anywhere, not checked here?
             // FIXME: should we?

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1113,6 +1113,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             debug!("CACHE MISS");
             self.insert_evaluation_cache(param_env, fresh_trait_pred, dep_node, result);
             stack.cache().on_completion(stack.dfn);
+        } else if let Some(_guar) = self.infcx.tainted_by_errors() {
+            // When an error has occurred, we allow global caching of results even if they
+            // appear stack-dependent. This prevents exponential re-evaluation of cycles
+            // in the presence of errors, avoiding compiler hangs like #150907.
+            // This is safe because compilation will fail anyway.
+            debug!("CACHE MISS (tainted by errors)");
+            self.insert_evaluation_cache(param_env, fresh_trait_pred, dep_node, result);
+            stack.cache().on_completion(stack.dfn);
         } else {
             debug!("PROVISIONAL");
             debug!(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2780,6 +2780,7 @@ fn add_without_unwanted_attributes<'hir>(
             hir::Attribute::Parsed(AttributeKind::Doc(box d)) => {
                 // Remove attributes from `normal` that should not be inherited by `use` re-export.
                 let DocAttribute {
+                    first_span: _,
                     aliases,
                     hidden,
                     inline,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -960,6 +960,7 @@ fn maybe_from_hir_attr(attr: &hir::Attribute, item_id: ItemId, tcx: TyCtxt<'_>) 
             }
 
             let DocAttribute {
+                first_span: _,
                 aliases,
                 hidden,
                 inline,

--- a/tests/ui/attributes/where-doc.rs
+++ b/tests/ui/attributes/where-doc.rs
@@ -16,6 +16,19 @@ where
 //~^ ERROR most attributes are not supported in `where` clauses
 ():,
 
+// == That the doc attributes below don't trigger the error is a bug
+#[doc()]
+():,
+
+#[doc(5)]
+():,
+
+#[doc]
+():,
+
+#[doc = 5]
+():,
+
 { }
 
 fn main() {}

--- a/tests/ui/attributes/where-doc.rs
+++ b/tests/ui/attributes/where-doc.rs
@@ -1,0 +1,21 @@
+#![feature(where_clause_attrs)]
+#![allow(invalid_doc_attributes)]
+
+fn test()
+where
+#[doc(alias = ":(")]
+//~^ ERROR most attributes are not supported in `where` clauses
+//~| ERROR `#[doc(alias = "...")]` isn't allowed on where predicate
+():,
+
+#[doc(hidden)]
+//~^ ERROR most attributes are not supported in `where` clauses
+():,
+
+#[doc = ""]
+//~^ ERROR most attributes are not supported in `where` clauses
+():,
+
+{ }
+
+fn main() {}

--- a/tests/ui/attributes/where-doc.stderr
+++ b/tests/ui/attributes/where-doc.stderr
@@ -1,0 +1,32 @@
+error: most attributes are not supported in `where` clauses
+  --> $DIR/where-doc.rs:6:1
+   |
+LL | #[doc(alias = ":(")]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/where-doc.rs:11:1
+   |
+LL | #[doc(hidden)]
+   | ^^^^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: most attributes are not supported in `where` clauses
+  --> $DIR/where-doc.rs:15:1
+   |
+LL | #[doc = ""]
+   | ^^^^^^^^^^^
+   |
+   = help: only `#[cfg]` and `#[cfg_attr]` are supported
+
+error: `#[doc(alias = "...")]` isn't allowed on where predicate
+  --> $DIR/where-doc.rs:6:15
+   |
+LL | #[doc(alias = ":(")]
+   |               ^^^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/traits/cycle-cache-err-150907.rs
+++ b/tests/ui/traits/cycle-cache-err-150907.rs
@@ -1,0 +1,125 @@
+// Test that we don't hang or take exponential time when evaluating
+// auto-traits for cyclic types containing errors, based on the reproducer
+// provided in issue #150907.
+
+use std::sync::Arc;
+use std::marker::PhantomData;
+
+struct Weak<T>(PhantomData<T>);
+unsafe impl<T: Sync + Send> Send for Weak<T> {}
+unsafe impl<T: Sync + Send> Sync for Weak<T> {}
+
+struct BTreeMap<K, V>(K, V);
+
+trait DeviceOps: Send {}
+
+struct SerialDevice {
+    terminal: Weak<Terminal>,
+}
+
+impl DeviceOps for SerialDevice {}
+
+struct TtyState {
+    terminals: Weak<Terminal>,
+}
+
+struct TerminalMutableState {
+    controller: TerminalController,
+}
+
+struct Terminal {
+    weak_self: Weak<Self>,
+    state: Arc<TtyState>,
+    mutable_state: Weak<TerminalMutableState>,
+}
+
+struct TerminalController {
+    session: Weak<Session>,
+}
+
+struct Kernel {
+    weak_self: Weak<Kernel>,
+    kthreads: KernelThreads,
+    pids: Weak<PidTable>,
+}
+
+struct KernelThreads {
+    system_task: SystemTask,
+    kernel: Weak<Kernel>,
+}
+
+struct SystemTask {
+    system_thread_group: Weak<ThreadGroup>,
+}
+
+enum ProcessEntry {
+    ThreadGroup(Weak<ThreadGroup>),
+}
+
+struct PidEntry {
+    task: Arc<Task>,
+    process: ProcessEntry,
+}
+
+struct PidTable {
+    table: PidEntry,
+    process_groups: Arc<ProcessGroup>,
+}
+
+struct ProcessGroupMutableState {
+    thread_groups: Weak<ThreadGroup>,
+}
+
+struct ProcessGroup {
+    session: Arc<Session>,
+    mutable_state: Arc<ProcessGroupMutableState>,
+}
+
+struct SessionMutableState {
+    process_groups: BTreeMap<(), Weak<ProcessGroup>>,
+    controlling_terminal: ControllingTerminal,
+}
+
+struct Session {
+    mutable_state: Weak<SessionMutableState>,
+}
+
+struct ControllingTerminal {
+    terminal: Arc<Terminal>,
+}
+
+struct TaskPersistentInfoState {
+    thread_group_key: ThreadGroupKey,
+}
+
+struct Task {
+    thread_group_key: ThreadGroupKey,
+    kernel: Arc<Kernel>,
+    thread_group: Arc<ThreadGroup>,
+    persistent_info: Arc<TaskPersistentInfoState>,
+    vfork_event: Arc, //~ ERROR missing generics for struct `Arc`
+}
+
+struct ThreadGroupKey {
+    thread_group: Arc<ThreadGroup>,
+}
+
+struct ThreadGroupMutableState {
+    tasks: BTreeMap<(), TaskContainer>,
+    children: BTreeMap<(), Weak<ThreadGroup>>,
+    process_group: Arc<ProcessGroup>,
+}
+
+struct ThreadGroup {
+    kernel: Arc<Kernel>,
+    mutable_state: Weak<ThreadGroupMutableState>,
+}
+
+struct TaskContainer(Arc<Task>, Arc<TaskPersistentInfoState>);
+
+fn main() {
+    // Trigger auto-trait check for one of the cyclic types
+    is_send::<Kernel>();
+}
+
+fn is_send<T: Send>() {}

--- a/tests/ui/traits/cycle-cache-err-150907.stderr
+++ b/tests/ui/traits/cycle-cache-err-150907.stderr
@@ -1,0 +1,14 @@
+error[E0107]: missing generics for struct `Arc`
+  --> $DIR/cycle-cache-err-150907.rs:100:18
+   |
+LL |     vfork_event: Arc,
+   |                  ^^^ expected at least 1 generic argument
+   |
+help: add missing generic argument
+   |
+LL |     vfork_event: Arc<T>,
+   |                     +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/traits/next-solver/normalization-shadowing/is-global-norm-binius_field-regression.rs
+++ b/tests/ui/traits/next-solver/normalization-shadowing/is-global-norm-binius_field-regression.rs
@@ -1,0 +1,51 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// One of the minimizations from trait-system-refactor-initiative#257 which ended up
+// getting fixed by #153614. It seems somewhat likely that this is somewhat
+// accidental by changing the exact shape of the cycle, causing us to avoid the
+// underlying issue of trait-system-refactor-initiative#257.
+
+pub trait Field: Sized + HasUnderlier<Underlier: PackScalar<Self>> {}
+pub trait PackScalar<F>: 'static + UnderlierType {
+    type Packed;
+}
+trait PackedField {
+    type Scalar;
+}
+pub trait UnderlierType {}
+pub trait HasUnderlier {
+    type Underlier;
+}
+impl<U: UnderlierType> HasUnderlier for U {
+    type Underlier = U;
+}
+impl UnderlierType for u8 {}
+struct MyField;
+impl Field for MyField {}
+impl HasUnderlier for MyField {
+    type Underlier = u8;
+}
+impl<F> PackScalar<F> for u8
+where
+    F: Field,
+{
+    type Packed = PackedPrimitiveType<F>;
+}
+pub struct PackedPrimitiveType<Scalar: Field>(Scalar);
+impl<Scalar> PackedField for PackedPrimitiveType<Scalar>
+where
+    Scalar: Field,
+{
+    type Scalar = Scalar;
+}
+
+pub trait PackedTransformationFactory<OP> {}
+trait TaggedPackedTransformationFactory<OP>: PackedField<Scalar: Field> {}
+impl<OP> PackedTransformationFactory<OP> for PackedPrimitiveType<MyField> where
+    Self: TaggedPackedTransformationFactory<OP>
+{
+}
+fn main() {}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -940,9 +940,11 @@ message = "`triagebot.toml` has been modified, there may have been changes to th
 cc = ["@davidtwco", "@wesleywiser"]
 
 [mentions."compiler/rustc_codegen_cranelift"]
+message = "The Cranelift subtree was changed"
 cc = ["@bjorn3"]
 
 [mentions."compiler/rustc_codegen_gcc"]
+message = "The GCC codegen subtree was changed"
 cc = ["@antoyo", "@GuillaumeGomez"]
 
 [mentions."compiler/rustc_const_eval/src/"]
@@ -1140,6 +1142,7 @@ cc = [
 cc = ["@ehuss"]
 
 [mentions."src/tools/clippy"]
+message = "The Clippy subtree was changed"
 cc = ["@rust-lang/clippy"]
 
 [mentions."src/tools/compiletest"]
@@ -1169,6 +1172,7 @@ this change to [rust-lang/rust-analyzer] instead.
 cc = ["@rust-lang/rust-analyzer"]
 
 [mentions."src/tools/rustfmt"]
+message = "The Rustfmt subtree was changed"
 cc = ["@rust-lang/rustfmt"]
 
 [mentions."compiler/rustc_middle/src/mir/syntax.rs"]


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#154465 (triagebot: Mention 'subtree' in clippy message)
 - rust-lang/rust#155355 (Fix pathological performance in trait solver cycles with errors)
 - rust-lang/rust#155716 (arm64e: set ptrauth ABI subtype on lib.rmeta Mach-O objects)
 - rust-lang/rust#155864 (Fix panic for doc attributes on where predicates)
 - rust-lang/rust#155865 (add test for accidentally fixed `binius_field` issue)
 - rust-lang/rust#155866 (Render `ConstContext` for diagnostics once)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=154465,155355,155716,155864,155865,155866)
<!-- homu-ignore:end -->

