### PR TITLE
Add regression test for #101363

### DIFF
--- a/tests/ui/consts/const-eval/static-promotion-issue-101363.rs
+++ b/tests/ui/consts/const-eval/static-promotion-issue-101363.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+// Regression test for <https://github.com/rust-lang/rust/issues/101363>
+
+const OPTIONAL_SLICE_V1: Option<&'static [u8]> = Some(&{
+    let array = [1, 2, 3];
+    array
+});
+
+fn main() {
+    let _ = OPTIONAL_SLICE_V1;
+}


### PR DESCRIPTION
Adds test for rust-lang/rust#101363

Since it's my first time adding tests, I'm not sure if the test itself, its location, or its name are appropriate.
