### PR TITLE
ssa_range_prop: avoid ICE on self-loop successors

### DIFF
--- a/compiler/rustc_mir_transform/src/ssa_range_prop.rs
+++ b/compiler/rustc_mir_transform/src/ssa_range_prop.rs
@@ -164,10 +164,11 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
             {
                 let successor = Location { block: *target, statement_index: 0 };
                 if location.dominates(successor, &self.dominators) {
-                    assert_ne!(location.block, successor.block);
-                    let val = *expected as u128;
-                    let range = WrappingRange { start: val, end: val };
-                    self.insert_range(place, successor, range);
+                    if location.block != successor.block {
+                        let val = *expected as u128;
+                        let range = WrappingRange { start: val, end: val };
+                        self.insert_range(place, successor, range);
+                    }
                 }
             }
             TerminatorKind::SwitchInt { discr, targets }
@@ -188,7 +189,9 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
                     }
                     let successor = Location { block: target, statement_index: 0 };
                     if self.unique_predecessors.contains(successor.block) {
-                        assert_ne!(location.block, successor.block);
+                        if location.block == successor.block {
+                            continue;
+                        }
                         let range = WrappingRange { start: val, end: val };
                         self.insert_range(place, successor, range);
                     }
@@ -201,13 +204,14 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
                     && let [val] = targets.all_values()
                     && self.unique_predecessors.contains(otherwise.block)
                 {
-                    assert_ne!(location.block, otherwise.block);
-                    let range = if val.get() == 0 {
-                        WrappingRange { start: 1, end: 1 }
-                    } else {
-                        WrappingRange { start: 0, end: 0 }
-                    };
-                    self.insert_range(place, otherwise, range);
+                    if location.block != otherwise.block {
+                        let range = if val.get() == 0 {
+                            WrappingRange { start: 1, end: 1 }
+                        } else {
+                            WrappingRange { start: 0, end: 0 }
+                        };
+                        self.insert_range(place, otherwise, range);
+                    }
                 }
             }
             _ => {}

--- a/tests/ui/mir/ssa-range-prop-self-loop-155836.rs
+++ b/tests/ui/mir/ssa-range-prop-self-loop-155836.rs
@@ -1,0 +1,13 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/155836>.
+// Ensure SSA range propagation does not ICE on self-loops.
+//@ compile-flags: -C opt-level=2
+//@ check-pass
+
+#![crate_type = "lib"]
+
+pub fn trigger(b: usize) -> usize {
+    while 0 != 2 {
+        b % b;
+    }
+    b
+}


### PR DESCRIPTION
Fixes #155836.

Replace block-inequality assertions in `ssa_range_prop` terminator handling
with guards that skip propagation for self-loop successors.

Added regression test:
`tests/ui/mir/ssa-range-prop-self-loop-155836.rs`
(`-C opt-level=2`, `check-pass`).

Validation commands:
- ./x.py check compiler/rustc_mir_transform
- ./x.py test tests/ui/mir/ssa-range-prop-self-loop-155836.rs