### PR TITLE
`dlltool`: Set the working directory to workaround `--temp-prefix` bug

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -217,12 +217,10 @@ fn create_mingw_dll_import_lib(
     // able to control the *exact* spelling of each of the symbols that are being imported:
     // hence we don't want `dlltool` adding leading underscores automatically.
     let dlltool = find_binutils_dlltool(sess);
-    let temp_prefix = {
-        let mut path = PathBuf::from(&output_path);
-        path.pop();
-        path.push(lib_name);
-        path
-    };
+    // temp_prefix doesn't handle paths with spaces so
+    // use a relative path and set the current working directory
+    let cwd = output_path.parent().unwrap_or(output_path);
+    let temp_prefix = lib_name;
     // dlltool target architecture args from:
     // https://github.com/llvm/llvm-project-release-prs/blob/llvmorg-15.0.6/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp#L69
     let (dlltool_target_arch, dlltool_target_bitness) = match &sess.target.arch {
@@ -246,7 +244,8 @@ fn create_mingw_dll_import_lib(
         .arg(dlltool_target_bitness)
         .arg("--no-leading-underscore")
         .arg("--temp-prefix")
-        .arg(temp_prefix);
+        .arg(temp_prefix)
+        .current_dir(cwd);
 
     match dlltool_cmd.output() {
         Err(e) => {

--- a/tests/run-make/raw-dylib-custom-dlltool/script.cmd
+++ b/tests/run-make/raw-dylib-custom-dlltool/script.cmd
@@ -1,2 +1,2 @@
-echo Called dlltool via script.cmd> actual.txt
+echo Called dlltool via script.cmd> %~dp0\actual.txt
 dlltool.exe %*

--- a/tests/run-make/raw-dylib-whitespace/main.rs
+++ b/tests/run-make/raw-dylib-whitespace/main.rs
@@ -1,0 +1,18 @@
+type BOOL = i32;
+
+#[cfg_attr(
+    target_arch = "x86",
+    link(name = "bcryptprimitives", kind = "raw-dylib", import_name_type = "undecorated")
+)]
+#[cfg_attr(not(target_arch = "x86"), link(name = "bcryptprimitives", kind = "raw-dylib"))]
+extern "system" {
+    fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
+}
+
+fn main() {
+    let mut num: u8 = 0;
+    unsafe {
+        ProcessPrng(&mut num, 1);
+    }
+    println!("{num}");
+}

--- a/tests/run-make/raw-dylib-whitespace/rmake.rs
+++ b/tests/run-make/raw-dylib-whitespace/rmake.rs
@@ -1,0 +1,15 @@
+// Ensure that raw-dylib still works if the output directory contains spaces.
+
+//@ only-windows-gnu
+//@ ignore-cross-compile
+//@ needs-dlltool
+// Reason: this test specifically checks the dlltool feature,
+// which is only used on windows-gnu.
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    let out_dir = std::path::absolute("path with spaces").unwrap();
+    rfs::create_dir_all(&out_dir);
+    rustc().crate_type("bin").input("main.rs").out_dir(&out_dir).env("TMP", &out_dir).run();
+}

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
@@ -7,7 +7,6 @@
 //@ normalize-stderr: "[^ ]*/foo.dll_imports.lib" -> "$$LIB_FILE"
 //@ normalize-stderr: "-m [^ ]*" -> "$$TARGET_MACHINE"
 //@ normalize-stderr: "-f [^ ]*" -> "$$ASM_FLAGS"
-//@ normalize-stderr: "--temp-prefix [^ ]*/foo.dll" -> "$$TEMP_PREFIX"
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {
     // `@1` is an invalid name to export, as it usually indicates that something

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
@@ -1,4 +1,4 @@
-error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore $TEMP_PREFIX:
+error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore --temp-prefix foo.dll:
        
        $DLLTOOL: Syntax error in def file $DEF_FILE:1␍
        


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155899)*
<!-- homu-ignore:end -->

dlltool's `--temp-prefix` argument incorrectly splits paths that contain spaces. To workaround this, we pass a relative path to `--temp-prefix` and set the working directory.

fixes rust-lang/rust#155591