### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -533,7 +533,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     ty::FnDef(def_id, _) => {
                         let name = self.infcx.tcx.item_name(*def_id);
                         let identity_args = GenericArgs::identity_for_item(self.infcx.tcx, *def_id);
-                        let desc = format!("a function pointer to `{name}`");
+                        let desc = format!("the function item type defined by `{name}`");
                         let note = format!(
                             "the function `{name}` is invariant over the parameter `{}`",
                             identity_args[param_index as usize]

--- a/tests/ui/codegen/huge-stacks.rs
+++ b/tests/ui/codegen/huge-stacks.rs
@@ -1,0 +1,23 @@
+//@ revisions: unoptimized optimized
+//@[optimized]compile-flags: -O
+//@ run-pass
+//@ only-64bit
+//@ min-llvm-version: 22
+
+// Regression test for https://github.com/rust-lang/rust/issues/83060
+
+fn func() {
+    const CAP: usize = std::u32::MAX as usize;
+    let mut x: [u8; CAP] = [0; CAP];
+    x[2] = 123;
+    assert_eq!(x[2], 123);
+}
+
+fn main() {
+    std::thread::Builder::new()
+        .stack_size(5 * 1024 * 1024 * 1024)
+        .spawn(func)
+        .unwrap()
+        .join()
+        .unwrap();
+}

--- a/tests/ui/fn/fn_def_coercion.stderr
+++ b/tests/ui/fn/fn_def_coercion.stderr
@@ -9,7 +9,7 @@ LL |     let mut x = foo::<&'a ()>;
    |                 ^^^^^^^^^^^^^ assignment requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -25,7 +25,7 @@ LL |     x = foo::<&'b ()>;
    |     ^^^^^^^^^^^^^^^^^ assignment requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -56,7 +56,7 @@ LL |     x = foo::<&'b ()>;
    |     ^^^^^^^^^^^^^^^^^ assignment requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -72,7 +72,7 @@ LL |     x = foo::<&'a ()>;
    |     ^^^^^^^^^^^^^^^^^ assignment requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -92,7 +92,7 @@ LL |         true => foo::<&'b ()>,
    |                 ^^^^^^^^^^^^^ assignment requires that `'a` must outlive `'b`
    |
    = help: consider adding the following bound: `'a: 'b`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -108,7 +108,7 @@ LL |         false => foo::<&'a ()>,
    |                  ^^^^^^^^^^^^^ assignment requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -128,7 +128,7 @@ LL |         true => foo::<&'c ()>,
    |                 ^^^^^^^^^^^^^ assignment requires that `'a` must outlive `'c`
    |
    = help: consider adding the following bound: `'a: 'c`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
@@ -144,7 +144,7 @@ LL |         false => foo::<&'a ()>,
    |                  ^^^^^^^^^^^^^ assignment requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a function pointer to `foo`
+   = note: requirement occurs because of the function item type defined by `foo`
    = note: the function `foo` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1493,6 +1493,7 @@ libs = [
     "@tgross35",
     "@thomcc",
     "@joboet",
+    "@nia-e",
 ]
 infra-ci = [
     "@Mark-Simulacrum",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155894 (triagebot: add myself to libs rotation)
 - rust-lang/rust#155897 (Add regression test for LLVM bug with huge stack frames)
 - rust-lang/rust#155900 (Refer to `FnDef` as "function item", not "function pointer")

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155894,155897,155900)
<!-- homu-ignore:end -->

