### PR TITLE
when bailing on ambiguity, don't force other results to ambig

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/search_graph.rs
@@ -107,6 +107,7 @@ where
         response_no_constraints(cx, input, Certainty::overflow(true))
     }
 
+    const FIXPOINT_OVERFLOW_AMBIGUITY_KIND: Certainty = Certainty::overflow(false);
     fn fixpoint_overflow_result(
         cx: I,
         input: CanonicalInput<I>,
@@ -124,14 +125,6 @@ where
                 None
             }
         })
-    }
-
-    fn propagate_ambiguity(
-        cx: I,
-        for_input: CanonicalInput<I>,
-        certainty: Certainty,
-    ) -> (QueryResult<I>, AccessedOpaques<I>) {
-        response_no_constraints(cx, for_input, certainty)
     }
 
     fn compute_goal(

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -680,7 +680,7 @@ impl<T, R, E> CollectAndApply<T, R> for Result<T, E> {
 impl<I: Interner> search_graph::Cx for I {
     type Input = CanonicalInput<I>;
     type Result = (QueryResult<I>, AccessedOpaques<I>);
-    type AmbiguityInfo = Certainty;
+    type AmbiguityKind = Certainty;
 
     type DepNodeIndex = I::DepNodeIndex;
     type Tracked<T: Debug + Clone> = I::Tracked<T>;

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -40,7 +40,7 @@ pub use global_cache::GlobalCache;
 pub trait Cx: Copy {
     type Input: Debug + Eq + Hash + Copy;
     type Result: Debug + Eq + Hash + Copy;
-    type AmbiguityInfo: Debug + Eq + Hash + Copy;
+    type AmbiguityKind: Debug + Eq + Hash + Copy;
 
     type DepNodeIndex;
     type Tracked<T: Debug + Clone>: Debug;
@@ -92,6 +92,8 @@ pub trait Delegate: Sized {
         cx: Self::Cx,
         input: <Self::Cx as Cx>::Input,
     ) -> <Self::Cx as Cx>::Result;
+
+    const FIXPOINT_OVERFLOW_AMBIGUITY_KIND: <Self::Cx as Cx>::AmbiguityKind;
     fn fixpoint_overflow_result(
         cx: Self::Cx,
         input: <Self::Cx as Cx>::Input,
@@ -99,12 +101,7 @@ pub trait Delegate: Sized {
 
     fn is_ambiguous_result(
         result: <Self::Cx as Cx>::Result,
-    ) -> Option<<Self::Cx as Cx>::AmbiguityInfo>;
-    fn propagate_ambiguity(
-        cx: Self::Cx,
-        for_input: <Self::Cx as Cx>::Input,
-        ambiguity_info: <Self::Cx as Cx>::AmbiguityInfo,
-    ) -> <Self::Cx as Cx>::Result;
+    ) -> Option<<Self::Cx as Cx>::AmbiguityKind>;
 
     fn compute_goal(
         search_graph: &mut SearchGraph<Self>,
@@ -955,8 +952,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
 #[derive_where(Debug; X: Cx)]
 enum RebaseReason<X: Cx> {
     NoCycleUsages,
-    Ambiguity(X::AmbiguityInfo),
-    Overflow,
+    Ambiguity(X::AmbiguityKind),
     /// We've actually reached a fixpoint.
     ///
     /// This either happens in the first evaluation step for the cycle head.
@@ -987,10 +983,9 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
     /// cache entries to also be ambiguous. This causes some undesirable ambiguity for nested
     /// goals whose result doesn't actually depend on this cycle head, but that's acceptable
     /// to me.
-    #[instrument(level = "trace", skip(self, cx))]
+    #[instrument(level = "trace", skip(self))]
     fn rebase_provisional_cache_entries(
         &mut self,
-        cx: X,
         stack_entry: &StackEntry<X>,
         rebase_reason: RebaseReason<X>,
     ) {
@@ -1065,18 +1060,22 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                     }
 
                     // The provisional cache entry does depend on the provisional result
-                    // of the popped cycle head. We need to mutate the result of our
-                    // provisional cache entry in case we did not reach a fixpoint.
+                    // of the popped cycle head. In case we didn't actually reach a fixpoint,
+                    // we must not keep potentially incorrect provisional cache entries around.
                     match rebase_reason {
                         // If the cycle head does not actually depend on itself, then
                         // the provisional result used by the provisional cache entry
                         // is not actually equal to the final provisional result. We
                         // need to discard the provisional cache entry in this case.
                         RebaseReason::NoCycleUsages => return false,
-                        RebaseReason::Ambiguity(info) => {
-                            *result = D::propagate_ambiguity(cx, input, info);
+                        // If we avoid rerunning a goal due to ambiguity, we only keep provisional
+                        // results which depend on that cycle head if these are already ambiguous
+                        // themselves.
+                        RebaseReason::Ambiguity(kind) => {
+                            if !D::is_ambiguous_result(*result).is_some_and(|k| k == kind) {
+                                return false;
+                            }
                         }
-                        RebaseReason::Overflow => *result = D::fixpoint_overflow_result(cx, input),
                         RebaseReason::ReachedFixpoint(None) => {}
                         RebaseReason::ReachedFixpoint(Some(path_kind)) => {
                             if !popped_head.usages.is_single(path_kind) {
@@ -1380,17 +1379,12 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             // final result is equal to the initial response for that case.
             if let Ok(fixpoint) = self.reached_fixpoint(&stack_entry, usages, result) {
                 self.rebase_provisional_cache_entries(
-                    cx,
                     &stack_entry,
                     RebaseReason::ReachedFixpoint(fixpoint),
                 );
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             } else if usages.is_empty() {
-                self.rebase_provisional_cache_entries(
-                    cx,
-                    &stack_entry,
-                    RebaseReason::NoCycleUsages,
-                );
+                self.rebase_provisional_cache_entries(&stack_entry, RebaseReason::NoCycleUsages);
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             }
 
@@ -1399,19 +1393,15 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             // response in the next iteration in this case. These changes would
             // likely either be caused by incompleteness or can change the maybe
             // cause from ambiguity to overflow. Returning ambiguity always
-            // preserves soundness and completeness even if the goal is be known
-            // to succeed or fail.
+            // preserves soundness and completeness even if the goal could
+            // otherwise succeed or fail.
             //
             // This prevents exponential blowup affecting multiple major crates.
             // As we only get to this branch if we haven't yet reached a fixpoint,
             // we also taint all provisional cache entries which depend on the
             // current goal.
-            if let Some(info) = D::is_ambiguous_result(result) {
-                self.rebase_provisional_cache_entries(
-                    cx,
-                    &stack_entry,
-                    RebaseReason::Ambiguity(info),
-                );
+            if let Some(kind) = D::is_ambiguous_result(result) {
+                self.rebase_provisional_cache_entries(&stack_entry, RebaseReason::Ambiguity(kind));
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             };
 
@@ -1421,7 +1411,10 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             if i >= D::FIXPOINT_STEP_LIMIT {
                 debug!("canonical cycle overflow");
                 let result = D::fixpoint_overflow_result(cx, input);
-                self.rebase_provisional_cache_entries(cx, &stack_entry, RebaseReason::Overflow);
+                self.rebase_provisional_cache_entries(
+                    &stack_entry,
+                    RebaseReason::Ambiguity(D::FIXPOINT_OVERFLOW_AMBIGUITY_KIND),
+                );
                 return EvaluationResult::finalize(stack_entry, encountered_overflow, result);
             }
 

--- a/tests/ui/traits/next-solver/global-where-bound-normalization.rs
+++ b/tests/ui/traits/next-solver/global-where-bound-normalization.rs
@@ -1,0 +1,45 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Regression test for https://github.com/rust-lang/trait-system-refactor-initiative/issues/257.
+
+#![feature(rustc_attrs)]
+#![expect(internal_features)]
+#![rustc_no_implicit_bounds]
+
+pub trait Bound {}
+impl Bound for u8 {}
+
+pub trait Proj {
+    type Assoc;
+}
+impl<U: Bound> Proj for U {
+    type Assoc = U;
+}
+impl Proj for MyField {
+    type Assoc = u8;
+}
+
+// While wf-checking the global bounds of `fn foo`, elaborating this outlives predicate triggered a
+// cycle in the search graph along a particular probe path, which was not an actual solution.
+// That cycle then resulted in a forced false-positive ambiguity due to a performance hack in the
+// search graph and then ended up floundering the root goal evaluation.
+pub trait Field: Proj<Assoc: Bound + 'static> {}
+
+struct MyField;
+impl Field for MyField {}
+
+trait IdReqField {
+    type This;
+}
+impl<F: Field> IdReqField for F {
+    type This = F;
+}
+
+fn foo()
+where
+    <MyField as IdReqField>::This: Field,
+{
+}
+
+fn main() {}


### PR DESCRIPTION
A smaller version of rust-lang/rust#149904 which doesn't cause the perf issue in bevy, or at least in the minimization

While not necessarily necessary for https://github.com/rust-lang/trait-system-refactor-initiative/issues/257 due to rust-lang/rust#158643. This does fix the underlying issues there.

This change does affect `binius_field`, the remaining issues are tracked in https://github.com/rust-lang/trait-system-refactor-initiative/issues/274.

The core idea is that for
- A
  - B
    - A (cycle with initial result)
- B <---

We normally run A until we reach a fixpoint. We don't do so in case trying to do so encounters overflow or the result of `A` ends up ambiguous to avoid performance issues.

We want to generally keep the provisional cache entries which depend on A around. Evaluating these goals depends on the current provisional result of A. This means it is fine to keep them around if A reached a fixpoint. If we bail without reaching a fixpoint, the provisional result used while computing B differs from the final result of A. This means the entry for B is not valid and we'd need to discard it.

Discarding all nested provisional cache entries when not reaching a fixpoint causes perf issues. In case the final result of A is ambiguous, then this PR keeps nested cache entries which are ambiguous and don't have any inference constraints around. That is sound, as having more goals be ambiguous is never an issue, the trait solver can always say ":shrug: idk". It also shouldn't cause any incorrect ambiguity errors issues, as changing the provisional result of A to be ambiguity should not change B to go from being ambiguous to something else.

The current implementation mutated the result of all nested provisional cache entries to be ambiguous, which resulted in incorrect ambiguity errors in https://github.com/rust-lang/trait-system-refactor-initiative/issues/257. This PR differs from that by dropping goals whose result isn't already ambiguous. That's means we don't keep quite as many cache entries around, which is potentially worse for perf, but from what I can tell this doens't cause issues in practice. 

r? BoxyUwU