### PR TITLE
Update with new LLVM 22 target for `wasm32-wali-linux-musl` target

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32_wali_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wali_linux_musl.rs
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::Yes),
         &[
-            "--target=wasm32-wasi-threads",
+            "--target=wasm32-linux-muslwali",
             "-Wl,--export-memory,",
             "-Wl,--shared-memory",
             "-Wl,--max-memory=1073741824",
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
     );
 
     Target {
-        llvm_target: "wasm32-wasi".into(),
+        llvm_target: "wasm32-linux-muslwali".into(),
         metadata: TargetMetadata {
             description: Some("WebAssembly Linux Interface with musl-libc".into()),
             tier: Some(3),


### PR DESCRIPTION
This is a reopening of rust-lang/rust#155654, which was closed abruptly due to changed commit SHAs on my end during merge.
