### PR TITLE
remove review queue triagebot mentions

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -940,10 +940,6 @@ Issue #{number} "{title}" has been added.
 # Mentions
 # ------------------------------------------------------------------------------
 
-[mentions."triagebot.toml"]
-message = "`triagebot.toml` has been modified, there may have been changes to the review queue."
-cc = ["@davidtwco", "@wesleywiser"]
-
 [mentions."compiler/rustc_codegen_cranelift"]
 message = "The Cranelift subtree was changed"
 cc = ["@bjorn3"]


### PR DESCRIPTION
t-compiler's review queue isn't in the `triagebot.toml` anymore so these pings don't make sense.