### PR TITLE
Use repeat_n in Vec::extend_with

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3615,31 +3615,7 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
     #[cfg(not(no_global_oom_handling))]
     /// Extend the vector by `n` clones of value.
     fn extend_with(&mut self, n: usize, value: T) {
-        self.reserve(n);
-
-        unsafe {
-            let mut ptr = self.as_mut_ptr().add(self.len());
-            // Use SetLenOnDrop to work around bug where compiler
-            // might not realize the store through `ptr` through self.set_len()
-            // don't alias.
-            let mut local_len = SetLenOnDrop::new(&mut self.len);
-
-            // Write all elements except the last one
-            for _ in 1..n {
-                ptr::write(ptr, value.clone());
-                ptr = ptr.add(1);
-                // Increment the length in every step in case clone() panics
-                local_len.increment_len(1);
-            }
-
-            if n > 0 {
-                // We can write the last element directly without cloning needlessly
-                ptr::write(ptr, value);
-                local_len.increment_len(1);
-            }
-
-            // len set by scope guard
-        }
+        self.extend(core::iter::repeat_n(value, n));
     }
 }
 


### PR DESCRIPTION
Simplify `Vec::extend_with` to use `extend(repeat_n(...))`. This delegates to `extend_trusted` which essentially does the same thing but using a single loop; the "don't clone the last element" logic is handled inside of the `repeat_n` iterator.

This generates slightly better code by removing the manual store of the last element: https://godbolt.org/z/TG6GPY9Eh