### PR TITLE
remap OUT_DIR paths to fix build script path leakage in crate metadata. 

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1082,7 +1082,7 @@ impl Builder<'_> {
                         // rustc creates absolute paths (in part bc of the `rust-src` unremap
                         // and for working directory) so let's remap the build directory as well.
                         format!("{}={map_to}", self.build.src.display()),
-                        // remap OUT_DIR so they don't leak into artifacs.
+                        // remap OUT_DIR so they don't leak into artifacts.
                         format!("{}={map_to}/out", self.build.out.display()),
                     ]
                     .join("\t");

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1082,6 +1082,8 @@ impl Builder<'_> {
                         // rustc creates absolute paths (in part bc of the `rust-src` unremap
                         // and for working directory) so let's remap the build directory as well.
                         format!("{}={map_to}", self.build.src.display()),
+                        // remap OUT_DIR so they don't leak into artifacs.
+                        format!("{}={map_to}/out", self.build.out.display()),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);
@@ -1102,6 +1104,8 @@ impl Builder<'_> {
                         // rustc creates absolute paths (in part bc of the `rust-src` unremap
                         // and for working directory) so let's remap the build directory as well.
                         format!("{}={map_to}", self.build.src.display()),
+                        // remap OUT_DIR so they don't leak into artifacts.
+                        format!("{}={map_to}/out", self.build.out.display()),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);


### PR DESCRIPTION


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

### problem: 
- build script outputs (`OUT_DIR`) leak absolute paths into crate metadata causing non-determinism across identical builds. 
- bootstrap remaps source paths (`self.build.src`) and registry sources but doesn't not remap `self.build.out` used by `OUT_DIR`

### fix:
- adding `--remap-path-prefix` for `self.build.out` , mapping it to a stable virtual prefix, consistent with existing remappings

### result:
- removes path-based non-determinism from build script outputs
- verified via stage 2 reproducibility testing. 

r? @Urgau 