### PR TITLE
Rename `SharedContext::emit_dyn_lint*` into `emit_lint*`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -224,7 +224,7 @@ pub(crate) fn parse_name_value<S: Stage>(
 
     match cx.sess.psess.check_config.expecteds.get(&name) {
         Some(ExpectedValues::Some(values)) if !values.contains(&value.map(|(v, _)| v)) => cx
-            .emit_dyn_lint_with_sess(
+            .emit_lint_with_sess(
                 UNEXPECTED_CFGS,
                 move |dcx, level, sess| {
                     check_cfg::unexpected_cfg_value(sess, (name, name_span), value)
@@ -232,7 +232,7 @@ pub(crate) fn parse_name_value<S: Stage>(
                 },
                 span,
             ),
-        None if cx.sess.psess.check_config.exhaustive_names => cx.emit_dyn_lint_with_sess(
+        None if cx.sess.psess.check_config.exhaustive_names => cx.emit_lint_with_sess(
             UNEXPECTED_CFGS,
             move |dcx, level, sess| {
                 check_cfg::unexpected_cfg_name(sess, (name, name_span), value).into_diag(dcx, level)

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -67,7 +67,7 @@ impl<S: Stage> CombineAttributeParser<S> for CrateTypeParser {
                     None,
                 );
                 let span = n.value_span;
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     UNKNOWN_CRATE_TYPES,
                     move |dcx, level| {
                         UnknownCrateTypes {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -24,7 +24,7 @@ impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser) -> Option<AttributeKind> {
         let attr_span = cx.attr_span;
         if !matches!(args, ArgParser::NoArgs) {
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 |dcx, level| crate::errors::DoNotRecommendDoesNotExpectArgs.into_diag(dcx, level),
                 attr_span,
@@ -33,7 +33,7 @@ impl<S: Stage> SingleAttributeParser<S> for DoNotRecommendParser {
 
         if !matches!(cx.target, Target::Impl { of_trait: true }) {
             let target_span = cx.target_span;
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| {
                     IncorrectDoNotRecommendLocation { target_span }.into_diag(dcx, level)

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -140,7 +140,7 @@ fn merge<T, S: Stage>(
         (Some(_) | None, None) => {}
         (Some((first_span, _)), Some((later_span, _))) => {
             let first_span = *first_span;
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| {
                     IgnoredDiagnosticOption { first_span, later_span, option_name }
@@ -167,14 +167,14 @@ fn parse_list<'p, S: Stage>(
             // We're dealing with `#[diagnostic::attr()]`.
             // This can be because that is what the user typed, but that's also what we'd see
             // if the user used non-metaitem syntax. See `ArgParser::from_attr_args`.
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| NonMetaItemDiagnosticAttribute.into_diag(dcx, level),
                 list.span,
             );
         }
         ArgParser::NoArgs => {
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| {
                     MissingOptionsForDiagnosticAttribute {
@@ -187,7 +187,7 @@ fn parse_list<'p, S: Stage>(
             );
         }
         ArgParser::NameValue(_) => {
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| {
                     MalFormedDiagnosticAttributeLint {
@@ -221,7 +221,7 @@ fn parse_directive_items<'p, S: Stage>(
         let span = item.span();
 
         macro malformed() {{
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| {
                     MalFormedDiagnosticAttributeLint {
@@ -249,7 +249,7 @@ fn parse_directive_items<'p, S: Stage>(
 
         macro duplicate($name: ident, $($first_span:tt)*) {{
             let first_span = $($first_span)*;
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| IgnoredDiagnosticOption {
                     first_span,
@@ -285,7 +285,7 @@ fn parse_directive_items<'p, S: Stage>(
                         | FormatWarning::PositionalArgument { span }
                         | FormatWarning::IndexedArgument { span }
                         | FormatWarning::DisallowedPlaceholder { span, .. }) = warning;
-                        cx.emit_dyn_lint(
+                        cx.emit_lint(
                             MALFORMED_DIAGNOSTIC_FORMAT_LITERALS,
                             move |dcx, level| warning.into_diag(dcx, level),
                             span,
@@ -295,7 +295,7 @@ fn parse_directive_items<'p, S: Stage>(
                     f
                 }
                 Err(e) => {
-                    cx.emit_dyn_lint(
+                    cx.emit_lint(
                         MALFORMED_DIAGNOSTIC_FORMAT_LITERALS,
                         move |dcx, level| {
                             WrappedParserError {

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -28,7 +28,7 @@ impl<S: Stage> AttributeParser<S> for OnConstParser {
             // so non-constness is still checked in check_attr.rs
             if !matches!(cx.target, Target::Impl { of_trait: true }) {
                 let target_span = cx.target_span;
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                     move |dcx, level| {
                         DiagnosticOnConstOnlyForTraitImpls { target_span }.into_diag(dcx, level)

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -33,7 +33,7 @@ impl OnMoveParser {
         self.span = Some(span);
 
         if !matches!(cx.target, Target::Enum | Target::Struct | Target::Union) {
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| DiagnosticOnMoveOnlyForAdt.into_diag(dcx, level),
                 span,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -23,7 +23,7 @@ impl OnUnimplementedParser {
         self.span = Some(span);
 
         if !matches!(cx.target, Target::Trait) {
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| DiagnosticOnUnimplementedOnlyForTraits.into_diag(dcx, level),
                 span,

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -35,7 +35,7 @@ impl OnUnknownParser {
 
         if !early && !matches!(cx.target, Target::Use) {
             let target_span = cx.target_span;
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                 move |dcx, level| {
                     DiagnosticOnUnknownOnlyForImports { target_span }.into_diag(dcx, level)

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
@@ -25,7 +25,7 @@ impl<S: Stage> AttributeParser<S> for OnUnmatchArgsParser {
             this.span = Some(span);
 
             if !matches!(cx.target, Target::MacroDef) {
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     MISPLACED_DIAGNOSTIC_ATTRIBUTES,
                     move |dcx, level| DiagnosticOnUnmatchArgsOnlyForMacros.into_diag(dcx, level),
                     span,

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -68,7 +68,7 @@ fn check_attr_not_crate_level<S: Stage>(
 /// Checks that an attribute is used at the crate level. Returns `true` if valid.
 fn check_attr_crate_level<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Span) -> bool {
     if cx.shared.target != Target::Crate {
-        cx.emit_dyn_lint(
+        cx.emit_lint(
             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
             |dcx, level| AttrCrateLevelOnly.into_diag(dcx, level),
             span,
@@ -84,7 +84,7 @@ fn expected_name_value<S: Stage>(
     span: Span,
     _name: Option<Symbol>,
 ) {
-    cx.emit_dyn_lint(
+    cx.emit_lint(
         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
         |dcx, level| ExpectedNameValue.into_diag(dcx, level),
         span,
@@ -93,7 +93,7 @@ fn expected_name_value<S: Stage>(
 
 // FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
 fn expected_no_args<S: Stage>(cx: &mut AcceptContext<'_, '_, S>, span: Span) {
-    cx.emit_dyn_lint(
+    cx.emit_lint(
         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
         |dcx, level| ExpectedNoArgs.into_diag(dcx, level),
         span,
@@ -107,7 +107,7 @@ fn expected_string_literal<S: Stage>(
     span: Span,
     _actual_literal: Option<&MetaItemLit>,
 ) {
-    cx.emit_dyn_lint(
+    cx.emit_lint(
         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
         |dcx, level| MalformedDoc.into_diag(dcx, level),
         span,
@@ -177,7 +177,7 @@ impl DocParser {
 
                 if let Some(used_span) = self.attribute.no_crate_inject {
                     let unused_span = path.span();
-                    cx.emit_dyn_lint(
+                    cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                         move |dcx, level| {
                             rustc_errors::lints::UnusedDuplicate {
@@ -203,7 +203,7 @@ impl DocParser {
                     // FIXME: remove this method once merged and uncomment the line below instead.
                     // cx.expected_list(cx.attr_span, args);
                     let span = cx.attr_span;
-                    cx.emit_dyn_lint(
+                    cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                         |dcx, level| MalformedDoc.into_diag(dcx, level),
                         span,
@@ -217,14 +217,14 @@ impl DocParser {
                 }
             }
             Some(name) => {
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| DocTestUnknown { name }.into_diag(dcx, level),
                     path.span(),
                 );
             }
             None => {
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     |dcx, level| DocTestLiteral.into_diag(dcx, level),
                     path.span(),
@@ -261,7 +261,7 @@ impl DocParser {
         }
 
         if let Some(first_definition) = self.attribute.aliases.get(&alias).copied() {
-            cx.emit_dyn_lint(
+            cx.emit_lint(
                 rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
                 move |dcx, level| DocAliasDuplicated { first_definition }.into_diag(dcx, level),
                 span,
@@ -349,7 +349,7 @@ impl DocParser {
             ArgParser::List(list) => {
                 for meta in list.mixed() {
                     let MetaItemOrLitParser::MetaItemParser(item) = meta else {
-                        cx.emit_dyn_lint(
+                        cx.emit_lint(
                             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                             |dcx, level| DocAutoCfgExpectsHideOrShow.into_diag(dcx, level),
                             meta.span(),
@@ -360,7 +360,7 @@ impl DocParser {
                         Some(sym::hide) => (HideOrShow::Hide, sym::hide),
                         Some(sym::show) => (HideOrShow::Show, sym::show),
                         _ => {
-                            cx.emit_dyn_lint(
+                            cx.emit_lint(
                                 rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                                 |dcx, level| DocAutoCfgExpectsHideOrShow.into_diag(dcx, level),
                                 item.span(),
@@ -369,7 +369,7 @@ impl DocParser {
                         }
                     };
                     let ArgParser::List(list) = item.args() else {
-                        cx.emit_dyn_lint(
+                        cx.emit_lint(
                             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                             move |dcx, level| {
                                 DocAutoCfgHideShowExpectsList { attr_name }.into_diag(dcx, level)
@@ -383,7 +383,7 @@ impl DocParser {
 
                     for item in list.mixed() {
                         let MetaItemOrLitParser::MetaItemParser(sub_item) = item else {
-                            cx.emit_dyn_lint(
+                            cx.emit_lint(
                                 rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                                 move |dcx, level| {
                                     DocAutoCfgHideShowUnexpectedItem { attr_name }
@@ -399,7 +399,7 @@ impl DocParser {
                                     // FIXME: remove this method once merged and uncomment the line
                                     // below instead.
                                     // cx.expected_identifier(sub_item.path().span());
-                                    cx.emit_dyn_lint(
+                                    cx.emit_lint(
                                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                                         |dcx, level| MalformedDoc.into_diag(dcx, level),
                                         sub_item.path().span(),
@@ -426,7 +426,7 @@ impl DocParser {
                                 }
                             }
                             _ => {
-                                cx.emit_dyn_lint(
+                                cx.emit_lint(
                                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                                     move |dcx, level| {
                                         DocAutoCfgHideShowUnexpectedItem { attr_name }
@@ -444,7 +444,7 @@ impl DocParser {
             ArgParser::NameValue(nv) => {
                 let MetaItemLit { kind: LitKind::Bool(bool_value), span, .. } = nv.value_as_lit()
                 else {
-                    cx.emit_dyn_lint(
+                    cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                         move |dcx, level| DocAutoCfgWrongLiteral.into_diag(dcx, level),
                         nv.value_span,
@@ -588,7 +588,7 @@ impl DocParser {
             Some(sym::auto_cfg) => self.parse_auto_cfg(cx, path, args),
             Some(sym::test) => {
                 let Some(list) = args.as_list() else {
-                    cx.emit_dyn_lint(
+                    cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                         |dcx, level| DocTestTakesList.into_diag(dcx, level),
                         args.span().unwrap_or(path.span()),
@@ -605,7 +605,7 @@ impl DocParser {
                             // FIXME: remove this method once merged and uncomment the line
                             // below instead.
                             // cx.unexpected_literal(lit.span);
-                            cx.emit_dyn_lint(
+                            cx.emit_lint(
                                 rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                                 |dcx, level| MalformedDoc.into_diag(dcx, level),
                                 lit.span,
@@ -616,7 +616,7 @@ impl DocParser {
             }
             Some(sym::spotlight) => {
                 let span = path.span();
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| DocUnknownSpotlight { sugg_span: span }.into_diag(dcx, level),
                     span,
@@ -629,7 +629,7 @@ impl DocParser {
                 };
                 let value = nv.value_as_lit().symbol;
                 let span = path.span();
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| {
                         DocUnknownInclude {
@@ -644,7 +644,7 @@ impl DocParser {
             }
             Some(name @ (sym::passes | sym::no_default_passes)) => {
                 let span = path.span();
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| {
                         DocUnknownPasses { name, note_span: span }.into_diag(dcx, level)
@@ -654,14 +654,14 @@ impl DocParser {
             }
             Some(sym::plugins) => {
                 let span = path.span();
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| DocUnknownPlugins { label_span: span }.into_diag(dcx, level),
                     span,
                 );
             }
             Some(name) => {
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| DocUnknownAny { name }.into_diag(dcx, level),
                     path.span(),
@@ -671,7 +671,7 @@ impl DocParser {
                 let full_name =
                     path.segments().map(|s| s.as_str()).intersperse("::").collect::<String>();
                 let name = Symbol::intern(&full_name);
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| DocUnknownAny { name }.into_diag(dcx, level),
                     path.span(),
@@ -689,7 +689,7 @@ impl DocParser {
             ArgParser::NoArgs => {
                 let suggestions = cx.adcx().suggestions();
                 let span = cx.attr_span;
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
                     move |dcx, level| {
                         IllFormedAttributeInput::new(&suggestions, None, None).into_diag(dcx, level)

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -122,7 +122,7 @@ fn parse_derive_like<S: Stage>(
                 return None;
             }
             if rustc_feature::is_builtin_attr_name(ident.name) {
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     AMBIGUOUS_DERIVE_HELPERS,
                     |dcx, level| crate::errors::AmbiguousDeriveHelpers.into_diag(dcx, level),
                     ident.span,

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -462,7 +462,7 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
     /// Emit a lint. This method is somewhat special, since lints emitted during attribute parsing
     /// must be delayed until after HIR is built. This method will take care of the details of
     /// that.
-    pub(crate) fn emit_dyn_lint<
+    pub(crate) fn emit_lint<
         F: for<'a> Fn(DiagCtxtHandle<'a>, Level) -> Diag<'a, ()> + DynSend + DynSync + 'static,
     >(
         &mut self,
@@ -477,7 +477,7 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
         );
     }
 
-    pub(crate) fn emit_dyn_lint_with_sess<
+    pub(crate) fn emit_lint_with_sess<
         F: for<'a> Fn(DiagCtxtHandle<'a>, Level, &Session) -> Diag<'a, ()>
             + DynSend
             + DynSync
@@ -507,7 +507,7 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
     }
 
     pub(crate) fn warn_unused_duplicate(&mut self, used_span: Span, unused_span: Span) {
-        self.emit_dyn_lint(
+        self.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
             move |dcx, level| {
                 rustc_errors::lints::UnusedDuplicate {
@@ -526,7 +526,7 @@ impl<'f, 'sess: 'f, S: Stage> SharedContext<'f, 'sess, S> {
         used_span: Span,
         unused_span: Span,
     ) {
-        self.emit_dyn_lint(
+        self.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
             move |dcx, level| {
                 rustc_errors::lints::UnusedDuplicate {
@@ -951,7 +951,7 @@ where
     pub(crate) fn warn_empty_attribute(&mut self, span: Span) {
         let attr_path = self.attr_path.to_string();
         let valid_without_list = self.template.word;
-        self.emit_dyn_lint(
+        self.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
             move |dcx, level| {
                 crate::errors::EmptyAttributeList {
@@ -975,7 +975,7 @@ where
     ) {
         let suggestions = self.suggestions();
         let span = self.attr_span;
-        self.emit_dyn_lint(
+        self.emit_lint(
             lint,
             move |dcx, level| {
                 crate::errors::IllFormedAttributeInput::new(&suggestions, None, help.as_deref())

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -142,7 +142,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
                 };
 
                 let attr_span = cx.attr_span;
-                cx.emit_dyn_lint(
+                cx.emit_lint(
                     lint,
                     move |dcx, level| {
                         InvalidTargetLint {
@@ -186,7 +186,7 @@ impl<'sess, S: Stage> AttributeParser<'sess, S> {
         let target_span = cx.target_span;
         let attr_span = cx.attr_span;
 
-        cx.emit_dyn_lint(
+        cx.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
             move |dcx, level| {
                 crate::errors::InvalidAttrStyle {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/153099.

Very small cleanup while I figure out how to have a `Diagnostic` argument instead of the current closures.

r? @JonathanBrouwer 