### PR TITLE
Refuse to push changes with a dirty git client

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -21,7 +21,7 @@ if $SKIP; then
     exit 0
 fi
 
-if [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     echo "error: working tree is dirty, refusing to push"
     echo "       commit, stash, or discard changes first."
     echo "You may use \`git push --no-verify\` to skip this check."

--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -21,6 +21,13 @@ if $SKIP; then
     exit 0
 fi
 
+if [ -n "$(git status --porcelain)" ]; then
+    echo "error: working tree is dirty, refusing to push"
+    echo "       commit, stash, or discard changes first."
+    echo "You may use \`git push --no-verify\` to skip this check."
+    exit 1
+fi
+
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 echo "Running pre-push script $ROOT_DIR/x test tidy"


### PR DESCRIPTION
I've run into the issue more than once where I've fixed an issue in my client but forgotten to commit it one way or another. The verification succeeds because the files on disk are correct even though the files in the commit being pushed are incorrect.

This change checks to see if there are any uncommitted changes in tracked files in the client before running the tidy checks.
