### PR TITLE
tests: mark simple UI tests as check-pass

### DIFF
--- a/tests/ui/associated-consts/associated-const-trait-bound.rs
+++ b/tests/ui/associated-consts/associated-const-trait-bound.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 trait ConstDefault {
     const DEFAULT: Self;

--- a/tests/ui/associated-type-bounds/entails-sized-dyn-compatibility.rs
+++ b/tests/ui/associated-type-bounds/entails-sized-dyn-compatibility.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 trait Tr1: Sized { type As1; }
 trait Tr2<'a>: Sized { type As2; }

--- a/tests/ui/associated-type-bounds/trait-params.rs
+++ b/tests/ui/associated-type-bounds/trait-params.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 use std::iter::Once;
 use std::ops::Range;

--- a/tests/ui/closure-expected-type/expect-fn-supply-fn-multiple.rs
+++ b/tests/ui/closure-expected-type/expect-fn-supply-fn-multiple.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 #![allow(warnings)]
 

--- a/tests/ui/closure-expected-type/expect-infer-var-supply-ty-with-bound-region.rs
+++ b/tests/ui/closure-expected-type/expect-infer-var-supply-ty-with-bound-region.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 fn with_closure<F, A>(_: F)
     where F: FnOnce(A, &u32)

--- a/tests/ui/closure-expected-type/expect-infer-var-supply-ty-with-free-region.rs
+++ b/tests/ui/closure-expected-type/expect-infer-var-supply-ty-with-free-region.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 fn with_closure<F, A>(_: F)
     where F: FnOnce(A, &u32)

--- a/tests/ui/closures/closure_promotion.rs
+++ b/tests/ui/closures/closure_promotion.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 fn main() {
     let x: &'static _ = &|| { let z = 3; z };

--- a/tests/ui/coherence/coherence_copy_like_err_fundamental_struct.rs
+++ b/tests/ui/coherence/coherence_copy_like_err_fundamental_struct.rs
@@ -2,7 +2,7 @@
 // `MyType: !MyTrait` along with other "fundamental" wrappers.
 
 //@ aux-build:coherence_copy_like_lib.rs
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 // skip-codgen
 #![allow(dead_code)]
 

--- a/tests/ui/deprecation/derive_on_deprecated.rs
+++ b/tests/ui/deprecation/derive_on_deprecated.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 #![deny(deprecated)]
 

--- a/tests/ui/deprecation/derive_on_deprecated_forbidden.rs
+++ b/tests/ui/deprecation/derive_on_deprecated_forbidden.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 #![forbid(deprecated)]
 

--- a/tests/ui/dyn-compatibility/by-value-self.rs
+++ b/tests/ui/dyn-compatibility/by-value-self.rs
@@ -1,6 +1,6 @@
 // Check that a trait with by-value self is considered dyn-compatible.
 
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 #![allow(dead_code)]
 #![allow(trivial_casts)]
 

--- a/tests/ui/dyn-compatibility/phantom-fn.rs
+++ b/tests/ui/dyn-compatibility/phantom-fn.rs
@@ -1,6 +1,6 @@
 // Check that `Self` appearing in a phantom fn does not make a trait dyn-incompatible.
 
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 #![allow(dead_code)]
 
 trait Baz {

--- a/tests/ui/variance/variance-use-contravariant-struct-2.rs
+++ b/tests/ui/variance/variance-use-contravariant-struct-2.rs
@@ -2,7 +2,7 @@
 // they permit lifetimes to be approximated as expected.
 
 #![allow(dead_code)]
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 struct SomeStruct<T>(fn(T));
 

--- a/tests/ui/variance/variance-use-covariant-struct-2.rs
+++ b/tests/ui/variance/variance-use-covariant-struct-2.rs
@@ -2,7 +2,7 @@
 // be shortened.
 
 #![allow(dead_code)]
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 struct SomeStruct<T>(T);
 


### PR DESCRIPTION
This changes 14 simple UI tests from build-pass to check-pass.

These tests cover type checking, trait bounds, closure inference, deprecation diagnostics, dyn compatibility, and variance. They do not need codegen or linking, so check-pass keeps the intended coverage while removing old FIXME(62277) markers.