### PR TITLE
Update `opt_ast_lowering_delayed_lints` query to allow "stealing" lints, allowing to use `FnOnce` instead of `Fn`

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -765,7 +765,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let mut bodies = std::mem::take(&mut self.bodies);
         let define_opaque = std::mem::take(&mut self.define_opaque);
         let trait_map = std::mem::take(&mut self.trait_map);
-        let delayed_lints = std::mem::take(&mut self.delayed_lints).into_boxed_slice();
+        let delayed_lints = Steal::new(std::mem::take(&mut self.delayed_lints).into_boxed_slice());
 
         #[cfg(debug_assertions)]
         for (id, attrs) in attrs.iter() {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -18,6 +18,7 @@ pub use rustc_ast::{
 };
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::sorted_map::SortedMap;
+use rustc_data_structures::steal::Steal;
 use rustc_data_structures::tagged_ptr::TaggedRef;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 use rustc_index::IndexVec;
@@ -1636,7 +1637,7 @@ pub struct OwnerInfo<'hir> {
     /// WARNING: The delayed lints are not hashed as a part of the `OwnerInfo`, and therefore
     ///          should only be accessed in `eval_always` queries.
     #[stable_hasher(ignore)]
-    pub delayed_lints: DelayedLints,
+    pub delayed_lints: Steal<DelayedLints>,
 }
 
 impl<'tcx> OwnerInfo<'tcx> {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1041,7 +1041,7 @@ impl<'a, 'b, 'tcx> Diagnostic<'a, ()> for DiagCallback<'b, 'tcx> {
 pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
     for owner_id in tcx.hir_crate_items(()).delayed_lint_items() {
         if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id) {
-            for lint in delayed_lints {
+            for lint in delayed_lints.steal() {
                 tcx.emit_node_span_lint(
                     lint.lint_id.lint,
                     lint.id,
@@ -1117,7 +1117,7 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
             let hir_items = tcx.hir_crate_items(());
             for owner_id in hir_items.owners() {
                 if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id)
-                    && !delayed_lints.is_empty()
+                    && !delayed_lints.borrow().is_empty()
                 {
                     // Assert that delayed_lint_items also picked up this item to have lints.
                     assert!(hir_items.delayed_lint_items().any(|i| i == owner_id));

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -274,7 +274,7 @@ rustc_queries! {
     ///
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
-    query opt_ast_lowering_delayed_lints(key: hir::OwnerId) -> Option<&'tcx hir::lints::DelayedLints> {
+    query opt_ast_lowering_delayed_lints(key: hir::OwnerId) -> Option<&'tcx Steal<hir::lints::DelayedLints>> {
         desc { "getting AST lowering delayed lints in `{}`", tcx.def_path_str(key) }
         // This query has to be `no_hash` and `eval_always`,
         // because it accesses `delayed_lints` which is not hashed as part of the HIR


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/153099.

This is needed for https://github.com/rust-lang/rust/pull/156002 which will allow to pass `Diagnostic` instead of a closure.

As asked by @JonathanBrouwer, I make this as a stand-alone PR. :)

r? @JonathanBrouwer 