### PR TITLE
use the new `//@ needs-asm-mnemonic: ret` more

### DIFF
--- a/tests/codegen-llvm/cffi/c-variadic-naked.rs
+++ b/tests/codegen-llvm/cffi/c-variadic-naked.rs
@@ -1,5 +1,5 @@
 //@ needs-asm-support
-//@ only-x86_64
+//@ needs-asm-mnemonic: ret
 
 // tests that `va_start` is not injected into naked functions
 

--- a/tests/codegen-llvm/naked-fn/aligned.rs
+++ b/tests/codegen-llvm/naked-fn/aligned.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 //@ needs-asm-support
-//@ ignore-arm no "ret" mnemonic
+//@ needs-asm-mnemonic: ret
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/naked-fn/min-function-alignment.rs
+++ b/tests/codegen-llvm/naked-fn/min-function-alignment.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0 -Zmin-function-alignment=16
 //@ needs-asm-support
-//@ ignore-arm no "ret" mnemonic
+//@ needs-asm-mnemonic: ret
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/155692 we have this neat new rule, and a couple of tests should be able to use them.
