### PR TITLE
ci(free-disk-space): remove more tools and fix warnings

### DIFF
--- a/src/ci/scripts/free-disk-space-linux.sh
+++ b/src/ci/scripts/free-disk-space-linux.sh
@@ -96,15 +96,11 @@ removeUnusedFilesAndDirs() {
     )
 
     if isGitHubRunner; then
+        # Paths common to all runners (both x86 and ARM)
         to_remove+=(
             "/usr/local/aws-sam-cli"
             "/usr/local/doc/cmake"
-            "/usr/local/julia"*
-            "/usr/local/lib/android"
-            "/usr/local/share/chromedriver-"*
-            "/usr/local/share/chromium"
             "/usr/local/share/cmake-"*
-            "/usr/local/share/edge_driver"
             "/usr/local/share/emacs"
             "/usr/local/share/gecko_driver"
             "/usr/local/share/icons"
@@ -112,16 +108,13 @@ removeUnusedFilesAndDirs() {
             "/usr/local/share/vcpkg"
             "/usr/local/share/vim"
             "/usr/share/apache-maven-"*
-            "/usr/share/gradle-"*
             "/usr/share/kotlinc"
-            "/usr/share/miniconda"
             "/usr/share/php"
             "/usr/share/ri"
             "/usr/share/swift"
 
             # binaries
             "/usr/local/bin/azcopy"
-            "/usr/local/bin/bicep"
             "/usr/local/bin/ccmake"
             "/usr/local/bin/cmake-"*
             "/usr/local/bin/cmake"
@@ -135,15 +128,52 @@ removeUnusedFilesAndDirs() {
             "/usr/local/bin/phpunit"
             "/usr/local/bin/pulumi-"*
             "/usr/local/bin/pulumi"
-            "/usr/local/bin/stack"
-
-            # Haskell runtime
-            "/usr/local/.ghcup"
 
             # Azure
             "/opt/az"
             "/usr/share/az_"*
+
+            # Microsoft Edge and powershell
+            "/opt/microsoft"
+
+            "/opt/pipx"
+            "/opt/pipx_bin"
         )
+
+        # Paths only present in x86 runners
+        local github_runner_x86_paths=(
+            "/usr/local/julia"*
+            "/usr/local/lib/android"
+            "/usr/local/share/chromedriver-"*
+            "/usr/local/share/chromium"
+            "/usr/local/share/edge_driver"
+            "/usr/share/gradle-"*
+            "/usr/share/miniconda"
+
+            # binaries
+            "/usr/local/bin/bicep"
+            "/usr/local/bin/stack"
+
+            # Haskell runtime
+            "/usr/local/.ghcup"
+        )
+
+        if isX86; then
+            to_remove+=("${github_runner_x86_paths[@]}")
+        else
+            # warn if x86-only paths are present in other runners
+            local existing_github_runner_x86_paths=()
+            local x86_path
+            for x86_path in "${github_runner_x86_paths[@]}"; do
+                if [ -e "$x86_path" ]; then
+                    existing_github_runner_x86_paths+=("$x86_path")
+                fi
+            done
+
+            if [ "${#existing_github_runner_x86_paths[@]}" -ne 0 ]; then
+                echo "::warning::You can remove the following paths to save space: ${existing_github_runner_x86_paths[*]}"
+            fi
+        fi
 
         if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then
             # Environment variable set by GitHub Actions
@@ -201,10 +231,22 @@ cleanPackages() {
         '^dotnet-.*'
         '^llvm-.*'
         '^mongodb-.*'
+        '^temurin-.*-jdk'
+        'buildah'
         'firefox'
+        'google-cloud-cli'
+        'google-cloud-sdk'
+        'kubectl'
         'libgl1-mesa-dri'
         'mono-devel'
         'php.*'
+        'podman'
+        'skopeo'
+    )
+    local x86_only_packages=(
+        'google-chrome-stable'
+        'microsoft-edge-stable'
+        'powershell'
     )
 
     if isGitHubRunner; then
@@ -213,12 +255,20 @@ cleanPackages() {
         )
 
         if isX86; then
-            packages+=(
-                'google-chrome-stable'
-                'google-cloud-cli'
-                'google-cloud-sdk'
-                'powershell'
-            )
+            packages+=("${x86_only_packages[@]}")
+        else
+            # warn if x86-only packages are installed on other runners
+            local installed_x86_only_packages=()
+            local package
+            for package in "${x86_only_packages[@]}"; do
+                if dpkg-query -W -f='${binary:Package}\n' "$package" >/dev/null 2>&1; then
+                    installed_x86_only_packages+=("$package")
+                fi
+            done
+
+            if [ "${#installed_x86_only_packages[@]}" -ne 0 ]; then
+                echo "::warning::You can remove the following packages to save space: ${installed_x86_only_packages[*]}"
+            fi
         fi
     else
         packages+=(
@@ -235,11 +285,19 @@ cleanPackages() {
         || echo "::warning::The command [sudo apt-get clean] failed"
 }
 
-# Remove Docker images.
-# Ubuntu 22 runners have docker images already installed.
-# They aren't present in ubuntu 24 runners.
+# Remove preinstalled Docker images.
 cleanDocker() {
+    local images
+    images=$(sudo docker image ls -q)
+
+    if [ -z "$images" ]; then
+        echo "=> No docker images to remove."
+        return
+    fi
+
     echo "=> Removing the following docker images:"
+    # Use "docker image ls" without "-q" to get the full table output which contains
+    # also the image names and sizes.
     sudo docker image ls
     echo "=> Removing docker images..."
     sudo docker image prune --all --force || true
@@ -253,7 +311,8 @@ cleanSwap() {
 }
 
 sufficientSpaceEarlyExit() {
-    local available_space_kb=$(df -k . --output=avail | tail -n 1)
+    local available_space_kb
+    available_space_kb=$(df -k . --output=avail | tail -n 1)
 
     if [ "$available_space_kb" -ge "$space_target_kb" ]; then
         echo "Sufficient disk space available (${available_space_kb}KB >= ${space_target_kb}KB). Skipping cleanup."
@@ -267,7 +326,8 @@ sufficientSpaceEarlyExit() {
 checkAlternative() {
     local gha_alt_disk="/mnt"
 
-    local available_space_kb=$(df -k "$gha_alt_disk" --output=avail | tail -n 1)
+    local available_space_kb
+    available_space_kb=$(df -k "$gha_alt_disk" --output=avail | tail -n 1)
 
     # mount options that trade durability for performance
     # ignore-tidy-linelength
@@ -276,7 +336,8 @@ checkAlternative() {
     # GHA has a 2nd disk mounted at /mnt that is almost empty.
     # Check if it's a valid mountpoint and it has enough available space.
     if mountpoint "$gha_alt_disk" && [ "$available_space_kb" -ge "$space_target_kb" ]; then
-        local blkdev=$(df -k "$gha_alt_disk" --output=source | tail -n 1)
+        local blkdev
+        blkdev=$(df -k "$gha_alt_disk" --output=source | tail -n 1)
         echo "Sufficient space available on $blkdev mounted at $gha_alt_disk"
         # see cleanSwap(), swapfile may be mounted under /mnt
         sudo swapoff -a || true


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

With this PR I remove more space and improve the free-disk-space-linux script.
If you prefer me to split this PR into multiple ones, let me know.

Discussed in [#t-infra > some jobs running out of disk space](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/some.20jobs.20running.20out.20of.20disk.20space/with/591666099)

## Test

I tested this change in https://github.com/marcoieni/actions-test/commit/196ce70df07febc673dd883c15eb861e3beec414. As you can see the workflows run without warnings, which ensures that we can remove all the space possible from the arm runners.

I also tested this change in this repository, by commenting out the mechanism to skip disk cleanup in case there is sufficient available disk space. ( see https://github.com/rust-lang/rust/pull/155958/commits/86529fb29d42eec3d5070b50efe7f11ce669da32 )
If I don't comment out the code, it can happen that the CI skips the code I edited because there's enough disk space in the runners that this CI is running.

Here's the change of that commit:

```
# sufficientSpaceEarlyExit
# checkAlternative
```

## Storage saved

In that temporary commit, I measured how much we are saving. It looks like this PR saves ~2GB:

* Before this PR, from https://github.com/rust-lang/rust/actions/runs/25082499114/job/73490814240: `Total saved: Saved   35GiB`
* In this PR, from https://github.com/rust-lang/rust/actions/runs/25099446145/job/73544774148: `Total saved: Saved   37GiB`