### PR TITLE
Deny warnings in the test for crates that are available on stable

### DIFF
--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -375,13 +375,17 @@ pub struct EarlyBinder<I: Interner, T> {
 
 impl<I: Interner, T: Eq> Eq for EarlyBinder<I, T> {}
 
-/// For early binders, you should first call `instantiate` before using any visitors.
+// FIXME(154045): Recommended as per https://github.com/rust-lang/rust/issues/154045, this is so sad :((
 #[cfg(feature = "nightly")]
-impl<I: Interner, T> !TypeFoldable<I> for ty::EarlyBinder<I, T> {}
+macro_rules! generate { ($( $tt:tt )*) => { $( $tt )* } }
 
-/// For early binders, you should first call `instantiate` before using any visitors.
 #[cfg(feature = "nightly")]
-impl<I: Interner, T> !TypeVisitable<I> for ty::EarlyBinder<I, T> {}
+generate!(
+    /// For early binders, you should first call `instantiate` before using any visitors.
+    impl<I: Interner, T> !TypeFoldable<I> for ty::EarlyBinder<I, T> {}
+    /// For early binders, you should first call `instantiate` before using any visitors.
+    impl<I: Interner, T> !TypeVisitable<I> for ty::EarlyBinder<I, T> {}
+);
 
 impl<I: Interner, T> EarlyBinder<I, T> {
     pub fn bind(value: T) -> EarlyBinder<I, T> {

--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -1,11 +1,12 @@
 use std::fmt;
 
 use crate::{
-    AliasTerm, AliasTy, Binder, ClosureKind, CoercePredicate, ExistentialProjection,
-    ExistentialTraitRef, FnSig, HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate,
-    PatternKind, Placeholder, ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef,
-    UnevaluatedConst,
+    AliasTerm, AliasTy, Binder, CoercePredicate, ExistentialProjection, ExistentialTraitRef, FnSig,
+    HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate, PatternKind, Placeholder,
+    ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef,
 };
+#[cfg(feature = "nightly")]
+use crate::{ClosureKind, UnevaluatedConst};
 
 pub trait IrPrint<T> {
     fn print(t: &T, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/tests/run-make-cargo/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make-cargo/rustc-crates-on-stable/rmake.rs
@@ -10,7 +10,7 @@ fn main() {
         .env("RUSTC_STAGE", "0")
         .env("RUSTC", rustc_path())
         // We want to disallow all nightly features to simulate a stable build
-        .env("RUSTFLAGS", "-Zallow-features=")
+        .env("RUSTFLAGS", "-D warnings -Zallow-features=")
         .arg("build")
         .arg("--manifest-path")
         .arg(source_root().join("Cargo.toml"))


### PR DESCRIPTION
We've got a couple of crates, like `rustc_type_ir` that have parts disabled on stable. I believe part of this is so, for example, rust-analyzer can use bits of the compiler. We previously allowed warnings here, and I ran into one. This denies warnings in the test that compiles these stable crates (I chose not to on the crate itself, so you don't *constantly* run into the warnings if you have turned that off in `config.toml`). This test doesn't run by default, but it does run in CI.