### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -765,7 +765,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let mut bodies = std::mem::take(&mut self.bodies);
         let define_opaque = std::mem::take(&mut self.define_opaque);
         let trait_map = std::mem::take(&mut self.trait_map);
-        let delayed_lints = std::mem::take(&mut self.delayed_lints).into_boxed_slice();
+        let delayed_lints = Steal::new(std::mem::take(&mut self.delayed_lints).into_boxed_slice());
 
         #[cfg(debug_assertions)]
         for (id, attrs) in attrs.iter() {

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -2313,65 +2313,8 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         self.vector_extremum(a, b, ExtremumOperation::Min)
     }
 
-    #[cfg(feature = "master")]
-    pub fn vector_reduce_fmin(&mut self, src: RValue<'gcc>) -> RValue<'gcc> {
-        let vector_type = src.get_type().unqualified().dyncast_vector().expect("vector type");
-        let element_count = vector_type.get_num_units();
-        let mut acc = self
-            .context
-            .new_vector_access(self.location, src, self.context.new_rvalue_zero(self.int_type))
-            .to_rvalue();
-        for i in 1..element_count {
-            let elem = self
-                .context
-                .new_vector_access(
-                    self.location,
-                    src,
-                    self.context.new_rvalue_from_int(self.int_type, i as _),
-                )
-                .to_rvalue();
-            let cmp = self.context.new_comparison(self.location, ComparisonOp::LessThan, acc, elem);
-            acc = self.select(cmp, acc, elem);
-        }
-        acc
-    }
-
-    #[cfg(not(feature = "master"))]
-    pub fn vector_reduce_fmin(&mut self, _src: RValue<'gcc>) -> RValue<'gcc> {
-        unimplemented!();
-    }
-
     pub fn vector_maximum_number_nsz(&mut self, a: RValue<'gcc>, b: RValue<'gcc>) -> RValue<'gcc> {
         self.vector_extremum(a, b, ExtremumOperation::Max)
-    }
-
-    #[cfg(feature = "master")]
-    pub fn vector_reduce_fmax(&mut self, src: RValue<'gcc>) -> RValue<'gcc> {
-        let vector_type = src.get_type().unqualified().dyncast_vector().expect("vector type");
-        let element_count = vector_type.get_num_units();
-        let mut acc = self
-            .context
-            .new_vector_access(self.location, src, self.context.new_rvalue_zero(self.int_type))
-            .to_rvalue();
-        for i in 1..element_count {
-            let elem = self
-                .context
-                .new_vector_access(
-                    self.location,
-                    src,
-                    self.context.new_rvalue_from_int(self.int_type, i as _),
-                )
-                .to_rvalue();
-            let cmp =
-                self.context.new_comparison(self.location, ComparisonOp::GreaterThan, acc, elem);
-            acc = self.select(cmp, acc, elem);
-        }
-        acc
-    }
-
-    #[cfg(not(feature = "master"))]
-    pub fn vector_reduce_fmax(&mut self, _src: RValue<'gcc>) -> RValue<'gcc> {
-        unimplemented!();
     }
 
     pub fn vector_select(

--- a/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
@@ -1422,7 +1422,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     );
 
     macro_rules! minmax_red {
-        ($name:ident: $int_red:ident, $float_red:ident) => {
+        ($name:ident: $int_red:ident) => {
             if name == sym::$name {
                 require!(
                     ret_ty == in_elem,
@@ -1430,7 +1430,6 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
                 );
                 return match *in_elem.kind() {
                     ty::Int(_) | ty::Uint(_) => Ok(bx.$int_red(args[0].immediate())),
-                    ty::Float(_) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                         span,
                         name,
@@ -1444,8 +1443,8 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
         };
     }
 
-    minmax_red!(simd_reduce_min: vector_reduce_min, vector_reduce_fmin);
-    minmax_red!(simd_reduce_max: vector_reduce_max, vector_reduce_fmax);
+    minmax_red!(simd_reduce_min: vector_reduce_min);
+    minmax_red!(simd_reduce_max: vector_reduce_max);
 
     macro_rules! bitwise_red {
         ($name:ident : $op:expr, $boolean:expr) => {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1668,12 +1668,6 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
     pub(crate) fn vector_reduce_xor(&mut self, src: &'ll Value) -> &'ll Value {
         self.call_intrinsic("llvm.vector.reduce.xor", &[self.val_ty(src)], &[src])
     }
-    pub(crate) fn vector_reduce_fmin(&mut self, src: &'ll Value) -> &'ll Value {
-        self.call_intrinsic("llvm.vector.reduce.fmin", &[self.val_ty(src)], &[src])
-    }
-    pub(crate) fn vector_reduce_fmax(&mut self, src: &'ll Value) -> &'ll Value {
-        self.call_intrinsic("llvm.vector.reduce.fmax", &[self.val_ty(src)], &[src])
-    }
     pub(crate) fn vector_reduce_min(&mut self, src: &'ll Value, is_signed: bool) -> &'ll Value {
         self.call_intrinsic(
             if is_signed { "llvm.vector.reduce.smin" } else { "llvm.vector.reduce.umin" },

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -2922,7 +2922,7 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
     );
 
     macro_rules! minmax_red {
-        ($name:ident: $int_red:ident, $float_red:ident) => {
+        ($name:ident: $int_red:ident) => {
             if name == sym::$name {
                 require!(
                     ret_ty == in_elem,
@@ -2931,7 +2931,6 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
                 return match in_elem.kind() {
                     ty::Int(_i) => Ok(bx.$int_red(args[0].immediate(), true)),
                     ty::Uint(_u) => Ok(bx.$int_red(args[0].immediate(), false)),
-                    ty::Float(_f) => Ok(bx.$float_red(args[0].immediate())),
                     _ => return_error!(InvalidMonomorphization::UnsupportedSymbol {
                         span,
                         name,
@@ -2945,8 +2944,9 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
         };
     }
 
-    minmax_red!(simd_reduce_min: vector_reduce_min, vector_reduce_fmin);
-    minmax_red!(simd_reduce_max: vector_reduce_max, vector_reduce_fmax);
+    // Currently no support for float due to <https://github.com/llvm/llvm-project/issues/185827>.
+    minmax_red!(simd_reduce_min: vector_reduce_min);
+    minmax_red!(simd_reduce_max: vector_reduce_max);
 
     macro_rules! bitwise_red {
         ($name:ident : $red:ident, $boolean:expr) => {

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -217,12 +217,10 @@ fn create_mingw_dll_import_lib(
     // able to control the *exact* spelling of each of the symbols that are being imported:
     // hence we don't want `dlltool` adding leading underscores automatically.
     let dlltool = find_binutils_dlltool(sess);
-    let temp_prefix = {
-        let mut path = PathBuf::from(&output_path);
-        path.pop();
-        path.push(lib_name);
-        path
-    };
+    // temp_prefix doesn't handle paths with spaces so
+    // use a relative path and set the current working directory
+    let cwd = output_path.parent().unwrap_or(output_path);
+    let temp_prefix = lib_name;
     // dlltool target architecture args from:
     // https://github.com/llvm/llvm-project-release-prs/blob/llvmorg-15.0.6/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp#L69
     let (dlltool_target_arch, dlltool_target_bitness) = match &sess.target.arch {
@@ -246,7 +244,8 @@ fn create_mingw_dll_import_lib(
         .arg(dlltool_target_bitness)
         .arg("--no-leading-underscore")
         .arg("--temp-prefix")
-        .arg(temp_prefix);
+        .arg(temp_prefix)
+        .current_dir(cwd);
 
     match dlltool_cmd.output() {
         Err(e) => {

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -9,7 +9,7 @@ use ar_archive_writer::{
     ArchiveKind, COFFShortExport, MachineTypes, NewArchiveMember, write_archive_to_stream,
 };
 pub use ar_archive_writer::{DEFAULT_OBJECT_READER, ObjectReader};
-use object::read::archive::ArchiveFile;
+use object::read::archive::{ArchiveFile, ArchiveKind as ObjectArchiveKind};
 use object::read::macho::FatArch;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::memmap::Mmap;
@@ -320,6 +320,50 @@ pub trait ArchiveBuilder {
     fn build(self: Box<Self>, output: &Path) -> bool;
 }
 
+fn target_archive_format_to_object_kind(format: &str) -> Option<ObjectArchiveKind> {
+    match format {
+        "gnu" => Some(ObjectArchiveKind::Gnu),
+        "bsd" => Some(ObjectArchiveKind::Bsd),
+        "darwin" => Some(ObjectArchiveKind::Bsd64),
+        "coff" => Some(ObjectArchiveKind::Coff),
+        "aix_big" => Some(ObjectArchiveKind::AixBig),
+        _ => None,
+    }
+}
+
+fn archive_kinds_compatible(actual: ObjectArchiveKind, expected: ObjectArchiveKind) -> bool {
+    if actual == expected {
+        return true;
+    }
+    matches!(
+        (actual, expected),
+        // An archive without long filenames or symbol table is detected as Unknown;
+        // this is compatible with any target format.
+        (ObjectArchiveKind::Unknown, _)
+        // 64-bit symbol table variants are compatible with their 32-bit counterparts
+        | (ObjectArchiveKind::Gnu64, ObjectArchiveKind::Gnu)
+        | (ObjectArchiveKind::Gnu, ObjectArchiveKind::Gnu64)
+        | (ObjectArchiveKind::Bsd64, ObjectArchiveKind::Bsd)
+        | (ObjectArchiveKind::Bsd, ObjectArchiveKind::Bsd64)
+        // GNU and COFF archives share the same magic and member header format;
+        // only the symbol table layout differs.
+        | (ObjectArchiveKind::Gnu, ObjectArchiveKind::Coff)
+        | (ObjectArchiveKind::Coff, ObjectArchiveKind::Gnu)
+        | (ObjectArchiveKind::Gnu64, ObjectArchiveKind::Coff)
+    )
+}
+
+fn archive_kind_display_name(kind: ObjectArchiveKind) -> String {
+    match kind {
+        ObjectArchiveKind::Gnu | ObjectArchiveKind::Gnu64 => "GNU".to_string(),
+        ObjectArchiveKind::Bsd => "BSD".to_string(),
+        ObjectArchiveKind::Bsd64 => "Darwin".to_string(),
+        ObjectArchiveKind::Coff => "COFF".to_string(),
+        ObjectArchiveKind::AixBig => "AIX big".to_string(),
+        _ => format!("{kind:?}"),
+    }
+}
+
 pub struct ArArchiveBuilderBuilder;
 
 impl ArchiveBuilderBuilder for ArArchiveBuilderBuilder {
@@ -420,6 +464,19 @@ impl<'a> ArchiveBuilder for ArArchiveBuilder<'a> {
             .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
         let archive_index = self.src_archives.len();
 
+        if let Some(expected_kind) =
+            target_archive_format_to_object_kind(&self.sess.target.archive_format)
+        {
+            let actual_kind = archive.kind();
+            if !archive_kinds_compatible(actual_kind, expected_kind) {
+                self.sess.dcx().emit_warn(crate::errors::IncompatibleArchiveFormat {
+                    path: archive_path.clone(),
+                    actual: archive_kind_display_name(actual_kind),
+                    expected: archive_kind_display_name(expected_kind),
+                });
+            }
+        }
+
         for entry in archive.members() {
             let entry = entry.map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
             let file_name = String::from_utf8(entry.name().to_vec())
@@ -482,9 +539,24 @@ impl<'a> ArArchiveBuilder<'a> {
                 match entry {
                     ArchiveEntry::FromArchive { archive_index, file_range } => {
                         let src_archive = &self.src_archives[archive_index];
-
-                        let data = &src_archive.1
-                            [file_range.0 as usize..file_range.0 as usize + file_range.1 as usize];
+                        let archive_data = &src_archive.1;
+                        let start = file_range.0 as usize;
+                        let end = start + file_range.1 as usize;
+                        let Some(data) = archive_data.get(start..end) else {
+                            return Err(io_error_context(
+                                "invalid archive member",
+                                io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!(
+                                        "archive member at offset {start} with size {} \
+                                         exceeds archive size {} in `{}`",
+                                        file_range.1,
+                                        archive_data.len(),
+                                        src_archive.0.display(),
+                                    ),
+                                ),
+                            ));
+                        };
 
                         Box::new(data) as Box<dyn AsRef<[u8]>>
                     }

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -706,6 +706,18 @@ pub(crate) struct UnknownArchiveKind<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag("archive `{$path}` was built as {$actual} format, but the target expects {$expected}")]
+#[help(
+    "this often occurs when using BSD-format archive tools on a Linux target; \
+    rebuild the archive with the correct format for the target platform"
+)]
+pub(crate) struct IncompatibleArchiveFormat {
+    pub path: PathBuf,
+    pub actual: String,
+    pub expected: String,
+}
+
+#[derive(Diagnostic)]
 #[diag("linking static libraries is not supported for BPF")]
 pub(crate) struct BpfStaticlibNotSupported;
 

--- a/compiler/rustc_data_structures/src/flat_map_in_place.rs
+++ b/compiler/rustc_data_structures/src/flat_map_in_place.rs
@@ -67,8 +67,13 @@ impl<V: FlatMapInPlaceVec> FlatMapInPlace<V::Elem> for V {
     }
 }
 
-// A vec-like type must implement these operations to support `flat_map_in_place`.
-pub trait FlatMapInPlaceVec {
+/// A vec-like type must implement these operations to support `flat_map_in_place`.
+///
+/// # Safety
+///
+/// The memory safety of the unsafe block in `flat_map_in_place` relies on impls of this trait
+/// implementing all the operations correctly.
+pub unsafe trait FlatMapInPlaceVec {
     type Elem;
 
     fn len(&self) -> usize;
@@ -78,7 +83,7 @@ pub trait FlatMapInPlaceVec {
     fn insert(&mut self, idx: usize, elem: Self::Elem);
 }
 
-impl<T> FlatMapInPlaceVec for Vec<T> {
+unsafe impl<T> FlatMapInPlaceVec for Vec<T> {
     type Elem = T;
 
     fn len(&self) -> usize {
@@ -104,7 +109,7 @@ impl<T> FlatMapInPlaceVec for Vec<T> {
     }
 }
 
-impl<T> FlatMapInPlaceVec for ThinVec<T> {
+unsafe impl<T> FlatMapInPlaceVec for ThinVec<T> {
     type Elem = T;
 
     fn len(&self) -> usize {
@@ -130,7 +135,7 @@ impl<T> FlatMapInPlaceVec for ThinVec<T> {
     }
 }
 
-impl<T, const N: usize> FlatMapInPlaceVec for SmallVec<[T; N]> {
+unsafe impl<T, const N: usize> FlatMapInPlaceVec for SmallVec<[T; N]> {
     type Elem = T;
 
     fn len(&self) -> usize {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -18,6 +18,7 @@ pub use rustc_ast::{
 };
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::sorted_map::SortedMap;
+use rustc_data_structures::steal::Steal;
 use rustc_data_structures::tagged_ptr::TaggedRef;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 use rustc_index::IndexVec;
@@ -1636,7 +1637,7 @@ pub struct OwnerInfo<'hir> {
     /// WARNING: The delayed lints are not hashed as a part of the `OwnerInfo`, and therefore
     ///          should only be accessed in `eval_always` queries.
     #[stable_hasher(ignore)]
-    pub delayed_lints: DelayedLints,
+    pub delayed_lints: Steal<DelayedLints>,
 }
 
 impl<'tcx> OwnerInfo<'tcx> {

--- a/compiler/rustc_hir_analysis/src/check/always_applicable.rs
+++ b/compiler/rustc_hir_analysis/src/check/always_applicable.rs
@@ -217,16 +217,26 @@ fn ensure_all_fields_are_const_destruct<'tcx>(
                 unreachable!()
             };
             let field_ty = eff.trait_ref.self_ty();
-            let diag = struct_span_code_err!(
+            let mut diag = struct_span_code_err!(
                 tcx.dcx(),
                 error.root_obligation.cause.span,
                 E0367,
                 "`{field_ty}` does not implement `[const] Destruct`",
             )
             .with_span_note(impl_span, "required for this `Drop` impl");
-            if field_ty.has_param() {
-                // FIXME: suggest adding `[const] Destruct` by teaching
-                // `suggest_restricting_param_bound` about const traits.
+            if field_ty.has_param()
+                && let Some(generics) = tcx.hir_node_by_def_id(impl_def_id).generics()
+            {
+                let destruct_def_id = tcx.lang_items().destruct_trait();
+                ty::suggest_constraining_type_param(
+                    tcx,
+                    generics,
+                    &mut diag,
+                    &field_ty.to_string(),
+                    "[const] Destruct",
+                    destruct_def_id,
+                    None,
+                );
             }
             Err(diag.emit())
         })

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1041,7 +1041,7 @@ impl<'a, 'b, 'tcx> Diagnostic<'a, ()> for DiagCallback<'b, 'tcx> {
 pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
     for owner_id in tcx.hir_crate_items(()).delayed_lint_items() {
         if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id) {
-            for lint in delayed_lints {
+            for lint in delayed_lints.steal() {
                 tcx.emit_node_span_lint(
                     lint.lint_id.lint,
                     lint.id,
@@ -1117,7 +1117,7 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
             let hir_items = tcx.hir_crate_items(());
             for owner_id in hir_items.owners() {
                 if let Some(delayed_lints) = tcx.opt_ast_lowering_delayed_lints(owner_id)
-                    && !delayed_lints.is_empty()
+                    && !delayed_lints.borrow().is_empty()
                 {
                     // Assert that delayed_lint_items also picked up this item to have lints.
                     assert!(hir_items.delayed_lint_items().any(|i| i == owner_id));

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -207,12 +207,11 @@ impl<Id: Eq + Hash> EffectiveVisibilities<Id> {
         self.map.get(&id)
     }
 
-    // FIXME: Share code with `fn update`.
     pub fn effective_vis_or_private(
         &mut self,
         id: Id,
         lazy_private_vis: impl FnOnce() -> Visibility,
-    ) -> &EffectiveVisibility {
+    ) -> &mut EffectiveVisibility {
         self.map.entry(id).or_insert_with(|| EffectiveVisibility::from_vis(lazy_private_vis()))
     }
 
@@ -226,11 +225,7 @@ impl<Id: Eq + Hash> EffectiveVisibilities<Id> {
         tcx: TyCtxt<'_>,
     ) -> bool {
         let mut changed = false;
-        let mut current_effective_vis = self
-            .map
-            .get(&id)
-            .copied()
-            .unwrap_or_else(|| EffectiveVisibility::from_vis(lazy_private_vis()));
+        let current_effective_vis = self.effective_vis_or_private(id, lazy_private_vis);
 
         let mut inherited_effective_vis_at_prev_level = *inherited_effective_vis.at_level(level);
         let mut calculated_effective_vis = inherited_effective_vis_at_prev_level;
@@ -268,7 +263,6 @@ impl<Id: Eq + Hash> EffectiveVisibilities<Id> {
             }
         }
 
-        self.map.insert(id, current_effective_vis);
         changed
     }
 }

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -274,7 +274,7 @@ rustc_queries! {
     ///
     /// This can be conveniently accessed by `tcx.hir_*` methods.
     /// Avoid calling this query directly.
-    query opt_ast_lowering_delayed_lints(key: hir::OwnerId) -> Option<&'tcx hir::lints::DelayedLints> {
+    query opt_ast_lowering_delayed_lints(key: hir::OwnerId) -> Option<&'tcx Steal<hir::lints::DelayedLints>> {
         desc { "getting AST lowering delayed lints in `{}`", tcx.def_path_str(key) }
         // This query has to be `no_hash` and `eval_always`,
         // because it accesses `delayed_lints` which is not hashed as part of the HIR

--- a/compiler/rustc_target/src/spec/targets/wasm32_wali_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wali_linux_musl.rs
@@ -13,7 +13,7 @@ pub(crate) fn target() -> Target {
     options.add_pre_link_args(
         LinkerFlavor::WasmLld(Cc::Yes),
         &[
-            "--target=wasm32-wasi-threads",
+            "--target=wasm32-linux-muslwali",
             "-Wl,--export-memory,",
             "-Wl,--shared-memory",
             "-Wl,--max-memory=1073741824",
@@ -21,7 +21,7 @@ pub(crate) fn target() -> Target {
     );
 
     Target {
-        llvm_target: "wasm32-wasi".into(),
+        llvm_target: "wasm32-linux-muslwali".into(),
         metadata: TargetMetadata {
             description: Some("WebAssembly Linux Interface with musl-libc".into()),
             tier: Some(3),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -25,8 +25,8 @@ use rustc_middle::traits::select::OverflowError;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
 use rustc_middle::ty::print::{
-    PrintPolyTraitPredicateExt, PrintTraitPredicateExt as _, PrintTraitRefExt as _,
-    with_forced_trimmed_paths,
+    PrintPolyTraitPredicateExt, PrintPolyTraitRefExt as _, PrintTraitPredicateExt as _,
+    PrintTraitRefExt as _, with_forced_trimmed_paths,
 };
 use rustc_middle::ty::{
     self, GenericArgKind, TraitRef, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable,
@@ -886,6 +886,23 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     );
                 }
             }
+        } else if let ty::Param(param) = trait_ref.self_ty().skip_binder().kind()
+            && let Some(generics) =
+                self.tcx.hir_node_by_def_id(main_obligation.cause.body_id).generics()
+        {
+            let constraint = ty::print::with_no_trimmed_paths!(format!(
+                "[const] {}",
+                trait_ref.map_bound(|tr| tr.trait_ref).print_trait_sugared(),
+            ));
+            ty::suggest_constraining_type_param(
+                self.tcx,
+                generics,
+                &mut diag,
+                param.name.as_str(),
+                &constraint,
+                Some(trait_ref.def_id()),
+                None,
+            );
         }
         diag
     }
@@ -2708,7 +2725,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     fn predicate_can_apply(
         &self,
         param_env: ty::ParamEnv<'tcx>,
-        pred: ty::PolyTraitPredicate<'tcx>,
+        pred: impl Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>> + TypeFoldable<TyCtxt<'tcx>>,
     ) -> bool {
         struct ParamToVarFolder<'a, 'tcx> {
             infcx: &'a InferCtxt<'tcx>,

--- a/library/core/src/intrinsics/simd/mod.rs
+++ b/library/core/src/intrinsics/simd/mod.rs
@@ -520,7 +520,7 @@ pub unsafe fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
 
 /// Checks if all mask values are true.
 ///
-/// `T` must be a vector of integer primitive types.
+/// `T` must be a vector of integers.
 ///
 /// # Safety
 /// `x` must contain only `0` or `!0`.
@@ -530,7 +530,7 @@ pub const unsafe fn simd_reduce_all<T>(x: T) -> bool;
 
 /// Checks if any mask value is true.
 ///
-/// `T` must be a vector of integer primitive types.
+/// `T` must be a vector of integers.
 ///
 /// # Safety
 /// `x` must contain only `0` or `!0`.
@@ -540,29 +540,25 @@ pub const unsafe fn simd_reduce_any<T>(x: T) -> bool;
 
 /// Returns the maximum element of a vector.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
-///
-/// For floating-point values, uses IEEE-754 `maxNum`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_reduce_max<T, U>(x: T) -> U;
 
 /// Returns the minimum element of a vector.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
-///
-/// For floating-point values, uses IEEE-754 `minNum`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub const unsafe fn simd_reduce_min<T, U>(x: T) -> U;
 
 /// Logical "and"s all elements together.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
@@ -571,7 +567,7 @@ pub const unsafe fn simd_reduce_and<T, U>(x: T) -> U;
 
 /// Logical "ors" all elements together.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
@@ -580,7 +576,7 @@ pub const unsafe fn simd_reduce_or<T, U>(x: T) -> U;
 
 /// Logical "exclusive ors" all elements together.
 ///
-/// `T` must be a vector of integers or floats.
+/// `T` must be a vector of integers.
 ///
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]

--- a/library/std_detect/src/detect/os/windows/aarch64.rs
+++ b/library/std_detect/src/detect/os/windows/aarch64.rs
@@ -31,8 +31,14 @@ pub(crate) fn detect_features() -> cache::Initializer {
     const PF_ARM_SVE_SHA3_INSTRUCTIONS_AVAILABLE: u32 = 55;
     const PF_ARM_SVE_SM4_INSTRUCTIONS_AVAILABLE: u32 = 56;
     // const PF_ARM_SVE_I8MM_INSTRUCTIONS_AVAILABLE: u32 = 57;
-    // const PF_ARM_SVE_F32MM_INSTRUCTIONS_AVAILABLE: u32 = 58;
-    // const PF_ARM_SVE_F64MM_INSTRUCTIONS_AVAILABLE: u32 = 59;
+    const PF_ARM_SVE_F32MM_INSTRUCTIONS_AVAILABLE: u32 = 58;
+    const PF_ARM_SVE_F64MM_INSTRUCTIONS_AVAILABLE: u32 = 59;
+    const PF_ARM_LSE2_AVAILABLE: u32 = 62;
+    const PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE: u32 = 64;
+    const PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE: u32 = 65;
+    const PF_ARM_V82_I8MM_INSTRUCTIONS_AVAILABLE: u32 = 66;
+    const PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE: u32 = 67;
+    const PF_ARM_V86_BF16_INSTRUCTIONS_AVAILABLE: u32 = 68;
 
     unsafe extern "system" {
         fn IsProcessorFeaturePresent(ProcessorFeature: DWORD) -> BOOL;
@@ -46,9 +52,11 @@ pub(crate) fn detect_features() -> cache::Initializer {
             }
         };
 
-        // Some features may be supported on current CPU,
-        // but no way to detect it by OS API.
-        // Also, we require unsafe block for the extern "system" calls.
+        // Some features may be supported on the current CPU but have no
+        // detection path through the Win32 API; those report `false`.
+        // SAFETY: `IsProcessorFeaturePresent` is a Win32 entry point taking a
+        // `DWORD` by value and returning a `BOOL`. No pointer parameters,
+        // no out-parameters, no thread-safety constraints.
         unsafe {
             enable_feature(
                 Feature::fp,
@@ -111,6 +119,46 @@ pub(crate) fn detect_features() -> cache::Initializer {
             enable_feature(
                 Feature::sve2_sm4,
                 IsProcessorFeaturePresent(PF_ARM_SVE_SM4_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::f32mm,
+                IsProcessorFeaturePresent(PF_ARM_SVE_F32MM_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::f64mm,
+                IsProcessorFeaturePresent(PF_ARM_SVE_F64MM_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::lse2,
+                IsProcessorFeaturePresent(PF_ARM_LSE2_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::fp16,
+                IsProcessorFeaturePresent(PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::i8mm,
+                IsProcessorFeaturePresent(PF_ARM_V82_I8MM_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            enable_feature(
+                Feature::bf16,
+                IsProcessorFeaturePresent(PF_ARM_V86_BF16_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            // stdarch `sha3` is FEAT_SHA3 + FEAT_SHA512 together; Windows
+            // exposes them as two separate flags.
+            enable_feature(
+                Feature::sha3,
+                IsProcessorFeaturePresent(PF_ARM_SHA3_INSTRUCTIONS_AVAILABLE) != FALSE
+                    && IsProcessorFeaturePresent(PF_ARM_SHA512_INSTRUCTIONS_AVAILABLE) != FALSE,
+            );
+            // No PF_ARM_RDM_* constant exists. Derive FEAT_RDM from FEAT_DotProd:
+            // DotProd is an optional v8.2-A feature only present on cores that
+            // implement at least v8.1-A; v8.1-A with AdvSIMD mandates FEAT_RDM
+            // (Arm ARM K.a §D17.2.91), and AdvSIMD is universal on Windows-on-ARM.
+            // Same inference shipped in .NET 10 (dotnet/runtime PR 109493).
+            enable_feature(
+                Feature::rdm,
+                IsProcessorFeaturePresent(PF_ARM_V82_DP_INSTRUCTIONS_AVAILABLE) != FALSE,
             );
             // PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE means aes, sha1, sha2 and
             // pmull support

--- a/library/std_detect/tests/cpu-detection.rs
+++ b/library/std_detect/tests/cpu-detection.rs
@@ -150,14 +150,22 @@ fn aarch64_linux() {
 fn aarch64_windows() {
     println!("asimd: {:?}", is_aarch64_feature_detected!("asimd"));
     println!("fp: {:?}", is_aarch64_feature_detected!("fp"));
+    println!("fp16: {:?}", is_aarch64_feature_detected!("fp16"));
     println!("crc: {:?}", is_aarch64_feature_detected!("crc"));
     println!("lse: {:?}", is_aarch64_feature_detected!("lse"));
+    println!("lse2: {:?}", is_aarch64_feature_detected!("lse2"));
+    println!("rdm: {:?}", is_aarch64_feature_detected!("rdm"));
     println!("dotprod: {:?}", is_aarch64_feature_detected!("dotprod"));
+    println!("i8mm: {:?}", is_aarch64_feature_detected!("i8mm"));
+    println!("bf16: {:?}", is_aarch64_feature_detected!("bf16"));
     println!("jsconv: {:?}", is_aarch64_feature_detected!("jsconv"));
     println!("rcpc: {:?}", is_aarch64_feature_detected!("rcpc"));
     println!("aes: {:?}", is_aarch64_feature_detected!("aes"));
     println!("pmull: {:?}", is_aarch64_feature_detected!("pmull"));
     println!("sha2: {:?}", is_aarch64_feature_detected!("sha2"));
+    println!("sha3: {:?}", is_aarch64_feature_detected!("sha3"));
+    println!("f32mm: {:?}", is_aarch64_feature_detected!("f32mm"));
+    println!("f64mm: {:?}", is_aarch64_feature_detected!("f64mm"));
 }
 
 #[test]

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1082,7 +1082,7 @@ impl Builder<'_> {
                         // rustc creates absolute paths (in part bc of the `rust-src` unremap
                         // and for working directory) so let's remap the build directory as well.
                         format!("{}={map_to}", self.build.src.display()),
-                        // remap OUT_DIR so they don't leak into artifacs.
+                        // remap OUT_DIR so they don't leak into artifacts.
                         format!("{}={map_to}/out", self.build.out.display()),
                     ]
                     .join("\t");

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1082,6 +1082,8 @@ impl Builder<'_> {
                         // rustc creates absolute paths (in part bc of the `rust-src` unremap
                         // and for working directory) so let's remap the build directory as well.
                         format!("{}={map_to}", self.build.src.display()),
+                        // remap OUT_DIR so they don't leak into artifacs.
+                        format!("{}={map_to}/out", self.build.out.display()),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);
@@ -1102,6 +1104,8 @@ impl Builder<'_> {
                         // rustc creates absolute paths (in part bc of the `rust-src` unremap
                         // and for working directory) so let's remap the build directory as well.
                         format!("{}={map_to}", self.build.src.display()),
+                        // remap OUT_DIR so they don't leak into artifacts.
+                        format!("{}={map_to}/out", self.build.out.display()),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);

--- a/src/ci/scripts/free-disk-space-linux.sh
+++ b/src/ci/scripts/free-disk-space-linux.sh
@@ -96,15 +96,11 @@ removeUnusedFilesAndDirs() {
     )
 
     if isGitHubRunner; then
+        # Paths common to all runners (both x86 and ARM)
         to_remove+=(
             "/usr/local/aws-sam-cli"
             "/usr/local/doc/cmake"
-            "/usr/local/julia"*
-            "/usr/local/lib/android"
-            "/usr/local/share/chromedriver-"*
-            "/usr/local/share/chromium"
             "/usr/local/share/cmake-"*
-            "/usr/local/share/edge_driver"
             "/usr/local/share/emacs"
             "/usr/local/share/gecko_driver"
             "/usr/local/share/icons"
@@ -112,16 +108,13 @@ removeUnusedFilesAndDirs() {
             "/usr/local/share/vcpkg"
             "/usr/local/share/vim"
             "/usr/share/apache-maven-"*
-            "/usr/share/gradle-"*
             "/usr/share/kotlinc"
-            "/usr/share/miniconda"
             "/usr/share/php"
             "/usr/share/ri"
             "/usr/share/swift"
 
             # binaries
             "/usr/local/bin/azcopy"
-            "/usr/local/bin/bicep"
             "/usr/local/bin/ccmake"
             "/usr/local/bin/cmake-"*
             "/usr/local/bin/cmake"
@@ -135,15 +128,52 @@ removeUnusedFilesAndDirs() {
             "/usr/local/bin/phpunit"
             "/usr/local/bin/pulumi-"*
             "/usr/local/bin/pulumi"
-            "/usr/local/bin/stack"
-
-            # Haskell runtime
-            "/usr/local/.ghcup"
 
             # Azure
             "/opt/az"
             "/usr/share/az_"*
+
+            # Microsoft Edge and powershell
+            "/opt/microsoft"
+
+            "/opt/pipx"
+            "/opt/pipx_bin"
         )
+
+        # Paths only present in x86 runners
+        local github_runner_x86_paths=(
+            "/usr/local/julia"*
+            "/usr/local/lib/android"
+            "/usr/local/share/chromedriver-"*
+            "/usr/local/share/chromium"
+            "/usr/local/share/edge_driver"
+            "/usr/share/gradle-"*
+            "/usr/share/miniconda"
+
+            # binaries
+            "/usr/local/bin/bicep"
+            "/usr/local/bin/stack"
+
+            # Haskell runtime
+            "/usr/local/.ghcup"
+        )
+
+        if isX86; then
+            to_remove+=("${github_runner_x86_paths[@]}")
+        else
+            # warn if x86-only paths are present in other runners
+            local existing_github_runner_x86_paths=()
+            local x86_path
+            for x86_path in "${github_runner_x86_paths[@]}"; do
+                if [ -e "$x86_path" ]; then
+                    existing_github_runner_x86_paths+=("$x86_path")
+                fi
+            done
+
+            if [ "${#existing_github_runner_x86_paths[@]}" -ne 0 ]; then
+                echo "::warning::You can remove the following paths to save space: ${existing_github_runner_x86_paths[*]}"
+            fi
+        fi
 
         if [ -n "${AGENT_TOOLSDIRECTORY:-}" ]; then
             # Environment variable set by GitHub Actions
@@ -201,10 +231,22 @@ cleanPackages() {
         '^dotnet-.*'
         '^llvm-.*'
         '^mongodb-.*'
+        '^temurin-.*-jdk'
+        'buildah'
         'firefox'
+        'google-cloud-cli'
+        'google-cloud-sdk'
+        'kubectl'
         'libgl1-mesa-dri'
         'mono-devel'
         'php.*'
+        'podman'
+        'skopeo'
+    )
+    local x86_only_packages=(
+        'google-chrome-stable'
+        'microsoft-edge-stable'
+        'powershell'
     )
 
     if isGitHubRunner; then
@@ -213,12 +255,20 @@ cleanPackages() {
         )
 
         if isX86; then
-            packages+=(
-                'google-chrome-stable'
-                'google-cloud-cli'
-                'google-cloud-sdk'
-                'powershell'
-            )
+            packages+=("${x86_only_packages[@]}")
+        else
+            # warn if x86-only packages are installed on other runners
+            local installed_x86_only_packages=()
+            local package
+            for package in "${x86_only_packages[@]}"; do
+                if dpkg-query -W -f='${binary:Package}\n' "$package" >/dev/null 2>&1; then
+                    installed_x86_only_packages+=("$package")
+                fi
+            done
+
+            if [ "${#installed_x86_only_packages[@]}" -ne 0 ]; then
+                echo "::warning::You can remove the following packages to save space: ${installed_x86_only_packages[*]}"
+            fi
         fi
     else
         packages+=(
@@ -235,11 +285,19 @@ cleanPackages() {
         || echo "::warning::The command [sudo apt-get clean] failed"
 }
 
-# Remove Docker images.
-# Ubuntu 22 runners have docker images already installed.
-# They aren't present in ubuntu 24 runners.
+# Remove preinstalled Docker images.
 cleanDocker() {
+    local images
+    images=$(sudo docker image ls -q)
+
+    if [ -z "$images" ]; then
+        echo "=> No docker images to remove."
+        return
+    fi
+
     echo "=> Removing the following docker images:"
+    # Use "docker image ls" without "-q" to get the full table output which contains
+    # also the image names and sizes.
     sudo docker image ls
     echo "=> Removing docker images..."
     sudo docker image prune --all --force || true
@@ -253,7 +311,8 @@ cleanSwap() {
 }
 
 sufficientSpaceEarlyExit() {
-    local available_space_kb=$(df -k . --output=avail | tail -n 1)
+    local available_space_kb
+    available_space_kb=$(df -k . --output=avail | tail -n 1)
 
     if [ "$available_space_kb" -ge "$space_target_kb" ]; then
         echo "Sufficient disk space available (${available_space_kb}KB >= ${space_target_kb}KB). Skipping cleanup."
@@ -267,7 +326,8 @@ sufficientSpaceEarlyExit() {
 checkAlternative() {
     local gha_alt_disk="/mnt"
 
-    local available_space_kb=$(df -k "$gha_alt_disk" --output=avail | tail -n 1)
+    local available_space_kb
+    available_space_kb=$(df -k "$gha_alt_disk" --output=avail | tail -n 1)
 
     # mount options that trade durability for performance
     # ignore-tidy-linelength
@@ -276,7 +336,8 @@ checkAlternative() {
     # GHA has a 2nd disk mounted at /mnt that is almost empty.
     # Check if it's a valid mountpoint and it has enough available space.
     if mountpoint "$gha_alt_disk" && [ "$available_space_kb" -ge "$space_target_kb" ]; then
-        local blkdev=$(df -k "$gha_alt_disk" --output=source | tail -n 1)
+        local blkdev
+        blkdev=$(df -k "$gha_alt_disk" --output=source | tail -n 1)
         echo "Sufficient space available on $blkdev mounted at $gha_alt_disk"
         # see cleanSwap(), swapfile may be mounted under /mnt
         sudo swapoff -a || true

--- a/tests/codegen-llvm/cffi/c-variadic-naked.rs
+++ b/tests/codegen-llvm/cffi/c-variadic-naked.rs
@@ -1,5 +1,5 @@
 //@ needs-asm-support
-//@ only-x86_64
+//@ needs-asm-mnemonic: ret
 
 // tests that `va_start` is not injected into naked functions
 

--- a/tests/codegen-llvm/naked-fn/aligned.rs
+++ b/tests/codegen-llvm/naked-fn/aligned.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 //@ needs-asm-support
-//@ ignore-arm no "ret" mnemonic
+//@ needs-asm-mnemonic: ret
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/naked-fn/min-function-alignment.rs
+++ b/tests/codegen-llvm/naked-fn/min-function-alignment.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0 -Zmin-function-alignment=16
 //@ needs-asm-support
-//@ ignore-arm no "ret" mnemonic
+//@ needs-asm-mnemonic: ret
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity

--- a/tests/run-make/archive-corrupt-error/corrupt.a
+++ b/tests/run-make/archive-corrupt-error/corrupt.a
@@ -1,0 +1,3 @@
+!<arch>
+corrupt.o/      0           0     0     100644  10000     `
+small_data

--- a/tests/run-make/archive-corrupt-error/lib.rs
+++ b/tests/run-make/archive-corrupt-error/lib.rs
@@ -1,0 +1,3 @@
+extern "C" {
+    fn foo() -> i32;
+}

--- a/tests/run-make/archive-corrupt-error/rmake.rs
+++ b/tests/run-make/archive-corrupt-error/rmake.rs
@@ -1,0 +1,21 @@
+// Regression test for https://github.com/rust-lang/rust/issues/148217
+// A corrupt archive with member offset exceeding file boundary should produce
+// an error, not an ICE.
+
+//@ ignore-cross-compile
+
+use run_make_support::{path, rfs, rustc, static_lib_name};
+
+fn main() {
+    rfs::create_dir("archive");
+    rfs::copy("corrupt.a", path("archive").join(static_lib_name("corrupt")));
+    rustc()
+        .input("lib.rs")
+        .crate_type("rlib")
+        .library_search_path("archive")
+        .arg("-lstatic=corrupt")
+        .run_fail()
+        .assert_stderr_not_contains("panicked")
+        .assert_stderr_not_contains("unexpectedly panicked")
+        .assert_stderr_contains("invalid archive member");
+}

--- a/tests/run-make/archive-format-error/lib.rs
+++ b/tests/run-make/archive-format-error/lib.rs
@@ -1,0 +1,3 @@
+extern "C" {
+    fn foo() -> i32;
+}

--- a/tests/run-make/archive-format-error/native.c
+++ b/tests/run-make/archive-format-error/native.c
@@ -1,0 +1,1 @@
+int foo() { return 42; }

--- a/tests/run-make/archive-format-error/rmake.rs
+++ b/tests/run-make/archive-format-error/rmake.rs
@@ -1,0 +1,22 @@
+// Regression test for https://github.com/rust-lang/rust/issues/148217
+// BSD format archive on a Linux target should emit a format mismatch warning.
+
+//@ ignore-cross-compile
+//@ only-linux
+
+use run_make_support::{cc, llvm_ar, path, rfs, rustc, static_lib_name};
+
+fn main() {
+    rfs::create_dir("archive");
+
+    cc().arg("-c").input("native.c").output("archive/native.o").run();
+    let bsd_archive = path("archive").join(static_lib_name("native_bsd"));
+    llvm_ar().arg("rcus").arg("--format=bsd").output_input(&bsd_archive, "archive/native.o").run();
+    rustc()
+        .input("lib.rs")
+        .crate_type("rlib")
+        .library_search_path("archive")
+        .arg("-lstatic=native_bsd")
+        .run()
+        .assert_stderr_contains("was built as BSD format, but the target expects GNU");
+}

--- a/tests/run-make/raw-dylib-custom-dlltool/script.cmd
+++ b/tests/run-make/raw-dylib-custom-dlltool/script.cmd
@@ -1,2 +1,2 @@
-echo Called dlltool via script.cmd> actual.txt
+echo Called dlltool via script.cmd> %~dp0\actual.txt
 dlltool.exe %*

--- a/tests/run-make/raw-dylib-whitespace/main.rs
+++ b/tests/run-make/raw-dylib-whitespace/main.rs
@@ -1,0 +1,18 @@
+type BOOL = i32;
+
+#[cfg_attr(
+    target_arch = "x86",
+    link(name = "bcryptprimitives", kind = "raw-dylib", import_name_type = "undecorated")
+)]
+#[cfg_attr(not(target_arch = "x86"), link(name = "bcryptprimitives", kind = "raw-dylib"))]
+extern "system" {
+    fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
+}
+
+fn main() {
+    let mut num: u8 = 0;
+    unsafe {
+        ProcessPrng(&mut num, 1);
+    }
+    println!("{num}");
+}

--- a/tests/run-make/raw-dylib-whitespace/rmake.rs
+++ b/tests/run-make/raw-dylib-whitespace/rmake.rs
@@ -1,0 +1,15 @@
+// Ensure that raw-dylib still works if the output directory contains spaces.
+
+//@ only-windows-gnu
+//@ ignore-cross-compile
+//@ needs-dlltool
+// Reason: this test specifically checks the dlltool feature,
+// which is only used on windows-gnu.
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    let out_dir = std::path::absolute("path with spaces").unwrap();
+    rfs::create_dir_all(&out_dir);
+    rustc().crate_type("bin").input("main.rs").out_dir(&out_dir).env("TMP", &out_dir).run();
+}

--- a/tests/ui/consts/drop-impl-nonconst-drop-field.stderr
+++ b/tests/ui/consts/drop-impl-nonconst-drop-field.stderr
@@ -21,6 +21,10 @@ note: required for this `Drop` impl
    |
 LL | impl<T> const Drop for ConstDrop2<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: consider restricting type parameter `T` with unstable trait `Destruct`
+   |
+LL | impl<T: [const] Destruct> const Drop for ConstDrop2<T> {
+   |       ++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/trait_alias.fail.stderr
+++ b/tests/ui/consts/trait_alias.fail.stderr
@@ -3,6 +3,11 @@ error[E0277]: the trait bound `T: [const] Baz` is not satisfied
    |
 LL |         x.baz();
    |           ^^^
+   |
+help: consider further restricting type parameter `T` with trait `Baz`
+   |
+LL | const fn foo<T: [const] Foo + [const] Baz>(x: &T) {
+   |                             +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/trait_alias.next_fail.stderr
+++ b/tests/ui/consts/trait_alias.next_fail.stderr
@@ -3,6 +3,11 @@ error[E0277]: the trait bound `T: [const] Baz` is not satisfied
    |
 LL |         x.baz();
    |           ^^^
+   |
+help: consider further restricting type parameter `T` with trait `Baz`
+   |
+LL | const fn foo<T: [const] Foo + [const] Baz>(x: &T) {
+   |                             +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
@@ -7,7 +7,6 @@
 //@ normalize-stderr: "[^ ]*/foo.dll_imports.lib" -> "$$LIB_FILE"
 //@ normalize-stderr: "-m [^ ]*" -> "$$TARGET_MACHINE"
 //@ normalize-stderr: "-f [^ ]*" -> "$$ASM_FLAGS"
-//@ normalize-stderr: "--temp-prefix [^ ]*/foo.dll" -> "$$TEMP_PREFIX"
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {
     // `@1` is an invalid name to export, as it usually indicates that something

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
@@ -1,4 +1,4 @@
-error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore $TEMP_PREFIX:
+error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore --temp-prefix foo.dll:
        
        $DLLTOOL: Syntax error in def file $DEF_FILE:1␍
        

--- a/tests/ui/simd/intrinsic/generic-reduction-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction-pass.rs
@@ -109,10 +109,11 @@ const fn ordered() {
         let r: f32 = simd_reduce_mul_ordered(x, 2.);
         assert_eq!(r, -48_f32);
 
-        let r: f32 = simd_reduce_min(x);
-        assert_eq!(r, -2_f32);
-        let r: f32 = simd_reduce_max(x);
-        assert_eq!(r, 4_f32);
+        // FIXME: re-enable when the intrinsic works on floats again.
+        // let r: f32 = simd_reduce_min(x);
+        // assert_eq!(r, -2_f32);
+        // let r: f32 = simd_reduce_max(x);
+        // assert_eq!(r, 4_f32);
     }
 
     unsafe {

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
@@ -15,6 +15,11 @@ error[E0277]: the trait bound `T: [const] Foo` is not satisfied
    |
 LL |     x.a();
    |       ^
+   |
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL | const fn foo<T: Bar + [const] Foo>(x: &T) {
+   |                     +++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yy.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yy.stderr
@@ -3,6 +3,11 @@ error[E0277]: the trait bound `T: [const] Foo` is not satisfied
    |
 LL |     x.a();
    |       ^
+   |
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL | const fn foo<T: Bar + [const] Foo>(x: &T) {
+   |                     +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yyn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yyn.stderr
@@ -38,6 +38,11 @@ error[E0277]: the trait bound `T: [const] Foo` is not satisfied
    |
 LL |     x.a();
    |       ^
+   |
+help: consider further restricting type parameter `T` with trait `Foo`
+   |
+LL | const fn foo<T: [const] Bar + [const] Foo>(x: &T) {
+   |                             +++++++++++++
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155189 (simd_reduce_min/max: remove float support)
 - rust-lang/rust#155721 (When archive format is wrong produce an error instead of ICE)
 - rust-lang/rust#155794 (privacy: share effective visibility initialization)
 - rust-lang/rust#155856 (std_detect: support detecting more features on aarch64 Windows)
 - rust-lang/rust#155861 (Suggest `[const] Trait` bounds in more places)
 - rust-lang/rust#155899 (`dlltool`: Set the working directory to workaround `--temp-prefix` bug)
 - rust-lang/rust#155916 (Update with new LLVM 22 target for `wasm32-wali-linux-musl` target)
 - rust-lang/rust#155935 (remap OUT_DIR paths to fix build script path leakage in crate metadata. )
 - rust-lang/rust#155950 (use the new `//@ needs-asm-mnemonic: ret` more)
 - rust-lang/rust#155958 (ci(free-disk-space): remove more tools and fix warnings)
 - rust-lang/rust#155949 (Update `opt_ast_lowering_delayed_lints` query to allow "stealing" lints, allowing to use `FnOnce` instead of `Fn`)
 - rust-lang/rust#155951 (Make `FlatMapInPlaceVec` an unsafe trait.)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155189,155721,155794,155856,155861,155899,155916,155935,155950,155958,155949,155951)
<!-- homu-ignore:end -->

