### PR TITLE
Fix `doc_cfg` feature for extern items

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3260,14 +3260,22 @@ fn clean_maybe_renamed_foreign_item<'tcx>(
             hir::ForeignItemKind::Type => ForeignTypeItem,
         };
 
-        generate_item_with_correct_attrs(
+        let mut clean_item = generate_item_with_correct_attrs(
             cx,
             kind,
             item.owner_id.def_id.to_def_id(),
             item.ident.name,
             import_id.as_slice(),
             renamed,
-        )
+        );
+        // We also need to take into account the `extern` block (doc_)cfg attributes.
+        let mut attrs = Attributes::from_hir(inline::load_attrs(
+            cx.tcx,
+            cx.tcx.hir_owner_parent(item.owner_id).owner.to_def_id(),
+        ));
+        attrs.merge_with(std::mem::take(&mut clean_item.inner.attrs));
+        clean_item.inner.attrs = attrs;
+        clean_item
     })
 }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1093,6 +1093,12 @@ impl Attributes {
         }
         aliases.into_iter().collect::<Vec<_>>().into()
     }
+
+    pub(crate) fn merge_with(&mut self, other: Self) {
+        let Self { doc_strings, other_attrs } = other;
+        self.doc_strings.extend(doc_strings);
+        self.other_attrs.extend(other_attrs);
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/tests/rustdoc-html/doc-cfg/extern-items.rs
+++ b/tests/rustdoc-html/doc-cfg/extern-items.rs
@@ -1,0 +1,26 @@
+// Ensure that the `cfg` on the extern blocks are correctly taken into account by
+// their children.
+// Regression test for <https://github.com/rust-lang/rust/issues/150268>.
+
+#![feature(doc_cfg)]
+#![crate_name = "foo"]
+
+//@has 'foo/index.html'
+//@count - '//*[@class="stab portability"]' 2
+//@has - '//*[@class="stab portability"]' 'Non-banana'
+
+//@has 'foo/fn.doc_cfg_doesnt_work.html'
+//@has - '//*[@class="stab portability"]' 'Available on non-crate feature banana only.'
+
+//@has 'foo/fn.doc_cfg_works.html'
+//@has - '//*[@class="stab portability"]' 'Available on non-crate feature banana only.'
+
+unsafe extern "C" {
+    #[cfg(not(feature = "banana"))]
+    pub fn doc_cfg_works();
+}
+
+#[cfg(not(feature = "banana"))]
+unsafe extern "C" {
+    pub fn doc_cfg_doesnt_work();
+}


### PR DESCRIPTION
Part of rust-lang/rust#150268.

It only solves the extern items issue, but not the others listed in the issue. I will need to think about how to fix them nicely.

r? @Urgau 