### PR TITLE
Fix closure HIR span context mismatch

### DIFF
--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -982,8 +982,8 @@ impl<'tcx> TyCtxt<'tcx> {
                 span,
                 ..
             }) => {
-                // Ensure that the returned span has the item's SyntaxContext.
-                fn_decl_span.find_ancestor_inside(*span).unwrap_or(*span)
+                // Ensure that the returned span has the closure expression's SyntaxContext.
+                fn_decl_span.find_ancestor_inside_same_ctxt(*span).unwrap_or(*span)
             }
             _ => self.hir_span_with_body(hir_id),
         };

--- a/tests/ui/proc-macro/auxiliary/closure-hir-span.rs
+++ b/tests/ui/proc-macro/auxiliary/closure-hir-span.rs
@@ -1,0 +1,23 @@
+//@ edition:2024
+
+extern crate proc_macro;
+
+#[proc_macro]
+pub fn m(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let mut iter = input.into_iter();
+    let move_token = iter.next().unwrap();
+    let pipe1 = iter.next().unwrap();
+    let pipe2 = iter.next().unwrap();
+    let body = iter.next().unwrap();
+
+    let mut inner = proc_macro::TokenStream::new();
+    inner.extend([body]);
+    let new_body = proc_macro::TokenTree::Group(proc_macro::Group::new(
+        proc_macro::Delimiter::Brace,
+        inner,
+    ));
+
+    let mut out = proc_macro::TokenStream::new();
+    out.extend([move_token, pipe1, pipe2, new_body]);
+    out
+}

--- a/tests/ui/proc-macro/closure-hir-span.rs
+++ b/tests/ui/proc-macro/closure-hir-span.rs
@@ -1,0 +1,10 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/155724>
+//@ check-pass
+//@ edition:2024
+//@ proc-macro: closure-hir-span.rs
+
+extern crate closure_hir_span;
+
+fn main() {
+    closure_hir_span::m!(move || {});
+}


### PR DESCRIPTION
Ensure span has the closure expression's SyntaxContext.

Closes rust-lang/rust#155724

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
