### PR TITLE
experiment: Support NonZero<u16> in ToSocketAddr impls

### DIFF
--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -1,6 +1,7 @@
 use super::display_buffer::DisplayBuffer;
 use crate::fmt::{self, Write};
 use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use crate::num::NonZero;
 
 /// An internet socket address, either IPv4 or IPv6.
 ///
@@ -622,6 +623,20 @@ impl<I: [const] Into<IpAddr>> const From<(I, u16)> for SocketAddr {
     /// `u16` is treated as port of the newly created [`SocketAddr`].
     fn from(pieces: (I, u16)) -> SocketAddr {
         SocketAddr::new(pieces.0.into(), pieces.1)
+    }
+}
+
+#[stable(feature = "nonzerou16_to_socket_addrs", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_unstable(feature = "const_convert", issue = "143773")]
+impl<I: [const] Into<IpAddr>> const From<(I, NonZero<u16>)> for SocketAddr {
+    /// Converts a tuple struct (Into<[`IpAddr`]>, [`NonZero<u16>`]) into a [`SocketAddr`].
+    ///
+    /// This conversion creates a [`SocketAddr::V4`] for an [`IpAddr::V4`]
+    /// and creates a [`SocketAddr::V6`] for an [`IpAddr::V6`].
+    ///
+    /// `u16` is treated as port of the newly created [`SocketAddr`].
+    fn from(pieces: (I, NonZero<u16>)) -> SocketAddr {
+        SocketAddr::new(pieces.0.into(), pieces.1.get())
     }
 }
 

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -4,6 +4,7 @@ mod tests;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use core::num::NonZero;
 
 use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use crate::{io, iter, option, slice, vec};
@@ -171,6 +172,14 @@ impl ToSocketAddrs for (IpAddr, u16) {
     }
 }
 
+#[stable(feature = "nonzerou16_to_socket_addrs", since = "CURRENT_RUSTC_VERSION")]
+impl ToSocketAddrs for (IpAddr, NonZero<u16>) {
+    type Iter = <(IpAddr, u16) as ToSocketAddrs>::Iter;
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        (self.0, self.1.get()).to_socket_addrs()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ToSocketAddrs for (Ipv4Addr, u16) {
     type Iter = option::IntoIter<SocketAddr>;
@@ -180,12 +189,28 @@ impl ToSocketAddrs for (Ipv4Addr, u16) {
     }
 }
 
+#[stable(feature = "nonzerou16_to_socket_addrs", since = "CURRENT_RUSTC_VERSION")]
+impl ToSocketAddrs for (Ipv4Addr, NonZero<u16>) {
+    type Iter = <(Ipv4Addr, u16) as ToSocketAddrs>::Iter;
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        (self.0, self.1.get()).to_socket_addrs()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ToSocketAddrs for (Ipv6Addr, u16) {
     type Iter = option::IntoIter<SocketAddr>;
     fn to_socket_addrs(&self) -> io::Result<option::IntoIter<SocketAddr>> {
         let (ip, port) = *self;
         SocketAddrV6::new(ip, port, 0, 0).to_socket_addrs()
+    }
+}
+
+#[stable(feature = "nonzerou16_to_socket_addrs", since = "CURRENT_RUSTC_VERSION")]
+impl ToSocketAddrs for (Ipv6Addr, NonZero<u16>) {
+    type Iter = <(Ipv6Addr, u16) as ToSocketAddrs>::Iter;
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        (self.0, self.1.get()).to_socket_addrs()
     }
 }
 
@@ -206,10 +231,26 @@ impl ToSocketAddrs for (&str, u16) {
     }
 }
 
+#[stable(feature = "nonzerou16_to_socket_addrs", since = "CURRENT_RUSTC_VERSION")]
+impl<'a> ToSocketAddrs for (&'a str, NonZero<u16>) {
+    type Iter = <(&'a str, u16) as ToSocketAddrs>::Iter;
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        (self.0, self.1.get()).to_socket_addrs()
+    }
+}
+
 #[stable(feature = "string_u16_to_socket_addrs", since = "1.46.0")]
 impl ToSocketAddrs for (String, u16) {
     type Iter = vec::IntoIter<SocketAddr>;
     fn to_socket_addrs(&self) -> io::Result<vec::IntoIter<SocketAddr>> {
+        (&*self.0, self.1).to_socket_addrs()
+    }
+}
+
+#[stable(feature = "nonzerou16_to_socket_addrs", since = "CURRENT_RUSTC_VERSION")]
+impl ToSocketAddrs for (String, NonZero<u16>) {
+    type Iter = <(String, u16) as ToSocketAddrs>::Iter;
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
         (&*self.0, self.1).to_socket_addrs()
     }
 }


### PR DESCRIPTION
This is a draft PR for a crater run requested in rust-lang/libs-team#781.

-----

All tuple `From` implementations for `ToSocketAddr` currently only accept a `u16` as the port number. This results in a small ergonomics penalty for users that parse out a `NonZero` port number from the program's arguments.

This adds a small set of implementations that copies any tuple implementation on `ToSocketAddr` that takes in a u16 as a port and instead accepts a `NonZero<u16>`.

For consistency, a `From<(I, NonZeroU16)>` implementation for `SocketAddr` was also implemented.

As far as I can tell, these implementations will be insta-stable.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
