### PR TITLE
tests/run-make/print-cfg: add Android target_env case

### DIFF
--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -48,6 +48,12 @@ fn main() {
         includes: &["unix", "target_abi=\"eabihf\""],
         disallow: &["windows"],
     });
+    // Regression test for #90834: Android must not have `target_env="gnu"`.
+    check(PrintCfg {
+        target: "i686-linux-android",
+        includes: &["unix", "target_os=\"android\""],
+        disallow: &["windows", "target_env=\"gnu\""],
+    });
 }
 
 fn check(PrintCfg { target, includes, disallow }: PrintCfg) {


### PR DESCRIPTION
Regression test for rust-lang/rust#90834

rust-lang/rust#77729 + rust-lang/rust#78929 accidentally gave Android targets `target_env="gnu"`
through `android_base` inheriting from `linux_gnu_base`. rust-lang/rust#90834 moved it
back to plain `linux_base` but didn't add a test, so a future target-spec
refactor could bring it back unnoticed. This adds an Android case to
`tests/run-make/print-cfg` covering exactly that.

r? @petrochenkov