### PR TITLE
Update `transmute_copy` to ub_checks and `?Sized`

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -35,6 +35,7 @@ use crate::clone::TrivialClone;
 use crate::cmp::Ordering;
 use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
+use crate::ub_checks::assert_unsafe_precondition;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
 
 mod alignment;
@@ -1077,6 +1078,27 @@ pub const fn copy<T: Copy>(x: &T) -> T {
 ///
 /// [ub]: ../../reference/behavior-considered-undefined.html
 ///
+/// If you have a raw pointer instead of a reference, you might be looking for
+/// `src.cast::<Dst>().`[`read_unaligned()`](pointer#method.read_unaligned) instead.
+///
+/// # Safety
+///
+/// - Requires `size_of_val::<Src>(src) >= size_of::<Dst>()`
+/// - The first `size_of::<Dst>()` bytes behind `src` must be *readable*
+/// - The first `size_of::<Dst>()` bytes behind `src` must be *[valid]*
+///   when interpreted as a `Dst`.
+///
+/// On top of that, remember that most types have additional invariants beyond merely
+/// being considered initialized at the type level. For example, a `1`-initialized [`Vec<T>`]
+/// is considered initialized (under the current implementation; this does not constitute
+/// a stable guarantee) because the only requirement the compiler knows about it
+/// is that the data pointer must be non-null. Creating such a `Vec<T>` does not cause
+/// *immediate* undefined behavior, but will cause undefined behavior with most
+/// safe operations (including dropping it).
+///
+/// [valid]: ../../reference/behavior-considered-undefined.html#r-undefined.validity
+/// [`Vec<T>`]: ../../std/vec/struct.Vec.html
+///
 /// # Examples
 ///
 /// ```
@@ -1101,20 +1123,32 @@ pub const fn copy<T: Copy>(x: &T) -> T {
 ///
 /// // The contents of 'foo_array' should not have changed
 /// assert_eq!(foo_array, [10]);
+///
+/// let bytes: &[u8] = &[1, 2, 3, 4, 5, 6, 7];
+/// assert_eq!(
+///     unsafe { mem::transmute_copy::<[u8], u32>(bytes) },
+///     u32::from_ne_bytes(*bytes.first_chunk().unwrap()),
+/// );
 /// ```
 #[inline]
 #[must_use]
 #[track_caller]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_transmute_copy", since = "1.74.0")]
-pub const unsafe fn transmute_copy<Src, Dst>(src: &Src) -> Dst {
-    assert!(
-        size_of::<Src>() >= size_of::<Dst>(),
-        "cannot transmute_copy if Dst is larger than Src"
+pub const unsafe fn transmute_copy<Src: ?Sized, Dst>(src: &Src) -> Dst {
+    // library UB because it's possible for the `Src` to be only a subset of the allocation
+    // and thus for a failure to not be immediate language UB
+    assert_unsafe_precondition!(
+        check_library_ub,
+        "cannot transmute_copy if Dst is larger than Src",
+        (
+            src_size: usize = size_of_val::<Src>(src),
+            dst_size: usize = Dst::SIZE,
+        ) => src_size >= dst_size
     );
 
     // If Dst has a higher alignment requirement, src might not be suitably aligned.
-    if align_of::<Dst>() > align_of::<Src>() {
+    if align_of::<Dst>() > align_of_val::<Src>(src) {
         // SAFETY: `src` is a reference which is guaranteed to be valid for reads.
         // The caller must guarantee that the actual transmutation is safe.
         unsafe { ptr::read_unaligned(src as *const Src as *const Dst) }

--- a/library/coretests/tests/mem.rs
+++ b/library/coretests/tests/mem.rs
@@ -139,32 +139,6 @@ fn test_transmute_copy_unaligned() {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
-fn test_transmute_copy_grow_panics() {
-    use std::panic;
-
-    let err = panic::catch_unwind(panic::AssertUnwindSafe(|| unsafe {
-        let _unused: u64 = transmute_copy(&1_u8);
-    }));
-
-    match err {
-        Ok(_) => unreachable!(),
-        Err(payload) => {
-            payload
-                .downcast::<&'static str>()
-                .and_then(|s| {
-                    if *s == "cannot transmute_copy if Dst is larger than Src" {
-                        Ok(s)
-                    } else {
-                        Err(s)
-                    }
-                })
-                .unwrap_or_else(|p| panic::resume_unwind(p));
-        }
-    }
-}
-
-#[test]
 #[allow(dead_code)]
 fn test_discriminant_send_sync() {
     enum Regular {

--- a/tests/codegen-llvm/lib-optimizations/transmute_copy.rs
+++ b/tests/codegen-llvm/lib-optimizations/transmute_copy.rs
@@ -1,0 +1,65 @@
+//@ compile-flags: -Copt-level=1
+//@ only-64bit
+
+#![crate_type = "lib"]
+
+// Check that we don't have runtime alignment checks, just a safe alignment.
+// (Rust emits a branch, but LLVM merges the loads from the arms.)
+
+use std::mem::transmute_copy;
+
+// CHECK-LABEL: @transmute_copy_i16_from_i32_slice
+// CHECK-SAME: ptr{{.+}}%_0,
+// CHECK-SAME: ptr{{.+}}%x.0,
+// CHECK-SAME: i64{{.+}}%x.1)
+#[no_mangle]
+pub unsafe fn transmute_copy_i16_from_i32_slice(x: &[i32]) -> [i16; 7] {
+    // CHECK: start:
+    // CHECK-NEXT: @llvm.memcpy
+    // CHECK-SAME: align 2{{.+}}%_0,
+    // CHECK-SAME: align 4{{.+}}%x.0,
+    // CHECK-SAME: i64 14,
+    // CHECK-NEXT: ret void
+    transmute_copy(x)
+}
+
+// CHECK-LABEL: @transmute_copy_i32_from_i16_slice
+// CHECK-SAME: ptr{{.+}}%_0,
+// CHECK-SAME: ptr{{.+}}%x.0,
+// CHECK-SAME: i64{{.+}}%x.1)
+#[no_mangle]
+pub unsafe fn transmute_copy_i32_from_i16_slice(x: &[i16]) -> [i32; 3] {
+    // CHECK: start:
+    // CHECK-NEXT: @llvm.memcpy
+    // CHECK-SAME: align 4{{.+}}%_0,
+    // CHECK-SAME: align 2{{.+}}%x.0,
+    // CHECK-SAME: i64 12,
+    // CHECK-NEXT: ret void
+    transmute_copy(x)
+}
+
+// CHECK-LABEL: i32 @transmute_copy_i32_from_dyn
+// CHECK-SAME: ptr{{.+}}%x.0,
+// CHECK-SAME: ptr{{.+}}%x.1)
+#[no_mangle]
+pub unsafe fn transmute_copy_i32_from_dyn(x: &dyn std::fmt::Debug) -> i32 {
+    // CHECK: start:
+    // CHECK-NEXT: [[TEMP:%.+]] = load i32, ptr %x.0, align 1
+    // CHECK-NEXT: ret i32 [[TEMP]]
+    transmute_copy(x)
+}
+
+// CHECK-LABEL: @transmute_copy_i16_array_from_dyn
+// CHECK-SAME: ptr{{.+}}%_0,
+// CHECK-SAME: ptr{{.+}}%x.0,
+// CHECK-SAME: ptr{{.+}}%x.1)
+#[no_mangle]
+pub unsafe fn transmute_copy_i16_array_from_dyn(x: &dyn std::fmt::Debug) -> [i16; 7] {
+    // CHECK: start:
+    // CHECK-NEXT: @llvm.memcpy
+    // CHECK-SAME: align 2{{.+}}%_0,
+    // CHECK-SAME: align 1{{.+}}%x.0,
+    // CHECK-SAME: i64 14,
+    // CHECK-NEXT: ret void
+    transmute_copy(x)
+}

--- a/tests/ui/precondition-checks/transmute_copy.rs
+++ b/tests/ui/precondition-checks/transmute_copy.rs
@@ -1,0 +1,9 @@
+//@ run-crash
+//@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
+//@ error-pattern: unsafe precondition(s) violated: cannot transmute_copy if Dst is larger than Src
+
+fn main() {
+    unsafe {
+        let _unused: u64 = std::mem::transmute_copy(&1_u8);
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155989)*
<!-- homu-ignore:end -->

The `assert!` in `transmute_copy` is from rust-lang/rust#98839.  However, it was controversial at the time because it's possible to write `transmute_copy`s that were UB by the description but didn't pass the documented conditions.  It's also sub-optimal to have possible `panic`s in unsafe code where the panic can actually make things worse by dropping things in the middle of what the programmer expected to be panic-free.  Now that we have the `UbChecks` possibility, though, we can do this better: this PR makes it a *non-unwinding* panic when not meeting the documented condition when UB checks are enabled, but which very clearly emphasizes that said check isn't a documented behaviour of the function.

Also, I was staring at the signature and couldn't figure out why it needs `Src: Sized`.  Since it *always* takes a reference, there seems to be no downside to accepting `Src: ?Sized`.  That would also give it more of a reason to exist even if <https://doc.rust-lang.org/nightly/std/mem/fn.transmute_prefix.html> exists (as `transmute_prefix(x)` existing will no longer need the `transmute_copy(&ManuallyDrop::new(x))` polyfill, cc https://github.com/rust-lang/rfcs/pull/3844).  That definitely needs an FCP, though.

(The change to `assert_unsafe_precondition` here doesn't technically need libs-api assent, but I'd still like to hear your thoughts since it's different from the "promise the assert" that IIRC you were also asked to consider elsewhere.)

A partial replacement for rust-lang/rust#154665
