### PR TITLE
-Zembed-source: also embed external source

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
@@ -47,7 +47,8 @@ fn osstr_as_utf8_bytes(path: &OsStr) -> &[u8] {
 
 fn make_file_info(source_file: &SourceFile, embed_source: bool) -> Option<FileInfo> {
     let has_md5 = source_file.src_hash.kind == SourceFileHashAlgorithm::Md5;
-    let has_source = embed_source && source_file.src.is_some();
+    let has_source = embed_source
+        && (source_file.src.is_some() || source_file.external_src.read().get_source().is_some());
 
     if !has_md5 && !has_source {
         return None;
@@ -61,6 +62,8 @@ fn make_file_info(source_file: &SourceFile, embed_source: bool) -> Option<FileIn
 
     if embed_source {
         if let Some(src) = &source_file.src {
+            info.source = Some(LineString::String(src.as_bytes().to_vec()));
+        } else if let Some(src) = source_file.external_src.read().get_source() {
             info.source = Some(LineString::String(src.as_bytes().to_vec()));
         }
     }
@@ -79,19 +82,22 @@ impl DebugContext {
         let span = hygiene::walk_chain_collapsed(span, function_span);
         match tcx.sess.source_map().lookup_line(span.lo()) {
             Ok(SourceFileAndLine { sf: file, line }) => {
-                let file_id = self.add_source_file(&file);
+                let file_id = self.add_source_file(tcx, &file);
                 let line_pos = file.lines()[line];
                 let col = file.relative_position(span.lo()) - line_pos;
 
                 (file_id, u64::try_from(line).unwrap() + 1, u64::from(col.to_u32()) + 1)
             }
-            Err(file) => (self.add_source_file(&file), 0, 0),
+            Err(file) => (self.add_source_file(tcx, &file), 0, 0),
         }
     }
 
-    pub(crate) fn add_source_file(&mut self, source_file: &SourceFile) -> FileId {
+    pub(crate) fn add_source_file(&mut self, tcx: TyCtxt<'_>, source_file: &SourceFile) -> FileId {
         let cache_key = (source_file.stable_id, source_file.src_hash);
         *self.created_files.entry(cache_key).or_insert_with(|| {
+            if self.embed_source && source_file.src.is_none() {
+                tcx.sess.source_map().ensure_source_file_source_present(source_file);
+            }
             let line_program: &mut LineProgram = &mut self.dwarf.unit.line_program;
             let line_strings: &mut LineStringTable = &mut self.dwarf.line_strings;
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::{assert_matches, iter, ptr};
 
 use libc::{c_longlong, c_uint};
@@ -607,8 +606,16 @@ pub(crate) fn file_metadata<'ll>(cx: &CodegenCx<'ll, '_>, source_file: &SourceFi
         };
         let hash_value = hex_encode(source_file.src_hash.hash_bytes());
 
-        let source =
-            cx.sess().opts.unstable_opts.embed_source.then_some(()).and(source_file.src.as_ref());
+        let mut source = None;
+        let external_src;
+        if cx.sess().opts.unstable_opts.embed_source {
+            source = source_file.src.as_deref().map(String::as_str);
+            if source.is_none() {
+                cx.tcx.sess.source_map().ensure_source_file_source_present(source_file);
+                external_src = source_file.external_src.read();
+                source = external_src.get_source();
+            }
+        }
 
         create_file(DIB(cx), &file_name, &directory, &hash_value, hash_kind, source)
     }
@@ -626,7 +633,7 @@ fn create_file<'ll>(
     directory: &str,
     hash_value: &str,
     hash_kind: llvm::ChecksumKind,
-    source: Option<&Arc<String>>,
+    source: Option<&str>,
 ) -> &'ll DIFile {
     unsafe {
         llvm::LLVMRustDIBuilderCreateFile(


### PR DESCRIPTION
Hi,

I've been using `-Zembed-source` for a while and noticed that some sources are not embedded when compiling in release mode. See the minimal reproducer below for missing embedded source code.

The current implementation only emits source from the `src` field in `SourceFile`, but for multi-codegen-unit scenarios the source might only be available via the `external_src` field.

I've updated the LLVM and Cranelift backends to fall back to `external_src` if `src` is not available.

Minimal reproducer:
```console
$ cat Cargo.toml
[package]
name = "repro"
version = "0.0.1"
edition = "2021"
[profile.release]
strip = "none"
debug = true
$ cat src/lib.rs
// marker comment
pub fn foo() -> u64 { 42 }
$ cat src/main.rs
fn main() {
    println!("{}", repro::foo());
}
$ RUSTFLAGS="-g -Zembed-source=yes -Zdwarf-version=5" cargo build -r
   Compiling repro v0.0.1 (/tmp/repro)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.08s
$ # Note: Source for lib.rs is missing here:
$ llvm-dwarfdump --debug-line target/release/repro | grep "marker comment"
$ RUSTFLAGS="-g -Zembed-source=yes -Zdwarf-version=5" cargo +stage1 build -r
    Finished `release` profile [optimized + debuginfo] target(s) in 0.04s
$ llvm-dwarfdump --debug-line target/release/repro | grep "marker comment"
         source: "// marker comment\npub fn foo() -> u64 { 42 }\n"
```

Thanks!

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
