### PR TITLE
Allow to use `Diagnostic` directly in `SharedContext::emit_lint`

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_hir::attrs::{CrateType, WindowsSubsystemKind};
 use rustc_session::lint::builtin::UNKNOWN_CRATE_TYPES;
 use rustc_span::Symbol;
@@ -61,12 +60,8 @@ impl CombineAttributeParser for CrateTypeParser {
                 let span = n.value_span;
                 cx.emit_lint(
                     UNKNOWN_CRATE_TYPES,
-                    move |dcx, level| {
-                        UnknownCrateTypes {
-                            sugg: candidate
-                                .map(|s| UnknownCrateTypesSuggestion { span, snippet: s }),
-                        }
-                        .into_diag(dcx, level)
+                    UnknownCrateTypes {
+                        sugg: candidate.map(|s| UnknownCrateTypesSuggestion { span, snippet: s }),
                     },
                     span,
                 );

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_feature::{AttributeTemplate, template};
 use rustc_hir::Target;
 use rustc_hir::attrs::AttributeKind;
@@ -26,7 +25,7 @@ impl SingleAttributeParser for DoNotRecommendParser {
         if !matches!(args, ArgParser::NoArgs) {
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                |dcx, level| crate::errors::DoNotRecommendDoesNotExpectArgs.into_diag(dcx, level),
+                crate::errors::DoNotRecommendDoesNotExpectArgs,
                 attr_span,
             );
         }
@@ -35,9 +34,7 @@ impl SingleAttributeParser for DoNotRecommendParser {
             let target_span = cx.target_span;
             cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| {
-                    IncorrectDoNotRecommendLocation { target_span }.into_diag(dcx, level)
-                },
+                IncorrectDoNotRecommendLocation { target_span },
                 attr_span,
             );
             return None;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use rustc_errors::{Diagnostic, E0232};
+use rustc_errors::E0232;
 use rustc_hir::AttrPath;
 use rustc_hir::attrs::diagnostic::{
     Directive, FilterFormatString, Flag, FormatArg, FormatString, LitOrArg, Name, NameValue,
@@ -142,10 +142,7 @@ fn merge<T>(
             let first_span = *first_span;
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| {
-                    IgnoredDiagnosticOption { first_span, later_span, option_name }
-                        .into_diag(dcx, level)
-                },
+                IgnoredDiagnosticOption { first_span, later_span, option_name },
                 later_span,
             );
         }
@@ -169,19 +166,16 @@ fn parse_list<'p>(
             // if the user used non-metaitem syntax. See `ArgParser::from_attr_args`.
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| NonMetaItemDiagnosticAttribute.into_diag(dcx, level),
+                NonMetaItemDiagnosticAttribute,
                 list.span,
             );
         }
         ArgParser::NoArgs => {
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| {
-                    MissingOptionsForDiagnosticAttribute {
-                        attribute: mode.as_str(),
-                        options: mode.expected_options(),
-                    }
-                    .into_diag(dcx, level)
+                MissingOptionsForDiagnosticAttribute {
+                    attribute: mode.as_str(),
+                    options: mode.expected_options(),
                 },
                 span,
             );
@@ -189,13 +183,10 @@ fn parse_list<'p>(
         ArgParser::NameValue(_) => {
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| {
-                    MalFormedDiagnosticAttributeLint {
-                        attribute: mode.as_str(),
-                        options: mode.allowed_options(),
-                        span,
-                    }
-                    .into_diag(dcx, level)
+                MalFormedDiagnosticAttributeLint {
+                    attribute: mode.as_str(),
+                    options: mode.allowed_options(),
+                    span,
                 },
                 span,
             );
@@ -223,13 +214,10 @@ fn parse_directive_items<'p>(
         macro malformed() {{
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| {
-                    MalFormedDiagnosticAttributeLint {
-                        attribute: mode.as_str(),
-                        options: mode.allowed_options(),
-                        span,
-                    }
-                    .into_diag(dcx, level)
+                MalFormedDiagnosticAttributeLint {
+                    attribute: mode.as_str(),
+                    options: mode.allowed_options(),
+                    span,
                 },
                 span,
             );
@@ -251,11 +239,11 @@ fn parse_directive_items<'p>(
             let first_span = $($first_span)*;
             cx.emit_lint(
                 MALFORMED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| IgnoredDiagnosticOption {
+                IgnoredDiagnosticOption {
                     first_span,
                     later_span: span,
                     option_name: $name,
-                }.into_diag(dcx, level),
+                },
                 span,
             );
         }}
@@ -285,11 +273,7 @@ fn parse_directive_items<'p>(
                         | FormatWarning::PositionalArgument { span }
                         | FormatWarning::IndexedArgument { span }
                         | FormatWarning::DisallowedPlaceholder { span, .. }) = warning;
-                        cx.emit_lint(
-                            MALFORMED_DIAGNOSTIC_FORMAT_LITERALS,
-                            move |dcx, level| warning.into_diag(dcx, level),
-                            span,
-                        );
+                        cx.emit_lint(MALFORMED_DIAGNOSTIC_FORMAT_LITERALS, warning, span);
                     }
 
                     f
@@ -297,13 +281,10 @@ fn parse_directive_items<'p>(
                 Err(e) => {
                     cx.emit_lint(
                         MALFORMED_DIAGNOSTIC_FORMAT_LITERALS,
-                        move |dcx, level| {
-                            WrappedParserError {
-                                description: &e.description,
-                                label: &e.label,
-                                span: slice_span(input.span, e.span.clone(), is_snippet),
-                            }
-                            .into_diag(dcx, level)
+                        WrappedParserError {
+                            description: e.description,
+                            label: e.label,
+                            span: slice_span(input.span, e.span.clone(), is_snippet),
                         },
                         input.span,
                     );

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -30,9 +29,7 @@ impl AttributeParser for OnConstParser {
                 let target_span = cx.target_span;
                 cx.emit_lint(
                     MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                    move |dcx, level| {
-                        DiagnosticOnConstOnlyForTraitImpls { target_span }.into_diag(dcx, level)
-                    },
+                    DiagnosticOnConstOnlyForTraitImpls { target_span },
                     span,
                 );
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_feature::template;
 use rustc_hir::attrs::AttributeKind;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
@@ -28,11 +27,7 @@ impl OnMoveParser {
         self.span = Some(span);
 
         if !matches!(cx.target, Target::Enum | Target::Struct | Target::Union) {
-            cx.emit_lint(
-                MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| DiagnosticOnMoveOnlyForAdt.into_diag(dcx, level),
-                span,
-            );
+            cx.emit_lint(MISPLACED_DIAGNOSTIC_ATTRIBUTES, DiagnosticOnMoveOnlyForAdt, span);
             return;
         }
 

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -20,7 +19,7 @@ impl OnUnimplementedParser {
         if !matches!(cx.target, Target::Trait) {
             cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| DiagnosticOnUnimplementedOnlyForTraits.into_diag(dcx, level),
+                DiagnosticOnUnimplementedOnlyForTraits,
                 span,
             );
             return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -32,9 +31,7 @@ impl OnUnknownParser {
             let target_span = cx.target_span;
             cx.emit_lint(
                 MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                move |dcx, level| {
-                    DiagnosticOnUnknownOnlyForImports { target_span }.into_diag(dcx, level)
-                },
+                DiagnosticOnUnknownOnlyForImports { target_span },
                 span,
             );
             return;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -27,7 +26,7 @@ impl AttributeParser for OnUnmatchArgsParser {
             if !matches!(cx.target, Target::MacroDef) {
                 cx.emit_lint(
                     MISPLACED_DIAGNOSTIC_ATTRIBUTES,
-                    move |dcx, level| DiagnosticOnUnmatchArgsOnlyForMacros.into_diag(dcx, level),
+                    DiagnosticOnUnmatchArgsOnlyForMacros,
                     span,
                 );
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -1,5 +1,5 @@
 use rustc_ast::ast::{AttrStyle, LitKind, MetaItemLit};
-use rustc_errors::{Applicability, Diagnostic, msg};
+use rustc_errors::{Applicability, msg};
 use rustc_feature::template;
 use rustc_hir::Target;
 use rustc_hir::attrs::{
@@ -66,7 +66,7 @@ fn check_attr_crate_level(cx: &mut AcceptContext<'_, '_>, span: Span) -> bool {
     if cx.shared.target != Target::Crate {
         cx.emit_lint(
             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-            |dcx, level| AttrCrateLevelOnly.into_diag(dcx, level),
+            AttrCrateLevelOnly,
             span,
         );
         return false;
@@ -76,20 +76,12 @@ fn check_attr_crate_level(cx: &mut AcceptContext<'_, '_>, span: Span) -> bool {
 
 // FIXME: To be removed once merged and replace with `cx.expected_name_value(span, _name)`.
 fn expected_name_value(cx: &mut AcceptContext<'_, '_>, span: Span, _name: Option<Symbol>) {
-    cx.emit_lint(
-        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-        |dcx, level| ExpectedNameValue.into_diag(dcx, level),
-        span,
-    );
+    cx.emit_lint(rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES, ExpectedNameValue, span);
 }
 
 // FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
 fn expected_no_args(cx: &mut AcceptContext<'_, '_>, span: Span) {
-    cx.emit_lint(
-        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-        |dcx, level| ExpectedNoArgs.into_diag(dcx, level),
-        span,
-    );
+    cx.emit_lint(rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES, ExpectedNoArgs, span);
 }
 
 // FIXME: remove this method once merged and use `cx.expected_no_args(span)` instead.
@@ -99,11 +91,7 @@ fn expected_string_literal(
     span: Span,
     _actual_literal: Option<&MetaItemLit>,
 ) {
-    cx.emit_lint(
-        rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-        |dcx, level| MalformedDoc.into_diag(dcx, level),
-        span,
-    );
+    cx.emit_lint(rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES, MalformedDoc, span);
 }
 
 fn parse_keyword_and_attribute(
@@ -171,13 +159,10 @@ impl DocParser {
                     let unused_span = path.span();
                     cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                        move |dcx, level| {
-                            rustc_errors::lints::UnusedDuplicate {
-                                this: unused_span,
-                                other: used_span,
-                                warning: true,
-                            }
-                            .into_diag(dcx, level)
+                        rustc_errors::lints::UnusedDuplicate {
+                            this: unused_span,
+                            other: used_span,
+                            warning: true,
                         },
                         unused_span,
                     );
@@ -197,7 +182,7 @@ impl DocParser {
                     let span = cx.attr_span;
                     cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                        |dcx, level| MalformedDoc.into_diag(dcx, level),
+                        MalformedDoc,
                         span,
                     );
                     return;
@@ -211,14 +196,14 @@ impl DocParser {
             Some(name) => {
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| DocTestUnknown { name }.into_diag(dcx, level),
+                    DocTestUnknown { name },
                     path.span(),
                 );
             }
             None => {
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    |dcx, level| DocTestLiteral.into_diag(dcx, level),
+                    DocTestLiteral,
                     path.span(),
                 );
             }
@@ -250,7 +235,7 @@ impl DocParser {
         if let Some(first_definition) = self.attribute.aliases.get(&alias).copied() {
             cx.emit_lint(
                 rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
-                move |dcx, level| DocAliasDuplicated { first_definition }.into_diag(dcx, level),
+                DocAliasDuplicated { first_definition },
                 span,
             );
         }
@@ -338,7 +323,7 @@ impl DocParser {
                     let MetaItemOrLitParser::MetaItemParser(item) = meta else {
                         cx.emit_lint(
                             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                            |dcx, level| DocAutoCfgExpectsHideOrShow.into_diag(dcx, level),
+                            DocAutoCfgExpectsHideOrShow,
                             meta.span(),
                         );
                         continue;
@@ -349,7 +334,7 @@ impl DocParser {
                         _ => {
                             cx.emit_lint(
                                 rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                                |dcx, level| DocAutoCfgExpectsHideOrShow.into_diag(dcx, level),
+                                DocAutoCfgExpectsHideOrShow,
                                 item.span(),
                             );
                             continue;
@@ -358,9 +343,7 @@ impl DocParser {
                     let ArgParser::List(list) = item.args() else {
                         cx.emit_lint(
                             rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                            move |dcx, level| {
-                                DocAutoCfgHideShowExpectsList { attr_name }.into_diag(dcx, level)
-                            },
+                            DocAutoCfgHideShowExpectsList { attr_name },
                             item.span(),
                         );
                         continue;
@@ -372,10 +355,7 @@ impl DocParser {
                         let MetaItemOrLitParser::MetaItemParser(sub_item) = item else {
                             cx.emit_lint(
                                 rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                                move |dcx, level| {
-                                    DocAutoCfgHideShowUnexpectedItem { attr_name }
-                                        .into_diag(dcx, level)
-                                },
+                                DocAutoCfgHideShowUnexpectedItem { attr_name },
                                 item.span(),
                             );
                             continue;
@@ -388,7 +368,7 @@ impl DocParser {
                                     // cx.expected_identifier(sub_item.path().span());
                                     cx.emit_lint(
                                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                                        |dcx, level| MalformedDoc.into_diag(dcx, level),
+                                        MalformedDoc,
                                         sub_item.path().span(),
                                     );
                                     continue;
@@ -415,10 +395,7 @@ impl DocParser {
                             _ => {
                                 cx.emit_lint(
                                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                                    move |dcx, level| {
-                                        DocAutoCfgHideShowUnexpectedItem { attr_name }
-                                            .into_diag(dcx, level)
-                                    },
+                                    DocAutoCfgHideShowUnexpectedItem { attr_name },
                                     sub_item.span(),
                                 );
                                 continue;
@@ -433,7 +410,7 @@ impl DocParser {
                 else {
                     cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                        move |dcx, level| DocAutoCfgWrongLiteral.into_diag(dcx, level),
+                        DocAutoCfgWrongLiteral,
                         nv.value_span,
                     );
                     return;
@@ -573,7 +550,7 @@ impl DocParser {
                 let Some(list) = args.as_list() else {
                     cx.emit_lint(
                         rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                        |dcx, level| DocTestTakesList.into_diag(dcx, level),
+                        DocTestTakesList,
                         args.span().unwrap_or(path.span()),
                     );
                     return;
@@ -590,7 +567,7 @@ impl DocParser {
                             // cx.unexpected_literal(lit.span);
                             cx.emit_lint(
                                 rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                                |dcx, level| MalformedDoc.into_diag(dcx, level),
+                                MalformedDoc,
                                 lit.span,
                             );
                         }
@@ -601,7 +578,7 @@ impl DocParser {
                 let span = path.span();
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| DocUnknownSpotlight { sugg_span: span }.into_diag(dcx, level),
+                    DocUnknownSpotlight { sugg_span: span },
                     span,
                 );
             }
@@ -614,14 +591,7 @@ impl DocParser {
                 let span = path.span();
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| {
-                        DocUnknownInclude {
-                            inner,
-                            value,
-                            sugg: (span, Applicability::MaybeIncorrect),
-                        }
-                        .into_diag(dcx, level)
-                    },
+                    DocUnknownInclude { inner, value, sugg: (span, Applicability::MaybeIncorrect) },
                     span,
                 );
             }
@@ -629,9 +599,7 @@ impl DocParser {
                 let span = path.span();
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| {
-                        DocUnknownPasses { name, note_span: span }.into_diag(dcx, level)
-                    },
+                    DocUnknownPasses { name, note_span: span },
                     span,
                 );
             }
@@ -639,14 +607,14 @@ impl DocParser {
                 let span = path.span();
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| DocUnknownPlugins { label_span: span }.into_diag(dcx, level),
+                    DocUnknownPlugins { label_span: span },
                     span,
                 );
             }
             Some(name) => {
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| DocUnknownAny { name }.into_diag(dcx, level),
+                    DocUnknownAny { name },
                     path.span(),
                 );
             }
@@ -656,7 +624,7 @@ impl DocParser {
                 let name = Symbol::intern(&full_name);
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| DocUnknownAny { name }.into_diag(dcx, level),
+                    DocUnknownAny { name },
                     path.span(),
                 );
             }
@@ -670,9 +638,7 @@ impl DocParser {
                 let span = cx.attr_span;
                 cx.emit_lint(
                     rustc_session::lint::builtin::INVALID_DOC_ATTRIBUTES,
-                    move |dcx, level| {
-                        IllFormedAttributeInput::new(&suggestions, None, None).into_diag(dcx, level)
-                    },
+                    IllFormedAttributeInput::new(&suggestions, None, None),
                     span,
                 );
             }

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -1,4 +1,3 @@
-use rustc_errors::Diagnostic;
 use rustc_session::lint::builtin::AMBIGUOUS_DERIVE_HELPERS;
 
 use super::prelude::*;
@@ -124,7 +123,7 @@ fn parse_derive_like(
             if rustc_feature::is_builtin_attr_name(ident.name) {
                 cx.emit_lint(
                     AMBIGUOUS_DERIVE_HELPERS,
-                    |dcx, level| crate::errors::AmbiguousDeriveHelpers.into_diag(dcx, level),
+                    crate::errors::AmbiguousDeriveHelpers,
                     ident.span,
                 );
             }

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -371,23 +371,21 @@ impl<'f, 'sess: 'f> SharedContext<'f, 'sess> {
     /// Emit a lint. This method is somewhat special, since lints emitted during attribute parsing
     /// must be delayed until after HIR is built. This method will take care of the details of
     /// that.
-    pub(crate) fn emit_lint<
-        F: for<'a> Fn(DiagCtxtHandle<'a>, Level) -> Diag<'a, ()> + DynSend + DynSync + 'static,
-    >(
+    pub(crate) fn emit_lint(
         &mut self,
         lint: &'static Lint,
-        callback: F,
+        diagnostic: impl for<'x> Diagnostic<'x, ()> + DynSend + DynSync + 'static,
         span: impl Into<MultiSpan>,
     ) {
         self.emit_lint_inner(
             lint,
-            EmitAttribute(Box::new(move |dcx, level, _| callback(dcx, level))),
+            EmitAttribute(Box::new(move |dcx, level, _| diagnostic.into_diag(dcx, level))),
             span,
         );
     }
 
     pub(crate) fn emit_lint_with_sess<
-        F: for<'a> Fn(DiagCtxtHandle<'a>, Level, &Session) -> Diag<'a, ()>
+        F: for<'a> FnOnce(DiagCtxtHandle<'a>, Level, &Session) -> Diag<'a, ()>
             + DynSend
             + DynSync
             + 'static,
@@ -418,13 +416,10 @@ impl<'f, 'sess: 'f> SharedContext<'f, 'sess> {
     pub(crate) fn warn_unused_duplicate(&mut self, used_span: Span, unused_span: Span) {
         self.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
-            move |dcx, level| {
-                rustc_errors::lints::UnusedDuplicate {
-                    this: unused_span,
-                    other: used_span,
-                    warning: false,
-                }
-                .into_diag(dcx, level)
+            rustc_errors::lints::UnusedDuplicate {
+                this: unused_span,
+                other: used_span,
+                warning: false,
             },
             unused_span,
         )
@@ -437,13 +432,10 @@ impl<'f, 'sess: 'f> SharedContext<'f, 'sess> {
     ) {
         self.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
-            move |dcx, level| {
-                rustc_errors::lints::UnusedDuplicate {
-                    this: unused_span,
-                    other: used_span,
-                    warning: true,
-                }
-                .into_diag(dcx, level)
+            rustc_errors::lints::UnusedDuplicate {
+                this: unused_span,
+                other: used_span,
+                warning: true,
             },
             unused_span,
         )
@@ -967,14 +959,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
         let valid_without_list = self.template.word;
         self.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
-            move |dcx, level| {
-                crate::errors::EmptyAttributeList {
-                    attr_span: span,
-                    attr_path: &attr_path,
-                    valid_without_list,
-                }
-                .into_diag(dcx, level)
-            },
+            crate::errors::EmptyAttributeList { attr_span: span, attr_path, valid_without_list },
             span,
         );
     }
@@ -991,10 +976,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
         let span = self.attr_span;
         self.emit_lint(
             lint,
-            move |dcx, level| {
-                crate::errors::IllFormedAttributeInput::new(&suggestions, None, help.as_deref())
-                    .into_diag(dcx, level)
-            },
+            crate::errors::IllFormedAttributeInput::new(&suggestions, None, help.as_deref()),
             span,
         );
     }

--- a/compiler/rustc_attr_parsing/src/errors.rs
+++ b/compiler/rustc_attr_parsing/src/errors.rs
@@ -118,7 +118,7 @@ struct IllFormedAttributeInputHelp {
         *[other] using `{$attr_path}` with an empty list has no effect
     }"
 )]
-pub(crate) struct EmptyAttributeList<'a> {
+pub(crate) struct EmptyAttributeList {
     #[suggestion(
         "{$valid_without_list ->
             [true] remove these parentheses
@@ -128,7 +128,7 @@ pub(crate) struct EmptyAttributeList<'a> {
         applicability = "machine-applicable"
     )]
     pub attr_span: Span,
-    pub attr_path: &'a str,
+    pub attr_path: String,
     pub valid_without_list: bool,
 }
 
@@ -159,8 +159,8 @@ pub(crate) struct InvalidTargetLint {
         *[other] the `#![{$name}]` attribute can only be used at the crate root
     }"
 )]
-pub(crate) struct InvalidAttrStyle<'a> {
-    pub name: &'a str,
+pub(crate) struct InvalidAttrStyle {
+    pub name: String,
     pub is_used_as_inner: bool,
     #[note("this attribute does not have an `!`, which means it is applied to this {$target}")]
     pub target_span: Option<Span>,
@@ -359,11 +359,11 @@ pub(crate) struct MalFormedDiagnosticAttributeLint {
 
 #[derive(Diagnostic)]
 #[diag("{$description}")]
-pub(crate) struct WrappedParserError<'a> {
-    pub description: &'a str,
+pub(crate) struct WrappedParserError {
+    pub description: String,
     #[label("{$label}")]
     pub span: Span,
-    pub label: &'a str,
+    pub label: String,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -23,7 +23,7 @@ use crate::{OmitDoc, ShouldEmit};
 
 pub struct EmitAttribute(
     pub  Box<
-        dyn for<'a> Fn(DiagCtxtHandle<'a>, Level, &Session) -> Diag<'a, ()>
+        dyn for<'a> FnOnce(DiagCtxtHandle<'a>, Level, &Session) -> Diag<'a, ()>
             + DynSend
             + DynSync
             + 'static,

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -142,9 +142,9 @@ impl<'sess> AttributeParser<'sess> {
                 };
 
                 let attr_span = cx.attr_span;
-                cx.emit_lint(
+                cx.emit_lint_with_sess(
                     lint,
-                    move |dcx, level| {
+                    move |dcx, level, _| {
                         InvalidTargetLint {
                             name: name.to_string(),
                             target: target.plural_name(),
@@ -188,14 +188,11 @@ impl<'sess> AttributeParser<'sess> {
 
         cx.emit_lint(
             rustc_session::lint::builtin::UNUSED_ATTRIBUTES,
-            move |dcx, level| {
-                crate::errors::InvalidAttrStyle {
-                    name: &name,
-                    is_used_as_inner,
-                    target_span: (!is_used_as_inner).then_some(target_span),
-                    target: target.name(),
-                }
-                .into_diag(dcx, level)
+            crate::errors::InvalidAttrStyle {
+                name,
+                is_used_as_inner,
+                target_span: (!is_used_as_inner).then_some(target_span),
+                target: target.name(),
             },
             attr_span,
         );

--- a/compiler/rustc_hir/src/lints.rs
+++ b/compiler/rustc_hir/src/lints.rs
@@ -18,7 +18,7 @@ pub struct DelayedLint {
     pub id: HirId,
     pub span: MultiSpan,
     pub callback: Box<
-        dyn for<'a> Fn(DiagCtxtHandle<'a>, Level, &dyn std::any::Any) -> Diag<'a, ()>
+        dyn for<'a> FnOnce(DiagCtxtHandle<'a>, Level, &dyn std::any::Any) -> Diag<'a, ()>
             + DynSend
             + DynSync
             + 'static,

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1025,14 +1025,14 @@ pub fn create_and_enter_global_ctxt<T, F: for<'tcx> FnOnce(TyCtxt<'tcx>) -> T>(
     )
 }
 
-struct DiagCallback<'a, 'tcx> {
-    callback: &'a Box<
-        dyn for<'b> Fn(DiagCtxtHandle<'b>, Level, &dyn Any) -> Diag<'b, ()> + DynSend + DynSync,
+struct DiagCallback<'tcx> {
+    callback: Box<
+        dyn for<'b> FnOnce(DiagCtxtHandle<'b>, Level, &dyn Any) -> Diag<'b, ()> + DynSend + DynSync,
     >,
     tcx: TyCtxt<'tcx>,
 }
 
-impl<'a, 'b, 'tcx> Diagnostic<'a, ()> for DiagCallback<'b, 'tcx> {
+impl<'a, 'tcx> Diagnostic<'a, ()> for DiagCallback<'tcx> {
     fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
         (self.callback)(dcx, level, self.tcx.sess)
     }
@@ -1046,7 +1046,7 @@ pub fn emit_delayed_lints(tcx: TyCtxt<'_>) {
                     lint.lint_id.lint,
                     lint.id,
                     lint.span.clone(),
-                    DiagCallback { callback: &lint.callback, tcx },
+                    DiagCallback { callback: lint.callback, tcx },
                 );
             }
         }


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/153099.

r? @JonathanBrouwer 