### PR TITLE
Pass Session to optimize_and_codegen_fat_lto

### DIFF
--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -430,8 +430,8 @@ impl WriteBackendMethods for GccCodegenBackend {
     }
 
     fn optimize_and_codegen_fat_lto(
+        sess: &Session,
         cgcx: &CodegenContext,
-        prof: &SelfProfilerRef,
         shared_emitter: &SharedEmitter,
         _tm_factory: TargetMachineFactoryFn<Self>,
         // FIXME(bjorn3): Limit LTO exports to these symbols
@@ -439,7 +439,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         each_linked_rlib_for_lto: &[PathBuf],
         modules: Vec<FatLtoInput<Self>>,
     ) -> CompiledModule {
-        back::lto::run_fat(cgcx, prof, shared_emitter, each_linked_rlib_for_lto, modules)
+        back::lto::run_fat(cgcx, &sess.prof, shared_emitter, each_linked_rlib_for_lto, modules)
     }
 
     fn run_thin_lto(

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -133,8 +133,8 @@ impl WriteBackendMethods for LlvmCodegenBackend {
         back::write::target_machine_factory(sess, optlvl, target_features)
     }
     fn optimize_and_codegen_fat_lto(
+        sess: &Session,
         cgcx: &CodegenContext,
-        prof: &SelfProfilerRef,
         shared_emitter: &SharedEmitter,
         tm_factory: TargetMachineFactoryFn<LlvmCodegenBackend>,
         exported_symbols_for_lto: &[String],
@@ -143,7 +143,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     ) -> CompiledModule {
         let mut module = back::lto::run_fat(
             cgcx,
-            prof,
+            &sess.prof,
             shared_emitter,
             tm_factory,
             exported_symbols_for_lto,
@@ -153,9 +153,9 @@ impl WriteBackendMethods for LlvmCodegenBackend {
 
         let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
         let dcx = dcx.handle();
-        back::lto::run_pass_manager(cgcx, prof, dcx, &mut module, false);
+        back::lto::run_pass_manager(cgcx, &sess.prof, dcx, &mut module, false);
 
-        back::write::codegen(cgcx, prof, shared_emitter, module, &cgcx.module_config)
+        back::write::codegen(cgcx, &sess.prof, shared_emitter, module, &cgcx.module_config)
     }
     fn run_thin_lto(
         cgcx: &CodegenContext,

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -961,15 +961,15 @@ fn execute_copy_from_cache_work_item(
 }
 
 fn do_fat_lto<B: WriteBackendMethods>(
+    sess: &Session,
     cgcx: &CodegenContext,
-    prof: &SelfProfilerRef,
     shared_emitter: SharedEmitter,
     tm_factory: TargetMachineFactoryFn<B>,
     exported_symbols_for_lto: &[String],
     each_linked_rlib_for_lto: &[PathBuf],
     needs_fat_lto: Vec<FatLtoInput<B>>,
 ) -> CompiledModule {
-    let _timer = prof.verbose_generic_activity("LLVM_fatlto");
+    let _timer = sess.prof.verbose_generic_activity("LLVM_fatlto");
 
     let dcx = DiagCtxt::new(Box::new(shared_emitter.clone()));
     let dcx = dcx.handle();
@@ -977,8 +977,8 @@ fn do_fat_lto<B: WriteBackendMethods>(
     check_lto_allowed(&cgcx, dcx);
 
     B::optimize_and_codegen_fat_lto(
+        sess,
         cgcx,
-        prof,
         &shared_emitter,
         tm_factory,
         exported_symbols_for_lto,
@@ -2177,8 +2177,8 @@ impl<B: WriteBackendMethods> OngoingCodegen<B> {
 
                 CompiledModules {
                     modules: vec![do_fat_lto(
+                        sess,
                         &cgcx,
-                        &sess.prof,
                         shared_emitter,
                         tm_factory,
                         &exported_symbols_for_lto,

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -30,8 +30,8 @@ pub trait WriteBackendMethods: Clone + 'static {
     /// Performs fat LTO by merging all modules into a single one, running autodiff
     /// if necessary and running any further optimizations
     fn optimize_and_codegen_fat_lto(
+        sess: &Session,
         cgcx: &CodegenContext,
-        prof: &SelfProfilerRef,
         shared_emitter: &SharedEmitter,
         tm_factory: TargetMachineFactoryFn<Self>,
         exported_symbols_for_lto: &[String],


### PR DESCRIPTION
This is necessary to fix incremental LTO in cg_gcc as well as to do some LTO refactorings I want to do. The actual fix for cg_gcc will be done on the cg_gcc repo to test it in CI.