### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -217,12 +217,10 @@ fn create_mingw_dll_import_lib(
     // able to control the *exact* spelling of each of the symbols that are being imported:
     // hence we don't want `dlltool` adding leading underscores automatically.
     let dlltool = find_binutils_dlltool(sess);
-    let temp_prefix = {
-        let mut path = PathBuf::from(&output_path);
-        path.pop();
-        path.push(lib_name);
-        path
-    };
+    // temp_prefix doesn't handle paths with spaces so
+    // use a relative path and set the current working directory
+    let cwd = output_path.parent().unwrap_or(output_path);
+    let temp_prefix = lib_name;
     // dlltool target architecture args from:
     // https://github.com/llvm/llvm-project-release-prs/blob/llvmorg-15.0.6/llvm/lib/ToolDrivers/llvm-dlltool/DlltoolDriver.cpp#L69
     let (dlltool_target_arch, dlltool_target_bitness) = match &sess.target.arch {
@@ -246,7 +244,8 @@ fn create_mingw_dll_import_lib(
         .arg(dlltool_target_bitness)
         .arg("--no-leading-underscore")
         .arg("--temp-prefix")
-        .arg(temp_prefix);
+        .arg(temp_prefix)
+        .current_dir(cwd);
 
     match dlltool_cmd.output() {
         Err(e) => {

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -207,7 +207,7 @@ use prelude::rust_2024::*;
 #[macro_use]
 mod macros;
 
-#[stable(feature = "assert_matches", since = "1.95.0")]
+#[stable(feature = "assert_matches", since = "1.96.0")]
 pub use crate::macros::{assert_matches, debug_assert_matches};
 
 #[unstable(feature = "derive_from", issue = "144889")]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -168,7 +168,7 @@ macro_rules! assert_ne {
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semiopaque"]
 pub macro assert_matches {
-    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {{
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
@@ -179,8 +179,8 @@ pub macro assert_matches {
                 );
             }
         }
-    },
-    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )?, $($arg:tt)+) => {
+    }},
+    ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )?, $($arg:tt)+) => {{
         match $left {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
@@ -191,7 +191,7 @@ pub macro assert_matches {
                 );
             }
         }
-    },
+    }},
 }
 
 /// Selects code at compile-time based on `cfg` predicates.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -164,7 +164,7 @@ macro_rules! assert_ne {
 /// assert_matches!(a, Some(x) if x > 100);
 /// // assert_matches!(a, Some(x) if x < 100); // panics
 /// ```
-#[stable(feature = "assert_matches", since = "1.95.0")]
+#[stable(feature = "assert_matches", since = "1.96.0")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semiopaque"]
 pub macro assert_matches {
@@ -391,7 +391,7 @@ macro_rules! debug_assert_ne {
 /// debug_assert_matches!(a, Some(x) if x > 100);
 /// // debug_assert_matches!(a, Some(x) if x < 100); // panics
 /// ```
-#[stable(feature = "assert_matches", since = "1.95.0")]
+#[stable(feature = "assert_matches", since = "1.96.0")]
 #[allow_internal_unstable(assert_matches)]
 #[rustc_macro_transparency = "semiopaque"]
 pub macro debug_assert_matches($($arg:tt)*) {

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -1,5 +1,7 @@
 #![allow(unused_must_use)]
 
+use std::{assert_matches, debug_assert_matches};
+
 #[allow(dead_code)]
 trait Trait {
     fn blah(&self);
@@ -218,4 +220,25 @@ fn _expression() {
 fn _matches_does_not_trigger_non_exhaustive_omitted_patterns_lint(o: core::sync::atomic::Ordering) {
     // Ordering is a #[non_exhaustive] enum from a separate crate
     let _m = matches!(o, core::sync::atomic::Ordering::Relaxed);
+}
+
+struct MutRefWithDrop<'a>(&'a mut u32);
+
+// MutRefWithDrop needs to have a non-trivial drop to encounter potential lifetime issues if the
+// macros don't introduce a temporary scope.
+impl Drop for MutRefWithDrop<'_> {
+    fn drop(&mut self) {
+        *self.0 = u32::MAX;
+    }
+}
+
+#[test]
+fn temporary_scope_introduction() {
+    // Fails to compile if the macros don't introduce a temporary scope, since `&mut val` would
+    // create a second mutable borrow while `MutRefWithDrop` still holds a unique ref.
+    let mut val = 0;
+
+    (assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
+
+    (debug_assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
 }

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -236,9 +236,12 @@ impl Drop for MutRefWithDrop<'_> {
 fn temporary_scope_introduction() {
     // Fails to compile if the macros don't introduce a temporary scope, since `&mut val` would
     // create a second mutable borrow while `MutRefWithDrop` still holds a unique ref.
+    // See https://github.com/rust-lang/rust/issues/154406 for reference.
     let mut val = 0;
 
     (assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
+    (assert_matches!(*MutRefWithDrop(&mut val).0, 0, "msg"), std::mem::take(&mut val));
 
     (debug_assert_matches!(*MutRefWithDrop(&mut val).0, 0), std::mem::take(&mut val));
+    (debug_assert_matches!(*MutRefWithDrop(&mut val).0, 0, "msg"), std::mem::take(&mut val));
 }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -731,7 +731,7 @@ pub use core::{
     assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne, r#try, unimplemented,
     unreachable, write, writeln,
 };
-#[stable(feature = "assert_matches", since = "1.95.0")]
+#[stable(feature = "assert_matches", since = "1.96.0")]
 pub use core::{assert_matches, debug_assert_matches};
 
 // Re-export unstable derive macro defined through core.

--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -655,16 +655,6 @@ deleted once compilation finishes. It takes one of the following values:
 * `y`, `yes`, `on`, `true` or no value: save temporary files.
 * `n`, `no`, `off` or `false`: delete temporary files (the default).
 
-## soft-float
-
-This option controls whether `rustc` generates code that emulates floating
-point instructions in software. It takes one of the following values:
-
-* `y`, `yes`, `on`, `true` or no value: use soft floats.
-* `n`, `no`, `off` or `false`: use hardware floats (the default).
-
-This flag only works on `*eabihf` targets and **is unsound and deprecated**.
-
 ## split-debuginfo
 
 This option controls the emission of "split debuginfo" for debug information

--- a/tests/run-make/raw-dylib-custom-dlltool/script.cmd
+++ b/tests/run-make/raw-dylib-custom-dlltool/script.cmd
@@ -1,2 +1,2 @@
-echo Called dlltool via script.cmd> actual.txt
+echo Called dlltool via script.cmd> %~dp0\actual.txt
 dlltool.exe %*

--- a/tests/run-make/raw-dylib-whitespace/main.rs
+++ b/tests/run-make/raw-dylib-whitespace/main.rs
@@ -1,0 +1,18 @@
+type BOOL = i32;
+
+#[cfg_attr(
+    target_arch = "x86",
+    link(name = "bcryptprimitives", kind = "raw-dylib", import_name_type = "undecorated")
+)]
+#[cfg_attr(not(target_arch = "x86"), link(name = "bcryptprimitives", kind = "raw-dylib"))]
+extern "system" {
+    fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
+}
+
+fn main() {
+    let mut num: u8 = 0;
+    unsafe {
+        ProcessPrng(&mut num, 1);
+    }
+    println!("{num}");
+}

--- a/tests/run-make/raw-dylib-whitespace/rmake.rs
+++ b/tests/run-make/raw-dylib-whitespace/rmake.rs
@@ -1,0 +1,15 @@
+// Ensure that raw-dylib still works if the output directory contains spaces.
+
+//@ only-windows-gnu
+//@ ignore-cross-compile
+//@ needs-dlltool
+// Reason: this test specifically checks the dlltool feature,
+// which is only used on windows-gnu.
+
+use run_make_support::{rfs, rustc};
+
+fn main() {
+    let out_dir = std::path::absolute("path with spaces").unwrap();
+    rfs::create_dir_all(&out_dir);
+    rustc().crate_type("bin").input("main.rs").out_dir(&out_dir).env("TMP", &out_dir).run();
+}

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
@@ -7,7 +7,6 @@
 //@ normalize-stderr: "[^ ]*/foo.dll_imports.lib" -> "$$LIB_FILE"
 //@ normalize-stderr: "-m [^ ]*" -> "$$TARGET_MACHINE"
 //@ normalize-stderr: "-f [^ ]*" -> "$$ASM_FLAGS"
-//@ normalize-stderr: "--temp-prefix [^ ]*/foo.dll" -> "$$TEMP_PREFIX"
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {
     // `@1` is an invalid name to export, as it usually indicates that something

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.stderr
@@ -1,4 +1,4 @@
-error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore $TEMP_PREFIX:
+error: dlltool could not create import library with $DLLTOOL -d $DEF_FILE -D foo.dll -l $LIB_FILE $TARGET_MACHINE $ASM_FLAGS --no-leading-underscore --temp-prefix foo.dll:
        
        $DLLTOOL: Syntax error in def file $DEF_FILE:1␍
        


### PR DESCRIPTION
- Add temporary scope to assert_matches rust-lang/rust#155431
- fix: ✏️ forgot to change the stable version for `assert_matches!` macro. rust-lang/rust#155943
- codegen-options docs: remove -Csoft-float rust-lang/rust#155514
- `dlltool`: Set the working directory to workaround `--temp-prefix` bug rust-lang/rust#155899

r? cuviper
