### PR TITLE
tests: Fix cdylib-export-c-library-symbols to work with LTO-enabled CFLAGS

### DIFF
--- a/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
+++ b/tests/run-make/cdylib-export-c-library-symbols/rmake.rs
@@ -7,11 +7,12 @@
 //@ ignore-apple
 // Reason: the compiled binary is executed
 
-use run_make_support::{build_native_static_lib, cc, dynamic_lib_name, is_darwin, llvm_nm, rustc};
+use run_make_support::{cc, dynamic_lib_name, is_darwin, llvm_ar, llvm_nm, rustc, static_lib_name};
 
 fn main() {
-    cc().input("foo.c").arg("-c").out_exe("foo.o").run();
-    build_native_static_lib("foo");
+    // Compile C code without LTO
+    cc().input("foo.c").arg("-c").arg("-fno-lto").out_exe("foo.o").run();
+    llvm_ar().obj_to_ar().output_input(&static_lib_name("foo"), "foo.o").run();
 
     rustc().input("foo.rs").arg("-lstatic=foo").crate_type("cdylib").run();
 


### PR DESCRIPTION
The test fails on systems where default CFLAGS include LTO flags (e.g., `-flto=auto -ffat-lto-objects`), which is common in RHEL, Fedora, and CentOS distributions:
```
=== STDERR ===
error: failed to process C static library `foo`: LTO object in C static library is not supported
error: aborting due to 1 previous error
```

The issue occurs because `build_native_static_lib()` recompiles the C source using system CFLAGS, which may include LTO. When rustc tries to process this static library with the `+export-symbols` modifier, it correctly rejects it as LTO objects in C static libraries are not supported (see rust-lang/rust#150992).

Fix by manually compiling the C code passing `-fno-lto` to `cc()` to override system defaults, then using `llvm-ar()` directly to create the static library. This ensures the test validates the `+export-symbols` feature rather than LTO compatibility.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
