### PR TITLE
rustdoc: Fix cosmetic issues when reporting unresolved paths in `broken_intra_doc_links`

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -13,6 +13,7 @@
 #![feature(rustc_private)]
 #![feature(test)]
 #![feature(trim_prefix_suffix)]
+#![feature(variant_count)]
 #![recursion_limit = "256"]
 #![warn(rustc::internal)]
 // tidy-alphabetical-end

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2044,17 +2044,37 @@ fn resolution_failure(
 
                     // Check if _any_ parent of the path gets resolved.
                     // If so, report it and say the first which failed; if not, say the first path segment didn't resolve.
+                    // Also check if `path_str` is an invalid path.
+
+                    // Examples of `path_str` that are invalid:
+                    // - "std::::path", during splitting this would yield an empty segment
+                    // - "std:::path", this would eventually yield "std:"
+                    let mut path_is_invalid = false;
+                    let is_invalid_segment =
+                        |segment: &str| segment.is_empty() || segment.contains(':');
+
                     let mut name = path_str;
                     'outer: loop {
                         // FIXME(jynelson): this might conflict with my `Self` fix in #76467
                         let Some((start, end)) = name.rsplit_once("::") else {
                             // `name` is now the first path segment, which didn't resolve.
                             // avoid bug that marked [Quux::Z] as missing Z, not Quux
+                            if is_invalid_segment(name) {
+                                path_is_invalid = true;
+                                break;
+                            }
                             if partial_res.is_none() {
                                 *unresolved = name.into();
+                                // If `partial_res` somehow had a value, we preserve the original `unresolved`.
                             }
                             break;
                         };
+                        if is_invalid_segment(end) {
+                            // If any segment is invalid, stop and say so, instead of saying
+                            // "no item named ...", which would look nonsensical.
+                            path_is_invalid = true;
+                            break;
+                        }
                         for ns in [TypeNS, ValueNS, MacroNS] {
                             if let Ok(v_res) =
                                 collector.resolve(start, ns, None, item_id, module_id)
@@ -2067,10 +2087,10 @@ fn resolution_failure(
                                 }
                             }
                         }
-                        *unresolved = end.into();
                         if start.is_empty() && partial_res.is_none() {
                             // `start` being empty means `path_str` was written like "::path::to::item".
                             // In this case, `end` is the first path segment that we should report.
+                            *unresolved = end.into();
                             break;
                         }
                         name = start;
@@ -2083,7 +2103,9 @@ fn resolution_failure(
                     };
                     // See if this was a module: `[path]` or `[std::io::nope]`
                     if let Some(module) = last_found_module {
-                        let note = if partial_res.is_some() {
+                        let note = if path_is_invalid {
+                            "has invalid path separator".into()
+                        } else if partial_res.is_some() {
                             // Part of the link resolved; e.g. `std::io::nonexistent`
                             let module_name = tcx.item_name(module);
                             format!("no item named `{unresolved}` in module `{module_name}`")

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2105,7 +2105,7 @@ fn resolution_failure(
                     // See if this was a module: `[path]` or `[std::io::nope]`
                     if let Some(module) = last_found_module {
                         let note = if path_is_invalid {
-                            "has invalid path separator".into()
+                            "invalid path separator".into()
                         } else if partial_res.is_some() {
                             // Part of the link resolved; e.g. `std::io::nonexistent`
                             let module_name = tcx.item_name(module);
@@ -2340,7 +2340,7 @@ fn report_malformed_generics(
                     );
                     "fully-qualified syntax is unsupported"
                 }
-                MalformedGenerics::InvalidPathSeparator => "has invalid path separator",
+                MalformedGenerics::InvalidPathSeparator => "invalid path separator",
                 MalformedGenerics::TooManyAngleBrackets => "too many angle brackets",
                 MalformedGenerics::EmptyAngleBrackets => "empty angle brackets",
             };

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2022,7 +2022,8 @@ fn resolution_failure(
                 )
             };
             // ignore duplicates
-            let mut variants_seen = SmallVec::<[_; 3]>::new();
+            let mut variants_seen =
+                SmallVec::<[_; const { mem::variant_count::<ResolutionFailure<'_>>() }]>::new();
             for mut failure in kinds {
                 let variant = mem::discriminant(&failure);
                 if variants_seen.contains(&variant) {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2048,13 +2048,13 @@ fn resolution_failure(
                     'outer: loop {
                         // FIXME(jynelson): this might conflict with my `Self` fix in #76467
                         let Some((start, end)) = name.rsplit_once("::") else {
+                            // `name` is now the first path segment, which didn't resolve.
                             // avoid bug that marked [Quux::Z] as missing Z, not Quux
                             if partial_res.is_none() {
                                 *unresolved = name.into();
                             }
                             break;
                         };
-                        name = start;
                         for ns in [TypeNS, ValueNS, MacroNS] {
                             if let Ok(v_res) =
                                 collector.resolve(start, ns, None, item_id, module_id)
@@ -2068,6 +2068,12 @@ fn resolution_failure(
                             }
                         }
                         *unresolved = end.into();
+                        if start.is_empty() && partial_res.is_none() {
+                            // `start` being empty means `path_str` was written like "::path::to::item".
+                            // In this case, `end` is the first path segment that we should report.
+                            break;
+                        }
+                        name = start;
                     }
 
                     let last_found_module = match *partial_res {

--- a/tests/rustdoc-ui/intra-doc/global-path.rs
+++ b/tests/rustdoc-ui/intra-doc/global-path.rs
@@ -5,4 +5,7 @@
 
 /// [::Unresolved]
 //~^ WARN unresolved link to `::Unresolved`
+///
+/// [::std::unresolved]
+//~^ WARN unresolved link to `::std::unresolved`
 pub struct Item;

--- a/tests/rustdoc-ui/intra-doc/global-path.stderr
+++ b/tests/rustdoc-ui/intra-doc/global-path.stderr
@@ -2,9 +2,15 @@ warning: unresolved link to `::Unresolved`
   --> $DIR/global-path.rs:6:6
    |
 LL | /// [::Unresolved]
-   |      ^^^^^^^^^^^^ no item named `` in scope
+   |      ^^^^^^^^^^^^ no item named `Unresolved` in scope
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
 
-warning: 1 warning emitted
+warning: unresolved link to `::std::unresolved`
+  --> $DIR/global-path.rs:9:6
+   |
+LL | /// [::std::unresolved]
+   |      ^^^^^^^^^^^^^^^^^ no item named `unresolved` in module `std`
+
+warning: 2 warnings emitted
 

--- a/tests/rustdoc-ui/intra-doc/invalid-path-separator.rs
+++ b/tests/rustdoc-ui/intra-doc/invalid-path-separator.rs
@@ -1,0 +1,18 @@
+// This test shows that `broken_intra_doc_links` emits a more meaningful message when
+// it encounters a path that is unresolvable due to being invalid.
+#![deny(rustdoc::broken_intra_doc_links)]
+
+//! [std:path]
+//~^ ERROR
+//
+//! [std:::path]
+//~^ ERROR
+//
+//! [std::::path]
+//~^ ERROR
+//
+//! [std:::::path]
+//~^ ERROR
+//
+//! [std2::::path]
+//~^ ERROR

--- a/tests/rustdoc-ui/intra-doc/invalid-path-separator.stderr
+++ b/tests/rustdoc-ui/intra-doc/invalid-path-separator.stderr
@@ -2,7 +2,7 @@ error: unresolved link to `std:path`
   --> $DIR/invalid-path-separator.rs:5:6
    |
 LL | //! [std:path]
-   |      ^^^^^^^^ has invalid path separator
+   |      ^^^^^^^^ invalid path separator
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 note: the lint level is defined here
@@ -15,25 +15,25 @@ error: unresolved link to `std:::path`
   --> $DIR/invalid-path-separator.rs:8:6
    |
 LL | //! [std:::path]
-   |      ^^^^^^^^^^ has invalid path separator
+   |      ^^^^^^^^^^ invalid path separator
 
 error: unresolved link to `std::::path`
   --> $DIR/invalid-path-separator.rs:11:6
    |
 LL | //! [std::::path]
-   |      ^^^^^^^^^^^ has invalid path separator
+   |      ^^^^^^^^^^^ invalid path separator
 
 error: unresolved link to `std:::::path`
   --> $DIR/invalid-path-separator.rs:14:6
    |
 LL | //! [std:::::path]
-   |      ^^^^^^^^^^^^ has invalid path separator
+   |      ^^^^^^^^^^^^ invalid path separator
 
 error: unresolved link to `std2::::path`
   --> $DIR/invalid-path-separator.rs:17:6
    |
 LL | //! [std2::::path]
-   |      ^^^^^^^^^^^^ has invalid path separator
+   |      ^^^^^^^^^^^^ invalid path separator
 
 error: aborting due to 5 previous errors
 

--- a/tests/rustdoc-ui/intra-doc/invalid-path-separator.stderr
+++ b/tests/rustdoc-ui/intra-doc/invalid-path-separator.stderr
@@ -1,0 +1,39 @@
+error: unresolved link to `std:path`
+  --> $DIR/invalid-path-separator.rs:5:6
+   |
+LL | //! [std:path]
+   |      ^^^^^^^^ has invalid path separator
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+note: the lint level is defined here
+  --> $DIR/invalid-path-separator.rs:3:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unresolved link to `std:::path`
+  --> $DIR/invalid-path-separator.rs:8:6
+   |
+LL | //! [std:::path]
+   |      ^^^^^^^^^^ has invalid path separator
+
+error: unresolved link to `std::::path`
+  --> $DIR/invalid-path-separator.rs:11:6
+   |
+LL | //! [std::::path]
+   |      ^^^^^^^^^^^ has invalid path separator
+
+error: unresolved link to `std:::::path`
+  --> $DIR/invalid-path-separator.rs:14:6
+   |
+LL | //! [std:::::path]
+   |      ^^^^^^^^^^^^ has invalid path separator
+
+error: unresolved link to `std2::::path`
+  --> $DIR/invalid-path-separator.rs:17:6
+   |
+LL | //! [std2::::path]
+   |      ^^^^^^^^^^^^ has invalid path separator
+
+error: aborting due to 5 previous errors
+

--- a/tests/rustdoc-ui/intra-doc/malformed-generics.stderr
+++ b/tests/rustdoc-ui/intra-doc/malformed-generics.stderr
@@ -62,7 +62,7 @@ error: unresolved link to `Vec:<T>:new`
   --> $DIR/malformed-generics.rs:17:6
    |
 LL | //! [Vec:<T>:new()]
-   |      ^^^^^^^^^^^^^ has invalid path separator
+   |      ^^^^^^^^^^^^^ invalid path separator
 
 error: unresolved link to `Vec<<T>>`
   --> $DIR/malformed-generics.rs:19:6

--- a/tests/rustdoc-ui/intra-doc/malformed-paths.stderr
+++ b/tests/rustdoc-ui/intra-doc/malformed-paths.stderr
@@ -2,7 +2,7 @@ error: unresolved link to `Type::`
   --> $DIR/malformed-paths.rs:5:7
    |
 LL | //! [`Type::`]
-   |       ^^^^^^ has invalid path separator
+   |       ^^^^^^ invalid path separator
    |
 note: the lint level is defined here
   --> $DIR/malformed-paths.rs:2:9

--- a/tests/rustdoc-ui/intra-doc/malformed-paths.stderr
+++ b/tests/rustdoc-ui/intra-doc/malformed-paths.stderr
@@ -2,7 +2,7 @@ error: unresolved link to `Type::`
   --> $DIR/malformed-paths.rs:5:7
    |
 LL | //! [`Type::`]
-   |       ^^^^^^ the struct `Type` has no field or associated item named ``
+   |       ^^^^^^ has invalid path separator
    |
 note: the lint level is defined here
   --> $DIR/malformed-paths.rs:2:9

--- a/tests/rustdoc-ui/intra-doc/warning.stderr
+++ b/tests/rustdoc-ui/intra-doc/warning.stderr
@@ -40,7 +40,7 @@ warning: unresolved link to `Qux:Y`
   --> $DIR/warning.rs:14:13
    |
 LL |        /// [Qux:Y]
-   |             ^^^^^ no item named `Qux:Y` in scope
+   |             ^^^^^ has invalid path separator
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 

--- a/tests/rustdoc-ui/intra-doc/warning.stderr
+++ b/tests/rustdoc-ui/intra-doc/warning.stderr
@@ -40,7 +40,7 @@ warning: unresolved link to `Qux:Y`
   --> $DIR/warning.rs:14:13
    |
 LL |        /// [Qux:Y]
-   |             ^^^^^ has invalid path separator
+   |             ^^^^^ invalid path separator
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fix some minor issues with how the `rustdoc::broken_intra_doc_links` lint labels unresolved items:

- [`a469a4a`] For unresolved "extern prelude" links like `::unresolved::item`
  - Previously: ```no item named `` in scope```
  - Now: ```no item named `unresolved` in scope```
- [`eeb96fa`] Some malformed paths are now accounted for, for example:
  - `std:::path`
    - Previously: ```no item named `std:` in scope```
    - Now: `has invalid path separator`
  - `std::::path`
    - Previously: ```no item named `` in scope```
    - Now: `has invalid path separator`

This PR is broken down into a few commits with their own descriptions, which I hope makes reviewing easier!

Fixes rust-lang/rust#141095

[`a469a4a`]: https://github.com/rust-lang/rust/commit/a469a4ae638200c264c553e72204335e20d661a1
[`eeb96fa`]: https://github.com/rust-lang/rust/commit/eeb96fab7c7882dca4c48aa8b5817e4acbf0d7d2