### PR TITLE
`bufreader::Buffer`: Remove leftover note about `initialized` field

### DIFF
--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -23,9 +23,8 @@ pub struct Buffer {
     filled: usize,
     // Whether `buf` has been fully initialized. We track this so that we can accurately tell
     // `read_buf` how many bytes of buf are initialized, to bypass as much of its defensive
-    // initialization as possible. Note that while this often the same as `filled`, it doesn't need
-    // to be. Calls to `fill_buf` are not required to actually fill the buffer, and omitting this
-    // is a huge perf regression for `Read` impls that do not.
+    // initialization as possible. Calls to `fill_buf` are not required to actually fill the buffer,
+    // and omitting this is a huge perf regression for `Read` impls that do not.
     initialized: bool,
 }
 


### PR DESCRIPTION
Just a boring little doc fix! : v)

https://github.com/rust-lang/rust/pull/150129 reworked the `initialized` field to be a `bool` instead of a `usize`.
And then https://github.com/rust-lang/rust/pull/155314 reworked this field's comment (among other things).
But, there's still a leftover note in the comment, which no longer makes sense:
``Note that while this often the same as `filled`, it doesn't need to be.``
This is referencing that back when `initialized` was a `usize`, it was common for it to have the same value as `filled`.

----

Fun fact: there's a typo in the note too! It's missing an "is" before or after "often".