### PR TITLE
Add AcceptContext::expect_no_args

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
@@ -52,10 +52,7 @@ impl SingleAttributeParser for RustcAutodiffParser {
             cx.adcx().expected_identifier(mode.span());
             return None;
         };
-        let Ok(()) = mode.args().no_args() else {
-            cx.adcx().expected_identifier(mode.span());
-            return None;
-        };
+        cx.expect_no_args(mode.args())?;
         let Some(mode) = mode.path().word() else {
             cx.adcx().expected_identifier(mode.span());
             return None;
@@ -85,11 +82,7 @@ impl SingleAttributeParser for RustcAutodiffParser {
                     .expected_specific_argument(activity.span(), DiffActivity::all_activities());
                 return None;
             };
-            let Ok(()) = activity.args().no_args() else {
-                cx.adcx()
-                    .expected_specific_argument(activity.span(), DiffActivity::all_activities());
-                return None;
-            };
+            cx.expect_no_args(activity.args())?;
             let Some(activity) = activity.path().word() else {
                 cx.adcx()
                     .expected_specific_argument(activity.span(), DiffActivity::all_activities());

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -195,10 +195,9 @@ pub(crate) struct NakedParser {
 impl AttributeParser for NakedParser {
     const ATTRIBUTES: AcceptMapping<Self> =
         &[(&[sym::naked], template!(Word), |this, cx, args| {
-            if let Err(span) = args.no_args() {
-                cx.adcx().expected_no_args(span);
+            let Some(()) = cx.expect_no_args(args) else {
                 return;
-            }
+            };
 
             if let Some(earlier) = this.span {
                 let span = cx.attr_span;

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -299,11 +299,9 @@ impl CombineAttributeParser for FeatureParser {
                 cx.adcx().expected_identifier(elem.span());
                 continue;
             };
-            if let Err(arg_span) = elem.args().no_args() {
-                cx.adcx().expected_no_args(arg_span);
+            let Some(()) = cx.expect_no_args(elem.args()) else {
                 continue;
-            }
-
+            };
             let path = elem.path();
             let Some(ident) = path.word() else {
                 cx.adcx().expected_identifier(path.span());
@@ -345,10 +343,9 @@ impl CombineAttributeParser for RegisterToolParser {
                 cx.adcx().expected_identifier(elem.span());
                 continue;
             };
-            if let Err(arg_span) = elem.args().no_args() {
-                cx.adcx().expected_no_args(arg_span);
+            let Some(()) = cx.expect_no_args(elem.args()) else {
                 continue;
-            }
+            };
 
             let path = elem.path();
             let Some(ident) = path.word() else {

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -162,7 +162,7 @@ impl DocParser {
 
         match path.word_sym() {
             Some(sym::no_crate_inject) => {
-                if let Err(span) = args.no_args() {
+                if let Err(span) = args.as_no_args() {
                     expected_no_args(cx, span);
                     return;
                 }
@@ -295,7 +295,7 @@ impl DocParser {
         args: &ArgParser,
         inline: DocInline,
     ) {
-        if let Err(span) = args.no_args() {
+        if let Err(span) = args.as_no_args() {
             expected_no_args(cx, span);
             return;
         }
@@ -449,7 +449,7 @@ impl DocParser {
 
         macro_rules! no_args {
             ($ident: ident) => {{
-                if let Err(span) = args.no_args() {
+                if let Err(span) = args.as_no_args() {
                     expected_no_args(cx, span);
                     return;
                 }
@@ -468,7 +468,7 @@ impl DocParser {
         }
         macro_rules! no_args_and_not_crate_level {
             ($ident: ident) => {{
-                if let Err(span) = args.no_args() {
+                if let Err(span) = args.as_no_args() {
                     expected_no_args(cx, span);
                     return;
                 }
@@ -484,7 +484,7 @@ impl DocParser {
                 no_args_and_crate_level!($ident, |span| {});
             }};
             ($ident: ident, |$span:ident| $extra_validation:block) => {{
-                if let Err(span) = args.no_args() {
+                if let Err(span) = args.as_no_args() {
                     expected_no_args(cx, span);
                     return;
                 }

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -86,10 +86,9 @@ impl AttributeParser for MacroUseParser {
                                     cx.adcx().expected_identifier(item.span());
                                     continue;
                                 };
-                                if let Err(err_span) = item.args().no_args() {
-                                    cx.adcx().expected_no_args(err_span);
+                                let Some(()) = cx.expect_no_args(item.args()) else {
                                     continue;
-                                }
+                                };
                                 let Some(item) = item.path().word() else {
                                     cx.adcx().expected_identifier(item.span());
                                     continue;
@@ -179,9 +178,7 @@ impl SingleAttributeParser for CollapseDebugInfoParser {
             cx.adcx().expected_not_literal(single.span());
             return None;
         };
-        if let Err(err) = mi.args().no_args() {
-            cx.adcx().expected_no_args(err);
-        }
+        let _ = cx.expect_no_args(mi.args());
         let path = mi.path().word_sym();
         let info = match path {
             Some(sym::yes) => CollapseMacroDebuginfo::Yes,

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -258,9 +258,7 @@ impl<T: NoArgsAttributeParser> SingleAttributeParser for WithoutArgs<T> {
     const TEMPLATE: AttributeTemplate = template!(Word);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
-        if let Err(span) = args.no_args() {
-            cx.adcx().expected_no_args(span);
-        }
+        let _ = cx.expect_no_args(args);
         Some(T::CREATE(cx.attr_span))
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -59,7 +59,7 @@ fn parse_derive_like(
 ) -> Option<(Option<Symbol>, ThinVec<Symbol>)> {
     let Some(list) = args.as_list() else {
         // For #[rustc_builtin_macro], it is permitted to leave out the trait name
-        if args.no_args().is_ok() && !trait_name_mandatory {
+        if args.as_no_args().is_ok() && !trait_name_mandatory {
             return Some((None, ThinVec::new()));
         }
         let attr_span = cx.attr_span;
@@ -85,10 +85,7 @@ fn parse_derive_like(
         cx.adcx().expected_identifier(trait_ident.span);
         return None;
     }
-    if let Err(e) = trait_attr.args().no_args() {
-        cx.adcx().expected_no_args(e);
-        return None;
-    };
+    cx.expect_no_args(trait_attr.args())?;
 
     // Parse optional attributes
     let mut attributes = ThinVec::new();
@@ -109,10 +106,7 @@ fn parse_derive_like(
                 cx.adcx().expected_identifier(attr.span());
                 return None;
             };
-            if let Err(e) = attr.args().no_args() {
-                cx.adcx().expected_no_args(e);
-                return None;
-            };
+            cx.expect_no_args(attr.args())?;
             let Some(ident) = attr.path().word() else {
                 cx.adcx().expected_identifier(attr.path().span());
                 return None;

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -36,10 +36,7 @@ impl SingleAttributeParser for RustcDumpDefPathParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
-        if let Err(span) = args.no_args() {
-            cx.adcx().expected_no_args(span);
-            return None;
-        }
+        cx.expect_no_args(args)?;
         Some(AttributeKind::RustcDumpDefPath(cx.attr_span))
     }
 }
@@ -203,10 +200,7 @@ impl SingleAttributeParser for RustcDumpSymbolNameParser {
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
-        if let Err(span) = args.no_args() {
-            cx.adcx().expected_no_args(span);
-            return None;
-        }
+        cx.expect_no_args(args)?;
         Some(AttributeKind::RustcDumpSymbolName(cx.attr_span))
     }
 }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -555,7 +555,7 @@ impl SingleAttributeParser for RustcScalableVectorParser {
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
-        if args.no_args().is_ok() {
+        if args.as_no_args().is_ok() {
             return Some(AttributeKind::RustcScalableVector {
                 element_count: None,
                 span: cx.attr_span,

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -30,7 +30,7 @@ impl SingleAttributeParser for IgnoreParser {
                 ArgParser::List(list) => {
                     let help =
                         list.as_single().and_then(|item| item.meta_item()).and_then(|item| {
-                            item.args().no_args().ok()?;
+                            item.args().as_no_args().ok()?;
                             Some(item.path().to_string())
                         });
                     cx.adcx().warn_ill_formed_attribute_input_with_help(

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -27,9 +27,7 @@ impl SingleAttributeParser for RustcSkipDuringMethodDispatchParser {
                 cx.adcx().expected_not_literal(arg.span());
                 continue;
             };
-            if let Err(span) = arg.args().no_args() {
-                cx.adcx().expected_no_args(span);
-            }
+            let _ = cx.expect_no_args(arg.args());
             let path = arg.path();
             let (key, skip): (Symbol, &mut bool) = match path.word_sym() {
                 Some(key @ sym::array) => (key, &mut array),

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -570,6 +570,16 @@ impl<'f, 'sess: 'f> AcceptContext<'f, 'sess> {
     {
         arg.expect_name_value(self, span, name)
     }
+
+    /// Assert that an [`ArgParser`] has no args, or emits an error and return `None`.
+    pub(crate) fn expect_no_args<'arg>(&mut self, arg: &'arg ArgParser) -> Option<()> {
+        if let Err(span) = arg.as_no_args() {
+            self.adcx().expected_no_args(span);
+            return None;
+        }
+
+        Some(())
+    }
 }
 
 pub(crate) trait ExpectNameValue {

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -202,7 +202,7 @@ impl ArgParser {
     /// Assert that there were no args.
     /// If there were, get a span to the arguments
     /// (to pass to [`AttributeDiagnosticContext::expected_no_args`](crate::context::AttributeDiagnosticContext::expected_no_args)).
-    pub fn no_args(&self) -> Result<(), Span> {
+    pub fn as_no_args(&self) -> Result<(), Span> {
         match self {
             Self::NoArgs => Ok(()),
             Self::List(args) => Err(args.span),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This PR adds `AcceptContext::expect_no_args` that follows the same style as what was added in rust-lang/rust#155696 and rust-lang/rust#155831 (albeit much smaller this time).

- There is still one (1) usage of `AttributeDiagnosticContext::expected_no_args` in [`proc_macro_attrs:136`](https://github.com/rust-lang/rust/blob/0469a92a76c327df972cb6c1356934b7a0c6b86d/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs#L136) and I have no idea how to remove it. Any suggestion on what to replace this call with is welcome :)
- Some usages of `ArgParser::no_args` still remain in places where we emit custom errors. They show up in the diff due to the `no_args` -> `as_no_args` renaming.

I did a little experiment in which I made `AcceptContext::expect_no_args` unconditionally return `Some(())` so parsing always continues, but it led to lots of gibberish errors being emitted. Full diff for this is available here: [expect_no_args_experiment.patch](https://github.com/user-attachments/files/27271423/expect_no_args_experiment.patch). This means there's no simple way to get rid of the `let _ = cx.expect_no_args(/* ... */);` and I am not super happy with that.

<!-- homu-ignore:end -->


