### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
@@ -47,7 +47,8 @@ fn osstr_as_utf8_bytes(path: &OsStr) -> &[u8] {
 
 fn make_file_info(source_file: &SourceFile, embed_source: bool) -> Option<FileInfo> {
     let has_md5 = source_file.src_hash.kind == SourceFileHashAlgorithm::Md5;
-    let has_source = embed_source && source_file.src.is_some();
+    let has_source = embed_source
+        && (source_file.src.is_some() || source_file.external_src.read().get_source().is_some());
 
     if !has_md5 && !has_source {
         return None;
@@ -61,6 +62,8 @@ fn make_file_info(source_file: &SourceFile, embed_source: bool) -> Option<FileIn
 
     if embed_source {
         if let Some(src) = &source_file.src {
+            info.source = Some(LineString::String(src.as_bytes().to_vec()));
+        } else if let Some(src) = source_file.external_src.read().get_source() {
             info.source = Some(LineString::String(src.as_bytes().to_vec()));
         }
     }
@@ -79,19 +82,22 @@ impl DebugContext {
         let span = hygiene::walk_chain_collapsed(span, function_span);
         match tcx.sess.source_map().lookup_line(span.lo()) {
             Ok(SourceFileAndLine { sf: file, line }) => {
-                let file_id = self.add_source_file(&file);
+                let file_id = self.add_source_file(tcx, &file);
                 let line_pos = file.lines()[line];
                 let col = file.relative_position(span.lo()) - line_pos;
 
                 (file_id, u64::try_from(line).unwrap() + 1, u64::from(col.to_u32()) + 1)
             }
-            Err(file) => (self.add_source_file(&file), 0, 0),
+            Err(file) => (self.add_source_file(tcx, &file), 0, 0),
         }
     }
 
-    pub(crate) fn add_source_file(&mut self, source_file: &SourceFile) -> FileId {
+    pub(crate) fn add_source_file(&mut self, tcx: TyCtxt<'_>, source_file: &SourceFile) -> FileId {
         let cache_key = (source_file.stable_id, source_file.src_hash);
         *self.created_files.entry(cache_key).or_insert_with(|| {
+            if self.embed_source && source_file.src.is_none() {
+                tcx.sess.source_map().ensure_source_file_source_present(source_file);
+            }
             let line_program: &mut LineProgram = &mut self.dwarf.unit.line_program;
             let line_strings: &mut LineStringTable = &mut self.dwarf.line_strings;
 

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::{assert_matches, iter, ptr};
 
 use libc::{c_longlong, c_uint};
@@ -607,8 +606,16 @@ pub(crate) fn file_metadata<'ll>(cx: &CodegenCx<'ll, '_>, source_file: &SourceFi
         };
         let hash_value = hex_encode(source_file.src_hash.hash_bytes());
 
-        let source =
-            cx.sess().opts.unstable_opts.embed_source.then_some(()).and(source_file.src.as_ref());
+        let mut source = None;
+        let external_src;
+        if cx.sess().opts.unstable_opts.embed_source {
+            source = source_file.src.as_deref().map(String::as_str);
+            if source.is_none() {
+                cx.tcx.sess.source_map().ensure_source_file_source_present(source_file);
+                external_src = source_file.external_src.read();
+                source = external_src.get_source();
+            }
+        }
 
         create_file(DIB(cx), &file_name, &directory, &hash_value, hash_kind, source)
     }
@@ -626,7 +633,7 @@ fn create_file<'ll>(
     directory: &str,
     hash_value: &str,
     hash_kind: llvm::ChecksumKind,
-    source: Option<&Arc<String>>,
+    source: Option<&str>,
 ) -> &'ll DIFile {
     unsafe {
         llvm::LLVMRustDIBuilderCreateFile(

--- a/compiler/rustc_data_structures/src/graph/dominators/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/dominators/mod.rs
@@ -386,6 +386,24 @@ impl<Node: Idx> Dominators<Node> {
             }
         }
     }
+
+    /// Returns true if `a` **strictly** dominates `b`
+    ///
+    /// # Panics
+    ///
+    /// Panics if `b` is unreachable
+    #[inline]
+    pub fn strictly_dominates(&self, a: Node, b: Node) -> bool {
+        match &self.kind {
+            Kind::Path => a.index() < b.index(),
+            Kind::General(g) => {
+                let a = g.time[a];
+                let b = g.time[b];
+                assert!(b.start != 0, "node {b:?} is not reachable");
+                a.start < b.start && b.finish < a.finish
+            }
+        }
+    }
 }
 
 /// Describes the number of vertices discovered at the time when processing of a particular vertex

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2174,28 +2174,51 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // Case 2. Reference to a variant constructor.
             DefKind::Ctor(CtorOf::Variant, ..) | DefKind::Variant => {
                 let (generics_def_id, index) = if let Some(self_ty) = self_ty {
+                    // We have something like `<module::Enum>::Variant`.
+
                     let adt_def = self.probe_adt(span, self_ty).unwrap();
                     debug_assert!(adt_def.is_enum());
+
+                    // FIXME: Stating that the last segment (here: `Variant`) is allowed to have
+                    // generic args is a lie! We should set the index to `None` instead as it's
+                    // the *self type* that's allowed to have args.
+                    // HIR typeck's `instantiate_value_path` actually contains a special case to
+                    // reject args on `DefKind::Ctor` segments (see `is_alias_variant_ctor`).
+                    // Using `None` here for this should allow us to get rid of that workaround.
+                    //
+                    // (For additional context, `DefKind::Variant` segments never actually reach
+                    // this branch as they're interpreted as `TypeRelative` paths whose lowering
+                    // routines manually reject args on them).
+
                     (adt_def.did(), last)
-                } else if last >= 1 && segments[last - 1].args.is_some() {
-                    // Everything but the penultimate segment should have no
-                    // parameters at all.
-                    let mut def_id = def_id;
+                } else if let [.., second_to_last, _] = segments
+                    && second_to_last.args.is_some()
+                    && let Res::Def(DefKind::Enum, _) = second_to_last.res
+                {
+                    // We have something like `module::Enum::<…>::Variant`.
+                    // No segment other than the penultimate one is allowed to have generic args.
+
+                    // We had to check that the second to last segment actually referred to an enum
+                    // since at this stage it could very well refer to a module in which case we
+                    // certainly don't want to allow generic args on it!
 
                     // `DefKind::Ctor` -> `DefKind::Variant`
-                    if let DefKind::Ctor(..) = kind {
-                        def_id = tcx.parent(def_id);
-                    }
+                    let def_id = match kind {
+                        DefKind::Ctor(..) => tcx.parent(def_id),
+                        _ => def_id,
+                    };
 
                     // `DefKind::Variant` -> `DefKind::Enum`
                     let enum_def_id = tcx.parent(def_id);
+
                     (enum_def_id, last - 1)
                 } else {
+                    // We have something like `module::Enum::Variant` or `module::Variant`.
+                    // No segment other than the final one is allowed to have generic args.
+
                     // FIXME: lint here recommending `Enum::<...>::Variant` form
                     // instead of `Enum::Variant::<...>` form.
 
-                    // Everything but the final segment should have no
-                    // parameters at all.
                     let generics = tcx.generics_of(def_id);
                     // Variant and struct constructors use the
                     // generics of their parent type definition.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1609,6 +1609,11 @@ impl Location {
             dominators.dominates(self.block, other.block)
         }
     }
+
+    #[inline]
+    pub fn strictly_dominates(&self, other: Location, dominators: &Dominators<BasicBlock>) -> bool {
+        self.block != other.block && dominators.strictly_dominates(self.block, other.block)
+    }
 }
 
 /// `DefLocation` represents the location of a definition - either an argument or an assignment

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -600,6 +600,12 @@ impl From<Local> for PlaceRef<'_> {
     }
 }
 
+/// Checks whether reading `src` while assigning to `dest` would violate MIR's
+/// non-overlap requirement for assignments.
+pub fn places_conflict_for_assignment<'tcx>(dest: Place<'tcx>, src: Place<'tcx>) -> bool {
+    dest == src || (dest.local == src.local && !dest.is_indirect() && !src.is_indirect())
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Operands
 

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -600,12 +600,6 @@ impl From<Local> for PlaceRef<'_> {
     }
 }
 
-/// Checks whether reading `src` while assigning to `dest` would violate MIR's
-/// non-overlap requirement for assignments.
-pub fn places_conflict_for_assignment<'tcx>(dest: Place<'tcx>, src: Place<'tcx>) -> bool {
-    dest == src || (dest.local == src.local && !dest.is_indirect() && !src.is_indirect())
-}
-
 ///////////////////////////////////////////////////////////////////////////
 // Operands
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -539,14 +539,14 @@ pub struct FreeRegionInfo {
 
 /// This struct should only be created by `create_def`.
 #[derive(Copy, Clone)]
-pub struct TyCtxtFeed<'tcx, KEY: Copy> {
+pub struct TyCtxtFeed<'tcx, K: Copy> {
     pub tcx: TyCtxt<'tcx>,
     // Do not allow direct access, as downstream code must not mutate this field.
-    key: KEY,
+    key: K,
 }
 
 /// Only queries that create a `DefId` are allowed to feed queries for that `DefId`.
-impl<KEY: Copy> !HashStable for TyCtxtFeed<'_, KEY> {}
+impl<K: Copy> !HashStable for TyCtxtFeed<'_, K> {}
 
 /// Some workarounds to use cases that cannot use `create_def`.
 /// Do not add new ways to create `TyCtxtFeed` without consulting
@@ -600,9 +600,9 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 }
 
-impl<'tcx, KEY: Copy> TyCtxtFeed<'tcx, KEY> {
+impl<'tcx, K: Copy> TyCtxtFeed<'tcx, K> {
     #[inline(always)]
-    pub fn key(&self) -> KEY {
+    pub fn key(&self) -> K {
         self.key
     }
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use std::env::VarError;
 use std::ffi::OsStr;
 use std::hash::{Hash, Hasher};
-use std::marker::{PhantomData, PointeeSized};
+use std::marker::PointeeSized;
 use std::ops::{Bound, Deref};
 use std::sync::{Arc, OnceLock};
 use std::{fmt, iter, mem};
@@ -545,30 +545,8 @@ pub struct TyCtxtFeed<'tcx, KEY: Copy> {
     key: KEY,
 }
 
-/// Never return a `Feed` from a query. Only queries that create a `DefId` are
-/// allowed to feed queries for that `DefId`.
+/// Only queries that create a `DefId` are allowed to feed queries for that `DefId`.
 impl<KEY: Copy> !HashStable for TyCtxtFeed<'_, KEY> {}
-
-/// The same as `TyCtxtFeed`, but does not contain a `TyCtxt`.
-/// Use this to pass around when you have a `TyCtxt` elsewhere.
-/// Just an optimization to save space and not store hundreds of
-/// `TyCtxtFeed` in the resolver.
-#[derive(Copy, Clone)]
-pub struct Feed<'tcx, KEY: Copy> {
-    _tcx: PhantomData<TyCtxt<'tcx>>,
-    // Do not allow direct access, as downstream code must not mutate this field.
-    key: KEY,
-}
-
-/// Never return a `Feed` from a query. Only queries that create a `DefId` are
-/// allowed to feed queries for that `DefId`.
-impl<KEY: Copy> !HashStable for Feed<'_, KEY> {}
-
-impl<T: fmt::Debug + Copy> fmt::Debug for Feed<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.key.fmt(f)
-    }
-}
 
 /// Some workarounds to use cases that cannot use `create_def`.
 /// Do not add new ways to create `TyCtxtFeed` without consulting
@@ -626,23 +604,6 @@ impl<'tcx, KEY: Copy> TyCtxtFeed<'tcx, KEY> {
     #[inline(always)]
     pub fn key(&self) -> KEY {
         self.key
-    }
-
-    #[inline(always)]
-    pub fn downgrade(self) -> Feed<'tcx, KEY> {
-        Feed { _tcx: PhantomData, key: self.key }
-    }
-}
-
-impl<'tcx, KEY: Copy> Feed<'tcx, KEY> {
-    #[inline(always)]
-    pub fn key(&self) -> KEY {
-        self.key
-    }
-
-    #[inline(always)]
-    pub fn upgrade(self, tcx: TyCtxt<'tcx>) -> TyCtxtFeed<'tcx, KEY> {
-        TyCtxtFeed { tcx, key: self.key }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -83,7 +83,7 @@ pub use self::consts::{
     const_lit_matches_ty,
 };
 pub use self::context::{
-    CtxtInterners, CurrentGcx, Feed, FreeRegionInfo, GlobalCtxt, Lift, TyCtxt, TyCtxtFeed, tls,
+    CtxtInterners, CurrentGcx, FreeRegionInfo, GlobalCtxt, Lift, TyCtxt, TyCtxtFeed, tls,
 };
 pub use self::fold::*;
 pub use self::instance::{Instance, InstanceKind, ReifyReason};

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -326,36 +326,61 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     );
 
                     let state_place = scrutinee_place_builder.to_place(this);
+                    let state_result = this.temp(state_ty, expr_span);
+                    let state_result_place = Place::from(state_result);
 
                     // This is logic for the labeled block: a block is a drop scope, hence
                     // `in_scope`, and a labeled block can be broken out of with a `break 'label`,
                     // hence the `in_breakable_scope`.
                     //
+                    // The state update is still modeled like `state = 'blk: { ... }`: normal
+                    // match arm results and ordinary breaks to the block are first written to
+                    // `state_result_place`, then written back to `state_place`. This avoids
+                    // building an overlapping assignment like `state = state`.
+                    //
                     // Then `in_const_continuable_scope` stores information for the lowering of
-                    // `#[const_continue]`, and finally the match is lowered in the standard way.
+                    // `#[const_continue]`, which still updates the actual `state_place` directly
+                    // so it can jump to the statically known next match branch.
                     unpack!(
                         body_block = this.in_scope(
                             (region_scope, source_info),
                             LintLevel::Inherited,
                             move |this| {
-                                this.in_breakable_scope(None, state_place, expr_span, |this| {
-                                    Some(this.in_const_continuable_scope(
-                                        Box::from(arms),
-                                        built_tree.clone(),
-                                        state_place,
-                                        expr_span,
-                                        |this| {
-                                            this.lower_match_arms(
-                                                state_place,
-                                                scrutinee_place_builder,
-                                                scrutinee_span,
-                                                arms,
-                                                built_tree,
-                                                this.source_info(match_span),
+                                this.in_const_continuable_scope(
+                                    Box::from(arms),
+                                    built_tree.clone(),
+                                    state_place,
+                                    expr_span,
+                                    |this| {
+                                        let block = this
+                                            .in_breakable_scope(
+                                                None,
+                                                state_result_place,
+                                                expr_span,
+                                                |this| {
+                                                    Some(this.lower_match_arms(
+                                                        state_result_place,
+                                                        scrutinee_place_builder,
+                                                        scrutinee_span,
+                                                        arms,
+                                                        built_tree,
+                                                        this.source_info(match_span),
+                                                    ))
+                                                },
                                             )
-                                        },
-                                    ))
-                                })
+                                            .into_block();
+
+                                        this.cfg.push_assign(
+                                            block,
+                                            source_info,
+                                            state_place,
+                                            Rvalue::Use(
+                                                this.consume_by_copy_or_move(state_result_place),
+                                            ),
+                                        );
+                                        block.unit()
+                                    },
+                                )
                             }
                         )
                     );
@@ -812,19 +837,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 debug_assert!(Category::of(&expr.kind) == Some(Category::Place));
 
                 let place = unpack!(block = this.as_place(block, expr_id));
-                let operand = if places_conflict_for_assignment(destination, place) {
-                    let temp = this.temp(expr.ty, expr_span);
-                    this.cfg.push_assign(
-                        block,
-                        source_info,
-                        temp,
-                        Rvalue::Use(this.consume_by_copy_or_move(place)),
-                    );
-                    this.consume_by_copy_or_move(temp)
-                } else {
-                    this.consume_by_copy_or_move(place)
-                };
-                let rvalue = Rvalue::Use(operand);
+                let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place));
                 this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
             }

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -812,7 +812,19 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 debug_assert!(Category::of(&expr.kind) == Some(Category::Place));
 
                 let place = unpack!(block = this.as_place(block, expr_id));
-                let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place));
+                let operand = if places_conflict_for_assignment(destination, place) {
+                    let temp = this.temp(expr.ty, expr_span);
+                    this.cfg.push_assign(
+                        block,
+                        source_info,
+                        temp,
+                        Rvalue::Use(this.consume_by_copy_or_move(place)),
+                    );
+                    this.consume_by_copy_or_move(temp)
+                } else {
+                    this.consume_by_copy_or_move(place)
+                };
+                let rvalue = Rvalue::Use(operand);
                 this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
             }

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -76,6 +76,14 @@ const MAX_COST: u8 = 100;
 
 impl<'tcx> crate::MirPass<'tcx> for JumpThreading {
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        if sess.target.is_like_gpu {
+            // Jump threading can duplicate calls in control-flow.
+            // This leads to incorrect code when done for so called "convergent" operations on GPU
+            // targets, similar to how inline assembly cannot be duplicated on all targets.
+            // Conservatively prevent this by disabling the pass.
+            // See also issue #137086.
+            return false;
+        }
         sess.mir_opt_level() >= 2
     }
 

--- a/compiler/rustc_mir_transform/src/lint.rs
+++ b/compiler/rustc_mir_transform/src/lint.rs
@@ -66,6 +66,12 @@ impl<'a, 'tcx> Lint<'a, 'tcx> {
     }
 }
 
+/// Checks whether reading `src` while assigning to `dest` would violate MIR's
+/// non-overlap requirement for assignments.
+fn places_conflict_for_assignment<'tcx>(dest: Place<'tcx>, src: Place<'tcx>) -> bool {
+    dest == src || (dest.local == src.local && !dest.is_indirect() && !src.is_indirect())
+}
+
 impl<'a, 'tcx> Visitor<'tcx> for Lint<'a, 'tcx> {
     fn visit_local(&mut self, local: Local, context: PlaceContext, location: Location) {
         if context.is_use() {

--- a/compiler/rustc_mir_transform/src/lint.rs
+++ b/compiler/rustc_mir_transform/src/lint.rs
@@ -96,11 +96,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Lint<'a, 'tcx> {
                 // The sides of an assignment must not alias.
                 if forbid_aliasing {
                     VisitPlacesWith(|src: Place<'tcx>, _| {
-                        if *dest == src
-                            || (dest.local == src.local
-                                && !dest.is_indirect()
-                                && !src.is_indirect())
-                        {
+                        if places_conflict_for_assignment(*dest, src) {
                             self.fail(
                                 location,
                                 format!(

--- a/compiler/rustc_mir_transform/src/ssa_range_prop.rs
+++ b/compiler/rustc_mir_transform/src/ssa_range_prop.rs
@@ -163,8 +163,7 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
                     && self.is_ssa(place) =>
             {
                 let successor = Location { block: *target, statement_index: 0 };
-                if location.dominates(successor, &self.dominators) {
-                    assert_ne!(location.block, successor.block);
+                if location.strictly_dominates(successor, &self.dominators) {
                     let val = *expected as u128;
                     let range = WrappingRange { start: val, end: val };
                     self.insert_range(place, successor, range);

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -115,7 +115,7 @@ pub(crate) fn lex_token_trees<'psess, 'src>(
         Err(errs) => {
             // We emit delimiter mismatch errors first, then emit the unclosing delimiter mismatch
             // because the delimiter mismatch is more likely to be the root cause of error
-            unmatched_closing_delims.extend(errs);
+            unmatched_closing_delims.push(errs);
             Err(unmatched_closing_delims)
         }
     }

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -14,7 +14,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
     pub(super) fn lex_token_trees(
         &mut self,
         is_delimited: bool,
-    ) -> Result<(Spacing, TokenStream), Vec<Diag<'psess>>> {
+    ) -> Result<(Spacing, TokenStream), Diag<'psess>> {
         // Move past the opening delimiter.
         let open_spacing = self.bump_minimal();
 
@@ -35,11 +35,11 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                 return if is_delimited {
                     Ok((open_spacing, TokenStream::new(buf)))
                 } else {
-                    Err(vec![self.close_delim_err(delim)])
+                    Err(self.close_delim_err(delim))
                 };
             } else if self.token.kind == token::Eof {
                 return if is_delimited {
-                    Err(vec![self.eof_err()])
+                    Err(self.eof_err())
                 } else {
                     Ok((open_spacing, TokenStream::new(buf)))
                 };
@@ -54,7 +54,7 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
     fn lex_token_tree_open_delim(
         &mut self,
         open_delim: Delimiter,
-    ) -> Result<TokenTree, Vec<Diag<'psess>>> {
+    ) -> Result<TokenTree, Diag<'psess>> {
         // The span for beginning of the delimited section.
         let pre_span = self.token.span;
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -35,9 +35,10 @@ use crate::imports::{ImportData, ImportKind, OnUnknownData};
 use crate::macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
 use crate::ref_mut::CmCell;
 use crate::{
-    BindingKey, Decl, DeclData, DeclKind, ExternModule, ExternPreludeEntry, Finalize, IdentKey,
-    LocalModule, MacroData, Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, Res,
-    Resolver, Segment, Used, VisResolutionError, errors,
+    BindingKey, Decl, DeclData, DeclKind, DelayedVisResolutionError, ExternModule,
+    ExternPreludeEntry, Finalize, IdentKey, LocalModule, MacroData, Module, ModuleKind,
+    ModuleOrUniformRoot, ParentScope, PathResult, Res, Resolver, Segment, Used, VisResolutionError,
+    errors,
 };
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
@@ -235,6 +236,111 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
+    pub(crate) fn try_resolve_visibility(
+        &mut self,
+        parent_scope: &ParentScope<'ra>,
+        vis: &ast::Visibility,
+        finalize: bool,
+    ) -> Result<Visibility, VisResolutionError> {
+        match vis.kind {
+            ast::VisibilityKind::Public => Ok(Visibility::Public),
+            ast::VisibilityKind::Inherited => {
+                Ok(match parent_scope.module.kind {
+                    // Any inherited visibility resolved directly inside an enum or trait
+                    // (i.e. variants, fields, and trait items) inherits from the visibility
+                    // of the enum or trait.
+                    ModuleKind::Def(DefKind::Enum | DefKind::Trait, def_id, _) => {
+                        self.tcx.visibility(def_id).expect_local()
+                    }
+                    // Otherwise, the visibility is restricted to the nearest parent `mod` item.
+                    _ => Visibility::Restricted(
+                        parent_scope.module.nearest_parent_mod().expect_local(),
+                    ),
+                })
+            }
+            ast::VisibilityKind::Restricted { ref path, id, .. } => {
+                // For visibilities we are not ready to provide correct implementation of "uniform
+                // paths" right now, so on 2018 edition we only allow module-relative paths for now.
+                // On 2015 edition visibilities are resolved as crate-relative by default,
+                // so we are prepending a root segment if necessary.
+                let ident = path.segments.get(0).expect("empty path in visibility").ident;
+                let crate_root = if ident.is_path_segment_keyword() {
+                    None
+                } else if ident.span.is_rust_2015() {
+                    Some(Segment::from_ident(Ident::new(
+                        kw::PathRoot,
+                        path.span.shrink_to_lo().with_ctxt(ident.span.ctxt()),
+                    )))
+                } else {
+                    return Err(VisResolutionError::Relative2018(
+                        ident.span,
+                        path.as_ref().clone(),
+                    ));
+                };
+                let segments = crate_root
+                    .into_iter()
+                    .chain(path.segments.iter().map(|seg| seg.into()))
+                    .collect::<Vec<_>>();
+                let expected_found_error = |res| {
+                    Err(VisResolutionError::ExpectedFound(
+                        path.span,
+                        Segment::names_to_string(&segments),
+                        res,
+                    ))
+                };
+                match self.cm().resolve_path(
+                    &segments,
+                    None,
+                    parent_scope,
+                    finalize.then(|| Finalize::new(id, path.span)),
+                    None,
+                    None,
+                ) {
+                    PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
+                        let res = module.res().expect("visibility resolved to unnamed block");
+                        if module.is_normal() {
+                            match res {
+                                Res::Err => {
+                                    if finalize {
+                                        self.record_partial_res(id, PartialRes::new(res));
+                                    }
+                                    Ok(Visibility::Public)
+                                }
+                                _ => {
+                                    let vis = Visibility::Restricted(res.def_id());
+                                    if self.is_accessible_from(vis, parent_scope.module) {
+                                        if finalize {
+                                            self.record_partial_res(id, PartialRes::new(res));
+                                        }
+                                        Ok(vis.expect_local())
+                                    } else {
+                                        Err(VisResolutionError::AncestorOnly(path.span))
+                                    }
+                                }
+                            }
+                        } else {
+                            expected_found_error(res)
+                        }
+                    }
+                    PathResult::Module(..) => Err(VisResolutionError::ModuleOnly(path.span)),
+                    PathResult::NonModule(partial_res) => {
+                        expected_found_error(partial_res.expect_full_res())
+                    }
+                    PathResult::Failed {
+                        span, label, suggestion, message, segment_name, ..
+                    } => Err(VisResolutionError::FailedToResolve(
+                        span,
+                        segment_name,
+                        label,
+                        suggestion,
+                        message,
+                    )),
+                    PathResult::Indeterminate => Err(VisResolutionError::Indeterminate(path.span)),
+                }
+            }
+        }
+    }
+
     pub(crate) fn build_reduced_graph_external(&self, module: ExternModule<'ra>) {
         let def_id = module.def_id();
         let children = self.tcx.module_children(def_id);
@@ -362,106 +468,15 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     }
 
     fn resolve_visibility(&mut self, vis: &ast::Visibility) -> Visibility {
-        self.try_resolve_visibility(vis, true).unwrap_or_else(|err| {
-            self.r.report_vis_error(err);
-            Visibility::Public
-        })
-    }
-
-    fn try_resolve_visibility<'ast>(
-        &mut self,
-        vis: &'ast ast::Visibility,
-        finalize: bool,
-    ) -> Result<Visibility, VisResolutionError<'ast>> {
-        let parent_scope = &self.parent_scope;
-        match vis.kind {
-            ast::VisibilityKind::Public => Ok(Visibility::Public),
-            ast::VisibilityKind::Inherited => {
-                Ok(match self.parent_scope.module.kind {
-                    // Any inherited visibility resolved directly inside an enum or trait
-                    // (i.e. variants, fields, and trait items) inherits from the visibility
-                    // of the enum or trait.
-                    ModuleKind::Def(DefKind::Enum | DefKind::Trait, def_id, _) => {
-                        self.r.tcx.visibility(def_id).expect_local()
-                    }
-                    // Otherwise, the visibility is restricted to the nearest parent `mod` item.
-                    _ => Visibility::Restricted(
-                        self.parent_scope.module.nearest_parent_mod().expect_local(),
-                    ),
-                })
-            }
-            ast::VisibilityKind::Restricted { ref path, id, .. } => {
-                // For visibilities we are not ready to provide correct implementation of "uniform
-                // paths" right now, so on 2018 edition we only allow module-relative paths for now.
-                // On 2015 edition visibilities are resolved as crate-relative by default,
-                // so we are prepending a root segment if necessary.
-                let ident = path.segments.get(0).expect("empty path in visibility").ident;
-                let crate_root = if ident.is_path_segment_keyword() {
-                    None
-                } else if ident.span.is_rust_2015() {
-                    Some(Segment::from_ident(Ident::new(
-                        kw::PathRoot,
-                        path.span.shrink_to_lo().with_ctxt(ident.span.ctxt()),
-                    )))
-                } else {
-                    return Err(VisResolutionError::Relative2018(ident.span, path));
-                };
-
-                let segments = crate_root
-                    .into_iter()
-                    .chain(path.segments.iter().map(|seg| seg.into()))
-                    .collect::<Vec<_>>();
-                let expected_found_error = |res| {
-                    Err(VisResolutionError::ExpectedFound(
-                        path.span,
-                        Segment::names_to_string(&segments),
-                        res,
-                    ))
-                };
-                match self.r.cm().resolve_path(
-                    &segments,
-                    None,
-                    parent_scope,
-                    finalize.then(|| Finalize::new(id, path.span)),
-                    None,
-                    None,
-                ) {
-                    PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
-                        let res = module.res().expect("visibility resolved to unnamed block");
-                        if finalize {
-                            self.r.record_partial_res(id, PartialRes::new(res));
-                        }
-                        if module.is_normal() {
-                            match res {
-                                Res::Err => Ok(Visibility::Public),
-                                _ => {
-                                    let vis = Visibility::Restricted(res.def_id());
-                                    if self.r.is_accessible_from(vis, parent_scope.module) {
-                                        Ok(vis.expect_local())
-                                    } else {
-                                        Err(VisResolutionError::AncestorOnly(path.span))
-                                    }
-                                }
-                            }
-                        } else {
-                            expected_found_error(res)
-                        }
-                    }
-                    PathResult::Module(..) => Err(VisResolutionError::ModuleOnly(path.span)),
-                    PathResult::NonModule(partial_res) => {
-                        expected_found_error(partial_res.expect_full_res())
-                    }
-                    PathResult::Failed {
-                        span, label, suggestion, message, segment_name, ..
-                    } => Err(VisResolutionError::FailedToResolve(
-                        span,
-                        segment_name,
-                        label,
-                        suggestion,
-                        message,
-                    )),
-                    PathResult::Indeterminate => Err(VisResolutionError::Indeterminate(path.span)),
-                }
+        match self.r.try_resolve_visibility(&self.parent_scope, vis, true) {
+            Ok(vis) => vis,
+            Err(error) => {
+                self.r.delayed_vis_resolution_errors.push(DelayedVisResolutionError {
+                    vis: vis.clone(),
+                    parent_scope: self.parent_scope,
+                    error,
+                });
+                Visibility::Public
             }
         }
     }
@@ -904,7 +919,8 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                         // correct visibilities for unnamed field placeholders specifically, so the
                         // constructor visibility should still be determined correctly.
                         let field_vis = self
-                            .try_resolve_visibility(&field.vis, false)
+                            .r
+                            .try_resolve_visibility(&self.parent_scope, &field.vis, false)
                             .unwrap_or(Visibility::Public);
                         if ctor_vis.greater_than(field_vis, self.r.tcx) {
                             ctor_vis = field_vis;
@@ -1339,9 +1355,10 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             let vis = match item.kind {
                 // Visibilities must not be resolved non-speculatively twice
                 // and we already resolved this one as a `fn` item visibility.
-                ItemKind::Fn(..) => {
-                    self.try_resolve_visibility(&item.vis, false).unwrap_or(Visibility::Public)
-                }
+                ItemKind::Fn(..) => self
+                    .r
+                    .try_resolve_visibility(&self.parent_scope, &item.vis, false)
+                    .unwrap_or(Visibility::Public),
                 _ => self.resolve_visibility(&item.vis),
             };
             if !vis.is_public() {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-filelength
+use std::mem;
 use std::ops::ControlFlow;
 
 use itertools::Itertools as _;
@@ -48,10 +49,10 @@ use crate::imports::{Import, ImportKind};
 use crate::late::{DiagMetadata, PatternSource, Rib};
 use crate::{
     AmbiguityError, AmbiguityKind, AmbiguityWarning, BindingError, BindingKey, Decl, DeclKind,
-    Finalize, ForwardGenericParamBanReason, HasGenericParams, IdentKey, LateDecl, MacroRulesScope,
-    Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, PrivacyError, Res,
-    ResolutionError, Resolver, Scope, ScopeSet, Segment, UseError, Used, VisResolutionError,
-    errors as errs, path_names_to_string,
+    DelayedVisResolutionError, Finalize, ForwardGenericParamBanReason, HasGenericParams, IdentKey,
+    LateDecl, MacroRulesScope, Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult,
+    PrivacyError, Res, ResolutionError, Resolver, Scope, ScopeSet, Segment, UseError, Used,
+    VisResolutionError, errors as errs, path_names_to_string,
 };
 
 /// A vector of spans and replacements, a message and applicability.
@@ -137,6 +138,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     pub(crate) fn report_errors(&mut self, krate: &Crate) {
+        self.report_delayed_vis_resolution_errors();
         self.report_with_use_injections(krate);
 
         for &(span_use, span_def) in &self.macro_expanded_macro_export_errors {
@@ -171,16 +173,27 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         let mut reported_spans = FxHashSet::default();
-        for error in std::mem::take(&mut self.privacy_errors) {
+        for error in mem::take(&mut self.privacy_errors) {
             if reported_spans.insert(error.dedup_span) {
                 self.report_privacy_error(&error);
             }
         }
     }
 
+    fn report_delayed_vis_resolution_errors(&mut self) {
+        for DelayedVisResolutionError { vis, parent_scope, error } in
+            mem::take(&mut self.delayed_vis_resolution_errors)
+        {
+            match self.try_resolve_visibility(&parent_scope, &vis, true) {
+                Ok(_) => self.report_vis_error(error),
+                Err(error) => self.report_vis_error(error),
+            };
+        }
+    }
+
     fn report_with_use_injections(&mut self, krate: &Crate) {
         for UseError { mut err, candidates, def_id, instead, suggestion, path, is_call } in
-            std::mem::take(&mut self.use_injections)
+            mem::take(&mut self.use_injections)
         {
             let (span, found_use) = if let Some(def_id) = def_id.as_local() {
                 UsePlacementFinder::check(krate, self.def_id_to_node_id(def_id))
@@ -1127,7 +1140,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     pub(crate) fn report_vis_error(
         &mut self,
-        vis_resolution_error: VisResolutionError<'_>,
+        vis_resolution_error: VisResolutionError,
     ) -> ErrorGuaranteed {
         match vis_resolution_error {
             VisResolutionError::Relative2018(span, path) => {
@@ -1136,7 +1149,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     path_span: path.span,
                     // intentionally converting to String, as the text would also be used as
                     // in suggestion context
-                    path_str: pprust::path_to_string(path),
+                    path_str: pprust::path_to_string(&path),
                 })
             }
             VisResolutionError::AncestorOnly(span) => {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -336,8 +336,9 @@ enum ResolutionError<'ra> {
     BindingInNeverPattern,
 }
 
-enum VisResolutionError<'a> {
-    Relative2018(Span, &'a ast::Path),
+#[derive(Debug)]
+enum VisResolutionError {
+    Relative2018(Span, ast::Path),
     AncestorOnly(Span),
     FailedToResolve(Span, Symbol, String, Option<Suggestion>, String),
     ExpectedFound(Span, String, Res),
@@ -997,6 +998,13 @@ struct UseError<'a> {
     is_call: bool,
 }
 
+#[derive(Debug)]
+struct DelayedVisResolutionError<'ra> {
+    vis: ast::Visibility,
+    parent_scope: ParentScope<'ra>,
+    error: VisResolutionError,
+}
+
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum AmbiguityKind {
     BuiltinAttr,
@@ -1351,6 +1359,8 @@ pub struct Resolver<'ra, 'tcx> {
     issue_145575_hack_applied: bool = false,
     /// `use` injections are delayed for better placement and deduplication.
     use_injections: Vec<UseError<'tcx>> = Vec::new(),
+    /// Visibility path resolution failures are delayed until all modules are collected.
+    delayed_vis_resolution_errors: Vec<DelayedVisResolutionError<'ra>> = Vec::new(),
     /// Crate-local macro expanded `macro_export` referred to by a module-relative path.
     macro_expanded_macro_export_errors: BTreeSet<(Span, Span)> = BTreeSet::new(),
 

--- a/library/stdarch/crates/core_arch/src/amdgpu/intrinsic_is_convergent.md
+++ b/library/stdarch/crates/core_arch/src/amdgpu/intrinsic_is_convergent.md
@@ -1,0 +1,6 @@
+This intrinsic does not behave like a normal function call; it is a "[convergent]" operation and as such has non-standard control-flow effects which need special treatment by the language.
+Rust currently does not properly support convergent operations.
+This operation is hence provided on a best-effort basis.
+Using it may result in incorrect code under some circumstances.
+
+[convergent]: https://llvm.org/docs/ConvergentOperations.html

--- a/library/stdarch/crates/core_arch/src/amdgpu/mod.rs
+++ b/library/stdarch/crates/core_arch/src/amdgpu/mod.rs
@@ -244,6 +244,8 @@ pub fn wavefrontsize() -> u32 {
 /// Synchronize all wavefronts in a workgroup.
 ///
 /// Each wavefronts in a workgroup waits at the barrier until all wavefronts in the workgroup arrive at a barrier.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn s_barrier() {
@@ -253,6 +255,8 @@ pub fn s_barrier() {
 /// Signal a specific barrier type.
 ///
 /// Only for non-named barriers.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn s_barrier_signal<const BARRIER_TYPE: i32>() {
@@ -265,6 +269,8 @@ pub unsafe fn s_barrier_signal<const BARRIER_TYPE: i32>() {
 /// Provides access to the s_barrier_signal_first instruction;
 /// additionally ensures that the result value is valid even when
 /// the intrinsic is used from a wavefront that is not running in a workgroup.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn s_barrier_signal_isfirst<const BARRIER_TYPE: i32>() -> bool {
@@ -274,6 +280,8 @@ pub unsafe fn s_barrier_signal_isfirst<const BARRIER_TYPE: i32>() -> bool {
 /// Wait for a specific barrier type.
 ///
 /// Only for non-named barriers.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn s_barrier_wait<const BARRIER_TYPE: i16>() {
@@ -283,6 +291,8 @@ pub unsafe fn s_barrier_wait<const BARRIER_TYPE: i16>() {
 /// Get the state of a specific barrier type.
 ///
 /// The `barrier_type` argument must be uniform, otherwise behavior is undefined.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn s_get_barrier_state<const BARRIER_TYPE: i32>() -> u32 {
@@ -292,6 +302,8 @@ pub unsafe fn s_get_barrier_state<const BARRIER_TYPE: i32>() -> u32 {
 /// A barrier for only the threads within the current wavefront.
 ///
 /// Does not result in an instruction but restricts the compiler.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_barrier() {
@@ -315,6 +327,8 @@ pub fn wave_barrier() {
 /// - 0x0100: All DS read instructions may be scheduled across `sched_barrier`.
 /// - 0x0200: All DS write instructions may be scheduled across `sched_barrier`.
 /// - 0x0400: All Transcendental (e.g. V_EXP) instructions may be scheduled across `sched_barrier`.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn sched_barrier<const MASK: u32>() {
@@ -345,6 +359,8 @@ pub unsafe fn sched_barrier<const MASK: u32>() {
 /// // 5 MFMA
 /// sched_group_barrier::<8, 5, 0>()
 /// ```
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn sched_group_barrier<const MASK: u32, const SIZE: u32, const SYNC_ID: u32>() {
@@ -366,6 +382,8 @@ pub fn s_sleep<const COUNT: u32>() {
 /// Stop execution of the kernel.
 ///
 /// This usually signals an error state.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn s_sethalt<const VALUE: u32>() -> ! {
@@ -407,6 +425,8 @@ pub fn mbcnt_hi(value: u32, init: u32) -> u32 {
 
 /// Returns a bitfield (`u32` or `u64`) containing the result of its i1 argument
 /// in all active lanes, and zero in all inactive lanes.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn ballot(b: bool) -> u64 {
@@ -419,6 +439,8 @@ pub fn ballot(b: bool) -> u64 {
 /// While [`ballot`] converts a `bool` to a mask, `inverse_ballot` converts a mask back to a `bool`.
 /// This means `inverse_ballot(ballot(b)) == b`.
 /// The inverse of `ballot(inverse_ballot(value)) ~= value` is not always true as inactive lanes are set to zero by `ballot`.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn inverse_ballot(value: u64) -> bool {
@@ -433,6 +455,8 @@ pub fn inverse_ballot(value: u64) -> bool {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_umin<const STRATEGY: u32>(value: u32) -> u32 {
@@ -447,6 +471,8 @@ pub fn wave_reduce_umin<const STRATEGY: u32>(value: u32) -> u32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_min<const STRATEGY: u32>(value: i32) -> i32 {
@@ -462,6 +488,8 @@ pub fn wave_reduce_min<const STRATEGY: u32>(value: i32) -> i32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_umax<const STRATEGY: u32>(value: u32) -> u32 {
@@ -476,6 +504,8 @@ pub fn wave_reduce_umax<const STRATEGY: u32>(value: u32) -> u32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_max<const STRATEGY: u32>(value: i32) -> i32 {
@@ -491,6 +521,8 @@ pub fn wave_reduce_max<const STRATEGY: u32>(value: i32) -> i32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_add<const STRATEGY: u32>(value: u32) -> u32 {
@@ -506,6 +538,8 @@ pub fn wave_reduce_add<const STRATEGY: u32>(value: u32) -> u32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_and<const STRATEGY: u32>(value: u32) -> u32 {
@@ -520,6 +554,8 @@ pub fn wave_reduce_and<const STRATEGY: u32>(value: u32) -> u32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_or<const STRATEGY: u32>(value: u32) -> u32 {
@@ -534,6 +570,8 @@ pub fn wave_reduce_or<const STRATEGY: u32>(value: u32) -> u32 {
 /// - 2: DPP
 ///
 /// If target does not support the DPP operations (e.g. gfx6/7), reduction will be performed using default iterative strategy.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn wave_reduce_xor<const STRATEGY: u32>(value: u32) -> u32 {
@@ -544,12 +582,16 @@ pub fn wave_reduce_xor<const STRATEGY: u32>(value: u32) -> u32 {
 // The following intrinsics can have multiple sizes
 
 /// Get `value` from the first active lane in the wavefront.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn readfirstlane_u32(value: u32) -> u32 {
     llvm_readfirstlane_u32(value)
 }
 /// Get `value` from the first active lane in the wavefront.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn readfirstlane_u64(value: u64) -> u64 {
@@ -559,6 +601,8 @@ pub fn readfirstlane_u64(value: u64) -> u64 {
 ///
 /// The lane argument must be uniform across the currently active threads
 /// of the current wavefront. Otherwise, the result is undefined.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn readlane_u32(value: u32, lane: u32) -> u32 {
@@ -568,6 +612,8 @@ pub unsafe fn readlane_u32(value: u32, lane: u32) -> u32 {
 ///
 /// The lane argument must be uniform across the currently active threads
 /// of the current wavefront. Otherwise, the result is undefined.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn readlane_u64(value: u64, lane: u32) -> u64 {
@@ -582,6 +628,8 @@ pub unsafe fn readlane_u64(value: u64, lane: u32) -> u64 {
 ///
 /// `value` is the value returned by `lane`.
 /// `default` is the value returned by all lanes other than `lane`.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn writelane_u32(value: u32, lane: u32, default: u32) -> u32 {
@@ -596,6 +644,8 @@ pub unsafe fn writelane_u32(value: u32, lane: u32, default: u32) -> u32 {
 ///
 /// `value` is the value returned by `lane`.
 /// `default` is the value returned by all lanes other than `lane`.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn writelane_u64(value: u64, lane: u32, default: u64) -> u64 {
@@ -605,6 +655,8 @@ pub unsafe fn writelane_u64(value: u64, lane: u32, default: u64) -> u64 {
 /// Stop execution of the wavefront.
 ///
 /// This usually signals the end of a successful execution.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub fn endpgm() -> ! {
@@ -621,6 +673,8 @@ pub fn endpgm() -> ! {
 /// v_mov_b32 <dest> <old>
 /// v_mov_b32 <dest> <src> <dpp_ctrl> <row_mask> <bank_mask> <bound_ctrl>
 /// ```
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn update_dpp<
@@ -651,6 +705,8 @@ pub fn s_memrealtime() -> u64 {
 ///
 /// Reading from inactive lanes returns `0`.
 /// In case multiple values get written to the same `lane`, the value from the source lane with the higher index is taken.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn ds_permute(lane: u32, value: u32) -> u32 {
@@ -661,6 +717,8 @@ pub unsafe fn ds_permute(lane: u32, value: u32) -> u32 {
 /// Returns the `value` given to `ds_permute` by lane `lane`.
 ///
 /// Reading from inactive lanes returns `0`.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn ds_bpermute(lane: u32, value: u32) -> u32 {
@@ -680,6 +738,8 @@ pub unsafe fn perm(src0: u32, src1: u32, selector: u32) -> u32 {
 ///
 /// The third and fourth inputs must be uniform across the current wavefront.
 /// These are combined into a single 64-bit value representing lane selects used to swizzle within each row.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlane16_u32<const FI: bool, const BOUND_CONTROL: bool>(
@@ -696,6 +756,8 @@ pub unsafe fn permlane16_u32<const FI: bool, const BOUND_CONTROL: bool>(
 ///
 /// The third and fourth inputs must be uniform across the current wavefront.
 /// These are combined into a single 64-bit value representing lane selects used to swizzle within each row.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlanex16_u32<const FI: bool, const BOUND_CONTROL: bool>(
@@ -718,6 +780,8 @@ pub fn s_get_waveid_in_workgroup() -> u32 {
 /// Swap `value` between upper and lower 32 lanes in a wavefront.
 ///
 /// Does nothing for wave32.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlane64_u32(value: u32) -> u32 {
@@ -728,6 +792,8 @@ pub unsafe fn permlane64_u32(value: u32) -> u32 {
 /// Performs arbitrary gather-style operation within a row (16 contiguous lanes) of the second input operand.
 ///
 /// In contrast to [`permlane16_u32`], allows each lane to specify its own gather lane.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlane16_var<const FI: bool, const BOUND_CONTROL: bool>(
@@ -742,6 +808,8 @@ pub unsafe fn permlane16_var<const FI: bool, const BOUND_CONTROL: bool>(
 /// Performs arbitrary gather-style operation across two rows (16 contiguous lanes) of the second input operand.
 ///
 /// In contrast to [`permlanex16_u32`], allows each lane to specify its own gather lane.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlanex16_var<const FI: bool, const BOUND_CONTROL: bool>(
@@ -766,6 +834,8 @@ pub fn wave_id() -> u32 {
 /// Odd rows of the first operand are swapped with even rows of the second operand (one row is 16 lanes).
 /// Returns a pair for the swapped registers.
 /// The first element of the return corresponds to the swapped element of the first argument.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlane16_swap<const FI: bool, const BOUND_CONTROL: bool>(
@@ -782,6 +852,8 @@ pub unsafe fn permlane16_swap<const FI: bool, const BOUND_CONTROL: bool>(
 /// Rows 2 and 3 of the first operand are swapped with rows 0 and 1 of the second operand (one row is 16 lanes).
 /// Returns a pair for the swapped registers.
 /// The first element of the return corresponds to the swapped element of the first argument.
+///
+#[doc = include_str!("intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_amdgpu", issue = "149988")]
 pub unsafe fn permlane32_swap<const FI: bool, const BOUND_CONTROL: bool>(

--- a/library/stdarch/crates/core_arch/src/nvptx/mod.rs
+++ b/library/stdarch/crates/core_arch/src/nvptx/mod.rs
@@ -49,6 +49,8 @@ unsafe extern "C" {
 }
 
 /// Synchronizes all threads in the block.
+///
+#[doc = include_str!("../amdgpu/intrinsic_is_convergent.md")]
 #[inline]
 #[unstable(feature = "stdarch_nvptx", issue = "111199")]
 pub unsafe fn _syncthreads() -> () {

--- a/src/doc/rustc-dev-guide/src/tests/minicore.md
+++ b/src/doc/rustc-dev-guide/src/tests/minicore.md
@@ -2,7 +2,7 @@
 
 <!-- date-check: Oct 2025 -->
 
-[`tests/auxiliary/minicore.rs`][`minicore`] is a test auxiliary for ui/codegen/assembly test suites.
+[`tests/auxiliary/minicore.rs`][`minicore`] is a test auxiliary for ui/codegen/assembly/mir-opt test suites.
 It provides `core` stubs for tests that need to
 build for cross-compiled targets but do not need/want to run.
 

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -492,9 +492,12 @@ impl TestProps {
     fn update_add_minicore(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
         let add_minicore = config.parse_name_directive(ln, directives::ADD_MINICORE);
         if add_minicore {
-            if !matches!(config.mode, TestMode::Ui | TestMode::Codegen | TestMode::Assembly) {
+            if !matches!(
+                config.mode,
+                TestMode::Ui | TestMode::Codegen | TestMode::Assembly | TestMode::MirOpt
+            ) {
                 panic!(
-                    "`add-minicore` is currently only supported for ui, codegen and assembly test modes"
+                    "`add-minicore` is currently only supported for ui, codegen, assembly and mir-opt test modes"
                 );
             }
 

--- a/tests/mir-opt/building/loop_match_diverges.break_to_block_unit.built.after.mir
+++ b/tests/mir-opt/building/loop_match_diverges.break_to_block_unit.built.after.mir
@@ -4,6 +4,7 @@ fn break_to_block_unit() -> u8 {
     let mut _0: u8;
     let mut _1: i32;
     let mut _2: !;
+    let mut _3: i32;
     scope 1 {
         debug state => _1;
     }
@@ -22,7 +23,7 @@ fn break_to_block_unit() -> u8 {
 
     bb2: {
         PlaceMention(_1);
-        _1 = const 2_i32;
+        _3 = const 2_i32;
         goto -> bb5;
     }
 
@@ -44,6 +45,7 @@ fn break_to_block_unit() -> u8 {
     }
 
     bb7: {
+        _1 = copy _3;
         goto -> bb1;
     }
 

--- a/tests/mir-opt/building/loop_match_diverges.infinite_a.built.after.mir
+++ b/tests/mir-opt/building/loop_match_diverges.infinite_a.built.after.mir
@@ -4,9 +4,10 @@ fn infinite_a(_1: u8) -> () {
     debug state => _1;
     let mut _0: ();
     let mut _2: !;
-    let _3: u8;
+    let mut _3: u8;
+    let _4: u8;
     scope 1 {
-        debug a => _3;
+        debug a => _4;
     }
 
     bb0: {
@@ -20,10 +21,10 @@ fn infinite_a(_1: u8) -> () {
 
     bb2: {
         PlaceMention(_1);
-        StorageLive(_3);
-        _3 = copy _1;
-        _1 = copy _3;
-        StorageDead(_3);
+        StorageLive(_4);
+        _4 = copy _1;
+        _3 = copy _4;
+        StorageDead(_4);
         goto -> bb4;
     }
 
@@ -33,6 +34,7 @@ fn infinite_a(_1: u8) -> () {
     }
 
     bb4: {
+        _1 = copy _3;
         goto -> bb1;
     }
 

--- a/tests/mir-opt/building/loop_match_diverges.simple.built.after.mir
+++ b/tests/mir-opt/building/loop_match_diverges.simple.built.after.mir
@@ -5,14 +5,15 @@ fn simple(_1: State) -> State {
     let mut _0: State;
     let _2: ();
     let mut _3: isize;
-    let mut _4: !;
-    let mut _5: isize;
-    let mut _6: bool;
-    let mut _7: !;
-    let mut _8: isize;
-    let mut _9: !;
-    let mut _10: isize;
-    let mut _11: !;
+    let mut _4: State;
+    let mut _5: !;
+    let mut _6: isize;
+    let mut _7: bool;
+    let mut _8: !;
+    let mut _9: isize;
+    let mut _10: !;
+    let mut _11: isize;
+    let mut _12: !;
 
     bb0: {
         StorageLive(_2);
@@ -60,14 +61,14 @@ fn simple(_1: State) -> State {
     }
 
     bb10: {
-        StorageLive(_6);
-        _6 = const true;
-        switchInt(move _6) -> [0: bb17, otherwise: bb16];
+        StorageLive(_7);
+        _7 = const true;
+        switchInt(move _7) -> [0: bb17, otherwise: bb16];
     }
 
     bb11: {
         _1 = State::B;
-        _5 = discriminant(_1);
+        _6 = discriminant(_1);
         falseEdge -> [real: bb12, imaginary: bb13];
     }
 
@@ -89,7 +90,7 @@ fn simple(_1: State) -> State {
 
     bb16: {
         _1 = State::C;
-        _8 = discriminant(_1);
+        _9 = discriminant(_1);
         falseEdge -> [real: bb18, imaginary: bb19];
     }
 
@@ -106,7 +107,7 @@ fn simple(_1: State) -> State {
     }
 
     bb20: {
-        StorageDead(_6);
+        StorageDead(_7);
         goto -> bb8;
     }
 
@@ -120,7 +121,7 @@ fn simple(_1: State) -> State {
 
     bb23: {
         _1 = State::A;
-        _10 = discriminant(_1);
+        _11 = discriminant(_1);
         falseEdge -> [real: bb24, imaginary: bb25];
     }
 
@@ -133,7 +134,7 @@ fn simple(_1: State) -> State {
     }
 
     bb26: {
-        StorageDead(_6);
+        StorageDead(_7);
         goto -> bb11;
     }
 
@@ -146,7 +147,7 @@ fn simple(_1: State) -> State {
     }
 
     bb29: {
-        StorageDead(_6);
+        StorageDead(_7);
         goto -> bb32;
     }
 
@@ -159,11 +160,12 @@ fn simple(_1: State) -> State {
     }
 
     bb32: {
+        _1 = move _4;
         goto -> bb35;
     }
 
     bb33: {
-        StorageDead(_6);
+        StorageDead(_7);
         goto -> bb34;
     }
 

--- a/tests/mir-opt/building/loop_match_no_self_assign.helper.built.after.mir
+++ b/tests/mir-opt/building/loop_match_no_self_assign.helper.built.after.mir
@@ -4,8 +4,8 @@ fn helper() -> u8 {
     let mut _0: u8;
     let mut _1: u8;
     let mut _2: !;
-    let mut _3: !;
-    let mut _4: u8;
+    let mut _3: u8;
+    let mut _4: !;
     scope 1 {
         debug state => _1;
     }
@@ -24,8 +24,7 @@ fn helper() -> u8 {
 
     bb2: {
         PlaceMention(_1);
-        _4 = copy _1;
-        _1 = copy _4;
+        _3 = copy _1;
         goto -> bb7;
     }
 
@@ -51,6 +50,7 @@ fn helper() -> u8 {
     }
 
     bb8: {
+        _1 = copy _3;
         goto -> bb1;
     }
 

--- a/tests/mir-opt/building/loop_match_no_self_assign.helper.built.after.mir
+++ b/tests/mir-opt/building/loop_match_no_self_assign.helper.built.after.mir
@@ -1,0 +1,70 @@
+// MIR for `helper` after built
+
+fn helper() -> u8 {
+    let mut _0: u8;
+    let mut _1: u8;
+    let mut _2: !;
+    let mut _3: !;
+    let mut _4: u8;
+    scope 1 {
+        debug state => _1;
+    }
+
+    bb0: {
+        StorageLive(_1);
+        _1 = const 0_u8;
+        FakeRead(ForLet(None), _1);
+        StorageLive(_2);
+        goto -> bb1;
+    }
+
+    bb1: {
+        falseUnwind -> [real: bb2, unwind: bb11];
+    }
+
+    bb2: {
+        PlaceMention(_1);
+        _4 = copy _1;
+        _1 = copy _4;
+        goto -> bb7;
+    }
+
+    bb3: {
+        FakeRead(ForMatchedPlace(None), _1);
+        unreachable;
+    }
+
+    bb4: {
+        unreachable;
+    }
+
+    bb5: {
+        goto -> bb6;
+    }
+
+    bb6: {
+        goto -> bb8;
+    }
+
+    bb7: {
+        goto -> bb8;
+    }
+
+    bb8: {
+        goto -> bb1;
+    }
+
+    bb9: {
+        unreachable;
+    }
+
+    bb10: {
+        StorageDead(_2);
+        StorageDead(_1);
+        return;
+    }
+
+    bb11 (cleanup): {
+        resume;
+    }
+}

--- a/tests/mir-opt/building/loop_match_no_self_assign.rs
+++ b/tests/mir-opt/building/loop_match_no_self_assign.rs
@@ -1,4 +1,4 @@
-// skip-filecheck
+//@ skip-filecheck
 #![allow(incomplete_features, unused_labels)]
 #![feature(loop_match)]
 #![crate_type = "lib"]

--- a/tests/mir-opt/building/loop_match_no_self_assign.rs
+++ b/tests/mir-opt/building/loop_match_no_self_assign.rs
@@ -1,0 +1,20 @@
+// skip-filecheck
+#![allow(incomplete_features, unused_labels)]
+#![feature(loop_match)]
+#![crate_type = "lib"]
+
+// Regression test for <https://github.com/rust-lang/rust/issues/143806>
+// This used to avoid building invalid MIR with a self-assignment like `_1 = copy _1`.
+
+// EMIT_MIR loop_match_no_self_assign.helper.built.after.mir
+fn helper() -> u8 {
+    let mut state = 0u8;
+    #[loop_match]
+    'a: loop {
+        state = 'blk: {
+            match state {
+                _ => break 'blk state,
+            }
+        }
+    }
+}

--- a/tests/mir-opt/issues/issue_137086.rs
+++ b/tests/mir-opt/issues/issue_137086.rs
@@ -1,0 +1,50 @@
+// Check that GPU targets do not run jump-threading
+
+//@ ignore-backends: gcc
+//@ add-minicore
+//@ revisions: cpu gpu
+//@ compile-flags: -Z mir-opt-level=4
+//@[cpu] compile-flags: --target x86_64-unknown-linux-gnu
+//@[cpu] needs-llvm-components: x86
+//@[gpu] compile-flags: --target nvptx64-nvidia-cuda
+//@[gpu] needs-llvm-components: nvptx
+
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[inline(never)]
+fn opaque() {}
+
+#[inline(never)]
+fn opaque2() {}
+
+#[inline(never)]
+fn syncthreads() {}
+
+pub fn function(cond: bool) {
+    // CHECK-LABEL: fn function
+    // Jump-threading duplicates syncthreads
+    // cpu: syncthreads()
+    // cpu: syncthreads()
+
+    // Must not duplicate syncthreads
+    // gpu: syncthreads()
+    // gpu-NOT: syncthreads()
+
+    if cond {
+        opaque();
+    } else {
+        opaque2();
+    }
+    syncthreads();
+    if cond {
+        opaque();
+    } else {
+        opaque2();
+    }
+}

--- a/tests/ui/enum/enum-variant-generic-args-in-module-segment.rs
+++ b/tests/ui/enum/enum-variant-generic-args-in-module-segment.rs
@@ -1,0 +1,19 @@
+// Test that we don't assume that the penultimate segment of an enum variant path refers to the
+// enum just because it has generic arguments.
+//
+// We once used to accept the code below interpreting `module::<i32>::Variant`
+// as `module::Variant::<i32>` basically.
+//
+// issue: <https://github.com/rust-lang/rust/issues/154962>
+
+enum Enum<T> { Variant, Carry(T) }
+
+mod module { pub(super) use super::Enum::Variant; }
+
+fn main() {
+    let _ = module::<i32>::Variant;
+    //~^ ERROR type arguments are not allowed on module `module`
+
+    let _ = self::module::<()>::Variant {};
+    //~^ ERROR type arguments are not allowed on module `module`
+}

--- a/tests/ui/enum/enum-variant-generic-args-in-module-segment.stderr
+++ b/tests/ui/enum/enum-variant-generic-args-in-module-segment.stderr
@@ -1,0 +1,19 @@
+error[E0109]: type arguments are not allowed on module `module`
+  --> $DIR/enum-variant-generic-args-in-module-segment.rs:14:22
+   |
+LL |     let _ = module::<i32>::Variant;
+   |             ------   ^^^ type argument not allowed
+   |             |
+   |             not allowed on module `module`
+
+error[E0109]: type arguments are not allowed on module `module`
+  --> $DIR/enum-variant-generic-args-in-module-segment.rs:17:28
+   |
+LL |     let _ = self::module::<()>::Variant {};
+   |                   ------   ^^ type argument not allowed
+   |                   |
+   |                   not allowed on module `module`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0109`.

--- a/tests/ui/loop-match/no-self-assign-ice.rs
+++ b/tests/ui/loop-match/no-self-assign-ice.rs
@@ -1,0 +1,19 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/143806>
+//@ check-pass
+//@ compile-flags: -Zlint-mir
+
+#![feature(loop_match)]
+
+fn main() {}
+
+fn helper() -> u8 {
+    let mut state = 0u8;
+    #[loop_match]
+    'a: loop {
+        state = 'blk: {
+            match state {
+                _ => break 'blk state,
+            }
+        }
+    }
+}

--- a/tests/ui/mir/ssa-range-prop-bb-self-domination.rs
+++ b/tests/ui/mir/ssa-range-prop-bb-self-domination.rs
@@ -1,0 +1,22 @@
+/// Regression test for <https://github.com/rust-lang/rust/issues/155836>.
+///
+/// SsaRangeProp pass used to fail the assert when encountering self-dominating block
+/// e.g. small loops like in `a`
+
+//@ compile-flags: -Copt-level=2
+//@ build-pass
+
+use std::hint::black_box;
+fn a(d: u8) {
+    loop {
+        1 % d;
+    }
+}
+pub fn e(d: u8) {
+    if d == 0 || black_box(false) {
+        a(d);
+    }
+}
+fn main() {
+    e(1);
+}

--- a/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.nll.stderr
@@ -1,0 +1,14 @@
+error[E0502]: cannot borrow `one` as immutable because it is also borrowed as mutable
+  --> $DIR/location-insensitive-constraints-issue-70044.rs:22:20
+   |
+LL |         let mut y = &mut one;
+   |                     -------- mutable borrow occurs here
+...
+LL |     println!("{}", one);
+   |                    ^^^ immutable borrow occurs here
+LL |     println!("{}", zero);
+   |                    ---- mutable borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.rs
+++ b/tests/ui/nll/polonius/location-insensitive-constraints-issue-70044.rs
@@ -1,0 +1,24 @@
+// This test is taken from https://github.com/rust-lang/rust/issues/70044.
+// This test demonstrates how NLL's outlives constraints are flow-insensitive,
+// and are wrongly expected to hold outside the inner scope.
+
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ revisions: nll polonius legacy
+//@ [polonius] check-pass
+//@ [polonius] compile-flags: -Z polonius=next
+//@ [legacy] check-pass
+//@ [legacy] compile-flags: -Z polonius=legacy
+
+fn main() {
+    let mut zero = &mut 0;
+    let mut one = 1;
+
+    {
+        let mut _r = &mut zero;
+        let mut y = &mut one;
+        _r = &mut y;
+    }
+
+    println!("{}", one); //[nll]~ ERROR: cannot borrow `one` as immutable
+    println!("{}", zero);
+}

--- a/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.nll.stderr
+++ b/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.nll.stderr
@@ -1,0 +1,16 @@
+error[E0499]: cannot borrow `*a` as mutable more than once at a time
+  --> $DIR/nll-problem-case-2-issue-92038.rs:16:26
+   |
+LL | fn reborrow(a: &mut u8) -> &mut u8 {
+   |                - let's call the lifetime of this reference `'1`
+LL |     let b = &mut *a;
+   |             ------- first mutable borrow occurs here
+LL |     if true { b } else { a }
+   |     ---------------------^--
+   |     |                    |
+   |     |                    second mutable borrow occurs here
+   |     returning this value requires that `*a` is borrowed for `'1`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0499`.

--- a/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.rs
+++ b/tests/ui/nll/polonius/nll-problem-case-2-issue-92038.rs
@@ -1,0 +1,17 @@
+#![crate_type = "lib"]
+
+// This test demonstrates a shortcoming of NLL known as problem case #2
+// https://rust-lang.github.io/rfcs/2094-nll.html#problem-case-2-conditional-control-flow
+// This MCVE is copied from https://github.com/rust-lang/rust/issues/92038.
+
+//@ ignore-compare-mode-polonius (explicit revisions)
+//@ revisions: nll polonius legacy
+//@ [polonius] check-pass
+//@ [polonius] compile-flags: -Z polonius=next
+//@ [legacy] check-pass
+//@ [legacy] compile-flags: -Z polonius=legacy
+
+fn reborrow(a: &mut u8) -> &mut u8 {
+    let b = &mut *a;
+    if true { b } else { a } //[nll]~ ERROR: cannot borrow `*a` as mutable more than once at a time
+}

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -1,3 +1,15 @@
+error[E0364]: `f` is private, and cannot be re-exported
+  --> $DIR/test.rs:22:24
+   |
+LL |         pub(super) use foo::bar::f as g;
+   |                        ^^^^^^^^^^^^^^^^
+   |
+note: consider marking `f` as `pub` in the imported module
+  --> $DIR/test.rs:22:24
+   |
+LL |         pub(super) use foo::bar::f as g;
+   |                        ^^^^^^^^^^^^^^^^
+
 error[E0433]: cannot find module or crate `bad` in the crate root
   --> $DIR/test.rs:51:12
    |
@@ -14,18 +26,6 @@ error[E0742]: visibilities can only be restricted to ancestor modules
    |
 LL |     pub(in foo) mod m2 {}
    |            ^^^
-
-error[E0364]: `f` is private, and cannot be re-exported
-  --> $DIR/test.rs:22:24
-   |
-LL |         pub(super) use foo::bar::f as g;
-   |                        ^^^^^^^^^^^^^^^^
-   |
-note: consider marking `f` as `pub` in the imported module
-  --> $DIR/test.rs:22:24
-   |
-LL |         pub(super) use foo::bar::f as g;
-   |                        ^^^^^^^^^^^^^^^^
 
 error[E0603]: struct `Crate` is private
   --> $DIR/test.rs:39:25

--- a/tests/ui/resolve/resolve-bad-visibility.rs
+++ b/tests/ui/resolve/resolve-bad-visibility.rs
@@ -6,11 +6,9 @@ pub(in E) struct S; //~ ERROR expected module, found enum `::E`
 pub(in Tr) struct Z; //~ ERROR expected module, found trait `::Tr`
 pub(in std::vec) struct F; //~ ERROR visibilities can only be restricted to ancestor modules
 pub(in nonexistent) struct G; //~ ERROR cannot find
-pub(in too_soon) struct H; //~ ERROR cannot find
+pub(in too_soon) struct H; //~ ERROR visibilities can only be restricted
 
-// Visibilities are resolved eagerly without waiting for modules becoming fully populated.
-// Visibilities can only use ancestor modules legally which are always available in time,
-// so the worst thing that can happen due to eager resolution is a suboptimal error message.
+// The module exists, but it is not an ancestor module.
 mod too_soon {}
 
 fn main () {}

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -27,16 +27,11 @@ help: you might be missing a crate named `nonexistent`, add it to your project a
 LL + extern crate nonexistent;
    |
 
-error[E0433]: cannot find module or crate `too_soon` in the crate root
+error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/resolve-bad-visibility.rs:9:8
    |
 LL | pub(in too_soon) struct H;
-   |        ^^^^^^^^ use of unresolved module or unlinked crate `too_soon`
-   |
-help: you might be missing a crate named `too_soon`, add it to your project and import it in your code
-   |
-LL + extern crate too_soon;
-   |
+   |        ^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/visibility-indeterminate.stderr
+++ b/tests/ui/resolve/visibility-indeterminate.stderr
@@ -1,14 +1,14 @@
-error[E0433]: cannot find `bar` in the crate root
-  --> $DIR/visibility-indeterminate.rs:5:10
-   |
-LL | pub(in ::bar) struct Baz {}
-   |          ^^^ could not find `bar` in the list of imported crates
-
 error: cannot find macro `foo` in this scope
   --> $DIR/visibility-indeterminate.rs:3:1
    |
 LL | foo!();
    | ^^^
+
+error[E0433]: cannot find `bar` in the crate root
+  --> $DIR/visibility-indeterminate.rs:5:10
+   |
+LL | pub(in ::bar) struct Baz {}
+   |          ^^^ could not find `bar` in the list of imported crates
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/visibility-order-dependent.rs
+++ b/tests/ui/resolve/visibility-order-dependent.rs
@@ -1,0 +1,14 @@
+//@ edition: 2021
+// Regression test for <https://github.com/rust-lang/rust/issues/40066>.
+
+mod foo {
+    pub(in crate::bar) struct Foo;
+    //~^ ERROR visibilities can only be restricted to ancestor modules
+}
+
+mod bar {
+    pub(in crate::foo) struct Bar;
+    //~^ ERROR visibilities can only be restricted to ancestor modules
+}
+
+fn main() {}

--- a/tests/ui/resolve/visibility-order-dependent.stderr
+++ b/tests/ui/resolve/visibility-order-dependent.stderr
@@ -1,0 +1,15 @@
+error[E0742]: visibilities can only be restricted to ancestor modules
+  --> $DIR/visibility-order-dependent.rs:5:12
+   |
+LL |     pub(in crate::bar) struct Foo;
+   |            ^^^^^^^^^^
+
+error[E0742]: visibilities can only be restricted to ancestor modules
+  --> $DIR/visibility-order-dependent.rs:10:12
+   |
+LL |     pub(in crate::foo) struct Bar;
+   |            ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0742`.

--- a/tests/ui/span/visibility-ty-params.stderr
+++ b/tests/ui/span/visibility-ty-params.stderr
@@ -4,17 +4,17 @@ error: unexpected generic arguments in path
 LL | m!{ crate::S<u8> }
    |             ^^^^
 
-error[E0433]: cannot find module `S` in `crate`
-  --> $DIR/visibility-ty-params.rs:6:12
-   |
-LL | m!{ crate::S<u8> }
-   |            ^ `S` is a struct, not a module
-
 error: unexpected generic arguments in path
   --> $DIR/visibility-ty-params.rs:10:17
    |
 LL |     m!{ crate::m<> }
    |                 ^^
+
+error[E0433]: cannot find module `S` in `crate`
+  --> $DIR/visibility-ty-params.rs:6:12
+   |
+LL | m!{ crate::S<u8> }
+   |            ^ `S` is a struct, not a module
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/use/use-self-type.stderr
+++ b/tests/ui/use/use-self-type.stderr
@@ -1,14 +1,14 @@
-error[E0433]: cannot find `Self` in this scope
-  --> $DIR/use-self-type.rs:7:16
-   |
-LL |         pub(in Self::f) struct Z;
-   |                ^^^^ `Self` cannot be used in imports
-
 error[E0432]: unresolved import `Self`
   --> $DIR/use-self-type.rs:6:13
    |
 LL |         use Self::f;
    |             ^^^^ `Self` cannot be used in imports
+
+error[E0433]: cannot find `Self` in this scope
+  --> $DIR/use-self-type.rs:7:16
+   |
+LL |         pub(in Self::f) struct Z;
+   |                ^^^^ `Self` cannot be used in imports
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#149637 (Do not run jump-threading for GPUs)
 - rust-lang/rust#154971 (Verify that penultimate segment of enum variant path refers to enum if it has args)
 - rust-lang/rust#155186 (Avoid loop_match self-assignment in MIR lowering)
 - rust-lang/rust#155948 (Fix order-dependent visibility diagnostics)
 - rust-lang/rust#156001 (ssa-range-prop: fix ICE when encountering self-domiating bb)
 - rust-lang/rust#155600 (Adds a couple UI tests for polonius)
 - rust-lang/rust#155995 (-Zembed-source: also embed external source)
 - rust-lang/rust#156019 (Feed cleanups)
 - rust-lang/rust#156031 (Return a single diagnostic from `lex_token_trees`.)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=149637,154971,155186,155948,156001,155600,155995,156019,156031)
<!-- homu-ignore:end -->

