### PR TITLE
compiler: Print valid `-Zmir-enable-passes` names if invalid name is used

### DIFF
--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -1,6 +1,7 @@
 use rustc_errors::codes::*;
 use rustc_errors::{
-    Applicability, Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, Subdiagnostic, msg,
+    Applicability, Diag, DiagCtxtHandle, DiagSymbolList, Diagnostic, EmissionGuarantee, Level,
+    Subdiagnostic, msg,
 };
 use rustc_macros::{Diagnostic, Subdiagnostic};
 use rustc_middle::mir::AssertKind;
@@ -118,6 +119,12 @@ pub(crate) struct UnalignedPackedRef {
 #[diag("MIR pass `{$name}` is unknown and will be ignored")]
 pub(crate) struct UnknownPassName<'a> {
     pub(crate) name: &'a str,
+}
+
+#[derive(Diagnostic)]
+#[diag("valid MIR pass names are: {$valid_passes}")]
+pub(crate) struct ValidPassNames<'a> {
+    pub(crate) valid_passes: DiagSymbolList<&'a str>,
 }
 
 pub(crate) struct AssertLint<P> {

--- a/compiler/rustc_mir_transform/src/pass_manager.rs
+++ b/compiler/rustc_mir_transform/src/pass_manager.rs
@@ -253,8 +253,16 @@ fn run_passes_inner<'tcx>(
     let named_passes: FxIndexSet<_> =
         overridden_passes.iter().map(|(name, _)| name.as_str()).collect();
 
+    let mut unknown_found = false;
     for &name in named_passes.difference(&*crate::PASS_NAMES) {
         tcx.dcx().emit_warn(errors::UnknownPassName { name });
+        unknown_found = true;
+    }
+
+    if unknown_found {
+        let mut valid_pass_names = crate::PASS_NAMES.iter().copied().collect::<Vec<_>>();
+        valid_pass_names.sort();
+        tcx.dcx().emit_note(errors::ValidPassNames { valid_passes: valid_pass_names.into() });
     }
 
     // Verify that no passes are missing from the `declare_passes` invocation

--- a/tests/ui/mir/enable_passes_validation.all_unknown.stderr
+++ b/tests/ui/mir/enable_passes_validation.all_unknown.stderr
@@ -2,11 +2,17 @@ warning: MIR pass `ThisPass` is unknown and will be ignored
 
 warning: MIR pass `DoesNotExist` is unknown and will be ignored
 
+note: valid MIR pass names are: $PASS_NAMES
+
 warning: MIR pass `ThisPass` is unknown and will be ignored
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 warning: MIR pass `DoesNotExist` is unknown and will be ignored
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: valid MIR pass names are: $PASS_NAMES
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/mir/enable_passes_validation.enum_not_in_pass_names.stderr
+++ b/tests/ui/mir/enable_passes_validation.enum_not_in_pass_names.stderr
@@ -1,6 +1,12 @@
 warning: MIR pass `SimplifyCfg` is unknown and will be ignored
 
+note: valid MIR pass names are: $PASS_NAMES
+
 warning: MIR pass `SimplifyCfg` is unknown and will be ignored
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: valid MIR pass names are: $PASS_NAMES
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/mir/enable_passes_validation.mixed.stderr
+++ b/tests/ui/mir/enable_passes_validation.mixed.stderr
@@ -1,6 +1,12 @@
 warning: MIR pass `ThisPassDoesNotExist` is unknown and will be ignored
 
+note: valid MIR pass names are: $PASS_NAMES
+
 warning: MIR pass `ThisPassDoesNotExist` is unknown and will be ignored
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: valid MIR pass names are: $PASS_NAMES
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/mir/enable_passes_validation.rs
+++ b/tests/ui/mir/enable_passes_validation.rs
@@ -1,5 +1,6 @@
 //@ revisions: empty unprefixed all_unknown all_known mixed
 //@ revisions: enum_not_in_pass_names enum_in_pass_names
+//@ normalize-stderr: "note: valid MIR pass names are: .*" -> "note: valid MIR pass names are: $$PASS_NAMES"
 
 //@[empty] compile-flags: -Zmir-enable-passes=
 


### PR DESCRIPTION
If a user passes an invalid name to `-Zmir-enable-passes`, print the valid names as a note.

To avoid the annoyance of having to keep blessing test output, completely normalize away the list of names in the test.

The diagnostic is duplicated, but that is not introduced by this commit. In other words, we don't make matters worse. The existing "is unknown and will be ignored" diagnostic is already duplicated, as can be seen in the existing test stderr.

The output is on one long line, but that makes normalization in tests easier, and I don't think we have to overdo this. We can let terminals wrap the line.

<details>

<summary>Click to expand current output</summary>

`note: valid MIR pass names are: AbortUnwindingCalls, AddCallGuards, AddMovesForPackedDrops, AddRetag, CheckAlignment, CheckCallRecursion, CheckConstItemMutation, CheckDropRecursion, CheckEnums, CheckForceInline, CheckInlineAlwaysTargetFeature, CheckLiveDrops, CheckNull, CheckPackedRef, CleanupPostBorrowck, CopyProp, CtfeLimit, DataflowConstProp, DeadStoreElimination-final, DeadStoreElimination-initial, Derefer, DestinationPropagation, EarlyOtherwiseBranch, ElaborateBoxDerefs, ElaborateDrops, EnumSizeOpt, EraseDerefTemps, ForceInline, FunctionItemReferences, GVN, ImpossiblePredicates, Inline, InstSimplify-after-simplifycfg, InstSimplify-before-inline, InstrumentCoverage, JumpThreading, KnownPanicsLint, LowerIntrinsics, LowerSliceLenCalls, Marker, MatchBranchSimplification, MentionedItems, MultipleReturnTerminators, PostAnalysisNormalize, PreCodegen, PromoteTemps, ReferencePropagation, RemoveNoopLandingPads, RemovePlaceMention, RemoveStorageMarkers, RemoveUninitDrops, RemoveUnneededDrops, RemoveZsts, ReorderBasicBlocks, ReorderLocals, RequiredConstsVisitor, SanityCheck, ScalarReplacementOfAggregates, SimplifyCfg-after-unreachable-enum-branching, SimplifyCfg-final, SimplifyCfg-initial, SimplifyCfg-make_shim, SimplifyCfg-post-analysis, SimplifyCfg-pre-optimizations, SimplifyCfg-promote-consts, SimplifyCfg-remove-false-edges, SimplifyComparisonIntegral, SimplifyConstCondition-after-const-prop, SimplifyConstCondition-after-inst-simplify, SimplifyConstCondition-final, SimplifyLocals-after-value-numbering, SimplifyLocals-before-const-prop, SimplifyLocals-final, SingleUseConsts, SsaRangePropagation, StateTransform, StripDebugInfo, Subtyper, UnreachableEnumBranching, UnreachablePropagation, Validator`

</details>


