### PR TITLE
Map `WSAESHUTDOWN` to `io::ErrorKind::BrokenPipe`

### DIFF
--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -82,8 +82,8 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::WSAENETUNREACH => NetworkUnreachable,
         c::WSAEDQUOT => QuotaExceeded,
         // Not a prefect mapping but this error is only returned when writing to
-        // the closed end of a socket. On Unix targets EPIPE is returned in those
-        // cases.
+        // a socket after shutting down the write-end. On Unix targets, EPIPE is
+        // returned in those cases.
         c::WSAESHUTDOWN => BrokenPipe,
 
         _ => Uncategorized,

--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -81,6 +81,10 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::WSAENETDOWN => NetworkDown,
         c::WSAENETUNREACH => NetworkUnreachable,
         c::WSAEDQUOT => QuotaExceeded,
+        // Not a prefect mapping but this error is only returned when writing to
+        // the closed end of a socket. On Unix targets EPIPE is returned in those
+        // cases.
+        c::WSAESHUTDOWN => BrokenPipe,
 
         _ => Uncategorized,
     }

--- a/library/std/src/sys/io/error/windows.rs
+++ b/library/std/src/sys/io/error/windows.rs
@@ -81,7 +81,7 @@ pub fn decode_error_kind(errno: i32) -> io::ErrorKind {
         c::WSAENETDOWN => NetworkDown,
         c::WSAENETUNREACH => NetworkUnreachable,
         c::WSAEDQUOT => QuotaExceeded,
-        // Not a prefect mapping but this error is only returned when writing to
+        // Not a perfect mapping but this error is only returned when writing to
         // a socket after shutting down the write-end. On Unix targets, EPIPE is
         // returned in those cases.
         c::WSAESHUTDOWN => BrokenPipe,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

As discussed in [#t-libs > WSAESHUTDOWN error on Windows](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/WSAESHUTDOWN.20error.20on.20Windows/with/591883531), this adds the mapping for `WSAESHUTDOWN` on Windows to `io::ErrorKind::BrokenPipe`.

r? RalfJung