### PR TITLE
Do not depend on typeck to borrow-check inline consts.

### DIFF
--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -23,6 +23,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_index::IndexVec;
 use rustc_infer::infer::NllRegionVariableOrigin;
 use rustc_macros::extension;
+use rustc_middle::mir::RETURN_PLACE;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
     self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionVid, Ty,
@@ -584,7 +585,6 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
     /// see `DefiningTy` for details.
     fn defining_ty(&self) -> DefiningTy<'tcx> {
         let tcx = self.infcx.tcx;
-        let typeck_root_def_id = tcx.typeck_root_def_id_local(self.mir_def);
 
         match tcx.hir_body_owner_kind(self.mir_def) {
             BodyOwnerKind::Closure | BodyOwnerKind::Fn => {
@@ -614,36 +614,40 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
             }
 
             BodyOwnerKind::Const { .. } | BodyOwnerKind::Static(..) => {
-                let identity_args = GenericArgs::identity_for_item(tcx, typeck_root_def_id);
-                if self.mir_def == typeck_root_def_id {
-                    let args = self.infcx.replace_free_regions_with_nll_infer_vars(
-                        NllRegionVariableOrigin::FreeRegion,
-                        identity_args,
-                    );
-                    DefiningTy::Const(self.mir_def.to_def_id(), args)
-                } else {
-                    // FIXME: this line creates a query dependency between borrowck and typeck.
-                    //
-                    // This is required for `AscribeUserType` canonical query, which will call
-                    // `type_of(inline_const_def_id)`. That `type_of` would inject erased lifetimes
-                    // into borrowck, which is ICE #78174.
-                    //
-                    // As a workaround, inline consts have an additional generic param (`ty`
-                    // below), so that `type_of(inline_const_def_id).args(args)` uses the
-                    // proper type with NLL infer vars.
-                    let ty = tcx
-                        .typeck(self.mir_def)
-                        .node_type(tcx.local_def_id_to_hir_id(self.mir_def));
-                    let args = InlineConstArgs::new(
-                        tcx,
-                        InlineConstArgsParts { parent_args: identity_args, ty },
-                    )
-                    .args;
-                    let args = self.infcx.replace_free_regions_with_nll_infer_vars(
-                        NllRegionVariableOrigin::FreeRegion,
-                        args,
-                    );
-                    DefiningTy::InlineConst(self.mir_def.to_def_id(), args)
+                match tcx.def_kind(self.mir_def) {
+                    DefKind::InlineConst => {
+                        // This is required for `AscribeUserType` canonical query, which will call
+                        // `type_of(inline_const_def_id)`. That `type_of` would inject erased lifetimes
+                        // into borrowck, which is ICE #78174.
+                        //
+                        // As a workaround, inline consts have an additional generic param (`ty`
+                        // below), so that `type_of(inline_const_def_id).substs(substs)` uses the
+                        // proper type with NLL infer vars.
+                        //
+                        // Fetch the actual type from MIR, as `type_of` returns something useless
+                        // like `<const_ty>`.
+                        let body = tcx.mir_promoted(self.mir_def).0.borrow();
+                        let ty = body.local_decls[RETURN_PLACE].ty;
+                        let typeck_root_def_id = tcx.typeck_root_def_id(self.mir_def.to_def_id());
+                        let parent_args = GenericArgs::identity_for_item(tcx, typeck_root_def_id);
+                        let args =
+                            InlineConstArgs::new(tcx, InlineConstArgsParts { parent_args, ty })
+                                .args;
+                        let args = self.infcx.replace_free_regions_with_nll_infer_vars(
+                            NllRegionVariableOrigin::FreeRegion,
+                            args,
+                        );
+                        DefiningTy::InlineConst(self.mir_def.to_def_id(), args)
+                    }
+                    _ => {
+                        let identity_args =
+                            GenericArgs::identity_for_item(tcx, self.mir_def.to_def_id());
+                        let args = self.infcx.replace_free_regions_with_nll_infer_vars(
+                            NllRegionVariableOrigin::FreeRegion,
+                            identity_args,
+                        );
+                        DefiningTy::Const(self.mir_def.to_def_id(), args)
+                    }
                 }
             }
 


### PR DESCRIPTION
Instead fetch the type from the inline-const's MIR, which comes from exactly the same typeck information.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
