### PR TITLE
Add extra symbol check for `.to_owned()`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3536,17 +3536,18 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 && let ty::Adt(adt_def, _) = return_ty.kind()
                 && adt_def.did() == cow_did
             {
-                if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(return_span) {
-                    if let Some(pos) = snippet.rfind(".to_owned") {
-                        let byte_pos = BytePos(pos as u32 + 1u32);
-                        let to_owned_span = return_span.with_hi(return_span.lo() + byte_pos);
-                        err.span_suggestion_short(
-                            to_owned_span.shrink_to_hi(),
-                            "try using `.into_owned()` if you meant to convert a `Cow<'_, T>` to an owned `T`",
-                            "in",
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
+                let typeck = tcx.typeck(self.mir_def_id());
+                if let Some(expr) = self.find_expr(return_span)
+                    && let Some(def_id) = typeck.type_dependent_def_id(expr.hir_id)
+                    && tcx.is_diagnostic_item(sym::to_owned_method, def_id)
+                    && let Some(to_owned_ident) = expr.method_ident()
+                {
+                    err.span_suggestion_short(
+                        to_owned_ident.span.shrink_to_lo(),
+                        "try using `.into_owned()` if you meant to convert a `Cow<'_, T>` to an owned `T`",
+                        "in",
+                        Applicability::MaybeIncorrect,
+                    );
                 }
             }
         }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2046,6 +2046,7 @@ symbols! {
         thumb2,
         thumb_mode: "thumb-mode",
         tmm_reg,
+        to_owned_method,
         to_string,
         to_vec,
         tool_attributes,

--- a/src/tools/clippy/clippy_utils/src/sym.rs
+++ b/src/tools/clippy/clippy_utils/src/sym.rs
@@ -606,7 +606,6 @@ generate! {
     to_ne_bytes,
     to_os_string,
     to_owned,
-    to_owned_method,
     to_path_buf,
     to_string_method,
     to_uppercase,


### PR DESCRIPTION
Follow up of rust-lang/rust#154646

Previously when adding a suggestion for using `Cow::into_owned()` instead of `ToOwned::to_owned()`, the compiler would just convert the methods `Span` into a `String` and do checks on that `String`. This PR adds an extra guard to that suggestion by checking if the method is `sym::to_owned_method`.

r? @davidtwco since you added the review to the previous PR
