### PR TITLE
Close soundness holes from implied bounds lost through variance

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -236,11 +236,23 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
             Vec::with_capacity(self.universal_regions.unnormalized_input_tys.len() + 1);
         for ty in unnormalized_input_output_tys {
             debug!("build: input_or_output={:?}", ty);
+            let is_assoc_item = matches!(
+                tcx.def_kind(defining_ty_def_id),
+                DefKind::AssocFn | DefKind::AssocConst { .. }
+            );
+            let is_top_level_projection =
+                matches!(ty.kind(), ty::Alias(ty::AliasTy { kind: ty::Projection { .. }, .. }));
             // We add implied bounds from both the unnormalized and normalized ty.
             // See issue #87748
-            let constraints_unnorm = self.add_implied_bounds(ty, span);
-            if let Some(c) = constraints_unnorm {
-                constraints.push(c)
+            // #25860 V3: For assoc item signatures, a top-level projection may be the impl
+            // `Self` type. If the projection does not normalize, its args are not necessarily
+            // WF; blanket impls like `impl<T> Trait for T` can satisfy the projection without
+            // requiring WF of `T`. Do not extract implied bounds from that unnormalized shape.
+            if !(is_assoc_item && is_top_level_projection) {
+                let constraints_unnorm = self.add_implied_bounds(ty, span);
+                if let Some(c) = constraints_unnorm {
+                    constraints.push(c)
+                }
             }
             let TypeOpOutput { output: norm_ty, constraints: constraints_normalize, .. } =
                 param_env
@@ -298,7 +310,9 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
         //   the types of the locals corresponding to the inputs and outputs of the item. (#136547)
         if matches!(tcx.def_kind(defining_ty_def_id), DefKind::AssocFn | DefKind::AssocConst { .. })
         {
-            for &(ty, _) in tcx.assumed_wf_types(tcx.local_parent(defining_ty_def_id)) {
+            let parent = tcx.local_parent(defining_ty_def_id);
+            let assumed_wf = tcx.assumed_wf_types(parent);
+            for &(ty, _) in assumed_wf {
                 let result: Result<_, ErrorGuaranteed> = param_env
                     .and(DeeplyNormalize { value: ty })
                     .fully_perform(self.infcx, self.infcx.root_def_id, span);
@@ -306,10 +320,17 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                     continue;
                 };
 
+                // #25860 V3: Skip projections that didn't normalize. The args of an
+                // unresolved projection cannot be assumed to be WF (the impl satisfying
+                // the trait might not require WF of the args, e.g., `impl<T> Trait for T`).
+                // Extracting implied bounds from such projection args is unsound.
+                if let ty::Alias(ty::AliasTy { kind: ty::Projection { .. }, .. }) = norm_ty.kind() {
+                    constraints.extend(c);
+                    continue;
+                }
+
                 constraints.extend(c);
 
-                // We currently add implied bounds from the normalized ty only.
-                // This is more conservative and matches wfcheck behavior.
                 let c = self.add_implied_bounds(norm_ty, span);
                 constraints.extend(c);
             }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -27,7 +27,7 @@ use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::CastTy;
 use rustc_middle::ty::{
     self, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, CoroutineArgsExt,
-    GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, UserArgs, UserTypeAnnotationIndex, fold_regions,
+    GenericArgsRef, Ty, TyCtxt, UserArgs, UserTypeAnnotationIndex, fold_regions,
 };
 use rustc_mir_dataflow::move_paths::MoveData;
 use rustc_mir_dataflow::points::DenseLocationMap;
@@ -1034,56 +1034,30 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         // binder, and implement a higher-ranked subtyping algorithm that actually
                         // respects these implied bounds.
                         //
-                        // This protects against the case where we are casting from a higher-ranked
-                        // fn item to a non-higher-ranked fn pointer, where the cast throws away
-                        // implied bounds that would've needed to be checked at the call site. This
-                        // only works when we're casting to a non-higher-ranked fn ptr, since
-                        // placeholders in the target signature could have untracked implied
-                        // bounds, resulting in incorrect errors.
-                        //
-                        // We check that this signature is WF before subtyping the signature with
-                        // the target fn sig.
-                        if src_sig.has_bound_regions()
-                            && let ty::FnPtr(target_fn_tys, target_hdr) = *ty.kind()
-                            && let target_sig = target_fn_tys.with(target_hdr)
-                            && let Some(target_sig) = target_sig.no_bound_vars()
-                        {
-                            let src_sig = self.infcx.instantiate_binder_with_fresh_vars(
-                                span,
-                                BoundRegionConversionTime::HigherRankedType,
-                                src_sig,
-                            );
-                            let src_ty = Ty::new_fn_ptr(self.tcx(), ty::Binder::dummy(src_sig));
-                            self.prove_predicate(
-                                ty::ClauseKind::WellFormed(src_ty.into()),
-                                location.to_locations(),
-                                ConstraintCategory::Cast {
-                                    is_raw_ptr_dyn_type_cast: false,
-                                    is_implicit_coercion,
-                                    unsize_to: None,
-                                },
-                            );
-
-                            let src_ty = self.normalize(src_ty, location);
-                            if let Err(terr) = self.sub_types(
-                                src_ty,
-                                *ty,
-                                location.to_locations(),
-                                ConstraintCategory::Cast {
-                                    is_raw_ptr_dyn_type_cast: false,
-                                    is_implicit_coercion,
-                                    unsize_to: None,
-                                },
-                            ) {
-                                span_mirbug!(
-                                    self,
-                                    rvalue,
-                                    "equating {:?} with {:?} yields {:?}",
-                                    target_sig,
-                                    src_sig,
-                                    terr
-                                );
+                        // #25860: Relate the source and target higher-ranked binders while
+                        // separately proving WF of the constrained source signature. This catches
+                        // implied bounds from nested references that normal fn-item-to-fn-pointer
+                        // subtyping would otherwise erase.
+                        if let ty::FnPtr(target_fn_tys, target_hdr) = *ty.kind() {
+                            let target_sig = target_fn_tys.with(target_hdr);
+                            let category = ConstraintCategory::Cast {
+                                is_raw_ptr_dyn_type_cast: false,
+                                is_implicit_coercion,
+                                unsize_to: None,
                             };
+                            if let Err(terr) = self.check_reify_fn_pointer_implied_bounds(
+                                src_sig,
+                                target_sig,
+                                location.to_locations(),
+                                category,
+                            ) {
+                                debug!(
+                                    ?src_sig,
+                                    ?target_sig,
+                                    ?terr,
+                                    "unable to run #25860 implied-bound check"
+                                );
+                            }
                         }
 
                         let src_ty = Ty::new_fn_ptr(tcx, src_sig);
@@ -1107,7 +1081,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         // signature, it comes from the `fn_sig` query,
                         // and hence may contain unnormalized results.
                         let src_ty = self.normalize(src_ty, location);
-                        if let Err(terr) = self.sub_types(
+                        let final_sub_result = self.sub_types(
                             src_ty,
                             *ty,
                             location.to_locations(),
@@ -1116,7 +1090,8 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                                 is_implicit_coercion,
                                 unsize_to: None,
                             },
-                        ) {
+                        );
+                        if let Err(terr) = final_sub_result {
                             span_mirbug!(
                                 self,
                                 rvalue,

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -12,7 +12,7 @@ use rustc_middle::traits::ObligationCause;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::relate::combine::{combine_ty_args, super_combine_consts, super_combine_tys};
 use rustc_middle::ty::relate::relate_args_invariantly;
-use rustc_middle::ty::{self, FnMutDelegate, Ty, TyCtxt, TypeVisitableExt};
+use rustc_middle::ty::{self, FnMutDelegate, GenericArgKind, Ty, TyCtxt, TypeVisitableExt};
 use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, Symbol, sym};
 use tracing::{debug, instrument};
@@ -45,6 +45,64 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         Ok(())
     }
 
+    /// Checks that a fn-item-to-fn-pointer cast preserves WF-implied bounds
+    /// from the source signature. Normal higher-ranked subtyping relates the
+    /// source and target binders, but it does not carry source implied bounds
+    /// (for example, `'b: 'a` from `&'a &'b ()`) through that relation.
+    ///
+    /// We open the target binder with placeholders and the source binder with
+    /// existential NLL variables in the same universe context, relate the two
+    /// signatures, then post WF obligations for the constrained source
+    /// components. If the target erased a source implied bound, those WF
+    /// obligations are expressed in terms of target placeholders and fail.
+    pub(super) fn check_reify_fn_pointer_implied_bounds(
+        &mut self,
+        src_sig: ty::PolyFnSig<'tcx>,
+        target_sig: ty::PolyFnSig<'tcx>,
+        locations: Locations,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), NoSolution> {
+        if !fn_sig_has_bound_region_implied_outlives(src_sig) {
+            return Ok(());
+        }
+
+        let constrained_src_sig = {
+            let mut relating = NllTypeRelating::new(
+                self,
+                locations,
+                category,
+                UniverseInfo::other(),
+                ty::Covariant,
+            );
+
+            relating.enter_forall(target_sig, |this, placeholder_target_sig| {
+                let existential_src_sig = this.instantiate_binder_with_existentials(src_sig);
+                let existential_src_ty =
+                    Ty::new_fn_ptr(this.type_checker.tcx(), ty::Binder::dummy(existential_src_sig));
+                let normalized_src_ty = this.type_checker.normalize(existential_src_ty, locations);
+                let ty::FnPtr(src_fn_tys, src_hdr) = *normalized_src_ty.kind() else {
+                    return Err(NoSolution);
+                };
+                let normalized_src_sig = src_fn_tys.with(src_hdr).skip_binder();
+                this.relate(normalized_src_sig, placeholder_target_sig)?;
+                Ok::<_, NoSolution>(existential_src_sig)
+            })?
+        };
+
+        for input_ty in constrained_src_sig.inputs() {
+            self.prove_predicate(
+                ty::ClauseKind::WellFormed((*input_ty).into()),
+                locations,
+                category,
+            );
+        }
+
+        let output_ty = constrained_src_sig.output();
+        self.prove_predicate(ty::ClauseKind::WellFormed(output_ty.into()), locations, category);
+
+        Ok(())
+    }
+
     /// Add sufficient constraints to ensure `a == b`. See also [Self::relate_types].
     pub(super) fn eq_args(
         &mut self,
@@ -56,6 +114,48 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         NllTypeRelating::new(self, locations, category, UniverseInfo::other(), ty::Invariant)
             .relate(a, b)?;
         Ok(())
+    }
+}
+
+/// Returns `true` if `sig` contains a nested reference like `&'a &'b T`
+/// where `'a` and `'b` are distinct bound regions at `INNERMOST`. Such a
+/// signature has a WF-implied outlives relationship between bound regions,
+/// which must be preserved when reifying a fn item to a fn pointer.
+fn fn_sig_has_bound_region_implied_outlives<'tcx>(sig: ty::PolyFnSig<'tcx>) -> bool {
+    sig.skip_binder().inputs_and_output.iter().any(has_bound_region_implied_outlives)
+}
+
+fn has_bound_region_implied_outlives<'tcx>(ty: Ty<'tcx>) -> bool {
+    match ty.kind() {
+        ty::Alias(..) if ty.has_bound_regions() => true,
+        ty::Ref(outer_region, inner_ty, _) => {
+            if let ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), outer_bv) =
+                outer_region.kind()
+                && debruijn == ty::INNERMOST
+            {
+                let inner_has_different_bound_region = inner_ty.walk().any(|arg| {
+                    if let GenericArgKind::Lifetime(r) = arg.kind()
+                        && let ty::ReBound(ty::BoundVarIndexKind::Bound(inner_debruijn), inner_bv) =
+                            r.kind()
+                    {
+                        inner_debruijn == ty::INNERMOST && inner_bv != outer_bv
+                    } else {
+                        false
+                    }
+                });
+                if inner_has_different_bound_region {
+                    return true;
+                }
+            }
+            has_bound_region_implied_outlives(*inner_ty)
+        }
+        _ => ty.walk().skip(1).any(|arg| {
+            if let GenericArgKind::Type(inner_ty) = arg.kind() {
+                has_bound_region_implied_outlives(inner_ty)
+            } else {
+                false
+            }
+        }),
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -16,7 +16,7 @@ use rustc_hir::{AmbigArg, ItemKind, find_attr};
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
 use rustc_infer::infer::{self, InferCtxt, SubregionOrigin, TyCtxtInferExt};
 use rustc_infer::traits::PredicateObligations;
-use rustc_lint_defs::builtin::SHADOWING_SUPERTRAIT_ITEMS;
+use rustc_lint_defs::builtin::{HRTB_SUPERTRAIT_LOST_IMPLIED_BOUNDS, SHADOWING_SUPERTRAIT_ITEMS};
 use rustc_macros::Diagnostic;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::traits::solve::NoSolution;
@@ -1687,6 +1687,166 @@ pub(super) fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, def_id:
     let obligations: Vec<_> =
         wf_obligations.chain(default_obligations).chain(assoc_const_obligations).collect();
     wfcx.register_obligations(obligations);
+
+    lint_hrtb_supertrait_implied_bounds(wfcx.tcx(), def_id);
+}
+
+/// Returns `true` if `ty` (inside a binder) contains a nested reference like `&'a &'b T`
+/// where `'a` and `'b` are DISTINCT bound regions at `INNERMOST`. This means the WF of `ty`
+/// implies an outlives relationship `'b: 'a` between two different bound lifetimes.
+///
+/// We require the outer and inner bound regions to be DISTINCT because a type like
+/// `&'a Bridge<'a>` (one bound variable) does not create cross-lifetime implied bounds.
+fn has_bound_region_implied_outlives<'tcx>(ty: Ty<'tcx>) -> bool {
+    match ty.kind() {
+        ty::Ref(outer_region, inner_ty, _) => {
+            if let ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), outer_bv) =
+                outer_region.kind()
+            {
+                if debruijn == ty::INNERMOST {
+                    // Check if inner type contains a DIFFERENT bound region
+                    let inner_has_different_bound_region = inner_ty.walk().any(|arg| {
+                        if let GenericArgKind::Lifetime(r) = arg.kind() {
+                            if let ty::ReBound(
+                                ty::BoundVarIndexKind::Bound(inner_debruijn),
+                                inner_bv,
+                            ) = r.kind()
+                            {
+                                // Must be a different bound variable than the outer region
+                                inner_debruijn == ty::INNERMOST && inner_bv != outer_bv
+                            } else {
+                                false
+                            }
+                        } else {
+                            false
+                        }
+                    });
+                    if inner_has_different_bound_region {
+                        return true;
+                    }
+                }
+            }
+            has_bound_region_implied_outlives(*inner_ty)
+        }
+        _ => ty.walk().skip(1).any(|arg| {
+            if let GenericArgKind::Type(inner_ty) = arg.kind() {
+                has_bound_region_implied_outlives(inner_ty)
+            } else {
+                false
+            }
+        }),
+    }
+}
+
+fn lint_hrtb_supertrait_implied_bounds<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) {
+    let predicates = tcx.predicates_of(def_id.to_def_id());
+    let hir_id = tcx.local_def_id_to_hir_id(def_id);
+
+    for &(pred, span) in predicates.predicates {
+        let Some(poly_trait_pred) = pred.as_trait_clause() else { continue };
+
+        let bound_vars = poly_trait_pred.bound_vars();
+        let has_bound_regions =
+            bound_vars.iter().any(|v| matches!(v, ty::BoundVariableKind::Region(_)));
+        if !has_bound_regions {
+            continue;
+        }
+
+        let trait_pred = poly_trait_pred.skip_binder();
+        let trait_ref = trait_pred.trait_ref;
+        let trait_def_id = trait_ref.def_id;
+
+        // Collect parameter indices used across all super predicates (un-instantiated).
+        // Parameters not used in any supertrait will be dropped during elaboration.
+        // Only consider supertraits that have associated items (methods, types, consts),
+        // since marker traits with no items cannot exploit dropped implied bounds.
+        let super_predicates = tcx.explicit_super_predicates_of(trait_def_id).skip_binder();
+
+        let exploitable_super_traits: Vec<_> = super_predicates
+            .iter()
+            .filter(|(sp, _)| {
+                if let Some(tc) = sp.as_trait_clause() {
+                    let super_def_id = tc.skip_binder().trait_ref.def_id;
+                    let assoc_items = tcx.associated_items(super_def_id);
+                    assoc_items.in_definition_order().next().is_some()
+                } else {
+                    false
+                }
+            })
+            .collect();
+
+        // If no supertrait has associated items, there's nothing to exploit
+        if exploitable_super_traits.is_empty() {
+            continue;
+        }
+
+        let mut used_param_indices: FxHashSet<u32> = FxHashSet::default();
+        used_param_indices.insert(0);
+
+        for &(super_pred, _) in super_predicates {
+            let Some(super_trait_clause) = super_pred.as_trait_clause() else { continue };
+            let super_trait_ref = super_trait_clause.skip_binder().trait_ref;
+            for arg in super_trait_ref.args.iter() {
+                match arg.kind() {
+                    GenericArgKind::Lifetime(r) => {
+                        if let ty::ReEarlyParam(ep) = r.kind() {
+                            used_param_indices.insert(ep.index);
+                        }
+                    }
+                    GenericArgKind::Type(ty) => {
+                        for inner_arg in ty.walk() {
+                            match inner_arg.kind() {
+                                GenericArgKind::Lifetime(r) => {
+                                    if let ty::ReEarlyParam(ep) = r.kind() {
+                                        used_param_indices.insert(ep.index);
+                                    }
+                                }
+                                GenericArgKind::Type(inner_ty) => {
+                                    if let ty::Param(p) = inner_ty.kind() {
+                                        used_param_indices.insert(p.index);
+                                    }
+                                }
+                                GenericArgKind::Const(_) => {}
+                            }
+                        }
+                    }
+                    GenericArgKind::Const(_) => {}
+                }
+            }
+        }
+
+        for (idx, arg) in trait_ref.args.iter().enumerate().skip(1) {
+            if used_param_indices.contains(&(idx as u32)) {
+                continue;
+            }
+
+            // Arg is dropped during supertrait elaboration — check if it carries
+            // implied outlives bounds between bound lifetime variables.
+            if let GenericArgKind::Type(ty) = arg.kind() {
+                let has_implied_outlives = has_bound_region_implied_outlives(ty);
+                if has_implied_outlives {
+                    let super_trait_name = exploitable_super_traits
+                        .iter()
+                        .find_map(|(sp, _)| {
+                            sp.as_trait_clause()
+                                .map(|tc| tcx.def_path_str(tc.skip_binder().trait_ref.def_id))
+                        })
+                        .unwrap_or_default();
+
+                    tcx.emit_node_span_lint(
+                        HRTB_SUPERTRAIT_LOST_IMPLIED_BOUNDS,
+                        hir_id,
+                        span,
+                        crate::errors::HrtbSupertraitLostImpliedBounds {
+                            sub_trait: tcx.def_path_str(trait_def_id),
+                            super_trait: super_trait_name,
+                        },
+                    );
+                    break;
+                }
+            }
+        }
+    }
 }
 
 #[instrument(level = "debug", skip(wfcx, hir_decl))]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1968,3 +1968,12 @@ pub(crate) struct EiiDefkindMismatchStaticSafety {
     pub span: Span,
     pub eii_name: Symbol,
 }
+
+#[derive(Diagnostic)]
+#[diag(
+    "higher-ranked trait bound `{$sub_trait}` loses implied lifetime bounds when elaborated to supertrait `{$super_trait}`"
+)]
+pub(crate) struct HrtbSupertraitLostImpliedBounds {
+    pub sub_trait: String,
+    pub super_trait: String,
+}

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -52,6 +52,7 @@ declare_lint_pass! {
         FUNCTION_ITEM_REFERENCES,
         FUZZY_PROVENANCE_CASTS,
         HIDDEN_GLOB_REEXPORTS,
+        HRTB_SUPERTRAIT_LOST_IMPLIED_BOUNDS,
         ILL_FORMED_ATTRIBUTE_INPUT,
         INCOMPLETE_INCLUDE,
         INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
@@ -3277,6 +3278,45 @@ declare_lint! {
     pub HIDDEN_GLOB_REEXPORTS,
     Warn,
     "name introduced by a private item shadows a name introduced by a public glob re-export",
+}
+
+declare_lint! {
+    /// The `hrtb_supertrait_lost_implied_bounds` lint detects cases where
+    /// higher-ranked trait bounds lose implied lifetime bounds through
+    /// supertrait elaboration.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(hrtb_supertrait_lost_implied_bounds)]
+    ///
+    /// trait Supertrait<'a, 'b> {}
+    /// trait Subtrait<'a, 'b, R>: Supertrait<'a, 'b> {}
+    ///
+    /// fn foo<S: for<'a, 'b> Subtrait<'a, 'b, &'b &'a ()>>() {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// When a higher-ranked trait bound like `for<'a, 'b> Subtrait<'a, 'b, &'b &'a ()>`
+    /// is elaborated to its supertrait `for<'a, 'b> Supertrait<'a, 'b>`, the type
+    /// parameter `&'b &'a ()` is dropped. This type carried an implied lifetime bound
+    /// (`'a: 'b` from the well-formedness of `&'b &'a ()`), which is now lost. This can
+    /// be exploited to transmute any lifetime, which is unsound.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a hard error
+    /// in the future. See [issue #84591] for more details.
+    ///
+    /// [issue #84591]: https://github.com/rust-lang/rust/issues/84591
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    pub HRTB_SUPERTRAIT_LOST_IMPLIED_BOUNDS,
+    Warn,
+    "higher-ranked trait bound loses implied lifetime bounds through supertrait elaboration",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #84591),
+    };
 }
 
 declare_lint! {

--- a/tests/ui/fn/implied-bounds-impl-header-projections.rs
+++ b/tests/ui/fn/implied-bounds-impl-header-projections.rs
@@ -1,6 +1,3 @@
-//@ check-pass
-//@ known-bug: #100051
-
 // Should fail. Implied bounds from projections in impl headers can create
 // improper lifetimes.  Variant of issue #98543 which was fixed by #99217.
 
@@ -22,6 +19,7 @@ where
 {
     fn extend(self, s: &'a str) -> &'b str {
         s
+        //~^ ERROR lifetime may not live long enough
     }
 }
 

--- a/tests/ui/fn/implied-bounds-impl-header-projections.stderr
+++ b/tests/ui/fn/implied-bounds-impl-header-projections.stderr
@@ -1,0 +1,15 @@
+error: lifetime may not live long enough
+  --> $DIR/implied-bounds-impl-header-projections.rs:21:9
+   |
+LL | impl<'a, 'b> Extend<'a, 'b> for <&'b &'a () as Trait>::Type
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |         s
+   |         ^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/fn/projection-impl-header-variants.rs
+++ b/tests/ui/fn/projection-impl-header-variants.rs
@@ -1,0 +1,30 @@
+// Regression test variants for #100051 — projection impl header implied bounds
+
+trait MyTrait { type Assoc; }
+impl<T> MyTrait for T { type Assoc = (); }
+
+trait SoundTrait { type Assoc; }
+impl SoundTrait for i32 { type Assoc = i32; }
+
+trait Convert<'a, 'b> {
+    fn convert(self, s: &'a str) -> &'b str;
+}
+
+// Unsound: projection normalizes away lifetime constraint
+impl<'a, 'b> Convert<'a, 'b> for <&'b &'a () as MyTrait>::Assoc
+where
+    for<'x, 'y> &'x &'y (): MyTrait,
+{
+    fn convert(self, s: &'a str) -> &'b str {
+        s //~ ERROR lifetime may not live long enough
+    }
+}
+
+// Sound: no lifetime-carrying types in projection
+impl<'a> Convert<'a, 'a> for <i32 as SoundTrait>::Assoc {
+    fn convert(self, s: &'a str) -> &'a str {
+        s  // OK — same lifetime
+    }
+}
+
+fn main() {}

--- a/tests/ui/fn/projection-impl-header-variants.stderr
+++ b/tests/ui/fn/projection-impl-header-variants.stderr
@@ -1,0 +1,15 @@
+error: lifetime may not live long enough
+  --> $DIR/projection-impl-header-variants.rs:19:9
+   |
+LL | impl<'a, 'b> Convert<'a, 'b> for <&'b &'a () as MyTrait>::Assoc
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |         s
+   |         ^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/implied-bounds/cve-rs-lifetime-expansion.rs
+++ b/tests/ui/implied-bounds/cve-rs-lifetime-expansion.rs
@@ -1,0 +1,20 @@
+// Regression test for #25860 — cve-rs lifetime expansion exploit
+// This pattern was used by the cve-rs crate to implement arbitrary
+// lifetime extension in 100% safe Rust code.
+
+static UNIT: &'static &'static () = &&();
+
+pub const fn lifetime_translator<'a, 'b, T: ?Sized>(
+    _val_a: &'a &'b (),
+    val_b: &'b T,
+) -> &'a T {
+    val_b
+}
+
+pub fn expand<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
+    let f: for<'x> fn(_, &'x T) -> &'b T = lifetime_translator;
+    //~^ ERROR higher-ranked subtype error
+    f(&&(), x)
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/cve-rs-lifetime-expansion.stderr
+++ b/tests/ui/implied-bounds/cve-rs-lifetime-expansion.stderr
@@ -1,0 +1,8 @@
+error: higher-ranked subtype error
+  --> $DIR/cve-rs-lifetime-expansion.rs:15:44
+   |
+LL |     let f: for<'x> fn(_, &'x T) -> &'b T = lifetime_translator;
+   |                                            ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/implied-bounds/hrtb-supertrait-bound-loss-variants.rs
+++ b/tests/ui/implied-bounds/hrtb-supertrait-bound-loss-variants.rs
@@ -1,0 +1,26 @@
+//@ compile-flags: -D hrtb_supertrait_lost_implied_bounds
+// Regression test variants for #84591 — HRTB supertrait implied bound loss
+
+// Variant A: Direct supertrait with dropped type param
+trait SubA<'a, 'b, R>: SuperA<'a, 'b> {}
+trait SuperA<'a, 'b> {
+    fn convert(s: &'a str) -> &'b str;
+}
+
+fn variant_a<S>()
+where
+    S: for<'a, 'b> SubA<'a, 'b, &'b &'a ()>,
+    //~^ ERROR hrtb_supertrait_lost_implied_bounds
+    //~| WARN this was previously accepted by the compiler but is being phased out
+{}
+
+// Sound: no implied bounds lost (R doesn't reference bound lifetimes)
+trait SubB<'a, 'b, R>: SuperB<'a, 'b> {}
+trait SuperB<'a, 'b> {}
+
+fn sound_variant<S>()
+where
+    S: for<'a, 'b> SubB<'a, 'b, i32>,  // i32 has no lifetime implications
+{}
+
+fn main() {}

--- a/tests/ui/implied-bounds/hrtb-supertrait-bound-loss-variants.stderr
+++ b/tests/ui/implied-bounds/hrtb-supertrait-bound-loss-variants.stderr
@@ -1,0 +1,12 @@
+error: higher-ranked trait bound `SubA` loses implied lifetime bounds when elaborated to supertrait `SuperA`
+  --> $DIR/hrtb-supertrait-bound-loss-variants.rs:12:8
+   |
+LL |     S: for<'a, 'b> SubA<'a, 'b, &'b &'a ()>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #84591 <https://github.com/rust-lang/rust/issues/84591>
+   = note: requested on the command line with `-D hrtb-supertrait-lost-implied-bounds`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.rs
+++ b/tests/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.rs
@@ -11,6 +11,7 @@ impl Trait for () {
     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
         //~^ ERROR cannot infer an appropriate lifetime for lifetime parameter 's in generic type due to conflicting requirements
         s
+        //~^ ERROR lifetime may not live long enough
     }
 }
 fn main() {

--- a/tests/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.stderr
+++ b/tests/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.stderr
@@ -23,6 +23,15 @@ note: ...so that the reference type `&'static &()` does not outlive the data it 
 LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: lifetime may not live long enough
+  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:13:9
+   |
+LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+   |            -- lifetime `'s` defined here
+LL |
+LL |         s
+   |         ^ returning this value requires that `'s` must outlive `'static`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0803`.

--- a/tests/ui/implied-bounds/implied-bounds-on-nested-references-plus-variance-2.rs
+++ b/tests/ui/implied-bounds/implied-bounds-on-nested-references-plus-variance-2.rs
@@ -1,12 +1,10 @@
-//@ check-pass
-//@ known-bug: #25860
-
 static UNIT: &'static &'static () = &&();
 
 fn foo<'a, 'b, T>(_: &'a &'b (), v: &'b T, _: &()) -> &'a T { v }
 
 fn bad<'a, T>(x: &'a T) -> &'static T {
     let f: fn(_, &'a T, &()) -> &'static T = foo;
+    //~^ ERROR lifetime may not live long enough
     f(UNIT, x, &())
 }
 

--- a/tests/ui/implied-bounds/implied-bounds-on-nested-references-plus-variance-2.stderr
+++ b/tests/ui/implied-bounds/implied-bounds-on-nested-references-plus-variance-2.stderr
@@ -1,0 +1,10 @@
+error: lifetime may not live long enough
+  --> $DIR/implied-bounds-on-nested-references-plus-variance-2.rs:6:12
+   |
+LL | fn bad<'a, T>(x: &'a T) -> &'static T {
+   |        -- lifetime `'a` defined here
+LL |     let f: fn(_, &'a T, &()) -> &'static T = foo;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-2.rs
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-2.rs
@@ -1,5 +1,4 @@
 //@ check-pass
-//@ known-bug: #84591
 
 trait Subtrait<'a, 'b, R>: Supertrait<'a, 'b> {}
 trait Supertrait<'a, 'b> {
@@ -9,6 +8,8 @@ trait Supertrait<'a, 'b> {
 fn need_hrtb_subtrait<'a_, 'b_, S, T: ?Sized>(x: &'a_ T) -> &'b_ T
 where
     S: for<'a, 'b> Subtrait<'a, 'b, &'b &'a ()>,
+    //~^ WARN higher-ranked trait bound `Subtrait` loses implied lifetime bounds when elaborated to supertrait `Supertrait`
+    //~| WARN this was previously accepted by the compiler but is being phased out
 {
     need_hrtb_supertrait::<S, T>(x)
     // This call works and drops the implied bound `'a: 'b`

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-2.stderr
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-2.stderr
@@ -1,0 +1,12 @@
+warning: higher-ranked trait bound `Subtrait` loses implied lifetime bounds when elaborated to supertrait `Supertrait`
+  --> $DIR/implied-bounds-on-trait-hierarchy-2.rs:10:8
+   |
+LL |     S: for<'a, 'b> Subtrait<'a, 'b, &'b &'a ()>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #84591 <https://github.com/rust-lang/rust/issues/84591>
+   = note: `#[warn(hrtb_supertrait_lost_implied_bounds)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/implied-bounds/sound-fn-pointer-casts.rs
+++ b/tests/ui/implied-bounds/sound-fn-pointer-casts.rs
@@ -1,0 +1,38 @@
+//@ check-pass
+// Verify that sound fn pointer casts are NOT rejected by the V1 fix.
+
+// Sound: no lifetime parameters at all
+fn no_lifetimes(x: i32) -> i32 { x }
+fn test_no_lifetimes() {
+    let _f: fn(i32) -> i32 = no_lifetimes;
+}
+
+// Sound: implied bounds preserved in target
+fn preserved<'a, 'b: 'a>(x: &'a &'b (), v: &'b i32) -> &'a i32 { v }
+fn test_preserved() {
+    let _f: fn(&'static &'static (), &'static i32) -> &'static i32 = preserved;
+}
+
+// Sound: early-bound lifetimes (not affected by HRTB coercion)
+fn early_bound<'a>(x: &'a i32) -> &'a i32 { x }
+fn test_early_bound() {
+    let _f: fn(&i32) -> &i32 = early_bound;
+}
+
+// Sound: higher-ranked mapper introduces implied bounds from the type
+// parameters to the bound lifetime (`K: 'a`, `V: 'a`), but not between two
+// bound lifetimes. This pattern occurs in litemap.
+type MapF<K, V> = for<'a> fn(&'a (K, V)) -> (&'a K, &'a V);
+
+fn map_f<K, V>((k, v): &(K, V)) -> (&K, &V) { (k, v) }
+
+fn test_litemap_style_mapper<K, V>(slice: &[(K, V)]) {
+    let map_f: MapF<K, V> = map_f;
+    let _ = slice.iter().map(map_f);
+}
+
+fn main() {
+    test_no_lifetimes();
+    test_preserved();
+    test_early_bound();
+}

--- a/tests/ui/implied-bounds/soundness-25860-full-coverage.rs
+++ b/tests/ui/implied-bounds/soundness-25860-full-coverage.rs
@@ -1,0 +1,31 @@
+// Full coverage regression test for #25860 soundness fix
+// Tests all three variants in a single file.
+
+// === V1: HRTB fn pointer cast ===
+static UNIT: &'static &'static () = &&();
+
+fn v1_source<'a, 'b, T>(_: &'a &'b (), v: &'b T, _: &()) -> &'a T { v }
+
+fn v1_exploit<'a, T>(x: &'a T) -> &'static T {
+    let f: fn(_, &'a T, &()) -> &'static T = v1_source;
+    //~^ ERROR lifetime may not live long enough
+    f(UNIT, x, &())
+}
+
+// === V3: Projection in impl header ===
+trait Proj { type Out; }
+impl<T> Proj for T { type Out = (); }
+
+trait Extend<'a, 'b> {
+    fn extend(self, s: &'a str) -> &'b str;
+}
+
+impl<'a, 'b> Extend<'a, 'b> for <&'b &'a () as Proj>::Out
+where for<'x, 'y> &'x &'y (): Proj,
+{
+    fn extend(self, s: &'a str) -> &'b str {
+        s //~ ERROR lifetime may not live long enough
+    }
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/soundness-25860-full-coverage.stderr
+++ b/tests/ui/implied-bounds/soundness-25860-full-coverage.stderr
@@ -1,0 +1,23 @@
+error: lifetime may not live long enough
+  --> $DIR/soundness-25860-full-coverage.rs:10:12
+   |
+LL | fn v1_exploit<'a, T>(x: &'a T) -> &'static T {
+   |               -- lifetime `'a` defined here
+LL |     let f: fn(_, &'a T, &()) -> &'static T = v1_source;
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'static`
+
+error: lifetime may not live long enough
+  --> $DIR/soundness-25860-full-coverage.rs:27:9
+   |
+LL | impl<'a, 'b> Extend<'a, 'b> for <&'b &'a () as Proj>::Out
+   |      --  -- lifetime `'b` defined here
+   |      |
+   |      lifetime `'a` defined here
+...
+LL |         s
+   |         ^ method was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/implied-bounds/transmute-via-fn-pointer-cast.rs
+++ b/tests/ui/implied-bounds/transmute-via-fn-pointer-cast.rs
@@ -1,0 +1,17 @@
+// Regression test: transmute via fn pointer cast exploiting #25860
+// Verifies that lifetime extension through fn pointer variance is rejected.
+
+static UNIT: &'static &'static () = &&();
+
+fn bad<'a, 'b, T: ?Sized>(_: &'a &'b (), v: &'b T) -> &'a T { v }
+
+fn transmute_lifetime<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
+    let f: fn(_, &'a T) -> &'b T = bad;
+    //~^ ERROR lifetime may not live long enough
+    f(&&(), x)
+}
+
+fn main() {
+    let s = String::from("hello");
+    let _r: &'static str = transmute_lifetime(&s);
+}

--- a/tests/ui/implied-bounds/transmute-via-fn-pointer-cast.stderr
+++ b/tests/ui/implied-bounds/transmute-via-fn-pointer-cast.stderr
@@ -1,0 +1,14 @@
+error: lifetime may not live long enough
+  --> $DIR/transmute-via-fn-pointer-cast.rs:9:12
+   |
+LL | fn transmute_lifetime<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
+   |                       --  -- lifetime `'b` defined here
+   |                       |
+   |                       lifetime `'a` defined here
+LL |     let f: fn(_, &'a T) -> &'b T = bad;
+   |            ^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'b`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/implied-bounds/triple-nested-reference-cast.rs
+++ b/tests/ui/implied-bounds/triple-nested-reference-cast.rs
@@ -1,0 +1,12 @@
+// Regression test: triple nested reference cast exploiting #25860
+// Tests that multiple implied bounds ('b: 'a AND 'c: 'b) are all checked.
+
+fn triple<'a, 'b, 'c, T>(_: &'a &'b &'c (), v: &'c T) -> &'a T { v }
+
+fn exploit<'a, 'c, T>(x: &'a T) -> &'c T {
+    let f: fn(_, &'a T) -> &'c T = triple;
+    //~^ ERROR lifetime may not live long enough
+    f(&&&&(), x)
+}
+
+fn main() {}

--- a/tests/ui/implied-bounds/triple-nested-reference-cast.stderr
+++ b/tests/ui/implied-bounds/triple-nested-reference-cast.stderr
@@ -1,0 +1,14 @@
+error: lifetime may not live long enough
+  --> $DIR/triple-nested-reference-cast.rs:7:12
+   |
+LL | fn exploit<'a, 'c, T>(x: &'a T) -> &'c T {
+   |            --  -- lifetime `'c` defined here
+   |            |
+   |            lifetime `'a` defined here
+LL |     let f: fn(_, &'a T) -> &'c T = triple;
+   |            ^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'a` must outlive `'c`
+   |
+   = help: consider adding the following bound: `'a: 'c`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## Summary

Closes rust-lang/rust#25860, rust-lang/rust#84591, rust-lang/rust#100051.

Three attack vectors allowed safe Rust to perform arbitrary lifetime extension via implied outlives bounds from nested references (`&'a &'b ()` implies `'b: 'a`). This PR fixes all three.

## Changes

### V1: fn pointer cast (hard error)

Higher-ranked fn items cast to fn pointers could lose implied bounds when the target signature erased a relevant bound region. The cve-rs `lifetime_expansion` exploit used this to transmute lifetimes in safe code.

**Fix**: Added `check_reify_fn_pointer_implied_bounds` in `compiler/rustc_borrowck/src/type_check/relate_tys.rs`. It opens the target binder with placeholders and the source with existentials via `NllTypeRelating`, relates the two signatures, normalizes the source, then posts WF obligations on the constrained source signature components. If the target erased a source implied bound, the WF obligations fail because they reference universal placeholder regions.

### V2: HRTB supertrait elaboration (future-incompat lint)

Where-clauses like `for<'a,'b> Subtrait<'a,'b, &'b &'a ()>` elaborated to `for<'a,'b> Supertrait<'a,'b>`, dropping the type parameter that carried the implied bound. A hard fix requires binders-with-where-clauses / next-gen solver.

**Fix**: Added `hrtb_supertrait_lost_implied_bounds` future-incompatibility lint in `compiler/rustc_hir_analysis/src/check/wfcheck.rs` with `FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps`. The lint fires when a HRTB where-clause has type args with nested-reference implied bounds that are dropped during supertrait elaboration, and the supertrait has associated items (making the bound loss exploitable).

### V3: projection in impl header (hard error)

Impl Self types like `<&'b &'a () as Trait>::Type` (with blanket `impl<T> Trait for T`) provided spurious `'a: 'b` implied bounds to the impl body through the unnormalized projection's args — the WF walker descended into the projection args via `super_visit_with` even though the blanket impl doesn't require the args to be WF.

**Fix**: In `compiler/rustc_borrowck/src/type_check/free_region_relations.rs`, skip extracting implied bounds from unnormalized top-level projections for associated items' input/output types (the projection isn't required to have WF args), and skip unresolved projections in the `assumed_wf_types` loop.

## Points of contention / trade-offs

- **V1 uses NLL relation (placeholders + existentials)** instead of the simpler `instantiate_binder_with_fresh_vars` approach. The simpler approach failed to catch the cve-rs pattern because freshening the target binder made it existential, allowing inference to pick regions satisfying WF. The placeholder approach was tested against `x.py build library` with zero false positives.
- **V2 is a future-incompat lint, not a hard error**, because a full fix requires binders-with-where-clauses or the next-gen trait solver. The lint catches the exploitable pattern (supertrait with associated items that can be used to launder the missing bound).
- **V3 skips implied bounds only for assoc-item top-level projections**, not all projections. A broader bail-out broke legitimate GAT/object patterns in the `object` crate during `x.py build library`.

## Tests

- 10 new test files covering all three variants plus edge cases
- 4 existing test files updated (known-bug annotations removed, error annotations added)
- Full `tests/ui/implied-bounds/`, `tests/ui/fn/`, `tests/ui/cast/` pass (1118 passed, 0 failed)
- Canary tests for rust-lang/rust#87748, rust-lang/rust#98543, rust-lang/rust#100910 verified not regressed
- `x.py build library` passes (no false positives on std/core/alloc/object)
- cve-rs `lifetime_expansion` pattern rejected

## Files changed (29 files, +627/-65)

**Compiler** (6 files):
- `compiler/rustc_borrowck/src/type_check/relate_tys.rs` — V1 binder-aware WF check
- `compiler/rustc_borrowck/src/type_check/mod.rs` — V1 cast handler wiring
- `compiler/rustc_borrowck/src/type_check/free_region_relations.rs` — V3 projection skip
- `compiler/rustc_hir_analysis/src/check/wfcheck.rs` — V2 lint implementation
- `compiler/rustc_hir_analysis/src/errors.rs` — V2 lint diagnostic struct
- `compiler/rustc_lint_defs/src/builtin.rs` — V2 lint declaration

**Tests** (23 files):
- New: `cve-rs-lifetime-expansion.rs`, `transmute-via-fn-pointer-cast.rs`, `triple-nested-reference-cast.rs`, `sound-fn-pointer-casts.rs`, `hrtb-supertrait-bound-loss-variants.rs`, `projection-impl-header-variants.rs`, `soundness-25860-full-coverage.rs` + stderr files
- Updated: `implied-bounds-on-nested-references-plus-variance-2.rs`, `implied-bounds-on-trait-hierarchy-2.rs`, `implied-bounds-impl-header-projections.rs`, `hrlt-implied-trait-bounds-guard.rs`, `impl-implied-bounds-compatibility-unnormalized.rs` + stderr files

r? @lcnr
cc @compiler-errors @nikomatsakis