### PR TITLE
VaList::next_arg: track_caller for better Miri errors

### DIFF
--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -422,6 +422,7 @@ impl<'f> VaList<'f> {
     /// [`c_void`]: core::ffi::c_void
     #[inline] // Avoid codegen when not used to help backends that don't support VaList.
     #[rustc_const_unstable(feature = "const_c_variadic", issue = "151787")]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub const unsafe fn next_arg<T: VaArgSafe>(&mut self) -> T {
         // SAFETY: the caller must uphold the safety contract for `va_arg`.
         unsafe { va_arg(self) }

--- a/src/tools/miri/tests/fail/c-variadic.rs
+++ b/src/tools/miri/tests/fail/c-variadic.rs
@@ -1,10 +1,8 @@
 #![feature(c_variadic)]
 
-//@error-in-other-file: Undefined Behavior: more C-variadic arguments read than were passed
-
 fn read_too_many() {
     unsafe extern "C" fn variadic(mut ap: ...) {
-        ap.next_arg::<i32>();
+        ap.next_arg::<i32>(); //~ERROR: more C-variadic arguments read than were passed
     }
 
     unsafe { variadic() };

--- a/src/tools/miri/tests/fail/c-variadic.stderr
+++ b/src/tools/miri/tests/fail/c-variadic.stderr
@@ -1,19 +1,17 @@
 error: Undefined Behavior: more C-variadic arguments read than were passed
-  --> RUSTLIB/core/src/ffi/va_list.rs:LL:CC
+  --> tests/fail/c-variadic.rs:LL:CC
    |
-LL |         unsafe { va_arg(self) }
-   |                  ^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |         ap.next_arg::<i32>();
+   |         ^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: stack backtrace:
-           0: std::ffi::VaList::<'_>::next_arg
-               at RUSTLIB/core/src/ffi/va_list.rs:LL:CC
-           1: read_too_many::variadic
+           0: read_too_many::variadic
                at tests/fail/c-variadic.rs:LL:CC
-           2: read_too_many
+           1: read_too_many
                at tests/fail/c-variadic.rs:LL:CC
-           3: main
+           2: main
                at tests/fail/c-variadic.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace


### PR DESCRIPTION
The test diff should explain why this is better. :)

r? @folkertdev 