### PR TITLE
Fix unused_parens for pinned reference patterns

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -636,7 +636,7 @@ impl UnusedParens {
         avoid_mut: bool,
         keep_space: (bool, bool),
     ) {
-        use ast::{BindingMode, PatKind};
+        use ast::{BindingMode, ByRef, Mutability, PatKind, Pinnedness};
 
         if let PatKind::Paren(inner) = &value.kind {
             match inner.kind {
@@ -649,8 +649,16 @@ impl UnusedParens {
                 PatKind::Guard(..) => return,
                 // Avoid `p0 | .. | pn` if we should.
                 PatKind::Or(..) if avoid_or => return,
-                // Avoid `mut x` and `mut x @ p` if we should:
-                PatKind::Ident(BindingMode::MUT, ..) if avoid_mut => {
+                // Avoid bindings that start with `mut`, like `mut x`, `mut x @ p`,
+                // and `mut ref pin const x`, if we should.
+                PatKind::Ident(BindingMode(_, Mutability::Mut), ..) if avoid_mut => {
+                    return;
+                }
+                PatKind::Ref(_, Pinnedness::Pinned, _)
+                | PatKind::Ident(BindingMode(ByRef::Yes(Pinnedness::Pinned, _), _), ..)
+                    // FIXME(pin_ergonomics): Remove this gate once pinned patterns are stable.
+                    if !cx.builder.features().pin_ergonomics() =>
+                {
                     return;
                 }
                 // Otherwise proceed with linting.
@@ -756,8 +764,8 @@ impl EarlyLintPass for UnusedParens {
     }
 
     fn check_pat(&mut self, cx: &EarlyContext<'_>, p: &ast::Pat) {
-        use ast::Mutability;
         use ast::PatKind::*;
+        use ast::{Mutability, Pinnedness};
         let keep_space = (false, false);
         match &p.kind {
             // Do not lint on `(..)` as that will result in the other arms being useless.
@@ -789,11 +797,24 @@ impl EarlyLintPass for UnusedParens {
                 self.check_unused_parens_pat(cx, p, true, false, keep_space)
             }
             // Avoid linting on `&(mut x)` as `&mut x` has a different meaning, #55342.
+            // This only applies to plain shared reference patterns. In `&pin const (mut x)`,
+            // `pin const` is consumed before parsing the subpattern, so removing the
+            // parentheses preserves `mut x` as a binding pattern.
             // Also avoid linting on `& mut? (p0 | .. | pn)`, #64106.
-            // FIXME(pin_ergonomics): check pinned patterns
-            Ref(p, _, m) => {
-                self.check_unused_parens_pat(cx, p, true, *m == Mutability::Not, keep_space)
+            Ref(p, pinned, m)
+                if *pinned != Pinnedness::Pinned
+                    // FIXME(pin_ergonomics): Remove this gate once pinned patterns are stable.
+                    || cx.builder.features().pin_ergonomics() =>
+            {
+                self.check_unused_parens_pat(
+                    cx,
+                    p,
+                    true,
+                    *pinned == Pinnedness::Not && *m == Mutability::Not,
+                    keep_space,
+                );
             }
+            Ref(..) => {}
         }
     }
 

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -649,8 +649,8 @@ impl UnusedParens {
                 PatKind::Guard(..) => return,
                 // Avoid `p0 | .. | pn` if we should.
                 PatKind::Or(..) if avoid_or => return,
-                // Avoid bindings that start with `mut`, like `mut x`, `mut x @ p`,
-                // and `mut ref pin const x`, if we should.
+                // Avoid bindings whose own binding mutability is `mut`, like `mut x`,
+                // `mut x @ p`, and `mut ref pin const x`, if we should.
                 PatKind::Ident(BindingMode(_, Mutability::Mut), ..) if avoid_mut => {
                     return;
                 }

--- a/tests/ui/lint/unused-parens-pinned-reference-patterns-no-feature.rs
+++ b/tests/ui/lint/unused-parens-pinned-reference-patterns-no-feature.rs
@@ -1,0 +1,9 @@
+#![feature(mut_ref)]
+#![warn(unused_parens)]
+
+fn main() {
+    let pin_const: &pin const i32 = todo!();
+    //~^ ERROR pinned reference syntax is experimental
+    let &pin const (_x) = pin_const;
+    //~^ ERROR pinned reference syntax is experimental
+}

--- a/tests/ui/lint/unused-parens-pinned-reference-patterns-no-feature.stderr
+++ b/tests/ui/lint/unused-parens-pinned-reference-patterns-no-feature.stderr
@@ -1,0 +1,23 @@
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/unused-parens-pinned-reference-patterns-no-feature.rs:5:21
+   |
+LL |     let pin_const: &pin const i32 = todo!();
+   |                     ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/unused-parens-pinned-reference-patterns-no-feature.rs:7:10
+   |
+LL |     let &pin const (_x) = pin_const;
+   |          ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/lint/unused-parens-pinned-reference-patterns.fixed
+++ b/tests/ui/lint/unused-parens-pinned-reference-patterns.fixed
@@ -1,0 +1,56 @@
+//@ run-rustfix
+//@ check-pass
+//@ normalize-stderr: "warning: 9 warnings emitted\n\n" -> "warning: 9 warnings emitted\n"
+#![feature(pin_ergonomics, mut_ref)]
+#![allow(dead_code)]
+#![warn(unused_parens)]
+
+fn pinned_reference_patterns(
+    pin_const: &pin const i32,
+    pin_mut: &pin mut i32,
+    nested_pin_const: &pin const &pin const i32,
+) {
+    let &pin const _x = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const mut _x = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const mut _x @ _ = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin mut mut _x = pin_mut;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const &pin const _x = nested_pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const ref pin const _x = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin mut ref pin mut _x = pin_mut;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const mut ref pin const _x = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin mut mut ref pin mut _x = pin_mut;
+    //~^ WARN unnecessary parentheses around pattern
+}
+
+fn pinned_or_patterns_are_still_ambiguous(pin_const: &pin const i32) {
+    match pin_const {
+        &pin const (0 | 1) => {}
+        _ => {}
+    }
+}
+
+fn plain_shared_reference_patterns_still_need_parens(shared: &i32) {
+    let &(mut _x) = shared;
+
+    let &(mut ref _x) = shared;
+
+    let &(mut ref pin const _x) = shared;
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-parens-pinned-reference-patterns.rs
+++ b/tests/ui/lint/unused-parens-pinned-reference-patterns.rs
@@ -1,0 +1,56 @@
+//@ run-rustfix
+//@ check-pass
+//@ normalize-stderr: "warning: 9 warnings emitted\n\n" -> "warning: 9 warnings emitted\n"
+#![feature(pin_ergonomics, mut_ref)]
+#![allow(dead_code)]
+#![warn(unused_parens)]
+
+fn pinned_reference_patterns(
+    pin_const: &pin const i32,
+    pin_mut: &pin mut i32,
+    nested_pin_const: &pin const &pin const i32,
+) {
+    let &pin const (_x) = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const (mut _x) = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const (mut _x @ _) = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin mut (mut _x) = pin_mut;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const (&pin const _x) = nested_pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const (ref pin const _x) = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin mut (ref pin mut _x) = pin_mut;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin const (mut ref pin const _x) = pin_const;
+    //~^ WARN unnecessary parentheses around pattern
+
+    let &pin mut (mut ref pin mut _x) = pin_mut;
+    //~^ WARN unnecessary parentheses around pattern
+}
+
+fn pinned_or_patterns_are_still_ambiguous(pin_const: &pin const i32) {
+    match pin_const {
+        &pin const (0 | 1) => {}
+        _ => {}
+    }
+}
+
+fn plain_shared_reference_patterns_still_need_parens(shared: &i32) {
+    let &(mut _x) = shared;
+
+    let &(mut ref _x) = shared;
+
+    let &(mut ref pin const _x) = shared;
+}
+
+fn main() {}

--- a/tests/ui/lint/unused-parens-pinned-reference-patterns.stderr
+++ b/tests/ui/lint/unused-parens-pinned-reference-patterns.stderr
@@ -1,0 +1,114 @@
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:13:20
+   |
+LL |     let &pin const (_x) = pin_const;
+   |                    ^  ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:6:9
+   |
+LL | #![warn(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     let &pin const (_x) = pin_const;
+LL +     let &pin const _x = pin_const;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:16:20
+   |
+LL |     let &pin const (mut _x) = pin_const;
+   |                    ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin const (mut _x) = pin_const;
+LL +     let &pin const mut _x = pin_const;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:19:20
+   |
+LL |     let &pin const (mut _x @ _) = pin_const;
+   |                    ^          ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin const (mut _x @ _) = pin_const;
+LL +     let &pin const mut _x @ _ = pin_const;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:22:18
+   |
+LL |     let &pin mut (mut _x) = pin_mut;
+   |                  ^      ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin mut (mut _x) = pin_mut;
+LL +     let &pin mut mut _x = pin_mut;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:25:20
+   |
+LL |     let &pin const (&pin const _x) = nested_pin_const;
+   |                    ^             ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin const (&pin const _x) = nested_pin_const;
+LL +     let &pin const &pin const _x = nested_pin_const;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:28:20
+   |
+LL |     let &pin const (ref pin const _x) = pin_const;
+   |                    ^                ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin const (ref pin const _x) = pin_const;
+LL +     let &pin const ref pin const _x = pin_const;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:31:18
+   |
+LL |     let &pin mut (ref pin mut _x) = pin_mut;
+   |                  ^              ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin mut (ref pin mut _x) = pin_mut;
+LL +     let &pin mut ref pin mut _x = pin_mut;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:34:20
+   |
+LL |     let &pin const (mut ref pin const _x) = pin_const;
+   |                    ^                    ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin const (mut ref pin const _x) = pin_const;
+LL +     let &pin const mut ref pin const _x = pin_const;
+   |
+
+warning: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-pinned-reference-patterns.rs:37:18
+   |
+LL |     let &pin mut (mut ref pin mut _x) = pin_mut;
+   |                  ^                  ^
+   |
+help: remove these parentheses
+   |
+LL -     let &pin mut (mut ref pin mut _x) = pin_mut;
+LL +     let &pin mut mut ref pin mut _x = pin_mut;
+   |
+
+warning: 9 warnings emitted


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156089)*
<!-- homu-ignore:end -->

The unused_parens lint previously treated pinned shared-reference patterns like plain shared-reference patterns when deciding whether removing parentheses could change the meaning of a leading `mut` binding.

That was too conservative for pinned reference patterns such as `&pin const (mut x)`. The `pin const` part belongs to the outer reference pattern, so removing the inner parentheses still leaves `mut x` as the subpattern.

This updates the ambiguity check so the leading-`mut` suppression only applies to plain shared reference patterns. Pinned reference patterns can now receive correct rustfix suggestions.

The patch also broadens the binding check from only plain `mut` bindings to all binding modes whose binding mutability is `Mutability::Mut`, covering forms such as `mut ref pin const`.

@rustbot label F-pin_ergonomics
