### PR TITLE
Hand-implement `impl Debug for NumBuffer` to avoid constraining `T` or printing MaybeUninit

### DIFF
--- a/library/core/src/fmt/num_buffer.rs
+++ b/library/core/src/fmt/num_buffer.rs
@@ -35,12 +35,18 @@ impl_NumBufferTrait! {
 /// A buffer wrapper of which the internal size is based on the maximum
 /// number of digits the associated integer can have.
 #[unstable(feature = "int_format_into", issue = "138215")]
-#[derive(Debug)]
 pub struct NumBuffer<T: NumBufferTrait> {
     // FIXME: Once const generics feature is working, use `T::BUF_SIZE` instead of 40.
     pub(crate) buf: [MaybeUninit<u8>; 40],
     // FIXME: Remove this field once we can actually use `T`.
     phantom: core::marker::PhantomData<T>,
+}
+
+#[unstable(feature = "int_format_into", issue = "138215")]
+impl<T: NumBufferTrait> core::fmt::Debug for NumBuffer<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NumBuffer").finish()
+    }
 }
 
 #[unstable(feature = "int_format_into", issue = "138215")]


### PR DESCRIPTION
The derived implementation requires `T: Debug`, and doesn't need to.
