### PR TITLE
Fix E0040 suggestion for explicit `Drop::drop` UFCS calls

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -42,7 +42,7 @@ pub(crate) fn check_legal_trait_for_method_call(
     if tcx.is_lang_item(trait_id, LangItem::Drop) {
         let sugg = if let Some(receiver) = receiver.filter(|s| !s.is_empty()) {
             errors::ExplicitDestructorCallSugg::Snippet {
-                lo: expr_span.shrink_to_lo(),
+                lo: expr_span.shrink_to_lo().to(receiver.shrink_to_lo()),
                 hi: receiver.shrink_to_hi().to(expr_span.shrink_to_hi()),
             }
         } else {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1013,10 +1013,24 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 debug!(?def_id, ?container, ?container_id);
                 match container {
                     ty::AssocContainer::Trait => {
+                        let arg_span = if let hir::Node::Expr(call_expr) =
+                            self.tcx.parent_hir_node(hir_id)
+                            && let hir::ExprKind::Call(_, args) = call_expr.kind
+                            && let Some(first_arg) = args.first()
+                        {
+                            let mut arg = first_arg;
+                            while let hir::ExprKind::AddrOf(_, _, inner) = arg.kind {
+                                arg = inner;
+                            }
+                            Some(arg.span)
+                        } else {
+                            None
+                        };
+
                         if let Err(e) = callee::check_legal_trait_for_method_call(
                             tcx,
                             path_span,
-                            None,
+                            arg_span,
                             span,
                             container_id,
                             self.body_id.to_def_id(),

--- a/tests/ui/drop/explicit-drop-call-error.fixed
+++ b/tests/ui/drop/explicit-drop-call-error.fixed
@@ -11,5 +11,5 @@ impl Drop for Foo {
 }
 
 fn main() {
-    drop(&mut Foo) //~ ERROR explicit use of destructor method
+    drop(Foo) //~ ERROR explicit use of destructor method
 }

--- a/tests/ui/drop/explicit-drop-call-named-ref.fixed
+++ b/tests/ui/drop/explicit-drop-call-named-ref.fixed
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+fn foo(f: Foo) {
+    drop(f); //~ ERROR explicit use of destructor method
+    //~| HELP: consider using `drop` function
+}
+
+fn main() {
+    let f = Foo;
+    foo(f);
+}

--- a/tests/ui/drop/explicit-drop-call-named-ref.rs
+++ b/tests/ui/drop/explicit-drop-call-named-ref.rs
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+fn foo(f: Foo) {
+    Drop::drop(&mut f); //~ ERROR explicit use of destructor method
+    //~| HELP: consider using `drop` function
+}
+
+fn main() {
+    let f = Foo;
+    foo(f);
+}

--- a/tests/ui/drop/explicit-drop-call-named-ref.stderr
+++ b/tests/ui/drop/explicit-drop-call-named-ref.stderr
@@ -1,13 +1,13 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/explicit-drop-call-error.rs:14:5
+  --> $DIR/explicit-drop-call-named-ref.rs:10:5
    |
-LL |     Drop::drop(&mut Foo)
+LL |     Drop::drop(&mut f);
    |     ^^^^^^^^^^ explicit destructor calls not allowed
    |
 help: consider using `drop` function
    |
-LL -     Drop::drop(&mut Foo)
-LL +     drop(Foo)
+LL -     Drop::drop(&mut f);
+LL +     drop(f);
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
`Drop::drop(&mut f)` now correctly suggests `drop(f)` instead of the bare `drop` with no argument.

Fix: rust-lang/rust#156017
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
