### PR TITLE
repr(transparent): never consider arrays trivial for the ABI

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -11,7 +11,7 @@ use rustc_hir::def::{CtorKind, DefKind};
 use rustc_hir::{LangItem, Node, find_attr, intravisit};
 use rustc_infer::infer::{RegionVariableOrigin, TyCtxtInferExt};
 use rustc_infer::traits::{Obligation, ObligationCauseCode, WellFormedLoc};
-use rustc_lint_defs::builtin::{REPR_TRANSPARENT_NON_ZST_FIELDS, UNSUPPORTED_CALLING_CONVENTIONS};
+use rustc_lint_defs::builtin::UNSUPPORTED_CALLING_CONVENTIONS;
 use rustc_macros::Diagnostic;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::resolve_bound_vars::ResolvedArg;
@@ -1689,39 +1689,6 @@ pub(super) fn check_packed_inner(
 }
 
 pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) {
-    struct ZeroSizedFieldReprTransparentIncompatibility<'tcx> {
-        unsuited: UnsuitedInfo<'tcx>,
-    }
-
-    impl<'a, 'tcx> Diagnostic<'a, ()> for ZeroSizedFieldReprTransparentIncompatibility<'tcx> {
-        fn into_diag(self, dcx: DiagCtxtHandle<'a>, level: Level) -> Diag<'a, ()> {
-            let Self { unsuited } = self;
-            let (title, note) = match unsuited.reason {
-                UnsuitedReason::NonExhaustive => (
-                    "external non-exhaustive types",
-                    "is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.",
-                ),
-                UnsuitedReason::PrivateField => (
-                    "external types with private fields",
-                    "contains private fields, so it could become non-zero-sized in the future.",
-                ),
-                UnsuitedReason::ReprC => (
-                    "`repr(C)` types",
-                    "is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.",
-                ),
-            };
-            Diag::new(
-                dcx,
-                level,
-                format!("zero-sized fields in `repr(transparent)` cannot contain {title}"),
-            )
-            .with_note(format!(
-                "this field contains `{field_ty}`, which {note}",
-                field_ty = unsuited.ty,
-            ))
-        }
-    }
-
     if !adt.repr().transparent() {
         return;
     }
@@ -1741,108 +1708,137 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
         // Don't bother checking the fields.
         return;
     }
+    let variant = adt.variant(VariantIdx::ZERO);
 
-    let typing_env = ty::TypingEnv::non_body_analysis(tcx, adt.did());
-    // For each field, figure out if it has "trivial" layout (i.e., is a 1-ZST).
-    struct FieldInfo<'tcx> {
-        span: Span,
-        trivial: bool,
-        ty: Ty<'tcx>,
-    }
-
-    let field_infos = adt.all_fields().map(|field| {
-        let ty = field.ty(tcx, GenericArgs::identity_for_item(tcx, field.did));
-        let layout = tcx.layout_of(typing_env.as_query_input(ty));
-        // We are currently checking the type this field came from, so it must be local
-        let span = tcx.hir_span_if_local(field.did).unwrap();
-        let trivial = layout.is_ok_and(|layout| layout.is_1zst());
-        FieldInfo { span, trivial, ty }
-    });
-
-    let non_trivial_fields = field_infos
-        .clone()
-        .filter_map(|field| if !field.trivial { Some(field.span) } else { None });
-    let non_trivial_count = non_trivial_fields.clone().count();
-    if non_trivial_count >= 2 {
-        bad_non_zero_sized_fields(
-            tcx,
-            adt,
-            non_trivial_count,
-            non_trivial_fields,
-            tcx.def_span(adt.did()),
-        );
+    if variant.fields.len() <= 1 {
+        // No need to check when there's at most one field.
         return;
     }
 
-    // Even some 1-ZST fields are not allowed though, if they have `non_exhaustive` or private
-    // fields or `repr(C)`. We call those fields "unsuited".
-    struct UnsuitedInfo<'tcx> {
-        /// The source of the problem, a type that is found somewhere within the field type.
-        ty: Ty<'tcx>,
-        reason: UnsuitedReason,
+    let typing_env = ty::TypingEnv::non_body_analysis(tcx, adt.did());
+
+    /// We call a field "trivial" for `repr(transparent)` purposes if it can be ignored.
+    /// IOW, `repr(transparent)` is allowed if there is at most one non-trivial field.
+    /// This enum captuers all the reasons why a field might not be "trivial".
+    enum NonTrivialReason<'tcx> {
+        UnknownLayout,
+        NonZeroSized,
+        NonTrivialAlignment,
+        PrivateField { inside: Ty<'tcx> },
+        NonExhaustive { ty: Ty<'tcx> },
+        ReprC { ty: Ty<'tcx> },
     }
-    enum UnsuitedReason {
-        NonExhaustive,
-        PrivateField,
-        ReprC,
+    struct NonTrivialFieldInfo<'tcx> {
+        span: Span,
+        reason: NonTrivialReason<'tcx>,
     }
 
-    fn check_unsuited<'tcx>(
+    /// Check if this type is "trivial" for `repr(transparent)`. If not, return the reason why
+    /// and the problematic type.
+    fn is_trivial<'tcx>(
         tcx: TyCtxt<'tcx>,
         typing_env: ty::TypingEnv<'tcx>,
         ty: Ty<'tcx>,
-    ) -> ControlFlow<UnsuitedInfo<'tcx>> {
+    ) -> ControlFlow<NonTrivialReason<'tcx>> {
         // We can encounter projections during traversal, so ensure the type is normalized.
         let ty =
             tcx.try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty)).unwrap_or(ty);
         match ty.kind() {
-            ty::Tuple(list) => list.iter().try_for_each(|t| check_unsuited(tcx, typing_env, t)),
-            ty::Array(ty, _) => check_unsuited(tcx, typing_env, *ty),
+            ty::Tuple(list) => list.iter().try_for_each(|t| is_trivial(tcx, typing_env, t)),
+            ty::Array(ty, _) => is_trivial(tcx, typing_env, *ty),
             ty::Adt(def, args) => {
                 if !def.did().is_local() && !find_attr!(tcx, def.did(), RustcPubTransparent(_)) {
                     let non_exhaustive = def.is_variant_list_non_exhaustive()
                         || def.variants().iter().any(ty::VariantDef::is_field_list_non_exhaustive);
+                    if non_exhaustive {
+                        return ControlFlow::Break(NonTrivialReason::NonExhaustive { ty });
+                    }
                     let has_priv = def.all_fields().any(|f| !f.vis.is_public());
-                    if non_exhaustive || has_priv {
-                        return ControlFlow::Break(UnsuitedInfo {
-                            ty,
-                            reason: if non_exhaustive {
-                                UnsuitedReason::NonExhaustive
-                            } else {
-                                UnsuitedReason::PrivateField
-                            },
-                        });
+                    if has_priv {
+                        return ControlFlow::Break(NonTrivialReason::PrivateField { inside: ty });
                     }
                 }
                 if def.repr().c() {
-                    return ControlFlow::Break(UnsuitedInfo { ty, reason: UnsuitedReason::ReprC });
+                    return ControlFlow::Break(NonTrivialReason::ReprC { ty });
                 }
                 def.all_fields()
                     .map(|field| field.ty(tcx, args))
-                    .try_for_each(|t| check_unsuited(tcx, typing_env, t))
+                    .try_for_each(|t| is_trivial(tcx, typing_env, t))
             }
             _ => ControlFlow::Continue(()),
         }
     }
 
-    let mut prev_unsuited_1zst = false;
-    for field in field_infos {
-        if field.trivial
-            && let Some(unsuited) = check_unsuited(tcx, typing_env, field.ty).break_value()
-        {
-            // If there are any non-trivial fields, then there can be no non-exhaustive 1-zsts.
-            // Otherwise, it's only an issue if there's >1 non-exhaustive 1-zst.
-            if non_trivial_count > 0 || prev_unsuited_1zst {
-                tcx.emit_node_span_lint(
-                    REPR_TRANSPARENT_NON_ZST_FIELDS,
-                    tcx.local_def_id_to_hir_id(adt.did().expect_local()),
-                    field.span,
-                    ZeroSizedFieldReprTransparentIncompatibility { unsuited },
-                );
-            } else {
-                prev_unsuited_1zst = true;
+    let non_trivial_fields = variant
+        .fields
+        .iter()
+        .filter_map(|field| {
+            let ty = field.ty(tcx, GenericArgs::identity_for_item(tcx, field.did));
+            let layout = tcx.layout_of(typing_env.as_query_input(ty));
+            // We are currently checking the type this field came from, so it must be local
+            let span = tcx.hir_span_if_local(field.did).unwrap();
+            // Rule out non-1ZST
+            if !layout.is_ok_and(|layout| layout.is_1zst()) {
+                let reason = match layout {
+                    Err(_) => NonTrivialReason::UnknownLayout,
+                    Ok(layout) => {
+                        if !(layout.is_sized() && layout.size.bytes() == 0) {
+                            NonTrivialReason::NonZeroSized
+                        } else {
+                            NonTrivialReason::NonTrivialAlignment
+                        }
+                    }
+                };
+                return Some(NonTrivialFieldInfo { span, reason });
             }
+            // Recursively check for other things that have to be ruled out.
+            if let Some(reason) = is_trivial(tcx, typing_env, ty).break_value() {
+                return Some(NonTrivialFieldInfo { span, reason });
+            }
+            // Otherwise,
+            None
+        })
+        .collect::<Vec<_>>();
+
+    if non_trivial_fields.len() >= 2 {
+        let count = non_trivial_fields.len();
+        let desc = if adt.is_enum() {
+            format_args!("the variant of a transparent {}", adt.descr())
+        } else {
+            format_args!("transparent {}", adt.descr())
+        };
+        let ty_span = tcx.def_span(adt.did());
+        let mut diag = tcx.dcx().struct_span_err(
+            ty_span,
+            format!("{desc} needs at most one non-trivial field, but has {count}"),
+        );
+        diag.code(E0690);
+
+        // Label for the type.
+        diag.span_label(ty_span, format!("needs at most one non-trivial field, but has {count}"));
+        // Label for each non-trivial field.
+        for field in non_trivial_fields {
+            let msg = match field.reason {
+                NonTrivialReason::UnknownLayout => {
+                    format!("this field is generic and hence may have non-zero size")
+                }
+                NonTrivialReason::NonZeroSized => format!("this field has non-zero size"),
+                NonTrivialReason::NonTrivialAlignment => format!("this field requires alignment"),
+                NonTrivialReason::PrivateField { inside } => format!(
+                    "this field contains `{inside}`, which has private fields, so it could become non-zero-sized in the future"
+                ),
+                NonTrivialReason::NonExhaustive { ty } => format!(
+                    "this field contains `{ty}`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future"
+                ),
+                NonTrivialReason::ReprC { ty } => format!(
+                    "this field contains `{ty}`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets"
+                ),
+            };
+            diag.span_label(field.span, msg);
         }
+
+        diag.emit();
+        return;
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1727,6 +1727,7 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
         PrivateField { inside: Ty<'tcx> },
         NonExhaustive { ty: Ty<'tcx> },
         ReprC { ty: Ty<'tcx> },
+        Array,
     }
     struct NonTrivialFieldInfo<'tcx> {
         span: Span,
@@ -1745,7 +1746,11 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
             tcx.try_normalize_erasing_regions(typing_env, Unnormalized::new_wip(ty)).unwrap_or(ty);
         match ty.kind() {
             ty::Tuple(list) => list.iter().try_for_each(|t| is_trivial(tcx, typing_env, t)),
-            ty::Array(ty, _) => is_trivial(tcx, typing_env, *ty),
+            ty::Array(..) => {
+                // Arrays are meant to be ABI-compatible with what happens in other languages,
+                // so we should not promise that they are "trivial".
+                return ControlFlow::Break(NonTrivialReason::Array);
+            }
             ty::Adt(def, args) => {
                 if !def.did().is_local() && !find_attr!(tcx, def.did(), RustcPubTransparent(_)) {
                     let non_exhaustive = def.is_variant_list_non_exhaustive()
@@ -1832,6 +1837,9 @@ pub(super) fn check_transparent<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>) 
                 ),
                 NonTrivialReason::ReprC { ty } => format!(
                     "this field contains `{ty}`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets"
+                ),
+                NonTrivialReason::Array => format!(
+                    "this field contains an array, which might be relevant for the ABI on some targets"
                 ),
             };
             diag.span_label(field.span, msg);

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -590,32 +590,6 @@ fn bad_variant_count<'tcx>(tcx: TyCtxt<'tcx>, adt: ty::AdtDef<'tcx>, sp: Span, d
     });
 }
 
-/// Emit an error when encountering two or more non-zero-sized fields in a transparent
-/// enum.
-fn bad_non_zero_sized_fields<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    adt: ty::AdtDef<'tcx>,
-    field_count: usize,
-    field_spans: impl Iterator<Item = Span>,
-    sp: Span,
-) {
-    if adt.is_enum() {
-        tcx.dcx().emit_err(errors::TransparentNonZeroSizedEnum {
-            span: sp,
-            spans: field_spans.collect(),
-            field_count,
-            desc: adt.descr(),
-        });
-    } else {
-        tcx.dcx().emit_err(errors::TransparentNonZeroSized {
-            span: sp,
-            spans: field_spans.collect(),
-            field_count,
-            desc: adt.descr(),
-        });
-    }
-}
-
 // FIXME: Consider moving this method to a more fitting place.
 pub fn potentially_plural_count(count: usize, word: &str) -> String {
     format!("{} {}{}", count, word, pluralize!(count))

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1007,30 +1007,6 @@ pub(crate) struct TransparentEnumVariant {
 }
 
 #[derive(Diagnostic)]
-#[diag("the variant of a transparent {$desc} needs at most one field with non-trivial size or alignment, but has {$field_count}", code = E0690)]
-pub(crate) struct TransparentNonZeroSizedEnum<'a> {
-    #[primary_span]
-    #[label("needs at most one field with non-trivial size or alignment, but has {$field_count}")]
-    pub span: Span,
-    #[label("this field has non-zero size or requires alignment")]
-    pub spans: Vec<Span>,
-    pub field_count: usize,
-    pub desc: &'a str,
-}
-
-#[derive(Diagnostic)]
-#[diag("transparent {$desc} needs at most one field with non-trivial size or alignment, but has {$field_count}", code = E0690)]
-pub(crate) struct TransparentNonZeroSized<'a> {
-    #[primary_span]
-    #[label("needs at most one field with non-trivial size or alignment, but has {$field_count}")]
-    pub span: Span,
-    #[label("this field has non-zero size or requires alignment")]
-    pub spans: Vec<Span>,
-    pub field_count: usize,
-    pub desc: &'a str,
-}
-
-#[derive(Diagnostic)]
 #[diag("extern static is too large for the target architecture")]
 pub(crate) struct TooLargeStatic {
     #[primary_span]

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -370,10 +370,6 @@ fn register_builtins(store: &mut LintStore) {
     store.register_renamed("static_mut_ref", "static_mut_refs");
     store.register_renamed("temporary_cstring_as_ptr", "dangling_pointers_from_temporaries");
     store.register_renamed("elided_named_lifetimes", "mismatched_lifetime_syntaxes");
-    store.register_renamed(
-        "repr_transparent_external_private_fields",
-        "repr_transparent_non_zst_fields",
-    );
 
     // These were moved to tool lints, but rustc still sees them when compiling normally, before
     // tool lints are registered, so `check_tool_name_for_backwards_compat` doesn't work. Use
@@ -644,6 +640,16 @@ fn register_builtins(store: &mut LintStore) {
     );
     store.register_removed("wasm_c_abi", "the wasm C ABI has been fixed");
     store.register_removed("soft_unstable", "the general soft-unstable mechanism has been removed");
+    store.register_removed(
+        "repr_transparent_external_private_fields",
+        "converted into hard error, \
+         see <https://github.com/rust-lang/rust/issues/78586> for more information",
+    );
+    store.register_removed(
+        "repr_transparent_non_zst_fields",
+        "converted into hard error, \
+         see <https://github.com/rust-lang/rust/issues/78586> for more information",
+    );
 }
 
 fn register_internals(store: &mut LintStore) {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -94,7 +94,6 @@ declare_lint_pass! {
         REFINING_IMPL_TRAIT_REACHABLE,
         RENAMED_AND_REMOVED_LINTS,
         REPR_C_ENUMS_LARGER_THAN_INT,
-        REPR_TRANSPARENT_NON_ZST_FIELDS,
         RESOLVING_TO_ITEMS_SHADOWING_SUPERTRAIT_ITEMS,
         RTSAN_NONBLOCKING_ASYNC,
         RUST_2021_INCOMPATIBLE_CLOSURE_CAPTURES,
@@ -3080,77 +3079,6 @@ declare_lint! {
     pub EXPLICIT_BUILTIN_CFGS_IN_FLAGS,
     Deny,
     "detects builtin cfgs set via the `--cfg`"
-}
-
-declare_lint! {
-    /// The `repr_transparent_non_zst_fields` lint
-    /// detects types marked `#[repr(transparent)]` that (transitively)
-    /// contain a type that is not guaranteed to remain a ZST type under all configurations.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,ignore (needs external crate)
-    /// #![deny(repr_transparent_external_private_fields)]
-    /// use foo::NonExhaustiveZst;
-    ///
-    /// #[repr(C)]
-    /// struct CZst([u8; 0]);
-    ///
-    /// #[repr(transparent)]
-    /// struct Bar(u32, ([u32; 0], NonExhaustiveZst));
-    /// #[repr(transparent)]
-    /// struct Baz(u32, CZst);
-    /// ```
-    ///
-    /// This will produce:
-    ///
-    /// ```text
-    /// error: zero-sized fields in repr(transparent) cannot contain external non-exhaustive types
-    ///  --> src/main.rs:5:28
-    ///   |
-    /// 5 | struct Bar(u32, ([u32; 0], NonExhaustiveZst));
-    ///   |                            ^^^^^^^^^^^^^^^^
-    ///   |
-    /// note: the lint level is defined here
-    ///  --> src/main.rs:1:9
-    ///   |
-    /// 1 | #![deny(repr_transparent_external_private_fields)]
-    ///   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    ///   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    ///   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-    ///   = note: this field contains `NonExhaustiveZst`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-    ///
-    /// error: zero-sized fields in repr(transparent) cannot contain `#[repr(C)]` types
-    ///  --> src/main.rs:5:28
-    ///   |
-    /// 5 | struct Baz(u32, CZst);
-    ///   |                 ^^^^
-    ///   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    ///   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-    ///   = note: this field contains `CZst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-    /// ```
-    ///
-    /// ### Explanation
-    ///
-    /// Previous, Rust accepted fields that contain external private zero-sized types, even though
-    /// those types could gain a non-zero-sized field in a future, semver-compatible update.
-    ///
-    /// Rust also accepted fields that contain `repr(C)` zero-sized types, even though those types
-    /// are not guaranteed to be zero-sized on all targets, and even though those types can
-    /// make a difference for the ABI (and therefore cannot be ignored by `repr(transparent)`).
-    ///
-    /// This is a [future-incompatible] lint to transition this
-    /// to a hard error in the future. See [issue #78586] for more details.
-    ///
-    /// [issue #78586]: https://github.com/rust-lang/rust/issues/78586
-    /// [future-incompatible]: ../index.md#future-incompatible-lints
-    pub REPR_TRANSPARENT_NON_ZST_FIELDS,
-    Deny,
-    "transparent type contains an external ZST that is marked #[non_exhaustive] or contains private fields",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: fcw!(FutureReleaseError #78586),
-        report_in_deps: true,
-    };
 }
 
 declare_lint! {

--- a/tests/ui/derives/coercepointee/deriving-coerce-pointee-neg.rs
+++ b/tests/ui/derives/coercepointee/deriving-coerce-pointee-neg.rs
@@ -153,7 +153,7 @@ struct RcWithId<T: ?Sized> {
 #[derive(CoercePointee)]
 //~^ ERROR implementing `CoerceUnsized` does not allow multiple fields to be coerced
 struct MoreThanOneField<T: ?Sized> {
-    //~^ ERROR transparent struct needs at most one field with non-trivial size or alignment, but has 2
+    //~^ ERROR transparent struct needs at most one non-trivial field, but has 2
     inner1: Box<T>,
     inner2: Box<T>,
 }

--- a/tests/ui/derives/coercepointee/deriving-coerce-pointee-neg.stderr
+++ b/tests/ui/derives/coercepointee/deriving-coerce-pointee-neg.stderr
@@ -140,16 +140,16 @@ LL |
 LL | struct UsingNonCoercePointeeData<T: ?Sized>(NotCoercePointeeData<T>);
    |                                             ----------------------- `NotCoercePointeeData<T>` must be a pointer, reference, or smart pointer that is allowed to be unsized
 
-error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
   --> $DIR/deriving-coerce-pointee-neg.rs:155:1
    |
 LL | struct MoreThanOneField<T: ?Sized> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one non-trivial field, but has 2
 LL |
 LL |     inner1: Box<T>,
-   |     -------------- this field has non-zero size or requires alignment
+   |     -------------- this field is generic and hence may have non-zero size
 LL |     inner2: Box<T>,
-   |     -------------- this field has non-zero size or requires alignment
+   |     -------------- this field is generic and hence may have non-zero size
 
 error: aborting due to 21 previous errors
 

--- a/tests/ui/lint/improper-ctypes/lint-ctypes.rs
+++ b/tests/ui/lint/improper-ctypes/lint-ctypes.rs
@@ -37,9 +37,6 @@ pub struct TransparentRef<'a>(&'a TransparentInt);
 pub struct TransparentLifetime<'a>(*const u8, PhantomData<&'a ()>);
 #[repr(transparent)]
 pub struct TransparentUnit<U>(f32, PhantomData<U>);
-#[repr(transparent)]
-#[allow(repr_transparent_non_zst_fields)]
-pub struct TransparentCustomZst(i32, ZeroSize);
 
 #[repr(C)]
 pub struct ZeroSizeWithPhantomData(::std::marker::PhantomData<i32>);
@@ -88,7 +85,6 @@ extern "C" {
     pub fn good14(p: TransparentRef);
     pub fn good15(p: TransparentLifetime);
     pub fn good16(p: TransparentUnit<ZeroSize>);
-    pub fn good17(p: TransparentCustomZst);
     #[allow(improper_ctypes)]
     pub fn good18(_: &String);
     pub fn good20(arr: *const [u8; 8]);

--- a/tests/ui/lint/improper-ctypes/lint-ctypes.stderr
+++ b/tests/ui/lint/improper-ctypes/lint-ctypes.stderr
@@ -1,5 +1,5 @@
 error: `extern` block uses type `Foo`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:48:28
+  --> $DIR/lint-ctypes.rs:45:28
    |
 LL |     pub fn ptr_type1(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -18,7 +18,7 @@ LL | #![deny(improper_ctypes)]
    |         ^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `Foo`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:49:28
+  --> $DIR/lint-ctypes.rs:46:28
    |
 LL |     pub fn ptr_type2(size: *const Foo);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -32,7 +32,7 @@ LL | pub struct Foo;
    | ^^^^^^^^^^^^^^
 
 error: `extern` block uses type `((),)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:51:25
+  --> $DIR/lint-ctypes.rs:48:25
    |
 LL |     pub fn ptr_tuple(p: *const ((),));
    |                         ^^^^^^^^^^^^ not FFI-safe
@@ -41,7 +41,7 @@ LL |     pub fn ptr_tuple(p: *const ((),));
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `[u32]`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:52:26
+  --> $DIR/lint-ctypes.rs:49:26
    |
 LL |     pub fn slice_type(p: &[u32]);
    |                          ^^^^^^ not FFI-safe
@@ -50,7 +50,7 @@ LL |     pub fn slice_type(p: &[u32]);
    = note: slices have no C equivalent
 
 error: `extern` block uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:53:24
+  --> $DIR/lint-ctypes.rs:50:24
    |
 LL |     pub fn str_type(p: &str);
    |                        ^^^^ not FFI-safe
@@ -59,7 +59,7 @@ LL |     pub fn str_type(p: &str);
    = note: string slices have no C equivalent
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:54:24
+  --> $DIR/lint-ctypes.rs:51:24
    |
 LL |     pub fn box_type(p: Box<u32>);
    |                        ^^^^^^^^ not FFI-safe
@@ -68,7 +68,7 @@ LL |     pub fn box_type(p: Box<u32>);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `char`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:56:25
+  --> $DIR/lint-ctypes.rs:53:25
    |
 LL |     pub fn char_type(p: char);
    |                         ^^^^ not FFI-safe
@@ -77,7 +77,7 @@ LL |     pub fn char_type(p: char);
    = note: the `char` type has no C equivalent
 
 error: `extern` block uses type `dyn Bar`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:57:26
+  --> $DIR/lint-ctypes.rs:54:26
    |
 LL |     pub fn trait_type(p: &dyn Bar);
    |                          ^^^^^^^^ not FFI-safe
@@ -85,7 +85,7 @@ LL |     pub fn trait_type(p: &dyn Bar);
    = note: trait objects have no C equivalent
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:58:26
+  --> $DIR/lint-ctypes.rs:55:26
    |
 LL |     pub fn tuple_type(p: (i32, i32));
    |                          ^^^^^^^^^^ not FFI-safe
@@ -94,7 +94,7 @@ LL |     pub fn tuple_type(p: (i32, i32));
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:59:27
+  --> $DIR/lint-ctypes.rs:56:27
    |
 LL |     pub fn tuple_type2(p: I32Pair);
    |                           ^^^^^^^ not FFI-safe
@@ -103,7 +103,7 @@ LL |     pub fn tuple_type2(p: I32Pair);
    = note: tuples have unspecified layout
 
 error: `extern` block uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:60:25
+  --> $DIR/lint-ctypes.rs:57:25
    |
 LL |     pub fn zero_size(p: ZeroSize);
    |                         ^^^^^^^^ not FFI-safe
@@ -117,20 +117,20 @@ LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:61:33
+  --> $DIR/lint-ctypes.rs:58:33
    |
 LL |     pub fn zero_size_phantom(p: ZeroSizeWithPhantomData);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 note: the type is defined here
-  --> $DIR/lint-ctypes.rs:45:1
+  --> $DIR/lint-ctypes.rs:42:1
    |
 LL | pub struct ZeroSizeWithPhantomData(::std::marker::PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` block uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:64:12
+  --> $DIR/lint-ctypes.rs:61:12
    |
 LL |         -> ::std::marker::PhantomData<bool>;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -138,7 +138,7 @@ LL |         -> ::std::marker::PhantomData<bool>;
    = note: composed only of `PhantomData`
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:65:23
+  --> $DIR/lint-ctypes.rs:62:23
    |
 LL |     pub fn fn_type(p: RustFn);
    |                       ^^^^^^ not FFI-safe
@@ -147,7 +147,7 @@ LL |     pub fn fn_type(p: RustFn);
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` block uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:66:24
+  --> $DIR/lint-ctypes.rs:63:24
    |
 LL |     pub fn fn_type2(p: fn());
    |                        ^^^^ not FFI-safe
@@ -156,7 +156,7 @@ LL |     pub fn fn_type2(p: fn());
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:67:28
+  --> $DIR/lint-ctypes.rs:64:28
    |
 LL |     pub fn fn_contained(p: RustBadRet);
    |                            ^^^^^^^^^^ not FFI-safe
@@ -165,7 +165,7 @@ LL |     pub fn fn_contained(p: RustBadRet);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `str`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:68:31
+  --> $DIR/lint-ctypes.rs:65:31
    |
 LL |     pub fn transparent_str(p: TransparentStr);
    |                               ^^^^^^^^^^^^^^ not FFI-safe
@@ -174,7 +174,7 @@ LL |     pub fn transparent_str(p: TransparentStr);
    = note: string slices have no C equivalent
 
 error: `extern` block uses type `Box<u32>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:69:30
+  --> $DIR/lint-ctypes.rs:66:30
    |
 LL |     pub fn transparent_fn(p: TransparentBadFn);
    |                              ^^^^^^^^^^^^^^^^ not FFI-safe
@@ -183,7 +183,7 @@ LL |     pub fn transparent_fn(p: TransparentBadFn);
    = note: this struct has unspecified layout
 
 error: `extern` block uses type `[u8; 8]`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:70:27
+  --> $DIR/lint-ctypes.rs:67:27
    |
 LL |     pub fn raw_array(arr: [u8; 8]);
    |                           ^^^^^^^ not FFI-safe
@@ -192,7 +192,7 @@ LL |     pub fn raw_array(arr: [u8; 8]);
    = note: passing raw arrays by value is not FFI-safe
 
 error: `extern` block uses type `Option<UnsafeCell<extern "C" fn()>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:72:26
+  --> $DIR/lint-ctypes.rs:69:26
    |
 LL |     pub fn no_niche_a(a: Option<UnsafeCell<extern "C" fn()>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -201,7 +201,7 @@ LL |     pub fn no_niche_a(a: Option<UnsafeCell<extern "C" fn()>>);
    = note: enum has no representation hint
 
 error: `extern` block uses type `Option<UnsafeCell<&i32>>`, which is not FFI-safe
-  --> $DIR/lint-ctypes.rs:74:26
+  --> $DIR/lint-ctypes.rs:71:26
    |
 LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -210,15 +210,4 @@ LL |     pub fn no_niche_b(b: Option<UnsafeCell<&i32>>);
    = note: enum has no representation hint
 
 error: aborting due to 21 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-warning: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/lint-ctypes.rs:42:38
-   |
-LL | pub struct TransparentCustomZst(i32, ZeroSize);
-   |                                      ^^^^^^^^
-   |
-   = note: this field contains `ZeroSize`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
 

--- a/tests/ui/lint/improper-ctypes/lint-fn.rs
+++ b/tests/ui/lint/improper-ctypes/lint-fn.rs
@@ -53,10 +53,6 @@ pub struct TransparentLifetime<'a>(*const u8, PhantomData<&'a ()>);
 #[repr(transparent)]
 pub struct TransparentUnit<U>(f32, PhantomData<U>);
 
-#[repr(transparent)]
-#[allow(repr_transparent_non_zst_fields)]
-pub struct TransparentCustomZst(i32, ZeroSize);
-
 #[repr(C)]
 pub struct ZeroSizeWithPhantomData(PhantomData<i32>);
 
@@ -147,8 +143,6 @@ pub extern "C" fn good14(p: TransparentRef) { }
 pub extern "C" fn good15(p: TransparentLifetime) { }
 
 pub extern "C" fn good16(p: TransparentUnit<ZeroSize>) { }
-
-pub extern "C" fn good17(p: TransparentCustomZst) { }
 
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn good18(_: &String) { }

--- a/tests/ui/lint/improper-ctypes/lint-fn.stderr
+++ b/tests/ui/lint/improper-ctypes/lint-fn.stderr
@@ -1,5 +1,5 @@
 error: `extern` fn uses type `[u32]`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:71:33
+  --> $DIR/lint-fn.rs:67:33
    |
 LL | pub extern "C" fn slice_type(p: &[u32]) { }
    |                                 ^^^^^^ not FFI-safe
@@ -13,7 +13,7 @@ LL | #![deny(improper_ctypes_definitions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:74:31
+  --> $DIR/lint-fn.rs:70:31
    |
 LL | pub extern "C" fn str_type(p: &str) { }
    |                               ^^^^ not FFI-safe
@@ -22,7 +22,7 @@ LL | pub extern "C" fn str_type(p: &str) { }
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `Box<[u8]>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:81:34
+  --> $DIR/lint-fn.rs:77:34
    |
 LL | pub extern "C" fn boxed_slice(p: Box<[u8]>) { }
    |                                  ^^^^^^^^^ not FFI-safe
@@ -30,7 +30,7 @@ LL | pub extern "C" fn boxed_slice(p: Box<[u8]>) { }
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `Box<str>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:84:35
+  --> $DIR/lint-fn.rs:80:35
    |
 LL | pub extern "C" fn boxed_string(p: Box<str>) { }
    |                                   ^^^^^^^^ not FFI-safe
@@ -38,7 +38,7 @@ LL | pub extern "C" fn boxed_string(p: Box<str>) { }
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `Box<dyn Trait>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:87:34
+  --> $DIR/lint-fn.rs:83:34
    |
 LL | pub extern "C" fn boxed_trait(p: Box<dyn Trait>) { }
    |                                  ^^^^^^^^^^^^^^ not FFI-safe
@@ -46,7 +46,7 @@ LL | pub extern "C" fn boxed_trait(p: Box<dyn Trait>) { }
    = note: box cannot be represented as a single pointer
 
 error: `extern` fn uses type `char`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:90:32
+  --> $DIR/lint-fn.rs:86:32
    |
 LL | pub extern "C" fn char_type(p: char) { }
    |                                ^^^^ not FFI-safe
@@ -55,7 +55,7 @@ LL | pub extern "C" fn char_type(p: char) { }
    = note: the `char` type has no C equivalent
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:93:33
+  --> $DIR/lint-fn.rs:89:33
    |
 LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    |                                 ^^^^^^^^^^ not FFI-safe
@@ -64,7 +64,7 @@ LL | pub extern "C" fn tuple_type(p: (i32, i32)) { }
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `(i32, i32)`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:96:34
+  --> $DIR/lint-fn.rs:92:34
    |
 LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    |                                  ^^^^^^^ not FFI-safe
@@ -73,7 +73,7 @@ LL | pub extern "C" fn tuple_type2(p: I32Pair) { }
    = note: tuples have unspecified layout
 
 error: `extern` fn uses type `ZeroSize`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:99:32
+  --> $DIR/lint-fn.rs:95:32
    |
 LL | pub extern "C" fn zero_size(p: ZeroSize) { }
    |                                ^^^^^^^^ not FFI-safe
@@ -87,20 +87,20 @@ LL | pub struct ZeroSize;
    | ^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `ZeroSizeWithPhantomData`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:102:40
+  --> $DIR/lint-fn.rs:98:40
    |
 LL | pub extern "C" fn zero_size_phantom(p: ZeroSizeWithPhantomData) { }
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
    |
    = note: composed only of `PhantomData`
 note: the type is defined here
-  --> $DIR/lint-fn.rs:61:1
+  --> $DIR/lint-fn.rs:57:1
    |
 LL | pub struct ZeroSizeWithPhantomData(PhantomData<i32>);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:105:51
+  --> $DIR/lint-fn.rs:101:51
    |
 LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    |                                                   ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -108,7 +108,7 @@ LL | pub extern "C" fn zero_size_phantom_toplevel() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:110:30
+  --> $DIR/lint-fn.rs:106:30
    |
 LL | pub extern "C" fn fn_type(p: RustFn) { }
    |                              ^^^^^^ not FFI-safe
@@ -117,7 +117,7 @@ LL | pub extern "C" fn fn_type(p: RustFn) { }
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `fn()`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:113:31
+  --> $DIR/lint-fn.rs:109:31
    |
 LL | pub extern "C" fn fn_type2(p: fn()) { }
    |                               ^^^^ not FFI-safe
@@ -126,7 +126,7 @@ LL | pub extern "C" fn fn_type2(p: fn()) { }
    = note: this function pointer has Rust-specific calling convention
 
 error: `extern` fn uses type `str`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:118:38
+  --> $DIR/lint-fn.rs:114:38
    |
 LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    |                                      ^^^^^^^^^^^^^^ not FFI-safe
@@ -135,7 +135,7 @@ LL | pub extern "C" fn transparent_str(p: TransparentStr) { }
    = note: string slices have no C equivalent
 
 error: `extern` fn uses type `PhantomData<bool>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:170:43
+  --> $DIR/lint-fn.rs:164:43
    |
 LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    |                                           ^^^^^^^^^^^^^^^^^ not FFI-safe
@@ -143,7 +143,7 @@ LL | pub extern "C" fn unused_generic2<T>() -> PhantomData<bool> {
    = note: composed only of `PhantomData`
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:183:39
+  --> $DIR/lint-fn.rs:177:39
    |
 LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    |                                       ^^^^^^ not FFI-safe
@@ -152,7 +152,7 @@ LL | pub extern "C" fn used_generic4<T>(x: Vec<T>) { }
    = note: this struct has unspecified layout
 
 error: `extern` fn uses type `Vec<T>`, which is not FFI-safe
-  --> $DIR/lint-fn.rs:186:41
+  --> $DIR/lint-fn.rs:180:41
    |
 LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    |                                         ^^^^^^ not FFI-safe
@@ -161,15 +161,4 @@ LL | pub extern "C" fn used_generic5<T>() -> Vec<T> {
    = note: this struct has unspecified layout
 
 error: aborting due to 17 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-warning: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/lint-fn.rs:58:38
-   |
-LL | pub struct TransparentCustomZst(i32, ZeroSize);
-   |                                      ^^^^^^^^
-   |
-   = note: this field contains `ZeroSize`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
 

--- a/tests/ui/repr/repr-transparent-non-exhaustive-transparent-in-prose.rs
+++ b/tests/ui/repr/repr-transparent-non-exhaustive-transparent-in-prose.rs
@@ -2,7 +2,6 @@
 
 #![feature(sync_unsafe_cell)]
 #![allow(unused)]
-#![deny(repr_transparent_non_zst_fields)]
 
 // https://github.com/rust-lang/rust/issues/129470
 

--- a/tests/ui/repr/repr-transparent-non-exhaustive.rs
+++ b/tests/ui/repr/repr-transparent-non-exhaustive.rs
@@ -1,5 +1,3 @@
-#![deny(repr_transparent_non_zst_fields)]
-
 //@ aux-build: repr-transparent-non-exhaustive.rs
 extern crate repr_transparent_non_exhaustive;
 
@@ -41,89 +39,72 @@ pub struct T3(Sized, InternalIndirection<(InternalPrivate, InternalNonExhaustive
 pub struct T4(Sized, ExternalIndirection<(InternalPrivate, InternalNonExhaustive)>);
 
 #[repr(transparent)]
-pub struct T5(Sized, Private);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-//~| WARN this was previously accepted by the compiler
+pub struct T5<T>(T, Private);
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T6(Sized, NonExhaustive);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T6a(Sized, <i32 as Trait>::Assoc); // normalizes to `NonExhaustive`
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T7(Sized, NonExhaustiveEnum);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T8(Sized, NonExhaustiveVariant);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T9(Sized, InternalIndirection<Private>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T10(Sized, InternalIndirection<NonExhaustive>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T11(Sized, InternalIndirection<NonExhaustiveEnum>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T12(Sized, InternalIndirection<NonExhaustiveVariant>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T13(Sized, ExternalIndirection<Private>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T14(Sized, ExternalIndirection<NonExhaustive>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T15(Sized, ExternalIndirection<NonExhaustiveEnum>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T16(Sized, ExternalIndirection<NonExhaustiveVariant>);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T17(NonExhaustive, Sized);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T18(NonExhaustive, NonExhaustive);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T19(NonExhaustive, Private);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T19Flipped(Private, NonExhaustive);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T20(NonExhaustive);

--- a/tests/ui/repr/repr-transparent-non-exhaustive.stderr
+++ b/tests/ui/repr/repr-transparent-non-exhaustive.stderr
@@ -1,449 +1,156 @@
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:44:22
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:42:1
    |
-LL | pub struct T5(Sized, Private);
-   |                      ^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | pub struct T5<T>(T, Private);
+   | ^^^^^^^^^^^^^^^^ -  ------- this field contains `Private`, which has private fields, so it could become non-zero-sized in the future
+   | |                |
+   | |                this field is generic and hence may have non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:49:22
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:46:1
    |
 LL | pub struct T6(Sized, NonExhaustive);
-   |                      ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^ -----  ------------- this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |             |
+   | |             this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:54:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:50:1
    |
 LL | pub struct T6a(Sized, <i32 as Trait>::Assoc); // normalizes to `NonExhaustive`
-   |                       ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  --------------------- this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:59:22
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:54:1
    |
 LL | pub struct T7(Sized, NonExhaustiveEnum);
-   |                      ^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^ -----  ----------------- this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |             |
+   | |             this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:64:22
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:58:1
    |
 LL | pub struct T8(Sized, NonExhaustiveVariant);
-   |                      ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^ -----  -------------------- this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |             |
+   | |             this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:69:22
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:62:1
    |
 LL | pub struct T9(Sized, InternalIndirection<Private>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^ -----  ---------------------------- this field contains `Private`, which has private fields, so it could become non-zero-sized in the future
+   | |             |
+   | |             this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:74:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:66:1
    |
 LL | pub struct T10(Sized, InternalIndirection<NonExhaustive>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  ---------------------------------- this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:79:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:70:1
    |
 LL | pub struct T11(Sized, InternalIndirection<NonExhaustiveEnum>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  -------------------------------------- this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:84:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:74:1
    |
 LL | pub struct T12(Sized, InternalIndirection<NonExhaustiveVariant>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  ----------------------------------------- this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:89:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:78:1
    |
 LL | pub struct T13(Sized, ExternalIndirection<Private>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  ---------------------------- this field contains `Private`, which has private fields, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:94:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:82:1
    |
 LL | pub struct T14(Sized, ExternalIndirection<NonExhaustive>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  ---------------------------------- this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:99:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:86:1
    |
 LL | pub struct T15(Sized, ExternalIndirection<NonExhaustiveEnum>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  -------------------------------------- this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:104:23
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:90:1
    |
 LL | pub struct T16(Sized, ExternalIndirection<NonExhaustiveVariant>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -----  ----------------------------------------- this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:109:16
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:94:1
    |
 LL | pub struct T17(NonExhaustive, Sized);
-   |                ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -------------  ----- this field has non-zero size
+   | |              |
+   | |              this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:114:31
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:98:1
    |
 LL | pub struct T18(NonExhaustive, NonExhaustive);
-   |                               ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -------------  ------------- this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:119:31
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:102:1
    |
 LL | pub struct T19(NonExhaustive, Private);
-   |                               ^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^ -------------  ------- this field contains `Private`, which has private fields, so it could become non-zero-sized in the future
+   | |              |
+   | |              this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:124:32
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-non-exhaustive.rs:106:1
    |
 LL | pub struct T19Flipped(Private, NonExhaustive);
-   |                                ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^^^^^^^^^ -------  ------------- this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future
+   | |                     |
+   | |                     this field contains `Private`, which has private fields, so it could become non-zero-sized in the future
+   | needs at most one non-trivial field, but has 2
 
 error: aborting due to 17 previous errors
 
-Future incompatibility report: Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:44:22
-   |
-LL | pub struct T5(Sized, Private);
-   |                      ^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:49:22
-   |
-LL | pub struct T6(Sized, NonExhaustive);
-   |                      ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:54:23
-   |
-LL | pub struct T6a(Sized, <i32 as Trait>::Assoc); // normalizes to `NonExhaustive`
-   |                       ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:59:22
-   |
-LL | pub struct T7(Sized, NonExhaustiveEnum);
-   |                      ^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:64:22
-   |
-LL | pub struct T8(Sized, NonExhaustiveVariant);
-   |                      ^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:69:22
-   |
-LL | pub struct T9(Sized, InternalIndirection<Private>);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:74:23
-   |
-LL | pub struct T10(Sized, InternalIndirection<NonExhaustive>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:79:23
-   |
-LL | pub struct T11(Sized, InternalIndirection<NonExhaustiveEnum>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:84:23
-   |
-LL | pub struct T12(Sized, InternalIndirection<NonExhaustiveVariant>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:89:23
-   |
-LL | pub struct T13(Sized, ExternalIndirection<Private>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:94:23
-   |
-LL | pub struct T14(Sized, ExternalIndirection<NonExhaustive>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:99:23
-   |
-LL | pub struct T15(Sized, ExternalIndirection<NonExhaustiveEnum>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveEnum`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:104:23
-   |
-LL | pub struct T16(Sized, ExternalIndirection<NonExhaustiveVariant>);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustiveVariant`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:109:16
-   |
-LL | pub struct T17(NonExhaustive, Sized);
-   |                ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:114:31
-   |
-LL | pub struct T18(NonExhaustive, NonExhaustive);
-   |                               ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external types with private fields
-  --> $DIR/repr-transparent-non-exhaustive.rs:119:31
-   |
-LL | pub struct T19(NonExhaustive, Private);
-   |                               ^^^^^^^
-   |
-   = note: this field contains `Private`, which contains private fields, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain external non-exhaustive types
-  --> $DIR/repr-transparent-non-exhaustive.rs:124:32
-   |
-LL | pub struct T19Flipped(Private, NonExhaustive);
-   |                                ^^^^^^^^^^^^^
-   |
-   = note: this field contains `NonExhaustive`, which is marked with `#[non_exhaustive]`, so it could become non-zero-sized in the future.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-non-exhaustive.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+For more information about this error, try `rustc --explain E0690`.

--- a/tests/ui/repr/repr-transparent-repr-c.rs
+++ b/tests/ui/repr/repr-transparent-repr-c.rs
@@ -1,5 +1,3 @@
-#![deny(repr_transparent_non_zst_fields)]
-
 #[repr(C)]
 pub struct ReprC1Zst {
     pub _f: (),
@@ -16,17 +14,14 @@ pub struct T3(ReprC1Zst, ());
 
 #[repr(transparent)]
 pub struct T5(Sized, ReprC1Zst);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 pub struct T6(ReprC1Zst, Sized);
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-//~| WARN this was previously accepted by the compiler
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
-pub struct T7(T1, Sized); // still wrong, even when the repr(C) is hidden inside another type
-//~^ ERROR zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-//~| WARN this was previously accepted by the compiler
+pub struct T7(T1, [Sized; 0]); // still wrong, even when the repr(C) is hidden inside another type
+//~^ ERROR needs at most one non-trivial field
 
 fn main() {}

--- a/tests/ui/repr/repr-transparent-repr-c.stderr
+++ b/tests/ui/repr/repr-transparent-repr-c.stderr
@@ -1,85 +1,30 @@
-error: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/repr-transparent-repr-c.rs:18:22
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-repr-c.rs:16:1
    |
 LL | pub struct T5(Sized, ReprC1Zst);
-   |                      ^^^^^^^^^
-   |
-   = note: this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-repr-c.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^ -----  --------- this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets
+   | |             |
+   | |             this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/repr-transparent-repr-c.rs:23:15
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-repr-c.rs:20:1
    |
 LL | pub struct T6(ReprC1Zst, Sized);
-   |               ^^^^^^^^^
-   |
-   = note: this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+   | ^^^^^^^^^^^^^ ---------  ----- this field has non-zero size
+   | |             |
+   | |             this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets
+   | needs at most one non-trivial field, but has 2
 
-error: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/repr-transparent-repr-c.rs:28:15
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent-repr-c.rs:24:1
    |
-LL | pub struct T7(T1, Sized); // still wrong, even when the repr(C) is hidden inside another type
-   |               ^^
-   |
-   = note: this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
+LL | pub struct T7(T1, [Sized; 0]); // still wrong, even when the repr(C) is hidden inside another type
+   | ^^^^^^^^^^^^^ --  ---------- this field requires alignment
+   | |             |
+   | |             this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets
+   | needs at most one non-trivial field, but has 2
 
 error: aborting due to 3 previous errors
 
-Future incompatibility report: Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/repr-transparent-repr-c.rs:18:22
-   |
-LL | pub struct T5(Sized, ReprC1Zst);
-   |                      ^^^^^^^^^
-   |
-   = note: this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-repr-c.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/repr-transparent-repr-c.rs:23:15
-   |
-LL | pub struct T6(ReprC1Zst, Sized);
-   |               ^^^^^^^^^
-   |
-   = note: this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-repr-c.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: zero-sized fields in `repr(transparent)` cannot contain `repr(C)` types
-  --> $DIR/repr-transparent-repr-c.rs:28:15
-   |
-LL | pub struct T7(T1, Sized); // still wrong, even when the repr(C) is hidden inside another type
-   |               ^^
-   |
-   = note: this field contains `ReprC1Zst`, which is a `#[repr(C)]` type, so it is not guaranteed to be zero-sized on all targets.
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #78586 <https://github.com/rust-lang/rust/issues/78586>
-note: the lint level is defined here
-  --> $DIR/repr-transparent-repr-c.rs:1:9
-   |
-LL | #![deny(repr_transparent_non_zst_fields)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+For more information about this error, try `rustc --explain E0690`.

--- a/tests/ui/repr/repr-transparent.rs
+++ b/tests/ui/repr/repr-transparent.rs
@@ -23,26 +23,32 @@ struct ContainsMultipleZst(PhantomData<*const i32>, NoFields);
 struct ContainsZstAndNonZst((), [i32; 2]);
 
 #[repr(transparent)]
-struct MultipleNonZst(u8, u8); //~ ERROR needs at most one field with non-trivial size or alignment
+struct MultipleNonZst(u8, u8); //~ ERROR needs at most one non-trivial field
 
 trait Mirror { type It: ?Sized; }
 impl<T: ?Sized> Mirror for T { type It = Self; }
 
 #[repr(transparent)]
 pub struct StructWithProjection(f32, <f32 as Mirror>::It);
-//~^ ERROR needs at most one field with non-trivial size or alignment
+//~^ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
-struct NontrivialAlignZst(u32, [u16; 0]); //~ ERROR needs at most one field with non-trivial size or alignment
+struct NontrivialAlignZst(u32, [u16; 0]); //~ ERROR needs at most one non-trivial field
 
 #[repr(align(32))]
 struct ZstAlign32<T>(PhantomData<T>);
 
 #[repr(transparent)]
-struct GenericAlign<T>(ZstAlign32<T>, u32); //~ ERROR needs at most one field with non-trivial size or alignment
+struct GenericAlign<T>(ZstAlign32<T>, u32); //~ ERROR needs at most one non-trivial field
 
 #[repr(transparent)]
 struct WrapsZstWithAlignment([i32; 0]);
+
+#[repr(transparent)]
+struct Generic<T>(T, T); //~ ERROR needs at most one non-trivial field
+
+#[repr(transparent)]
+struct GenericAndNonTrivial<T>(T, [i32; 0]); //~ ERROR needs at most one non-trivial field
 
 #[repr(transparent)] //~ ERROR unsupported representation for zero-variant enum
 enum Void {} //~ ERROR transparent enum needs exactly one variant, but has 0
@@ -61,7 +67,7 @@ enum UnitFieldEnum {
 enum TooManyFieldsEnum {
     Foo(u32, String),
 }
-//~^^^ ERROR transparent enum needs at most one field with non-trivial size or alignment, but has 2
+//~^^^ ERROR transparent enum needs at most one non-trivial field, but has 2
 
 #[repr(transparent)]
 enum MultipleVariants { //~ ERROR transparent enum needs exactly one variant, but has 2
@@ -70,12 +76,12 @@ enum MultipleVariants { //~ ERROR transparent enum needs exactly one variant, bu
 }
 
 #[repr(transparent)]
-enum NontrivialAlignZstEnum { //~ ERROR needs at most one field with non-trivial size or alignment
+enum NontrivialAlignZstEnum { //~ ERROR needs at most one non-trivial field
     Foo(u32, [u16; 0]),
 }
 
 #[repr(transparent)]
-enum GenericAlignEnum<T> { //~ ERROR needs at most one field with non-trivial size or alignment
+enum GenericAlignEnum<T> { //~ ERROR needs at most one non-trivial field
     Foo { bar: ZstAlign32<T>, baz: u32 }
 }
 
@@ -85,7 +91,7 @@ union UnitUnion {
 }
 
 #[repr(transparent)]
-union TooManyFields { //~ ERROR transparent union needs at most one field with non-trivial size or alignment, but has 2
+union TooManyFields { //~ ERROR transparent union needs at most one non-trivial field, but has 2
     u: u32,
     s: i32
 }

--- a/tests/ui/repr/repr-transparent.stderr
+++ b/tests/ui/repr/repr-transparent.stderr
@@ -1,41 +1,59 @@
-error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
   --> $DIR/repr-transparent.rs:26:1
    |
 LL | struct MultipleNonZst(u8, u8);
-   | ^^^^^^^^^^^^^^^^^^^^^ --  -- this field has non-zero size or requires alignment
+   | ^^^^^^^^^^^^^^^^^^^^^ --  -- this field has non-zero size
    | |                     |
-   | |                     this field has non-zero size or requires alignment
-   | needs at most one field with non-trivial size or alignment, but has 2
+   | |                     this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
   --> $DIR/repr-transparent.rs:32:1
    |
 LL | pub struct StructWithProjection(f32, <f32 as Mirror>::It);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---  ------------------- this field has non-zero size or requires alignment
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---  ------------------- this field has non-zero size
    | |                               |
-   | |                               this field has non-zero size or requires alignment
-   | needs at most one field with non-trivial size or alignment, but has 2
+   | |                               this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
   --> $DIR/repr-transparent.rs:36:1
    |
 LL | struct NontrivialAlignZst(u32, [u16; 0]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ ---  -------- this field has non-zero size or requires alignment
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ ---  -------- this field requires alignment
    | |                         |
-   | |                         this field has non-zero size or requires alignment
-   | needs at most one field with non-trivial size or alignment, but has 2
+   | |                         this field has non-zero size
+   | needs at most one non-trivial field, but has 2
 
-error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
   --> $DIR/repr-transparent.rs:42:1
    |
 LL | struct GenericAlign<T>(ZstAlign32<T>, u32);
-   | ^^^^^^^^^^^^^^^^^^^^^^ -------------  --- this field has non-zero size or requires alignment
+   | ^^^^^^^^^^^^^^^^^^^^^^ -------------  --- this field has non-zero size
    | |                      |
-   | |                      this field has non-zero size or requires alignment
-   | needs at most one field with non-trivial size or alignment, but has 2
+   | |                      this field requires alignment
+   | needs at most one non-trivial field, but has 2
+
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent.rs:48:1
+   |
+LL | struct Generic<T>(T, T);
+   | ^^^^^^^^^^^^^^^^^ -  - this field is generic and hence may have non-zero size
+   | |                 |
+   | |                 this field is generic and hence may have non-zero size
+   | needs at most one non-trivial field, but has 2
+
+error[E0690]: transparent struct needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent.rs:51:1
+   |
+LL | struct GenericAndNonTrivial<T>(T, [i32; 0]);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -  -------- this field requires alignment
+   | |                              |
+   | |                              this field is generic and hence may have non-zero size
+   | needs at most one non-trivial field, but has 2
 
 error[E0084]: unsupported representation for zero-variant enum
-  --> $DIR/repr-transparent.rs:47:8
+  --> $DIR/repr-transparent.rs:53:8
    |
 LL | #[repr(transparent)]
    |        ^^^^^^^^^^^
@@ -43,23 +61,23 @@ LL | enum Void {}
    | --------- zero-variant enum
 
 error[E0731]: transparent enum needs exactly one variant, but has 0
-  --> $DIR/repr-transparent.rs:48:1
+  --> $DIR/repr-transparent.rs:54:1
    |
 LL | enum Void {}
    | ^^^^^^^^^ needs exactly one variant, but has 0
 
-error[E0690]: the variant of a transparent enum needs at most one field with non-trivial size or alignment, but has 2
-  --> $DIR/repr-transparent.rs:61:1
+error[E0690]: the variant of a transparent enum needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent.rs:67:1
    |
 LL | enum TooManyFieldsEnum {
-   | ^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
+   | ^^^^^^^^^^^^^^^^^^^^^^ needs at most one non-trivial field, but has 2
 LL |     Foo(u32, String),
-   |         ---  ------ this field has non-zero size or requires alignment
+   |         ---  ------ this field has non-zero size
    |         |
-   |         this field has non-zero size or requires alignment
+   |         this field has non-zero size
 
 error[E0731]: transparent enum needs exactly one variant, but has 2
-  --> $DIR/repr-transparent.rs:67:1
+  --> $DIR/repr-transparent.rs:73:1
    |
 LL | enum MultipleVariants {
    | ^^^^^^^^^^^^^^^^^^^^^ needs exactly one variant, but has 2
@@ -68,37 +86,37 @@ LL |     Foo(String),
 LL |     Bar,
    |     --- too many variants in `MultipleVariants`
 
-error[E0690]: the variant of a transparent enum needs at most one field with non-trivial size or alignment, but has 2
-  --> $DIR/repr-transparent.rs:73:1
+error[E0690]: the variant of a transparent enum needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent.rs:79:1
    |
 LL | enum NontrivialAlignZstEnum {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one non-trivial field, but has 2
 LL |     Foo(u32, [u16; 0]),
-   |         ---  -------- this field has non-zero size or requires alignment
+   |         ---  -------- this field requires alignment
    |         |
-   |         this field has non-zero size or requires alignment
+   |         this field has non-zero size
 
-error[E0690]: the variant of a transparent enum needs at most one field with non-trivial size or alignment, but has 2
-  --> $DIR/repr-transparent.rs:78:1
+error[E0690]: the variant of a transparent enum needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent.rs:84:1
    |
 LL | enum GenericAlignEnum<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one non-trivial field, but has 2
 LL |     Foo { bar: ZstAlign32<T>, baz: u32 }
-   |           ------------------  -------- this field has non-zero size or requires alignment
+   |           ------------------  -------- this field has non-zero size
    |           |
-   |           this field has non-zero size or requires alignment
+   |           this field requires alignment
 
-error[E0690]: transparent union needs at most one field with non-trivial size or alignment, but has 2
-  --> $DIR/repr-transparent.rs:88:1
+error[E0690]: transparent union needs at most one non-trivial field, but has 2
+  --> $DIR/repr-transparent.rs:94:1
    |
 LL | union TooManyFields {
-   | ^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
+   | ^^^^^^^^^^^^^^^^^^^ needs at most one non-trivial field, but has 2
 LL |     u: u32,
-   |     ------ this field has non-zero size or requires alignment
+   |     ------ this field has non-zero size
 LL |     s: i32
-   |     ------ this field has non-zero size or requires alignment
+   |     ------ this field has non-zero size
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0084, E0690, E0731.
 For more information about an error, try `rustc --explain E0084`.


### PR DESCRIPTION
This is a simplified version of https://github.com/rust-lang/rust/pull/155984 for cratering purposes. It's not meant to be landed as-is (at the very least, tons of tests would have to be adjusted to not involve arrays any more).