### PR TITLE
Regression test for trait-system-refactor#7

### DIFF
--- a/tests/ui/traits/next-solver/alias-relate/transitive-inference.rs
+++ b/tests/ui/traits/next-solver/alias-relate/transitive-inference.rs
@@ -2,7 +2,11 @@
 //@[next] compile-flags: -Znext-solver=globally
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@ check-pass
-// Regression test for trait-system-refactor-initiative#7
+// Regression test for trait-system-refactor-initiative#7. This test
+// would error if we were to rely on lazy normalization here.
+//
+// We eagerly normalize the associated types, here, causing this to
+// compile.
 
 use std::marker::PhantomData;
 

--- a/tests/ui/traits/next-solver/alias-relate/transitive-inference.rs
+++ b/tests/ui/traits/next-solver/alias-relate/transitive-inference.rs
@@ -1,0 +1,38 @@
+//@ revisions: old next
+//@[next] compile-flags: -Znext-solver=globally
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ check-pass
+// Regression test for trait-system-refactor-initiative#7
+
+use std::marker::PhantomData;
+
+#[derive(Default)]
+struct Foo<T, U>(PhantomData<(T, U)>);
+
+trait Trait {
+    type Assoc;
+
+    fn to_assoc(self) -> Self::Assoc;
+}
+
+impl Trait for Foo<u32, i32> {
+    type Assoc = Foo<u32, i32>;
+    fn to_assoc(self) -> Self::Assoc {
+        Foo(PhantomData)
+    }
+}
+impl Trait for Foo<i32, u32> {
+    type Assoc = Foo<i32, u32>;
+    fn to_assoc(self) -> Self::Assoc {
+        Foo(PhantomData)
+    }
+}
+
+#[allow(unused_assignments)]
+fn main() {
+    let mut x: Foo<_, _> = Default::default();
+    let mut assoc = x.to_assoc();
+    assoc = Foo::<u32, _>(PhantomData);
+    assoc = Foo::<_, i32>(PhantomData);
+    x = assoc;
+}


### PR DESCRIPTION
Adds a regression test for [`AliasRelate` hides info in transitive cases](https://github.com/rust-lang/trait-system-refactor-initiative/issues/7).

The example previously errored under the new solver but compiles cleanly now thanks to eager normalization (post-rust-lang/rust#119106). Verified on both the `old` and `next` revisions.

The issue body has an older TODO suggesting a goal-proving variant test; per lcnr's recent note in `#t-types/trait-system-refactor` ("this isn't an issue as we eagerly normalize"), the underlying mechanism is now resolved across both inference and goal-proving paths, so this single regression test is sufficient. Closing the upstream issue manually after merge.

r? @lcnr