### PR TITLE
Add a `doc_cfg` regression test to ensure foreign types impls are working as expected

### DIFF
--- a/tests/rustdoc-html/doc-cfg/impl-foreign-type.rs
+++ b/tests/rustdoc-html/doc-cfg/impl-foreign-type.rs
@@ -1,0 +1,15 @@
+// This test ensures that the `doc_cfg` feature works on foreign types impl.
+// Regression test for <https://github.com/rust-lang/rust/issues/150268>.
+
+// ignore-tidy-linelength
+
+#![feature(doc_cfg)]
+#![crate_name = "foo"]
+
+//@has 'foo/trait.Blob.html'
+//@has - '//*[@id="impl-Blob-for-Box%3CR%3E"]//*[@class="stab portability"]' 'Available on non-crate feature alloc only.'
+
+pub trait Blob {}
+
+#[cfg(not(feature = "alloc"))]
+impl<R: ?Sized> Blob for std::boxed::Box<R> {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/150268.

This is the last case mentioned in the issue that wasn't tested. With this, the issue can be closed.

r? @Urgau 