### PR TITLE
refactor using ExprParenthesesNeeded where possible

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -21,6 +21,7 @@ use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::{self, IsSuggestable, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
 use rustc_middle::{bug, span_bug};
 use rustc_session::Session;
+use rustc_session::errors::ExprParenthesesNeeded;
 use rustc_span::{DUMMY_SP, Ident, Span, kw, sym};
 use rustc_trait_selection::error_reporting::infer::{FailureCode, ObligationCauseExt};
 use rustc_trait_selection::infer::InferCtxtExt;
@@ -954,14 +955,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         // wrapping in parentheses. We find the statement or expression
                         // following the `match` (`&& true`) and see if it is something that
                         // can reasonably be interpreted as a binop following an expression.
-                        err.multipart_suggestion(
-                            "parentheses are required to parse this as an expression",
-                            vec![
-                                (expr.span.shrink_to_lo(), "(".to_string()),
-                                (expr.span.shrink_to_hi(), ")".to_string()),
-                            ],
-                            Applicability::MachineApplicable,
-                        );
+                        err.subdiagnostic(ExprParenthesesNeeded::surrounding(expr.span));
                     } else if expr.can_have_side_effects() {
                         self.suggest_semicolon_at_end(expr.span, err);
                     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -799,14 +799,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     && let hir::StmtKind::Expr(_) = stmt.kind
                     && self.is_next_stmt_expr_continuation(stmt.hir_id)
                 {
-                    err.multipart_suggestion(
-                        "parentheses are required to parse this as an expression",
-                        vec![
-                            (stmt.span.shrink_to_lo(), "(".to_string()),
-                            (stmt.span.shrink_to_hi(), ")".to_string()),
-                        ],
-                        Applicability::MachineApplicable,
-                    );
+                    err.subdiagnostic(ExprParenthesesNeeded::surrounding(stmt.span));
                 } else {
                     err.span_suggestion(
                         expression.span.shrink_to_hi(),
@@ -843,14 +836,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // wrapping in parentheses. We find the statement or expression following the
                     // `if` (`&& true`) and see if it is something that can reasonably be
                     // interpreted as a binop following an expression.
-                    err.multipart_suggestion(
-                        "parentheses are required to parse this as an expression",
-                        vec![
-                            (stmt.span.shrink_to_lo(), "(".to_string()),
-                            (stmt.span.shrink_to_hi(), ")".to_string()),
-                        ],
-                        Applicability::MachineApplicable,
-                    );
+                    err.subdiagnostic(ExprParenthesesNeeded::surrounding(stmt.span));
                 }
             }
         }


### PR DESCRIPTION
Found multiple instances where the equivalent of `ExprParenthesesNeeded` was done 'manually'.
Replaced them with an `ExprParenthesesNeeded::surrounding` call.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
