### PR TITLE
.mailmap: prefer matching just based on commit emails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -259,11 +259,9 @@ Gregor Peach <gregorpeach@gmail.com>
 Grzegorz Bartoszek <grzegorz.bartoszek@thaumatec.com>
 Guanqun Lu <guanqun.lu@gmail.com>
 Guillaume Gomez <contact@guillaume-gomez.fr>
-Guillaume Gomez <contact@guillaume-gomez.fr> Guillaume Gomez <guillaume1.gomez@gmail.com>
-Guillaume Gomez <contact@guillaume-gomez.fr> ggomez <guillaume1.gomez@gmail.com>
-Guillaume Gomez <contact@guillaume-gomez.fr> ggomez <ggomez@ggo.ifr.lan>
-Guillaume Gomez <contact@guillaume-gomez.fr> Guillaume Gomez <ggomez@ggo.ifr.lan>
-Guillaume Gomez <contact@guillaume-gomez.fr> Guillaume Gomez <guillaume.gomez@huawei.com>
+Guillaume Gomez <contact@guillaume-gomez.fr> <guillaume1.gomez@gmail.com>
+Guillaume Gomez <contact@guillaume-gomez.fr> <ggomez@ggo.ifr.lan>
+Guillaume Gomez <contact@guillaume-gomez.fr> <guillaume.gomez@huawei.com>
 gnzlbg <gonzalobg88@gmail.com> <gnzlbg@users.noreply.github.com>
 hamidreza kalbasi <hamidrezakalbasi@protonmail.com>
 Hanna Kruppe <hanna.kruppe@gmail.com> <robin.kruppe@gmail.com>


### PR DESCRIPTION
So that commits under different names are still caught

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

r? @GuillaumeGomez
<!-- homu-ignore:end -->
