### PR TITLE
compiletest: Migrate from `PassMode`/`FailMode` to `PassFailMode`

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -82,6 +82,48 @@ string_enum! {
 }
 
 string_enum! {
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    pub(crate) enum PassFailMode {
+        CheckFail => "check-fail",
+        CheckPass => "check-pass",
+        BuildFail => "build-fail",
+        BuildPass => "build-pass",
+        RunFail => "run-fail",
+        RunCrash => "run-crash",
+        RunFailOrCrash => "run-fail-or-crash",
+        RunPass => "run-pass",
+    }
+}
+
+impl PassFailMode {
+    pub(crate) fn fail_mode(&self) -> Option<FailMode> {
+        match self {
+            PassFailMode::CheckFail => Some(FailMode::Check),
+            PassFailMode::BuildFail => Some(FailMode::Build),
+            PassFailMode::RunFail => Some(FailMode::Run(RunFailMode::Fail)),
+            PassFailMode::RunCrash => Some(FailMode::Run(RunFailMode::Crash)),
+            PassFailMode::RunFailOrCrash => Some(FailMode::Run(RunFailMode::FailOrCrash)),
+
+            PassFailMode::CheckPass | PassFailMode::BuildPass | PassFailMode::RunPass => None,
+        }
+    }
+
+    pub(crate) fn pass_mode(&self) -> Option<PassMode> {
+        match self {
+            PassFailMode::CheckPass => Some(PassMode::Check),
+            PassFailMode::BuildPass => Some(PassMode::Build),
+            PassFailMode::RunPass => Some(PassMode::Run),
+
+            PassFailMode::CheckFail
+            | PassFailMode::BuildFail
+            | PassFailMode::RunFail
+            | PassFailMode::RunCrash
+            | PassFailMode::RunFailOrCrash => None,
+        }
+    }
+}
+
+string_enum! {
     #[derive(Clone, Copy, PartialEq, Debug, Hash)]
     pub(crate) enum PassMode {
         Check => "check",

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -88,44 +88,67 @@ string_enum! {
         CheckPass => "check-pass",
         BuildFail => "build-fail",
         BuildPass => "build-pass",
+        /// Running the program must make it exit with a regular failure exit code
+        /// in the range `1..=127`. If the program is terminated by e.g. a signal
+        /// the test will fail.
         RunFail => "run-fail",
+        /// Running the program must result in a crash, e.g. by `SIGABRT` or
+        /// `SIGSEGV` on Unix or on Windows by having an appropriate NTSTATUS high
+        /// bit in the exit code.
         RunCrash => "run-crash",
+        /// Running the program must either fail or crash. Useful for e.g. sanitizer
+        /// tests since some sanitizer implementations exit the process with code 1
+        /// to in the face of memory errors while others abort (crash) the process
+        /// in the face of memory errors.
         RunFailOrCrash => "run-fail-or-crash",
         RunPass => "run-pass",
     }
 }
 
 impl PassFailMode {
-    pub(crate) fn fail_mode(&self) -> Option<FailMode> {
+    pub(crate) fn is_pass(&self) -> bool {
         match self {
-            PassFailMode::CheckFail => Some(FailMode::Check),
-            PassFailMode::BuildFail => Some(FailMode::Build),
-            PassFailMode::RunFail => Some(FailMode::Run(RunFailMode::Fail)),
-            PassFailMode::RunCrash => Some(FailMode::Run(RunFailMode::Crash)),
-            PassFailMode::RunFailOrCrash => Some(FailMode::Run(RunFailMode::FailOrCrash)),
-
-            PassFailMode::CheckPass | PassFailMode::BuildPass | PassFailMode::RunPass => None,
-        }
-    }
-
-    pub(crate) fn pass_mode(&self) -> Option<PassMode> {
-        match self {
-            PassFailMode::CheckPass => Some(PassMode::Check),
-            PassFailMode::BuildPass => Some(PassMode::Build),
-            PassFailMode::RunPass => Some(PassMode::Run),
+            PassFailMode::CheckPass | PassFailMode::BuildPass | PassFailMode::RunPass => true,
 
             PassFailMode::CheckFail
             | PassFailMode::BuildFail
             | PassFailMode::RunFail
             | PassFailMode::RunCrash
-            | PassFailMode::RunFailOrCrash => None,
+            | PassFailMode::RunFailOrCrash => false,
+        }
+    }
+
+    pub(crate) fn is_check(&self) -> bool {
+        match self {
+            PassFailMode::CheckFail | PassFailMode::CheckPass => true,
+
+            PassFailMode::BuildFail
+            | PassFailMode::BuildPass
+            | PassFailMode::RunFail
+            | PassFailMode::RunCrash
+            | PassFailMode::RunFailOrCrash
+            | PassFailMode::RunPass => false,
+        }
+    }
+
+    pub(crate) fn is_run(&self) -> bool {
+        match self {
+            PassFailMode::CheckFail
+            | PassFailMode::CheckPass
+            | PassFailMode::BuildFail
+            | PassFailMode::BuildPass => false,
+
+            PassFailMode::RunFail
+            | PassFailMode::RunCrash
+            | PassFailMode::RunFailOrCrash
+            | PassFailMode::RunPass => true,
         }
     }
 }
 
 string_enum! {
     #[derive(Clone, Copy, PartialEq, Debug, Hash)]
-    pub(crate) enum PassMode {
+    pub(crate) enum ForcePassMode {
         Check => "check",
         Build => "build",
         Run => "run",
@@ -139,30 +162,6 @@ string_enum! {
         Fail => "run-fail",
         Crash => "run-crash",
     }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
-pub(crate) enum RunFailMode {
-    /// Running the program must make it exit with a regular failure exit code
-    /// in the range `1..=127`. If the program is terminated by e.g. a signal
-    /// the test will fail.
-    Fail,
-    /// Running the program must result in a crash, e.g. by `SIGABRT` or
-    /// `SIGSEGV` on Unix or on Windows by having an appropriate NTSTATUS high
-    /// bit in the exit code.
-    Crash,
-    /// Running the program must either fail or crash. Useful for e.g. sanitizer
-    /// tests since some sanitizer implementations exit the process with code 1
-    /// to in the face of memory errors while others abort (crash) the process
-    /// in the face of memory errors.
-    FailOrCrash,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
-pub(crate) enum FailMode {
-    Check,
-    Build,
-    Run(RunFailMode),
 }
 
 string_enum! {
@@ -512,7 +511,7 @@ pub(crate) struct Config {
     /// FIXME: make it even more obvious (especially in PR CI where `--pass=check` is used) when a
     /// pass mode is forced when the test fails, because it can be very non-obvious when e.g. an
     /// error is emitted only when `//@ build-pass` but not `//@ check-pass`.
-    pub(crate) force_pass_mode: Option<PassMode>,
+    pub(crate) force_pass_mode: Option<ForcePassMode>,
 
     /// Explicitly enable or disable running of the target test binary.
     ///
@@ -549,7 +548,7 @@ pub(crate) struct Config {
     /// may override this setting.
     ///
     /// FIXME: this flag / config option is somewhat misleading. For instance, in ui tests, it's
-    /// *only* applied to the [`PassMode::Run`] test crate and not its auxiliaries.
+    /// *only* applied to the [`PassFailMode::RunPass`] test crate and not its auxiliaries.
     pub(crate) optimize_tests: bool,
 
     /// Target platform tuple.

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -6,7 +6,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use semver::Version;
 use tracing::*;
 
-use crate::common::{CodegenBackend, Config, Debugger, FailMode, PassMode, RunFailMode, TestMode};
+use crate::common::{CodegenBackend, Config, Debugger, FailMode, PassFailMode, PassMode, TestMode};
 use crate::debuggers::{extract_cdb_version, extract_gdb_version};
 use crate::directives::auxiliary::parse_and_update_aux;
 pub(crate) use crate::directives::auxiliary::{AuxCrate, AuxProps};
@@ -165,12 +165,13 @@ pub(crate) struct TestProps {
     // error annotations are needed, but this may be updated in the future to
     // include other relaxations.
     pub(crate) known_bug: bool,
-    // How far should the test proceed while still passing.
-    pass_mode: Option<PassMode>,
+    /// Whether this is a check, build, or build-and-run test, and whether the
+    /// final step should succeed or fail.
+    ///
+    /// None for non-UI tests, and for auxiliary crates used by UI tests.
+    pub(crate) pass_fail_mode: Option<PassFailMode>,
     // Ignore `--pass` overrides from the command line for this test.
     ignore_pass: bool,
-    // How far this test should proceed to start failing.
-    pub(crate) fail_mode: Option<FailMode>,
     // rustdoc will test the output of the `--test` option
     pub(crate) check_test_line_numbers_match: bool,
     // customized normalization rules
@@ -296,8 +297,7 @@ impl TestProps {
             incremental_dir: None,
             incremental: false,
             known_bug: false,
-            pass_mode: None,
-            fail_mode: None,
+            pass_fail_mode: None,
             ignore_pass: false,
             check_test_line_numbers_match: false,
             normalize_stdout: vec![],
@@ -343,10 +343,9 @@ impl TestProps {
         props.load_from(testfile, revision, config);
         props.exec_env.push(("RUSTC".to_string(), config.rustc_path.to_string()));
 
-        match (props.pass_mode, props.fail_mode) {
-            (None, None) if config.mode == TestMode::Ui => props.fail_mode = Some(FailMode::Check),
-            (Some(_), Some(_)) => panic!("cannot use a *-fail and *-pass mode together"),
-            _ => {}
+        // UI tests default to `//@ check-fail` if unspecified.
+        if config.mode == TestMode::Ui && props.pass_fail_mode.is_none() {
+            props.pass_fail_mode = Some(PassFailMode::CheckFail);
         }
 
         props
@@ -406,73 +405,37 @@ impl TestProps {
         }
     }
 
-    fn update_fail_mode(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
-        let check_ui = |mode: &str| {
-            if config.mode != TestMode::Ui {
-                panic!("`{}-fail` directive is only supported in UI tests", mode);
-            }
-        };
-        let fail_mode = if config.parse_name_directive(ln, "check-fail") {
-            check_ui("check");
-            Some(FailMode::Check)
-        } else if config.parse_name_directive(ln, "build-fail") {
-            check_ui("build");
-            Some(FailMode::Build)
-        } else if config.parse_name_directive(ln, "run-fail") {
-            check_ui("run");
-            Some(FailMode::Run(RunFailMode::Fail))
-        } else if config.parse_name_directive(ln, "run-crash") {
-            check_ui("run");
-            Some(FailMode::Run(RunFailMode::Crash))
-        } else if config.parse_name_directive(ln, "run-fail-or-crash") {
-            check_ui("run");
-            Some(FailMode::Run(RunFailMode::FailOrCrash))
-        } else {
-            None
-        };
-        match (self.fail_mode, fail_mode) {
-            (None, Some(_)) => self.fail_mode = fail_mode,
-            (Some(_), Some(_)) => panic!("multiple `*-fail` directives in a single test"),
-            (_, None) => {}
+    fn update_pass_fail_mode(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
+        let name = ln.name;
+        if config.mode != TestMode::Ui {
+            panic!("`{name}` directive is only supported in UI tests");
         }
+        if self.pass_fail_mode.is_some() {
+            panic!("multiple `*-fail` or `*-pass` directives in a single test");
+        }
+
+        let mode = ln.name.parse::<PassFailMode>().unwrap();
+        self.pass_fail_mode = Some(mode);
     }
 
-    fn update_pass_mode(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
-        let check_no_run = |s| match (config.mode, s) {
-            (TestMode::Ui, _) => (),
-            (mode, _) => panic!("`{s}` directive is not supported in `{mode}` tests"),
-        };
-        let pass_mode = if config.parse_name_directive(ln, "check-pass") {
-            check_no_run("check-pass");
-            Some(PassMode::Check)
-        } else if config.parse_name_directive(ln, "build-pass") {
-            check_no_run("build-pass");
-            Some(PassMode::Build)
-        } else if config.parse_name_directive(ln, "run-pass") {
-            check_no_run("run-pass");
-            Some(PassMode::Run)
-        } else {
-            None
-        };
-        match (self.pass_mode, pass_mode) {
-            (None, Some(_)) => self.pass_mode = pass_mode,
-            (Some(_), Some(_)) => panic!("multiple `*-pass` directives in a single test"),
-            (_, None) => {}
-        }
+    pub(crate) fn fail_mode(&self) -> Option<FailMode> {
+        self.pass_fail_mode?.fail_mode()
     }
 
     pub(crate) fn pass_mode(&self, config: &Config) -> Option<PassMode> {
-        if !self.ignore_pass && self.fail_mode.is_none() {
-            if let mode @ Some(_) = config.force_pass_mode {
-                return mode;
-            }
+        let declared = self.local_pass_mode()?;
+        if let Some(force_pass_mode) = config.force_pass_mode
+            && !self.ignore_pass
+        {
+            Some(force_pass_mode)
+        } else {
+            Some(declared)
         }
-        self.pass_mode
     }
 
     // does not consider CLI override for pass mode
     pub(crate) fn local_pass_mode(&self) -> Option<PassMode> {
-        self.pass_mode
+        self.pass_fail_mode?.pass_mode()
     }
 
     fn update_add_minicore(&mut self, ln: &DirectiveLine<'_>, config: &Config) {

--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -6,7 +6,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use semver::Version;
 use tracing::*;
 
-use crate::common::{CodegenBackend, Config, Debugger, FailMode, PassFailMode, PassMode, TestMode};
+use crate::common::{CodegenBackend, Config, Debugger, PassFailMode, TestMode};
 use crate::debuggers::{extract_cdb_version, extract_gdb_version};
 use crate::directives::auxiliary::parse_and_update_aux;
 pub(crate) use crate::directives::auxiliary::{AuxCrate, AuxProps};
@@ -171,7 +171,7 @@ pub(crate) struct TestProps {
     /// None for non-UI tests, and for auxiliary crates used by UI tests.
     pub(crate) pass_fail_mode: Option<PassFailMode>,
     // Ignore `--pass` overrides from the command line for this test.
-    ignore_pass: bool,
+    pub(crate) ignore_pass: bool,
     // rustdoc will test the output of the `--test` option
     pub(crate) check_test_line_numbers_match: bool,
     // customized normalization rules
@@ -418,26 +418,6 @@ impl TestProps {
         self.pass_fail_mode = Some(mode);
     }
 
-    pub(crate) fn fail_mode(&self) -> Option<FailMode> {
-        self.pass_fail_mode?.fail_mode()
-    }
-
-    pub(crate) fn pass_mode(&self, config: &Config) -> Option<PassMode> {
-        let declared = self.local_pass_mode()?;
-        if let Some(force_pass_mode) = config.force_pass_mode
-            && !self.ignore_pass
-        {
-            Some(force_pass_mode)
-        } else {
-            Some(declared)
-        }
-    }
-
-    // does not consider CLI override for pass mode
-    pub(crate) fn local_pass_mode(&self) -> Option<PassMode> {
-        self.pass_fail_mode?.pass_mode()
-    }
-
     fn update_add_minicore(&mut self, ln: &DirectiveLine<'_>, config: &Config) {
         let add_minicore = config.parse_name_directive(ln, directives::ADD_MINICORE);
         if add_minicore {
@@ -452,7 +432,7 @@ impl TestProps {
 
             // FIXME(jieyouxu): this check is currently order-dependent, but we should probably
             // collect all directives in one go then perform a validation pass after that.
-            if self.local_pass_mode().is_some_and(|pm| pm == PassMode::Run) {
+            if self.pass_fail_mode == Some(PassFailMode::RunPass) {
                 // `minicore` can only be used with non-run modes, because it's `core` prelude stubs
                 // and can't run.
                 panic!("`add-minicore` cannot be used to run the test binary");

--- a/src/tools/compiletest/src/directives/handlers.rs
+++ b/src/tools/compiletest/src/directives/handlers.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock};
 
-use crate::common::{Config, TestMode};
+use crate::common::{Config, PassFailMode, TestMode};
 use crate::directives::{
     DirectiveLine, NormalizeKind, NormalizeRule, TestProps, parse_and_update_aux,
     parse_edition_range, split_flags,
@@ -196,15 +196,9 @@ fn make_directive_handlers_map() -> HashMap<&'static str, Handler> {
                 &mut props.check_test_line_numbers_match,
             );
         }),
-        multi_handler(&["check-pass", "build-pass", "run-pass"], |config, ln, props| {
-            props.update_pass_mode(ln, config);
+        multi_handler(PassFailMode::STR_VARIANTS, |config, ln, props| {
+            props.update_pass_fail_mode(ln, config);
         }),
-        multi_handler(
-            &["check-fail", "build-fail", "run-fail", "run-crash", "run-fail-or-crash"],
-            |config, ln, props| {
-                props.update_fail_mode(ln, config);
-            },
-        ),
         handler(IGNORE_PASS, |config, ln, props| {
             config.set_name_directive(ln, IGNORE_PASS, &mut props.ignore_pass);
         }),

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -40,8 +40,8 @@ use walkdir::WalkDir;
 
 use self::directives::{EarlyProps, make_test_description};
 use crate::common::{
-    CodegenBackend, CompareMode, Config, Debugger, PassMode, TestMode, TestPaths, UI_EXTENSIONS,
-    expected_output_path, output_base_dir, output_relative_path,
+    CodegenBackend, CompareMode, Config, Debugger, ForcePassMode, TestMode, TestPaths,
+    UI_EXTENSIONS, expected_output_path, output_base_dir, output_relative_path,
 };
 use crate::directives::{AuxProps, DirectivesCache, FileDirectives};
 use crate::edition::parse_edition;
@@ -446,7 +446,7 @@ fn parse_config(args: Vec<String>) -> Config {
         skip: matches.opt_strs("skip"),
         filter_exact: matches.opt_present("exact"),
         force_pass_mode: matches.opt_str("pass").map(|mode| {
-            mode.parse::<PassMode>()
+            mode.parse::<ForcePassMode>()
                 .unwrap_or_else(|_| panic!("unknown `--pass` option `{}` given", mode))
         }),
         // FIXME: this run scheme is... confusing.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -14,7 +14,7 @@ use regex::{Captures, Regex};
 use tracing::*;
 
 use crate::common::{
-    CompareMode, Config, Debugger, FailMode, PassMode, RunFailMode, RunResult, TestMode, TestPaths,
+    CompareMode, Config, Debugger, ForcePassMode, PassFailMode, RunResult, TestMode, TestPaths,
     TestSuite, UI_EXTENSIONS, UI_FIXED, UI_RUN_STDERR, UI_RUN_STDOUT, UI_STDERR, UI_STDOUT, UI_SVG,
     UI_WINDOWS_SVG, expected_output_path, incremental_dir, output_base_dir, output_base_name,
 };
@@ -289,70 +289,68 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    fn pass_mode(&self) -> Option<PassMode> {
-        self.props.pass_mode(self.config)
-    }
+    /// Returns the pass/fail expectation of this UI test
+    /// (e.g. `//@ check-pass` or `//@ build-fail`),
+    /// possibly modified by an explicit `--pass=check` on the command-line.
+    fn effective_pass_fail_mode(&self) -> Option<PassFailMode> {
+        assert_eq!(self.config.mode, TestMode::Ui);
+        // UI tests always have a pass/fail mode, but their auxiliary crates never have one.
+        let declared = self.props.pass_fail_mode?;
 
-    fn should_run(&self, pm: Option<PassMode>) -> WillExecute {
-        let test_should_run = match self.config.mode {
-            TestMode::Ui => {
-                pm == Some(PassMode::Run)
-                    || matches!(self.props.fail_mode(), Some(FailMode::Run(_)))
+        // Specifying `--pass` only overrides `//@ pass-*` modes, and only if
+        // the test doesn't opt out with `//@ ignore-pass`.
+        if let Some(force_pass_mode) = self.config.force_pass_mode
+            && !self.props.ignore_pass
+            && declared.is_pass()
+        {
+            match force_pass_mode {
+                ForcePassMode::Check => Some(PassFailMode::CheckPass),
+                ForcePassMode::Build => Some(PassFailMode::BuildPass),
+                ForcePassMode::Run => Some(PassFailMode::RunPass),
             }
-            mode => panic!("unimplemented for mode {:?}", mode),
-        };
-        if test_should_run { self.run_if_enabled() } else { WillExecute::No }
+        } else {
+            Some(declared)
+        }
     }
 
     fn run_if_enabled(&self) -> WillExecute {
         if self.config.run_enabled() { WillExecute::Yes } else { WillExecute::Disabled }
     }
 
-    fn should_run_successfully(&self, pm: Option<PassMode>) -> bool {
-        match self.config.mode {
-            TestMode::Ui => pm == Some(PassMode::Run),
-            mode => panic!("unimplemented for mode {:?}", mode),
-        }
-    }
+    fn check_if_test_should_compile(&self, pass_fail: PassFailMode, proc_res: &ProcRes) {
+        assert_eq!(self.config.mode, TestMode::Ui);
 
-    fn should_compile_successfully(&self, pm: Option<PassMode>) -> bool {
-        match self.config.mode {
-            TestMode::RustdocJs => true,
-            TestMode::Ui => pm.is_some() || self.props.fail_mode() > Some(FailMode::Build),
-            TestMode::Crashes => false,
-            mode => panic!("unimplemented for mode {:?}", mode),
-        }
-    }
+        let should_compile_successfully = match pass_fail {
+            PassFailMode::CheckFail | PassFailMode::BuildFail => false,
 
-    fn check_if_test_should_compile(
-        &self,
-        fail_mode: Option<FailMode>,
-        pass_mode: Option<PassMode>,
-        proc_res: &ProcRes,
-    ) {
-        if self.should_compile_successfully(pass_mode) {
+            PassFailMode::CheckPass
+            | PassFailMode::BuildPass
+            | PassFailMode::RunFail
+            | PassFailMode::RunCrash
+            | PassFailMode::RunFailOrCrash
+            | PassFailMode::RunPass => true,
+        };
+
+        if should_compile_successfully {
             if !proc_res.status.success() {
-                match (fail_mode, pass_mode) {
-                    (Some(FailMode::Build), Some(PassMode::Check)) => {
-                        // A `build-fail` test needs to `check-pass`.
-                        self.fatal_proc_rec(
-                            "`build-fail` test is required to pass check build, but check build failed",
-                            proc_res,
-                        );
-                    }
-                    _ => {
-                        self.fatal_proc_rec(
-                            "test compilation failed although it shouldn't!",
-                            proc_res,
-                        );
-                    }
+                if pass_fail == PassFailMode::CheckPass
+                    && self.effective_pass_fail_mode() == Some(PassFailMode::BuildFail)
+                {
+                    // A `build-fail` test needs to `check-pass`.
+                    self.fatal_proc_rec(
+                        "`build-fail` test is required to pass check build, but check build failed",
+                        proc_res,
+                    );
+                } else {
+                    self.fatal_proc_rec("test compilation failed although it shouldn't!", proc_res);
                 }
             }
         } else {
             if proc_res.status.success() {
                 let err = &format!("{} test did not emit an error", self.config.mode);
-                let extra_note = (self.config.mode == crate::common::TestMode::Ui)
-                    .then_some("note: by default, ui tests are expected not to compile.\nhint: use check-pass, build-pass, or run-pass directive to change this behavior.");
+                let extra_note = Some(
+                    "note: by default, ui tests are expected not to compile.\nhint: use check-pass, build-pass, or run-pass directive to change this behavior.",
+                );
                 self.fatal_proc_rec_general(err, extra_note, proc_res, || ());
             }
 
@@ -907,15 +905,6 @@ impl<'test> TestCx<'test> {
         }
     }
 
-    fn should_emit_metadata(&self, pm: Option<PassMode>) -> Emit {
-        match (pm, self.props.fail_mode(), self.config.mode) {
-            (Some(PassMode::Check), ..) | (_, Some(FailMode::Check), TestMode::Ui) => {
-                Emit::Metadata
-            }
-            _ => Emit::None,
-        }
-    }
-
     fn compile_test(&self, will_execute: WillExecute, emit: Emit) -> ProcRes {
         self.compile_test_general(will_execute, emit, Vec::new())
     }
@@ -944,10 +933,12 @@ impl<'test> TestCx<'test> {
                 // let's just ignore unused code warnings by defaults and tests
                 // can turn it back on if needed.
                 if compiler_kind == CompilerKind::Rustc
-                    // Note that we use the local pass mode here as we don't want
+                    // Note that we use the declared pass mode here as we don't want
                     // to set unused to allow if we've overridden the pass mode
                     // via command line flags.
-                    && self.props.local_pass_mode() != Some(PassMode::Run)
+                    // FIXME(Zalathar): We should probably also warn in run-fail/crash
+                    // tests, but that requires changes to some existing tests.
+                    && self.props.pass_fail_mode != Some(PassFailMode::RunPass)
                 {
                     AllowUnused::Yes
                 } else {
@@ -1656,9 +1647,11 @@ impl<'test> TestCx<'test> {
                 TestMode::Ui => {
                     // If optimize-tests is true we still only want to optimize tests that actually get
                     // executed and that don't specify their own optimization levels.
-                    // Note: aux libs don't have a pass-mode, so they won't get optimized
+                    // Note: aux libs don't have a pass/fail mode, so they won't get optimized
                     // unless compile-flags are set in the aux file.
-                    if self.props.pass_mode(&self.config) == Some(PassMode::Run)
+                    // FIXME(Zalathar): We could also optimize run-fail/run-crash tests,
+                    // but it's unclear whether that would be helpful or a waste of time.
+                    if self.effective_pass_fail_mode() == Some(PassFailMode::RunPass)
                         && !self
                             .props
                             .compile_flags

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -296,7 +296,8 @@ impl<'test> TestCx<'test> {
     fn should_run(&self, pm: Option<PassMode>) -> WillExecute {
         let test_should_run = match self.config.mode {
             TestMode::Ui => {
-                pm == Some(PassMode::Run) || matches!(self.props.fail_mode, Some(FailMode::Run(_)))
+                pm == Some(PassMode::Run)
+                    || matches!(self.props.fail_mode(), Some(FailMode::Run(_)))
             }
             mode => panic!("unimplemented for mode {:?}", mode),
         };
@@ -317,7 +318,7 @@ impl<'test> TestCx<'test> {
     fn should_compile_successfully(&self, pm: Option<PassMode>) -> bool {
         match self.config.mode {
             TestMode::RustdocJs => true,
-            TestMode::Ui => pm.is_some() || self.props.fail_mode > Some(FailMode::Build),
+            TestMode::Ui => pm.is_some() || self.props.fail_mode() > Some(FailMode::Build),
             TestMode::Crashes => false,
             mode => panic!("unimplemented for mode {:?}", mode),
         }
@@ -907,7 +908,7 @@ impl<'test> TestCx<'test> {
     }
 
     fn should_emit_metadata(&self, pm: Option<PassMode>) -> Emit {
-        match (pm, self.props.fail_mode, self.config.mode) {
+        match (pm, self.props.fail_mode(), self.config.mode) {
             (Some(PassMode::Check), ..) | (_, Some(FailMode::Check), TestMode::Ui) => {
                 Emit::Metadata
             }

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -5,29 +5,29 @@ use std::io::Write;
 use rustfix::{Filter, apply_suggestions, get_suggestions_from_json};
 use tracing::debug;
 
+use crate::common::PassFailMode;
 use crate::json;
 use crate::runtest::{
-    AllowUnused, Emit, FailMode, LinkToAux, PassMode, ProcRes, RunFailMode, RunResult,
-    TargetLocation, TestCx, TestOutput, Truncated, UI_FIXED, WillExecute,
+    AllowUnused, Emit, LinkToAux, ProcRes, RunResult, TargetLocation, TestCx, TestOutput,
+    Truncated, UI_FIXED, WillExecute,
 };
 
 impl TestCx<'_> {
     pub(super) fn run_ui_test(&self) {
-        if let Some(FailMode::Build) = self.props.fail_mode() {
+        let pass_fail =
+            self.effective_pass_fail_mode().expect("UI tests always have a pass/fail mode");
+
+        if pass_fail == PassFailMode::BuildFail {
             // Make sure a build-fail test cannot fail due to failing analysis (e.g. typeck).
             let proc_res = self.compile_test(WillExecute::No, Emit::Metadata);
-            self.check_if_test_should_compile(
-                self.props.fail_mode(),
-                Some(PassMode::Check),
-                &proc_res,
-            );
+            self.check_if_test_should_compile(PassFailMode::CheckPass, &proc_res);
         }
 
-        let pm = self.pass_mode();
-        let should_run = self.should_run(pm);
-        let emit_metadata = self.should_emit_metadata(pm);
-        let proc_res = self.compile_test(should_run, emit_metadata);
-        self.check_if_test_should_compile(self.props.fail_mode(), pm, &proc_res);
+        let will_execute = if pass_fail.is_run() { self.run_if_enabled() } else { WillExecute::No };
+        let emit_metadata = if pass_fail.is_check() { Emit::Metadata } else { Emit::None };
+        let proc_res = self.compile_test(will_execute, emit_metadata);
+        self.check_if_test_should_compile(pass_fail, &proc_res);
+
         if matches!(proc_res.truncated, Truncated::Yes)
             && !self.props.dont_check_compiler_stdout
             && !self.props.dont_check_compiler_stderr
@@ -136,7 +136,7 @@ impl TestCx<'_> {
         // If the test is executed, capture its ProcRes separately so that
         // pattern/forbid checks can report the *runtime* stdout/stderr when they fail.
         let mut run_proc_res: Option<ProcRes> = None;
-        let output_to_check = if let WillExecute::Yes = should_run {
+        let output_to_check = if will_execute == WillExecute::Yes {
             let proc_res = self.exec_compiled_test();
             let run_output_errors = if self.props.check_run_results {
                 self.load_compare_outputs(&proc_res, TestOutput::Run, explicit)
@@ -160,14 +160,14 @@ impl TestCx<'_> {
             // Help users understand why the test failed by including the actual
             // exit code and actual run result in the failure message.
             let pass_hint = format!("code={code:?} so test would pass with `{run_result}`");
-            if self.should_run_successfully(pm) {
+            if pass_fail == PassFailMode::RunPass {
                 if run_result != RunResult::Pass {
                     self.fatal_proc_rec(
                         &format!("test did not exit with success! {pass_hint}"),
                         &proc_res,
                     );
                 }
-            } else if self.props.fail_mode() == Some(FailMode::Run(RunFailMode::Fail)) {
+            } else if pass_fail == PassFailMode::RunFail {
                 // If the test is marked as `run-fail` but do not support
                 // unwinding we allow it to crash, since a panic will trigger an
                 // abort (crash) instead of unwind (exit with code 101).
@@ -183,11 +183,11 @@ impl TestCx<'_> {
                     };
                     self.fatal_proc_rec(&err, &proc_res);
                 }
-            } else if self.props.fail_mode() == Some(FailMode::Run(RunFailMode::Crash)) {
+            } else if pass_fail == PassFailMode::RunCrash {
                 if run_result != RunResult::Crash {
                     self.fatal_proc_rec(&format!("test did not crash! {pass_hint}"), &proc_res);
                 }
-            } else if self.props.fail_mode() == Some(FailMode::Run(RunFailMode::FailOrCrash)) {
+            } else if pass_fail == PassFailMode::RunFailOrCrash {
                 if run_result != RunResult::Fail && run_result != RunResult::Crash {
                     self.fatal_proc_rec(
                         &format!("test did not exit with failure or crash! {pass_hint}"),

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -13,11 +13,11 @@ use crate::runtest::{
 
 impl TestCx<'_> {
     pub(super) fn run_ui_test(&self) {
-        if let Some(FailMode::Build) = self.props.fail_mode {
+        if let Some(FailMode::Build) = self.props.fail_mode() {
             // Make sure a build-fail test cannot fail due to failing analysis (e.g. typeck).
             let proc_res = self.compile_test(WillExecute::No, Emit::Metadata);
             self.check_if_test_should_compile(
-                self.props.fail_mode,
+                self.props.fail_mode(),
                 Some(PassMode::Check),
                 &proc_res,
             );
@@ -27,7 +27,7 @@ impl TestCx<'_> {
         let should_run = self.should_run(pm);
         let emit_metadata = self.should_emit_metadata(pm);
         let proc_res = self.compile_test(should_run, emit_metadata);
-        self.check_if_test_should_compile(self.props.fail_mode, pm, &proc_res);
+        self.check_if_test_should_compile(self.props.fail_mode(), pm, &proc_res);
         if matches!(proc_res.truncated, Truncated::Yes)
             && !self.props.dont_check_compiler_stdout
             && !self.props.dont_check_compiler_stderr
@@ -167,7 +167,7 @@ impl TestCx<'_> {
                         &proc_res,
                     );
                 }
-            } else if self.props.fail_mode == Some(FailMode::Run(RunFailMode::Fail)) {
+            } else if self.props.fail_mode() == Some(FailMode::Run(RunFailMode::Fail)) {
                 // If the test is marked as `run-fail` but do not support
                 // unwinding we allow it to crash, since a panic will trigger an
                 // abort (crash) instead of unwind (exit with code 101).
@@ -183,11 +183,11 @@ impl TestCx<'_> {
                     };
                     self.fatal_proc_rec(&err, &proc_res);
                 }
-            } else if self.props.fail_mode == Some(FailMode::Run(RunFailMode::Crash)) {
+            } else if self.props.fail_mode() == Some(FailMode::Run(RunFailMode::Crash)) {
                 if run_result != RunResult::Crash {
                     self.fatal_proc_rec(&format!("test did not crash! {pass_hint}"), &proc_res);
                 }
-            } else if self.props.fail_mode == Some(FailMode::Run(RunFailMode::FailOrCrash)) {
+            } else if self.props.fail_mode() == Some(FailMode::Run(RunFailMode::FailOrCrash)) {
                 if run_result != RunResult::Fail && run_result != RunResult::Crash {
                     self.fatal_proc_rec(
                         &format!("test did not exit with failure or crash! {pass_hint}"),

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -157,45 +157,61 @@ impl TestCx<'_> {
             } else {
                 RunResult::Crash
             };
+
             // Help users understand why the test failed by including the actual
             // exit code and actual run result in the failure message.
             let pass_hint = format!("code={code:?} so test would pass with `{run_result}`");
-            if pass_fail == PassFailMode::RunPass {
-                if run_result != RunResult::Pass {
-                    self.fatal_proc_rec(
-                        &format!("test did not exit with success! {pass_hint}"),
-                        &proc_res,
-                    );
+            match pass_fail {
+                PassFailMode::CheckFail
+                | PassFailMode::CheckPass
+                | PassFailMode::BuildFail
+                | PassFailMode::BuildPass => {
+                    unreachable!("test program should not have run in mode {pass_fail:?}")
                 }
-            } else if pass_fail == PassFailMode::RunFail {
-                // If the test is marked as `run-fail` but do not support
-                // unwinding we allow it to crash, since a panic will trigger an
-                // abort (crash) instead of unwind (exit with code 101).
-                let crash_ok = !self.config.can_unwind();
-                if run_result != RunResult::Fail && !(crash_ok && run_result == RunResult::Crash) {
-                    let err = if crash_ok {
-                        format!(
-                            "test did not exit with failure or crash (`{}` can't unwind)! {pass_hint}",
-                            self.config.target
-                        )
-                    } else {
-                        format!("test did not exit with failure! {pass_hint}")
-                    };
-                    self.fatal_proc_rec(&err, &proc_res);
+
+                PassFailMode::RunPass => {
+                    if run_result != RunResult::Pass {
+                        self.fatal_proc_rec(
+                            &format!("test did not exit with success! {pass_hint}"),
+                            &proc_res,
+                        );
+                    }
                 }
-            } else if pass_fail == PassFailMode::RunCrash {
-                if run_result != RunResult::Crash {
-                    self.fatal_proc_rec(&format!("test did not crash! {pass_hint}"), &proc_res);
+
+                PassFailMode::RunFail => {
+                    // If the test is marked as `run-fail` but do not support
+                    // unwinding we allow it to crash, since a panic will trigger an
+                    // abort (crash) instead of unwind (exit with code 101).
+                    let crash_ok = !self.config.can_unwind();
+                    if run_result != RunResult::Fail
+                        && !(crash_ok && run_result == RunResult::Crash)
+                    {
+                        let err = if crash_ok {
+                            format!(
+                                "test did not exit with failure or crash (`{}` can't unwind)! {pass_hint}",
+                                self.config.target
+                            )
+                        } else {
+                            format!("test did not exit with failure! {pass_hint}")
+                        };
+                        self.fatal_proc_rec(&err, &proc_res);
+                    }
                 }
-            } else if pass_fail == PassFailMode::RunFailOrCrash {
-                if run_result != RunResult::Fail && run_result != RunResult::Crash {
-                    self.fatal_proc_rec(
-                        &format!("test did not exit with failure or crash! {pass_hint}"),
-                        &proc_res,
-                    );
+
+                PassFailMode::RunCrash => {
+                    if run_result != RunResult::Crash {
+                        self.fatal_proc_rec(&format!("test did not crash! {pass_hint}"), &proc_res);
+                    }
                 }
-            } else {
-                unreachable!("run_ui_test() must not be called if the test should not run");
+
+                PassFailMode::RunFailOrCrash => {
+                    if run_result != RunResult::Fail && run_result != RunResult::Crash {
+                        self.fatal_proc_rec(
+                            &format!("test did not exit with failure or crash! {pass_hint}"),
+                            &proc_res,
+                        );
+                    }
+                }
             }
 
             let output = self.get_output(&proc_res);

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -95,21 +95,34 @@ macro_rules! static_regex {
 pub(crate) use static_regex;
 
 macro_rules! string_enum {
-    ($(#[$meta:meta])* $vis:vis enum $name:ident { $($variant:ident => $repr:expr,)* }) => {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $(
+                $variant:ident => $repr:expr,
+            )*
+        }
+    ) => {
         $(#[$meta])*
         $vis enum $name {
-            $($variant,)*
+            $(
+                $variant,
+            )*
         }
 
         impl $name {
             #[allow(dead_code)]
-            $vis const VARIANTS: &'static [Self] = &[$(Self::$variant,)*];
+            $vis const VARIANTS: &'static [Self] = &[
+                $( Self::$variant, )*
+            ];
             #[allow(dead_code)]
-            $vis const STR_VARIANTS: &'static [&'static str] = &[$(Self::$variant.to_str(),)*];
+            $vis const STR_VARIANTS: &'static [&'static str] = &[
+                $( Self::$variant.to_str(), )*
+            ];
 
             $vis const fn to_str(&self) -> &'static str {
                 match self {
-                    $(Self::$variant => $repr,)*
+                    $( Self::$variant => $repr, )*
                 }
             }
         }
@@ -125,7 +138,7 @@ macro_rules! string_enum {
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 match s {
-                    $($repr => Ok(Self::$variant),)*
+                    $( $repr => Ok(Self::$variant), )*
                     _ => Err(format!(concat!("unknown `", stringify!($name), "` variant: `{}`"), s)),
                 }
             }

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -99,6 +99,7 @@ macro_rules! string_enum {
         $(#[$meta:meta])*
         $vis:vis enum $name:ident {
             $(
+                $(#[$variant_meta:meta])*
                 $variant:ident => $repr:expr,
             )*
         }
@@ -106,6 +107,7 @@ macro_rules! string_enum {
         $(#[$meta])*
         $vis enum $name {
             $(
+                $(#[$variant_meta])*
                 $variant,
             )*
         }


### PR DESCRIPTION
Every UI test has an explicit or implicit “pass/fail mode” (e.g. `check-fail` or `build-pass`) that was historically stored in two separate optional fields (`pass_mode` and `fail_mode`). That split made it very hard to determine how the respective values were actually produced and consumed, especially in the presence of `--pass=check` on the command-line, or when building auxiliary crates.

This PR replaces the separate fields and enums for pass-mode and fail-mode with a single `PassFailMode` enum and a single `pass_fail_mode` field.

With this new representation, it should hopefully be easier to understand and modify the pass/fail-mode logic.

---

In order to focus on the main migration, I have mostly refrained from subsequent cleanups.

r? jieyouxu