### PR TITLE
Short-circuit `calculate_fallback_to_f32` when no float vars

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -147,6 +147,14 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
     /// foo(1.0);
     /// ```
     fn calculate_fallback_to_f32(&self, unresolved_variables: &[Ty<'tcx>]) -> UnordSet<FloatVid> {
+        // Short-circuit: if no unresolved variable is a float, no f32 fallback can apply,
+        // so we can skip the (potentially very expensive) work in `from_float_for_f32_root_vids`.
+        // Under the new solver, that function walks `visit_proof_tree` for every pending
+        // obligation, which is O(N × proof_tree_size) and can dominate type-checking on crates
+        // with many large pending obligations and no f32 involvement.
+        if unresolved_variables.iter().all(|ty| ty.float_vid().is_none()) {
+            return UnordSet::new();
+        }
         let roots: UnordSet<ty::FloatVid> = self.from_float_for_f32_root_vids();
         if roots.is_empty() {
             // Most functions have no `f32: From<{float}>` predicates, so short-circuit and return


### PR DESCRIPTION
Sharing a small fix.

When no unresolved variable is a `float_vid`, no f32 fallback can apply,
so we can skip `from_float_for_f32_root_vids` (which walks the proof tree
of every pending obligation under the new solver — O(N × M) on crates
with many large obligations).

On ReShell: stage1 wall-clock 2m35s → 1m46s (-49s, ~31%).

Context + profile breakdown will be linked at
rust-lang/trait-system-refactor-initiative#254 after this PR opens.

r? @lcnr