### PR TITLE
test new solver on CI until stabilization

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -374,7 +374,7 @@ where
         _ecx: &mut EvalCtxt<'_, D>,
         _goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolutionOrRerunNonErased> {
-        todo!("Iterator is not yet const")
+        Err(NoSolutionOrRerunNonErased::NoSolution(NoSolution))
     }
 
     fn consider_builtin_fused_iterator_candidate(

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -18,3 +18,8 @@ set -ex
 # This is intended to make sure that both `--pass=check` continues to
 # work.
 ../x.ps1 --stage 2 test tests/ui --pass=check --host='' --target=i686-unknown-linux-gnu
+
+# Rebuild the stdlib using the new trait solver, to ensure it doesn't regress
+# until stabilization.
+RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x --stage 1 build library \
+    --host='' --target=i686-unknown-linux-gnu

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -13,10 +13,7 @@ set -ex
 # despite having different output on 32-bit vs 64-bit targets.
 ../x --stage 2 test tests/mir-opt --host='' --target=i686-unknown-linux-gnu
 
-# Run the UI test suite again, but in `--pass=check` mode
-#
-# This is intended to make sure that both `--pass=check` continues to
-# work.
+# Run the UI test suite in `--pass=check` mode, to ensure it continues to work.
 ../x.ps1 --stage 2 test tests/ui --pass=check --host='' --target=i686-unknown-linux-gnu
 
 # Rebuild the stdlib using the new trait solver, to ensure it doesn't regress


### PR DESCRIPTION
We need the new solver to be able to build the stdlib, and this has regressed in the recent past. Things are broken right now, and we want to ensure this keeps working until stabilization later this year. 

I've added this to the `x86_64-gnu-llvm-XX` job (note no `-1/2/3` suffix) so it's run on PR and auto CI, and because it's roughly the fastest of these builders, though maybe the aarch64 llvm 1 and 2 are slightly faster.

Building the stage 1 `./x build library/` is generally quite quick, a couple minutes at most.

The new solver fix to build std is from @lcnr [on zulip](https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor/topic/weekly.20sync.2Fupdates/near/591998234).
r? @marcoieni 



