### PR TITLE
Don't return dummy MacroData in `get_macro`

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -37,8 +37,8 @@ use crate::ref_mut::CmCell;
 use crate::{
     BindingKey, Decl, DeclData, DeclKind, DelayedVisResolutionError, ExternModule,
     ExternPreludeEntry, Finalize, IdentKey, LocalModule, MacroData, Module, ModuleKind,
-    ModuleOrUniformRoot, ParentScope, PathResult, Res, Resolver, Segment, Used, VisResolutionError,
-    errors,
+    ModuleOrUniformRoot, ParentScope, PathResult, Res, Resolver, Segment, SyntaxExtension, Used,
+    VisResolutionError, errors,
 };
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
@@ -201,10 +201,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    pub(crate) fn get_macro(&self, res: Res) -> Option<&'ra MacroData> {
+    /// Gets the `SyntaxExtension` corresponding to `res`.
+    pub(crate) fn get_macro(&self, res: Res) -> Option<&Arc<SyntaxExtension>> {
         match res {
-            Res::Def(DefKind::Macro(..), def_id) => Some(self.get_macro_by_def_id(def_id)),
-            Res::NonMacroAttr(_) => Some(self.non_macro_attr),
+            Res::Def(DefKind::Macro(..), def_id) => Some(&self.get_macro_by_def_id(def_id).ext),
+            Res::NonMacroAttr(_) => Some(&self.non_macro_attr),
             _ => None,
         }
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1392,7 +1392,7 @@ pub struct Resolver<'ra, 'tcx> {
     extern_macro_map: CacheRefCell<FxHashMap<DefId, &'ra MacroData>>,
     dummy_ext_bang: Arc<SyntaxExtension>,
     dummy_ext_derive: Arc<SyntaxExtension>,
-    non_macro_attr: &'ra MacroData,
+    non_macro_attr: Arc<SyntaxExtension>,
     local_macro_def_scopes: FxHashMap<LocalDefId, LocalModule<'ra>> = default::fx_hash_map(),
     ast_transform_scopes: FxHashMap<LocalExpnId, LocalModule<'ra>> = default::fx_hash_map(),
     unused_macros: FxIndexMap<LocalDefId, (NodeId, Ident)>,
@@ -1812,8 +1812,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             extern_macro_map: Default::default(),
             dummy_ext_bang: Arc::new(SyntaxExtension::dummy_bang(edition)),
             dummy_ext_derive: Arc::new(SyntaxExtension::dummy_derive(edition)),
-            non_macro_attr: arenas
-                .alloc_macro(MacroData::new(Arc::new(SyntaxExtension::non_macro_attr(edition)))),
+            non_macro_attr: Arc::new(SyntaxExtension::non_macro_attr(edition)),
             unused_macros: Default::default(),
             unused_macro_rules: Default::default(),
             single_segment_macro_resolutions: Default::default(),
@@ -1984,7 +1983,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         match macro_kind {
             MacroKind::Bang => Arc::clone(&self.dummy_ext_bang),
             MacroKind::Derive => Arc::clone(&self.dummy_ext_derive),
-            MacroKind::Attr => Arc::clone(&self.non_macro_attr.ext),
+            MacroKind::Attr => Arc::clone(&self.non_macro_attr),
         }
     }
 
@@ -2013,11 +2012,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     fn is_builtin_macro(&self, res: Res) -> bool {
-        self.get_macro(res).is_some_and(|macro_data| macro_data.ext.builtin_name.is_some())
+        self.get_macro(res).is_some_and(|ext| ext.builtin_name.is_some())
     }
 
     fn is_specific_builtin_macro(&self, res: Res, symbol: Symbol) -> bool {
-        self.get_macro(res).is_some_and(|macro_data| macro_data.ext.builtin_name == Some(symbol))
+        self.get_macro(res).is_some_and(|ext| ext.builtin_name == Some(symbol))
     }
 
     fn macro_def(&self, mut ctxt: SyntaxContext) -> DefId {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -882,7 +882,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 _ => None,
             },
-            None => self.get_macro(res).map(|macro_data| Arc::clone(&macro_data.ext)),
+            None => self.get_macro(res).map(Arc::clone),
         };
         Ok((ext, res))
     }
@@ -1212,7 +1212,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Reserve some names that are not quite covered by the general check
         // performed on `Resolver::builtin_attrs`.
         if name == sym::cfg || name == sym::cfg_attr {
-            let macro_kinds = self.get_macro(res).map(|macro_data| macro_data.ext.macro_kinds());
+            let macro_kinds = res.macro_kinds();
             if macro_kinds.is_some() && sub_namespace_match(macro_kinds, Some(MacroKind::Attr)) {
                 self.dcx().emit_err(errors::NameReservedInAttributeNamespace { span, ident: name });
             }

--- a/tests/ui/cfg/reserved-macro-names-rename.rs
+++ b/tests/ui/cfg/reserved-macro-names-rename.rs
@@ -1,0 +1,29 @@
+//@edition:2018
+
+#![crate_type = "lib"]
+
+
+mod a {
+    use ignore as cfg;
+    //~^ERROR name `cfg` is reserved in attribute namespace
+}
+
+mod b {
+    use cfg_attr as cfg;
+    //~^ERROR name `cfg` is reserved in attribute namespace
+}
+
+mod c {
+    use cfg as cfg;
+    //~^ERROR `cfg` is ambiguous
+}
+
+mod d {
+    use inline as cfg_attr;
+    //~^ERROR name `cfg_attr` is reserved in attribute namespace
+}
+
+mod e {
+    use not_found as cfg; // trigger "unresolved import", not "cfg reserved".
+    //~^ ERROR unresolved import `not_found`
+}

--- a/tests/ui/cfg/reserved-macro-names-rename.stderr
+++ b/tests/ui/cfg/reserved-macro-names-rename.stderr
@@ -1,0 +1,39 @@
+error: name `cfg` is reserved in attribute namespace
+  --> $DIR/reserved-macro-names-rename.rs:7:19
+   |
+LL |     use ignore as cfg;
+   |                   ^^^
+
+error: name `cfg` is reserved in attribute namespace
+  --> $DIR/reserved-macro-names-rename.rs:12:21
+   |
+LL |     use cfg_attr as cfg;
+   |                     ^^^
+
+error: name `cfg_attr` is reserved in attribute namespace
+  --> $DIR/reserved-macro-names-rename.rs:22:19
+   |
+LL |     use inline as cfg_attr;
+   |                   ^^^^^^^^
+
+error[E0432]: unresolved import `not_found`
+  --> $DIR/reserved-macro-names-rename.rs:27:9
+   |
+LL |     use not_found as cfg; // trigger "unresolved import", not "cfg reserved".
+   |         ^^^^^^^^^^^^^^^^ no external crate `not_found`
+
+error[E0659]: `cfg` is ambiguous
+  --> $DIR/reserved-macro-names-rename.rs:17:9
+   |
+LL |     use cfg as cfg;
+   |         ^^^ ambiguous name
+   |
+   = note: ambiguous because of a name conflict with a builtin attribute
+   = note: `cfg` could refer to a built-in attribute
+note: `cfg` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0432, E0659.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156151)*
<!-- homu-ignore:end -->

I was experimenting with tool attributes and ast manipulation, and wasted some time figuring out that this was happening. AFAIK all users of `get_macro` are expecting an actual macro (and none were reading the dummy MacroData) so there should be no change in behavior.

