### PR TITLE
tests: mark import UI tests as check-pass

### DIFF
--- a/tests/ui/imports/extern-crate-self/extern-crate-self-macro-item.rs
+++ b/tests/ui/imports/extern-crate-self/extern-crate-self-macro-item.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 // Test that `extern crate self;` is accepted
 // syntactically as an item for use in a macro.

--- a/tests/ui/imports/extern-crate-self/extern-crate-self-pass.rs
+++ b/tests/ui/imports/extern-crate-self/extern-crate-self-pass.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 extern crate self as foo;
 

--- a/tests/ui/imports/extern-prelude-extern-crate-absolute-expanded.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-absolute-expanded.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 //@ edition:2018
 
 macro_rules! define_iso { () => {

--- a/tests/ui/imports/extern-prelude-extern-crate-cfg.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-cfg.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 //@ compile-flags:--cfg my_feature --check-cfg=cfg(my_feature)
 
 #![no_std]

--- a/tests/ui/imports/extern-prelude-extern-crate-pass.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-pass.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 //@ aux-build:two_macros.rs
 
 extern crate two_macros;

--- a/tests/ui/imports/extern-prelude-extern-crate-shadowing.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-shadowing.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 //@ aux-build:two_macros.rs
 
 extern crate two_macros as core;

--- a/tests/ui/imports/local-modularized-tricky-pass-1.rs
+++ b/tests/ui/imports/local-modularized-tricky-pass-1.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 macro_rules! define_exported { () => {
     #[macro_export]

--- a/tests/ui/imports/local-modularized.rs
+++ b/tests/ui/imports/local-modularized.rs
@@ -1,5 +1,5 @@
 //@ edition:2015
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 
 #[macro_export(local_inner_macros)]
 macro_rules! dollar_crate_exported {

--- a/tests/ui/resolve/extern-prelude.rs
+++ b/tests/ui/resolve/extern-prelude.rs
@@ -1,4 +1,4 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ check-pass
 //@ compile-flags:--extern extern_prelude --extern Vec
 //@ aux-build:extern-prelude.rs
 //@ aux-build:extern-prelude-vec.rs


### PR DESCRIPTION
These import and extern-prelude UI tests only exercise checking behavior, so they do not need codegen or linking.

Mark them as check-pass and remove the old FIXME(62277) markers.