### PR TITLE
macros: report unbound metavariables directly

### DIFF
--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -304,8 +304,10 @@ pub(super) fn emit_frag_parse_err(
     };
 
     if parser.token.kind == token::Dollar {
+        let dollar_span = parser.token.span;
         parser.bump();
         if let token::Ident(name, _) = parser.token.kind {
+            let metavar_span = dollar_span.to(parser.token.span);
             let mut bindings_names = vec![];
             for rule in bindings {
                 let MacroRule::Func { lhs, .. } = rule else { continue };
@@ -319,6 +321,15 @@ pub(super) fn emit_frag_parse_err(
             for param in matched_rule_bindings {
                 let MatcherLoc::MetaVarDecl { bind, .. } = param else { continue };
                 matched_rule_bindings_names.push(bind.name);
+            }
+
+            // Report the unbound metavariable as the primary error up front, so every
+            // case is consistent regardless of which suggestion (if any) we attach below.
+            e.primary_message(format!("cannot find macro parameter `${name}` in this scope"));
+            e.span(metavar_span);
+            e.span_label(metavar_span, "not found in this scope");
+            if parser.psess.source_map().is_imported(metavar_span) {
+                e.span_label(site_span, "in this macro invocation");
             }
 
             if let Some(matched_name) = rustc_span::edit_distance::find_best_match_for_name(
@@ -346,17 +357,13 @@ pub(super) fn emit_frag_parse_err(
                     matched_name,
                     Applicability::MaybeIncorrect,
                 );
-            } else {
+            } else if !matched_rule_bindings_names.is_empty() {
                 let msg = matched_rule_bindings_names
                     .iter()
                     .map(|sym| format!("${}", sym))
                     .collect::<Vec<_>>()
                     .join(", ");
-
-                e.span_label(parser.token.span, "macro metavariable not found");
-                if !matched_rule_bindings_names.is_empty() {
-                    e.note(format!("available metavariable names are: {msg}"));
-                }
+                e.note(format!("available metavariable names are: {msg}"));
             }
         }
     }

--- a/tests/ui/macros/issue-35450.rs
+++ b/tests/ui/macros/issue-35450.rs
@@ -1,5 +1,5 @@
 macro_rules! m { ($($t:tt)*) => { $($t)* } }
 
 fn main() {
-    m!($t); //~ ERROR expected expression
+    m!($t); //~ ERROR cannot find macro parameter `$t` in this scope
 }

--- a/tests/ui/macros/issue-35450.stderr
+++ b/tests/ui/macros/issue-35450.stderr
@@ -1,8 +1,8 @@
-error: expected expression, found `$`
+error: cannot find macro parameter `$t` in this scope
   --> $DIR/issue-35450.rs:4:8
    |
 LL |     m!($t);
-   |        ^ expected expression
+   |        ^^ not found in this scope
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/issue-6596-1.rs
+++ b/tests/ui/macros/issue-6596-1.rs
@@ -1,10 +1,18 @@
 macro_rules! e {
     ($inp:ident) => (
         $nonexistent
-        //~^ ERROR expected expression, found `$`
+        //~^ ERROR cannot find macro parameter `$nonexistent` in this scope
+    );
+}
+
+macro_rules! m {
+    () => (
+        $x
+        //~^ ERROR cannot find macro parameter `$x` in this scope
     );
 }
 
 fn main() {
     e!(foo);
+    m!();
 }

--- a/tests/ui/macros/issue-6596-1.stderr
+++ b/tests/ui/macros/issue-6596-1.stderr
@@ -1,11 +1,8 @@
-error: expected expression, found `$`
+error: cannot find macro parameter `$nonexistent` in this scope
   --> $DIR/issue-6596-1.rs:3:9
    |
 LL |         $nonexistent
-   |         ^-----------
-   |         ||
-   |         |macro metavariable not found
-   |         expected expression
+   |         ^^^^^^^^^^^^ not found in this scope
 ...
 LL |     e!(foo);
    |     ------- in this macro invocation
@@ -13,5 +10,16 @@ LL |     e!(foo);
    = note: available metavariable names are: $inp
    = note: this error originates in the macro `e` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: cannot find macro parameter `$x` in this scope
+  --> $DIR/issue-6596-1.rs:10:9
+   |
+LL |         $x
+   |         ^^ not found in this scope
+...
+LL |     m!();
+   |     ---- in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/typo-in-norepeat-expr-2.rs
+++ b/tests/ui/macros/typo-in-norepeat-expr-2.rs
@@ -3,9 +3,9 @@ macro_rules! err {
         [$arg]
     };
     (begin1 $arg1:ident end $agr2:expr) => {
-        [$follow] //~ ERROR: expected expression, found `$`
-        //~^ NOTE: there is an macro metavariable with this name in another macro matcher
-        //~| NOTE: expected expression
+        [$follow] //~ ERROR: cannot find macro parameter `$follow` in this scope
+        //~^ NOTE: not found in this scope
+        //~| NOTE: there is an macro metavariable with this name in another macro matcher
     };
 }
 
@@ -14,8 +14,8 @@ macro_rules! err1 {
         [$arg]
     };
     (begin1 $arg1:ident end) => {
-        [$follo] //~ ERROR: expected expression, found `$`
-        //~| NOTE: expected expression
+        [$follo] //~ ERROR: cannot find macro parameter `$follo` in this scope
+        //~^ NOTE: not found in this scope
         //~| HELP: there is a macro metavariable with a similar name in another macro matcher
     };
 }
@@ -25,10 +25,9 @@ macro_rules! err2 {
         [$arg]
     };
     (begin1 $arg1:ident end) => {
-        [$xyz] //~ ERROR: expected expression, found `$`
-        //~^ NOTE: expected expression
+        [$xyz] //~ ERROR: cannot find macro parameter `$xyz` in this scope
+        //~^ NOTE: not found in this scope
         //~| NOTE available metavariable names are: $arg1
-        //~| NOTE: macro metavariable not found
     };
 }
 

--- a/tests/ui/macros/typo-in-norepeat-expr-2.stderr
+++ b/tests/ui/macros/typo-in-norepeat-expr-2.stderr
@@ -1,22 +1,22 @@
-error: expected expression, found `$`
+error: cannot find macro parameter `$follow` in this scope
   --> $DIR/typo-in-norepeat-expr-2.rs:6:10
    |
 LL |         [$follow]
    |          ^------
    |          ||
    |          |there is an macro metavariable with this name in another macro matcher
-   |          expected expression
+   |          not found in this scope
 ...
 LL |     let _ = err![begin1 x  end ig];
    |             ---------------------- in this macro invocation
    |
    = note: this error originates in the macro `err` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: expected expression, found `$`
+error: cannot find macro parameter `$follo` in this scope
   --> $DIR/typo-in-norepeat-expr-2.rs:17:10
    |
 LL |         [$follo]
-   |          ^^^^^^ expected expression
+   |          ^^^^^^ not found in this scope
 ...
 LL |     let _ = err1![begin1 x  end];
    |             -------------------- in this macro invocation
@@ -27,14 +27,11 @@ help: there is a macro metavariable with a similar name in another macro matcher
 LL |         [$follow]
    |                +
 
-error: expected expression, found `$`
+error: cannot find macro parameter `$xyz` in this scope
   --> $DIR/typo-in-norepeat-expr-2.rs:28:10
    |
 LL |         [$xyz]
-   |          ^---
-   |          ||
-   |          |macro metavariable not found
-   |          expected expression
+   |          ^^^^ not found in this scope
 ...
 LL |     let _ = err2![begin1 x  end];
    |             -------------------- in this macro invocation

--- a/tests/ui/macros/typo-in-norepeat-expr.fixed
+++ b/tests/ui/macros/typo-in-norepeat-expr.fixed
@@ -1,12 +1,14 @@
 //@ run-rustfix
 macro_rules! m {
     (begin $ard:ident end) => {
-        [$ard] //~ ERROR: expected expression, found `$`
-        //~^ HELP: there is a macro metavariable with a similar name
+        [$ard] //~ ERROR: cannot find macro parameter `$arg` in this scope
+        //~^ NOTE: not found in this scope
+        //~| HELP: there is a macro metavariable with a similar name
     };
 }
 
 fn main() {
     let x = 1;
-    let _ = m![begin x end];
+    let _ = m![begin x end]; //~ NOTE: in this expansion of m!
+    //~| NOTE: in this expansion of m!
 }

--- a/tests/ui/macros/typo-in-norepeat-expr.rs
+++ b/tests/ui/macros/typo-in-norepeat-expr.rs
@@ -1,12 +1,14 @@
 //@ run-rustfix
 macro_rules! m {
     (begin $ard:ident end) => {
-        [$arg] //~ ERROR: expected expression, found `$`
-        //~^ HELP: there is a macro metavariable with a similar name
+        [$arg] //~ ERROR: cannot find macro parameter `$arg` in this scope
+        //~^ NOTE: not found in this scope
+        //~| HELP: there is a macro metavariable with a similar name
     };
 }
 
 fn main() {
     let x = 1;
-    let _ = m![begin x end];
+    let _ = m![begin x end]; //~ NOTE: in this expansion of m!
+    //~| NOTE: in this expansion of m!
 }

--- a/tests/ui/macros/typo-in-norepeat-expr.stderr
+++ b/tests/ui/macros/typo-in-norepeat-expr.stderr
@@ -1,8 +1,8 @@
-error: expected expression, found `$`
+error: cannot find macro parameter `$arg` in this scope
   --> $DIR/typo-in-norepeat-expr.rs:4:10
    |
 LL |         [$arg]
-   |          ^^^^ expected expression
+   |          ^^^^ not found in this scope
 ...
 LL |     let _ = m![begin x end];
    |             --------------- in this macro invocation


### PR DESCRIPTION
Fixes rust-lang/rust#95943.

When a macro expansion contains an unbound `$ident`, report it as a missing macro parameter instead of keeping the generic fragment parser error as the primary diagnostic.

This keeps the existing typo suggestions and available-metavariable notes.