### PR TITLE
Adjust getMCSubtargetInfo signature for LLVM 23+

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -97,7 +97,6 @@ extern "C" bool LLVMRustHasFeature(LLVMTargetMachineRef TM,
   const MCSubtargetInfo &MCInfo = *Target->getMCSubtargetInfo();
 #endif
   return MCInfo.checkFeatures(std::string("+") + Feature);
-
 }
 
 /// Check whether the target has a specific assembly mnemonic like `ret` or

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -93,11 +93,11 @@ extern "C" bool LLVMRustHasFeature(LLVMTargetMachineRef TM,
   TargetMachine *Target = unwrap(TM);
 #if LLVM_VERSION_GE(23, 0)
   const MCSubtargetInfo &MCInfo = Target->getMCSubtargetInfo();
-  return MCInfo.checkFeatures(std::string("+") + Feature);
 #else
-  const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
-  return MCInfo->checkFeatures(std::string("+") + Feature);
+  const MCSubtargetInfo &MCInfo = *Target->getMCSubtargetInfo();
 #endif
+  return MCInfo.checkFeatures(std::string("+") + Feature);
+
 }
 
 /// Check whether the target has a specific assembly mnemonic like `ret` or
@@ -297,13 +297,11 @@ extern "C" size_t LLVMRustGetTargetFeaturesCount(LLVMTargetMachineRef TM) {
   const TargetMachine *Target = unwrap(TM);
 #if LLVM_VERSION_GE(23, 0)
   const MCSubtargetInfo &MCInfo = Target->getMCSubtargetInfo();
+#else
+  const MCSubtargetInfo &MCInfo = *Target->getMCSubtargetInfo();
+#endif
   const ArrayRef<SubtargetFeatureKV> FeatTable =
       MCInfo.getAllProcessorFeatures();
-#else
-  const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
-  const ArrayRef<SubtargetFeatureKV> FeatTable =
-      MCInfo->getAllProcessorFeatures();
-#endif
   return FeatTable.size();
 }
 
@@ -313,13 +311,11 @@ extern "C" void LLVMRustGetTargetFeature(LLVMTargetMachineRef TM, size_t Index,
   const TargetMachine *Target = unwrap(TM);
 #if LLVM_VERSION_GE(23, 0)
   const MCSubtargetInfo &MCInfo = Target->getMCSubtargetInfo();
+#else
+  const MCSubtargetInfo &MCInfo = *Target->getMCSubtargetInfo();
+#endif
   const ArrayRef<SubtargetFeatureKV> FeatTable =
       MCInfo.getAllProcessorFeatures();
-#else
-  const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
-  const ArrayRef<SubtargetFeatureKV> FeatTable =
-      MCInfo->getAllProcessorFeatures();
-#endif
   const SubtargetFeatureKV Feat = FeatTable[Index];
   *Feature = Feat.Key;
   *Desc = Feat.Desc;

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -91,8 +91,13 @@ extern "C" void LLVMRustTimeTraceProfilerFinish(const char *FileName) {
 extern "C" bool LLVMRustHasFeature(LLVMTargetMachineRef TM,
                                    const char *Feature) {
   TargetMachine *Target = unwrap(TM);
+#if LLVM_VERSION_GE(23, 0)
+  const MCSubtargetInfo &MCInfo = Target->getMCSubtargetInfo();
+  return MCInfo.checkFeatures(std::string("+") + Feature);
+#else
   const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
   return MCInfo->checkFeatures(std::string("+") + Feature);
+#endif
 }
 
 /// Check whether the target has a specific assembly mnemonic like `ret` or
@@ -274,7 +279,11 @@ static llvm::DebugCompressionType fromRust(LLVMRustCompressionKind Kind) {
 extern "C" void LLVMRustPrintTargetCPUs(LLVMTargetMachineRef TM,
                                         RustStringRef OutStr) {
   ArrayRef<SubtargetSubTypeKV> CPUTable =
+#if LLVM_VERSION_GE(23, 0)
+      unwrap(TM)->getMCSubtargetInfo().getAllProcessorDescriptions();
+#else
       unwrap(TM)->getMCSubtargetInfo()->getAllProcessorDescriptions();
+#endif
   auto OS = RawRustStringOstream(OutStr);
 
   // Just print a bare list of target CPU names, and let Rust-side code handle
@@ -286,9 +295,15 @@ extern "C" void LLVMRustPrintTargetCPUs(LLVMTargetMachineRef TM,
 
 extern "C" size_t LLVMRustGetTargetFeaturesCount(LLVMTargetMachineRef TM) {
   const TargetMachine *Target = unwrap(TM);
+#if LLVM_VERSION_GE(23, 0)
+  const MCSubtargetInfo &MCInfo = Target->getMCSubtargetInfo();
+  const ArrayRef<SubtargetFeatureKV> FeatTable =
+      MCInfo.getAllProcessorFeatures();
+#else
   const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
   const ArrayRef<SubtargetFeatureKV> FeatTable =
       MCInfo->getAllProcessorFeatures();
+#endif
   return FeatTable.size();
 }
 
@@ -296,9 +311,15 @@ extern "C" void LLVMRustGetTargetFeature(LLVMTargetMachineRef TM, size_t Index,
                                          const char **Feature,
                                          const char **Desc) {
   const TargetMachine *Target = unwrap(TM);
+#if LLVM_VERSION_GE(23, 0)
+  const MCSubtargetInfo &MCInfo = Target->getMCSubtargetInfo();
+  const ArrayRef<SubtargetFeatureKV> FeatTable =
+      MCInfo.getAllProcessorFeatures();
+#else
   const MCSubtargetInfo *MCInfo = Target->getMCSubtargetInfo();
   const ArrayRef<SubtargetFeatureKV> FeatTable =
       MCInfo->getAllProcessorFeatures();
+#endif
   const SubtargetFeatureKV Feat = FeatTable[Index];
   *Feature = Feat.Key;
   *Desc = Feat.Desc;


### PR DESCRIPTION
A recent [LLVM PR](https://github.com/llvm/llvm-project/pull/195032) changed the signature of `getMCSubtargetInfo` to return a reference instead of a pointer. This adjusts uses of the function in `compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp` to account for the different signature.