### PR TITLE
[AIX] add -bdbg:namedsects:ss link arg

### DIFF
--- a/compiler/rustc_target/src/spec/targets/powerpc64_ibm_aix.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc64_ibm_aix.rs
@@ -5,7 +5,13 @@ pub(crate) fn target() -> Target {
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(
         LinkerFlavor::Unix(Cc::No),
-        &["-b64", "-bpT:0x100000000", "-bpD:0x110000000", "-bcdtors:mbr:0:s"],
+        &[
+            "-b64",
+            "-bpT:0x100000000",
+            "-bpD:0x110000000",
+            "-bcdtors:mbr:0:s",
+            "-bdbg:namedsects:ss", // PGO and ifunc support depends on the named sections linker feature
+        ],
     );
 
     Target {


### PR DESCRIPTION
On AIX, the PGO runtime and ifunc runtime support requires the named section linker feature which collects the name sections together and generates start/stop symbols for them.

This change adds the option to the default linker args for the target.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
