### PR TITLE
fix(clippy): `std_instead_of_core` false positive for `core::io`

### DIFF
--- a/src/tools/clippy/clippy_lints/src/std_instead_of_core.rs
+++ b/src/tools/clippy/clippy_lints/src/std_instead_of_core.rs
@@ -5,7 +5,7 @@ use clippy_utils::msrvs::Msrv;
 use rustc_errors::Applicability;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
-use rustc_hir::{Block, Body, HirId, Path, PathSegment, StabilityLevel, StableSince};
+use rustc_hir::{Block, Body, HirId, Path, PathSegment, Stability, StabilityLevel, StableSince};
 use rustc_lint::{LateContext, LateLintPass, Lint, LintContext};
 use rustc_session::impl_lint_pass;
 use rustc_span::symbol::kw;
@@ -238,21 +238,40 @@ fn get_first_segment<'tcx>(path: &Path<'tcx>) -> Option<&'tcx PathSegment<'tcx>>
 /// Does not catch individually moved items
 fn is_stable(cx: &LateContext<'_>, mut def_id: DefId, msrv: Msrv) -> bool {
     loop {
-        if let Some(stability) = cx.tcx.lookup_stability(def_id)
-            && let StabilityLevel::Stable {
-                since,
-                allowed_through_unstable_modules: None,
-            } = stability.level
-        {
-            let stable = match since {
-                StableSince::Version(v) => msrv.meets(cx, v),
-                StableSince::Current => msrv.current(cx).is_none(),
-                StableSince::Err(_) => false,
-            };
+        match cx.tcx.lookup_stability(def_id) {
+            // If we find anything unstable in the definition of this item, short-circuit as unstable.
+            // This works under the assumption that checking is performed from the item up through its parents.
+            Some(Stability {
+                level: StabilityLevel::Unstable { .. },
+                ..
+            }) => return false,
+            // If an item is stable since some MSRV
+            Some(Stability {
+                level:
+                    StabilityLevel::Stable {
+                        since,
+                        allowed_through_unstable_modules,
+                    },
+                ..
+            }) => {
+                let stable = match since {
+                    StableSince::Version(v) => msrv.meets(cx, v),
+                    StableSince::Current => msrv.current(cx).is_none(),
+                    StableSince::Err(_) => false,
+                };
 
-            if !stable {
-                return false;
-            }
+                if !stable {
+                    return false;
+                } else if allowed_through_unstable_modules.is_some() {
+                    // Items marked with #[rustc_allowed_through_unstable_modules = "..."]
+                    // can be short-circuited, since no instability of a parent module
+                    // can override this attribute.
+                    return true;
+                }
+            },
+            None => {
+                // Inconclusive, check the next path segment up.
+            },
         }
 
         match cx.tcx.opt_parent(def_id) {

--- a/src/tools/clippy/tests/ui/std_instead_of_core.fixed
+++ b/src/tools/clippy/tests/ui/std_instead_of_core.fixed
@@ -96,3 +96,9 @@ fn issue15579() {
 
     let layout = alloc::Layout::new::<u8>();
 }
+
+#[warn(clippy::std_instead_of_core)]
+fn issue13158_core_io() {
+    // items moved from std::io into core::io are stable in an unstable module.
+    type ErrorKindA = std::io::ErrorKind;
+}

--- a/src/tools/clippy/tests/ui/std_instead_of_core.rs
+++ b/src/tools/clippy/tests/ui/std_instead_of_core.rs
@@ -96,3 +96,9 @@ fn issue15579() {
 
     let layout = alloc::Layout::new::<u8>();
 }
+
+#[warn(clippy::std_instead_of_core)]
+fn issue13158_core_io() {
+    // items moved from std::io into core::io are stable in an unstable module.
+    type ErrorKindA = std::io::ErrorKind;
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

# Objective

- Fix false positive identified by @rktaxe in [this comment](https://github.com/rust-lang/rust-clippy/issues/13158#issuecomment-4373196346) on rust-lang/rust-clippy#13158.

## Solution

Previously the lint had an exception for all instances of a stable item in an unstable module, primarily to allow certain intrinsics such as `copy` to be accessible. Instead, I check for the presence of `rustc_allowed_through_unstable_modules` to handle those exceptions, and allow the `is_stable` check within the lint to early out as soon as any part of its path is unstable.

---

## Notes

- No AI tooling of any kind was used during the creation of this PR. 