### PR TITLE
add known-bug test for coroutine 'static-yields-non-'static unsoundness (#144442)

### DIFF
--- a/tests/ui/coroutine/static-coroutine-with-nonstatic-yield.rs
+++ b/tests/ui/coroutine/static-coroutine-with-nonstatic-yield.rs
@@ -1,0 +1,60 @@
+//@ check-pass
+//@ known-bug: #144442
+
+// Same family as #84366 / #112905: a coroutine that yields a non-`'static`
+// reference is wrongly `: 'static`, allowing a `Box<dyn Any>` downcast to
+// transmute between distinct lifetime substitutions and produce a UAF.
+
+#![forbid(unsafe_code)] // No `unsafe!`
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::ops::{Coroutine, CoroutineState};
+use std::pin::Pin;
+use std::rc::Rc;
+
+type Payload = Box<i32>;
+
+fn make_coro<'a>()
+-> impl Coroutine<Yield = Rc<RefCell<Option<&'a Payload>>>, Return = ()> + 'static {
+    #[coroutine]
+    || {
+        let storage: Rc<RefCell<Option<&'a Payload>>> = Rc::new(RefCell::new(None));
+        yield storage.clone();
+        yield storage;
+    }
+}
+
+pub fn expand<'a>(payload: &'a Payload) -> &'static Payload {
+    let mut coro1 = Box::pin(make_coro::<'a>());
+    let coro2 = make_coro::<'static>();
+    let CoroutineState::Yielded(storage) = coro1.as_mut().resume(()) else {
+        panic!()
+    };
+    *storage.borrow_mut() = Some(payload);
+    extract(coro1, coro2)
+}
+
+fn extract<
+    'a,
+    F: Coroutine<Yield = Rc<RefCell<Option<&'a Payload>>>, Return = ()> + 'static,
+    G: Coroutine<Yield = Rc<RefCell<Option<&'static Payload>>>, Return = ()> + 'static,
+>(
+    x: Pin<Box<F>>,
+    _: G,
+) -> &'static Payload {
+    let mut g: Pin<Box<G>> = *(Box::new(x) as Box<dyn Any>).downcast().unwrap();
+    let CoroutineState::Yielded(storage) = g.as_mut().resume(()) else {
+        panic!()
+    };
+    let payload = storage.borrow().unwrap();
+    payload
+}
+
+fn main() {
+    let x = Box::new(Box::new(1i32));
+    let y = expand(&x);
+    drop(x);
+    println!("{y}"); // Segfaults — UAF without `unsafe`.
+}


### PR DESCRIPTION
Add a `known-bug` regression test for [#144442 ("Unsoundness due to 'static coroutines that yield non-'static values").](https://github.com/rust-lang/rust/issues/144442)

Existing known-bug tests:
```
- tests/ui/closures/static-closures-with-nonstatic-return.rs
- tests/ui/implied-bounds/dyn-erasure-tait.rs
- tests/ui/implied-bounds/dyn-erasure-no-tait.rs
```

Verified in Darwin: running the compiled binary segfaults on current main, so the bug is still present.