### PR TITLE
windows/time: avoid being too close to 0

### DIFF
--- a/library/std/src/sys/time/windows.rs
+++ b/library/std/src/sys/time/windows.rs
@@ -35,7 +35,14 @@ impl Instant {
 
         let freq = perf_counter::frequency() as u64;
         let now = perf_counter::now();
+
+        // We convert now to `u64` to be able to use `Duration`.
         let instant_nsec = mul_div_u64(now as u64, NANOS_PER_SEC, freq);
+        // We can add an arbitrary offset to shift the epoch of this clock. We do that to avoid
+        // being too close to 0 which would lead to underflow when computing times in the past. Also
+        // see <https://github.com/rust-lang/rust/issues/156142>.
+        let instant_nsec = instant_nsec + (u64::MAX / 4);
+
         Self { t: Duration::from_nanos(instant_nsec) }
     }
 

--- a/library/std/tests/time.rs
+++ b/library/std/tests/time.rs
@@ -1,4 +1,5 @@
 #![feature(duration_constants)]
+#![feature(duration_constructors)]
 #![feature(time_systemtime_limits)]
 #![feature(time_saturating_systemtime)]
 
@@ -104,7 +105,8 @@ fn instant_math_is_associative() {
 #[test]
 fn instant_duration_since_saturates() {
     let a = Instant::now();
-    assert_eq!((a - Duration::SECOND).duration_since(a), Duration::ZERO);
+    // This also checks that computing an instant before program startup works.
+    assert_eq!((a - Duration::from_days(1)).duration_since(a), Duration::ZERO);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/156142 (but only for Windows -- should we still track it for non-tier-1-platforms?)