### PR TITLE
fix: remap ci-llvm debug paths via `-ffile-prefix-map`

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -273,6 +273,15 @@ fn main() {
         cfg.flag(&*flag);
     }
 
+    // Remap ci-llvm include paths in debug info for reproducible builds.
+    if let Some(maps) = tracked_env_var_os("RUSTC_DEBUGINFO_MAP")
+        && let Some(maps_str) = maps.to_str()
+    {
+        for map in maps_str.split('\t') {
+            cfg.flag(&format!("-fdebug-prefix-map={map}"));
+        }
+    }
+
     for component in &components {
         let mut flag = String::from("LLVM_COMPONENT_");
         flag.push_str(&component.to_uppercase());

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -278,7 +278,7 @@ fn main() {
         && let Some(maps_str) = maps.to_str()
     {
         for map in maps_str.split('\t') {
-            cfg.flag(&format!("-fdebug-prefix-map={map}"));
+            cfg.flag_if_supported(&format!("-ffile-prefix-map={map}"));
         }
     }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

### problem:
ci-llvm include paths leak into debuginfo of `librustc_driver` via C/C++ compilation in `rustc_llvm` , causing non-determinism across two stage2 hermetic builds. 

this exhibits as suffixes differing in `anon.*.llvm.<hash>` and mismatched GNU Build IDs, this persists even after stripping the debuginfo. 
`remap-debuginfo` does not cover this, it only applies to rustc and not to C/C++ compiler. 

### fix:
extend debug path remapping to the C/C++ build in `rustc_llvm` by converting `RUSTC_DEBUGINFO_MAP` into corresponding `-fdebug-prefix-map` flags and passing them through `cc::Build`.

**this is a targeted fix in rustc_llvm; a more general solution would involve propagating remap flags across rustc <-> cargo <-> build scripts.**

r? @Urgau 