### PR TITLE
obligations_for_self_ty: skip irrelevant goals (recompute sub_root from stalled_vars)

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -38,10 +38,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> bool {
         match predicate.kind().skip_binder() {
             ty::PredicateKind::Clause(ty::ClauseKind::Trait(data)) => {
-                self.type_matches_expected_vid(expected_vid, data.self_ty())
+                self.type_matches_expected_vid(data.self_ty(), expected_vid)
             }
             ty::PredicateKind::Clause(ty::ClauseKind::Projection(data)) => {
-                self.type_matches_expected_vid(expected_vid, data.projection_term.self_ty())
+                self.type_matches_expected_vid(data.projection_term.self_ty(), expected_vid)
             }
             ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(..))
             | ty::PredicateKind::Subtype(..)
@@ -61,7 +61,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     #[instrument(level = "debug", skip(self), ret)]
-    fn type_matches_expected_vid(&self, expected_vid: ty::TyVid, ty: Ty<'tcx>) -> bool {
+    fn type_matches_expected_vid(&self, ty: Ty<'tcx>, expected_vid: ty::TyVid) -> bool {
         let ty = self.shallow_resolve(ty);
         debug!(?ty);
 
@@ -77,7 +77,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         self_ty: ty::TyVid,
     ) -> PredicateObligations<'tcx> {
-        let obligations = self.fulfillment_cx.borrow().pending_obligations();
+        // We only look at obligations which may reference the self type.
+        // This lookup uses the `sub_root` instead of the inference variable
+        // itself as that's slightly nicer to implement. It shouldn't really
+        // matter.
+        //
+        // This is really impactful when typechecking functions with a lot of
+        // stalled obligations, e.g. in the `wg-grammar` benchmark.
+        let sub_root_var = self.sub_unification_table_root_var(self_ty);
+        let obligations = self
+            .fulfillment_cx
+            .borrow()
+            .pending_obligations_potentially_referencing_sub_root(sub_root_var);
         debug!(?obligations);
         let mut obligations_for_self_ty = PredicateObligations::new();
         for obligation in obligations {
@@ -186,6 +197,18 @@ impl<'tcx> ProofTreeVisitor<'tcx> for NestedObligationsForSelfTy<'_, 'tcx> {
         // No need to walk into goal subtrees that certainly hold, since they
         // wouldn't then be stalled on an infer var.
         if inspect_goal.result() == Ok(Certainty::Yes) {
+            return;
+        }
+
+        // We don't care about any pending goals which don't actually
+        // use the self type.
+        if !inspect_goal
+            .orig_values()
+            .iter()
+            .filter_map(|arg| arg.as_type())
+            .any(|ty| self.fcx.type_matches_expected_vid(ty, self.self_ty))
+        {
+            debug!(goal = ?inspect_goal.goal(), "goal does not mention self type");
             return;
         }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -88,7 +88,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let obligations = self
             .fulfillment_cx
             .borrow()
-            .pending_obligations_potentially_referencing_sub_root(sub_root_var);
+            .pending_obligations_potentially_referencing_sub_root(&self.infcx, sub_root_var);
         debug!(?obligations);
         let mut obligations_for_self_ty = PredicateObligations::new();
         for obligation in obligations {

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use rustc_hir::def_id::DefId;
-use rustc_middle::ty::{self, Ty, Upcast};
+use rustc_middle::ty::{self, Ty, TyVid, Upcast};
 
 use super::{ObligationCause, PredicateObligation, PredicateObligations};
 use crate::infer::InferCtxt;
@@ -107,6 +107,16 @@ pub trait TraitEngine<'tcx, E: 'tcx>: 'tcx {
     fn has_pending_obligations(&self) -> bool;
 
     fn pending_obligations(&self) -> PredicateObligations<'tcx>;
+
+    /// Returning all pending obligations which reference an inference
+    /// variable with `_sub_root`. This assumes that no type inference
+    /// progress has been made since the last `try_evaluate_obligations` call.
+    fn pending_obligations_potentially_referencing_sub_root(
+        &self,
+        _sub_root: TyVid,
+    ) -> PredicateObligations<'tcx> {
+        self.pending_obligations()
+    }
 
     /// Among all pending obligations, collect those are stalled on a inference variable which has
     /// changed since the last call to `try_evaluate_obligations`. Those obligations are marked as

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -109,10 +109,10 @@ pub trait TraitEngine<'tcx, E: 'tcx>: 'tcx {
     fn pending_obligations(&self) -> PredicateObligations<'tcx>;
 
     /// Returning all pending obligations which reference an inference
-    /// variable with `_sub_root`. This assumes that no type inference
-    /// progress has been made since the last `try_evaluate_obligations` call.
+    /// variable with `_sub_root`.
     fn pending_obligations_potentially_referencing_sub_root(
         &self,
+        _infcx: &InferCtxt<'tcx>,
         _sub_root: TyVid,
     ) -> PredicateObligations<'tcx> {
         self.pending_obligations()

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -108,8 +108,10 @@ pub trait TraitEngine<'tcx, E: 'tcx>: 'tcx {
 
     fn pending_obligations(&self) -> PredicateObligations<'tcx>;
 
-    /// Returning all pending obligations which reference an inference
-    /// variable with `_sub_root`.
+    /// Pending obligations potentially referencing an inference variable whose
+    /// sub-unification root is `_sub_root`. May be conservative: implementations
+    /// can return obligations that don't actually reference `_sub_root` (the
+    /// default just returns everything).
     fn pending_obligations_potentially_referencing_sub_root(
         &self,
         _infcx: &InferCtxt<'tcx>,

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -6,7 +6,7 @@ use rustc_infer::traits::query::NoSolution;
 use rustc_infer::traits::{
     FromSolverError, PredicateObligation, PredicateObligations, TraitEngine,
 };
-use rustc_middle::ty::{TyCtxt, TypeVisitableExt, TypingMode};
+use rustc_middle::ty::{self, TyCtxt, TyVid, TypeVisitableExt, TypingMode};
 use rustc_next_trait_solver::delegate::SolverDelegate as _;
 use rustc_next_trait_solver::solve::{
     GoalEvaluation, GoalStalledOn, HasChanged, MaybeInfo, SolverDelegateEvalExt as _,
@@ -75,6 +75,29 @@ impl<'tcx> ObligationStorage<'tcx> {
     fn clone_pending(&self) -> PredicateObligations<'tcx> {
         let mut obligations: PredicateObligations<'tcx> =
             self.pending.iter().map(|(o, _)| o.clone()).collect();
+        obligations.extend(self.overflowed.iter().cloned());
+        obligations
+    }
+
+    fn clone_pending_potentially_referencing_sub_root(
+        &self,
+        vid: TyVid,
+    ) -> PredicateObligations<'tcx> {
+        let mut obligations: PredicateObligations<'tcx> = self
+            .pending
+            .iter()
+            .filter(|(_, stalled_on)| {
+                // This may incorrectly return `false` in case we've made
+                // inference progress since the last time we tried to evaluate
+                // this obligation.
+                if let Some(stalled_on) = stalled_on {
+                    stalled_on.sub_roots.iter().any(|&r| r == vid)
+                } else {
+                    true
+                }
+            })
+            .map(|(o, _)| o.clone())
+            .collect();
         obligations.extend(self.overflowed.iter().cloned());
         obligations
     }
@@ -270,6 +293,13 @@ where
 
     fn pending_obligations(&self) -> PredicateObligations<'tcx> {
         self.obligations.clone_pending()
+    }
+
+    fn pending_obligations_potentially_referencing_sub_root(
+        &self,
+        vid: ty::TyVid,
+    ) -> PredicateObligations<'tcx> {
+        self.obligations.clone_pending_potentially_referencing_sub_root(vid)
     }
 
     fn drain_stalled_obligations_for_coroutines(

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -89,9 +89,14 @@ impl<'tcx> ObligationStorage<'tcx> {
             .iter()
             .filter(|(_, stalled_on)| {
                 let Some(stalled_on) = stalled_on else { return true };
-                // Conservative here: if any of its stalled vars are not infer var anymore,
-                // some unification happened, so this goal is no longer stalled.
-                // So include it to re-evaluate in the downstream.
+                // Don't reuse the sub-unification roots cached on `stalled_on`:
+                // a later sub-unification merge can have changed which root
+                // each stalled var belongs to, so the cached info can be stale.
+                // Walk `stalled_vars` and recompute the current root instead.
+                //
+                // Conservative here: if a stalled var no longer resolves to an
+                // infer var, some unification happened, so the goal is no longer
+                // stalled. Include it to be re-evaluated downstream.
                 stalled_on.stalled_vars.iter().filter_map(|arg| arg.as_type()).any(
                     |ty| match *infcx.shallow_resolve(ty).kind() {
                         ty::Infer(ty::TyVar(tv)) => infcx.sub_unification_table_root_var(tv) == vid,
@@ -303,6 +308,10 @@ where
         infcx: &InferCtxt<'tcx>,
         vid: ty::TyVid,
     ) -> PredicateObligations<'tcx> {
+        // `-Zdisable-fast-paths`: same gate as the other new-solver fast paths.
+        if infcx.tcx.disable_trait_solver_fast_paths() {
+            return self.obligations.clone_pending();
+        }
         self.obligations.clone_pending_potentially_referencing_sub_root(infcx, vid)
     }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -81,20 +81,17 @@ impl<'tcx> ObligationStorage<'tcx> {
 
     fn clone_pending_potentially_referencing_sub_root(
         &self,
+        infcx: &InferCtxt<'tcx>,
         vid: TyVid,
     ) -> PredicateObligations<'tcx> {
         let mut obligations: PredicateObligations<'tcx> = self
             .pending
             .iter()
             .filter(|(_, stalled_on)| {
-                // This may incorrectly return `false` in case we've made
-                // inference progress since the last time we tried to evaluate
-                // this obligation.
-                if let Some(stalled_on) = stalled_on {
-                    stalled_on.sub_roots.iter().any(|&r| r == vid)
-                } else {
-                    true
-                }
+                let Some(stalled_on) = stalled_on else { return true };
+                stalled_on.stalled_vars.iter().filter_map(|arg| arg.as_type()).any(|ty| {
+                    matches!(*ty.kind(), ty::Infer(ty::TyVar(tv)) if infcx.sub_unification_table_root_var(tv) == vid)
+                })
             })
             .map(|(o, _)| o.clone())
             .collect();
@@ -297,9 +294,10 @@ where
 
     fn pending_obligations_potentially_referencing_sub_root(
         &self,
+        infcx: &InferCtxt<'tcx>,
         vid: ty::TyVid,
     ) -> PredicateObligations<'tcx> {
-        self.obligations.clone_pending_potentially_referencing_sub_root(vid)
+        self.obligations.clone_pending_potentially_referencing_sub_root(infcx, vid)
     }
 
     fn drain_stalled_obligations_for_coroutines(

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -89,8 +89,14 @@ impl<'tcx> ObligationStorage<'tcx> {
             .iter()
             .filter(|(_, stalled_on)| {
                 let Some(stalled_on) = stalled_on else { return true };
+                // Conservative here: if any of its stalled vars are not infer var anymore,
+                // some unification happened, so this goal is no longer stalled.
+                // So include it to re-evaluate in the downstream.
                 stalled_on.stalled_vars.iter().filter_map(|arg| arg.as_type()).any(|ty| {
-                    matches!(*ty.kind(), ty::Infer(ty::TyVar(tv)) if infcx.sub_unification_table_root_var(tv) == vid)
+                    match *infcx.shallow_resolve(ty).kind() {
+                        ty::Infer(ty::TyVar(tv)) => infcx.sub_unification_table_root_var(tv) == vid,
+                        _ => true,
+                    }
                 })
             })
             .map(|(o, _)| o.clone())

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -92,12 +92,12 @@ impl<'tcx> ObligationStorage<'tcx> {
                 // Conservative here: if any of its stalled vars are not infer var anymore,
                 // some unification happened, so this goal is no longer stalled.
                 // So include it to re-evaluate in the downstream.
-                stalled_on.stalled_vars.iter().filter_map(|arg| arg.as_type()).any(|ty| {
-                    match *infcx.shallow_resolve(ty).kind() {
+                stalled_on.stalled_vars.iter().filter_map(|arg| arg.as_type()).any(
+                    |ty| match *infcx.shallow_resolve(ty).kind() {
                         ty::Infer(ty::TyVar(tv)) => infcx.sub_unification_table_root_var(tv) == vid,
                         _ => true,
-                    }
-                })
+                    },
+                )
             })
             .map(|(o, _)| o.clone())
             .collect();

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -317,6 +317,10 @@ impl<'a, 'tcx> InspectGoal<'a, 'tcx> {
         self.depth
     }
 
+    pub fn orig_values(&self) -> &[ty::GenericArg<'tcx>] {
+        &self.orig_values
+    }
+
     fn candidates_recur(
         &'a self,
         candidates: &mut Vec<InspectCandidate<'a, 'tcx>>,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156187)*
<!-- homu-ignore:end -->

Supersedes [#146759](https://github.com/rust-lang/rust/pull/146759). Since the original PR is having conflict now, I've rebased.

This includes 2 commit

1. the original one with rebase
2. above that, I've changed:

```
if stalled_on is Some: ignore sub_roots -> walk stalled_vars -> re-evaluate sub_root 
else: same with this PR
```

Why:
cached sub_roots can be stale if there is a sub-unification merge after stalling ([lcnr proposed on the original PR](https://github.com/rust-lang/rust/pull/146759#issuecomment-4378162413))
so re-evaluating when reads ---> so more conservative

Testing:

* next-solver / traits tests
* we can follow after merging rust-lang/rust#156172 with -Zdisable-fast-paths

Style question:

In my preference, inside filter, I used filter_map - matches, but do you prefer if-let chain?

Original author: [lcnr](https://github.com/lcnr) [#146759](https://github.com/rust-lang/rust/pull/146759)

r? @lcnr 