### PR TITLE
riscv: promote d, e, and f target_features to CfgStableToggleUnstable

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -610,9 +610,9 @@ static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("a", Stable, &["zaamo", "zalrsc"]),
     ("b", Stable, &["zba", "zbb", "zbs"]),
     ("c", Stable, &["zca"]),
-    ("d", Unstable(sym::riscv_target_feature), &["f"]),
-    ("e", Unstable(sym::riscv_target_feature), &[]),
-    ("f", Unstable(sym::riscv_target_feature), &["zicsr"]),
+    ("d", CfgStableToggleUnstable(sym::riscv_target_feature), &["f"]),
+    ("e", CfgStableToggleUnstable(sym::riscv_target_feature), &[]),
+    ("f", CfgStableToggleUnstable(sym::riscv_target_feature), &["zicsr"]),
     (
         "forced-atomics",
         Stability::Forbidden { reason: "unsound because it changes the ABI of atomic operations" },

--- a/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.riscv.stderr
+++ b/tests/ui/target-feature/abi-incompatible-target-feature-flag-enable.riscv.stderr
@@ -1,6 +1,6 @@
 warning: unstable feature specified for `-Ctarget-feature`: `d`
    |
-   = note: this feature is not stably supported; its behavior can change in the future
+   = note: this feature is allowed in cfg but unstable otherwise; its behavior can change in the future
 
 warning: target feature `d` must be disabled to ensure that the ABI of the current target can be implemented correctly
    |

--- a/tests/ui/target-feature/abi-required-target-feature-flag-disable.riscv.stderr
+++ b/tests/ui/target-feature/abi-required-target-feature-flag-disable.riscv.stderr
@@ -1,6 +1,6 @@
 warning: unstable feature specified for `-Ctarget-feature`: `d`
    |
-   = note: this feature is not stably supported; its behavior can change in the future
+   = note: this feature is allowed in cfg but unstable otherwise; its behavior can change in the future
 
 warning: target feature `d` must be enabled to ensure that the ABI of the current target can be implemented correctly
    |

--- a/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-attribute-riscv.rs
+++ b/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-attribute-riscv.rs
@@ -1,0 +1,17 @@
+//! Ensure cfg-only stable target_features trigger errors when enabled via attribute.
+//@ compile-flags: --crate-type=lib
+//@ compile-flags: --target=riscv64gc-unknown-none-elf
+//@ needs-llvm-components: riscv
+//@ add-minicore
+//@ ignore-backends: gcc
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[target_feature(enable = "v")]
+//~^ERROR: the target feature `v` is currently unstable
+#[target_feature(enable = "f")]
+//~^ERROR: the target feature `f` is allowed in cfg but unstable otherwise
+pub unsafe fn my_fun() {}

--- a/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-attribute-riscv.stderr
+++ b/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-attribute-riscv.stderr
@@ -1,0 +1,23 @@
+error[E0658]: the target feature `v` is currently unstable
+  --> $DIR/cfg-stable-toggle-unstable-target-feature-attribute-riscv.rs:13:18
+   |
+LL | #[target_feature(enable = "v")]
+   |                  ^^^^^^^^^^^^
+   |
+   = note: see issue #150257 <https://github.com/rust-lang/rust/issues/150257> for more information
+   = help: add `#![feature(riscv_target_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the target feature `f` is allowed in cfg but unstable otherwise
+  --> $DIR/cfg-stable-toggle-unstable-target-feature-attribute-riscv.rs:15:18
+   |
+LL | #[target_feature(enable = "f")]
+   |                  ^^^^^^^^^^^^
+   |
+   = note: see issue #150257 <https://github.com/rust-lang/rust/issues/150257> for more information
+   = help: add `#![feature(riscv_target_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-flag-enable-riscv.rs
+++ b/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-flag-enable-riscv.rs
@@ -1,0 +1,17 @@
+//! Ensure cfg-only stable target_features trigger warnings when enabled via compile flag.
+//@ check-pass
+//@ compile-flags: --crate-type=lib
+//@ compile-flags: --target=riscv64gc-unknown-none-elf -Ctarget-feature=+v -Ctarget-feature=+f
+// FIXME(#147881): *disable* the feature again for minicore as otherwise that will fail to build.
+//@ minicore-compile-flags: -Ctarget-feature=-v -Ctarget-feature=-f
+//@ needs-llvm-components: riscv
+//@ ignore-backends: gcc
+//@ add-minicore
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+//~? WARN unstable feature specified for `-Ctarget-feature`
+//~? WARN unstable feature specified for `-Ctarget-feature`

--- a/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-flag-enable-riscv.stderr
+++ b/tests/ui/target-feature/cfg-stable-toggle-unstable-target-feature-flag-enable-riscv.stderr
@@ -1,0 +1,10 @@
+warning: unstable feature specified for `-Ctarget-feature`: `v`
+   |
+   = note: this feature is not stably supported; its behavior can change in the future
+
+warning: unstable feature specified for `-Ctarget-feature`: `f`
+   |
+   = note: this feature is allowed in cfg but unstable otherwise; its behavior can change in the future
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Reference PR:

- https://github.com/rust-lang/reference/pull/2274

This PR is a continuation of rust-lang/rust#155962

It uses the new `CfgStableToggleUnstable` stability level for the `"d"`, `"e"`, and `"f"` `target_features` of RISC-V. This way, it will be possible to add conditional code blocks depending on whether the target architecture has FPU, for instance.

The PR is related to rust-lang/rust#150257

r? @RalfJung