### PR TITLE
Avoid deriving bounds from FnPtr

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -422,13 +422,10 @@ fn find_type_parameters(
 
     impl<'a, 'b> visit::Visitor<'a> for Visitor<'a, 'b> {
         fn visit_ty(&mut self, ty: &'a ast::Ty) {
-            let stack_len = self.bound_generic_params_stack.len();
-            if let ast::TyKind::FnPtr(fn_ptr) = &ty.kind
-                && !fn_ptr.generic_params.is_empty()
-            {
-                // Given a field `x: for<'a> fn(T::SomeType<'a>)`, we wan't to account for `'a` so
-                // that we generate `where for<'a> T::SomeType<'a>: ::core::clone::Clone`. #122622
-                self.bound_generic_params_stack.extend(fn_ptr.generic_params.iter().cloned());
+            // Cloning a function pointer copies the pointer value and never clones values
+            // of the input or output types, so they should not contribute derived bounds.
+            if let ast::TyKind::FnPtr(_) = &ty.kind {
+                return;
             }
 
             if let ast::TyKind::Path(_, path) = &ty.kind
@@ -442,7 +439,6 @@ fn find_type_parameters(
             }
 
             visit::walk_ty(self, ty);
-            self.bound_generic_params_stack.truncate(stack_len);
         }
 
         // Place bound generic params on a stack, to extract them when a type is encountered.

--- a/tests/ui/derives/derive-clone-fn-pointer-with-placeholder-lifetime-run.rs
+++ b/tests/ui/derives/derive-clone-fn-pointer-with-placeholder-lifetime-run.rs
@@ -1,0 +1,39 @@
+//@ run-pass
+// Cloned function pointer fields works fine even when the function's
+// input type is not Clone.
+
+#![allow(dead_code)]
+
+trait SomeTrait {
+    type SomeType<'a>;
+}
+
+#[derive(Clone)]
+struct Concrete;
+
+struct NotClone<'a> {
+    value: &'a u32,
+}
+
+impl SomeTrait for Concrete {
+    type SomeType<'a> = NotClone<'a>;
+}
+
+fn read_value(x: NotClone<'_>) -> u32 {
+    *x.value
+}
+
+#[derive(Clone)]
+struct Foo<T: SomeTrait> {
+    x: fn(T::SomeType<'_>) -> u32,
+    explicit: for<'a> fn(T::SomeType<'a>) -> u32,
+}
+
+fn main() {
+    let foo = Foo::<Concrete> { x: read_value, explicit: read_value };
+    let cloned = foo.clone();
+
+    let n = 42;
+    assert_eq!((cloned.x)(NotClone { value: &n }), 42);
+    assert_eq!((cloned.explicit)(NotClone { value: &n }), 42);
+}

--- a/tests/ui/derives/derive-clone-fn-pointer-with-placeholder-lifetime.rs
+++ b/tests/ui/derives/derive-clone-fn-pointer-with-placeholder-lifetime.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+// Issue #143131: `#[derive(Clone)]` should accept a function pointer field whose
+// input type contains a placeholder lifetime.
+
+#![allow(dead_code)]
+
+trait SomeTrait {
+    type SomeType<'a>;
+}
+
+#[derive(Clone)]
+struct Foo<T: SomeTrait> {
+    x: fn(T::SomeType<'_>),
+}
+
+fn main() {}

--- a/tests/ui/derives/derive-clone-nested-fn-pointer-with-placeholder-lifetime.rs
+++ b/tests/ui/derives/derive-clone-nested-fn-pointer-with-placeholder-lifetime.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+// Type parameters inside nested function pointer signatures should not
+// contribute bounds for derived Clone impls.
+
+#![allow(dead_code)]
+
+trait SomeTrait {
+    type SomeType<'a>;
+}
+
+#[derive(Clone)]
+struct Foo<T: SomeTrait> {
+    x: Option<Result<u32, fn(T::SomeType<'_>)>>,
+}
+
+fn main() {}


### PR DESCRIPTION
closes: https://github.com/rust-lang/rust/issues/143131

We don't need bounds for the inputs and outputs of function pointers.

for the code below, for example,

```rust
#![allow(dead_code)]
trait SomeTrait {
    type SomeType<'a>;
}

#[derive(Clone)]
struct Foo<T: SomeTrait> {
    x: fn(T::SomeType<'_>)
}

fn main() {}
```

Before
An error occurs for a lifetime.

```shell
rustc +nightly -Zunpretty=expanded main.rs
```

```shell
error[E0637]: `'_` cannot be used here
 --> main.rs:8:23
  |
8 |     x: fn(T::SomeType<'_>),
  |                       ^^ `'_` is a reserved lifetime name

#![feature(prelude_import)]
#![no_std]
#![allow(dead_code)]
extern crate std;
#[prelude_import]
use ::std::prelude::rust_2015::*;
trait SomeTrait {
    type SomeType<'a>;
}

struct Foo<T: SomeTrait> {
    x: fn(T::SomeType<'_>),
}
#[automatically_derived]
impl<T: ::core::clone::Clone + SomeTrait> ::core::clone::Clone for Foo<T>
    where T::SomeType<'_>: ::core::clone::Clone {
    #[inline]
    fn clone(&self) -> Foo<T> {
        Foo { x: ::core::clone::Clone::clone(&self.x) }
    }
}

fn main() {}
```


After
`where T::SomeType<'_>: ::core::clone::Clone`, which was incorrect, and unnecessary, has gone
No errors.

```shell
rustc +issue143131 -Zunpretty=expanded main.rs
```

```shell
#![feature(prelude_import)]
#![no_std]
#![allow(dead_code)]
extern crate std;
#[prelude_import]
use ::std::prelude::rust_2015::*;
trait SomeTrait {
    type SomeType<'a>;
}

struct Foo<T: SomeTrait> {
    x: fn(T::SomeType<'_>),
}
#[automatically_derived]
impl<T: ::core::clone::Clone + SomeTrait> ::core::clone::Clone for Foo<T> {
    #[inline]
    fn clone(&self) -> Foo<T> {
        Foo { x: ::core::clone::Clone::clone(&self.x) }
    }
}

fn main() {}
```
