### PR TITLE
Don't run ui-fulldeps tests twice in stage 1

### DIFF
--- a/src/ci/docker/scripts/x86_64-gnu-llvm3.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm3.sh
@@ -14,10 +14,6 @@ set -ex
 # despite having different output on 32-bit vs 64-bit targets.
 ../x.py --stage 1 test tests/mir-opt --host='' --target=i686-unknown-linux-gnu
 
-# Run `ui-fulldeps` in `--stage=1`, which actually uses the stage0
-# compiler, and is sensitive to the addition of new flags.
-../x.py --stage 1 test tests/ui-fulldeps
-
 # Rebuild the stdlib with the size optimizations enabled and run tests again.
 RUSTFLAGS_NOT_BOOTSTRAP="--cfg feature=\"optimize_for_size\"" ../x.py --stage 1 test \
     library/std library/alloc library/core


### PR DESCRIPTION
This removes a separate call in the x86_64-gnu-llvm-21-3 job which runs the ui-fulldeps a second time. ui-fulldeps is already running in the first call (`../x.py --stage 1 test`) as it is a default test suite.

This was added in https://github.com/rust-lang/rust/pull/116009, but I think that was a misunderstanding of the problem. The actual problem was fixed in https://github.com/rust-lang/rust/pull/116932 where the actual problem was the use of `&&`.

This doesn't really have much of an impact on CI time (only a couple seconds) because all the tests are skipped with `ignored, up-to-date`. I'm mainly doing this to clean up the script itself for clarity.
