### PR TITLE
Implemented `PathBuf::into_string`

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1796,6 +1796,25 @@ impl PathBuf {
         self.inner
     }
 
+    /// Converts the `PathBuf` into a `String` if it contains valid Unicode data.
+    ///
+    /// On failure, ownership of the original `PathBuf` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(pathbuf_into_string)]
+    /// use std::path::PathBuf;
+    ///
+    /// let path_buf = PathBuf::from("foo");
+    /// let string = path_buf.into_string();
+    /// assert_eq!(string, Ok(String::from("foo")));
+    /// ```
+    #[unstable(feature = "pathbuf_into_string", issue = "156203")]
+    pub fn into_string(self) -> Result<String, PathBuf> {
+        self.into_os_string().into_string().map_err(PathBuf::from)
+    }
+
     /// Converts this `PathBuf` into a [boxed](Box) [`Path`].
     #[stable(feature = "into_boxed_path", since = "1.20.0")]
     #[must_use = "`self` will be dropped if the result is not used"]


### PR DESCRIPTION
Noticed from this [Zulip chat](https://rust-lang.zulipchat.com/#narrow/channel/327149-t-libs-api.2Fapi-changes/topic/.E2.9C.94.20PathBuf.3A.3Ainto_string.3F/with/500962843) that there's been a pretty old [ACP](https://github.com/rust-lang/libs-team/issues/307) on introducing `PathBuf::into_string` that hasn't been implemented yet. I haven't seen anyone link a tracking issue to that [ACP](https://github.com/rust-lang/libs-team/issues/307), so I assume there have been no PRs to complete that ACP.

I made a tracking issue for this ACP [here](https://github.com/rust-lang/rust/issues/156203).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
