### PR TITLE
move generalization test

### DIFF
--- a/tests/ui/traits/next-solver/generalize/alias-with-bound-vars-incomplete-generalization.rs
+++ b/tests/ui/traits/next-solver/generalize/alias-with-bound-vars-incomplete-generalization.rs
@@ -2,7 +2,9 @@
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 
-// Regression test for the fourth variant of trait-system-refactor-initiative#191
+// Regression test for the fourth variant of trait-system-refactor-initiative#191.
+// We previously didn't normalize `<() as Trait<T>>::Assoc<'a>` before generalizing
+// here, resulting in an error.
 
 trait Trait<T> {
     type Assoc<'a>;


### PR DESCRIPTION
The forth test of https://github.com/rust-lang/trait-system-refactor-initiative/issues/191#issuecomment-3351555279 isn't actually related to closure signature inference.

closes https://github.com/rust-lang/trait-system-refactor-initiative/issues/191, which has already been fixed by https://github.com/rust-lang/rust/pull/155767

r? types