### PR TITLE
Emit retags in codegen to support BorrowSanitizer (part 1)

### DIFF
--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -6,7 +6,6 @@ use std::iter;
 
 use gccjit::{ComparisonOp, Function, FunctionType, RValue, ToRValue, Type, UnaryOp};
 use rustc_abi::{BackendRepr, HasDataLayout, WrappingRange};
-use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::base::wants_msvc_seh;
 use rustc_codegen_ssa::common::IntPredicate;
 use rustc_codegen_ssa::errors::InvalidMonomorphization;
@@ -18,6 +17,7 @@ use rustc_codegen_ssa::traits::{
     ArgAbiBuilderMethods, BaseTypeCodegenMethods, BuilderMethods, ConstCodegenMethods,
     IntrinsicCallBuilderMethods, LayoutTypeCodegenMethods,
 };
+use rustc_codegen_ssa::{MemFlags, RetagInfo};
 use rustc_data_structures::fx::FxHashSet;
 #[cfg(feature = "master")]
 use rustc_middle::ty::layout::FnAbiOf;
@@ -701,6 +701,14 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
     fn va_end(&mut self, _va_list: RValue<'gcc>) -> RValue<'gcc> {
         // FIXME(antoyo): implement.
         self.context.new_rvalue_from_int(self.int_type, 0)
+    }
+
+    fn retag_reg(&mut self, _ptr: Self::Value, _info: &RetagInfo<Self::Value>) -> Self::Value {
+        unimplemented!()
+    }
+
+    fn retag_mem(&mut self, _ptr: Self::Value, _info: &RetagInfo<Self::Value>) {
+        unimplemented!()
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -959,22 +959,47 @@ impl<'ll> CodegenCx<'ll, '_> {
         base_name: &str,
         type_params: &[&'ll Type],
     ) -> (&'ll Type, &'ll Value) {
-        // This isn't an "LLVM intrinsic", but LLVM's optimization passes
-        // recognize it like one (including turning it into `bcmp` sometimes)
-        // and we use it to implement intrinsics like `raw_eq` and `compare_bytes`
-        if base_name == "memcmp" {
-            let fn_ty = self
-                .type_func(&[self.type_ptr(), self.type_ptr(), self.type_isize()], self.type_int());
-            let f = self.declare_cfn("memcmp", llvm::UnnamedAddr::No, fn_ty);
+        match base_name {
+            // This isn't an "LLVM intrinsic", but LLVM's optimization passes
+            // recognize it like one (including turning it into `bcmp` sometimes)
+            // and we use it to implement intrinsics like `raw_eq` and `compare_bytes`
+            "memcmp" => {
+                let fn_ty = self.type_func(
+                    &[self.type_ptr(), self.type_ptr(), self.type_isize()],
+                    self.type_int(),
+                );
+                let f = self.declare_cfn("memcmp", llvm::UnnamedAddr::No, fn_ty);
 
-            return (fn_ty, f);
+                (fn_ty, f)
+            }
+            // Experimental retag intrinsics.
+            // This form is used to retag a pointer that has already been stored in a register. It receives
+            // the pointer and returns an alias with the same address, but different provenance.
+            "__rust_retag_reg" => {
+                let fn_ty = self.type_func(type_params, self.type_ptr());
+                let llfn = self.declare_cfn(base_name, llvm::UnnamedAddr::No, fn_ty);
+                let nounwind = llvm::AttributeKind::NoUnwind.create_attr(self.llcx);
+                attributes::apply_to_llfn(llfn, llvm::AttributePlace::Function, &[nounwind]);
+                (fn_ty, llfn)
+            }
+            // This form is used to retag a pointer that is stored in another place. It receives a pointer to the
+            // place and returns `void`. This communicates the indirection  without requiring an explicit load and
+            // store. If we used the `reg` form instead, then we would need to load the place, retag it, and then
+            // store the result back, which would be undefined behavior for `readonly` places.
+            "__rust_retag_mem" => {
+                let fn_ty = self.type_func(type_params, self.type_void());
+                let llfn = self.declare_cfn(base_name, llvm::UnnamedAddr::No, fn_ty);
+                let nounwind = llvm::AttributeKind::NoUnwind.create_attr(self.llcx);
+                attributes::apply_to_llfn(llfn, llvm::AttributePlace::Function, &[nounwind]);
+                (fn_ty, llfn)
+            }
+            _ => {
+                let intrinsic = llvm::Intrinsic::lookup(base_name.as_bytes())
+                    .unwrap_or_else(|| bug!("Unknown intrinsic: `{base_name}`"));
+                let f = intrinsic.get_declaration(self.llmod, &type_params);
+                (self.get_type_of_global(f), f)
+            }
         }
-
-        let intrinsic = llvm::Intrinsic::lookup(base_name.as_bytes())
-            .unwrap_or_else(|| bug!("Unknown intrinsic: `{base_name}`"));
-        let f = intrinsic.get_declaration(self.llmod, &type_params);
-
-        (self.get_type_of_global(f), f)
     }
 
     pub(crate) fn eh_catch_typeinfo(&self) -> &'ll Value {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -6,6 +6,7 @@ use rustc_abi::{
     AddressSpace, Align, BackendRepr, CVariadicStatus, Float, HasDataLayout, Integer,
     NumScalableVectors, Primitive, Size, WrappingRange,
 };
+use rustc_codegen_ssa::RetagInfo;
 use rustc_codegen_ssa::base::{compare_simd_types, wants_msvc_seh, wants_wasm_eh};
 use rustc_codegen_ssa::common::{IntPredicate, TypeKind};
 use rustc_codegen_ssa::errors::{ExpectedPointerMutability, InvalidMonomorphization};
@@ -1047,6 +1048,14 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
     fn va_end(&mut self, va_list: &'ll Value) -> &'ll Value {
         self.call_intrinsic("llvm.va_end", &[self.val_ty(va_list)], &[va_list])
     }
+
+    fn retag_reg(&mut self, ptr: Self::Value, info: &RetagInfo<Self::Value>) -> Self::Value {
+        codegen_retag_inner(self, "__rust_retag_reg", ptr, info)
+    }
+
+    fn retag_mem(&mut self, ptr: Self::Value, info: &RetagInfo<Self::Value>) {
+        codegen_retag_inner(self, "__rust_retag_mem", ptr, info);
+    }
 }
 
 fn llvm_arch_for(rust_arch: &Arch) -> Option<&'static str> {
@@ -1761,6 +1770,24 @@ fn get_rust_try_fn<'a, 'll, 'tcx>(
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);
     cx.rust_try_fn.set(Some(rust_try));
     rust_try
+}
+
+fn codegen_retag_inner<'ll, 'tcx>(
+    bx: &mut Builder<'_, 'll, 'tcx>,
+    name: &'static str,
+    ptr: &'ll Value,
+    info: &RetagInfo<&'ll Value>,
+) -> &'ll Value {
+    let size = bx.const_usize(info.size.bytes());
+    let perms = bx.const_u8(info.flags.bits());
+
+    bx.call_intrinsic(
+        name,
+        // Retag intrinsics have special handling within `CodegenCx::declare_intrinsic`
+        // to ensure that each form has the correct return type.
+        &[bx.type_ptr(), bx.val_ty(size), bx.type_i8(), bx.type_ptr(), bx.type_ptr()],
+        &[ptr, size, perms, info.im_layout, info.pin_layout],
+    )
 }
 
 fn codegen_autodiff<'ll, 'tcx>(

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -17,6 +17,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use rustc_abi::Size;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::unord::UnordMap;
 use rustc_hir::CRATE_HIR_ID;
@@ -164,6 +165,37 @@ bitflags::bitflags! {
         const VOLATILE = 1 << 0;
         const NONTEMPORAL = 1 << 1;
         const UNALIGNED = 1 << 2;
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct RetagInfo<V> {
+    /// The size of the initial range within the allocation that is
+    /// associated with the permission created by the retag.
+    pub size: Size,
+    /// Encoded type information used to determine the kind of permission
+    /// created by the retag.
+    pub flags: RetagFlags,
+    /// A pointer to a constant array of (offset, size) pairs describing
+    /// the ranges covered by `UnsafeCell` within the pointee type.
+    pub im_layout: V,
+    /// A pointer to a constant array of (offset, size) pairs describing
+    /// the ranges covered by `UnsafePinned` within the pointee type.
+    pub pin_layout: V,
+}
+
+bitflags::bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    pub struct RetagFlags: u8 {
+        /// If this is a function-entry retag.
+        const IS_PROTECTED = 1 << 0;
+        /// If this is a mutable reference or a `Box`.
+        const IS_MUTABLE = 1 << 1;
+        /// If this is a `Box`.
+        const IS_BOX = 1 << 2;
+        /// If the pointee type is `Freeze`
+        const IS_FREEZE = 1 << 3;
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -2,6 +2,7 @@ use rustc_middle::ty;
 use rustc_span::Span;
 
 use super::BackendTypes;
+use crate::RetagInfo;
 use crate::mir::operand::OperandRef;
 use crate::mir::place::PlaceRef;
 
@@ -49,4 +50,8 @@ pub trait IntrinsicCallBuilderMethods<'tcx>: BackendTypes {
     /// Trait method used to inject `va_end` on the "spoofed" `VaList` before
     /// Rust defined C-variadic functions return.
     fn va_end(&mut self, val: Self::Value) -> Self::Value;
+    /// Trait method used to retag a pointer stored within a place.
+    fn retag_mem(&mut self, place: Self::Value, info: &RetagInfo<Self::Value>);
+    /// Trait method used to retag a pointer that has been loaded into a register.
+    fn retag_reg(&mut self, ptr: Self::Value, info: &RetagInfo<Self::Value>) -> Self::Value;
 }


### PR DESCRIPTION
Tracking issue: rust-lang/rust#154760 
[Zulip Thread](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Staging.20for.20emitting.20retags.20in.20codegen/with/593004012)

This is the first of several PRs that will add experimental support for emitting retags as function calls in codegen. Each PR will be a minimal, improved slice of the changes in rust-lang/rust#155965. 

This PR contains all of the changes that will affect codegen backends. It adds methods to `IntrinsicCallBuilderMethods` for emitting each kind of retag call.

cc: @RalfJung 