### PR TITLE
tests/ui: fix MSVC clean build for issue-82833

### DIFF
--- a/tests/ui/codegen/issue-82833-slice-miscompile.rs
+++ b/tests/ui/codegen/issue-82833-slice-miscompile.rs
@@ -4,6 +4,8 @@
 
 // Make sure LLVM does not miscompile this.
 
+#![allow(linker_messages)]
+
 fn make_string(ch: char) -> String {
     let mut bytes = [0u8; 4];
     ch.encode_utf8(&mut bytes).into()


### PR DESCRIPTION
On MSVC, the incremental linker emits a "not found or not built by the last incremental link; performing full link" message on every clean build for this test.

This triggers the `linker_messages` lint, which is now explicitly `allow`ed.
