### PR TITLE
tests/ui: allow spaces in hashbrown src normalization

### DIFF
--- a/tests/ui/issues/issue-21763.rs
+++ b/tests/ui/issues/issue-21763.rs
@@ -1,6 +1,6 @@
 // Regression test for HashMap only impl'ing Send/Sync if its contents do
 
-//@ normalize-stderr: "\S+[\\/]hashbrown\S+" -> "$$HASHBROWN_SRC_LOCATION"
+//@ normalize-stderr: "(?:[A-Za-z]:[/\\]|/).*[\\/]hashbrown\S+" -> "$$HASHBROWN_SRC_LOCATION"
 
 use std::collections::HashMap;
 use std::rc::Rc;


### PR DESCRIPTION
If one's home directory contains a space, the default location for the hashbrown source location also contains a space, and so the UI test normalization in issue-21763 fails to normalize as expected.

While this new regex does not handle all valid paths, such as those beginning with `\\?\` or `\\name\`, this handles most absolute UNIX and Windows paths. Relative paths don't seem to be applicable.
