### PR TITLE
Additionally gate negative bounds behind new `-Zinternal-testing-features`

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -549,9 +549,17 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
         .emit();
     }
 
-    // Negative bounds are *super* internal.
-    // Under no circumstances do we want to advertise the feature name to users!
-    if !visitor.features.negative_bounds() {
+    // Negative bounds are *super* internal. We require `-Zinternal-testing-features` *and*
+    // `#![feature(negative_bounds)]` to prevent proliferation. Under no circumstances do we
+    // want to advertise the flag and the feature name to users!
+    //
+    // IMPORTANT: If you intend on turning negative bounds into a public-facing feature, please
+    //            consult T-types and T-lang first! Do **not** just remove the `-Z` check!
+    //
+    // NOTE: `T: !Bound` means "`T` implements `Bound` negatively",
+    //       it does **not** mean "`T` doesn't implement `Bound` (positively or negatively)"!
+    //       The latter would be a SemVer hazard!
+    if !sess.opts.unstable_opts.internal_testing_features || !visitor.features.negative_bounds() {
         for &span in spans.get(&sym::negative_bounds).into_iter().flatten() {
             sess.dcx().emit_err(diagnostics::NegativeBoundUnsupported { span });
         }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2431,6 +2431,14 @@ options! {
          `=skip-entry`
          `=skip-exit`
          Multiple options can be combined with commas."),
+    // The only purpose of this flag is to act as a deterrent:
+    // Marking a feature that's only meant for testing as internal might not preclude somebody from
+    // trying to use it in `core` or `std` as both enable various internal features and utilize them
+    // throughout. This is intentionally a flag not another internal feature as having to modify the
+    // build cfg in `bootstrap` is arguably scarier than just needing to add `#![feature]`. It also
+    // stands out a lot more during code review making it easier to get caught.
+    internal_testing_features: bool = (false, parse_bool, [TRACKED],
+        "allow certain internal language features to be enabled that help exercise & test the compiler"),
     large_data_threshold: Option<u64> = (None, parse_opt_number, [TRACKED],
         "set the threshold for objects to be stored in a \"large data\" section \
          (only effective with -Ccode-model=medium, default: 65536)"),

--- a/tests/ui/traits/negative-bounds/associated-constraints.rs
+++ b/tests/ui/traits/negative-bounds/associated-constraints.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Zinternal-testing-features
 #![feature(negative_bounds)]
 
 trait Trait {

--- a/tests/ui/traits/negative-bounds/associated-constraints.stderr
+++ b/tests/ui/traits/negative-bounds/associated-constraints.stderr
@@ -1,29 +1,29 @@
 error: associated type constraints not allowed on negative bounds
-  --> $DIR/associated-constraints.rs:7:19
+  --> $DIR/associated-constraints.rs:8:19
    |
 LL | fn test<T: !Trait<Assoc = i32>>() {}
    |                   ^^^^^^^^^^^
 
 error: associated type constraints not allowed on negative bounds
-  --> $DIR/associated-constraints.rs:10:31
+  --> $DIR/associated-constraints.rs:11:31
    |
 LL | fn test2<T>() where T: !Trait<Assoc = i32> {}
    |                               ^^^^^^^^^^^
 
 error: associated type constraints not allowed on negative bounds
-  --> $DIR/associated-constraints.rs:13:20
+  --> $DIR/associated-constraints.rs:14:20
    |
 LL | fn test3<T: !Trait<Assoc: Send>>() {}
    |                    ^^^^^^^^^^^
 
 error: associated type constraints not allowed on negative bounds
-  --> $DIR/associated-constraints.rs:16:31
+  --> $DIR/associated-constraints.rs:17:31
    |
 LL | fn test4<T>() where T: !Trait<Assoc: Send> {}
    |                               ^^^^^^^^^^^
 
 error: parenthetical notation may not be used for negative bounds
-  --> $DIR/associated-constraints.rs:19:25
+  --> $DIR/associated-constraints.rs:20:25
    |
 LL | fn test5<T>() where T: !Fn() -> i32 {}
    |                         ^^^^^^^^^^^

--- a/tests/ui/traits/negative-bounds/negative-metasized.current.stderr
+++ b/tests/ui/traits/negative-bounds/negative-metasized.current.stderr
@@ -1,35 +1,35 @@
 error[E0277]: the trait bound `T: !MetaSized` is not satisfied
-  --> $DIR/negative-metasized.rs:12:11
+  --> $DIR/negative-metasized.rs:13:11
    |
 LL |     foo::<T>();
    |           ^ the trait bound `T: !MetaSized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-metasized.rs:9:11
+  --> $DIR/negative-metasized.rs:10:11
    |
 LL | fn foo<T: !MetaSized>() {}
    |           ^^^^^^^^^^ required by this bound in `foo`
 
 error[E0277]: the trait bound `(): !MetaSized` is not satisfied
-  --> $DIR/negative-metasized.rs:17:11
+  --> $DIR/negative-metasized.rs:18:11
    |
 LL |     foo::<()>();
    |           ^^ the trait bound `(): !MetaSized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-metasized.rs:9:11
+  --> $DIR/negative-metasized.rs:10:11
    |
 LL | fn foo<T: !MetaSized>() {}
    |           ^^^^^^^^^^ required by this bound in `foo`
 
 error[E0277]: the trait bound `str: !MetaSized` is not satisfied
-  --> $DIR/negative-metasized.rs:19:11
+  --> $DIR/negative-metasized.rs:20:11
    |
 LL |     foo::<str>();
    |           ^^^ the trait bound `str: !MetaSized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-metasized.rs:9:11
+  --> $DIR/negative-metasized.rs:10:11
    |
 LL | fn foo<T: !MetaSized>() {}
    |           ^^^^^^^^^^ required by this bound in `foo`

--- a/tests/ui/traits/negative-bounds/negative-metasized.next.stderr
+++ b/tests/ui/traits/negative-bounds/negative-metasized.next.stderr
@@ -1,35 +1,35 @@
 error[E0277]: the trait bound `T: !MetaSized` is not satisfied
-  --> $DIR/negative-metasized.rs:12:11
+  --> $DIR/negative-metasized.rs:13:11
    |
 LL |     foo::<T>();
    |           ^ the trait bound `T: !MetaSized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-metasized.rs:9:11
+  --> $DIR/negative-metasized.rs:10:11
    |
 LL | fn foo<T: !MetaSized>() {}
    |           ^^^^^^^^^^ required by this bound in `foo`
 
 error[E0277]: the trait bound `(): !MetaSized` is not satisfied
-  --> $DIR/negative-metasized.rs:17:11
+  --> $DIR/negative-metasized.rs:18:11
    |
 LL |     foo::<()>();
    |           ^^ the trait bound `(): !MetaSized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-metasized.rs:9:11
+  --> $DIR/negative-metasized.rs:10:11
    |
 LL | fn foo<T: !MetaSized>() {}
    |           ^^^^^^^^^^ required by this bound in `foo`
 
 error[E0277]: the trait bound `str: !MetaSized` is not satisfied
-  --> $DIR/negative-metasized.rs:19:11
+  --> $DIR/negative-metasized.rs:20:11
    |
 LL |     foo::<str>();
    |           ^^^ the trait bound `str: !MetaSized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-metasized.rs:9:11
+  --> $DIR/negative-metasized.rs:10:11
    |
 LL | fn foo<T: !MetaSized>() {}
    |           ^^^^^^^^^^ required by this bound in `foo`

--- a/tests/ui/traits/negative-bounds/negative-metasized.rs
+++ b/tests/ui/traits/negative-bounds/negative-metasized.rs
@@ -1,6 +1,7 @@
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
+//@ compile-flags: -Zinternal-testing-features
 #![feature(negative_bounds)]
 #![feature(sized_hierarchy)]
 

--- a/tests/ui/traits/negative-bounds/negative-sized.rs
+++ b/tests/ui/traits/negative-bounds/negative-sized.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Zinternal-testing-features
 #![feature(negative_bounds)]
 
 fn foo<T: !Sized>() {}

--- a/tests/ui/traits/negative-bounds/negative-sized.stderr
+++ b/tests/ui/traits/negative-bounds/negative-sized.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `(): !Sized` is not satisfied
-  --> $DIR/negative-sized.rs:6:11
+  --> $DIR/negative-sized.rs:7:11
    |
 LL |     foo::<()>();
    |           ^^ the trait bound `(): !Sized` is not satisfied
    |
 note: required by a bound in `foo`
-  --> $DIR/negative-sized.rs:3:11
+  --> $DIR/negative-sized.rs:4:11
    |
 LL | fn foo<T: !Sized>() {}
    |           ^^^^^^ required by this bound in `foo`

--- a/tests/ui/traits/negative-bounds/on-unimplemented.rs
+++ b/tests/ui/traits/negative-bounds/on-unimplemented.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Zinternal-testing-features
 //@ reference: attributes.diagnostic.on_unimplemented.intro
 
 #![feature(negative_bounds)]

--- a/tests/ui/traits/negative-bounds/on-unimplemented.stderr
+++ b/tests/ui/traits/negative-bounds/on-unimplemented.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `NotFoo: !Foo` is not satisfied
-  --> $DIR/on-unimplemented.rs:9:15
+  --> $DIR/on-unimplemented.rs:10:15
    |
 LL | fn hello() -> impl !Foo {
    |               ^^^^^^^^^ unsatisfied trait bound
@@ -8,7 +8,7 @@ LL |     NotFoo
    |     ------ return type was inferred to be `NotFoo` here
    |
 help: the trait bound `NotFoo: !Foo` is not satisfied
-  --> $DIR/on-unimplemented.rs:7:1
+  --> $DIR/on-unimplemented.rs:8:1
    |
 LL | struct NotFoo;
    | ^^^^^^^^^^^^^

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Znext-solver
+//@ compile-flags: -Znext-solver -Zinternal-testing-features
 
 #![feature(negative_bounds, negative_impls)]
 

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Znext-solver
+//@ compile-flags: -Znext-solver -Zinternal-testing-features
 
 #![feature(negative_bounds, unboxed_closures)]
 

--- a/tests/ui/traits/negative-bounds/simple.rs
+++ b/tests/ui/traits/negative-bounds/simple.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Zinternal-testing-features
 #![feature(negative_bounds, negative_impls)]
 
 fn not_copy<T: !Copy>() {}

--- a/tests/ui/traits/negative-bounds/simple.stderr
+++ b/tests/ui/traits/negative-bounds/simple.stderr
@@ -1,57 +1,57 @@
 error[E0277]: the trait bound `T: !Copy` is not satisfied
-  --> $DIR/simple.rs:10:16
+  --> $DIR/simple.rs:11:16
    |
 LL |     not_copy::<T>();
    |                ^ the trait bound `T: !Copy` is not satisfied
    |
 note: required by a bound in `not_copy`
-  --> $DIR/simple.rs:3:16
+  --> $DIR/simple.rs:4:16
    |
 LL | fn not_copy<T: !Copy>() {}
    |                ^^^^^ required by this bound in `not_copy`
 
 error[E0277]: the trait bound `T: !Copy` is not satisfied
-  --> $DIR/simple.rs:15:16
+  --> $DIR/simple.rs:16:16
    |
 LL |     not_copy::<T>();
    |                ^ the trait bound `T: !Copy` is not satisfied
    |
 note: required by a bound in `not_copy`
-  --> $DIR/simple.rs:3:16
+  --> $DIR/simple.rs:4:16
    |
 LL | fn not_copy<T: !Copy>() {}
    |                ^^^^^ required by this bound in `not_copy`
 
 error[E0277]: the trait bound `Copyable: !Copy` is not satisfied
-  --> $DIR/simple.rs:30:16
+  --> $DIR/simple.rs:31:16
    |
 LL |     not_copy::<Copyable>();
    |                ^^^^^^^^ unsatisfied trait bound
    |
 help: the trait bound `Copyable: !Copy` is not satisfied
-  --> $DIR/simple.rs:27:1
+  --> $DIR/simple.rs:28:1
    |
 LL | struct Copyable;
    | ^^^^^^^^^^^^^^^
 note: required by a bound in `not_copy`
-  --> $DIR/simple.rs:3:16
+  --> $DIR/simple.rs:4:16
    |
 LL | fn not_copy<T: !Copy>() {}
    |                ^^^^^ required by this bound in `not_copy`
 
 error[E0277]: the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
-  --> $DIR/simple.rs:37:16
+  --> $DIR/simple.rs:38:16
    |
 LL |     not_copy::<NotNecessarilyCopyable>();
    |                ^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
-  --> $DIR/simple.rs:34:1
+  --> $DIR/simple.rs:35:1
    |
 LL | struct NotNecessarilyCopyable;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `not_copy`
-  --> $DIR/simple.rs:3:16
+  --> $DIR/simple.rs:4:16
    |
 LL | fn not_copy<T: !Copy>() {}
    |                ^^^^^ required by this bound in `not_copy`

--- a/tests/ui/traits/negative-bounds/supertrait.rs
+++ b/tests/ui/traits/negative-bounds/supertrait.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Zinternal-testing-features
 //@ check-pass
 
 #![feature(negative_bounds)]


### PR DESCRIPTION
Support for negative bounds (not to be confused with negative impls) was added in PR RUST-110791 (2023) for internal testing purposes only.

In PR RUST-119354 (2023) I marked it internal. Moreover, we intentionally never advertise this feature and we declare it as *an internal-only feature for testing the trait solver* in the Unstable Book ([via](https://doc.rust-lang.org/unstable-book/language-features/negative-bounds.html#negative_bounds)).

However, these measures didn't prevent someone from trying to use them in the public API of the stdlib[^1]! I can't blame them in the slightest: The stdlib uses unstable and internal features left and right, even in stable APIs. What's more, there's the sibling feature *negative impls* that obviously bears a similar name, is not internal and is used in stable APIs. I can see that it's easy to miss that their status differs so drastically.

Well, I have to admit, it's unlikely that such a PR would ever pass review. However, there's a chance it might, I don't know. Last time it was me who caught it.

I argue that "better docs" just wouldn't really help, a tidy rule would be too much effort & be too fragile and triagebot mentions would be the wrong tool for the job ([see also](https://github.com/rust-lang/triagebot/issues/2182#issuecomment-3308626154)) even if their functionality got extended.

Therefore I've decided to additionally gate negative bounds behind a new `-Zinternal-testing-features` flag. This should be deterrent enough since surely nobody would modify the build flags for the stdlib I'm thinking and the name should scream "I'm unfit for general use".

If y'all disagree with the hypothesis and the solution, please voice your concern! I'm fine with retracting this PR if it's not liked.

[^1]: This should go without saying but don't put any blame on individuals! Context: https://github.com/rust-lang/rust/pull/146668#issuecomment-3303881805.