### PR TITLE
Stabilize `Result::map_or_default` and `Option::map_or_default`

### DIFF
--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -1,5 +1,6 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
+#![cfg_attr(bootstrap, feature(result_option_map_or_default))]
 #![feature(error_iter)]
 #![feature(file_buffered)]
 #![feature(gen_blocks)]
@@ -7,7 +8,6 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(proc_macro_internals)]
-#![feature(result_option_map_or_default)]
 #![feature(strip_circumfix)]
 #![feature(trusted_len)]
 // tidy-alphabetical-end

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1283,8 +1283,6 @@ impl<T> Option<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(result_option_map_or_default)]
-    ///
     /// let x: Option<&str> = Some("hi");
     /// let y: Option<&str> = None;
     ///
@@ -1294,7 +1292,7 @@ impl<T> Option<T> {
     ///
     /// [default value]: Default::default
     #[inline]
-    #[unstable(feature = "result_option_map_or_default", issue = "138099")]
+    #[stable(feature = "result_option_map_or_default", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_option_ops", issue = "143956")]
     pub const fn map_or_default<U, F>(self, f: F) -> U
     where

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -912,8 +912,6 @@ impl<T, E> Result<T, E> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(result_option_map_or_default)]
-    ///
     /// let x: Result<_, &str> = Ok("foo");
     /// let y: Result<&str, _> = Err("bar");
     ///
@@ -923,7 +921,7 @@ impl<T, E> Result<T, E> {
     ///
     /// [default value]: Default::default
     #[inline]
-    #[unstable(feature = "result_option_map_or_default", issue = "138099")]
+    #[stable(feature = "result_option_map_or_default", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_result_trait_fn", issue = "144211")]
     pub const fn map_or_default<U, F>(self, f: F) -> U
     where

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -96,7 +96,6 @@
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]
 #![feature(ptr_metadata)]
-#![feature(result_option_map_or_default)]
 #![feature(rustc_attrs)]
 #![feature(signed_bigint_helpers)]
 #![feature(slice_from_ptr_range)]


### PR DESCRIPTION
Tracking issue: rust-lang/rust#138099
FCP completed: https://github.com/rust-lang/rust/issues/138099#issuecomment-4184062429
Closes: rust-lang/rust#138099