### PR TITLE
feat(num): improve error messages for `TryFromIntError`

### DIFF
--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -21,7 +21,14 @@ impl TryFromIntError {
 #[stable(feature = "try_from", since = "1.34.0")]
 impl fmt::Display for TryFromIntError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        "out of range integral type conversion attempted".fmt(f)
+        match self.0 {
+            IntErrorKind::Empty | IntErrorKind::InvalidDigit => unreachable!(),
+            IntErrorKind::PosOverflow => "number too large to fit in target type",
+            IntErrorKind::NegOverflow => "number too small to fit in target type",
+            IntErrorKind::Zero => "number would be zero for non-zero type",
+            IntErrorKind::NotAPowerOfTwo => "number is not a power of two",
+        }
+        .fmt(f)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

- Tracking issue: rust-lang/rust#153978

This pull request improves the `Display` trait implementation for `TryFromIntError` by providing more specific error messages based on the underlying `IntErrorKind`.

Currently, the error message is always `"out of range integral type conversion attempted"`. This makes debugging difficult because users cannot distinguish the detailed cause of the error from the error message.

`IntErrorKind::Empty` and `IntErrorKind::InvalidDigit` should be unreachable.

I don't think this is breaking changes, because similar changes were made in the past in rust-lang/rust#96168.

See also: <https://users.rust-lang.org/t/are-changes-to-fmt-display-considered-breaking/59775>