### PR TITLE
diagnostics: point to coroutine body on higher-ranked auto trait errors

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -332,7 +332,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             leading_ellipsis,
         );
 
-        self.tcx().dcx().create_err(TraitPlaceholderMismatch {
+        let mut err = self.tcx().dcx().create_err(TraitPlaceholderMismatch {
             span,
             satisfy_span,
             where_span,
@@ -340,7 +340,46 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             def_id,
             trait_def_id: self.tcx().def_path_str(trait_def_id),
             actual_impl_expl_notes,
-        })
+        });
+
+        let mut current_code = cause.code();
+        let mut coroutine_def_id = None;
+
+        loop {
+            match current_code {
+                ObligationCauseCode::MatchImpl(inner_cause, _) => {
+                    current_code = inner_cause.code();
+                }
+                ObligationCauseCode::BuiltinDerived(derived) => {
+                    let self_ty = derived.parent_trait_pred.skip_binder().self_ty();
+
+                    if let ty::Coroutine(def_id, _) | ty::CoroutineWitness(def_id, _) =
+                        self_ty.kind()
+                    {
+                        coroutine_def_id = Some(*def_id);
+                        break;
+                    }
+
+                    current_code = &derived.parent_code;
+                }
+                _ => break,
+            }
+        }
+
+        if let Some(def_id) = coroutine_def_id {
+            if self.tcx().trait_is_auto(trait_def_id) {
+                let c_span = self.tcx().def_span(def_id);
+                let descr = self.tcx().def_descr(def_id);
+                let trait_name = self.tcx().def_path_str(trait_def_id);
+
+                err.span_label(
+                    c_span,
+                    format!("this {descr} captures a value whose type is not `{trait_name}`"),
+                );
+            }
+        }
+
+        err
     }
 
     /// Add notes with details about the expected and actual trait refs, with attention to cases

--- a/tests/ui/async-await/coroutine-auto-trait-span-issue-155880.rs
+++ b/tests/ui/async-await/coroutine-auto-trait-span-issue-155880.rs
@@ -1,0 +1,30 @@
+//@ edition: 2021
+// Regression test for <https://github.com/rust-lang/rust/issues/155880>
+
+trait Trait {
+    type Assoc<'a>
+    where
+        Self: 'a;
+}
+
+impl<T> Trait for T {
+    type Assoc<'a> = ()
+    where
+        Self: 'a;
+}
+
+async fn inner<'a, T: Trait + 'a>(_: T, x: T::Assoc<'a>) -> T::Assoc<'a> {
+    std::future::ready(x).await
+}
+
+async fn outer<'a>() {
+    let x = 1u32;
+    inner(&x, ()).await;
+}
+
+fn is_send<T: Send>(_: T) {}
+
+fn main() {
+    is_send(outer())
+    //~^ ERROR implementation of `Send` is not general enough
+}

--- a/tests/ui/async-await/coroutine-auto-trait-span-issue-155880.stderr
+++ b/tests/ui/async-await/coroutine-auto-trait-span-issue-155880.stderr
@@ -1,0 +1,17 @@
+error: implementation of `Send` is not general enough
+  --> $DIR/coroutine-auto-trait-span-issue-155880.rs:28:5
+   |
+LL |   async fn inner<'a, T: Trait + 'a>(_: T, x: T::Assoc<'a>) -> T::Assoc<'a> {
+   |  __________________________________________________________________________-
+LL | |     std::future::ready(x).await
+LL | | }
+   | |_- this async fn captures a value whose type is not `Send`
+...
+LL |       is_send(outer())
+   |       ^^^^^^^^^^^^^^^^ implementation of `Send` is not general enough
+   |
+   = note: `Send` would have to be implemented for the type `&'0 u32`, for any lifetime `'0`...
+   = note: ...but `Send` is actually implemented for the type `&'1 u32`, for some specific lifetime `'1`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/async-await/higher-ranked-auto-trait-11.assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-11.assumptions.stderr
@@ -11,7 +11,10 @@ error: implementation of `Send` is not general enough
   --> $DIR/higher-ranked-auto-trait-11.rs:27:9
    |
 LL |         Box::pin(async move { <T as Foo<'a>>::foo().await })
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Send` is not general enough
+   |         ^^^^^^^^^----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |        |
+   |         |        this async block captures a value whose type is not `Send`
+   |         implementation of `Send` is not general enough
    |
    = note: `Send` would have to be implemented for the type `<T as Foo<'0>>::Future`, for any lifetime `'0`...
    = note: ...but `Send` is actually implemented for the type `<T as Foo<'1>>::Future`, for some specific lifetime `'1`

--- a/tests/ui/async-await/higher-ranked-auto-trait-11.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-11.no_assumptions.stderr
@@ -11,7 +11,10 @@ error: implementation of `Send` is not general enough
   --> $DIR/higher-ranked-auto-trait-11.rs:27:9
    |
 LL |         Box::pin(async move { <T as Foo<'a>>::foo().await })
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Send` is not general enough
+   |         ^^^^^^^^^----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |        |
+   |         |        this async block captures a value whose type is not `Send`
+   |         implementation of `Send` is not general enough
    |
    = note: `Send` would have to be implemented for the type `<T as Foo<'0>>::Future`, for any lifetime `'0`...
    = note: ...but `Send` is actually implemented for the type `<T as Foo<'1>>::Future`, for some specific lifetime `'1`

--- a/tests/ui/async-await/return-type-notation/issue-110963-early.no_assumptions.stderr
+++ b/tests/ui/async-await/return-type-notation/issue-110963-early.no_assumptions.stderr
@@ -1,7 +1,10 @@
 error: implementation of `Send` is not general enough
   --> $DIR/issue-110963-early.rs:17:5
    |
-LL | /     spawn(async move {
+LL |       spawn(async move {
+   |       ^     ---------- this async block captures a value whose type is not `Send`
+   |  _____|
+   | |
 LL | |         let mut hc = hc;
 LL | |         if !hc.check().await {
 LL | |             log_health_check_failure().await;
@@ -15,7 +18,10 @@ LL | |     });
 error: implementation of `Send` is not general enough
   --> $DIR/issue-110963-early.rs:17:5
    |
-LL | /     spawn(async move {
+LL |       spawn(async move {
+   |       ^     ---------- this async block captures a value whose type is not `Send`
+   |  _____|
+   | |
 LL | |         let mut hc = hc;
 LL | |         if !hc.check().await {
 LL | |             log_health_check_failure().await;

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -33,6 +33,9 @@ LL |     let generator = #[coroutine] static move || {
 error: implementation of `Foo` is not general enough
   --> $DIR/auto-trait-regions.rs:31:5
    |
+LL |     let generator = #[coroutine] move || {
+   |                                  ------- this coroutine captures a value whose type is not `Foo`
+...
 LL |     assert_foo(generator);
    |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
    |
@@ -42,6 +45,9 @@ LL |     assert_foo(generator);
 error: implementation of `Foo` is not general enough
   --> $DIR/auto-trait-regions.rs:51:5
    |
+LL |     let generator = #[coroutine] move || {
+   |                                  ------- this coroutine captures a value whose type is not `Foo`
+...
 LL |     assert_foo(generator);
    |     ^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
    |


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156226)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#155880

When encountering a higher-ranked auto trait bound error involving a coroutine or async function,the trait solver previously used the span of the outermost cause (eg. `spawn(...)` or `is_send(...)`).

This PR modifies the `TraitPlaceholderMismatch` formatting logic to walk down the `ObligationCauseCode` chain.If the obligation originates from a `ty::Coroutine` or `ty::CoroutineWitness`, it extracts that specific span, providing a much more accurate underline for the user.

#### Before:
```text
error: implementation of `Send` is not general enough
  --> src/main.rs:25:5
   |
25 |     is_send(outer())
   |     ^^^^^^^^^^^^^^^^ implementation of `Send` is not general enough
```

#### After:
```text
error: implementation of `Send` is not general enough
  --> src/main.rs:13:74
   |
13 |   async fn inner<'a, T: Trait + 'a>(_: T, x: T::Assoc<'a>) -> T::Assoc<'a> {
   |  __________________________________________________________________________^
14 | |     std::future::ready(x).await
15 | | }
   | |_^ implementation of `Send` is not general enough
```