### PR TITLE
Add Trusty OS to the generic error implementation.

### DIFF
--- a/library/std/src/sys/io/error/mod.rs
+++ b/library/std/src/sys/io/error/mod.rs
@@ -43,6 +43,7 @@ cfg_select! {
         target_os = "vexos",
         target_family = "wasm",
         target_os = "zkvm",
+        target_os = "trusty",
     ) => {
         mod generic;
         pub use generic::*;


### PR DESCRIPTION
Background:
* During this refactor, the Trusty OS was not targeted in the cfg_select: https://github.com/rust-lang/rust/commit/e259373ce9eca5a10201d74a016a4a2e7ab42ed7

r? @randomPoison 