### PR TITLE
Install additional LLVM DLL on Windows

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2569,6 +2569,12 @@ pub fn maybe_install_llvm_runtime(builder: &Builder<'_>, target: TargetSelection
     // statically.
     if builder.llvm_link_shared() {
         maybe_install_llvm(builder, target, &dst_libdir, false);
+
+        // To workaround lack of rpath on Windows, we bundle another copy of
+        // the LLVM DLL to make rust-lld and llvm-tools work when `sysroot/bin`
+        //  is missing from PATH, i.e. when they not launched by rustc.
+        let dst_libdir = sysroot.join("lib/rustlib").join(target).join("bin");
+        maybe_install_llvm(builder, target, &dst_libdir, false);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/155268

The problem is that with shared linking to LLVM lib we have binaries requiring it in `$sysroot/bin` and `$sysroot/lib/rustlib/triple/bin`, but place the DLL only in the first location. On Unix systems rpath would take care of that, but on Windows the required DLL must be next to the binary or be found in PATH.

This PR puts another copy of the library into that second location. The size overhead of such copy compared to static linking is much lower than I anticipated even though I couldn't manage to make bootstrap create hard links.

The sizes without and with `llvm-tools` component:
```
❯ du --summarize -h .rustup/toolchains/{additional-dll,static}*
638M    .rustup/toolchains/additional-dll
800M    .rustup/toolchains/additional-dll-tools
608M    .rustup/toolchains/static-link
1.1G    .rustup/toolchains/static-link-tools
```
Statically linked LLD sits at 139M while dynamically linked one is 7.5M + 150M for the libLLVM, so the difference is minor.

Alternatively, we could require that on Windows, binaries located in `$sysroot/lib/rustlib/triple/bin` must always be called with `$sysroot/bin` in the PATH. However, that sounds like something that would require an announcement and some grace period.