### PR TITLE
tests: check wasm compiler_builtins object architecture

### DIFF
--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 bstr = "1.12"
 gimli = "0.32"
 libc = "0.2"
-object = "0.37"
+object = { version = "0.37", features = ["wasm"] }
 regex = "1.11"
 serde_json = "1.0"
 similar = "2.7"

--- a/tests/run-make/wasm-compiler-builtins-object-arch/rmake.rs
+++ b/tests/run-make/wasm-compiler-builtins-object-arch/rmake.rs
@@ -1,0 +1,54 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/132802>.
+//!
+//! The prebuilt `libcompiler_builtins` rlib bundled in the wasm sysroot must
+//! contain wasm object files — never host ELF/Mach-O/COFF. Bootstrap could
+//! previously pick the host C toolchain for compiler-rt fallbacks on wasm
+//! targets and silently embed host objects into the wasm sysroot
+//! (fixed in rust-lang/rust#137457).
+
+//@ only-wasm32
+
+use run_make_support::object::read::Object;
+use run_make_support::object::read::archive::ArchiveFile;
+use run_make_support::object::{self, Architecture};
+use run_make_support::{has_extension, has_prefix, rfs, rustc, shallow_find_files};
+
+fn main() {
+    let libdir = rustc().print("target-libdir").run().stdout_utf8();
+    let libdir = libdir.trim();
+
+    let rlibs = shallow_find_files(libdir, |path| {
+        has_prefix(path, "libcompiler_builtins") && has_extension(path, "rlib")
+    });
+    assert!(!rlibs.is_empty(), "no libcompiler_builtins rlib found in {libdir}");
+
+    let data = rfs::read(&rlibs[0]);
+    let archive = ArchiveFile::parse(&*data).unwrap();
+
+    let mut checked = 0usize;
+    for member in archive.members() {
+        let member = member.unwrap();
+        let name = std::str::from_utf8(member.name()).unwrap_or("<invalid-utf8>");
+        if name.ends_with(".rmeta") || name.ends_with(".rmeta-link") {
+            continue;
+        }
+        let obj_data = member.data(&*data).unwrap();
+        let obj = object::File::parse(obj_data).unwrap_or_else(|e| {
+            panic!("failed to parse member `{name}` in compiler_builtins rlib: {e}")
+        });
+        let arch = obj.architecture();
+        assert!(
+            matches!(arch, Architecture::Wasm32 | Architecture::Wasm64),
+            "object `{name}` in compiler_builtins rlib has architecture {arch:?}, \
+             expected wasm — see rust-lang/rust#132802",
+        );
+        checked += 1;
+    }
+
+    assert!(
+        checked > 0,
+        "no object members found in compiler_builtins rlib at {} — \
+         archive should always contain object files",
+        rlibs[0].display(),
+    );
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156230)*
<!-- homu-ignore:end -->

See rust-lang/rust#132802

This adds a run-make test for the wasm sysroot regression fixed in rust-lang/rust#137457

The test checks that the `.o` members in the prebuilt
`libcompiler_builtins` rlib for `wasm32-wasip1` are wasm objects rather than
host ELF objects. Before that fix, bootstrap could use the host C compiler for
compiler-rt fallbacks on wasm targets and end up embedding host objects into
the wasm sysroot.

I used `wasm32-wasip1` because that's the wasm target covered by the existing
`tests/run-make` CI setup, and the test asserts that it actually saw `.o`
members in the archive.

Closes: https://github.com/rust-lang/rust/issues/132802

r? @tgross35