### PR TITLE
compiletest: prevent directives from having multiple revisions

### DIFF
--- a/src/tools/compiletest/src/directives/line.rs
+++ b/src/tools/compiletest/src/directives/line.rs
@@ -30,6 +30,20 @@ pub(crate) fn line_directive<'a>(
 
         revision = Some(line_revision);
         raw_directive = after_close_bracket.trim_start();
+
+        if line_revision.contains(",") {
+            let suggestion: Vec<_> = line_revision
+                .split(",")
+                .map(|revision| {
+                    format!("{COMPILETEST_DIRECTIVE_PREFIX} [{revision}]: {raw_directive}")
+                })
+                .collect();
+            panic!(
+                "malformed condition directive: multiple revisions aren't supported yet in `{}`, split them like\n{}",
+                original_line,
+                suggestion.join("\n"),
+            );
+        }
     } else {
         revision = None;
         raw_directive = after_comment;

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -633,6 +633,7 @@ fn test_miropt_mode_forbidden_revisions() {
 }
 
 #[test]
+#[should_panic(expected = "malformed condition directive: multiple revisions aren't supported yet")]
 fn test_multiple_revisions_in_directive() {
     let directive = "//@ [foo,bar] compile-flags: -Z hello";
 
@@ -640,6 +641,10 @@ fn test_multiple_revisions_in_directive() {
     let line_directive = line_directive(Utf8Path::new("foo.txt"), LineNumber::ZERO, directive);
     assert!(line_directive.is_some());
     assert_eq!(Some("foo,bar"), line_directive.unwrap().revision);
+
+    // The solution for now: forbid directives from having multiple revisions.
+    let config: Config = cfg().build();
+    parse_early_props(&config, directive);
 }
 
 #[test]

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -633,6 +633,16 @@ fn test_miropt_mode_forbidden_revisions() {
 }
 
 #[test]
+fn test_multiple_revisions_in_directive() {
+    let directive = "//@ [foo,bar] compile-flags: -Z hello";
+
+    // The problem: this is seen as a single revision.
+    let line_directive = line_directive(Utf8Path::new("foo.txt"), LineNumber::ZERO, directive);
+    assert!(line_directive.is_some());
+    assert_eq!(Some("foo,bar"), line_directive.unwrap().revision);
+}
+
+#[test]
 fn test_forbidden_revisions_allowed_in_non_filecheck_dir() {
     let revisions = ["CHECK", "COM", "NEXT", "SAME", "EMPTY", "NOT", "COUNT", "DAG", "LABEL"];
     let modes = [


### PR DESCRIPTION
Right now, a compiletest directive like `//@ [foo,bar] compile-flags: -Z hello` is accepted. While it looks similar to a `//[foo,bar]` error annotation matching multiple revisions, it will instead model a directive for a single revision named `foo,bar` and not for two revisions. Slightly inconsistent/confusing.

I don't know that it's common enough to make bigger changes to support it fully (`miri`'s test harness seems to support that use-case), but since I hit that today, this PR prevents that case for now. Otherwise, I think we'd have to turn all uses of `line_directive` as possibly creating multiple line directives, one per revision, etc.

Such a directive will now yield an error, with a best-effort suggestion to split it into multiple single-revision directives:

```
multiple revisions aren't supported yet in `//@ [foo,bar] compile-flags: -Z hello`, split them like
//@ [foo]: compile-flags: -Z hello
//@ [bar]: compile-flags: -Z hello
```