### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -2086,7 +2086,7 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
     }
 
     if name == sym::simd_splat {
-        let (_out_len, out_ty) = require_simd!(ret_ty, SimdReturn);
+        let (out_len, out_ty) = require_simd!(ret_ty, SimdReturn);
 
         require!(
             args[0].layout.ty == out_ty,
@@ -2105,7 +2105,8 @@ fn generic_simd_intrinsic<'ll, 'tcx>(
 
         // `shufflevector <N x elem> v0, <N x elem> poison, <N x i32> zeroinitializer`
         // The masks is all zeros, so this splats lane 0 (which has our element in it).
-        let splat = bx.shuffle_vector(v0, poison_vec, bx.const_null(llret_ty));
+        let mask_ty = bx.type_vector(bx.type_i32(), out_len);
+        let splat = bx.shuffle_vector(v0, poison_vec, bx.const_null(mask_ty));
 
         return Ok(splat);
     }

--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -9,7 +9,7 @@ use rustc_errors::ErrorGuaranteed;
 use rustc_hir::LangItem;
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{self, AdtDef, Ty};
+use rustc_middle::ty::{self, AdtDef, Ty, TypingMode};
 use rustc_middle::{bug, mir};
 use rustc_trait_selection::traits::{Obligation, ObligationCause, ObligationCtxt};
 use tracing::instrument;
@@ -100,13 +100,14 @@ impl Qualif for HasMutInterior {
         // Instead we invoke an obligation context manually, and provide the opaque type inference settings
         // that allow the trait solver to just error out instead of cycling.
         let freeze_def_id = cx.tcx.require_lang_item(LangItem::Freeze, cx.body.span);
-        // FIXME(#132279): Once we've got a typing mode which reveals opaque types using the HIR
-        // typeck results without causing query cycles, we should use this here instead of defining
-        // opaque types.
-        let typing_env = ty::TypingEnv::new(
-            cx.typing_env.param_env,
-            ty::TypingMode::analysis_in_body(cx.tcx, cx.body.source.def_id().expect_local()),
-        );
+        let did = cx.body.source.def_id().expect_local();
+
+        let typing_env = if cx.tcx.use_typing_mode_borrowck() {
+            cx.typing_env
+        } else {
+            ty::TypingEnv::new(cx.typing_env.param_env, TypingMode::analysis_in_body(cx.tcx, did))
+        };
+
         let (infcx, param_env) = cx.tcx.infer_ctxt().build_with_typing_env(typing_env);
         let ocx = ObligationCtxt::new(&infcx);
         let obligation = Obligation::new(

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -319,6 +319,27 @@ pub struct InferCtxt<'tcx> {
     pub obligation_inspector: Cell<Option<ObligationInspector<'tcx>>>,
 }
 
+impl<'tcx> Drop for InferCtxt<'tcx> {
+    fn drop(&mut self) {
+        // Defuse the drop bomb in the OpaqueTypeStorage when we're in TypingMode::Borrowck,
+        // and the InferCtxt doesn't consider regions. This is okay since in `Borrowck`,
+        // the only reason we care about opaques is in relation to regions.
+        // In some places *after* typeck, like in lints we use `TypingMode::Borrowck`
+        // to prevent defining opaque types and we simply don't care about regions.
+        match self.typing_mode() {
+            TypingMode::Coherence
+            | TypingMode::Analysis { .. }
+            | TypingMode::PostBorrowckAnalysis { .. }
+            | TypingMode::PostAnalysis => {}
+            TypingMode::Borrowck { .. } => {
+                if !self.considering_regions {
+                    let _ = self.inner.borrow_mut().opaque_type_storage.take_opaque_types();
+                }
+            }
+        }
+    }
+}
+
 /// See the `error_reporting` module for more details.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TypeFoldable, TypeVisitable)]
 pub enum ValuePairs<'tcx> {

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -321,9 +321,11 @@ pub struct InferCtxt<'tcx> {
 
 impl<'tcx> Drop for InferCtxt<'tcx> {
     fn drop(&mut self) {
-        // Defuse the drop bomb in the OpaqueTypeStorage when we're in TypingMode::Borrowck,
-        // and the InferCtxt doesn't consider regions. This is okay since in `Borrowck`,
-        // the only reason we care about opaques is in relation to regions.
+        let mut inner = self.inner.borrow_mut();
+        let opaque_type_storage = &mut inner.opaque_type_storage;
+
+        // No need for the drop bomb when we're in TypingMode::Borrowck, and the InferCtxt doesn't consider regions.
+        // This is okay since in `Borrowck`, the only reason we care about opaques is in relation to regions.
         // In some places *after* typeck, like in lints we use `TypingMode::Borrowck`
         // to prevent defining opaque types and we simply don't care about regions.
         match self.typing_mode() {
@@ -333,9 +335,13 @@ impl<'tcx> Drop for InferCtxt<'tcx> {
             | TypingMode::PostAnalysis => {}
             TypingMode::Borrowck { .. } => {
                 if !self.considering_regions {
-                    let _ = self.inner.borrow_mut().opaque_type_storage.take_opaque_types();
+                    return;
                 }
             }
+        }
+
+        if !opaque_type_storage.is_empty() {
+            ty::tls::with(|tcx| tcx.dcx().delayed_bug(format!("{opaque_type_storage:?}")));
         }
     }
 }

--- a/compiler/rustc_infer/src/infer/opaque_types/table.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/table.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::undo_log::UndoLogs;
 use rustc_middle::bug;
-use rustc_middle::ty::{self, OpaqueTypeKey, ProvisionalHiddenType, Ty};
+use rustc_middle::ty::{OpaqueTypeKey, ProvisionalHiddenType, Ty};
 use tracing::instrument;
 
 use crate::infer::snapshot::undo_log::{InferCtxtUndoLogs, UndoLog};
@@ -118,14 +118,6 @@ impl<'tcx> OpaqueTypeStorage<'tcx> {
         undo_log: &'a mut InferCtxtUndoLogs<'tcx>,
     ) -> OpaqueTypeTable<'a, 'tcx> {
         OpaqueTypeTable { storage: self, undo_log }
-    }
-}
-
-impl<'tcx> Drop for OpaqueTypeStorage<'tcx> {
-    fn drop(&mut self) {
-        if !self.is_empty() {
-            ty::tls::with(|tcx| tcx.dcx().delayed_bug(format!("{:?}", self.opaque_types)));
-        }
     }
 }
 

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -633,9 +633,14 @@ impl<'tcx> LateContext<'tcx> {
     /// The typing mode of the currently visited node. Use this when
     /// building a new `InferCtxt`.
     pub fn typing_mode(&self) -> TypingMode<'tcx> {
-        // FIXME(#132279): In case we're in a body, we should use a typing
-        // mode which reveals the opaque types defined by that body.
-        TypingMode::non_body_analysis()
+        if let Some(body_id) = self.enclosing_body
+            && self.tcx.use_typing_mode_borrowck()
+        {
+            let def_id = self.tcx.hir_enclosing_body_owner(body_id.hir_id);
+            TypingMode::borrowck(self.tcx, def_id)
+        } else {
+            TypingMode::non_body_analysis()
+        }
     }
 
     pub fn typing_env(&self) -> TypingEnv<'tcx> {

--- a/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
+++ b/compiler/rustc_lint/src/opaque_hidden_inferred_bound.rs
@@ -84,7 +84,7 @@ impl<'tcx> LateLintPass<'tcx> for OpaqueHiddenInferredBound {
         }
 
         let def_id = opaque.def_id.to_def_id();
-        let infcx = &cx.tcx.infer_ctxt().build(cx.typing_mode());
+        let infcx = &cx.tcx.infer_ctxt().ignoring_regions().build(cx.typing_mode());
         // For every projection predicate in the opaque type's explicit bounds,
         // check that the type that we're assigning actually satisfies the bounds
         // of the associated type.

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -257,10 +257,20 @@ fn check_struct_for_power_alignment<'tcx>(
     }
 }
 
+/// Annotates whether we are in the context of an item *defined* in rust
+/// and exposed to an FFI boundary,
+/// or the context of an item from elsewhere, whose interface is re-*declared* in rust.
 #[derive(Clone, Copy)]
 enum CItemKind {
     Declaration,
     Definition,
+}
+
+/// Annotates whether we are in the context of a function's argument types or return type.
+#[derive(Clone, Copy)]
+enum FnPos {
+    Arg,
+    Ret,
 }
 
 enum FfiResult<'tcx> {
@@ -286,8 +296,10 @@ enum IndirectionKind {
 }
 
 bitflags! {
+    /// VisitorState flags that are linked with the root type's use.
+    /// (These are the permanent part of the state, kept when visiting new Ty.)
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct VisitorState: u8 {
+    struct RootUseFlags: u8 {
         /// For use in (externally-linked) static variables.
         const STATIC = 0b000001;
         /// For use in functions in general.
@@ -302,7 +314,45 @@ bitflags! {
     }
 }
 
-impl VisitorState {
+/// Description of the relationship between current Ty and
+/// the type (or lack thereof) immediately containing it
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum OuterTyKind {
+    None,
+    /// A variant that should not exist,
+    /// but is needed because we don't change the lint's behavior yet
+    NoneThroughFnPtr,
+    /// Placeholder for properties that will be used eventually
+    Other,
+}
+
+impl OuterTyKind {
+    /// Computes the relationship by providing the containing Ty itself
+    fn from_ty<'tcx>(ty: Ty<'tcx>) -> Self {
+        match ty.kind() {
+            ty::FnPtr(..) => Self::NoneThroughFnPtr,
+            ty::RawPtr(..)
+            | ty::Ref(..)
+            | ty::Adt(..)
+            | ty::Tuple(..)
+            | ty::Array(..)
+            | ty::Slice(_) => OuterTyKind::Other,
+            _ => bug!("Unexpected outer type {ty:?}"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct VisitorState {
+    /// Flags describing both the overall context in which the current Ty is,
+    /// linked to how the Visitor's original Ty was used.
+    root_use_flags: RootUseFlags,
+    /// Flags describing both the immediate context in which the current Ty is,
+    /// linked to how it relates to its parent Ty (or lack thereof).
+    outer_ty_kind: OuterTyKind,
+}
+
+impl RootUseFlags {
     // The values that can be set.
     const STATIC_TY: Self = Self::STATIC;
     const ARGUMENT_TY_IN_DEFINITION: Self =
@@ -317,86 +367,85 @@ impl VisitorState {
     const RETURN_TY_IN_FNPTR: Self =
         Self::from_bits(Self::FUNC.bits() | Self::THEORETICAL.bits() | Self::FN_RETURN.bits())
             .unwrap();
+}
 
-    /// Get the proper visitor state for a given function's arguments.
-    fn argument_from_fnmode(fn_mode: CItemKind) -> Self {
-        match fn_mode {
-            CItemKind::Definition => VisitorState::ARGUMENT_TY_IN_DEFINITION,
-            CItemKind::Declaration => VisitorState::ARGUMENT_TY_IN_DECLARATION,
+impl VisitorState {
+    /// From an existing state, compute the state of any subtype of the current type.
+    /// (General case. For the case where the current type is a function pointer, see `next_in_fnptr`.)
+    fn next(&self, current_ty: Ty<'_>) -> Self {
+        assert!(!matches!(current_ty.kind(), ty::FnPtr(..)));
+        VisitorState {
+            root_use_flags: self.root_use_flags,
+            outer_ty_kind: OuterTyKind::from_ty(current_ty),
         }
     }
 
-    /// Get the proper visitor state for a given function's return type.
-    fn return_from_fnmode(fn_mode: CItemKind) -> Self {
-        match fn_mode {
-            CItemKind::Definition => VisitorState::RETURN_TY_IN_DEFINITION,
-            CItemKind::Declaration => VisitorState::RETURN_TY_IN_DECLARATION,
+    /// From an existing state, compute the state of any subtype of the current type.
+    /// (Case where the current type is a function pointer,
+    /// meaning we need to specify if the subtype is an argument or the return.)
+    fn next_in_fnptr(&self, current_ty: Ty<'_>, fn_pos: FnPos) -> Self {
+        assert!(matches!(current_ty.kind(), ty::FnPtr(..)));
+        VisitorState {
+            root_use_flags: match fn_pos {
+                FnPos::Ret => RootUseFlags::RETURN_TY_IN_FNPTR,
+                FnPos::Arg => RootUseFlags::ARGUMENT_TY_IN_FNPTR,
+            },
+            outer_ty_kind: OuterTyKind::from_ty(current_ty),
         }
+    }
+
+    /// Get the proper visitor state for a given function's arguments or return type.
+    fn fn_entry_point(fn_mode: CItemKind, fn_pos: FnPos) -> Self {
+        let p_flags = match (fn_mode, fn_pos) {
+            (CItemKind::Definition, FnPos::Ret) => RootUseFlags::RETURN_TY_IN_DEFINITION,
+            (CItemKind::Declaration, FnPos::Ret) => RootUseFlags::RETURN_TY_IN_DECLARATION,
+            (CItemKind::Definition, FnPos::Arg) => RootUseFlags::ARGUMENT_TY_IN_DEFINITION,
+            (CItemKind::Declaration, FnPos::Arg) => RootUseFlags::ARGUMENT_TY_IN_DECLARATION,
+        };
+        VisitorState { root_use_flags: p_flags, outer_ty_kind: OuterTyKind::None }
+    }
+
+    /// Get the proper visitor state for a static variable's type
+    fn static_entry_point() -> Self {
+        VisitorState { root_use_flags: RootUseFlags::STATIC_TY, outer_ty_kind: OuterTyKind::None }
     }
 
     /// Whether the type is used in a function.
-    fn is_in_function(self) -> bool {
-        let ret = self.contains(Self::FUNC);
+    fn is_in_function(&self) -> bool {
+        let ret = self.root_use_flags.contains(RootUseFlags::FUNC);
         if ret {
-            debug_assert!(!self.contains(Self::STATIC));
+            debug_assert!(!self.root_use_flags.contains(RootUseFlags::STATIC));
         }
         ret
     }
+
     /// Whether the type is used (directly or not) in a function, in return position.
-    fn is_in_function_return(self) -> bool {
-        let ret = self.contains(Self::FN_RETURN);
+    fn is_in_function_return(&self) -> bool {
+        let ret = self.root_use_flags.contains(RootUseFlags::FN_RETURN);
         if ret {
             debug_assert!(self.is_in_function());
         }
         ret
     }
+
     /// Whether the type is used (directly or not) in a defined function.
     /// In other words, whether or not we allow non-FFI-safe types behind a C pointer,
     /// to be treated as an opaque type on the other side of the FFI boundary.
-    fn is_in_defined_function(self) -> bool {
-        self.contains(Self::DEFINED) && self.is_in_function()
+    fn is_in_defined_function(&self) -> bool {
+        self.root_use_flags.contains(RootUseFlags::DEFINED) && self.is_in_function()
     }
 
     /// Whether the type is used (directly or not) in a function pointer type.
     /// Here, we also allow non-FFI-safe types behind a C pointer,
     /// to be treated as an opaque type on the other side of the FFI boundary.
-    fn is_in_fnptr(self) -> bool {
-        self.contains(Self::THEORETICAL) && self.is_in_function()
+    fn is_in_fnptr(&self) -> bool {
+        self.root_use_flags.contains(RootUseFlags::THEORETICAL) && self.is_in_function()
     }
 
     /// Whether we can expect type parameters and co in a given type.
-    fn can_expect_ty_params(self) -> bool {
+    fn can_expect_ty_params(&self) -> bool {
         // rust-defined functions, as well as FnPtrs
-        self.contains(Self::THEORETICAL) || self.is_in_defined_function()
-    }
-}
-
-bitflags! {
-    /// Data that summarises how an "outer type" surrounds its inner type(s)
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct OuterTyData: u8 {
-        /// To show that there is no outer type, the current type is directly used by a `static`
-        /// variable or a function/FnPtr
-        const NO_OUTER_TY = 0b01;
-        /// For NO_OUTER_TY cases, show that we are being directly used by a FnPtr specifically
-        /// FIXME(ctypes): this is only used for "bad behaviour" reproduced for compatibility's sake
-        const NO_OUTER_TY_FNPTR = 0b10;
-    }
-}
-
-impl OuterTyData {
-    /// Get the proper data for a given outer type.
-    fn from_ty<'tcx>(ty: Ty<'tcx>) -> Self {
-        match ty.kind() {
-            ty::FnPtr(..) => Self::NO_OUTER_TY | Self::NO_OUTER_TY_FNPTR,
-            ty::RawPtr(..)
-            | ty::Ref(..)
-            | ty::Adt(..)
-            | ty::Tuple(..)
-            | ty::Array(..)
-            | ty::Slice(_) => Self::empty(),
-            k @ _ => bug!("unexpected outer type {:?} of kind {:?}", ty, k),
-        }
+        self.root_use_flags.contains(RootUseFlags::THEORETICAL) || self.is_in_defined_function()
     }
 }
 
@@ -416,7 +465,7 @@ struct ImproperCTypesVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     fn new(cx: &'a LateContext<'tcx>, base_ty: Ty<'tcx>, base_fn_mode: CItemKind) -> Self {
-        Self { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
+        ImproperCTypesVisitor { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
     }
 
     /// Checks if the given indirection (box,ref,pointer) is "ffi-safe".
@@ -485,7 +534,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 {
                     FfiSafe
                 } else {
-                    self.visit_type(state, OuterTyData::from_ty(ty), inner_ty)
+                    self.visit_type(state.next(ty), inner_ty)
                 }
             }
         }
@@ -506,7 +555,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             if let Some(field) = super::transparent_newtype_field(self.cx.tcx, variant) {
                 // Transparent newtypes have at most one non-ZST field which needs to be checked..
                 let field_ty = get_type_from_field(self.cx, field, args);
-                match self.visit_type(state, OuterTyData::from_ty(ty), field_ty) {
+                match self.visit_type(state.next(ty), field_ty) {
                     FfiUnsafe { ty, .. } if ty.is_unit() => (),
                     r => return r,
                 }
@@ -525,7 +574,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         let mut all_phantom = !variant.fields.is_empty();
         for field in &variant.fields {
             let field_ty = get_type_from_field(self.cx, field, args);
-            all_phantom &= match self.visit_type(state, OuterTyData::from_ty(ty), field_ty) {
+            all_phantom &= match self.visit_type(state.next(ty), field_ty) {
                 FfiSafe => false,
                 // `()` fields are FFI-safe!
                 FfiUnsafe { ty, .. } if ty.is_unit() => false,
@@ -570,7 +619,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                         "consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct"
                     ))
                 } else {
-                    // FIXME(ctypes): confirm that this makes sense for unions once #60405 / RFC2645 stabilises
+                    // FIXME(#60405): confirm that this makes sense for unions once #60405 / RFC2645 stabilises
                     Some(msg!(
                         "consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this union"
                     ))
@@ -628,7 +677,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         if !def.repr().c() && !def.repr().transparent() && def.repr().int.is_none() {
             // Special-case types like `Option<extern fn()>` and `Result<extern fn(), ()>`
             if let Some(inner_ty) = repr_nullable_ptr(self.cx.tcx, self.cx.typing_env(), ty) {
-                return self.visit_type(state, OuterTyData::from_ty(ty), inner_ty);
+                return self.visit_type(state.next(ty), inner_ty);
             }
 
             return FfiUnsafe {
@@ -660,12 +709,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
     /// Checks if the given type is "ffi-safe" (has a stable, well-defined
     /// representation which can be exported to C code).
-    fn visit_type(
-        &mut self,
-        state: VisitorState,
-        outer_ty: OuterTyData,
-        ty: Ty<'tcx>,
-    ) -> FfiResult<'tcx> {
+    fn visit_type(&mut self, state: VisitorState, ty: Ty<'tcx>) -> FfiResult<'tcx> {
         use FfiResult::*;
 
         let tcx = self.cx.tcx;
@@ -709,7 +753,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             // Pattern types are just extra invariants on the type that you need to uphold,
             // but only the base type is relevant for being representable in FFI.
             // (note: this lint was written when pattern types could only be integers constrained to ranges)
-            ty::Pat(pat_ty, _) => self.visit_type(state, outer_ty, pat_ty),
+            // (also note: the lack of ".next(ty)" on the state is on purpose)
+            ty::Pat(pat_ty, _) => self.visit_type(state, pat_ty),
 
             // types which likely have a stable representation, if the target architecture defines those
             // note: before rust 1.77, 128-bit ints were not FFI-safe on x86_64
@@ -740,12 +785,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             },
 
             ty::Tuple(tuple) => {
-                // C functions can return void
-                let empty_and_safe = tuple.is_empty()
-                    && outer_ty.contains(OuterTyData::NO_OUTER_TY)
-                    && state.is_in_function_return();
-
-                if empty_and_safe {
+                if tuple.is_empty()
+                    && state.is_in_function_return()
+                    && matches!(
+                        state.outer_ty_kind,
+                        OuterTyKind::None | OuterTyKind::NoneThroughFnPtr
+                    )
+                {
+                    // C functions can return void
                     FfiSafe
                 } else {
                     FfiUnsafe {
@@ -774,9 +821,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
             ty::Array(inner_ty, _) => {
                 if state.is_in_function()
-                    && outer_ty.contains(OuterTyData::NO_OUTER_TY)
-                    // FIXME(ctypes): VVV-this-VVV shouldn't be the case
-                    && !outer_ty.contains(OuterTyData::NO_OUTER_TY_FNPTR)
+                    // FIXME(ctypes): VVV-this-VVV shouldn't make a difference between ::None and ::NoneThroughFnPtr
+                    && matches!(state.outer_ty_kind, OuterTyKind::None)
                 {
                     // C doesn't really support passing arrays by value - the only way to pass an array by value
                     // is through a struct.
@@ -788,7 +834,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 } else {
                     // let's allow phantoms to go through,
                     // since an array of 1-ZSTs is also a 1-ZST
-                    self.visit_type(state, OuterTyData::from_ty(ty), inner_ty)
+                    self.visit_type(state.next(ty), inner_ty)
                 }
             }
 
@@ -806,19 +852,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
 
                 let sig = tcx.instantiate_bound_regions_with_erased(sig);
                 for arg in sig.inputs() {
-                    match self.visit_type(
-                        VisitorState::ARGUMENT_TY_IN_FNPTR,
-                        OuterTyData::from_ty(ty),
-                        *arg,
-                    ) {
+                    match self.visit_type(state.next_in_fnptr(ty, FnPos::Arg), *arg) {
                         FfiSafe => {}
                         r => return r,
                     }
                 }
 
                 let ret_ty = sig.output();
-
-                self.visit_type(VisitorState::RETURN_TY_IN_FNPTR, OuterTyData::from_ty(ty), ret_ty)
+                self.visit_type(state.next_in_fnptr(ty, FnPos::Ret), ret_ty)
             }
 
             ty::Foreign(..) => FfiSafe,
@@ -896,7 +937,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             return res;
         }
 
-        self.visit_type(state, OuterTyData::NO_OUTER_TY, ty)
+        self.visit_type(state, ty)
     }
 }
 
@@ -925,7 +966,7 @@ impl<'tcx> ImproperCTypesLint {
                     self.spans.push(ty.span);
                 }
 
-                hir::intravisit::walk_ty(self, ty)
+                hir::intravisit::walk_ty(self, ty);
             }
         }
 
@@ -970,12 +1011,12 @@ impl<'tcx> ImproperCTypesLint {
         let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
 
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
-            let state = VisitorState::argument_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Arg);
             self.check_type_for_external_abi_fnptr(cx, state, input_hir, *input_ty, fn_mode);
         }
 
         if let hir::FnRetTy::Return(ret_hir) = decl.output {
-            let state = VisitorState::return_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Ret);
             self.check_type_for_external_abi_fnptr(cx, state, ret_hir, sig.output(), fn_mode);
         }
     }
@@ -1000,7 +1041,7 @@ impl<'tcx> ImproperCTypesLint {
     fn check_foreign_static(&mut self, cx: &LateContext<'tcx>, id: hir::OwnerId, span: Span) {
         let ty = cx.tcx.type_of(id).instantiate_identity().skip_norm_wip();
         let mut visitor = ImproperCTypesVisitor::new(cx, ty, CItemKind::Declaration);
-        let ffi_res = visitor.check_type(VisitorState::STATIC_TY, ty);
+        let ffi_res = visitor.check_type(VisitorState::static_entry_point(), ty);
         self.process_ffi_result(cx, span, ffi_res, CItemKind::Declaration);
     }
 
@@ -1016,14 +1057,14 @@ impl<'tcx> ImproperCTypesLint {
         let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
 
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
-            let state = VisitorState::argument_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Arg);
             let mut visitor = ImproperCTypesVisitor::new(cx, *input_ty, fn_mode);
             let ffi_res = visitor.check_type(state, *input_ty);
             self.process_ffi_result(cx, input_hir.span, ffi_res, fn_mode);
         }
 
         if let hir::FnRetTy::Return(ret_hir) = decl.output {
-            let state = VisitorState::return_from_fnmode(fn_mode);
+            let state = VisitorState::fn_entry_point(fn_mode, FnPos::Ret);
             let mut visitor = ImproperCTypesVisitor::new(cx, sig.output(), fn_mode);
             let ffi_res = visitor.check_type(state, sig.output());
             self.process_ffi_result(cx, ret_hir.span, ffi_res, fn_mode);
@@ -1124,7 +1165,7 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesLint {
             | hir::ItemKind::TyAlias(_, _, ty) => {
                 self.check_type_for_external_abi_fnptr(
                     cx,
-                    VisitorState::STATIC_TY,
+                    VisitorState::static_entry_point(),
                     ty,
                     cx.tcx.type_of(item.owner_id).instantiate_identity().skip_norm_wip(),
                     CItemKind::Definition,
@@ -1158,7 +1199,7 @@ impl<'tcx> LateLintPass<'tcx> for ImproperCTypesLint {
     fn check_field_def(&mut self, cx: &LateContext<'tcx>, field: &'tcx hir::FieldDef<'tcx>) {
         self.check_type_for_external_abi_fnptr(
             cx,
-            VisitorState::STATIC_TY,
+            VisitorState::static_entry_point(),
             field.ty,
             cx.tcx.type_of(field.def_id).instantiate_identity().skip_norm_wip(),
             CItemKind::Definition,

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -138,17 +138,16 @@ declare_lint_pass!(ImproperCTypesLint => [
     USES_POWER_ALIGNMENT
 ]);
 
-/// Getting the (normalized) type out of a field (for, e.g., an enum variant or a tuple).
-#[inline]
-fn get_type_from_field<'tcx>(
+/// A common pattern in this lint is to attempt normalize_erasing_regions,
+/// but keep the original type if it were to fail.
+/// This may or may not be supported in the logic behind the `Unnormalized` wrapper,
+/// (FIXME?)
+/// but it should be enough for non-wrapped types to be as normalised as this lint needs them to be.
+fn maybe_normalize_erasing_regions<'tcx>(
     cx: &LateContext<'tcx>,
-    field: &ty::FieldDef,
-    args: GenericArgsRef<'tcx>,
+    value: Unnormalized<'tcx, Ty<'tcx>>,
 ) -> Ty<'tcx> {
-    let field_ty = field.ty(cx.tcx, args);
-    cx.tcx
-        .try_normalize_erasing_regions(cx.typing_env(), Unnormalized::new_wip(field_ty))
-        .unwrap_or(field_ty)
+    cx.tcx.try_normalize_erasing_regions(cx.typing_env(), value).unwrap_or(value.skip_norm_wip())
 }
 
 /// Check a variant of a non-exhaustive enum for improper ctypes
@@ -464,8 +463,17 @@ struct ImproperCTypesVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
-    fn new(cx: &'a LateContext<'tcx>, base_ty: Ty<'tcx>, base_fn_mode: CItemKind) -> Self {
-        ImproperCTypesVisitor { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
+    fn new(
+        cx: &'a LateContext<'tcx>,
+        base_ty: Unnormalized<'tcx, Ty<'tcx>>,
+        base_fn_mode: CItemKind,
+    ) -> Self {
+        ImproperCTypesVisitor {
+            cx,
+            base_ty: maybe_normalize_erasing_regions(cx, base_ty),
+            base_fn_mode,
+            cache: FxHashSet::default(),
+        }
     }
 
     /// Checks if the given indirection (box,ref,pointer) is "ffi-safe".
@@ -554,7 +562,10 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         let transparent_with_all_zst_fields = if def.repr().transparent() {
             if let Some(field) = super::transparent_newtype_field(self.cx.tcx, variant) {
                 // Transparent newtypes have at most one non-ZST field which needs to be checked..
-                let field_ty = get_type_from_field(self.cx, field, args);
+                let field_ty = maybe_normalize_erasing_regions(
+                    self.cx,
+                    Unnormalized::new_wip(field.ty(self.cx.tcx, args)),
+                );
                 match self.visit_type(state.next(ty), field_ty) {
                     FfiUnsafe { ty, .. } if ty.is_unit() => (),
                     r => return r,
@@ -573,7 +584,10 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         // We can't completely trust `repr(C)` markings, so make sure the fields are actually safe.
         let mut all_phantom = !variant.fields.is_empty();
         for field in &variant.fields {
-            let field_ty = get_type_from_field(self.cx, field, args);
+            let field_ty = maybe_normalize_erasing_regions(
+                self.cx,
+                Unnormalized::new_wip(field.ty(self.cx.tcx, args)),
+            );
             all_phantom &= match self.visit_type(state.next(ty), field_ty) {
                 FfiSafe => false,
                 // `()` fields are FFI-safe!
@@ -927,12 +941,12 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         })
     }
 
-    fn check_type(&mut self, state: VisitorState, ty: Ty<'tcx>) -> FfiResult<'tcx> {
-        let ty = self
-            .cx
-            .tcx
-            .try_normalize_erasing_regions(self.cx.typing_env(), Unnormalized::new_wip(ty))
-            .unwrap_or(ty);
+    fn check_type(
+        &mut self,
+        state: VisitorState,
+        ty: Unnormalized<'tcx, Ty<'tcx>>,
+    ) -> FfiResult<'tcx> {
+        let ty = maybe_normalize_erasing_regions(self.cx, ty);
         if let Some(res) = self.visit_for_opaque_ty(ty) {
             return res;
         }
@@ -990,6 +1004,7 @@ impl<'tcx> ImproperCTypesLint {
 
         let all_types = iter::zip(visitor.tys.drain(..), visitor.spans.drain(..));
         for (fn_ptr_ty, span) in all_types {
+            let fn_ptr_ty = Unnormalized::new_wip(fn_ptr_ty);
             let mut visitor = ImproperCTypesVisitor::new(cx, fn_ptr_ty, fn_mode);
             // FIXME(ctypes): make a check_for_fnptr
             let ffi_res = visitor.check_type(state, fn_ptr_ty);
@@ -1039,7 +1054,7 @@ impl<'tcx> ImproperCTypesLint {
     }
 
     fn check_foreign_static(&mut self, cx: &LateContext<'tcx>, id: hir::OwnerId, span: Span) {
-        let ty = cx.tcx.type_of(id).instantiate_identity().skip_norm_wip();
+        let ty = cx.tcx.type_of(id).instantiate_identity();
         let mut visitor = ImproperCTypesVisitor::new(cx, ty, CItemKind::Declaration);
         let ffi_res = visitor.check_type(VisitorState::static_entry_point(), ty);
         self.process_ffi_result(cx, span, ffi_res, CItemKind::Declaration);
@@ -1057,16 +1072,18 @@ impl<'tcx> ImproperCTypesLint {
         let sig = cx.tcx.instantiate_bound_regions_with_erased(sig);
 
         for (input_ty, input_hir) in iter::zip(sig.inputs(), decl.inputs) {
+            let input_ty = Unnormalized::new_wip(*input_ty);
             let state = VisitorState::fn_entry_point(fn_mode, FnPos::Arg);
-            let mut visitor = ImproperCTypesVisitor::new(cx, *input_ty, fn_mode);
-            let ffi_res = visitor.check_type(state, *input_ty);
+            let mut visitor = ImproperCTypesVisitor::new(cx, input_ty, fn_mode);
+            let ffi_res = visitor.check_type(state, input_ty);
             self.process_ffi_result(cx, input_hir.span, ffi_res, fn_mode);
         }
 
         if let hir::FnRetTy::Return(ret_hir) = decl.output {
+            let output_ty = Unnormalized::new_wip(sig.output());
             let state = VisitorState::fn_entry_point(fn_mode, FnPos::Ret);
-            let mut visitor = ImproperCTypesVisitor::new(cx, sig.output(), fn_mode);
-            let ffi_res = visitor.check_type(state, sig.output());
+            let mut visitor = ImproperCTypesVisitor::new(cx, output_ty, fn_mode);
+            let ffi_res = visitor.check_type(state, output_ty);
             self.process_ffi_result(cx, ret_hir.span, ffi_res, fn_mode);
         }
     }

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -261,7 +261,8 @@ provide! { tcx, def_id, other, cdata,
             .coerce_unsized_info
             .get(cdata, def_id.index)
             .map(|lazy| lazy.decode((cdata, tcx)))
-            .process_decoded(tcx, || panic!("{def_id:?} does not have coerce_unsized_info"))) }
+            .process_decoded(tcx, || panic!("{def_id:?} does not have coerce_unsized_info")))
+    }
     mir_const_qualif => { table }
     rendered_const => { table }
     rendered_precise_capturing_args => { table }
@@ -300,10 +301,10 @@ provide! { tcx, def_id, other, cdata,
         Ok(cdata
             .root
             .tables
-            .trait_impl_trait_tys
+            .collect_return_position_impl_trait_in_trait_tys
             .get(cdata, def_id.index)
             .map(|lazy| lazy.decode((cdata, tcx)))
-            .process_decoded(tcx, || panic!("{def_id:?} does not have trait_impl_trait_tys")))
+            .process_decoded(tcx, || panic!("{def_id:?} does not have collect_return_position_impl_trait_in_trait_tys")))
     }
 
     associated_types_for_impl_traits_in_trait_or_impl => { table }
@@ -695,6 +696,7 @@ impl CrateStore for CStore {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     fn untracked_as_any(&mut self) -> &mut dyn Any {
         self
     }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1628,7 +1628,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if tcx.impl_method_has_trait_impl_trait_tys(def_id)
                 && let Ok(table) = self.tcx.collect_return_position_impl_trait_in_trait_tys(def_id)
             {
-                record!(self.tables.trait_impl_trait_tys[def_id] <- table);
+                record!(self.tables.collect_return_position_impl_trait_in_trait_tys[def_id] <- table);
             }
             if let DefKind::Impl { .. } | DefKind::Trait = def_kind {
                 let table = tcx.associated_types_for_impl_traits_in_trait_or_impl(def_id);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -466,7 +466,7 @@ define_tables! {
     macro_definition: Table<DefIndex, LazyValue<ast::DelimArgs>>,
     proc_macro: Table<DefIndex, MacroKind>,
     deduced_param_attrs: Table<DefIndex, LazyArray<DeducedParamAttrs>>,
-    trait_impl_trait_tys: Table<DefIndex, LazyValue<DefIdMap<ty::EarlyBinder<'static, Ty<'static>>>>>,
+    collect_return_position_impl_trait_in_trait_tys: Table<DefIndex, LazyValue<DefIdMap<ty::EarlyBinder<'static, Ty<'static>>>>>,
     doc_link_resolutions: Table<DefIndex, LazyValue<DocLinkResMap>>,
     doc_link_traits_in_scope: Table<DefIndex, LazyArray<DefId>>,
     assumed_wf_types_for_rpitit: Table<DefIndex, LazyArray<(Ty<'static>, Span)>>,

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -1,7 +1,7 @@
 /// This higher-order macro declares a list of types which can be allocated by `Arena`.
 ///
 /// Specifying the `decode` modifier will add decode impls for `&T` and `&[T]` where `T` is the type
-/// listed. These impls will appear in the implement_ty_decoder! macro.
+/// listed. See the `impl_arena_allocatable_decoder!` macro for more.
 #[macro_export]
 macro_rules! arena_types {
     ($macro:path) => (
@@ -9,8 +9,7 @@ macro_rules! arena_types {
             [] layout: rustc_abi::LayoutData<rustc_abi::FieldIdx, rustc_abi::VariantIdx>,
             [] proxy_coroutine_layout: rustc_middle::mir::CoroutineLayout<'tcx>,
             [] fn_abi: rustc_target::callconv::FnAbi<'tcx, rustc_middle::ty::Ty<'tcx>>,
-            // AdtDef are interned and compared by address
-            [decode] adt_def: rustc_middle::ty::AdtDefData,
+            [] adt_def: rustc_middle::ty::AdtDefData,
             [] steal_thir: rustc_data_structures::steal::Steal<rustc_middle::thir::Thir<'tcx>>,
             [] steal_mir: rustc_data_structures::steal::Steal<rustc_middle::mir::Body<'tcx>>,
             [decode] mir: rustc_middle::mir::Body<'tcx>,
@@ -27,7 +26,7 @@ macro_rules! arena_types {
                     rustc_middle::mir::Body<'tcx>
                 >,
             [decode] typeck_results: rustc_middle::ty::TypeckResults<'tcx>,
-            [decode] borrowck_result: rustc_data_structures::fx::FxIndexMap<
+            [] borrowck_result: rustc_data_structures::fx::FxIndexMap<
                 rustc_hir::def_id::LocalDefId,
                 rustc_middle::ty::DefinitionSiteHiddenType<'tcx>,
             >,
@@ -100,7 +99,7 @@ macro_rules! arena_types {
             // (during lowering) and the `rustc_middle` arena (for decoding MIR)
             [decode] asm_template: rustc_ast::InlineAsmTemplatePiece,
             [decode] used_trait_imports: rustc_data_structures::unord::UnordSet<rustc_hir::def_id::LocalDefId>,
-            [decode] is_late_bound_map: rustc_data_structures::fx::FxIndexSet<rustc_hir::ItemLocalId>,
+            [] is_late_bound_map: rustc_data_structures::fx::FxIndexSet<rustc_hir::ItemLocalId>,
             [decode] impl_source: rustc_middle::traits::ImplSource<'tcx, ()>,
 
             [] dep_kind_vtable: rustc_middle::dep_graph::DepKindVTable<'tcx>,
@@ -111,7 +110,7 @@ macro_rules! arena_types {
                     rustc_middle::ty::EarlyBinder<'tcx, rustc_middle::ty::Ty<'tcx>>
                 >,
             [] external_constraints: rustc_middle::traits::solve::ExternalConstraintsData<rustc_middle::ty::TyCtxt<'tcx>>,
-            [decode] doc_link_resolutions: rustc_hir::def::DocLinkResMap,
+            [] doc_link_resolutions: rustc_hir::def::DocLinkResMap,
             [] stripped_cfg_items: rustc_hir::attrs::StrippedCfgItem,
             [] mod_child: rustc_middle::metadata::ModChild,
             [] features: rustc_feature::Features,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -413,13 +413,36 @@ impl<'tcx> Body<'tcx> {
     }
 
     pub fn typing_env(&self, tcx: TyCtxt<'tcx>) -> TypingEnv<'tcx> {
-        match self.phase {
-            // FIXME(#132279): we should reveal the opaques defined in the body during analysis.
-            MirPhase::Built | MirPhase::Analysis(_) => TypingEnv::new(
-                tcx.param_env(self.source.def_id()),
-                ty::TypingMode::non_body_analysis(),
-            ),
-            MirPhase::Runtime(_) => TypingEnv::post_analysis(tcx, self.source.def_id()),
+        if tcx.use_typing_mode_borrowck() {
+            match self.phase {
+                MirPhase::Built if let Some(def_id) = self.source.def_id().as_local() => {
+                    TypingEnv::new(
+                        tcx.param_env(self.source.def_id()),
+                        ty::TypingMode::borrowck(tcx, def_id),
+                    )
+                }
+                MirPhase::Analysis(_) if let Some(def_id) = self.source.def_id().as_local() => {
+                    TypingEnv::new(
+                        tcx.param_env(self.source.def_id()),
+                        ty::TypingMode::post_borrowck_analysis(tcx, def_id),
+                    )
+                }
+                MirPhase::Built | MirPhase::Analysis(_) => {
+                    // This branch happens for drop glue and fn ptr shims.
+                    // FIXME: why do we do any of this analysis on drop glue etc?
+                    // This should ideally all be skipped.
+                    TypingEnv::post_analysis(tcx, self.source.def_id())
+                }
+                MirPhase::Runtime(_) => TypingEnv::post_analysis(tcx, self.source.def_id()),
+            }
+        } else {
+            match self.phase {
+                MirPhase::Built | MirPhase::Analysis(_) => TypingEnv::new(
+                    tcx.param_env(self.source.def_id()),
+                    ty::TypingMode::non_body_analysis(),
+                ),
+                MirPhase::Runtime(_) => TypingEnv::post_analysis(tcx, self.source.def_id()),
+            }
         }
     }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -513,9 +513,8 @@ macro_rules! __impl_decoder_methods {
 }
 
 macro_rules! impl_arena_allocatable_decoder {
-    ([]$args:tt) => {};
-    ([decode $(, $attrs:ident)*]
-     [$name:ident: $ty:ty]) => {
+    ([]       $name:ident: $ty:ty) => {};
+    ([decode] $name:ident: $ty:ty) => {
         impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for $ty {
             #[inline]
             fn decode(decoder: &mut D) -> &'tcx Self {
@@ -535,7 +534,7 @@ macro_rules! impl_arena_allocatable_decoder {
 macro_rules! impl_arena_allocatable_decoders {
     ([$($a:tt $name:ident: $ty:ty,)*]) => {
         $(
-            impl_arena_allocatable_decoder!($a [$name: $ty]);
+            impl_arena_allocatable_decoder!($a $name: $ty);
         )*
     }
 }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -528,12 +528,6 @@ pub trait HasTyCtxt<'tcx>: HasDataLayout {
 
 pub trait HasTypingEnv<'tcx> {
     fn typing_env(&self) -> ty::TypingEnv<'tcx>;
-
-    /// FIXME(#132279): This method should not be used as in the future
-    /// everything should take a `TypingEnv` instead. Remove it as that point.
-    fn param_env(&self) -> ty::ParamEnv<'tcx> {
-        self.typing_env().param_env
-    }
 }
 
 impl<'tcx> HasDataLayout for TyCtxt<'tcx> {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -720,13 +720,15 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                     decls: Default::default(),
                     nested,
                     id,
+                    def_id: feed.def_id(),
                 };
 
                 self.add_import(module_path, kind, use_tree.span(), item, root_span, item.id, vis);
             }
             ast::UseTreeKind::Glob(_) => {
                 if !ast::attr::contains_name(&item.attrs, sym::prelude_import) {
-                    let kind = ImportKind::Glob { max_vis: CmCell::new(None), id };
+                    let kind =
+                        ImportKind::Glob { max_vis: CmCell::new(None), id, def_id: feed.def_id() };
                     self.add_import(prefix, kind, use_tree.span(), item, root_span, item.id, vis);
                 } else {
                     // Resolve the prelude import early.
@@ -1018,7 +1020,12 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         })
         .unwrap_or((true, None, self.r.dummy_decl));
         let import = self.r.arenas.alloc_import(ImportData {
-            kind: ImportKind::ExternCrate { source: orig_name, target: orig_ident, id: item.id },
+            kind: ImportKind::ExternCrate {
+                source: orig_name,
+                target: orig_ident,
+                id: item.id,
+                def_id: local_def_id,
+            },
             root_id: item.id,
             parent_scope,
             imported_module: CmCell::new(module),

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1277,7 +1277,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
         if !ident.as_str().starts_with('_') {
             self.r.unused_macros.insert(def_id, (node_id, ident));
             let nrules = self.r.local_macro_map[&def_id].nrules;
-            self.r.unused_macro_rules.insert(node_id, DenseBitSet::new_filled(nrules));
+            self.r.unused_macro_rules.insert(node_id, (def_id, DenseBitSet::new_filled(nrules)));
         }
     }
 

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -431,8 +431,7 @@ impl Resolver<'_, '_> {
                         }
                     }
                 }
-                ImportKind::ExternCrate { id, .. } => {
-                    let def_id = self.local_def_id(id);
+                ImportKind::ExternCrate { id, def_id, .. } => {
                     if self.extern_crate_map.get(&def_id).is_none_or(|&cnum| {
                         !tcx.is_compiler_builtins(cnum)
                             && !tcx.is_panic_runtime(cnum)

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -45,10 +45,7 @@ impl Resolver<'_, '_> {
     fn private_vis_import(&self, decl: Decl<'_>) -> Visibility {
         let DeclKind::Import { import, .. } = decl.kind else { unreachable!() };
         Visibility::Restricted(
-            import
-                .id()
-                .map(|id| self.nearest_normal_mod(self.local_def_id(id)))
-                .unwrap_or(CRATE_DEF_ID),
+            import.def_id().map(|id| self.nearest_normal_mod(id)).unwrap_or(CRATE_DEF_ID),
         )
     }
 
@@ -96,8 +93,8 @@ impl<'a, 'ra, 'tcx> EffectiveVisibilitiesVisitor<'a, 'ra, 'tcx> {
         // is the maximum value among visibilities of declarations corresponding to that def id.
         for (decl, eff_vis) in visitor.import_effective_visibilities.iter() {
             let DeclKind::Import { import, .. } = decl.kind else { unreachable!() };
-            if let Some(node_id) = import.id() {
-                r.effective_visibilities.update_eff_vis(r.local_def_id(node_id), eff_vis, r.tcx)
+            if let Some(def_id) = import.def_id() {
+                r.effective_visibilities.update_eff_vis(def_id, eff_vis, r.tcx)
             }
             if decl.ambiguity.get().is_some() && eff_vis.is_public_at_level(Level::Reexported) {
                 exported_ambiguities.insert(*decl);

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -16,7 +16,7 @@ use rustc_hir::Attribute;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::attrs::diagnostic::{CustomDiagnostic, Directive, FormatArgs};
 use rustc_hir::def::{self, DefKind, PartialRes};
-use rustc_hir::def_id::{DefId, LocalDefIdMap};
+use rustc_hir::def_id::{DefId, LocalDefId, LocalDefIdMap};
 use rustc_middle::metadata::{AmbigModChild, ModChild, Reexport};
 use rustc_middle::span_bug;
 use rustc_middle::ty::{TyCtxt, Visibility};
@@ -90,17 +90,20 @@ pub(crate) enum ImportKind<'ra> {
         /// If this is the import for `foo::bar::a`, we would have the ID of the `UseTree`
         /// for `a` in this field.
         id: NodeId,
+        def_id: LocalDefId,
     },
     Glob {
         // The visibility of the greatest re-export.
         // n.b. `max_vis` is only used in `finalize_import` to check for re-export errors.
         max_vis: CmCell<Option<Visibility>>,
         id: NodeId,
+        def_id: LocalDefId,
     },
     ExternCrate {
         source: Option<Symbol>,
         target: Ident,
         id: NodeId,
+        def_id: LocalDefId,
     },
     MacroUse {
         /// A field has been added indicating whether it should be reported as a lint,
@@ -116,7 +119,7 @@ impl<'ra> std::fmt::Debug for ImportKind<'ra> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use ImportKind::*;
         match self {
-            Single { source, target, decls, nested, id, .. } => f
+            Single { source, target, decls, nested, id, def_id } => f
                 .debug_struct("Single")
                 .field("source", source)
                 .field("target", target)
@@ -127,15 +130,20 @@ impl<'ra> std::fmt::Debug for ImportKind<'ra> {
                 )
                 .field("nested", nested)
                 .field("id", id)
+                .field("def_id", def_id)
                 .finish(),
-            Glob { max_vis, id } => {
-                f.debug_struct("Glob").field("max_vis", max_vis).field("id", id).finish()
-            }
-            ExternCrate { source, target, id } => f
+            Glob { max_vis, id, def_id } => f
+                .debug_struct("Glob")
+                .field("max_vis", max_vis)
+                .field("id", id)
+                .field("def_id", def_id)
+                .finish(),
+            ExternCrate { source, target, id, def_id } => f
                 .debug_struct("ExternCrate")
                 .field("source", source)
                 .field("target", target)
                 .field("id", id)
+                .field("def_id", def_id)
                 .finish(),
             MacroUse { warn_private } => {
                 f.debug_struct("MacroUse").field("warn_private", warn_private).finish()
@@ -260,12 +268,11 @@ impl<'ra> ImportData<'ra> {
         }
     }
 
-    pub(crate) fn simplify(&self, r: &Resolver<'_, '_>) -> Reexport {
-        let to_def_id = |id| r.local_def_id(id).to_def_id();
+    pub(crate) fn simplify(&self) -> Reexport {
         match self.kind {
-            ImportKind::Single { id, .. } => Reexport::Single(to_def_id(id)),
-            ImportKind::Glob { id, .. } => Reexport::Glob(to_def_id(id)),
-            ImportKind::ExternCrate { id, .. } => Reexport::ExternCrate(to_def_id(id)),
+            ImportKind::Single { def_id, .. } => Reexport::Single(def_id.to_def_id()),
+            ImportKind::Glob { def_id, .. } => Reexport::Glob(def_id.to_def_id()),
+            ImportKind::ExternCrate { def_id, .. } => Reexport::ExternCrate(def_id.to_def_id()),
             ImportKind::MacroUse { .. } => Reexport::MacroUse,
             ImportKind::MacroExport => Reexport::MacroExport,
         }
@@ -1267,7 +1274,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         let (ident, target, bindings, import_id) = match import.kind {
             ImportKind::Single { source, target, ref decls, id, .. } => (source, target, decls, id),
-            ImportKind::Glob { ref max_vis, id } => {
+            ImportKind::Glob { ref max_vis, id, def_id: _ } => {
                 if import.module_path.len() <= 1 {
                     // HACK(eddyb) `lint_if_path_starts_with_module` needs at least
                     // 2 segments, so the `resolve_path` above won't trigger it.
@@ -1829,23 +1836,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut children = Vec::new();
         let mut ambig_children = Vec::new();
 
-        module.to_module().for_each_child(self, |this, ident, orig_ident_span, _, binding| {
+        module.to_module().for_each_child(self, |_this, ident, orig_ident_span, _, binding| {
             let res = binding.res().expect_non_local();
             if res != def::Res::Err {
                 let ident = ident.orig(orig_ident_span);
                 let child =
                     |reexport_chain| ModChild { ident, res, vis: binding.vis(), reexport_chain };
                 if let Some((ambig_binding1, ambig_binding2)) = binding.descent_to_ambiguity() {
-                    let main = child(ambig_binding1.reexport_chain(this));
+                    let main = child(ambig_binding1.reexport_chain());
                     let second = ModChild {
                         ident,
                         res: ambig_binding2.res().expect_non_local(),
                         vis: ambig_binding2.vis(),
-                        reexport_chain: ambig_binding2.reexport_chain(this),
+                        reexport_chain: ambig_binding2.reexport_chain(),
                     };
                     ambig_children.push(AmbigModChild { main, second })
                 } else {
-                    children.push(child(binding.reexport_chain(this)));
+                    children.push(child(binding.reexport_chain()));
                 }
             }
         });

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -356,13 +356,16 @@ struct UnresolvedImportError {
 
 // Reexports of the form `pub use foo as bar;` where `foo` is `extern crate foo;`
 // are permitted for backward-compatibility under a deprecation lint.
-fn pub_use_of_private_extern_crate_hack(import: ImportSummary, decl: Decl<'_>) -> Option<NodeId> {
+fn pub_use_of_private_extern_crate_hack(
+    import: ImportSummary,
+    decl: Decl<'_>,
+) -> Option<LocalDefId> {
     match (import.is_single, decl.kind) {
         (true, DeclKind::Import { import: decl_import, .. })
-            if let ImportKind::ExternCrate { id, .. } = decl_import.kind
+            if let ImportKind::ExternCrate { def_id, .. } = decl_import.kind
                 && import.vis.is_public() =>
         {
-            Some(id)
+            Some(def_id)
         }
         _ => None,
     }
@@ -1282,7 +1285,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         let (ident, target, bindings, import_id) = match import.kind {
             ImportKind::Single { source, target, ref decls, id, .. } => (source, target, decls, id),
-            ImportKind::Glob { ref max_vis, id, def_id: _ } => {
+            ImportKind::Glob { ref max_vis, id, def_id } => {
                 if import.module_path.len() <= 1 {
                     // HACK(eddyb) `lint_if_path_starts_with_module` needs at least
                     // 2 segments, so the `resolve_path` above won't trigger it.
@@ -1309,7 +1312,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 if let Some(max_vis) = max_vis.get()
                     && import.vis.greater_than(max_vis, self.tcx)
                 {
-                    let def_id = self.local_def_id(id);
                     self.lint_buffer.buffer_lint(
                         UNUSED_IMPORTS,
                         id,
@@ -1629,7 +1631,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if let Some(extern_crate_id) = pub_use_of_private_extern_crate_hack(import.summary(), decl)
         {
             let ImportKind::Single { id, .. } = import.kind else { unreachable!() };
-            let sugg = self.tcx.source_span(self.local_def_id(extern_crate_id)).shrink_to_lo();
+            let sugg = self.tcx.source_span(extern_crate_id).shrink_to_lo();
             let diagnostic = crate::errors::PrivateExternCrateReexport { ident, sugg };
             return Some(BufferedEarlyLint {
                 lint_id: LintId::of(PUB_USE_OF_PRIVATE_EXTERN_CRATE),
@@ -1671,7 +1673,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     pub(crate) fn check_for_redundant_imports(&mut self, import: Import<'ra>) -> bool {
         // This function is only called for single imports.
-        let ImportKind::Single { source, target, ref decls, id, .. } = import.kind else {
+        let ImportKind::Single { source, target, ref decls, id, def_id, .. } = import.kind else {
             unreachable!()
         };
 
@@ -1690,7 +1692,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Skip if the import is public or was used through non scope-based resolution,
         // e.g. through a module-relative path.
         if self.import_use_map.get(&import) == Some(&Used::Other)
-            || self.effective_visibilities.is_exported(self.local_def_id(id))
+            || self.effective_visibilities.is_exported(def_id)
         {
             return false;
         }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -268,6 +268,15 @@ impl<'ra> ImportData<'ra> {
         }
     }
 
+    pub(crate) fn def_id(&self) -> Option<LocalDefId> {
+        match self.kind {
+            ImportKind::Single { def_id, .. }
+            | ImportKind::Glob { def_id, .. }
+            | ImportKind::ExternCrate { def_id, .. } => Some(def_id),
+            ImportKind::MacroUse { .. } | ImportKind::MacroExport => None,
+        }
+    }
+
     pub(crate) fn simplify(&self) -> Reexport {
         match self.kind {
             ImportKind::Single { def_id, .. } => Reexport::Single(def_id.to_def_id()),
@@ -852,8 +861,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     if binding.res() != Res::Err
                         && glob_decl.res() != Res::Err
                         && let DeclKind::Import { import: glob_import, .. } = glob_decl.kind
-                        && let Some(glob_import_id) = glob_import.id()
-                        && let glob_import_def_id = self.local_def_id(glob_import_id)
+                        && let Some(glob_import_def_id) = glob_import.def_id()
                         && self.effective_visibilities.is_exported(glob_import_def_id)
                         && glob_decl.vis().is_public()
                         && !binding.vis().is_public()
@@ -882,7 +890,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
                 if let DeclKind::Import { import, .. } = binding.kind
                     && let Some(binding_id) = import.id()
-                    && let import_def_id = self.local_def_id(binding_id)
+                    && let import_def_id = import.def_id().unwrap()
                     && self.effective_visibilities.is_exported(import_def_id)
                     && let Res::Def(reexported_kind, reexported_def_id) = binding.res()
                     && !matches!(reexported_kind, DefKind::Ctor(..))

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1171,11 +1171,11 @@ impl<'ra> DeclData<'ra> {
         self.res().macro_kinds()
     }
 
-    fn reexport_chain(self: Decl<'ra>, r: &Resolver<'_, '_>) -> SmallVec<[Reexport; 2]> {
+    fn reexport_chain(self: Decl<'ra>) -> SmallVec<[Reexport; 2]> {
         let mut reexport_chain = SmallVec::new();
         let mut next_binding = self;
         while let DeclKind::Import { source_decl, import, .. } = next_binding.kind {
-            reexport_chain.push(import.simplify(r));
+            reexport_chain.push(import.simplify());
             next_binding = source_decl;
         }
         reexport_chain

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2291,8 +2291,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
     #[inline]
     fn add_to_glob_map(&mut self, import: Import<'_>, name: Symbol) {
-        if let ImportKind::Glob { id, .. } = import.kind {
-            let def_id = self.local_def_id(id);
+        if let ImportKind::Glob { def_id, .. } = import.kind {
             self.glob_map.entry(def_id).or_default().insert(name);
         }
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2155,8 +2155,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     ) -> &'tcx [LocalDefId] {
         let mut import_ids: SmallVec<[LocalDefId; 1]> = smallvec![];
         while let DeclKind::Import { import, source_decl, .. } = kind {
-            if let Some(node_id) = import.id() {
-                let def_id = self.local_def_id(node_id);
+            if let Some(def_id) = import.def_id() {
                 self.maybe_unused_trait_imports.insert(def_id);
                 import_ids.push(def_id);
             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1405,8 +1405,8 @@ pub struct Resolver<'ra, 'tcx> {
     local_macro_def_scopes: FxHashMap<LocalDefId, LocalModule<'ra>> = default::fx_hash_map(),
     ast_transform_scopes: FxHashMap<LocalExpnId, LocalModule<'ra>> = default::fx_hash_map(),
     unused_macros: FxIndexMap<LocalDefId, (NodeId, Ident)>,
-    /// A map from the macro to all its potentially unused arms.
-    unused_macro_rules: FxIndexMap<NodeId, DenseBitSet<usize>>,
+    /// A map from the macro to all its potentially unused arms and the `LocalDefId` of the macro itself.
+    unused_macro_rules: FxIndexMap<NodeId, (LocalDefId, DenseBitSet<usize>)>,
     proc_macro_stubs: FxHashSet<LocalDefId> = default::fx_hash_set(),
     /// Traces collected during macro resolution and validated when it's complete.
     single_segment_macro_resolutions:

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -339,7 +339,7 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
     }
 
     fn record_macro_rule_usage(&mut self, id: NodeId, rule_i: usize) {
-        if let Some(rules) = self.unused_macro_rules.get_mut(&id) {
+        if let Some((_, rules)) = self.unused_macro_rules.get_mut(&id) {
             rules.remove(rule_i);
         }
     }
@@ -356,11 +356,10 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             self.unused_macro_rules.swap_remove(&node_id);
         }
 
-        for (&node_id, unused_arms) in self.unused_macro_rules.iter() {
+        for (&node_id, (def_id, unused_arms)) in self.unused_macro_rules.iter() {
             if unused_arms.is_empty() {
                 continue;
             }
-            let def_id = self.local_def_id(node_id);
             let m = &self.local_macro_map[&def_id];
             let SyntaxExtensionKind::MacroRules(ref m) = m.ext.kind else {
                 continue;

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -375,13 +375,17 @@ pub struct EarlyBinder<I: Interner, T> {
 
 impl<I: Interner, T: Eq> Eq for EarlyBinder<I, T> {}
 
-/// For early binders, you should first call `instantiate` before using any visitors.
+// FIXME(154045): Recommended as per https://github.com/rust-lang/rust/issues/154045, this is so sad :((
 #[cfg(feature = "nightly")]
-impl<I: Interner, T> !TypeFoldable<I> for ty::EarlyBinder<I, T> {}
+macro_rules! generate { ($( $tt:tt )*) => { $( $tt )* } }
 
-/// For early binders, you should first call `instantiate` before using any visitors.
 #[cfg(feature = "nightly")]
-impl<I: Interner, T> !TypeVisitable<I> for ty::EarlyBinder<I, T> {}
+generate!(
+    /// For early binders, you should first call `instantiate` before using any visitors.
+    impl<I: Interner, T> !TypeFoldable<I> for ty::EarlyBinder<I, T> {}
+    /// For early binders, you should first call `instantiate` before using any visitors.
+    impl<I: Interner, T> !TypeVisitable<I> for ty::EarlyBinder<I, T> {}
+);
 
 impl<I: Interner, T> EarlyBinder<I, T> {
     pub fn bind(value: T) -> EarlyBinder<I, T> {

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -118,6 +118,11 @@ bitflags::bitflags! {
         /// Does this have any `ReErased` regions?
         const HAS_RE_ERASED               = 1 << 21;
 
+        /// Does this have any regions of any kind?
+        const HAS_REGIONS                 = TypeFlags::HAS_FREE_REGIONS.bits()
+                                          | TypeFlags::HAS_RE_BOUND.bits()
+                                          | TypeFlags::HAS_RE_ERASED.bits();
+
         /// Does this value have parameters/placeholders/inference variables which could be
         /// replaced later, in a way that would change the results of `impl` specialization?
         const STILL_FURTHER_SPECIALIZABLE = TypeFlags::HAS_TY_PARAM.bits()
@@ -192,7 +197,7 @@ impl<I: Interner> FlagComputation<I> {
     }
 
     fn add_flags(&mut self, flags: TypeFlags) {
-        self.flags = self.flags | flags;
+        self.flags |= flags;
     }
 
     /// indicates that `self` refers to something at binding level `binder`

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -139,7 +139,7 @@ bitflags::bitflags! {
         /// Does this type have any coroutines in it?
         const HAS_TY_CORO                 = 1 << 25;
 
-        /// Does this have have a `Bound(BoundVarIndexKind::Canonical, _)`?
+        /// Does this have a `Bound(BoundVarIndexKind::Canonical, _)`?
         const HAS_CANONICAL_BOUND         = 1 << 26;
     }
 }

--- a/compiler/rustc_type_ir/src/fold.rs
+++ b/compiler/rustc_type_ir/src/fold.rs
@@ -55,7 +55,7 @@ use tracing::{debug, instrument};
 
 use crate::inherent::*;
 use crate::visit::{TypeVisitable, TypeVisitableExt as _};
-use crate::{self as ty, BoundVarIndexKind, Interner, TypeFlags};
+use crate::{self as ty, BoundVarIndexKind, Interner};
 
 /// This trait is implemented for every type that can be folded,
 /// providing the skeleton of the traversal.
@@ -433,6 +433,10 @@ impl<I: Interner> TypeFolder<I> for Shifter<I> {
     fn fold_predicate(&mut self, p: I::Predicate) -> I::Predicate {
         if p.has_vars_bound_at_or_above(self.current_index) { p.super_fold_with(self) } else { p }
     }
+
+    fn fold_clauses(&mut self, c: I::Clauses) -> I::Clauses {
+        if c.has_vars_bound_at_or_above(self.current_index) { c.super_fold_with(self) } else { c }
+    }
 }
 
 pub fn shift_region<I: Interner>(cx: I, region: I::Region, amount: u32) -> I::Region {
@@ -535,32 +539,18 @@ where
     }
 
     fn fold_ty(&mut self, t: I::Ty) -> I::Ty {
-        if t.has_type_flags(
-            TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_RE_BOUND | TypeFlags::HAS_RE_ERASED,
-        ) {
-            t.super_fold_with(self)
-        } else {
-            t
-        }
+        if t.has_regions() { t.super_fold_with(self) } else { t }
     }
 
     fn fold_const(&mut self, ct: I::Const) -> I::Const {
-        if ct.has_type_flags(
-            TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_RE_BOUND | TypeFlags::HAS_RE_ERASED,
-        ) {
-            ct.super_fold_with(self)
-        } else {
-            ct
-        }
+        if ct.has_regions() { ct.super_fold_with(self) } else { ct }
     }
 
     fn fold_predicate(&mut self, p: I::Predicate) -> I::Predicate {
-        if p.has_type_flags(
-            TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_RE_BOUND | TypeFlags::HAS_RE_ERASED,
-        ) {
-            p.super_fold_with(self)
-        } else {
-            p
-        }
+        if p.has_regions() { p.super_fold_with(self) } else { p }
+    }
+
+    fn fold_clauses(&mut self, c: I::Clauses) -> I::Clauses {
+        if c.has_regions() { c.super_fold_with(self) } else { c }
     }
 }

--- a/compiler/rustc_type_ir/src/fold.rs
+++ b/compiler/rustc_type_ir/src/fold.rs
@@ -121,10 +121,6 @@ pub trait TypeSuperFoldable<I: Interner>: TypeFoldable<I> {
 /// default that does an "identity" fold. Implementations of these methods
 /// often fall back to a `super_fold_with` method if the primary argument
 /// doesn't satisfy a particular condition.
-///
-/// A blanket implementation of [`FallibleTypeFolder`] will defer to
-/// the infallible methods of this trait to ensure that the two APIs
-/// are coherent.
 pub trait TypeFolder<I: Interner>: Sized {
     fn cx(&self) -> I;
 
@@ -477,10 +473,10 @@ where
 /// Folds over the substructure of a type, visiting its component
 /// types and all regions that occur *free* within it.
 ///
-/// That is, function pointer types and trait object can introduce
-/// new bound regions which are not visited by this visitors as
+/// That is, function pointer types and trait objects can introduce
+/// new bound regions which are not visited by this visitor as
 /// they are not free; only regions that occur free will be
-/// visited by `fld_r`.
+/// visited by `fold_region_fn`.
 pub struct RegionFolder<I, F> {
     cx: I,
 
@@ -489,7 +485,7 @@ pub struct RegionFolder<I, F> {
     /// binder, it is incremented (via `shift_in`).
     current_index: ty::DebruijnIndex,
 
-    /// Callback invokes for each free region. The `DebruijnIndex`
+    /// Callback invoked for each free region. The `DebruijnIndex`
     /// points to the binder *just outside* the ones we have passed
     /// through.
     fold_region_fn: F,

--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -1,11 +1,12 @@
 use std::fmt;
 
 use crate::{
-    AliasTerm, AliasTy, Binder, ClosureKind, CoercePredicate, ExistentialProjection,
-    ExistentialTraitRef, FnSig, HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate,
-    PatternKind, Placeholder, ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef,
-    UnevaluatedConst,
+    AliasTerm, AliasTy, Binder, CoercePredicate, ExistentialProjection, ExistentialTraitRef, FnSig,
+    HostEffectPredicate, Interner, NormalizesTo, OutlivesPredicate, PatternKind, Placeholder,
+    ProjectionPredicate, SubtypePredicate, TraitPredicate, TraitRef,
 };
+#[cfg(feature = "nightly")]
+use crate::{ClosureKind, UnevaluatedConst};
 
 pub trait IrPrint<T> {
     fn print(t: &T, fmt: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -285,6 +285,10 @@ pub trait TypeVisitableExt<I: Interner>: TypeVisitable<I> {
         self.has_type_flags(TypeFlags::HAS_PARAM - TypeFlags::HAS_RE_PARAM)
     }
 
+    fn has_regions(&self) -> bool {
+        self.has_type_flags(TypeFlags::HAS_REGIONS)
+    }
+
     fn has_infer_regions(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_RE_INFER)
     }
@@ -363,13 +367,12 @@ pub trait TypeVisitableExt<I: Interner>: TypeVisitable<I> {
 
 impl<I: Interner, T: TypeVisitable<I>> TypeVisitableExt<I> for T {
     fn has_type_flags(&self, flags: TypeFlags) -> bool {
-        let res =
-            self.visit_with(&mut HasTypeFlagsVisitor { flags }) == ControlFlow::Break(FoundFlags);
-        res
+        self.visit_with(&mut HasTypeFlagsVisitor { flags }) == ControlFlow::Break(FoundFlags)
     }
 
     fn has_vars_bound_at_or_above(&self, binder: ty::DebruijnIndex) -> bool {
-        self.visit_with(&mut HasEscapingVarsVisitor { outer_index: binder }).is_break()
+        self.visit_with(&mut HasEscapingVarsVisitor { outer_index: binder })
+            == ControlFlow::Break(FoundEscapingVars)
     }
 
     fn error_reported(&self) -> Result<(), I::ErrorGuaranteed> {
@@ -438,8 +441,7 @@ impl<I: Interner> TypeVisitor<I> for HasTypeFlagsVisitor {
     #[inline]
     fn visit_ty(&mut self, t: I::Ty) -> Self::Result {
         // Note: no `super_visit_with` call.
-        let flags = t.flags();
-        if flags.intersects(self.flags) {
+        if t.flags().intersects(self.flags) {
             ControlFlow::Break(FoundFlags)
         } else {
             ControlFlow::Continue(())
@@ -449,8 +451,7 @@ impl<I: Interner> TypeVisitor<I> for HasTypeFlagsVisitor {
     #[inline]
     fn visit_region(&mut self, r: I::Region) -> Self::Result {
         // Note: no `super_visit_with` call, as usual for `Region`.
-        let flags = r.flags();
-        if flags.intersects(self.flags) {
+        if r.flags().intersects(self.flags) {
             ControlFlow::Break(FoundFlags)
         } else {
             ControlFlow::Continue(())

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -67,7 +67,7 @@ pub trait TypeVisitable<I: Interner>: fmt::Debug {
     /// each field/element.
     ///
     /// For types of interest (such as `Ty`), the implementation of this method
-    /// that calls a visitor method specifically for that type (such as
+    /// calls a visitor method specifically for that type (such as
     /// `V::visit_ty`). This is where control transfers from `TypeVisitable` to
     /// `TypeVisitor`.
     fn visit_with<V: TypeVisitor<I>>(&self, visitor: &mut V) -> V::Result;
@@ -102,8 +102,8 @@ pub trait TypeVisitor<I: Interner>: Sized {
         t.super_visit_with(self)
     }
 
-    // The default region visitor is a no-op because `Region` is non-recursive
-    // and has no `super_visit_with` method to call.
+    // `Region` is non-recursive so the default region visitor has no
+    // `super_visit_with` method to call.
     fn visit_region(&mut self, r: I::Region) -> Self::Result {
         if let ty::ReError(guar) = r.kind() {
             self.visit_error(guar)
@@ -251,10 +251,10 @@ pub trait TypeVisitableExt<I: Interner>: TypeVisitable<I> {
         self.has_vars_bound_at_or_above(binder.shifted_in(1))
     }
 
-    /// Return `true` if this type has regions that are not a part of the type.
-    /// For example, `for<'a> fn(&'a i32)` return `false`, while `fn(&'a i32)`
-    /// would return `true`. The latter can occur when traversing through the
-    /// former.
+    /// Returns `true` if this type has regions that are not a part of the
+    /// type. For example, given a `for<'a> fn(&'a i32)` this function returns
+    /// `false`, while given a `fn(&'a i32)` it returns `true`. The latter can
+    /// occur when traversing through the former.
     ///
     /// See [`HasEscapingVarsVisitor`] for more information.
     fn has_escaping_bound_vars(&self) -> bool {
@@ -571,7 +571,7 @@ impl<I: Interner> TypeVisitor<I> for HasEscapingVarsVisitor {
         // `outer_index`, that means that `ct` contains some content
         // bound at `outer_index` or above (because
         // `outer_exclusive_binder` is always 1 higher than the
-        // content in `t`). Therefore, `t` has some escaping vars.
+        // content in `ct`). Therefore, `ct` has some escaping vars.
         if ct.outer_exclusive_binder() > self.outer_index {
             ControlFlow::Break(FoundEscapingVars)
         } else {

--- a/tests/run-make-cargo/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make-cargo/rustc-crates-on-stable/rmake.rs
@@ -10,7 +10,7 @@ fn main() {
         .env("RUSTC_STAGE", "0")
         .env("RUSTC", rustc_path())
         // We want to disallow all nightly features to simulate a stable build
-        .env("RUSTFLAGS", "-Zallow-features=")
+        .env("RUSTFLAGS", "-D warnings -Zallow-features=")
         .arg("build")
         .arg("--manifest-path")
         .arg(source_root().join("Cargo.toml"))


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#146273 (lint ImproperCTypes: refactor linting architecture (part 2))
 - rust-lang/rust#156173 (Fewer global node_id_to_def_id lookups)
 - rust-lang/rust#155961 (Deny warnings in the test for crates that are available on stable)
 - rust-lang/rust#156130 (Fold/visit tweaks)
 - rust-lang/rust#156131 (Metadata macro/query cleanups)
 - rust-lang/rust#156141 (Resolve some cases of rust-lang/rust#132279 by using the right typing mode in the next solver)
 - rust-lang/rust#156202 (llvm: Use correct type for splat mask)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=146273,156173,155961,156130,156131,156141,156202)
<!-- homu-ignore:end -->

