### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -170,6 +170,7 @@ pub struct MacroRulesMacroExpander {
     transparency: Transparency,
     kinds: MacroKinds,
     rules: Vec<MacroRule>,
+    macro_rules: bool,
 }
 
 impl MacroRulesMacroExpander {
@@ -187,6 +188,14 @@ impl MacroRulesMacroExpander {
 
     pub fn kinds(&self) -> MacroKinds {
         self.kinds
+    }
+
+    pub fn nrules(&self) -> usize {
+        self.rules.len()
+    }
+
+    pub fn is_macro_rules(&self) -> bool {
+        self.macro_rules
     }
 
     pub fn expand_derive(
@@ -714,13 +723,12 @@ pub fn compile_declarative_macro(
     span: Span,
     node_id: NodeId,
     edition: Edition,
-) -> (SyntaxExtension, usize) {
+) -> SyntaxExtension {
     let mk_syn_ext = |kind| {
         let is_local = is_defined_in_current_crate(node_id);
         SyntaxExtension::new(sess, kind, span, Vec::new(), edition, ident.name, attrs, is_local)
     };
-    let dummy_syn_ext =
-        |guar| (mk_syn_ext(SyntaxExtensionKind::Bang(Arc::new(DummyBang(guar)))), 0);
+    let dummy_syn_ext = |guar| mk_syn_ext(SyntaxExtensionKind::Bang(Arc::new(DummyBang(guar))));
 
     let macro_rules = macro_def.macro_rules;
     let exp_sep = if macro_rules { exp!(Semi) } else { exp!(Comma) };
@@ -857,9 +865,6 @@ pub fn compile_declarative_macro(
         return dummy_syn_ext(guar);
     }
 
-    // Return the number of rules for unused rule linting, if this is a local macro.
-    let nrules = if is_defined_in_current_crate(node_id) { rules.len() } else { 0 };
-
     let on_unmatch_args = find_attr!(
         attrs,
         OnUnmatchArgs { directive, .. } => directive.clone()
@@ -875,8 +880,9 @@ pub fn compile_declarative_macro(
         on_unmatch_args,
         transparency,
         rules,
+        macro_rules,
     };
-    (mk_syn_ext(SyntaxExtensionKind::MacroRules(Arc::new(exp))), nrules)
+    mk_syn_ext(SyntaxExtensionKind::MacroRules(Arc::new(exp)))
 }
 
 fn check_no_eof(sess: &Session, p: &Parser<'_>, msg: &'static str) -> Option<ErrorGuaranteed> {

--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -8,7 +8,7 @@ use rustc_hir::def::{CtorKind, CtorOf, DefKind};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_span::{DUMMY_SP, Span, Symbol};
-use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
+use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::{CollectAndApply, Interner, TypeFoldable, Unnormalized, search_graph};
 
 use crate::dep_graph::{DepKind, DepNodeIndex};
@@ -39,6 +39,20 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     type AdtId = DefId;
     type ImplId = DefId;
     type UnevaluatedConstId = DefId;
+    type TraitAssocTyId = DefId;
+    type TraitAssocConstId = DefId;
+    type TraitAssocTermId = DefId;
+    type OpaqueTyId = DefId;
+    type LocalOpaqueTyId = LocalDefId;
+    type FreeTyAliasId = DefId;
+    type FreeConstAliasId = DefId;
+    type FreeTermAliasId = DefId;
+    type ImplOrTraitAssocTyId = DefId;
+    type ImplOrTraitAssocConstId = DefId;
+    type ImplOrTraitAssocTermId = DefId;
+    type InherentAssocTyId = DefId;
+    type InherentAssocConstId = DefId;
+    type InherentAssocTermId = DefId;
     type Span = Span;
 
     type GenericArgs = ty::GenericArgsRef<'tcx>;
@@ -288,7 +302,15 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.mk_type_list_from_iter(args)
     }
 
-    fn parent(self, def_id: DefId) -> DefId {
+    fn projection_parent(self, def_id: Self::TraitAssocTermId) -> Self::TraitId {
+        self.parent(def_id)
+    }
+
+    fn impl_or_trait_assoc_term_parent(self, def_id: Self::ImplOrTraitAssocTyId) -> DefId {
+        self.parent(def_id)
+    }
+
+    fn inherent_alias_term_parent(self, def_id: Self::InherentAssocTermId) -> Self::ImplId {
         self.parent(def_id)
     }
 
@@ -446,7 +468,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         !self.codegen_fn_attrs(def_id).target_features.is_empty()
     }
 
-    fn require_lang_item(self, lang_item: SolverLangItem) -> DefId {
+    fn require_projection_lang_item(self, lang_item: SolverProjectionLangItem) -> DefId {
         self.require_lang_item(solver_lang_item_to_lang_item(lang_item), DUMMY_SP)
     }
 
@@ -458,7 +480,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.require_lang_item(solver_adt_lang_item_to_lang_item(lang_item), DUMMY_SP)
     }
 
-    fn is_lang_item(self, def_id: DefId, lang_item: SolverLangItem) -> bool {
+    fn is_projection_lang_item(self, def_id: DefId, lang_item: SolverProjectionLangItem) -> bool {
         self.is_lang_item(def_id, solver_lang_item_to_lang_item(lang_item))
     }
 
@@ -478,7 +500,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.is_sizedness_trait(def_id)
     }
 
-    fn as_lang_item(self, def_id: DefId) -> Option<SolverLangItem> {
+    fn as_projection_lang_item(self, def_id: DefId) -> Option<SolverProjectionLangItem> {
         lang_item_to_solver_lang_item(self.lang_items().from_def_id(def_id)?)
     }
 
@@ -757,7 +779,7 @@ macro_rules! bidirectional_lang_item_map {
 }
 
 bidirectional_lang_item_map! {
-    SolverLangItem, fn lang_item_to_solver_lang_item, fn solver_lang_item_to_lang_item;
+    SolverProjectionLangItem, fn lang_item_to_solver_lang_item, fn solver_lang_item_to_lang_item;
 
 // tidy-alphabetical-start
     AsyncFnKindUpvars,
@@ -766,7 +788,6 @@ bidirectional_lang_item_map! {
     CallRefFuture,
     CoroutineReturn,
     CoroutineYield,
-    DynMetadata,
     FieldBase,
     FieldType,
     FutureOutput,
@@ -778,6 +799,7 @@ bidirectional_lang_item_map! {
     SolverAdtLangItem, fn lang_item_to_solver_adt_lang_item, fn solver_adt_lang_item_to_lang_item;
 
 // tidy-alphabetical-start
+    DynMetadata,
     Option,
     Poll,
 // tidy-alphabetical-end
@@ -791,7 +813,6 @@ bidirectional_lang_item_map! {
     AsyncFnKindHelper,
     AsyncFnMut,
     AsyncFnOnce,
-    AsyncFnOnceOutput,
     AsyncIterator,
     BikeshedGuaranteedNoDrop,
     Clone,

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -69,7 +69,7 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
 
     fn add_item_bounds_for_hidden_type(
         &self,
-        def_id: <Self::Interner as Interner>::DefId,
+        def_id: <Self::Interner as Interner>::OpaqueTyId,
         args: <Self::Interner as Interner>::GenericArgs,
         param_env: <Self::Interner as Interner>::ParamEnv,
         hidden_ty: <Self::Interner as Interner>::Ty,
@@ -79,7 +79,7 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
     fn fetch_eligible_assoc_item(
         &self,
         goal_trait_ref: ty::TraitRef<Self::Interner>,
-        trait_assoc_def_id: <Self::Interner as Interner>::DefId,
+        trait_assoc_def_id: <Self::Interner as Interner>::TraitAssocTermId,
         impl_def_id: <Self::Interner as Interner>::ImplId,
     ) -> FetchEligibleAssocItemResponse<Self::Interner>;
 

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/structural_traits.rs
@@ -4,7 +4,7 @@
 use derive_where::derive_where;
 use rustc_type_ir::data_structures::HashMap;
 use rustc_type_ir::inherent::*;
-use rustc_type_ir::lang_items::{SolverLangItem, SolverTraitLangItem};
+use rustc_type_ir::lang_items::{SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::SizedTraitKind;
 use rustc_type_ir::solve::inspect::ProbeKind;
 use rustc_type_ir::{
@@ -106,7 +106,9 @@ where
             // We can resolve the `impl Trait` to its concrete type,
             // which enforces a DAG between the functions requiring
             // the auto trait bounds in question.
-            Ok(ty::Binder::dummy(vec![cx.type_of(def_id).instantiate(cx, args).skip_norm_wip()]))
+            Ok(ty::Binder::dummy(vec![
+                cx.type_of(def_id.into()).instantiate(cx, args).skip_norm_wip(),
+            ]))
         }
     }
 }
@@ -541,7 +543,8 @@ pub(in crate::solve) fn extract_tupled_inputs_and_output_from_async_callable<I: 
                 );
             }
 
-            let future_output_def_id = cx.require_lang_item(SolverLangItem::FutureOutput);
+            let future_output_def_id =
+                cx.require_projection_lang_item(SolverProjectionLangItem::FutureOutput);
             let future_output_ty = Ty::new_projection(cx, future_output_def_id, [sig.output()]);
             Ok((
                 bound_sig.rebind(AsyncCallableRelevantTypes {
@@ -596,7 +599,8 @@ fn fn_item_to_async_callable<I: Interner>(
     let nested = vec![
         bound_sig.rebind(ty::TraitRef::new(cx, future_trait_def_id, [sig.output()])).upcast(cx),
     ];
-    let future_output_def_id = cx.require_lang_item(SolverLangItem::FutureOutput);
+    let future_output_def_id =
+        cx.require_projection_lang_item(SolverProjectionLangItem::FutureOutput);
     let future_output_ty = Ty::new_projection(cx, future_output_def_id, [sig.output()]);
     Ok((
         bound_sig.rebind(AsyncCallableRelevantTypes {
@@ -642,7 +646,8 @@ fn coroutine_closure_to_ambiguous_coroutine<I: Interner>(
     args: ty::CoroutineClosureArgs<I>,
     sig: ty::CoroutineClosureSignature<I>,
 ) -> I::Ty {
-    let upvars_projection_def_id = cx.require_lang_item(SolverLangItem::AsyncFnKindUpvars);
+    let upvars_projection_def_id =
+        cx.require_projection_lang_item(SolverProjectionLangItem::AsyncFnKindUpvars);
     let tupled_upvars_ty = Ty::new_projection(
         cx,
         upvars_projection_def_id,
@@ -920,7 +925,10 @@ where
             // show up in the bounds, but just ones that come from substituting
             // `Self` with the dyn type.
             let proj = proj.with_self_ty(cx, trait_ref.self_ty());
-            replace_projection_with.entry(proj.def_id()).or_default().push(bound.rebind(proj));
+            replace_projection_with
+                .entry(proj.def_id().into())
+                .or_default()
+                .push(bound.rebind(proj));
         }
     }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -702,7 +702,7 @@ where
         original_typing_mode: TypingMode<I>,
         parent_opaque_types: &[(OpaqueTypeKey<I>, I::Ty)],
     ) -> RerunDecision {
-        let parent_opaque_defids = parent_opaque_types.iter().map(|(key, _)| key.def_id);
+        let parent_opaque_defids = parent_opaque_types.iter().map(|(key, _)| key.def_id.into());
         let opaque_in_storage = |opaques: I::LocalDefIds, defids: SmallCopyList<_>| {
             if defids.as_ref().is_empty() {
                 RerunDecision::No
@@ -1357,7 +1357,7 @@ where
     pub(super) fn fetch_eligible_assoc_item(
         &self,
         goal_trait_ref: ty::TraitRef<I>,
-        trait_assoc_def_id: I::DefId,
+        trait_assoc_def_id: I::TraitAssocTermId,
         impl_def_id: I::ImplId,
     ) -> FetchEligibleAssocItemResponse<I> {
         self.delegate.fetch_eligible_assoc_item(goal_trait_ref, trait_assoc_def_id, impl_def_id)
@@ -1374,7 +1374,7 @@ where
 
     pub(super) fn add_item_bounds_for_hidden_type(
         &mut self,
-        opaque_def_id: I::DefId,
+        opaque_def_id: I::OpaqueTyId,
         opaque_args: I::GenericArgs,
         param_env: I::ParamEnv,
         hidden_ty: I::Ty,

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -357,7 +357,7 @@ where
         }
     }
 
-    fn opaque_type_is_rigid(&self, def_id: I::DefId) -> bool {
+    fn opaque_type_is_rigid(&self, def_id: I::OpaqueTyId) -> bool {
         match self
             .typing_mode()
             // Caller should handle erased mode
@@ -370,7 +370,7 @@ where
             TypingMode::Analysis { defining_opaque_types_and_generators: non_rigid_opaques }
             | TypingMode::Borrowck { defining_opaque_types: non_rigid_opaques }
             | TypingMode::PostBorrowckAnalysis { defined_opaque_types: non_rigid_opaques } => {
-                !def_id.as_local().is_some_and(|def_id| non_rigid_opaques.contains(&def_id))
+                !def_id.as_local().is_some_and(|def_id| non_rigid_opaques.contains(&def_id.into()))
             }
         }
     }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/anon_const.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/anon_const.rs
@@ -13,6 +13,7 @@ where
     pub(super) fn normalize_anon_const(
         &mut self,
         goal: Goal<I, ty::NormalizesTo<I>>,
+        def_id: I::UnevaluatedConstId,
     ) -> QueryResult<I> {
         let uv = goal.predicate.alias.expect_ct(self.cx());
         self.evaluate_const_and_instantiate_normalizes_to_term(goal, uv)

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/free_alias.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/free_alias.rs
@@ -32,11 +32,13 @@ where
 
         let actual = match free_alias.kind(cx) {
             ty::AliasTermKind::FreeTy { def_id } => {
-                cx.type_of(def_id).instantiate(cx, free_alias.args).skip_norm_wip().into()
+                cx.type_of(def_id.into()).instantiate(cx, free_alias.args).skip_norm_wip().into()
             }
-            ty::AliasTermKind::FreeConst { def_id } if cx.is_type_const(def_id) => {
-                cx.const_of_item(def_id).instantiate(cx, free_alias.args).skip_norm_wip().into()
-            }
+            ty::AliasTermKind::FreeConst { def_id } if cx.is_type_const(def_id.into()) => cx
+                .const_of_item(def_id.into())
+                .instantiate(cx, free_alias.args)
+                .skip_norm_wip()
+                .into(),
             ty::AliasTermKind::FreeConst { .. } => {
                 return self.evaluate_const_and_instantiate_normalizes_to_term(
                     goal,

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/inherent.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/inherent.rs
@@ -18,18 +18,19 @@ where
     pub(super) fn normalize_inherent_associated_term(
         &mut self,
         goal: Goal<I, ty::NormalizesTo<I>>,
+        def_id: I::InherentAssocTermId,
     ) -> QueryResult<I> {
         let cx = self.cx();
         let inherent = goal.predicate.alias;
 
-        let impl_def_id = cx.parent(inherent.def_id());
-        let impl_args = self.fresh_args_for_item(impl_def_id);
+        let impl_def_id = cx.inherent_alias_term_parent(def_id);
+        let impl_args = self.fresh_args_for_item(impl_def_id.into());
 
         // Equate impl header and add impl where clauses
         self.eq(
             goal.param_env,
             inherent.self_ty(),
-            cx.type_of(impl_def_id).instantiate(cx, impl_args).skip_norm_wip(),
+            cx.type_of(impl_def_id.into()).instantiate(cx, impl_args).skip_norm_wip(),
         )?;
 
         // Equate IAT with the RHS of the project goal
@@ -46,7 +47,7 @@ where
         // to be very careful when changing the impl where-clauses to be productive.
         self.add_goals(
             GoalSource::Misc,
-            cx.predicates_of(inherent.def_id())
+            cx.predicates_of(def_id.into())
                 .iter_instantiated(cx, inherent_args)
                 .map(Unnormalized::skip_norm_wip)
                 .map(|pred| goal.with(cx, pred)),
@@ -54,11 +55,13 @@ where
 
         let normalized = match inherent.kind(cx) {
             ty::AliasTermKind::InherentTy { def_id } => {
-                cx.type_of(def_id).instantiate(cx, inherent_args).skip_norm_wip().into()
+                cx.type_of(def_id.into()).instantiate(cx, inherent_args).skip_norm_wip().into()
             }
-            ty::AliasTermKind::InherentConst { def_id } if cx.is_type_const(def_id) => {
-                cx.const_of_item(def_id).instantiate(cx, inherent_args).skip_norm_wip().into()
-            }
+            ty::AliasTermKind::InherentConst { def_id } if cx.is_type_const(def_id.into()) => cx
+                .const_of_item(def_id.into())
+                .instantiate(cx, inherent_args)
+                .skip_norm_wip()
+                .into(),
             ty::AliasTermKind::InherentConst { .. } => {
                 // FIXME(gca): This is dead code at the moment. It should eventually call
                 // self.evaluate_const like projected consts do in consider_impl_candidate in

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -5,7 +5,7 @@ mod opaque_types;
 
 use rustc_type_ir::fast_reject::DeepRejectCtxt;
 use rustc_type_ir::inherent::*;
-use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
+use rustc_type_ir::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use rustc_type_ir::solve::{FetchEligibleAssocItemResponse, RerunReason};
 use rustc_type_ir::{
     self as ty, FieldInfo, Interner, NormalizesTo, PredicateKind, Unnormalized, Upcast as _,
@@ -32,72 +32,77 @@ where
         goal: Goal<I, NormalizesTo<I>>,
     ) -> QueryResult<I> {
         debug_assert!(self.term_is_fully_unconstrained(goal));
-        let cx = self.cx();
-        match goal.predicate.alias.kind(cx) {
+        match goal.predicate.alias.kind {
             ty::AliasTermKind::ProjectionTy { .. } | ty::AliasTermKind::ProjectionConst { .. } => {
-                let trait_ref = goal.predicate.alias.trait_ref(cx);
-                let (_, proven_via) =
-                    self.probe(|_| ProbeKind::ShadowedEnvProbing).enter(|ecx| {
-                        let trait_goal: Goal<I, ty::TraitPredicate<I>> = goal.with(cx, trait_ref);
-                        ecx.compute_trait_goal(trait_goal)
-                    })?;
-                self.assemble_and_merge_candidates(
-                    proven_via,
-                    goal,
-                    |ecx| {
-                        // FIXME(generic_associated_types): Addresses aggressive inference in #92917.
-                        //
-                        // If this type is a GAT with currently unconstrained arguments, we do not
-                        // want to normalize it via a candidate which only applies for a specific
-                        // instantiation. We could otherwise keep the GAT as rigid and succeed this way.
-                        // See tests/ui/generic-associated-types/no-incomplete-gat-arg-inference.rs.
-                        //
-                        // This only avoids normalization if a GAT argument is fully unconstrained.
-                        // This is quite arbitrary but fixing it causes some ambiguity, see #125196.
-                        for arg in goal.predicate.alias.own_args(cx).iter() {
-                            let Some(term) = arg.as_term() else {
-                                continue;
-                            };
-                            match ecx.structurally_normalize_term(goal.param_env, term) {
-                                Ok(term) => {
-                                    if term.is_infer() {
-                                        return Some(
-                                            ecx.evaluate_added_goals_and_make_canonical_response(
-                                                Certainty::AMBIGUOUS,
-                                            ),
-                                        );
-                                    }
-                                }
-                                Err(NoSolution) => return Some(Err(NoSolution)),
-                            }
-                        }
-
-                        None
-                    },
-                    |ecx| {
-                        ecx.probe(|&result| ProbeKind::RigidAlias { result })
-                            .enter(|this| {
-                                this.structurally_instantiate_normalizes_to_term(
-                                    goal,
-                                    goal.predicate.alias,
-                                );
-                                this.evaluate_added_goals_and_make_canonical_response(
-                                    Certainty::Yes,
-                                )
-                            })
-                            .map_err(Into::into)
-                    },
-                )
+                self.normalize_associated_term(goal)
             }
-            ty::AliasTermKind::InherentTy { .. } | ty::AliasTermKind::InherentConst { .. } => {
-                self.normalize_inherent_associated_term(goal)
+            ty::AliasTermKind::InherentTy { def_id } => {
+                self.normalize_inherent_associated_term(goal, def_id.into())
             }
-            ty::AliasTermKind::OpaqueTy { .. } => self.normalize_opaque_type(goal),
+            ty::AliasTermKind::InherentConst { def_id } => {
+                self.normalize_inherent_associated_term(goal, def_id.into())
+            }
+            ty::AliasTermKind::OpaqueTy { def_id } => self.normalize_opaque_type(goal, def_id),
             ty::AliasTermKind::FreeTy { .. } | ty::AliasTermKind::FreeConst { .. } => {
                 self.normalize_free_alias(goal)
             }
-            ty::AliasTermKind::UnevaluatedConst { .. } => self.normalize_anon_const(goal),
+            ty::AliasTermKind::UnevaluatedConst { def_id } => {
+                self.normalize_anon_const(goal, def_id)
+            }
         }
+    }
+
+    fn normalize_associated_term(&mut self, goal: Goal<I, NormalizesTo<I>>) -> QueryResult<I> {
+        let cx = self.cx();
+
+        let trait_ref = goal.predicate.alias.trait_ref(cx);
+        let (_, proven_via) = self.probe(|_| ProbeKind::ShadowedEnvProbing).enter(|ecx| {
+            let trait_goal: Goal<I, ty::TraitPredicate<I>> = goal.with(cx, trait_ref);
+            ecx.compute_trait_goal(trait_goal)
+        })?;
+        self.assemble_and_merge_candidates(
+            proven_via,
+            goal,
+            |ecx| {
+                // FIXME(generic_associated_types): Addresses aggressive inference in #92917.
+                //
+                // If this type is a GAT with currently unconstrained arguments, we do not
+                // want to normalize it via a candidate which only applies for a specific
+                // instantiation. We could otherwise keep the GAT as rigid and succeed this way.
+                // See tests/ui/generic-associated-types/no-incomplete-gat-arg-inference.rs.
+                //
+                // This only avoids normalization if a GAT argument is fully unconstrained.
+                // This is quite arbitrary but fixing it causes some ambiguity, see #125196.
+                for arg in goal.predicate.alias.own_args(cx).iter() {
+                    let Some(term) = arg.as_term() else {
+                        continue;
+                    };
+                    match ecx.structurally_normalize_term(goal.param_env, term) {
+                        Ok(term) => {
+                            if term.is_infer() {
+                                return Some(ecx.evaluate_added_goals_and_make_canonical_response(
+                                    Certainty::AMBIGUOUS,
+                                ));
+                            }
+                        }
+                        Err(NoSolution) => return Some(Err(NoSolution)),
+                    }
+                }
+
+                None
+            },
+            |ecx| {
+                ecx.probe(|&result| ProbeKind::RigidAlias { result })
+                    .enter(|this| {
+                        this.structurally_instantiate_normalizes_to_term(
+                            goal,
+                            goal.predicate.alias,
+                        );
+                        this.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
+                    })
+                    .map_err(Into::into)
+            },
+        )
     }
 
     /// When normalizing an associated item, constrain the expected term to `term`.
@@ -282,7 +287,7 @@ where
 
             let target_item_def_id = match ecx.fetch_eligible_assoc_item(
                 goal_trait_ref,
-                goal.predicate.def_id(),
+                goal.predicate.def_id().try_into().unwrap(),
                 impl_def_id,
             ) {
                 FetchEligibleAssocItemResponse::Found(target_item_def_id) => target_item_def_id,
@@ -354,7 +359,7 @@ where
                 }
             }
 
-            let target_container_def_id = cx.parent(target_item_def_id);
+            let target_container_def_id = cx.impl_or_trait_assoc_term_parent(target_item_def_id);
 
             // Getting the right args here is complex, e.g. given:
             // - a goal `<Vec<u32> as Trait<i32>>::Assoc<u64>`
@@ -371,10 +376,10 @@ where
                 impl_def_id,
                 impl_args,
                 impl_trait_ref,
-                target_container_def_id,
+                target_container_def_id.into(),
             )?;
 
-            if !cx.check_args_compatible(target_item_def_id, target_args) {
+            if !cx.check_args_compatible(target_item_def_id.into(), target_args) {
                 return error_response(
                     ecx,
                     cx.delay_bug("associated item has mismatched arguments"),
@@ -384,21 +389,21 @@ where
             // Finally we construct the actual value of the associated type.
             let term = match goal.predicate.alias.kind(cx) {
                 ty::AliasTermKind::ProjectionTy { .. } => cx
-                    .type_of(target_item_def_id)
+                    .type_of(target_item_def_id.into())
                     .instantiate(cx, target_args)
                     .skip_norm_wip()
                     .into(),
                 ty::AliasTermKind::ProjectionConst { .. }
-                    if cx.is_type_const(target_item_def_id) =>
+                    if cx.is_type_const(target_item_def_id.into()) =>
                 {
-                    cx.const_of_item(target_item_def_id)
+                    cx.const_of_item(target_item_def_id.into())
                         .instantiate(cx, target_args)
                         .skip_norm_wip()
                         .into()
                 }
                 ty::AliasTermKind::ProjectionConst { .. } => {
                     let uv = ty::UnevaluatedConst::new(
-                        target_item_def_id.try_into().unwrap(),
+                        target_item_def_id.into().try_into().unwrap(),
                         target_args,
                     );
                     return ecx.evaluate_const_and_instantiate_normalizes_to_term(goal, uv);
@@ -504,6 +509,7 @@ where
         goal_kind: ty::ClosureKind,
     ) -> Result<Candidate<I>, NoSolution> {
         let cx = ecx.cx();
+        let def_id = goal.predicate.def_id().try_into().unwrap();
 
         let env_region = match goal_kind {
             ty::ClosureKind::Fn | ty::ClosureKind::FnMut => goal.predicate.alias.args.region_at(2),
@@ -531,41 +537,42 @@ where
             [output_coroutine_ty],
         );
 
-        let (projection_term, term) =
-            if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CallOnceFuture) {
-                (
-                    ty::AliasTerm::new(
-                        cx,
-                        cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
-                        [goal.predicate.self_ty(), tupled_inputs_ty],
-                    ),
-                    output_coroutine_ty.into(),
-                )
-            } else if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CallRefFuture) {
-                (
-                    ty::AliasTerm::new(
-                        cx,
-                        cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
-                        [
-                            I::GenericArg::from(goal.predicate.self_ty()),
-                            tupled_inputs_ty.into(),
-                            env_region.into(),
-                        ],
-                    ),
-                    output_coroutine_ty.into(),
-                )
-            } else if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::AsyncFnOnceOutput) {
-                (
-                    ty::AliasTerm::new(
-                        cx,
-                        cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
-                        [goal.predicate.self_ty(), tupled_inputs_ty],
-                    ),
-                    coroutine_return_ty.into(),
-                )
-            } else {
-                panic!("no such associated type in `AsyncFn*`: {:?}", goal.predicate.def_id())
-            };
+        let (projection_term, term) = if cx
+            .is_projection_lang_item(def_id, SolverProjectionLangItem::CallOnceFuture)
+        {
+            (
+                ty::AliasTerm::new(
+                    cx,
+                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    [goal.predicate.self_ty(), tupled_inputs_ty],
+                ),
+                output_coroutine_ty.into(),
+            )
+        } else if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::CallRefFuture) {
+            (
+                ty::AliasTerm::new(
+                    cx,
+                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    [
+                        I::GenericArg::from(goal.predicate.self_ty()),
+                        tupled_inputs_ty.into(),
+                        env_region.into(),
+                    ],
+                ),
+                output_coroutine_ty.into(),
+            )
+        } else if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::AsyncFnOnceOutput) {
+            (
+                ty::AliasTerm::new(
+                    cx,
+                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    [goal.predicate.self_ty(), tupled_inputs_ty],
+                ),
+                coroutine_return_ty.into(),
+            )
+        } else {
+            panic!("no such associated type in `AsyncFn*`: {:?}", goal.predicate.def_id())
+        };
         let pred = ty::ProjectionPredicate { projection_term, term }.upcast(cx);
 
         Self::probe_and_consider_implied_clause(
@@ -639,8 +646,8 @@ where
         goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolution> {
         let cx = ecx.cx();
-        let metadata_def_id = cx.require_lang_item(SolverLangItem::Metadata);
-        assert_eq!(metadata_def_id, goal.predicate.def_id());
+        let metadata_def_id = cx.require_projection_lang_item(SolverProjectionLangItem::Metadata);
+        assert_eq!(Into::<I::DefId>::into(metadata_def_id), goal.predicate.def_id());
         let metadata_ty = match goal.predicate.self_ty().kind() {
             ty::Bool
             | ty::Char
@@ -666,8 +673,8 @@ where
             ty::Str | ty::Slice(_) => Ty::new_usize(cx),
 
             ty::Dynamic(_, _) => {
-                let dyn_metadata = cx.require_lang_item(SolverLangItem::DynMetadata);
-                cx.type_of(dyn_metadata)
+                let dyn_metadata = cx.require_adt_lang_item(SolverAdtLangItem::DynMetadata);
+                cx.type_of(dyn_metadata.into())
                     .instantiate(cx, &[I::GenericArg::from(goal.predicate.self_ty())])
                     .skip_norm_wip()
             }
@@ -865,10 +872,12 @@ where
         }
 
         let coroutine = args.as_coroutine();
+        let def_id = goal.predicate.def_id().try_into().unwrap();
 
-        let term = if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CoroutineReturn) {
+        let term = if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::CoroutineReturn)
+        {
             coroutine.return_ty().into()
-        } else if cx.is_lang_item(goal.predicate.def_id(), SolverLangItem::CoroutineYield) {
+        } else if cx.is_projection_lang_item(def_id, SolverProjectionLangItem::CoroutineYield) {
             coroutine.yield_ty().into()
         } else {
             panic!("unexpected associated item `{:?}` for `{self_ty:?}`", goal.predicate.def_id())
@@ -992,9 +1001,10 @@ where
         else {
             return Err(NoSolution);
         };
-        let ty = match ecx.cx().as_lang_item(goal.predicate.def_id()) {
-            Some(SolverLangItem::FieldBase) => base,
-            Some(SolverLangItem::FieldType) => ty,
+        let ty = match ecx.cx().as_projection_lang_item(goal.predicate.def_id().try_into().unwrap())
+        {
+            Some(SolverProjectionLangItem::FieldBase) => base,
+            Some(SolverProjectionLangItem::FieldType) => ty,
             _ => panic!("unexpected associated type {:?} in `Field`", goal.predicate),
         };
         ecx.probe_builtin_trait_candidate(BuiltinImplSource::Misc).enter(|ecx| {

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/opaque_types.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/opaque_types.rs
@@ -17,6 +17,7 @@ where
     pub(super) fn normalize_opaque_type(
         &mut self,
         goal: Goal<I, ty::NormalizesTo<I>>,
+        def_id: I::OpaqueTyId,
     ) -> QueryResult<I> {
         let cx = self.cx();
         let opaque_ty = goal.predicate.alias;
@@ -27,7 +28,7 @@ where
                 // An impossible opaque type bound is the only way this goal will fail
                 // e.g. assigning `impl Copy := NotCopy`
                 self.add_item_bounds_for_hidden_type(
-                    opaque_ty.def_id(),
+                    def_id,
                     opaque_ty.args,
                     goal.param_env,
                     expected,
@@ -43,10 +44,9 @@ where
                 defining_opaque_types_and_generators: defining_opaque_types,
             }
             | TypingMode::Borrowck { defining_opaque_types } => {
-                let Some(def_id) = opaque_ty
-                    .def_id()
+                let Some(def_id) = def_id
                     .as_local()
-                    .filter(|&def_id| defining_opaque_types.contains(&def_id))
+                    .filter(|&def_id| defining_opaque_types.contains(&def_id.into()))
                 else {
                     // If we're not in the defining scope, treat the alias as rigid.
                     self.structurally_instantiate_normalizes_to_term(goal, goal.predicate.alias);
@@ -134,7 +134,7 @@ where
             TypingMode::PostAnalysis => {
                 // FIXME: Add an assertion that opaque type storage is empty.
                 let actual =
-                    cx.type_of(opaque_ty.def_id()).instantiate(cx, opaque_ty.args).skip_norm_wip();
+                    cx.type_of(def_id.into()).instantiate(cx, opaque_ty.args).skip_norm_wip();
                 self.eq(goal.param_env, expected, actual)?;
                 self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
             }

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -242,7 +242,7 @@ where
             }
 
             debug_assert!(ecx.opaque_type_is_rigid(def_id));
-            for item_bound in cx.item_self_bounds(def_id).skip_binder() {
+            for item_bound in cx.item_self_bounds(def_id.into()).skip_binder() {
                 if item_bound
                     .as_trait_clause()
                     .is_some_and(|b| b.def_id() == goal.predicate.def_id())

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -14,7 +14,7 @@ use rustc_ast::{
     TyAlias,
 };
 use rustc_attr_parsing::AttributeParser;
-use rustc_expand::base::ResolverExpand;
+use rustc_expand::base::{ResolverExpand, SyntaxExtension, SyntaxExtensionKind};
 use rustc_hir::Attribute;
 use rustc_hir::attrs::{AttributeKind, MacroUseArgs};
 use rustc_hir::def::{self, *};
@@ -37,9 +37,8 @@ use crate::macros::{MacroRulesDecl, MacroRulesScope, MacroRulesScopeRef};
 use crate::ref_mut::CmCell;
 use crate::{
     BindingKey, Decl, DeclData, DeclKind, DelayedVisResolutionError, ExternModule,
-    ExternPreludeEntry, Finalize, IdentKey, LocalModule, MacroData, Module, ModuleKind,
-    ModuleOrUniformRoot, ParentScope, PathResult, Res, Resolver, Segment, Used, VisResolutionError,
-    errors,
+    ExternPreludeEntry, Finalize, IdentKey, LocalModule, Module, ModuleKind, ModuleOrUniformRoot,
+    ParentScope, PathResult, Res, Resolver, Segment, Used, VisResolutionError, errors,
 };
 
 impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
@@ -207,7 +206,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    pub(crate) fn get_macro(&self, res: Res) -> Option<&'ra MacroData> {
+    pub(crate) fn get_macro(&self, res: Res) -> Option<&'ra Arc<SyntaxExtension>> {
         match res {
             Res::Def(DefKind::Macro(..), def_id) => Some(self.get_macro_by_def_id(def_id)),
             Res::NonMacroAttr(_) => Some(self.non_macro_attr),
@@ -215,20 +214,20 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
     }
 
-    pub(crate) fn get_macro_by_def_id(&self, def_id: DefId) -> &'ra MacroData {
+    pub(crate) fn get_macro_by_def_id(&self, def_id: DefId) -> &'ra Arc<SyntaxExtension> {
         // Local macros are always compiled.
         match def_id.as_local() {
             Some(local_def_id) => self.local_macro_map[&local_def_id],
-            None => *self.extern_macro_map.borrow_mut().entry(def_id).or_insert_with(|| {
+            None => self.extern_macro_map.borrow_mut().entry(def_id).or_insert_with(|| {
                 let loaded_macro = self.cstore().load_macro_untracked(self.tcx, def_id);
-                let macro_data = match loaded_macro {
+                let ext = match loaded_macro {
                     LoadedMacro::MacroDef { def, ident, attrs, span, edition } => {
                         self.compile_macro(&def, ident, &attrs, span, ast::DUMMY_NODE_ID, edition)
                     }
-                    LoadedMacro::ProcMacro(ext) => MacroData::new(Arc::new(ext)),
+                    LoadedMacro::ProcMacro(ext) => ext,
                 };
 
-                self.arenas.alloc_macro(macro_data)
+                self.arenas.alloc_macro(Arc::new(ext))
             }),
         }
     }
@@ -1269,8 +1268,9 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
     fn insert_unused_macro(&mut self, ident: Ident, def_id: LocalDefId, node_id: NodeId) {
         if !ident.as_str().starts_with('_') {
             self.r.unused_macros.insert(def_id, (node_id, ident));
-            let nrules = self.r.local_macro_map[&def_id].nrules;
-            self.r.unused_macro_rules.insert(node_id, DenseBitSet::new_filled(nrules));
+            if let SyntaxExtensionKind::MacroRules(mr) = &self.r.local_macro_map[&def_id].kind {
+                self.r.unused_macro_rules.insert(node_id, DenseBitSet::new_filled(mr.nrules()));
+            }
         }
     }
 
@@ -1291,8 +1291,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                     Some((macro_kind, ident, span)) => {
                         let macro_kinds = macro_kind.into();
                         let res = Res::Def(DefKind::Macro(macro_kinds), def_id.to_def_id());
-                        let macro_data = MacroData::new(self.r.dummy_ext(macro_kind));
-                        self.r.new_local_macro(def_id, macro_data);
+                        self.r.new_local_macro(def_id, self.r.dummy_ext(macro_kind));
                         self.r.proc_macro_stubs.insert(def_id);
                         (res, ident, span, false)
                     }

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -1,4 +1,5 @@
 use std::mem;
+use std::sync::Arc;
 
 use rustc_ast::visit::FnKind;
 use rustc_ast::*;
@@ -117,7 +118,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
     fn visit_item(&mut self, i: &'a Item) {
         // Pick the def data. This need not be unique, but the more
         // information we encapsulate into, the better
-        let mut opt_macro_data = None;
+        let mut opt_syn_ext = None;
         let def_kind = match &i.kind {
             ItemKind::Impl(i) => DefKind::Impl { of_trait: i.of_trait.is_some() },
             ItemKind::ForeignMod(..) => DefKind::ForeignMod,
@@ -165,9 +166,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                     },
                 );
 
-                let macro_data = self.r.compile_macro(def, *ident, &attrs, i.span, i.id, edition);
-                let macro_kinds = macro_data.ext.macro_kinds();
-                opt_macro_data = Some(macro_data);
+                let ext = self.r.compile_macro(def, *ident, &attrs, i.span, i.id, edition);
+                let macro_kinds = ext.macro_kinds();
+                opt_syn_ext = Some(ext);
                 DefKind::Macro(macro_kinds)
             }
             ItemKind::GlobalAsm(..) => DefKind::GlobalAsm,
@@ -185,8 +186,8 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         };
         let feed = self.create_def(i.id, i.kind.ident().map(|ident| ident.name), def_kind, i.span);
 
-        if let Some(macro_data) = opt_macro_data {
-            self.r.new_local_macro(feed.def_id(), macro_data);
+        if let Some(ext) = opt_syn_ext {
+            self.r.new_local_macro(feed.def_id(), Arc::new(ext));
         }
 
         self.with_parent(feed.def_id(), |this| {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1742,7 +1742,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if let Some((def_id, unused_ident)) = unused_macro {
             let scope = self.local_macro_def_scopes[&def_id];
             let parent_nearest = parent_scope.module.nearest_parent_mod();
-            let unused_macro_kinds = self.local_macro_map[def_id].ext.macro_kinds();
+            let unused_macro_kinds = self.local_macro_map[def_id].macro_kinds();
             if !unused_macro_kinds.contains(macro_kind.into()) {
                 match macro_kind {
                     MacroKind::Bang => {
@@ -1860,13 +1860,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut all_attrs: UnordMap<Symbol, Vec<_>> = UnordMap::default();
         // We're collecting these in a hashmap, and handle ordering the output further down.
         #[allow(rustc::potential_query_instability)]
-        for (def_id, data) in self
+        for (def_id, ext) in self
             .local_macro_map
             .iter()
-            .map(|(local_id, data)| (local_id.to_def_id(), data))
+            .map(|(local_id, ext)| (local_id.to_def_id(), ext))
             .chain(self.extern_macro_map.borrow().iter().map(|(id, d)| (*id, d)))
         {
-            for helper_attr in &data.ext.helper_attrs {
+            for helper_attr in &ext.helper_attrs {
                 let item_name = self.tcx.item_name(def_id);
                 all_attrs.entry(*helper_attr).or_default().push(item_name);
                 if helper_attr == &ident.name {

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -271,7 +271,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             // The macro is a proc macro derive
             && let Some(def_id) = module.expansion.expn_data().macro_def_id
         {
-            let ext = &self.get_macro_by_def_id(def_id).ext;
+            let ext = self.get_macro_by_def_id(def_id);
             if ext.builtin_name.is_none()
                 && ext.macro_kinds() == MacroKinds::DERIVE
                 && parent.expansion.outer_expn_is_descendant_of(**ctxt)

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -12,6 +12,7 @@ use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, BufferedEarlyLint, Diagnostic, MultiSpan, pluralize, struct_span_code_err,
 };
+use rustc_expand::base::SyntaxExtensionKind;
 use rustc_hir::Attribute;
 use rustc_hir::attrs::AttributeKind;
 use rustc_hir::attrs::diagnostic::{CustomDiagnostic, Directive, FormatArgs};
@@ -1639,7 +1640,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             match decl.kind {
                 // exclude decl_macro
                 DeclKind::Def(Res::Def(DefKind::Macro(_), def_id))
-                    if self.get_macro_by_def_id(def_id).macro_rules =>
+                    if let SyntaxExtensionKind::MacroRules(mr) =
+                        &self.get_macro_by_def_id(def_id).kind
+                        && mr.is_macro_rules() =>
                 {
                     err.subdiagnostic(ConsiderAddingMacroExport { span: decl.span });
                     err.subdiagnostic(ConsiderMarkingAsPubCrate { vis_span: import.vis_span });

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1265,18 +1265,6 @@ struct DeriveData {
     has_derive_copy: bool,
 }
 
-struct MacroData {
-    ext: Arc<SyntaxExtension>,
-    nrules: usize,
-    macro_rules: bool,
-}
-
-impl MacroData {
-    fn new(ext: Arc<SyntaxExtension>) -> MacroData {
-        MacroData { ext, nrules: 0, macro_rules: false }
-    }
-}
-
 pub struct ResolverOutputs<'tcx> {
     pub global_ctxt: ResolverGlobalCtxt,
     pub ast_lowering: ResolverAstLowering<'tcx>,
@@ -1396,12 +1384,12 @@ pub struct Resolver<'ra, 'tcx> {
     registered_tools: &'tcx RegisteredTools,
     macro_use_prelude: FxIndexMap<Symbol, Decl<'ra>>,
     /// Eagerly populated map of all local macro definitions.
-    local_macro_map: FxHashMap<LocalDefId, &'ra MacroData> = default::fx_hash_map(),
+    local_macro_map: FxHashMap<LocalDefId, &'ra Arc<SyntaxExtension>> = default::fx_hash_map(),
     /// Lazily populated cache of macro definitions loaded from external crates.
-    extern_macro_map: CacheRefCell<FxHashMap<DefId, &'ra MacroData>>,
+    extern_macro_map: CacheRefCell<FxHashMap<DefId, &'ra Arc<SyntaxExtension>>>,
     dummy_ext_bang: Arc<SyntaxExtension>,
     dummy_ext_derive: Arc<SyntaxExtension>,
-    non_macro_attr: &'ra MacroData,
+    non_macro_attr: &'ra Arc<SyntaxExtension>,
     local_macro_def_scopes: FxHashMap<LocalDefId, LocalModule<'ra>> = default::fx_hash_map(),
     ast_transform_scopes: FxHashMap<LocalExpnId, LocalModule<'ra>> = default::fx_hash_map(),
     unused_macros: FxIndexMap<LocalDefId, (NodeId, Ident)>,
@@ -1520,7 +1508,7 @@ pub struct ResolverArenas<'ra> {
     imports: TypedArena<ImportData<'ra>>,
     name_resolutions: TypedArena<CmRefCell<NameResolution<'ra>>>,
     ast_paths: TypedArena<ast::Path>,
-    macros: TypedArena<MacroData>,
+    macros: TypedArena<Arc<SyntaxExtension>>,
     dropless: DroplessArena,
 }
 
@@ -1599,8 +1587,8 @@ impl<'ra> ResolverArenas<'ra> {
     fn alloc_ast_paths(&'ra self, paths: &[ast::Path]) -> &'ra [ast::Path] {
         self.ast_paths.alloc_from_iter(paths.iter().cloned())
     }
-    fn alloc_macro(&'ra self, macro_data: MacroData) -> &'ra MacroData {
-        self.macros.alloc(macro_data)
+    fn alloc_macro(&'ra self, ext: Arc<SyntaxExtension>) -> &'ra Arc<SyntaxExtension> {
+        self.macros.alloc(ext)
     }
     fn alloc_pattern_spans(&'ra self, spans: impl Iterator<Item = Span>) -> &'ra [Span] {
         self.dropless.alloc_from_iter(spans)
@@ -1821,8 +1809,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             extern_macro_map: Default::default(),
             dummy_ext_bang: Arc::new(SyntaxExtension::dummy_bang(edition)),
             dummy_ext_derive: Arc::new(SyntaxExtension::dummy_derive(edition)),
-            non_macro_attr: arenas
-                .alloc_macro(MacroData::new(Arc::new(SyntaxExtension::non_macro_attr(edition)))),
+            non_macro_attr: arenas.alloc_macro(Arc::new(SyntaxExtension::non_macro_attr(edition))),
             unused_macros: Default::default(),
             unused_macro_rules: Default::default(),
             single_segment_macro_resolutions: Default::default(),
@@ -1889,8 +1876,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         module
     }
 
-    fn new_local_macro(&mut self, def_id: LocalDefId, macro_data: MacroData) -> &'ra MacroData {
-        let mac = self.arenas.alloc_macro(macro_data);
+    fn new_local_macro(
+        &mut self,
+        def_id: LocalDefId,
+        ext: Arc<SyntaxExtension>,
+    ) -> &'ra Arc<SyntaxExtension> {
+        let mac = self.arenas.alloc_macro(ext);
         self.local_macro_map.insert(def_id, mac);
         mac
     }
@@ -1993,7 +1984,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         match macro_kind {
             MacroKind::Bang => Arc::clone(&self.dummy_ext_bang),
             MacroKind::Derive => Arc::clone(&self.dummy_ext_derive),
-            MacroKind::Attr => Arc::clone(&self.non_macro_attr.ext),
+            MacroKind::Attr => Arc::clone(self.non_macro_attr),
         }
     }
 
@@ -2022,11 +2013,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
     }
 
     fn is_builtin_macro(&self, res: Res) -> bool {
-        self.get_macro(res).is_some_and(|macro_data| macro_data.ext.builtin_name.is_some())
+        self.get_macro(res).is_some_and(|ext| ext.builtin_name.is_some())
     }
 
     fn is_specific_builtin_macro(&self, res: Res, symbol: Symbol) -> bool {
-        self.get_macro(res).is_some_and(|macro_data| macro_data.ext.builtin_name == Some(symbol))
+        self.get_macro(res).is_some_and(|ext| ext.builtin_name == Some(symbol))
     }
 
     fn macro_def(&self, mut ctxt: SyntaxContext) -> DefId {

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -43,7 +43,7 @@ use crate::hygiene::Macros20NormalizedSyntaxContext;
 use crate::imports::Import;
 use crate::{
     BindingKey, CacheCell, CmResolver, Decl, DeclKind, DeriveData, Determinacy, Finalize, IdentKey,
-    InvocationParent, MacroData, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, Res,
+    InvocationParent, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, Res,
     ResolutionError, Resolver, ScopeSet, Segment, Used,
 };
 
@@ -361,8 +361,8 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
                 continue;
             }
             let def_id = self.local_def_id(node_id);
-            let m = &self.local_macro_map[&def_id];
-            let SyntaxExtensionKind::MacroRules(ref m) = m.ext.kind else {
+            let ext = self.local_macro_map[&def_id];
+            let SyntaxExtensionKind::MacroRules(ref m) = ext.kind else {
                 continue;
             };
             for arm_i in unused_arms.iter() {
@@ -882,7 +882,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
                 _ => None,
             },
-            None => self.get_macro(res).map(|macro_data| Arc::clone(&macro_data.ext)),
+            None => self.get_macro(res).map(|ext| Arc::clone(ext)),
         };
         Ok((ext, res))
     }
@@ -1212,7 +1212,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // Reserve some names that are not quite covered by the general check
         // performed on `Resolver::builtin_attrs`.
         if name == sym::cfg || name == sym::cfg_attr {
-            let macro_kinds = self.get_macro(res).map(|macro_data| macro_data.ext.macro_kinds());
+            let macro_kinds = self.get_macro(res).map(|ext| ext.macro_kinds());
             if macro_kinds.is_some() && sub_namespace_match(macro_kinds, Some(MacroKind::Attr)) {
                 self.dcx().emit_err(errors::NameReservedInAttributeNamespace { span, ident: name });
             }
@@ -1230,8 +1230,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         span: Span,
         node_id: NodeId,
         edition: Edition,
-    ) -> MacroData {
-        let (mut ext, mut nrules) = compile_declarative_macro(
+    ) -> SyntaxExtension {
+        let mut ext = compile_declarative_macro(
             self.tcx.sess,
             self.tcx.features(),
             macro_def,
@@ -1248,13 +1248,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 // The macro is a built-in, replace its expander function
                 // while still taking everything else from the source code.
                 ext.kind = builtin_ext_kind.clone();
-                nrules = 0;
             } else {
                 self.dcx().emit_err(errors::CannotFindBuiltinMacroWithName { span, ident });
             }
         }
 
-        MacroData { ext: Arc::new(ext), nrules, macro_rules: macro_def.macro_rules }
+        ext
     }
 
     fn path_accessible(

--- a/compiler/rustc_target/src/spec/base/wasm.rs
+++ b/compiler/rustc_target/src/spec/base/wasm.rs
@@ -110,6 +110,14 @@ pub(crate) fn options() -> TargetOptions {
         // representation, so this is disabled.
         generate_arange_section: false,
 
+        // Differ from LLVM's default to use the legacy exception-handling
+        // proposal instructions and use the standard exception-handling
+        // instructions. Note that this is only applicable when unwinding is
+        // actually turned on, which it's not by default on this target. For
+        // `-Zbuild-std` builds, however, this affects when rebuilding libstd
+        // with unwinding.
+        llvm_args: cvs!["-wasm-use-legacy-eh=false"],
+
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
@@ -31,6 +31,11 @@ pub(crate) fn target() -> Target {
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         families: cvs!["unix", "wasm"],
+        // Explicitly override the `base::wasm`'s `llvm_args` back to empty. The
+        // base is to force using the most standard exception-handling
+        // instructions, when enabled, but this target is intended to follow
+        // Emscripten, which is whatever LLVM defaults to.
+        llvm_args: cvs![],
         ..base::wasm::options()
     };
     Target {

--- a/compiler/rustc_type_ir/src/generic_visit.rs
+++ b/compiler/rustc_type_ir/src/generic_visit.rs
@@ -212,6 +212,7 @@ trivial_impls!(
     rustc_hash::FxBuildHasher,
     crate::TypeFlags,
     crate::solve::GoalSource,
+    crate::solve::VisibleForLeakCheck,
     rustc_abi::ExternAbi,
 );
 

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -55,7 +55,11 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_alias(interner: I, alias_ty: ty::AliasTy<I>) -> Self;
 
-    fn new_projection_from_args(interner: I, def_id: I::DefId, args: I::GenericArgs) -> Self {
+    fn new_projection_from_args(
+        interner: I,
+        def_id: I::TraitAssocTyId,
+        args: I::GenericArgs,
+    ) -> Self {
         Self::new_alias(
             interner,
             ty::AliasTy::new_from_args(interner, ty::AliasTyKind::Projection { def_id }, args),
@@ -64,7 +68,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     fn new_projection(
         interner: I,
-        def_id: I::DefId,
+        def_id: I::TraitAssocTyId,
         args: impl IntoIterator<Item: Into<I::GenericArg>>,
     ) -> Self {
         Self::new_alias(
@@ -637,19 +641,24 @@ pub trait Features<I: Interner>: Copy {
 }
 
 #[rust_analyzer::prefer_underscore_import]
-pub trait DefId<I: Interner>: Copy + Debug + Hash + Eq + TypeFoldable<I> {
+pub trait DefId<I: Interner, Local = <I as Interner>::LocalDefId>:
+    Copy + Debug + Hash + Eq + TypeFoldable<I>
+{
     fn is_local(self) -> bool;
 
-    fn as_local(self) -> Option<I::LocalDefId>;
+    fn as_local(self) -> Option<Local>;
 }
 
-pub trait SpecificDefId<I: Interner>:
-    DefId<I> + Into<I::DefId> + TryFrom<I::DefId, Error: std::fmt::Debug>
+pub trait SpecificDefId<I: Interner, Local = <I as Interner>::LocalDefId>:
+    DefId<I, Local> + Into<I::DefId> + TryFrom<I::DefId, Error: std::fmt::Debug>
 {
 }
 
-impl<I: Interner, T: DefId<I> + Into<I::DefId> + TryFrom<I::DefId, Error: std::fmt::Debug>>
-    SpecificDefId<I> for T
+impl<
+    I: Interner,
+    T: DefId<I, Local> + Into<I::DefId> + TryFrom<I::DefId, Error: std::fmt::Debug>,
+    Local,
+> SpecificDefId<I, Local> for T
 {
 }
 

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -9,7 +9,7 @@ use rustc_index::bit_set::DenseBitSet;
 use crate::fold::TypeFoldable;
 use crate::inherent::*;
 use crate::ir_print::IrPrint;
-use crate::lang_items::{SolverAdtLangItem, SolverLangItem, SolverTraitLangItem};
+use crate::lang_items::{SolverAdtLangItem, SolverProjectionLangItem, SolverTraitLangItem};
 use crate::relate::Relate;
 use crate::solve::{
     AccessedOpaques, CanonicalInput, Certainty, ExternalConstraintsData, QueryResult, inspect,
@@ -56,6 +56,38 @@ pub trait Interner:
     type AdtId: SpecificDefId<Self>;
     type ImplId: SpecificDefId<Self>;
     type UnevaluatedConstId: SpecificDefId<Self>;
+    type TraitAssocTyId: SpecificDefId<Self>
+        + Into<Self::TraitAssocTermId>
+        + TryFrom<Self::TraitAssocTermId>;
+    type TraitAssocConstId: SpecificDefId<Self>
+        + Into<Self::TraitAssocTermId>
+        + Into<Self::UnevaluatedConstId>
+        + TryFrom<Self::TraitAssocTermId>;
+    type TraitAssocTermId: SpecificDefId<Self>;
+    type OpaqueTyId: SpecificDefId<Self, Self::LocalOpaqueTyId>;
+    type LocalOpaqueTyId: Copy
+        + Debug
+        + Hash
+        + Eq
+        + Into<Self::OpaqueTyId>
+        + Into<Self::LocalDefId>
+        + Into<Self::DefId>
+        + TypeFoldable<Self>;
+    type FreeTyAliasId: SpecificDefId<Self> + Into<Self::FreeTermAliasId>;
+    type FreeConstAliasId: SpecificDefId<Self>
+        + Into<Self::UnevaluatedConstId>
+        + Into<Self::FreeTermAliasId>;
+    type FreeTermAliasId: SpecificDefId<Self>;
+    type ImplOrTraitAssocTyId: SpecificDefId<Self> + Into<Self::ImplOrTraitAssocTermId>;
+    type ImplOrTraitAssocConstId: SpecificDefId<Self>
+        + Into<Self::UnevaluatedConstId>
+        + Into<Self::ImplOrTraitAssocTermId>;
+    type ImplOrTraitAssocTermId: SpecificDefId<Self>;
+    type InherentAssocTyId: SpecificDefId<Self> + Into<Self::InherentAssocTermId>;
+    type InherentAssocConstId: SpecificDefId<Self>
+        + Into<Self::UnevaluatedConstId>
+        + Into<Self::InherentAssocTermId>;
+    type InherentAssocTermId: SpecificDefId<Self>;
     type Span: Span<Self>;
 
     type GenericArgs: GenericArgs<Self>;
@@ -203,8 +235,10 @@ pub trait Interner:
     ) -> Option<Self::VariancesOf>;
 
     fn type_of(self, def_id: Self::DefId) -> ty::EarlyBinder<Self, Self::Ty>;
-    fn type_of_opaque_hir_typeck(self, def_id: Self::LocalDefId)
-    -> ty::EarlyBinder<Self, Self::Ty>;
+    fn type_of_opaque_hir_typeck(
+        self,
+        def_id: Self::LocalOpaqueTyId,
+    ) -> ty::EarlyBinder<Self, Self::Ty>;
     fn is_type_const(self, def_id: Self::DefId) -> bool;
     fn const_of_item(self, def_id: Self::DefId) -> ty::EarlyBinder<Self, Self::Const>;
     fn anon_const_kind(self, def_id: Self::DefId) -> ty::AnonConstKind;
@@ -219,7 +253,7 @@ pub trait Interner:
 
     fn trait_ref_and_own_args_for_alias(
         self,
-        def_id: Self::DefId,
+        def_id: Self::TraitAssocTermId,
         args: Self::GenericArgs,
     ) -> (ty::TraitRef<Self>, Self::GenericArgsSlice);
 
@@ -243,7 +277,12 @@ pub trait Interner:
         I: Iterator<Item = T>,
         T: CollectAndApply<Self::Ty, Self::Tys>;
 
-    fn parent(self, def_id: Self::DefId) -> Self::DefId;
+    fn projection_parent(self, def_id: Self::TraitAssocTermId) -> Self::TraitId;
+
+    /// This can be an impl, or a trait if this is a defaulted term.
+    fn impl_or_trait_assoc_term_parent(self, def_id: Self::ImplOrTraitAssocTermId) -> Self::DefId;
+
+    fn inherent_alias_term_parent(self, def_id: Self::InherentAssocTermId) -> Self::ImplId;
 
     fn recursion_limit(self) -> usize;
 
@@ -325,13 +364,20 @@ pub trait Interner:
 
     fn has_target_features(self, def_id: Self::FunctionId) -> bool;
 
-    fn require_lang_item(self, lang_item: SolverLangItem) -> Self::DefId;
+    fn require_projection_lang_item(
+        self,
+        lang_item: SolverProjectionLangItem,
+    ) -> Self::TraitAssocTyId;
 
     fn require_trait_lang_item(self, lang_item: SolverTraitLangItem) -> Self::TraitId;
 
     fn require_adt_lang_item(self, lang_item: SolverAdtLangItem) -> Self::AdtId;
 
-    fn is_lang_item(self, def_id: Self::DefId, lang_item: SolverLangItem) -> bool;
+    fn is_projection_lang_item(
+        self,
+        def_id: Self::TraitAssocTyId,
+        lang_item: SolverProjectionLangItem,
+    ) -> bool;
 
     fn is_trait_lang_item(self, def_id: Self::TraitId, lang_item: SolverTraitLangItem) -> bool;
 
@@ -341,7 +387,10 @@ pub trait Interner:
 
     fn is_sizedness_trait(self, def_id: Self::TraitId) -> bool;
 
-    fn as_lang_item(self, def_id: Self::DefId) -> Option<SolverLangItem>;
+    fn as_projection_lang_item(
+        self,
+        def_id: Self::TraitAssocTyId,
+    ) -> Option<SolverProjectionLangItem>;
 
     fn as_trait_lang_item(self, def_id: Self::TraitId) -> Option<SolverTraitLangItem>;
 
@@ -360,7 +409,7 @@ pub trait Interner:
     );
     fn for_each_blanket_impl(self, trait_def_id: Self::TraitId, f: impl FnMut(Self::ImplId));
 
-    fn has_item_definition(self, def_id: Self::DefId) -> bool;
+    fn has_item_definition(self, def_id: Self::ImplOrTraitAssocTermId) -> bool;
 
     fn impl_specializes(self, impl_def_id: Self::ImplId, victim_def_id: Self::ImplId) -> bool;
 

--- a/compiler/rustc_type_ir/src/lang_items.rs
+++ b/compiler/rustc_type_ir/src/lang_items.rs
@@ -1,6 +1,6 @@
 /// Lang items used by the new trait solver. This can be mapped to whatever internal
 /// representation of `LangItem`s used in the underlying compiler implementation.
-pub enum SolverLangItem {
+pub enum SolverProjectionLangItem {
     // tidy-alphabetical-start
     AsyncFnKindUpvars,
     AsyncFnOnceOutput,
@@ -8,7 +8,6 @@ pub enum SolverLangItem {
     CallRefFuture,
     CoroutineReturn,
     CoroutineYield,
-    DynMetadata,
     FieldBase,
     FieldType,
     FutureOutput,
@@ -18,6 +17,7 @@ pub enum SolverLangItem {
 
 pub enum SolverAdtLangItem {
     // tidy-alphabetical-start
+    DynMetadata,
     Option,
     Poll,
     // tidy-alphabetical-end
@@ -29,7 +29,6 @@ pub enum SolverTraitLangItem {
     AsyncFnKindHelper,
     AsyncFnMut,
     AsyncFnOnce,
-    AsyncFnOnceOutput,
     AsyncIterator,
     BikeshedGuaranteedNoDrop,
     Clone,

--- a/compiler/rustc_type_ir/src/opaque_ty.rs
+++ b/compiler/rustc_type_ir/src/opaque_ty.rs
@@ -13,7 +13,7 @@ use crate::{self as ty, Interner};
     derive(Encodable_NoContext, Decodable_NoContext, StableHash_NoContext)
 )]
 pub struct OpaqueTypeKey<I: Interner> {
-    pub def_id: I::LocalDefId,
+    pub def_id: I::LocalOpaqueTyId,
     pub args: I::GenericArgs,
 }
 

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -472,7 +472,7 @@ impl<I: Interner> ty::Binder<I, ExistentialTraitRef<I>> {
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
 pub struct ExistentialProjection<I: Interner> {
-    pub def_id: I::DefId,
+    pub def_id: I::TraitAssocTermId,
     pub args: I::GenericArgs,
     pub term: I::Term,
 
@@ -487,17 +487,17 @@ impl<I: Interner> Eq for ExistentialProjection<I> {}
 impl<I: Interner> ExistentialProjection<I> {
     pub fn new_from_args(
         interner: I,
-        def_id: I::DefId,
+        def_id: I::TraitAssocTermId,
         args: I::GenericArgs,
         term: I::Term,
     ) -> ExistentialProjection<I> {
-        interner.debug_assert_existential_args_compatible(def_id, args);
+        interner.debug_assert_existential_args_compatible(def_id.into(), args);
         Self { def_id, args, term, use_existential_projection_new_instead: () }
     }
 
     pub fn new(
         interner: I,
-        def_id: I::DefId,
+        def_id: I::TraitAssocTermId,
         args: impl IntoIterator<Item: Into<I::GenericArg>>,
         term: I::Term,
     ) -> ExistentialProjection<I> {
@@ -511,10 +511,10 @@ impl<I: Interner> ExistentialProjection<I> {
     /// then this function would return an `exists T. T: Iterator` existential trait
     /// reference.
     pub fn trait_ref(&self, interner: I) -> ExistentialTraitRef<I> {
-        let def_id = interner.parent(self.def_id);
-        let args_count = interner.generics_of(def_id).count() - 1;
+        let def_id = interner.projection_parent(self.def_id);
+        let args_count = interner.generics_of(def_id.into()).count() - 1;
         let args = interner.mk_args(&self.args.as_slice()[..args_count]);
-        ExistentialTraitRef::new_from_args(interner, def_id.try_into().unwrap(), args)
+        ExistentialTraitRef::new_from_args(interner, def_id, args)
     }
 
     pub fn with_self_ty(&self, interner: I, self_ty: I::Ty) -> ProjectionPredicate<I> {
@@ -524,7 +524,7 @@ impl<I: Interner> ExistentialProjection<I> {
         ProjectionPredicate {
             projection_term: AliasTerm::new(
                 interner,
-                interner.alias_term_kind_from_def_id(self.def_id),
+                interner.alias_term_kind_from_def_id(self.def_id.into()),
                 [self_ty.into()].iter().chain(self.args.iter()),
             ),
             term: self.term,
@@ -536,7 +536,7 @@ impl<I: Interner> ExistentialProjection<I> {
         projection_predicate.projection_term.args.type_at(0);
 
         Self {
-            def_id: projection_predicate.projection_term.def_id(),
+            def_id: projection_predicate.def_id(),
             args: interner.mk_args(&projection_predicate.projection_term.args.as_slice()[1..]),
             term: projection_predicate.term,
             use_existential_projection_new_instead: (),
@@ -549,13 +549,13 @@ impl<I: Interner> ty::Binder<I, ExistentialProjection<I>> {
         self.map_bound(|p| p.with_self_ty(cx, self_ty))
     }
 
-    pub fn item_def_id(&self) -> I::DefId {
+    pub fn item_def_id(&self) -> I::TraitAssocTermId {
         self.skip_binder().def_id
     }
 }
 
 #[derive_where(Clone, Copy, PartialEq, Eq, Hash, Debug; I: Interner)]
-#[derive(Lift_Generic)]
+#[derive(Lift_Generic, GenericTypeVisitable)]
 #[cfg_attr(
     feature = "nightly",
     derive(Encodable_NoContext, Decodable_NoContext, StableHash_NoContext)
@@ -570,12 +570,12 @@ pub enum AliasTermKind<I: Interner> {
     /// Note that the `def_id` is not the `DefId` of the `TraitRef` containing this
     /// associated type, which is in `interner.associated_item(def_id).container`,
     /// aka. `interner.parent(def_id)`.
-    ProjectionTy { def_id: I::DefId },
+    ProjectionTy { def_id: I::TraitAssocTyId },
 
     /// An associated type in an inherent `impl`
     ///
     /// The `def_id` is the `DefId` of the `ImplItem` for the associated type.
-    InherentTy { def_id: I::DefId },
+    InherentTy { def_id: I::InherentAssocTyId },
 
     /// An opaque type (usually from `impl Trait` in type aliases or function return types)
     ///
@@ -585,22 +585,22 @@ pub enum AliasTermKind<I: Interner> {
     ///
     /// During codegen, `interner.type_of(def_id)` can be used to get the type of the
     /// underlying type if the type is an opaque.
-    OpaqueTy { def_id: I::DefId },
+    OpaqueTy { def_id: I::OpaqueTyId },
 
     /// A type alias that actually checks its trait bounds.
     ///
     /// Currently only used if the type alias references opaque types.
     /// Can always be normalized away.
-    FreeTy { def_id: I::DefId },
+    FreeTy { def_id: I::FreeTyAliasId },
 
     /// An unevaluated anonymous constants.
-    UnevaluatedConst { def_id: I::DefId },
+    UnevaluatedConst { def_id: I::UnevaluatedConstId },
     /// An unevaluated const coming from an associated const.
-    ProjectionConst { def_id: I::DefId },
+    ProjectionConst { def_id: I::TraitAssocConstId },
     /// A top level const item not part of a trait or impl.
-    FreeConst { def_id: I::DefId },
+    FreeConst { def_id: I::FreeConstAliasId },
     /// An associated const in an inherent `impl`
-    InherentConst { def_id: I::DefId },
+    InherentConst { def_id: I::InherentAssocConstId },
 }
 
 impl<I: Interner> AliasTermKind<I> {
@@ -631,17 +631,18 @@ impl<I: Interner> AliasTermKind<I> {
         }
     }
 
-    // FIXME: replace with explicit matches
+    // FIXME(#156181): replace with explicit matches
     pub fn def_id(self) -> I::DefId {
-        let (AliasTermKind::ProjectionTy { def_id }
-        | AliasTermKind::InherentTy { def_id }
-        | AliasTermKind::OpaqueTy { def_id }
-        | AliasTermKind::FreeTy { def_id }
-        | AliasTermKind::UnevaluatedConst { def_id }
-        | AliasTermKind::ProjectionConst { def_id }
-        | AliasTermKind::FreeConst { def_id }
-        | AliasTermKind::InherentConst { def_id }) = self;
-        def_id
+        match self {
+            AliasTermKind::ProjectionTy { def_id } => def_id.into(),
+            AliasTermKind::InherentTy { def_id } => def_id.into(),
+            AliasTermKind::OpaqueTy { def_id } => def_id.into(),
+            AliasTermKind::FreeTy { def_id } => def_id.into(),
+            AliasTermKind::UnevaluatedConst { def_id } => def_id.into(),
+            AliasTermKind::ProjectionConst { def_id } => def_id.into(),
+            AliasTermKind::FreeConst { def_id } => def_id.into(),
+            AliasTermKind::InherentConst { def_id } => def_id.into(),
+        }
     }
 }
 
@@ -737,11 +738,11 @@ impl<I: Interner> AliasTerm<I> {
     }
 
     pub fn expect_ct(self, interner: I) -> ty::UnevaluatedConst<I> {
-        let def_id = match self.kind(interner) {
-            AliasTermKind::InherentConst { def_id }
-            | AliasTermKind::FreeConst { def_id }
-            | AliasTermKind::UnevaluatedConst { def_id }
-            | AliasTermKind::ProjectionConst { def_id } => def_id,
+        let def = match self.kind(interner) {
+            AliasTermKind::InherentConst { def_id } => def_id.into(),
+            AliasTermKind::FreeConst { def_id } => def_id.into(),
+            AliasTermKind::UnevaluatedConst { def_id } => def_id,
+            AliasTermKind::ProjectionConst { def_id } => def_id.into(),
             kind @ (AliasTermKind::ProjectionTy { .. }
             | AliasTermKind::InherentTy { .. }
             | AliasTermKind::OpaqueTy { .. }
@@ -749,7 +750,7 @@ impl<I: Interner> AliasTerm<I> {
                 panic!("Cannot turn `{}` into `UnevaluatedConst`", kind.descr())
             }
         };
-        ty::UnevaluatedConst { def: def_id.try_into().unwrap(), args: self.args }
+        ty::UnevaluatedConst { def, args: self.args }
     }
 
     // FIXME: remove this function (access the field instead)
@@ -763,17 +764,14 @@ impl<I: Interner> AliasTerm<I> {
     }
 
     pub fn to_term(self, interner: I) -> I::Term {
+        let unevaluated_const = |def_id| {
+            I::Const::new_unevaluated(interner, ty::UnevaluatedConst::new(def_id, self.args)).into()
+        };
         let alias_ty_kind = match self.kind(interner) {
-            AliasTermKind::FreeConst { def_id }
-            | AliasTermKind::InherentConst { def_id }
-            | AliasTermKind::UnevaluatedConst { def_id }
-            | AliasTermKind::ProjectionConst { def_id } => {
-                return I::Const::new_unevaluated(
-                    interner,
-                    ty::UnevaluatedConst::new(def_id.try_into().unwrap(), self.args),
-                )
-                .into();
-            }
+            AliasTermKind::FreeConst { def_id } => return unevaluated_const(def_id.into()),
+            AliasTermKind::InherentConst { def_id } => return unevaluated_const(def_id.into()),
+            AliasTermKind::UnevaluatedConst { def_id } => return unevaluated_const(def_id),
+            AliasTermKind::ProjectionConst { def_id } => return unevaluated_const(def_id.into()),
 
             AliasTermKind::ProjectionTy { def_id } => ty::Projection { def_id },
             AliasTermKind::InherentTy { def_id } => ty::Inherent { def_id },
@@ -804,15 +802,25 @@ impl<I: Interner> AliasTerm<I> {
         )
     }
 
+    fn projection_def_id(self) -> Option<I::TraitAssocTermId> {
+        match self.kind {
+            AliasTermKind::ProjectionTy { def_id } => Some(def_id.into()),
+            AliasTermKind::ProjectionConst { def_id } => Some(def_id.into()),
+            AliasTermKind::InherentTy { .. }
+            | AliasTermKind::OpaqueTy { .. }
+            | AliasTermKind::FreeTy { .. }
+            | AliasTermKind::UnevaluatedConst { .. }
+            | AliasTermKind::FreeConst { .. }
+            | AliasTermKind::InherentConst { .. } => None,
+        }
+    }
+
+    fn expect_projection_def_id(self) -> I::TraitAssocTermId {
+        self.projection_def_id().expect("expected a projection")
+    }
+
     pub fn trait_def_id(self, interner: I) -> I::TraitId {
-        assert!(
-            matches!(
-                self.kind(interner),
-                AliasTermKind::ProjectionTy { .. } | AliasTermKind::ProjectionConst { .. }
-            ),
-            "expected a projection"
-        );
-        interner.parent(self.def_id()).try_into().unwrap()
+        interner.projection_parent(self.expect_projection_def_id())
     }
 
     /// Extracts the underlying trait reference and own args from this projection.
@@ -820,7 +828,7 @@ impl<I: Interner> AliasTerm<I> {
     /// then this function would return a `T: StreamingIterator` trait reference and
     /// `['a]` as the own args.
     pub fn trait_ref_and_own_args(self, interner: I) -> (TraitRef<I>, I::GenericArgsSlice) {
-        interner.trait_ref_and_own_args_for_alias(self.def_id(), self.args)
+        interner.trait_ref_and_own_args_for_alias(self.expect_projection_def_id(), self.args)
     }
 
     /// Extracts the underlying trait reference from this projection.
@@ -918,8 +926,8 @@ impl<I: Interner> ProjectionPredicate<I> {
         self.projection_term.trait_def_id(interner)
     }
 
-    pub fn def_id(self) -> I::DefId {
-        self.projection_term.def_id()
+    pub fn def_id(self) -> I::TraitAssocTermId {
+        self.projection_term.expect_projection_def_id()
     }
 }
 

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -268,7 +268,10 @@ impl<I: Interner> Relate<I> for ty::ExistentialProjection<I> {
         b: ty::ExistentialProjection<I>,
     ) -> RelateResult<I, ty::ExistentialProjection<I>> {
         if a.def_id != b.def_id {
-            Err(TypeError::ProjectionMismatched(ExpectedFound::new(a.def_id, b.def_id)))
+            Err(TypeError::ProjectionMismatched(ExpectedFound::new(
+                a.def_id.into(),
+                b.def_id.into(),
+            )))
         } else {
             let term = relation.relate_with_variance(
                 ty::Invariant,

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -535,7 +535,7 @@ pub enum BuiltinImplSource {
 #[derive_where(Copy, Clone, Debug; I: Interner)]
 pub enum FetchEligibleAssocItemResponse<I: Interner> {
     Err(I::ErrorGuaranteed),
-    Found(I::DefId),
+    Found(I::ImplOrTraitAssocTermId),
     NotFound(TypingMode<I, CantBeErased>),
     NotFoundBecauseErased,
 }

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -39,12 +39,12 @@ pub enum AliasTyKind<I: Interner> {
     /// Note that the `def_id` is not the `DefId` of the `TraitRef` containing this
     /// associated type, which is in `interner.associated_item(def_id).container`,
     /// aka. `interner.parent(def_id)`.
-    Projection { def_id: I::DefId },
+    Projection { def_id: I::TraitAssocTyId },
 
     /// An associated type in an inherent `impl`
     ///
     /// The `def_id` is the `DefId` of the `ImplItem` for the associated type.
-    Inherent { def_id: I::DefId },
+    Inherent { def_id: I::InherentAssocTyId },
 
     /// An opaque type (usually from `impl Trait` in type aliases or function return types)
     ///
@@ -55,13 +55,13 @@ pub enum AliasTyKind<I: Interner> {
     ///
     /// During codegen, `interner.type_of(def_id)` can be used to get the type of the
     /// underlying type if the type is an opaque.
-    Opaque { def_id: I::DefId },
+    Opaque { def_id: I::OpaqueTyId },
 
     /// A type alias that actually checks its trait bounds.
     ///
     /// Currently only used if the type alias references opaque types.
     /// Can always be normalized away.
-    Free { def_id: I::DefId },
+    Free { def_id: I::FreeTyAliasId },
 }
 
 impl<I: Interner> AliasTyKind<I> {
@@ -79,12 +79,12 @@ impl<I: Interner> AliasTyKind<I> {
     }
 
     pub fn def_id(self) -> I::DefId {
-        let (AliasTyKind::Projection { def_id }
-        | AliasTyKind::Inherent { def_id }
-        | AliasTyKind::Opaque { def_id }
-        | AliasTyKind::Free { def_id }) = self;
-
-        def_id
+        match self {
+            AliasTyKind::Projection { def_id } => def_id.into(),
+            AliasTyKind::Inherent { def_id } => def_id.into(),
+            AliasTyKind::Opaque { def_id } => def_id.into(),
+            AliasTyKind::Free { def_id } => def_id.into(),
+        }
     }
 }
 
@@ -506,10 +506,10 @@ impl<I: Interner> AliasTy<I> {
         )
     }
 
-    pub fn trait_def_id(self, interner: I) -> I::DefId {
+    pub fn trait_def_id(self, interner: I) -> I::TraitId {
         let AliasTyKind::Projection { def_id } = self.kind else { panic!("expected a projection") };
 
-        interner.parent(def_id)
+        interner.projection_parent(def_id.into())
     }
 
     /// Extracts the underlying trait reference and own args from this projection.
@@ -520,7 +520,7 @@ impl<I: Interner> AliasTy<I> {
     pub fn trait_ref_and_own_args(self, interner: I) -> (ty::TraitRef<I>, I::GenericArgsSlice) {
         let AliasTyKind::Projection { def_id } = self.kind else { panic!("expected a projection") };
 
-        interner.trait_ref_and_own_args_for_alias(def_id, self.args)
+        interner.trait_ref_and_own_args_for_alias(def_id.into(), self.args)
     }
 
     /// Extracts the underlying trait reference from this projection.

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -33,6 +33,7 @@ cfg_select! {
         target_os = "psp",
         target_os = "solid_asp3",
         all(target_vendor = "fortanix", target_env = "sgx"),
+        all(target_os = "wasi", panic = "unwind"),
     ) => {
         mod libunwind;
         pub use libunwind::*;

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -75,7 +75,7 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
 pub const unwinder_private_data_size: usize = 20;
 
-#[cfg(all(target_arch = "wasm32", target_os = "linux"))]
+#[cfg(all(target_arch = "wasm32", any(target_os = "linux", target_os = "wasi")))]
 pub const unwinder_private_data_size: usize = 2;
 
 #[cfg(target_arch = "hexagon")]
@@ -111,6 +111,13 @@ pub type _Unwind_Exception_Cleanup_Fn =
     ),
     link(name = "unwind", kind = "static", modifiers = "-bundle")
 )]
+// Explicitly link the `unwind` library on WASI targets.
+//
+// This is provided in the self-contained sysroot for WASI targets by default.
+// Note that Rust defaults to `-Cpanic=abort` on WASI targets meaning that this
+// doesn't end up getting used by default, but this does mean that with
+// `-Zbuild-std` this'll automatically link it in.
+#[cfg_attr(target_os = "wasi", link(name = "unwind"))]
 unsafe extern "C-unwind" {
     pub fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> !;
 }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -457,6 +457,16 @@ fn copy_self_contained_objects(
                 DependencyType::TargetSelfContained,
             );
         }
+        if srcdir.join("eh").exists() {
+            copy_and_stamp(
+                builder,
+                &libdir_self_contained,
+                &srcdir.join("eh"),
+                "libunwind.a",
+                &mut target_deps,
+                DependencyType::TargetSelfContained,
+            );
+        }
     } else if target.is_windows_gnu() || target.is_windows_gnullvm() {
         for obj in ["crt2.o", "dllcrt2.o"].iter() {
             let src = compiler_file(builder, &builder.cc(target), target, CLang::C, obj);

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -1500,7 +1500,7 @@ impl Build {
         if let Some(path) = finder.maybe_have("wasmtime")
             && let Ok(mut path) = path.into_os_string().into_string()
         {
-            path.push_str(" run -C cache=n --dir .");
+            path.push_str(" run -Wexceptions -C cache=n --dir .");
             // Make sure that tests have access to RUSTC_BOOTSTRAP. This (for example) is
             // required for libtest to work on beta/stable channels.
             //

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -87,9 +87,9 @@ RUN /tmp/build-fuchsia-toolchain.sh
 COPY host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh /tmp/
 RUN /tmp/build-x86_64-fortanix-unknown-sgx-toolchain.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-32/wasi-sdk-32.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/tmp/wasi-sdk-32.0-x86_64-linux
+ENV WASI_SDK_PATH=/tmp/wasi-sdk-33.0-x86_64-linux
 
 COPY scripts/freebsd-toolchain.sh /tmp/
 RUN /tmp/freebsd-toolchain.sh i686

--- a/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/pr-check-2/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-32/wasi-sdk-32.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/wasi-sdk-32.0-x86_64-linux
+ENV WASI_SDK_PATH=/wasi-sdk-33.0-x86_64-linux
 
 ENV RUST_CONFIGURE_ARGS="--set rust.validate-mir-opts=3"
 

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -43,9 +43,9 @@ WORKDIR /
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-32/wasi-sdk-32.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-33/wasi-sdk-33.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/wasi-sdk-32.0-x86_64-linux
+ENV WASI_SDK_PATH=/wasi-sdk-33.0-x86_64-linux
 
 ENV RUST_CONFIGURE_ARGS="--musl-root-x86_64=/usr/local/x86_64-linux-musl \
   --set rust.lld"
@@ -57,9 +57,9 @@ ENV RUST_CONFIGURE_ARGS="--musl-root-x86_64=/usr/local/x86_64-linux-musl \
 ENV NO_DEBUG_ASSERTIONS=1
 ENV NO_OVERFLOW_CHECKS=1
 
-RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v38.0.4/wasmtime-v38.0.4-x86_64-linux.tar.xz | \
+RUN curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v44.0.1/wasmtime-v44.0.1-x86_64-linux.tar.xz | \
   tar -xJ
-ENV PATH="$PATH:/wasmtime-v38.0.4-x86_64-linux"
+ENV PATH="$PATH:/wasmtime-v44.0.1-x86_64-linux"
 
 ENV WASM_WASIP_TARGET=wasm32-wasip1
 ENV WASM_WASIP_SCRIPT="python3 /checkout/x.py --stage 2 test --host= --target $WASM_WASIP_TARGET \


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156061 (Support `-Cpanic=unwind` on WASI targets)
 - rust-lang/rust#156236 (resolve: Remove `MacroData`)
 - rust-lang/rust#155981 (Use special DefIds for aliases)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156061,156236,155981)
<!-- homu-ignore:end -->

