### PR TITLE
Document wasi-sdk minimum versions for WASI targets

### DIFF
--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -70,17 +70,16 @@ be used instead.
 
 [`wasi-libc`]: https://github.com/WebAssembly/wasi-libc
 
-## Building the target
+## Building the target in rustc
 
-To build this target first acquire a copy of
-[`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk/). At this time version 22
-is the minimum needed.
+To build this target first acquire a copy of [`wasi-sdk`]. At this time version
+33 is the minimum needed.
 
 Next configure the `WASI_SDK_PATH` environment variable to point to where this
 is installed. For example:
 
 ```text
-export WASI_SDK_PATH=/path/to/wasi-sdk-22.0
+export WASI_SDK_PATH=/path/to/wasi-sdk-33.0
 ```
 
 Next be sure to enable LLD when building Rust from source as LLVM's `wasm-ld`
@@ -102,6 +101,16 @@ Rust programs can be built for that target:
 ```text
 rustc --target wasm32-wasip1 your-code.rs
 ```
+
+The `wasm32-wasip1` toolchain comes with a self-contained sysroot meaning that
+no external compiler is required when building for this target. Users which
+build a `staticlib`, however, or use an external `-Clinker`, are recommended to
+use [`wasi-sdk`]. The minimum version required of [`wasi-sdk`] will change over
+time as it's updated in Rust and Rust relies on newer features that [`wasi-sdk`]
+has. See the documentation above about building the target in rustc for the
+minimum known working version.
+
+[`wasi-sdk`]: https://github.com/WebAssembly/wasi-sdk
 
 ## Cross-compilation
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -27,23 +27,20 @@ are required to support components since this target outputs a component as
 opposed to a core wasm module. As of the time of this writing Wasmtime 17 and
 above is able to run this target natively with no extra flags.
 
-## Building the target
+## Building the target in rustc
 
-To build this target first acquire a copy of
-[`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk/). At this time version 22
-is the minimum needed.
+See the documentation for the [building the `wasm32-wasip1` target in
+rustc](./wasm32-wasip1.md#building-the-target-in-rustc) for more information. The tl;dr;
+is that [`wasi-sdk`] is required, and the `wasm32-wasip1` target documents the
+minimum version required.
 
-Next configure the `WASI_SDK_PATH` environment variable to point to where this
-is installed. For example:
+[`wasi-sdk`]: https://github.com/WebAssembly/wasi-sdk
 
-```text
-export WASI_SDK_PATH=/path/to/wasi-sdk-22.0
-```
+## Building Rust programs
 
-Next be sure to enable LLD when building Rust from source as LLVM's `wasm-ld`
-driver for LLD is required when linking WebAssembly code together. Rust's build
-system will automatically pick up any necessary binaries and programs from
-`WASI_SDK_PATH`.
+For more information see the documentation [`wasm32-wasip1`
+target](./wasm32-wasip1.md#building-rust-programs). Replace `wasm32-wasip1`
+target strings with `wasm32-wasip2`, however.
 
 ## Testing
 


### PR DESCRIPTION
This commit updates the documentation for WASI targets in the rustc book to mention a minimum version of wasi-sdk that's required.

Closes rust-lang/rust#155971

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
