### PR TITLE
Don't create `Vec<Symbol>` just for diagnostic attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,6 +3594,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
+ "smallvec",
  "thin-vec",
 ]
 

--- a/compiler/rustc_attr_parsing/Cargo.toml
+++ b/compiler/rustc_attr_parsing/Cargo.toml
@@ -20,5 +20,6 @@ rustc_parse_format = { path = "../rustc_parse_format" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
+smallvec = "1.8.1"
 thin-vec = "0.2.15"
 # tidy-alphabetical-end

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -12,6 +12,7 @@ use rustc_lint_defs::RegisteredTools;
 use rustc_session::Session;
 use rustc_session::lint::LintId;
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span, Symbol, sym};
+use smallvec::SmallVec;
 
 use crate::attributes::AttributeSafety;
 use crate::context::{
@@ -158,17 +159,22 @@ impl<'sess> AttributeParser<'sess> {
         let ast::AttrKind::Normal(normal_attr) = &attr.kind else {
             panic!("parse_single called on a doc attr")
         };
-        let parts =
-            normal_attr.item.path.segments.iter().map(|seg| seg.ident.name).collect::<Vec<_>>();
+        let first = normal_attr.item.path.segments.first().map(|seg| seg.ident.name);
 
         let path = AttrPath::from_ast(&normal_attr.item.path, identity);
-        let args = ArgParser::from_attr_args(
+        let parser_ctor = if matches!(first, Some(sym::rustc_dummy | sym::diagnostic)) {
+            ArgParser::from_diagnostic_attr_args
+        } else {
+            ArgParser::from_attr_args
+        };
+
+        let args = parser_ctor(
             &normal_attr.item.args.unparsed_ref().unwrap(),
-            &parts,
             &sess.psess,
             emit_errors,
             allow_expr_metavar,
         )?;
+
         Self::parse_single_args(
             sess,
             attr.span,
@@ -339,8 +345,13 @@ impl<'sess> AttributeParser<'sess> {
                         }
                     };
 
-                    let parts =
-                        n.item.path.segments.iter().map(|seg| seg.ident.name).collect::<Vec<_>>();
+                    let parts = n
+                        .item
+                        .path
+                        .segments
+                        .iter()
+                        .map(|seg| seg.ident.name)
+                        .collect::<SmallVec<[_; 2]>>();
 
                     if let Some(accept) = ATTRIBUTE_PARSERS.accepters.get(parts.as_slice()) {
                         self.check_attribute_safety(
@@ -351,9 +362,15 @@ impl<'sess> AttributeParser<'sess> {
                             &mut emit_lint,
                         );
 
-                        let Some(args) = ArgParser::from_attr_args(
+                        let parser_ctor =
+                            if matches!(&*parts, [sym::rustc_dummy] | [sym::diagnostic, ..]) {
+                                ArgParser::from_diagnostic_attr_args
+                            } else {
+                                ArgParser::from_attr_args
+                            };
+
+                        let Some(args) = parser_ctor(
                             args,
-                            &parts,
                             &self.sess.psess,
                             self.should_emit,
                             AllowExprMetavar::No,

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -18,7 +18,7 @@ use rustc_parse::exp;
 use rustc_parse::parser::{ForceCollect, Parser, PathStyle, Recovery, token_descr};
 use rustc_session::errors::create_lit_error;
 use rustc_session::parse::ParseSess;
-use rustc_span::{Ident, Span, Symbol, sym};
+use rustc_span::{Ident, Span, Symbol};
 use thin_vec::ThinVec;
 
 use crate::ShouldEmit;
@@ -104,42 +104,64 @@ impl ArgParser {
         }
     }
 
+    /// Create an `ArgParser`.
     pub fn from_attr_args<'sess>(
         value: &AttrArgs,
-        parts: &[Symbol],
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
         allow_expr_metavar: AllowExprMetavar,
     ) -> Option<Self> {
+        Self::from_attr_args_inner(value, psess, should_emit, allow_expr_metavar, false)
+    }
+
+    /// Create an `ArgParser` for parsing diagnostic attributes.
+    ///
+    /// This parser will deal with invalid input by swallowing it, so it should never be
+    /// used outside of diagnostic attributes(or rustc_dummy).
+    pub fn from_diagnostic_attr_args<'sess>(
+        value: &AttrArgs,
+        psess: &'sess ParseSess,
+        should_emit: ShouldEmit,
+        allow_expr_metavar: AllowExprMetavar,
+    ) -> Option<Self> {
+        Self::from_attr_args_inner(value, psess, should_emit, allow_expr_metavar, true)
+    }
+
+    fn from_attr_args_inner<'sess>(
+        value: &AttrArgs,
+        psess: &'sess ParseSess,
+        should_emit: ShouldEmit,
+        allow_expr_metavar: AllowExprMetavar,
+        permit_malformed_delimited: bool,
+    ) -> Option<Self> {
         Some(match value {
             AttrArgs::Empty => Self::NoArgs,
-            AttrArgs::Delimited(args) => {
+            AttrArgs::Delimited(args) if permit_malformed_delimited => {
                 // Diagnostic attributes can't error if they encounter non meta item syntax.
                 // However, the current syntax for diagnostic attributes is meta item syntax.
                 // Therefore we can substitute with a dummy value on invalid syntax.
-                if matches!(parts, [sym::rustc_dummy] | [sym::diagnostic, ..]) {
-                    match MetaItemListParser::new(
-                        &args.tokens,
-                        args.dspan.entire(),
-                        psess,
-                        ShouldEmit::ErrorsAndLints { recovery: Recovery::Forbidden },
-                        allow_expr_metavar,
-                    ) {
-                        Ok(p) => return Some(ArgParser::List(p)),
-                        Err(e) => {
-                            // We can just dispose of the diagnostic and not bother with a lint,
-                            // because this will look like `#[diagnostic::attr()]` was used. This
-                            // is invalid for all diagnostic attrs, so a lint explaining the proper
-                            // form will be issued later.
-                            e.cancel();
-                            return Some(ArgParser::List(MetaItemListParser {
-                                sub_parsers: ThinVec::new(),
-                                span: args.dspan.entire(),
-                            }));
-                        }
+                match MetaItemListParser::new(
+                    &args.tokens,
+                    args.dspan.entire(),
+                    psess,
+                    ShouldEmit::ErrorsAndLints { recovery: Recovery::Forbidden },
+                    allow_expr_metavar,
+                ) {
+                    Ok(p) => return Some(ArgParser::List(p)),
+                    Err(e) => {
+                        // We can just dispose of the diagnostic and not bother with a lint,
+                        // because this will look like `#[diagnostic::attr()]` was used. This
+                        // is invalid for all diagnostic attrs, so a lint explaining the proper
+                        // form will be issued later.
+                        e.cancel();
+                        return Some(ArgParser::List(MetaItemListParser {
+                            sub_parsers: ThinVec::new(),
+                            span: args.dspan.entire(),
+                        }));
                     }
                 }
-
+            }
+            AttrArgs::Delimited(args) => {
                 if args.delim != Delimiter::Parenthesis {
                     should_emit.emit_err(psess.dcx().create_err(MetaBadDelim {
                         span: args.dspan.entire(),


### PR DESCRIPTION
We create this Vec just to check if this is the weird attribute that may never error.

Also switch to a SmallVec where we do actually need a `&[Symbol]` since this Vec is almost always 1 item and sometimes 2 (We don't parse any 2+ attributes AFAIK).

r? @JonathanBrouwer 