### PR TITLE
test: suppress deprecation warning

### DIFF
--- a/tests/ui/linking/ld64-cross-compilation.rs
+++ b/tests/ui/linking/ld64-cross-compilation.rs
@@ -6,6 +6,8 @@
 //@ run-pass
 //@ only-x86_64-apple-darwin
 
+#![allow(linker_messages)]
+
 fn main() {
     let dst: Vec<u8> = Vec::new();
     let len = broken_func(std::hint::black_box(2), dst);


### PR DESCRIPTION
The newer mac os ld linker emits a deprecation warning:
```
 warning: linker stderr: ld: -ld_classic is deprecated and will be removed in a future release
    |
    = note: `#[warn(linker_messages)]` on by default
```