### PR TITLE
Remove unused `ToStableHashKey` impls.

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -459,22 +459,6 @@ impl StableOrd for String {
     const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
 }
 
-impl ToStableHashKey for String {
-    type KeyType = String;
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> Self::KeyType {
-        self.clone()
-    }
-}
-
-impl<T1: ToStableHashKey, T2: ToStableHashKey> ToStableHashKey for (T1, T2) {
-    type KeyType = (T1::KeyType, T2::KeyType);
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> Self::KeyType {
-        (self.0.to_stable_hash_key(hcx), self.1.to_stable_hash_key(hcx))
-    }
-}
-
 impl StableHash for bool {
     #[inline]
     fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 
 use rustc_ast as ast;
 use rustc_ast::NodeId;
-use rustc_data_structures::stable_hasher::ToStableHashKey;
 use rustc_data_structures::unord::UnordMap;
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
 use rustc_macros::{Decodable, Encodable, StableHash};
@@ -709,15 +708,6 @@ impl Namespace {
 impl IntoDiagArg for Namespace {
     fn into_diag_arg(self, _: &mut Option<std::path::PathBuf>) -> DiagArgValue {
         DiagArgValue::Str(Cow::Borrowed(self.descr()))
-    }
-}
-
-impl ToStableHashKey for Namespace {
-    type KeyType = Namespace;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> Namespace {
-        *self
     }
 }
 

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -1,59 +1,7 @@
-use rustc_data_structures::stable_hasher::{
-    StableHash, StableHashCtxt, StableHasher, ToStableHashKey,
-};
-use rustc_span::def_id::DefPathHash;
+use rustc_data_structures::stable_hasher::{StableHash, StableHashCtxt, StableHasher};
 
 use crate::HashIgnoredAttrId;
-use crate::hir::{
-    AttributeMap, BodyId, ForeignItemId, ImplItemId, ItemId, OwnerNodes, TraitItemId,
-};
-use crate::hir_id::ItemLocalId;
-
-impl ToStableHashKey for BodyId {
-    type KeyType = (DefPathHash, ItemLocalId);
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> (DefPathHash, ItemLocalId) {
-        let BodyId { hir_id } = *self;
-        hir_id.to_stable_hash_key(hcx)
-    }
-}
-
-impl ToStableHashKey for ItemId {
-    type KeyType = DefPathHash;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> DefPathHash {
-        self.owner_id.def_id.to_stable_hash_key(hcx)
-    }
-}
-
-impl ToStableHashKey for TraitItemId {
-    type KeyType = DefPathHash;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> DefPathHash {
-        self.owner_id.def_id.to_stable_hash_key(hcx)
-    }
-}
-
-impl ToStableHashKey for ImplItemId {
-    type KeyType = DefPathHash;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> DefPathHash {
-        self.owner_id.def_id.to_stable_hash_key(hcx)
-    }
-}
-
-impl ToStableHashKey for ForeignItemId {
-    type KeyType = DefPathHash;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> DefPathHash {
-        self.owner_id.def_id.to_stable_hash_key(hcx)
-    }
-}
+use crate::hir::{AttributeMap, OwnerNodes};
 
 // The following implementations of StableHash for `ItemId`, `TraitItemId`, and
 // `ImplItemId` deserve special attention. Normally we do not hash `NodeId`s within

--- a/compiler/rustc_hir_id/src/lib.rs
+++ b/compiler/rustc_hir_id/src/lib.rs
@@ -176,22 +176,3 @@ pub const CRATE_HIR_ID: HirId =
     HirId { owner: OwnerId { def_id: CRATE_DEF_ID }, local_id: ItemLocalId::ZERO };
 
 pub const CRATE_OWNER_ID: OwnerId = OwnerId { def_id: CRATE_DEF_ID };
-
-impl ToStableHashKey for HirId {
-    type KeyType = (DefPathHash, ItemLocalId);
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> (DefPathHash, ItemLocalId) {
-        let def_path_hash = self.owner.def_id.to_stable_hash_key(hcx);
-        (def_path_hash, self.local_id)
-    }
-}
-
-impl ToStableHashKey for ItemLocalId {
-    type KeyType = ItemLocalId;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> ItemLocalId {
-        *self
-    }
-}

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -3,12 +3,11 @@ use std::fmt::Display;
 
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::stable_hasher::{
-    StableCompare, StableHash, StableHashCtxt, StableHasher, ToStableHashKey,
+    StableCompare, StableHash, StableHashCtxt, StableHasher,
 };
 use rustc_error_messages::{DiagArgValue, IntoDiagArg};
-use rustc_hir_id::{HirId, ItemLocalId};
+use rustc_hir_id::HirId;
 use rustc_macros::{Decodable, Encodable, StableHash};
-use rustc_span::def_id::DefPathHash;
 pub use rustc_span::edition::Edition;
 use rustc_span::{AttrId, Ident, Symbol, sym};
 use serde::{Deserialize, Serialize};
@@ -149,23 +148,6 @@ impl StableHash for LintExpectationId {
                 unreachable!(
                     "StableHash should only be called for filled and stable `LintExpectationId`"
                 )
-            }
-        }
-    }
-}
-
-impl ToStableHashKey for LintExpectationId {
-    type KeyType = (DefPathHash, ItemLocalId, u16, u16);
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> Self::KeyType {
-        match self {
-            LintExpectationId::Stable { hir_id, attr_index, lint_index: Some(lint_index) } => {
-                let (def_path_hash, lint_idx) = hir_id.to_stable_hash_key(hcx);
-                (def_path_hash, lint_idx, *attr_index, *lint_index)
-            }
-            _ => {
-                unreachable!("StableHash should only be called for a filled `LintExpectationId`")
             }
         }
     }
@@ -620,15 +602,6 @@ impl StableHash for LintId {
     #[inline]
     fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.lint_name_raw().stable_hash(hcx, hasher);
-    }
-}
-
-impl ToStableHashKey for LintId {
-    type KeyType = &'static str;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> &'static str {
-        self.lint_name_raw()
     }
 }
 

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -51,7 +51,7 @@ use std::fmt;
 use std::hash::Hash;
 
 use rustc_data_structures::fingerprint::{Fingerprint, PackedFingerprint};
-use rustc_data_structures::stable_hasher::{StableHasher, StableOrd, ToStableHashKey};
+use rustc_data_structures::stable_hasher::{StableHasher, StableOrd};
 use rustc_hir::def_id::DefId;
 use rustc_hir::definitions::DefPathHash;
 use rustc_macros::{Decodable, Encodable, StableHash};
@@ -231,13 +231,7 @@ impl WorkProductId {
         WorkProductId { hash: hasher.finish() }
     }
 }
-impl ToStableHashKey for WorkProductId {
-    type KeyType = Fingerprint;
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> Self::KeyType {
-        self.hash
-    }
-}
+
 impl StableOrd for WorkProductId {
     // Fingerprint can use unstable (just a tuple of `u64`s), so WorkProductId can as well
     const CAN_USE_UNSTABLE_SORT: bool = true;

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -7,11 +7,10 @@ use std::ptr;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{
-    HashingControls, StableHash, StableHashCtxt, StableHasher, ToStableHashKey,
+    HashingControls, StableHash, StableHashCtxt, StableHasher,
 };
 use tracing::trace;
 
-use crate::middle::region;
 use crate::{mir, ty};
 
 impl<'tcx, H, T> StableHash for &'tcx ty::list::RawList<H, T>
@@ -45,20 +44,6 @@ where
     }
 }
 
-impl<'tcx, H, T> ToStableHashKey for &'tcx ty::list::RawList<H, T>
-where
-    T: StableHash,
-{
-    type KeyType = Fingerprint;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> Fingerprint {
-        let mut hasher = StableHasher::new();
-        self.stable_hash(hcx, &mut hasher);
-        hasher.finish()
-    }
-}
-
 impl<'tcx> StableHash for ty::GenericArg<'tcx> {
     fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.kind().stable_hash(hcx, hasher);
@@ -79,14 +64,5 @@ impl StableHash for mir::interpret::AllocId {
 impl StableHash for mir::interpret::CtfeProvenance {
     fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.into_parts().stable_hash(hcx, hasher);
-    }
-}
-
-impl ToStableHashKey for region::Scope {
-    type KeyType = region::Scope;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> region::Scope {
-        *self
     }
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -14,7 +14,7 @@ use std::{cmp, fs, iter};
 
 use externs::{ExternOpt, split_extern_opt};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
-use rustc_data_structures::stable_hasher::{StableHasher, StableOrd, ToStableHashKey};
+use rustc_data_structures::stable_hasher::{StableHasher, StableOrd};
 use rustc_errors::emitter::HumanReadableErrorType;
 use rustc_errors::{ColorConfig, DiagCtxtFlags};
 use rustc_feature::UnstableFeatures;
@@ -628,22 +628,12 @@ macro_rules! define_output_types {
             )*
         }
 
-
         impl StableOrd for OutputType {
             const CAN_USE_UNSTABLE_SORT: bool = true;
 
             // Trivial C-Style enums have a stable sort order across compilation sessions.
             const THIS_IMPLEMENTATION_HAS_BEEN_TRIPLE_CHECKED: () = ();
         }
-
-        impl ToStableHashKey for OutputType {
-            type KeyType = Self;
-
-            fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> Self::KeyType {
-                *self
-            }
-        }
-
 
         impl OutputType {
             pub fn iter_all() -> impl Iterator<Item = OutputType> {

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -465,24 +465,6 @@ impl ToStableHashKey for LocalDefId {
     }
 }
 
-impl ToStableHashKey for CrateNum {
-    type KeyType = DefPathHash;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> DefPathHash {
-        self.as_def_id().to_stable_hash_key(hcx)
-    }
-}
-
-impl ToStableHashKey for DefPathHash {
-    type KeyType = DefPathHash;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> DefPathHash {
-        *self
-    }
-}
-
 macro_rules! typed_def_id {
     ($Name:ident, $LocalName:ident) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Encodable, Decodable, StableHash)]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -8,7 +8,7 @@ use std::{fmt, str};
 use rustc_arena::DroplessArena;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_data_structures::stable_hasher::{
-    StableCompare, StableHash, StableHashCtxt, StableHasher, ToStableHashKey,
+    StableCompare, StableHash, StableHashCtxt, StableHasher,
 };
 use rustc_data_structures::sync::Lock;
 use rustc_macros::{Decodable, Encodable, StableHash, symbols};
@@ -2636,14 +2636,6 @@ impl StableHash for Symbol {
     #[inline]
     fn stable_hash<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx, hasher: &mut StableHasher) {
         self.as_str().stable_hash(hcx, hasher);
-    }
-}
-
-impl ToStableHashKey for Symbol {
-    type KeyType = String;
-    #[inline]
-    fn to_stable_hash_key<Hcx>(&self, _: &mut Hcx) -> String {
-        self.as_str().to_string()
     }
 }
 

--- a/compiler/rustc_type_ir/src/fast_reject.rs
+++ b/compiler/rustc_type_ir/src/fast_reject.rs
@@ -5,12 +5,6 @@ use std::marker::PhantomData;
 
 use rustc_ast_ir::Mutability;
 #[cfg(feature = "nightly")]
-use rustc_data_structures::fingerprint::Fingerprint;
-#[cfg(feature = "nightly")]
-use rustc_data_structures::stable_hasher::{
-    StableHash, StableHashCtxt, StableHasher, ToStableHashKey,
-};
-#[cfg(feature = "nightly")]
 use rustc_macros::{Decodable_NoContext, Encodable_NoContext, StableHash};
 
 use crate::inherent::*;
@@ -46,18 +40,6 @@ pub enum SimplifiedType<DefId> {
     UnsafeBinder,
     Placeholder,
     Error,
-}
-
-#[cfg(feature = "nightly")]
-impl<DefId: StableHash> ToStableHashKey for SimplifiedType<DefId> {
-    type KeyType = Fingerprint;
-
-    #[inline]
-    fn to_stable_hash_key<Hcx: StableHashCtxt>(&self, hcx: &mut Hcx) -> Fingerprint {
-        let mut hasher = StableHasher::new();
-        self.stable_hash(hcx, &mut hasher);
-        hasher.finish()
-    }
 }
 
 /// Generic parameters are pretty much just bound variables, e.g.


### PR DESCRIPTION
There are quite a few.

r? @mejrs 