### PR TITLE
Don't ICE in has_self_borrows when coroutine captures-by-ref ty is still inferred

### DIFF
--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -378,92 +378,108 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // For coroutine-closures, we additionally must compute the
         // `coroutine_captures_by_ref_ty` type, which is used to generate the by-ref
         // version of the coroutine-closure's output coroutine.
-        if let UpvarArgs::CoroutineClosure(args) = args
-            && !args.references_error()
-        {
-            let closure_env_region: ty::Region<'_> = ty::Region::new_bound(
-                self.tcx,
-                ty::INNERMOST,
-                ty::BoundRegion { var: ty::BoundVar::ZERO, kind: ty::BoundRegionKind::ClosureEnv },
-            );
-
-            let num_args = args
-                .as_coroutine_closure()
-                .coroutine_closure_sig()
-                .skip_binder()
-                .tupled_inputs_ty
-                .tuple_fields()
-                .len();
-            let typeck_results = self.typeck_results.borrow();
-
-            let tupled_upvars_ty_for_borrow = Ty::new_tup_from_iter(
-                self.tcx,
-                ty::analyze_coroutine_closure_captures(
-                    typeck_results.closure_min_captures_flattened(closure_def_id),
-                    typeck_results
-                        .closure_min_captures_flattened(
-                            self.tcx.coroutine_for_closure(closure_def_id).expect_local(),
-                        )
-                        // Skip the captures that are just moving the closure's args
-                        // into the coroutine. These are always by move, and we append
-                        // those later in the `CoroutineClosureSignature` helper functions.
-                        .skip(num_args),
-                    |(_, parent_capture), (_, child_capture)| {
-                        // This is subtle. See documentation on function.
-                        let needs_ref = should_reborrow_from_env_of_parent_coroutine_closure(
-                            parent_capture,
-                            child_capture,
-                        );
-
-                        let upvar_ty = child_capture.place.ty();
-                        let capture = child_capture.info.capture_kind;
-                        // Not all upvars are captured by ref, so use
-                        // `apply_capture_kind_on_capture_ty` to ensure that we
-                        // compute the right captured type.
-                        apply_capture_kind_on_capture_ty(
-                            self.tcx,
-                            upvar_ty,
-                            capture,
-                            if needs_ref {
-                                closure_env_region
-                            } else {
-                                self.tcx.lifetimes.re_erased
-                            },
-                        )
-                    },
-                ),
-            );
-            let coroutine_captures_by_ref_ty = Ty::new_fn_ptr(
-                self.tcx,
-                ty::Binder::bind_with_vars(
-                    self.tcx.mk_fn_sig_safe_rust_abi([], tupled_upvars_ty_for_borrow),
-                    self.tcx.mk_bound_variable_kinds(&[ty::BoundVariableKind::Region(
-                        ty::BoundRegionKind::ClosureEnv,
-                    )]),
-                ),
-            );
-            self.demand_eqtype(
-                span,
-                args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
-                coroutine_captures_by_ref_ty,
-            );
-
-            // Additionally, we can now constrain the coroutine's kind type.
-            //
-            // We only do this if `infer_kind`, because if we have constrained
-            // the kind from closure signature inference, the kind inferred
-            // for the inner coroutine may actually be more restrictive.
-            if infer_kind {
-                let ty::Coroutine(_, coroutine_args) =
-                    *self.typeck_results.borrow().expr_ty(body.value).kind()
-                else {
-                    bug!();
-                };
+        //
+        // If the args already reference an error, computing the by-ref upvar
+        // tuple may itself reach malformed types. We still equate the
+        // `coroutine_captures_by_ref_ty` inference variable to an error type
+        // so downstream consumers (e.g. `has_self_borrows`) can rely on it
+        // being resolved to either an `FnPtr` or `Error` rather than remaining
+        // an unconstrained inference variable.
+        if let UpvarArgs::CoroutineClosure(args) = args {
+            if let Some(guar) = args.error_reported().err() {
                 self.demand_eqtype(
                     span,
-                    coroutine_args.as_coroutine().kind_ty(),
-                    Ty::from_coroutine_closure_kind(self.tcx, closure_kind),
+                    args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
+                    Ty::new_error(self.tcx, guar),
                 );
+            } else {
+                let closure_env_region: ty::Region<'_> = ty::Region::new_bound(
+                    self.tcx,
+                    ty::INNERMOST,
+                    ty::BoundRegion {
+                        var: ty::BoundVar::ZERO,
+                        kind: ty::BoundRegionKind::ClosureEnv,
+                    },
+                );
+
+                let num_args = args
+                    .as_coroutine_closure()
+                    .coroutine_closure_sig()
+                    .skip_binder()
+                    .tupled_inputs_ty
+                    .tuple_fields()
+                    .len();
+                let typeck_results = self.typeck_results.borrow();
+
+                let tupled_upvars_ty_for_borrow = Ty::new_tup_from_iter(
+                    self.tcx,
+                    ty::analyze_coroutine_closure_captures(
+                        typeck_results.closure_min_captures_flattened(closure_def_id),
+                        typeck_results
+                            .closure_min_captures_flattened(
+                                self.tcx.coroutine_for_closure(closure_def_id).expect_local(),
+                            )
+                            // Skip the captures that are just moving the closure's args
+                            // into the coroutine. These are always by move, and we append
+                            // those later in the `CoroutineClosureSignature` helper functions.
+                            .skip(num_args),
+                        |(_, parent_capture), (_, child_capture)| {
+                            // This is subtle. See documentation on function.
+                            let needs_ref = should_reborrow_from_env_of_parent_coroutine_closure(
+                                parent_capture,
+                                child_capture,
+                            );
+
+                            let upvar_ty = child_capture.place.ty();
+                            let capture = child_capture.info.capture_kind;
+                            // Not all upvars are captured by ref, so use
+                            // `apply_capture_kind_on_capture_ty` to ensure that we
+                            // compute the right captured type.
+                            apply_capture_kind_on_capture_ty(
+                                self.tcx,
+                                upvar_ty,
+                                capture,
+                                if needs_ref {
+                                    closure_env_region
+                                } else {
+                                    self.tcx.lifetimes.re_erased
+                                },
+                            )
+                        },
+                    ),
+                );
+                let coroutine_captures_by_ref_ty = Ty::new_fn_ptr(
+                    self.tcx,
+                    ty::Binder::bind_with_vars(
+                        self.tcx.mk_fn_sig_safe_rust_abi([], tupled_upvars_ty_for_borrow),
+                        self.tcx.mk_bound_variable_kinds(&[ty::BoundVariableKind::Region(
+                            ty::BoundRegionKind::ClosureEnv,
+                        )]),
+                    ),
+                );
+                self.demand_eqtype(
+                    span,
+                    args.as_coroutine_closure().coroutine_captures_by_ref_ty(),
+                    coroutine_captures_by_ref_ty,
+                );
+
+                // Additionally, we can now constrain the coroutine's kind type.
+                //
+                // We only do this if `infer_kind`, because if we have constrained
+                // the kind from closure signature inference, the kind inferred
+                // for the inner coroutine may actually be more restrictive.
+                if infer_kind {
+                    let ty::Coroutine(_, coroutine_args) =
+                        *self.typeck_results.borrow().expr_ty(body.value).kind()
+                    else {
+                        bug!();
+                    };
+                    self.demand_eqtype(
+                        span,
+                        coroutine_args.as_coroutine().kind_ty(),
+                        Ty::from_coroutine_closure_kind(self.tcx, closure_kind),
+                    );
+                }
             }
         }
 

--- a/tests/ui/async-await/async-closures/cast-as-infer-self-borrows.rs
+++ b/tests/ui/async-await/async-closures/cast-as-infer-self-borrows.rs
@@ -1,0 +1,10 @@
+//@ edition:2021
+
+// Regression test for #155999.
+
+fn needs_fn_mut<T>(x: impl FnMut() -> T) {
+    needs_fn_mut(async || x as _)
+    //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/cast-as-infer-self-borrows.stderr
+++ b/tests/ui/async-await/async-closures/cast-as-infer-self-borrows.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/cast-as-infer-self-borrows.rs:6:32
+   |
+LL |     needs_fn_mut(async || x as _)
+   |                                ^ cannot infer type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Closes rust-lang/rust#155999.

`coroutine_captures_by_ref_ty` is a fresh `next_ty_var` until upvar
inference unifies it to an `FnPtr`. If `has_self_borrows` is reached
before that — e.g. when the body contains an unresolved `as _` cast —
the `_ => panic!()` arm fires:

```rust
//@ edition:2021
fn needs_fn_mut<T>(x: impl FnMut() -> T) {
    needs_fn_mut(async || x as _)
}
```

Treat the `Infer` case like `Error`: report self-borrows defensively
so the closure falls back to `FnOnce`-only and the caller surfaces a
normal type-inference error instead of an ICE.