### PR TITLE
Implement some trait for next solver's lang item enums

### DIFF
--- a/compiler/rustc_type_ir/src/lang_items.rs
+++ b/compiler/rustc_type_ir/src/lang_items.rs
@@ -1,5 +1,6 @@
 /// Lang items used by the new trait solver. This can be mapped to whatever internal
 /// representation of `LangItem`s used in the underlying compiler implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SolverProjectionLangItem {
     // tidy-alphabetical-start
     AsyncFnKindUpvars,
@@ -15,6 +16,7 @@ pub enum SolverProjectionLangItem {
     // tidy-alphabetical-end
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SolverAdtLangItem {
     // tidy-alphabetical-start
     DynMetadata,
@@ -23,6 +25,7 @@ pub enum SolverAdtLangItem {
     // tidy-alphabetical-end
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SolverTraitLangItem {
     // tidy-alphabetical-start
     AsyncFn,


### PR DESCRIPTION
rust-analyzer needs that.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
