### PR TITLE
Rename the unstable integer `extend` function to `widen`

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -4036,14 +4036,14 @@ macro_rules! int_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
+        /// #![feature(integer_widen_truncate)]
         #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".truncate());")]
         #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").truncate());")]
         /// assert_eq!(120i8, 376i32.truncate());
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
         pub const fn truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4057,15 +4057,15 @@ macro_rules! int_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
+        /// #![feature(integer_widen_truncate)]
         #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".saturating_truncate());")]
         #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").saturating_truncate());")]
         /// assert_eq!(127i8, 376i32.saturating_truncate());
         /// assert_eq!(-128i8, (-1000i32).saturating_truncate());
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
         pub const fn saturating_truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4079,15 +4079,15 @@ macro_rules! int_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
+        /// #![feature(integer_widen_truncate)]
         #[doc = concat!("assert_eq!(Some(120i8), 120", stringify!($SelfT), ".checked_truncate());")]
         #[doc = concat!("assert_eq!(Some(-120i8), (-120", stringify!($SelfT), ").checked_truncate());")]
         /// assert_eq!(None, 376i32.checked_truncate::<i8>());
         /// assert_eq!(None, (-1000i32).checked_truncate::<i8>());
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
         pub const fn checked_truncate<Target>(self) -> Option<Target>
             where Self: [const] traits::TruncateTarget<Target>
@@ -4095,23 +4095,23 @@ macro_rules! int_impl {
             traits::TruncateTarget::internal_checked_truncate(self)
         }
 
-        /// Extend to an integer of the same size or larger, preserving its value.
+        /// Widen to an integer of the same size or larger, preserving its value.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
-        #[doc = concat!("assert_eq!(120i128, 120i8.extend());")]
-        #[doc = concat!("assert_eq!(-120i128, (-120i8).extend());")]
+        /// #![feature(integer_widen_truncate)]
+        #[doc = concat!("assert_eq!(120i128, 120i8.widen());")]
+        #[doc = concat!("assert_eq!(-120i128, (-120i8).widen());")]
         /// ```
-        #[must_use = "this returns the extended value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[must_use = "this returns the widened value and does not modify the original"]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
-        pub const fn extend<Target>(self) -> Target
-            where Self: [const] traits::ExtendTarget<Target>
+        pub const fn widen<Target>(self) -> Target
+            where Self: [const] traits::WidenTarget<Target>
         {
-            traits::ExtendTarget::internal_extend(self)
+            traits::WidenTarget::internal_widen(self)
         }
     }
 }

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -3,7 +3,7 @@
 
 /// Trait for types that this type can be truncated to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-#[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+#[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
 pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
     fn internal_truncate(self) -> Target;
@@ -15,12 +15,12 @@ pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
     fn internal_checked_truncate(self) -> Option<Target>;
 }
 
-/// Trait for types that this type can be truncated to
+/// Trait for types that this type can be widened to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-#[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
-pub const trait ExtendTarget<Target>: crate::sealed::Sealed {
+#[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+pub const trait WidenTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
-    fn internal_extend(self) -> Target;
+    fn internal_widen(self) -> Target;
 }
 
 macro_rules! impl_truncate {
@@ -40,7 +40,7 @@ macro_rules! impl_truncate {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         impl const TruncateTarget<$to> for $from {
             #[inline]
             fn internal_truncate(self) -> $to {
@@ -70,12 +70,12 @@ macro_rules! impl_truncate {
     )+)*};
 }
 
-macro_rules! impl_extend {
+macro_rules! impl_widen {
     ($($from:ty => $($to:ty),+;)*) => {$($(
         const _: () = assert!(
             size_of::<$from>() <= size_of::<$to>(),
             concat!(
-                "cannot extend ",
+                "cannot widen ",
                 stringify!($from),
                 " to ",
                 stringify!($to),
@@ -87,9 +87,9 @@ macro_rules! impl_extend {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
-        impl const ExtendTarget<$to> for $from {
-            fn internal_extend(self) -> $to {
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        impl const WidenTarget<$to> for $from {
+            fn internal_widen(self) -> $to {
                 self as _
             }
         }
@@ -112,7 +112,7 @@ impl_truncate! {
     isize => isize, i16, i8;
 }
 
-impl_extend! {
+impl_widen! {
     u8 => u8, u16, u32, u64, u128, usize;
     u16 => u16, u32, u64, u128, usize;
     u32 => u32, u64, u128;

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -4220,13 +4220,13 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
+        /// #![feature(integer_widen_truncate)]
         #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".truncate());")]
         /// assert_eq!(120u8, 376u32.truncate());
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
         pub const fn truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4240,13 +4240,13 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
+        /// #![feature(integer_widen_truncate)]
         #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".saturating_truncate());")]
         /// assert_eq!(255u8, 376u32.saturating_truncate());
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
         pub const fn saturating_truncate<Target>(self) -> Target
             where Self: [const] traits::TruncateTarget<Target>
@@ -4260,13 +4260,13 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
+        /// #![feature(integer_widen_truncate)]
         #[doc = concat!("assert_eq!(Some(120u8), 120", stringify!($SelfT), ".checked_truncate());")]
         /// assert_eq!(None, 376u32.checked_truncate::<u8>());
         /// ```
         #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
         pub const fn checked_truncate<Target>(self) -> Option<Target>
             where Self: [const] traits::TruncateTarget<Target>
@@ -4274,22 +4274,22 @@ macro_rules! uint_impl {
             traits::TruncateTarget::internal_checked_truncate(self)
         }
 
-        /// Extend to an integer of the same size or larger, preserving its value.
+        /// Widen to an integer of the same size or larger, preserving its value.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_extend_truncate)]
-        #[doc = concat!("assert_eq!(120u128, 120u8.extend());")]
+        /// #![feature(integer_widen_truncate)]
+        #[doc = concat!("assert_eq!(120u128, 120u8.widen());")]
         /// ```
-        #[must_use = "this returns the extended value and does not modify the original"]
-        #[unstable(feature = "integer_extend_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_extend_truncate", issue = "154330")]
+        #[must_use = "this returns the widened value and does not modify the original"]
+        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
         #[inline]
-        pub const fn extend<Target>(self) -> Target
-            where Self: [const] traits::ExtendTarget<Target>
+        pub const fn widen<Target>(self) -> Target
+            where Self: [const] traits::WidenTarget<Target>
         {
-            traits::ExtendTarget::internal_extend(self)
+            traits::WidenTarget::internal_widen(self)
         }
     }
 }

--- a/tests/ui/imports/issue-114682-3.stderr
+++ b/tests/ui/imports/issue-114682-3.stderr
@@ -5,17 +5,13 @@ LL |         fn ext(&self) {}
    |            --- the method is available for `u8` here
 ...
 LL |     a.ext();
-   |       ^^^
+   |       ^^^ method not found in `u8`
    |
    = help: items from traits can only be used if the trait is in scope
 help: trait `SettingsExt` which provides `ext` is implemented but not in scope; perhaps you want to import it
    |
 LL + use auto::SettingsExt;
    |
-help: there is a method `extend` with a similar name
-   |
-LL |     a.extend();
-   |          +++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This is consistent with our use of `widening` elsewhere.

Suggested-by: Gabriel Bjørnager Jensen <gabriel@achernar.io>
