### PR TITLE
Reject non-char-boundary ranges in `Literal::subspan`

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -792,6 +792,20 @@ impl server::Server for Rustc<'_, '_> {
             return None;
         }
 
+        // Reject subspans whose boundaries don't fall on UTF-8 char boundaries
+        // in the source text.
+        let on_boundary = self
+            .psess()
+            .source_map()
+            .span_to_source(span, |src, span_start, _| {
+                Ok(src.is_char_boundary(span_start + start)
+                    && src.is_char_boundary(span_start + end))
+            })
+            .unwrap_or(true);
+        if !on_boundary {
+            return None;
+        }
+
         let new_lo = span.lo() + BytePos::from_usize(start);
         let new_hi = span.lo() + BytePos::from_usize(end);
         Some(span.with_lo(new_lo).with_hi(new_hi))

--- a/tests/ui/proc-macro/auxiliary/subspan-non-char-boundary.rs
+++ b/tests/ui/proc-macro/auxiliary/subspan-non-char-boundary.rs
@@ -1,0 +1,15 @@
+#![feature(proc_macro_span)]
+
+extern crate proc_macro;
+
+use proc_macro::{Literal, TokenStream, TokenTree};
+
+#[proc_macro]
+pub fn check_non_char_boundary(input: TokenStream) -> TokenStream {
+    let TokenTree::Literal(lit) = input.into_iter().next().unwrap() else {
+        panic!("expected a string literal");
+    };
+    // Byte 2 is inside '🦀'; subspan should reject it.
+    assert!(lit.subspan(2..3).is_none(), "bad subspan");
+    TokenStream::new()
+}

--- a/tests/ui/proc-macro/subspan-non-char-boundary.rs
+++ b/tests/ui/proc-macro/subspan-non-char-boundary.rs
@@ -1,0 +1,15 @@
+// Regression test for https://github.com/rust-lang/rust/issues/156049
+//
+// Tests that `Literal::subspan` returns `None` when the byte range does not
+// fall on a UTF-8 char boundary in the source.
+
+//@ check-pass
+//@ proc-macro: subspan-non-char-boundary.rs
+
+extern crate subspan_non_char_boundary;
+
+use subspan_non_char_boundary::check_non_char_boundary;
+
+fn main() {
+    check_non_char_boundary!("🦀");
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Resolves rust-lang/rust#156049.

Prevent creation of subspans whose start or end falls inside a UTF-8 character in the source.

Before:
```
thread 'rustc' (2546552) panicked at compiler/rustc_span/src/source_map.rs:914:26:
start byte index 382 is not a char boundary; it is inside '🦀' (bytes 381..385 of string)
```

After: (doesn't ICE)