### PR TITLE
Require EIIs to be defined when we compile a rust dylib

### DIFF
--- a/compiler/rustc_passes/src/eii.rs
+++ b/compiler/rustc_passes/src/eii.rs
@@ -18,8 +18,8 @@ enum CheckingMode {
 }
 
 fn get_checking_mode(tcx: TyCtxt<'_>) -> CheckingMode {
-    // if any of the crate types is not rlib or dylib, we must check for existence.
-    if tcx.crate_types().iter().any(|i| !matches!(i, CrateType::Rlib | CrateType::Dylib)) {
+    // if any of the crate types is not rlib, we must check for existence.
+    if tcx.crate_types().iter().any(|i| !matches!(i, CrateType::Rlib)) {
         CheckingMode::CheckExistence
     } else {
         CheckingMode::CheckDuplicates

--- a/tests/ui/eii/dylib_needs_impl.rs
+++ b/tests/ui/eii/dylib_needs_impl.rs
@@ -1,0 +1,7 @@
+//@ no-prefer-dynamic
+//@ needs-crate-type: dylib
+#![crate_type = "dylib"]
+#![feature(extern_item_impls)]
+
+#[eii(eii1)] //~ ERROR `#[eii1]` required, but not found
+fn decl1(x: u64);

--- a/tests/ui/eii/dylib_needs_impl.stderr
+++ b/tests/ui/eii/dylib_needs_impl.stderr
@@ -1,0 +1,10 @@
+error: `#[eii1]` required, but not found
+  --> $DIR/dylib_needs_impl.rs:6:7
+   |
+LL | #[eii(eii1)]
+   |       ^^^^ expected because `#[eii1]` was declared here in crate `dylib_needs_impl`
+   |
+   = help: expected at least one implementation in crate `dylib_needs_impl` or any of its dependencies
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
The linker will complain about undefined symbols otherwise and on object file formats with two level namespaces (Mach-O and PE/COFF) it is required to know which dylib a symbol will be imported from when linking a dylib or executable.

r? @jdonszelmann