### PR TITLE
Handle --print=backend-has-mnemonic in cg_clif

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -200,6 +200,11 @@ impl CodegenBackend for CraneliftCodegenBackend {
         println!("Cranelift version: {}", cranelift_codegen::VERSION);
     }
 
+    fn has_mnemonic(&self, sess: &Session, mnemonic: &str) -> bool {
+        // All Cranelift supported targets support ret except for s390x
+        mnemonic == "ret" && sess.target.arch != Arch::S390x
+    }
+
     fn target_cpu(&self, sess: &Session) -> String {
         // FIXME handle `-Ctarget-cpu=native`
         match sess.opts.cg.target_cpu {

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -314,6 +314,10 @@ impl CodegenBackend for LlvmCodegenBackend {
         llvm::LLVMRustLLVMHasZstdCompression()
     }
 
+    fn has_mnemonic(&self, sess: &Session, mnemonic: &str) -> bool {
+        llvm_util::target_has_mnemonic(sess, mnemonic)
+    }
+
     fn target_config(&self, sess: &Session) -> TargetConfig {
         target_config(sess)
     }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -480,10 +480,6 @@ pub(crate) fn print(req: &PrintRequest, out: &mut String, sess: &Session) {
     match req.kind {
         PrintKind::TargetCPUs => print_target_cpus(sess, tm.raw(), out),
         PrintKind::TargetFeatures => print_target_features(sess, tm.raw(), out),
-        PrintKind::BackendHasMnemonic => {
-            let mnemonic = req.arg.as_deref().expect("BackendHasMnemonic requires arg");
-            print_target_has_mnemonic(tm.raw(), mnemonic, out)
-        }
         _ => bug!("rustc_codegen_llvm can't handle print request: {:?}", req),
     }
 }
@@ -746,9 +742,9 @@ pub(crate) fn tune_cpu(sess: &Session) -> Option<&str> {
     Some(handle_native(name))
 }
 
-fn print_target_has_mnemonic(tm: &llvm::TargetMachine, mnemonic: &str, out: &mut String) {
-    use std::fmt::Write;
+pub(crate) fn target_has_mnemonic(sess: &Session, mnemonic: &str) -> bool {
+    require_inited();
+    let tm = create_informational_target_machine(sess, false);
     let cstr = SmallCStr::new(mnemonic);
-    let has_mnemonic = unsafe { llvm::LLVMRustTargetHasMnemonic(tm, cstr.as_ptr()) };
-    writeln!(out, "{}", has_mnemonic).unwrap();
+    unsafe { llvm::LLVMRustTargetHasMnemonic(tm.raw(), cstr.as_ptr()) }
 }

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -92,6 +92,14 @@ pub trait CodegenBackend {
         false
     }
 
+    /// Value printed by `--print=backend-has-mnemonic:...`.
+    ///
+    /// Used by compiletest to determine whether tests involving `asm!()` should
+    /// be executed or skipped.
+    fn has_mnemonic(&self, _sess: &Session, _mnemonic: &str) -> bool {
+        false
+    }
+
     /// The metadata loader used to load rlib and dylib metadata.
     ///
     /// Alternative codegen backends may want to use different rlib or dylib formats than the

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -802,7 +802,9 @@ fn print_crate_info(
                 println_info!("{}", calling_conventions.join("\n"));
             }
             BackendHasMnemonic => {
-                codegen_backend.print(req, &mut crate_info, sess);
+                let has_mnemonic: bool =
+                    codegen_backend.has_mnemonic(sess, req.arg.as_ref().unwrap());
+                println_info!("{has_mnemonic}");
             }
             BackendHasZstd => {
                 let has_zstd: bool = codegen_backend.has_zstd();


### PR DESCRIPTION
And introduce a `has_mnemonic` method on `CodegenBackend` just like `--print=backend-has-zstd`.