### PR TITLE
Don't treat const param default as projection

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -867,7 +867,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for IllegalSelfTypeVisitor<'tcx> {
             ty::ConstKind::Unevaluated(proj) if self.tcx.features().min_generic_const_args() => {
                 match self.allow_self_projections {
                     AllowSelfProjections::Yes
-                        if let trait_def_id = self.tcx.parent(proj.def)
+                        if matches!(self.tcx.def_kind(proj.def), DefKind::AssocConst { .. })
+                            && let trait_def_id = self.tcx.parent(proj.def)
                             && self.tcx.def_kind(trait_def_id) == DefKind::Trait =>
                     {
                         let trait_ref = ty::TraitRef::from_assoc(self.tcx, trait_def_id, proj.args);

--- a/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
@@ -1,11 +1,12 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/156293>
-//@ edition: 2024
 //@ check-pass
 
-#![feature(min_generic_const_args, transmutability)]
+#![feature(min_generic_const_args)]
+
+trait Bar<const N: bool = false> {}
 
 trait Foo {
-    type AssocB: std::mem::TransmuteFrom<()>;
+    type AssocB: Bar;
 }
 
 fn main() {}

--- a/tests/ui/traits/associated_type_bound/generic-const-args-transmutability.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-transmutability.rs
@@ -1,0 +1,11 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/156293>
+//@ edition: 2024
+//@ check-pass
+
+#![feature(min_generic_const_args, transmutability)]
+
+trait Foo {
+    type AssocB: std::mem::TransmuteFrom<()>;
+}
+
+fn main() {}


### PR DESCRIPTION
Avoid treating const param default as associated const projection.

Closes rust-lang/rust#156293

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
