### PR TITLE
Avoid invalid spans in dotdotdot rest pattern suggestions

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -3238,7 +3238,7 @@ pub(crate) struct DotDotDotRestPattern {
     #[suggestion(
         "for a rest pattern, use `..` instead of `...`",
         style = "verbose",
-        code = "",
+        code = "..",
         applicability = "machine-applicable"
     )]
     pub suggestion: Option<Span>,

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -920,7 +920,7 @@ impl<'a> Parser<'a> {
             // The user probably mistook `...` for a rest pattern `..`.
             self.dcx().emit_err(DotDotDotRestPattern {
                 span: lo,
-                suggestion: Some(lo.with_lo(lo.hi() - BytePos(1))),
+                suggestion: Some(lo),
                 var_args: None,
             });
             PatKind::Rest

--- a/tests/ui/parser/dotdotdot-rest-pattern-suggestion-span.rs
+++ b/tests/ui/parser/dotdotdot-rest-pattern-suggestion-span.rs
@@ -1,0 +1,20 @@
+// Suggestions for `...` in patterns should not perform span manipulations that
+// assume the token is ASCII, because it could have been recovered from
+// similar-looking Unicode characters.
+//
+// Regression test for https://github.com/rust-lang/rust/issues/156316.
+
+// These dots are U+00B7 MIDDLE DOT, not ASCII periods.
+impl S { fn f(···>) }
+//~^ ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unknown start of token
+//~| ERROR unexpected `...`
+//~| ERROR expected `:`, found `>`
+//~| ERROR expected one of
+//~| ERROR associated function in `impl` without body
+//~| ERROR cannot find type `S` in this scope
+//~| ERROR missing pattern for `...` argument
+//~| WARN this was previously accepted by the compiler
+
+fn main() {}

--- a/tests/ui/parser/dotdotdot-rest-pattern-suggestion-span.stderr
+++ b/tests/ui/parser/dotdotdot-rest-pattern-suggestion-span.stderr
@@ -1,0 +1,110 @@
+error: unknown start of token: \u{b7}
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:15
+   |
+LL | impl S { fn f(···>) }
+   |               ^^^
+   |
+   = note: character appears 2 more times
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - impl S { fn f(···>) }
+LL + impl S { fn f(...>) }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:16
+   |
+LL | impl S { fn f(···>) }
+   |                ^^
+   |
+   = note: character appears once more
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - impl S { fn f(···>) }
+LL + impl S { fn f(·..>) }
+   |
+
+error: unknown start of token: \u{b7}
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:17
+   |
+LL | impl S { fn f(···>) }
+   |                 ^
+   |
+help: Unicode character '·' (Middle Dot) looks like '.' (Period), but it is not
+   |
+LL - impl S { fn f(···>) }
+LL + impl S { fn f(··.>) }
+   |
+
+error: unexpected `...`
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:15
+   |
+LL | impl S { fn f(···>) }
+   |               ^^^ not a valid pattern
+   |
+help: for a rest pattern, use `..` instead of `...`
+   |
+LL - impl S { fn f(···>) }
+LL + impl S { fn f(..>) }
+   |
+
+error: expected `:`, found `>`
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:18
+   |
+LL | impl S { fn f(···>) }
+   |                  ^ expected `:`
+
+error: expected one of `->`, `where`, or `{`, found `}`
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:21
+   |
+LL | impl S { fn f(···>) }
+   |             -       ^ expected one of `->`, `where`, or `{`
+   |             |
+   |             while parsing this `fn`
+
+error: associated function in `impl` without body
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:10
+   |
+LL | impl S { fn f(···>) }
+   |          ^^^^^^^^^^- help: provide a definition for the function: `{ <body> }`
+
+error[E0425]: cannot find type `S` in this scope
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:6
+   |
+LL | impl S { fn f(···>) }
+   |      ^ not found in this scope
+
+error: missing pattern for `...` argument
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:15
+   |
+LL | impl S { fn f(···>) }
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+   = note: `#[deny(varargs_without_pattern)]` (part of `#[deny(future_incompatible)]`) on by default
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL - impl S { fn f(···>) }
+LL + impl S { fn f(_: ...>) }
+   |
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0425`.
+Future incompatibility report: Future breakage diagnostic:
+error: missing pattern for `...` argument
+  --> $DIR/dotdotdot-rest-pattern-suggestion-span.rs:8:15
+   |
+LL | impl S { fn f(···>) }
+   |               ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #145544 <https://github.com/rust-lang/rust/issues/145544>
+   = note: `#[deny(varargs_without_pattern)]` (part of `#[deny(future_incompatible)]`) on by default
+help: name the argument, or use `_` to continue ignoring it
+   |
+LL - impl S { fn f(···>) }
+LL + impl S { fn f(_: ...>) }
+   |
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#156316

The parser recovers Unicode confusables such as `···` as `...`, while keeping the original source span over the multibyte characters.

`recover_dotdotdot_rest_pat` built its suggestion by subtracting `BytePos(1)` from the end of that recovered token span. For multibyte characters, that can create a span boundary inside a UTF-8, causing diagnostic emission to ICE.

This changes the suggestion to replace the whole recovered token span with `..` instead of slicing off one byte.