### PR TITLE
[PERF CHECK ONLY] Add `inline` to trivial cross-crate accessors

### DIFF
--- a/compiler/rustc_ast_ir/src/visit.rs
+++ b/compiler/rustc_ast_ir/src/visit.rs
@@ -16,9 +16,13 @@ impl VisitorResult for () {
     #[cfg(not(feature = "nightly"))]
     type Residual = core::convert::Infallible;
 
+    #[inline]
     fn output() -> Self {}
+    #[inline]
     fn from_residual(_: Self::Residual) -> Self {}
+    #[inline]
     fn from_branch(_: ControlFlow<Self::Residual>) -> Self {}
+    #[inline]
     fn branch(self) -> ControlFlow<Self::Residual> {
         ControlFlow::Continue(())
     }
@@ -27,15 +31,19 @@ impl VisitorResult for () {
 impl<T> VisitorResult for ControlFlow<T> {
     type Residual = T;
 
+    #[inline]
     fn output() -> Self {
         ControlFlow::Continue(())
     }
+    #[inline]
     fn from_residual(residual: Self::Residual) -> Self {
         ControlFlow::Break(residual)
     }
+    #[inline]
     fn from_branch(b: Self) -> Self {
         b
     }
+    #[inline]
     fn branch(self) -> Self {
         self
     }

--- a/compiler/rustc_index_macros/src/newtype.rs
+++ b/compiler/rustc_index_macros/src/newtype.rs
@@ -101,12 +101,14 @@ impl Parse for Newtype {
             quote! {
                 #gate_rustc_only
                 impl<D: ::rustc_serialize::Decoder> ::rustc_serialize::Decodable<D> for #name {
+                    #[inline]
                     fn decode(d: &mut D) -> Self {
                         Self::from_u32(d.read_u32())
                     }
                 }
                 #gate_rustc_only
                 impl<E: ::rustc_serialize::Encoder> ::rustc_serialize::Encodable<E> for #name {
+                    #[inline]
                     fn encode(&self, e: &mut E) {
                         e.emit_u32(self.as_u32());
                     }
@@ -138,11 +140,13 @@ impl Parse for Newtype {
                     }
                 }
                 impl ::std::cmp::Ord for #name {
+                    #[inline]
                     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
                         self.as_u32().cmp(&other.as_u32())
                     }
                 }
                 impl ::std::cmp::PartialOrd for #name {
+                    #[inline]
                     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
                         self.as_u32().partial_cmp(&other.as_u32())
                     }
@@ -156,6 +160,7 @@ impl Parse for Newtype {
             quote! {
                 #gate_rustc_only
                 impl ::rustc_data_structures::stable_hasher::StableHash for #name {
+                    #[inline]
                     fn stable_hash<
                         __Hcx: ::rustc_data_structures::stable_hasher::StableHashCtxt
                     >(
@@ -340,6 +345,7 @@ impl Parse for Newtype {
             impl ::std::cmp::Eq for #name {}
 
             impl ::std::cmp::PartialEq for #name {
+                #[inline]
                 fn eq(&self, other: &Self) -> bool {
                     self.as_u32().eq(&other.as_u32())
                 }
@@ -349,6 +355,7 @@ impl Parse for Newtype {
             impl ::std::marker::StructuralPartialEq for #name {}
 
             impl ::std::hash::Hash for #name {
+                #[inline]
                 fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
                     self.as_u32().hash(state)
                 }

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -255,10 +255,12 @@ impl<'tcx> AdtDef<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::AdtDef<TyCtxt<'tcx>> for AdtDef<'tcx> {
+    #[inline]
     fn def_id(self) -> DefId {
         self.did()
     }
 
+    #[inline]
     fn is_struct(self) -> bool {
         self.is_struct()
     }
@@ -273,14 +275,17 @@ impl<'tcx> rustc_type_ir::inherent::AdtDef<TyCtxt<'tcx>> for AdtDef<'tcx> {
         Some(interner.type_of(self.non_enum_variant().tail_opt()?.did))
     }
 
+    #[inline]
     fn is_phantom_data(self) -> bool {
         self.is_phantom_data()
     }
 
+    #[inline]
     fn is_manually_drop(self) -> bool {
         self.is_manually_drop()
     }
 
+    #[inline]
     fn field_representing_type_info(
         self,
         tcx: TyCtxt<'tcx>,
@@ -298,6 +303,7 @@ impl<'tcx> rustc_type_ir::inherent::AdtDef<TyCtxt<'tcx>> for AdtDef<'tcx> {
         )
     }
 
+    #[inline]
     fn sizedness_constraint(
         self,
         tcx: TyCtxt<'tcx>,
@@ -306,6 +312,7 @@ impl<'tcx> rustc_type_ir::inherent::AdtDef<TyCtxt<'tcx>> for AdtDef<'tcx> {
         self.sizedness_constraint(tcx, sizedness)
     }
 
+    #[inline]
     fn is_fundamental(self) -> bool {
         self.is_fundamental()
     }

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -263,10 +263,12 @@ impl<'tcx> rustc_type_ir::inherent::AdtDef<TyCtxt<'tcx>> for AdtDef<'tcx> {
         self.is_struct()
     }
 
+    #[inline]
     fn is_packed(self) -> bool {
         self.repr().packed()
     }
 
+    #[inline]
     fn struct_tail_ty(self, interner: TyCtxt<'tcx>) -> Option<ty::EarlyBinder<'tcx, Ty<'tcx>>> {
         Some(interner.type_of(self.non_enum_variant().tail_opt()?.did))
     }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -178,6 +178,7 @@ impl<'tcx> rustc_type_ir::inherent::Const<TyCtxt<'tcx>> for Const<'tcx> {
         Const::new_bound(interner, debruijn, bound_const)
     }
 
+    #[inline]
     fn new_anon_bound(tcx: TyCtxt<'tcx>, debruijn: ty::DebruijnIndex, var: ty::BoundVar) -> Self {
         Const::new_bound(tcx, debruijn, ty::BoundConst::new(var))
     }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -40,10 +40,12 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Const<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::Flags for Const<'tcx> {
+    #[inline]
     fn flags(&self) -> TypeFlags {
         self.0.flags
     }
 
+    #[inline]
     fn outer_exclusive_binder(&self) -> rustc_type_ir::DebruijnIndex {
         self.0.outer_exclusive_binder
     }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -33,6 +33,7 @@ pub struct Const<'tcx>(pub(super) Interned<'tcx, WithCachedTypeInfo<ConstKind<'t
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Const<'tcx> {
     type Kind = ConstKind<'tcx>;
 
+    #[inline]
     fn kind(self) -> ConstKind<'tcx> {
         self.kind()
     }
@@ -162,14 +163,17 @@ impl<'tcx> Const<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::Const<TyCtxt<'tcx>> for Const<'tcx> {
+    #[inline]
     fn new_infer(tcx: TyCtxt<'tcx>, infer: ty::InferConst) -> Self {
         Const::new_infer(tcx, infer)
     }
 
+    #[inline]
     fn new_var(tcx: TyCtxt<'tcx>, vid: ty::ConstVid) -> Self {
         Const::new_var(tcx, vid)
     }
 
+    #[inline]
     fn new_bound(
         interner: TyCtxt<'tcx>,
         debruijn: ty::DebruijnIndex,
@@ -183,22 +187,27 @@ impl<'tcx> rustc_type_ir::inherent::Const<TyCtxt<'tcx>> for Const<'tcx> {
         Const::new_bound(tcx, debruijn, ty::BoundConst::new(var))
     }
 
+    #[inline]
     fn new_canonical_bound(tcx: TyCtxt<'tcx>, var: rustc_type_ir::BoundVar) -> Self {
         Const::new_canonical_bound(tcx, var)
     }
 
+    #[inline]
     fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderConst<'tcx>) -> Self {
         Const::new_placeholder(tcx, placeholder)
     }
 
+    #[inline]
     fn new_unevaluated(interner: TyCtxt<'tcx>, uv: ty::UnevaluatedConst<'tcx>) -> Self {
         Const::new_unevaluated(interner, uv)
     }
 
+    #[inline]
     fn new_expr(interner: TyCtxt<'tcx>, expr: ty::Expr<'tcx>) -> Self {
         Const::new_expr(interner, expr)
     }
 
+    #[inline]
     fn new_error(interner: TyCtxt<'tcx>, guar: ErrorGuaranteed) -> Self {
         Const::new_error(interner, guar)
     }

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -23,6 +23,7 @@ pub struct Expr<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::ExprConst<TyCtxt<'tcx>> for Expr<'tcx> {
+    #[inline]
     fn args(self) -> ty::GenericArgsRef<'tcx> {
         self.args
     }

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -80,6 +80,7 @@ impl fmt::Debug for ValTree<'_> {
 impl<'tcx> rustc_type_ir::inherent::IntoKind for ty::ValTree<'tcx> {
     type Kind = ty::ValTreeKind<TyCtxt<'tcx>>;
 
+    #[inline]
     fn kind(self) -> Self::Kind {
         *self.0
     }
@@ -226,10 +227,12 @@ impl<'tcx> Value<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::ValueConst<TyCtxt<'tcx>> for Value<'tcx> {
+    #[inline]
     fn ty(self) -> Ty<'tcx> {
         self.ty
     }
 
+    #[inline]
     fn valtree(self) -> ValTree<'tcx> {
         self.valtree
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -86,10 +86,12 @@ impl<'tcx> rustc_type_ir::inherent::DefId<TyCtxt<'tcx>> for DefId {
 }
 
 impl<'tcx> rustc_type_ir::inherent::Safety<TyCtxt<'tcx>> for hir::Safety {
+    #[inline]
     fn safe() -> Self {
         hir::Safety::Safe
     }
 
+    #[inline]
     fn unsafe_mode() -> Self {
         hir::Safety::Unsafe
     }
@@ -131,6 +133,7 @@ impl<'tcx> rustc_type_ir::inherent::Features<TyCtxt<'tcx>> for &'tcx rustc_featu
 }
 
 impl<'tcx> rustc_type_ir::inherent::Span<TyCtxt<'tcx>> for Span {
+    #[inline]
     fn dummy() -> Self {
         DUMMY_SP
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -74,10 +74,12 @@ use crate::ty::{
 };
 
 impl<'tcx> rustc_type_ir::inherent::DefId<TyCtxt<'tcx>> for DefId {
+    #[inline]
     fn is_local(self) -> bool {
         self.is_local()
     }
 
+    #[inline]
     fn as_local(self) -> Option<LocalDefId> {
         self.as_local()
     }
@@ -92,24 +94,29 @@ impl<'tcx> rustc_type_ir::inherent::Safety<TyCtxt<'tcx>> for hir::Safety {
         hir::Safety::Unsafe
     }
 
+    #[inline]
     fn is_safe(self) -> bool {
         self.is_safe()
     }
 
+    #[inline]
     fn prefix_str(self) -> &'static str {
         self.prefix_str()
     }
 }
 
 impl<'tcx> rustc_type_ir::inherent::Features<TyCtxt<'tcx>> for &'tcx rustc_feature::Features {
+    #[inline]
     fn generic_const_exprs(self) -> bool {
         self.generic_const_exprs()
     }
 
+    #[inline]
     fn generic_const_args(self) -> bool {
         self.generic_const_args()
     }
 
+    #[inline]
     fn coroutine_clone(self) -> bool {
         self.coroutine_clone()
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -114,6 +114,7 @@ impl<'tcx> rustc_type_ir::inherent::Features<TyCtxt<'tcx>> for &'tcx rustc_featu
         self.coroutine_clone()
     }
 
+    #[inline]
     fn feature_bound_holds_in_crate(self, symbol: Symbol) -> bool {
         // We don't consider feature bounds to hold in the crate when `staged_api` feature is
         // enabled, even if it is enabled through `#[feature]`.

--- a/compiler/rustc_middle/src/ty/generic_args.rs
+++ b/compiler/rustc_middle/src/ty/generic_args.rs
@@ -41,6 +41,7 @@ pub struct GenericArg<'tcx> {
 impl<'tcx> rustc_type_ir::inherent::GenericArg<TyCtxt<'tcx>> for GenericArg<'tcx> {}
 
 impl<'tcx> rustc_type_ir::inherent::GenericArgs<TyCtxt<'tcx>> for ty::GenericArgsRef<'tcx> {
+    #[inline]
     fn rebase_onto(
         self,
         tcx: TyCtxt<'tcx>,
@@ -51,24 +52,29 @@ impl<'tcx> rustc_type_ir::inherent::GenericArgs<TyCtxt<'tcx>> for ty::GenericArg
     }
 
     #[track_caller]
+    #[inline]
     fn type_at(self, i: usize) -> Ty<'tcx> {
         self.type_at(i)
     }
 
     #[track_caller]
+    #[inline]
     fn region_at(self, i: usize) -> ty::Region<'tcx> {
         self.region_at(i)
     }
 
     #[track_caller]
+    #[inline]
     fn const_at(self, i: usize) -> ty::Const<'tcx> {
         self.const_at(i)
     }
 
+    #[inline]
     fn identity_for_item(tcx: TyCtxt<'tcx>, def_id: DefId) -> ty::GenericArgsRef<'tcx> {
         GenericArgs::identity_for_item(tcx, def_id)
     }
 
+    #[inline]
     fn extend_with_error(
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
@@ -130,6 +136,7 @@ impl<'tcx> rustc_type_ir::inherent::GenericArgs<TyCtxt<'tcx>> for ty::GenericArg
 impl<'tcx> rustc_type_ir::inherent::IntoKind for GenericArg<'tcx> {
     type Kind = GenericArgKind<'tcx>;
 
+    #[inline]
     fn kind(self) -> Self::Kind {
         self.kind()
     }

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -129,6 +129,7 @@ pub struct Generics {
 }
 
 impl<'tcx> rustc_type_ir::inherent::GenericsOf<TyCtxt<'tcx>> for &'tcx Generics {
+    #[inline]
     fn count(&self) -> usize {
         self.parent_count + self.own_params.len()
     }

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -144,10 +144,12 @@ impl<'a, H, T: Copy> rustc_type_ir::inherent::SliceLike for &'a RawList<H, T> {
 
     type IntoIter = iter::Copied<<&'a [T] as IntoIterator>::IntoIter>;
 
+    #[inline]
     fn iter(self) -> Self::IntoIter {
         (*self).iter()
     }
 
+    #[inline]
     fn as_slice(&self) -> &[Self::Item] {
         (*self).as_slice()
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -480,6 +480,7 @@ pub struct Ty<'tcx>(Interned<'tcx, WithCachedTypeInfo<TyKind<'tcx>>>);
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Ty<'tcx> {
     type Kind = TyKind<'tcx>;
 
+    #[inline]
     fn kind(self) -> TyKind<'tcx> {
         *self.kind()
     }
@@ -520,6 +521,7 @@ impl<'tcx> rustc_type_ir::inherent::Term<TyCtxt<'tcx>> for Term<'tcx> {}
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Term<'tcx> {
     type Kind = TermKind<'tcx>;
 
+    #[inline]
     fn kind(self) -> Self::Kind {
         self.kind()
     }
@@ -947,10 +949,12 @@ impl<'tcx> DefinitionSiteHiddenType<'tcx> {
 pub type Clauses<'tcx> = &'tcx ListWithCachedTypeInfo<Clause<'tcx>>;
 
 impl<'tcx> rustc_type_ir::Flags for Clauses<'tcx> {
+    #[inline]
     fn flags(&self) -> TypeFlags {
         (**self).flags()
     }
 
+    #[inline]
     fn outer_exclusive_binder(&self) -> DebruijnIndex {
         (**self).outer_exclusive_binder()
     }
@@ -973,6 +977,7 @@ pub struct ParamEnv<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::ParamEnv<TyCtxt<'tcx>> for ParamEnv<'tcx> {
+    #[inline]
     fn caller_bounds(self) -> impl inherent::SliceLike<Item = ty::Clause<'tcx>> {
         self.caller_bounds()
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -487,10 +487,12 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Ty<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::Flags for Ty<'tcx> {
+    #[inline]
     fn flags(&self) -> TypeFlags {
         self.0.flags
     }
 
+    #[inline]
     fn outer_exclusive_binder(&self) -> DebruijnIndex {
         self.0.outer_exclusive_binder
     }

--- a/compiler/rustc_middle/src/ty/pattern.rs
+++ b/compiler/rustc_middle/src/ty/pattern.rs
@@ -115,6 +115,7 @@ impl<'tcx> IrPrint<PatternKind<'tcx>> for TyCtxt<'tcx> {
 
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Pattern<'tcx> {
     type Kind = PatternKind<'tcx>;
+    #[inline]
     fn kind(self) -> Self::Kind {
         *self
     }

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -156,10 +156,12 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Clause<'tcx> {
 }
 
 impl<'tcx> Clause<'tcx> {
+    #[inline]
     pub fn as_predicate(self) -> Predicate<'tcx> {
         Predicate(self.0)
     }
 
+    #[inline]
     pub fn kind(self) -> ty::Binder<'tcx, ClauseKind<'tcx>> {
         self.0.internee.map_bound(|kind| match kind {
             PredicateKind::Clause(clause) => clause,
@@ -167,6 +169,7 @@ impl<'tcx> Clause<'tcx> {
         })
     }
 
+    #[inline]
     pub fn as_trait_clause(self) -> Option<ty::Binder<'tcx, TraitPredicate<'tcx>>> {
         let clause = self.kind();
         if let ty::ClauseKind::Trait(trait_clause) = clause.skip_binder() {
@@ -176,6 +179,7 @@ impl<'tcx> Clause<'tcx> {
         }
     }
 
+    #[inline]
     pub fn as_projection_clause(self) -> Option<ty::Binder<'tcx, ProjectionPredicate<'tcx>>> {
         let clause = self.kind();
         if let ty::ClauseKind::Projection(projection_clause) = clause.skip_binder() {
@@ -185,6 +189,7 @@ impl<'tcx> Clause<'tcx> {
         }
     }
 
+    #[inline]
     pub fn as_type_outlives_clause(self) -> Option<ty::Binder<'tcx, TypeOutlivesPredicate<'tcx>>> {
         let clause = self.kind();
         if let ty::ClauseKind::TypeOutlives(o) = clause.skip_binder() {
@@ -194,6 +199,7 @@ impl<'tcx> Clause<'tcx> {
         }
     }
 
+    #[inline]
     pub fn as_region_outlives_clause(
         self,
     ) -> Option<ty::Binder<'tcx, RegionOutlivesPredicate<'tcx>>> {
@@ -603,6 +609,7 @@ impl<'tcx> UpcastFrom<TyCtxt<'tcx>, NormalizesTo<'tcx>> for Predicate<'tcx> {
 }
 
 impl<'tcx> Predicate<'tcx> {
+    #[inline]
     pub fn as_trait_clause(self) -> Option<PolyTraitPredicate<'tcx>> {
         let predicate = self.kind();
         match predicate.skip_binder() {
@@ -611,6 +618,7 @@ impl<'tcx> Predicate<'tcx> {
         }
     }
 
+    #[inline]
     pub fn as_projection_clause(self) -> Option<PolyProjectionPredicate<'tcx>> {
         let predicate = self.kind();
         match predicate.skip_binder() {
@@ -620,6 +628,7 @@ impl<'tcx> Predicate<'tcx> {
     }
 
     /// Matches a `PredicateKind::Clause` and turns it into a `Clause`, otherwise returns `None`.
+    #[inline]
     pub fn as_clause(self) -> Option<Clause<'tcx>> {
         match self.kind().skip_binder() {
             PredicateKind::Clause(..) => Some(self.expect_clause()),
@@ -628,6 +637,7 @@ impl<'tcx> Predicate<'tcx> {
     }
 
     /// Assert that the predicate is a clause.
+    #[inline]
     pub fn expect_clause(self) -> Clause<'tcx> {
         match self.kind().skip_binder() {
             PredicateKind::Clause(..) => Clause(self.0),

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -47,6 +47,7 @@ pub struct Predicate<'tcx>(
 );
 
 impl<'tcx> rustc_type_ir::inherent::Predicate<TyCtxt<'tcx>> for Predicate<'tcx> {
+    #[inline]
     fn as_clause(self) -> Option<ty::Clause<'tcx>> {
         self.as_clause()
     }
@@ -55,6 +56,7 @@ impl<'tcx> rustc_type_ir::inherent::Predicate<TyCtxt<'tcx>> for Predicate<'tcx> 
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Predicate<'tcx> {
     type Kind = ty::Binder<'tcx, ty::PredicateKind<'tcx>>;
 
+    #[inline]
     fn kind(self) -> Self::Kind {
         self.kind()
     }
@@ -138,10 +140,12 @@ pub struct Clause<'tcx>(
 );
 
 impl<'tcx> rustc_type_ir::inherent::Clause<TyCtxt<'tcx>> for Clause<'tcx> {
+    #[inline]
     fn as_predicate(self) -> Predicate<'tcx> {
         self.as_predicate()
     }
 
+    #[inline]
     fn instantiate_supertrait(self, tcx: TyCtxt<'tcx>, trait_ref: ty::PolyTraitRef<'tcx>) -> Self {
         self.instantiate_supertrait(tcx, trait_ref)
     }
@@ -150,6 +154,7 @@ impl<'tcx> rustc_type_ir::inherent::Clause<TyCtxt<'tcx>> for Clause<'tcx> {
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Clause<'tcx> {
     type Kind = ty::Binder<'tcx, ClauseKind<'tcx>>;
 
+    #[inline]
     fn kind(self) -> Self::Kind {
         self.kind()
     }

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -63,10 +63,12 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Predicate<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::Flags for Predicate<'tcx> {
+    #[inline]
     fn flags(&self) -> TypeFlags {
         self.0.flags
     }
 
+    #[inline]
     fn outer_exclusive_binder(&self) -> ty::DebruijnIndex {
         self.0.outer_exclusive_binder
     }

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -29,6 +29,7 @@ impl<'tcx> rustc_type_ir::Flags for Region<'tcx> {
         self.type_flags()
     }
 
+    #[inline]
     fn outer_exclusive_binder(&self) -> ty::DebruijnIndex {
         match self.kind() {
             ty::ReBound(ty::BoundVarIndexKind::Bound(debruijn), _) => debruijn.shifted_in(1),

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -19,6 +19,7 @@ pub struct Region<'tcx>(pub Interned<'tcx, RegionKind<'tcx>>);
 impl<'tcx> rustc_type_ir::inherent::IntoKind for Region<'tcx> {
     type Kind = RegionKind<'tcx>;
 
+    #[inline]
     fn kind(self) -> RegionKind<'tcx> {
         *self.0.0
     }
@@ -183,6 +184,7 @@ impl<'tcx> rustc_type_ir::inherent::Region<TyCtxt<'tcx>> for Region<'tcx> {
         Region::new_placeholder(tcx, placeholder)
     }
 
+    #[inline]
     fn new_static(tcx: TyCtxt<'tcx>) -> Self {
         tcx.lifetimes.re_static
     }
@@ -368,6 +370,7 @@ impl EarlyParamRegion {
 }
 
 impl rustc_type_ir::inherent::ParamLike for EarlyParamRegion {
+    #[inline]
     fn index(self) -> u32 {
         self.index
     }

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -25,6 +25,7 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Region<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::Flags for Region<'tcx> {
+    #[inline]
     fn flags(&self) -> TypeFlags {
         self.type_flags()
     }
@@ -158,6 +159,7 @@ impl<'tcx> Region<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::Region<TyCtxt<'tcx>> for Region<'tcx> {
+    #[inline]
     fn new_bound(
         interner: TyCtxt<'tcx>,
         debruijn: ty::DebruijnIndex,
@@ -166,14 +168,17 @@ impl<'tcx> rustc_type_ir::inherent::Region<TyCtxt<'tcx>> for Region<'tcx> {
         Region::new_bound(interner, debruijn, var)
     }
 
+    #[inline]
     fn new_anon_bound(tcx: TyCtxt<'tcx>, debruijn: ty::DebruijnIndex, var: ty::BoundVar) -> Self {
         Region::new_bound(tcx, debruijn, ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon })
     }
 
+    #[inline]
     fn new_canonical_bound(tcx: TyCtxt<'tcx>, var: rustc_type_ir::BoundVar) -> Self {
         Region::new_canonical_bound(tcx, var)
     }
 
+    #[inline]
     fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderRegion<'tcx>) -> Self {
         Region::new_placeholder(tcx, placeholder)
     }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -509,6 +509,7 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Predicate<'tcx> {
 
 // FIXME(clause): This is wonky
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Clause<'tcx> {
+    #[inline]
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         folder: &mut F,
@@ -516,6 +517,7 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Clause<'tcx> {
         Ok(folder.try_fold_predicate(self.as_predicate())?.expect_clause())
     }
 
+    #[inline]
     fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
         folder.fold_predicate(self.as_predicate()).expect_clause()
     }
@@ -541,6 +543,7 @@ impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Predicate<'tcx> {
 }
 
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Clause<'tcx> {
+    #[inline]
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
         visitor.visit_predicate(self.as_predicate())
     }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -317,6 +317,7 @@ impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for Pattern<'tcx> {
 }
 
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
+    #[inline]
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         folder: &mut F,
@@ -324,12 +325,14 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for Ty<'tcx> {
         folder.try_fold_ty(self)
     }
 
+    #[inline]
     fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
         folder.fold_ty(self)
     }
 }
 
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for Ty<'tcx> {
+    #[inline]
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
         visitor.visit_ty(*self)
     }
@@ -476,6 +479,7 @@ impl<'tcx> TypeSuperVisitable<TyCtxt<'tcx>> for Ty<'tcx> {
 }
 
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Region<'tcx> {
+    #[inline]
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         folder: &mut F,
@@ -483,18 +487,21 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Region<'tcx> {
         folder.try_fold_region(self)
     }
 
+    #[inline]
     fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
         folder.fold_region(self)
     }
 }
 
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Region<'tcx> {
+    #[inline]
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
         visitor.visit_region(*self)
     }
 }
 
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Predicate<'tcx> {
+    #[inline]
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         folder: &mut F,
@@ -502,6 +509,7 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Predicate<'tcx> {
         folder.try_fold_predicate(self)
     }
 
+    #[inline]
     fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
         folder.fold_predicate(self)
     }
@@ -524,6 +532,7 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Clause<'tcx> {
 }
 
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Clauses<'tcx> {
+    #[inline]
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         folder: &mut F,
@@ -531,12 +540,14 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Clauses<'tcx> {
         folder.try_fold_clauses(self)
     }
 
+    #[inline]
     fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
         folder.fold_clauses(self)
     }
 }
 
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Predicate<'tcx> {
+    #[inline]
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
         visitor.visit_predicate(*self)
     }
@@ -579,6 +590,7 @@ impl<'tcx> TypeSuperVisitable<TyCtxt<'tcx>> for ty::Predicate<'tcx> {
 }
 
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Clauses<'tcx> {
+    #[inline]
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
         visitor.visit_clauses(self)
     }
@@ -604,6 +616,7 @@ impl<'tcx> TypeSuperFoldable<TyCtxt<'tcx>> for ty::Clauses<'tcx> {
 }
 
 impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Const<'tcx> {
+    #[inline]
     fn try_fold_with<F: FallibleTypeFolder<TyCtxt<'tcx>>>(
         self,
         folder: &mut F,
@@ -611,12 +624,14 @@ impl<'tcx> TypeFoldable<TyCtxt<'tcx>> for ty::Const<'tcx> {
         folder.try_fold_const(self)
     }
 
+    #[inline]
     fn fold_with<F: TypeFolder<TyCtxt<'tcx>>>(self, folder: &mut F) -> Self {
         folder.fold_const(self)
     }
 }
 
 impl<'tcx> TypeVisitable<TyCtxt<'tcx>> for ty::Const<'tcx> {
+    #[inline]
     fn visit_with<V: TypeVisitor<TyCtxt<'tcx>>>(&self, visitor: &mut V) -> V::Result {
         visitor.visit_const(*self)
     }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -285,6 +285,7 @@ pub struct ParamTy {
 }
 
 impl rustc_type_ir::inherent::ParamLike for ParamTy {
+    #[inline]
     fn index(self) -> u32 {
         self.index
     }
@@ -319,6 +320,7 @@ pub struct ParamConst {
 }
 
 impl rustc_type_ir::inherent::ParamLike for ParamConst {
+    #[inline]
     fn index(self) -> u32 {
         self.index
     }
@@ -927,10 +929,12 @@ impl<'tcx> Ty<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
+    #[inline]
     fn new_bool(tcx: TyCtxt<'tcx>) -> Self {
         tcx.types.bool
     }
 
+    #[inline]
     fn new_u8(tcx: TyCtxt<'tcx>) -> Self {
         tcx.types.u8
     }
@@ -1130,10 +1134,12 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_unsafe_binder(interner, ty)
     }
 
+    #[inline]
     fn new_unit(interner: TyCtxt<'tcx>) -> Self {
         interner.types.unit
     }
 
+    #[inline]
     fn new_usize(interner: TyCtxt<'tcx>) -> Self {
         interner.types.usize
     }
@@ -2191,6 +2197,7 @@ impl<'tcx> rustc_type_ir::inherent::Tys<TyCtxt<'tcx>> for &'tcx ty::List<Ty<'tcx
 }
 
 impl<'tcx> rustc_type_ir::inherent::Symbol<TyCtxt<'tcx>> for Symbol {
+    #[inline]
     fn is_kw_underscore_lifetime(self) -> bool {
         self == kw::UnderscoreLifetime
     }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2146,10 +2146,12 @@ impl<'tcx> Ty<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::inherent::Tys<TyCtxt<'tcx>> for &'tcx ty::List<Ty<'tcx>> {
+    #[inline]
     fn inputs(self) -> &'tcx [Ty<'tcx>] {
         self.split_last().unwrap().1
     }
 
+    #[inline]
     fn output(self) -> Ty<'tcx> {
         *self.split_last().unwrap().0
     }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -935,22 +935,27 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         tcx.types.u8
     }
 
+    #[inline]
     fn new_infer(tcx: TyCtxt<'tcx>, infer: ty::InferTy) -> Self {
         Ty::new_infer(tcx, infer)
     }
 
+    #[inline]
     fn new_var(tcx: TyCtxt<'tcx>, vid: ty::TyVid) -> Self {
         Ty::new_var(tcx, vid)
     }
 
+    #[inline]
     fn new_param(tcx: TyCtxt<'tcx>, param: ty::ParamTy) -> Self {
         Ty::new_param(tcx, param.index, param.name)
     }
 
+    #[inline]
     fn new_placeholder(tcx: TyCtxt<'tcx>, placeholder: ty::PlaceholderType<'tcx>) -> Self {
         Ty::new_placeholder(tcx, placeholder)
     }
 
+    #[inline]
     fn new_bound(
         interner: TyCtxt<'tcx>,
         debruijn: ty::DebruijnIndex,
@@ -959,22 +964,27 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_bound(interner, debruijn, var)
     }
 
+    #[inline]
     fn new_anon_bound(tcx: TyCtxt<'tcx>, debruijn: ty::DebruijnIndex, var: ty::BoundVar) -> Self {
         Ty::new_bound(tcx, debruijn, ty::BoundTy { var, kind: ty::BoundTyKind::Anon })
     }
 
+    #[inline]
     fn new_canonical_bound(tcx: TyCtxt<'tcx>, var: ty::BoundVar) -> Self {
         Ty::new_canonical_bound(tcx, var)
     }
 
+    #[inline]
     fn new_alias(interner: TyCtxt<'tcx>, alias_ty: ty::AliasTy<'tcx>) -> Self {
         Ty::new_alias(interner, alias_ty)
     }
 
+    #[inline]
     fn new_error(interner: TyCtxt<'tcx>, guar: ErrorGuaranteed) -> Self {
         Ty::new_error(interner, guar)
     }
 
+    #[inline]
     fn new_adt(
         interner: TyCtxt<'tcx>,
         adt_def: ty::AdtDef<'tcx>,
@@ -983,10 +993,12 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_adt(interner, adt_def, args)
     }
 
+    #[inline]
     fn new_foreign(interner: TyCtxt<'tcx>, def_id: DefId) -> Self {
         Ty::new_foreign(interner, def_id)
     }
 
+    #[inline]
     fn new_dynamic(
         interner: TyCtxt<'tcx>,
         preds: &'tcx List<ty::PolyExistentialPredicate<'tcx>>,
@@ -995,6 +1007,7 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_dynamic(interner, preds, region)
     }
 
+    #[inline]
     fn new_coroutine(
         interner: TyCtxt<'tcx>,
         def_id: DefId,
@@ -1003,6 +1016,7 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_coroutine(interner, def_id, args)
     }
 
+    #[inline]
     fn new_coroutine_closure(
         interner: TyCtxt<'tcx>,
         def_id: DefId,
@@ -1011,10 +1025,12 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_coroutine_closure(interner, def_id, args)
     }
 
+    #[inline]
     fn new_closure(interner: TyCtxt<'tcx>, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> Self {
         Ty::new_closure(interner, def_id, args)
     }
 
+    #[inline]
     fn new_coroutine_witness(
         interner: TyCtxt<'tcx>,
         def_id: DefId,
@@ -1023,6 +1039,7 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_coroutine_witness(interner, def_id, args)
     }
 
+    #[inline]
     fn new_coroutine_witness_for_coroutine(
         interner: TyCtxt<'tcx>,
         def_id: DefId,
@@ -1031,10 +1048,12 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_coroutine_witness_for_coroutine(interner, def_id, coroutine_args)
     }
 
+    #[inline]
     fn new_ptr(interner: TyCtxt<'tcx>, ty: Self, mutbl: hir::Mutability) -> Self {
         Ty::new_ptr(interner, ty, mutbl)
     }
 
+    #[inline]
     fn new_ref(
         interner: TyCtxt<'tcx>,
         region: ty::Region<'tcx>,
@@ -1044,18 +1063,22 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_ref(interner, region, ty, mutbl)
     }
 
+    #[inline]
     fn new_array_with_const_len(interner: TyCtxt<'tcx>, ty: Self, len: ty::Const<'tcx>) -> Self {
         Ty::new_array_with_const_len(interner, ty, len)
     }
 
+    #[inline]
     fn new_slice(interner: TyCtxt<'tcx>, ty: Self) -> Self {
         Ty::new_slice(interner, ty)
     }
 
+    #[inline]
     fn new_tup(interner: TyCtxt<'tcx>, tys: &[Ty<'tcx>]) -> Self {
         Ty::new_tup(interner, tys)
     }
 
+    #[inline]
     fn new_tup_from_iter<It, T>(interner: TyCtxt<'tcx>, iter: It) -> T::Output
     where
         It: Iterator<Item = T>,
@@ -1064,18 +1087,22 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::new_tup_from_iter(interner, iter)
     }
 
+    #[inline]
     fn tuple_fields(self) -> &'tcx ty::List<Ty<'tcx>> {
         self.tuple_fields()
     }
 
+    #[inline]
     fn to_opt_closure_kind(self) -> Option<ty::ClosureKind> {
         self.to_opt_closure_kind()
     }
 
+    #[inline]
     fn from_closure_kind(interner: TyCtxt<'tcx>, kind: ty::ClosureKind) -> Self {
         Ty::from_closure_kind(interner, kind)
     }
 
+    #[inline]
     fn from_coroutine_closure_kind(
         interner: TyCtxt<'tcx>,
         kind: rustc_type_ir::ClosureKind,
@@ -1083,18 +1110,22 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         Ty::from_coroutine_closure_kind(interner, kind)
     }
 
+    #[inline]
     fn new_fn_def(interner: TyCtxt<'tcx>, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> Self {
         Ty::new_fn_def(interner, def_id, args)
     }
 
+    #[inline]
     fn new_fn_ptr(interner: TyCtxt<'tcx>, sig: ty::Binder<'tcx, ty::FnSig<'tcx>>) -> Self {
         Ty::new_fn_ptr(interner, sig)
     }
 
+    #[inline]
     fn new_pat(interner: TyCtxt<'tcx>, ty: Self, pat: ty::Pattern<'tcx>) -> Self {
         Ty::new_pat(interner, ty, pat)
     }
 
+    #[inline]
     fn new_unsafe_binder(interner: TyCtxt<'tcx>, ty: ty::Binder<'tcx, Ty<'tcx>>) -> Self {
         Ty::new_unsafe_binder(interner, ty)
     }
@@ -1107,10 +1138,12 @@ impl<'tcx> rustc_type_ir::inherent::Ty<TyCtxt<'tcx>> for Ty<'tcx> {
         interner.types.usize
     }
 
+    #[inline]
     fn discriminant_ty(self, interner: TyCtxt<'tcx>) -> Ty<'tcx> {
         self.discriminant_ty(interner)
     }
 
+    #[inline]
     fn has_unsafe_fields(self) -> bool {
         Ty::has_unsafe_fields(self)
     }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -316,6 +316,49 @@ pub(super) fn opt_normalize_projection_term<'a, 'b, 'tcx>(
     // or else another kind of cache entry.
     let cache_entry = infcx.inner.borrow_mut().projection_cache().try_start(cache_key);
     match cache_entry {
+        // This is the hottest path in this function.
+        //
+        // If we find the value in the cache, then return it along with the
+        // obligations that went along with it. Note that, when using a
+        // fulfillment context, these obligations could in principle be
+        // ignored: they have already been registered when the cache entry
+        // was created (and hence the new ones will quickly be discarded as
+        // duplicated). But when doing trait evaluation this is not the
+        // case, and dropping the trait evaluations can causes ICEs (e.g.,
+        // #43132).
+        Err(ProjectionCacheEntry::NormalizedTerm { ty, complete: _ }) => {
+            debug!(?ty, "found normalized ty");
+            obligations.extend(ty.obligations);
+            Ok(Some(ty.value))
+        }
+        cache_entry => opt_normalize_projection_term_slow(
+            selcx,
+            param_env,
+            projection_term,
+            cause,
+            depth,
+            obligations,
+            cache_entry,
+            cache_key,
+        ),
+    }
+}
+
+/// Cold-path body of [`opt_normalize_projection_term`].
+#[cold]
+#[inline(never)]
+fn opt_normalize_projection_term_slow<'a, 'b, 'tcx>(
+    selcx: &'a mut SelectionContext<'b, 'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    projection_term: ty::AliasTerm<'tcx>,
+    cause: ObligationCause<'tcx>,
+    depth: usize,
+    obligations: &mut PredicateObligations<'tcx>,
+    cache_entry: Result<(), ProjectionCacheEntry<'tcx>>,
+    cache_key: ProjectionCacheKey<'tcx>,
+) -> Result<Option<Term<'tcx>>, InProgress> {
+    let infcx = selcx.infcx;
+    match cache_entry {
         Ok(()) => debug!("no cache"),
         Err(ProjectionCacheEntry::Ambiguous) => {
             // If we found ambiguity the last time, that means we will continue
@@ -345,21 +388,8 @@ pub(super) fn opt_normalize_projection_term<'a, 'b, 'tcx>(
             debug!("recur cache");
             return Err(InProgress);
         }
-        Err(ProjectionCacheEntry::NormalizedTerm { ty, complete: _ }) => {
-            // This is the hottest path in this function.
-            //
-            // If we find the value in the cache, then return it along
-            // with the obligations that went along with it. Note
-            // that, when using a fulfillment context, these
-            // obligations could in principle be ignored: they have
-            // already been registered when the cache entry was
-            // created (and hence the new ones will quickly be
-            // discarded as duplicated). But when doing trait
-            // evaluation this is not the case, and dropping the trait
-            // evaluations can causes ICEs (e.g., #43132).
-            debug!(?ty, "found normalized ty");
-            obligations.extend(ty.obligations);
-            return Ok(Some(ty.value));
+        Err(ProjectionCacheEntry::NormalizedTerm { .. }) => {
+            unreachable!("NormalizedTerm cache hit should be handled by the hot dispatcher");
         }
         Err(ProjectionCacheEntry::Error) => {
             debug!("opt_normalize_projection_type: found error");

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -109,6 +109,7 @@ where
         Binder { value, bound_vars: Default::default() }
     }
 
+    #[inline]
     pub fn bind_with_vars(value: T, bound_vars: I::BoundVarKinds) -> Binder<I, T> {
         if cfg!(debug_assertions) {
             let mut validator = ValidateBoundVars::new(bound_vars);
@@ -186,6 +187,7 @@ impl<I: Interner, T> Binder<I, T> {
         Binder { value: &self.value, bound_vars: self.bound_vars }
     }
 
+    #[inline]
     pub fn map_bound_ref<F, U: TypeVisitable<I>>(&self, f: F) -> Binder<I, U>
     where
         F: FnOnce(&T) -> U,
@@ -193,6 +195,7 @@ impl<I: Interner, T> Binder<I, T> {
         self.as_ref().map_bound(f)
     }
 
+    #[inline]
     pub fn map_bound<F, U: TypeVisitable<I>>(self, f: F) -> Binder<I, U>
     where
         F: FnOnce(T) -> U,
@@ -206,6 +209,7 @@ impl<I: Interner, T> Binder<I, T> {
         Binder { value, bound_vars }
     }
 
+    #[inline]
     pub fn try_map_bound<F, U: TypeVisitable<I>, E>(self, f: F) -> Result<Binder<I, U>, E>
     where
         F: FnOnce(T) -> Result<U, E>,
@@ -245,6 +249,7 @@ impl<I: Interner, T> Binder<I, T> {
     /// binders, but that would require adjusting the debruijn
     /// indices, and given the shallow binding structure we often use,
     /// would not be that useful.)
+    #[inline]
     pub fn no_bound_vars(self) -> Option<T>
     where
         T: TypeVisitable<I>,
@@ -396,6 +401,7 @@ impl<I: Interner, T> EarlyBinder<I, T> {
         EarlyBinder { value: &self.value, _tcx: PhantomData }
     }
 
+    #[inline]
     pub fn map_bound_ref<F, U>(&self, f: F) -> EarlyBinder<I, U>
     where
         F: FnOnce(&T) -> U,
@@ -403,6 +409,7 @@ impl<I: Interner, T> EarlyBinder<I, T> {
         self.as_ref().map_bound(f)
     }
 
+    #[inline]
     pub fn map_bound<F, U>(self, f: F) -> EarlyBinder<I, U>
     where
         F: FnOnce(T) -> U,
@@ -411,6 +418,7 @@ impl<I: Interner, T> EarlyBinder<I, T> {
         EarlyBinder { value, _tcx: PhantomData }
     }
 
+    #[inline]
     pub fn try_map_bound<F, U, E>(self, f: F) -> Result<EarlyBinder<I, U>, E>
     where
         F: FnOnce(T) -> Result<U, E>,

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -168,18 +168,22 @@ impl<I: Interner, T> Binder<I, T> {
     ///
     /// See existing uses of `.skip_binder()` in `rustc_trait_selection::traits::select`
     /// or `rustc_next_trait_solver` for examples.
+    #[inline]
     pub fn skip_binder(self) -> T {
         self.value
     }
 
+    #[inline]
     pub fn bound_vars(&self) -> I::BoundVarKinds {
         self.bound_vars
     }
 
+    #[inline]
     pub fn as_ref(&self) -> Binder<I, &T> {
         Binder { value: &self.value, bound_vars: self.bound_vars }
     }
 
+    #[inline]
     pub fn as_deref(&self) -> Binder<I, &T::Target>
     where
         T: Deref,
@@ -394,10 +398,12 @@ generate!(
 );
 
 impl<I: Interner, T> EarlyBinder<I, T> {
+    #[inline]
     pub fn bind(value: T) -> EarlyBinder<I, T> {
         EarlyBinder { value, _tcx: PhantomData }
     }
 
+    #[inline]
     pub fn as_ref(&self) -> EarlyBinder<I, &T> {
         EarlyBinder { value: &self.value, _tcx: PhantomData }
     }
@@ -428,6 +434,7 @@ impl<I: Interner, T> EarlyBinder<I, T> {
         Ok(EarlyBinder { value, _tcx: PhantomData })
     }
 
+    #[inline]
     pub fn rebind<U>(&self, value: U) -> EarlyBinder<I, U> {
         EarlyBinder { value, _tcx: PhantomData }
     }
@@ -448,6 +455,7 @@ impl<I: Interner, T> EarlyBinder<I, T> {
     ///
     /// See also [`Binder::skip_binder`](Binder::skip_binder), which is
     /// the analogous operation on [`Binder`].
+    #[inline]
     pub fn skip_binder(self) -> T {
         self.value
     }

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -232,6 +232,7 @@ impl<I: Interner, T> Binder<I, T> {
     /// don't actually track bound vars. However, semantically, it is different
     /// because bound vars aren't allowed to change here, whereas they are
     /// in `bind`. This may be (debug) asserted in the future.
+    #[inline]
     pub fn rebind<U>(&self, value: U) -> Binder<I, U>
     where
         U: TypeVisitable<I>,

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -185,6 +185,7 @@ impl<I: Interner> ty::Binder<I, TraitRef<I>> {
         self.map_bound_ref(|tr| tr.self_ty())
     }
 
+    #[inline]
     pub fn def_id(&self) -> I::TraitId {
         self.skip_binder().def_id
     }
@@ -228,6 +229,7 @@ impl<I: Interner> TraitPredicate<I> {
         self.trait_ref.def_id
     }
 
+    #[inline]
     pub fn self_ty(self) -> I::Ty {
         self.trait_ref.self_ty()
     }
@@ -454,6 +456,7 @@ impl<I: Interner> ExistentialTraitRef<I> {
 }
 
 impl<I: Interner> ty::Binder<I, ExistentialTraitRef<I>> {
+    #[inline]
     pub fn def_id(&self) -> I::TraitId {
         self.skip_binder().def_id
     }
@@ -552,6 +555,7 @@ impl<I: Interner> ty::Binder<I, ExistentialProjection<I>> {
         self.map_bound(|p| p.with_self_ty(cx, self_ty))
     }
 
+    #[inline]
     pub fn item_def_id(&self) -> I::TraitAssocTermId {
         self.skip_binder().def_id
     }
@@ -914,6 +918,7 @@ pub struct ProjectionPredicate<I: Interner> {
 impl<I: Interner> Eq for ProjectionPredicate<I> {}
 
 impl<I: Interner> ProjectionPredicate<I> {
+    #[inline]
     pub fn self_ty(self) -> I::Ty {
         self.projection_term.self_ty()
     }
@@ -925,10 +930,12 @@ impl<I: Interner> ProjectionPredicate<I> {
         }
     }
 
+    #[inline]
     pub fn trait_def_id(self, interner: I) -> I::TraitId {
         self.projection_term.trait_def_id(interner)
     }
 
+    #[inline]
     pub fn def_id(self) -> I::TraitAssocTermId {
         self.projection_term.expect_projection_def_id()
     }
@@ -941,6 +948,7 @@ impl<I: Interner> ty::Binder<I, ProjectionPredicate<I>> {
         self.skip_binder().projection_term.trait_def_id(cx)
     }
 
+    #[inline]
     pub fn term(&self) -> ty::Binder<I, I::Term> {
         self.map_bound(|predicate| predicate.term)
     }
@@ -978,6 +986,7 @@ pub struct NormalizesTo<I: Interner> {
 impl<I: Interner> Eq for NormalizesTo<I> {}
 
 impl<I: Interner> NormalizesTo<I> {
+    #[inline]
     pub fn self_ty(self) -> I::Ty {
         self.alias.self_ty()
     }
@@ -986,10 +995,12 @@ impl<I: Interner> NormalizesTo<I> {
         Self { alias: self.alias.with_replaced_self_ty(interner, self_ty), ..self }
     }
 
+    #[inline]
     pub fn trait_def_id(self, interner: I) -> I::TraitId {
         self.alias.trait_def_id(interner)
     }
 
+    #[inline]
     pub fn def_id(self) -> I::DefId {
         self.alias.def_id()
     }
@@ -1015,6 +1026,7 @@ pub struct HostEffectPredicate<I: Interner> {
 impl<I: Interner> Eq for HostEffectPredicate<I> {}
 
 impl<I: Interner> HostEffectPredicate<I> {
+    #[inline]
     pub fn self_ty(self) -> I::Ty {
         self.trait_ref.self_ty()
     }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -180,6 +180,7 @@ impl<I: Interner> TraitRef<I> {
 }
 
 impl<I: Interner> ty::Binder<I, TraitRef<I>> {
+    #[inline]
     pub fn self_ty(&self) -> ty::Binder<I, I::Ty> {
         self.map_bound_ref(|tr| tr.self_ty())
     }
@@ -233,11 +234,13 @@ impl<I: Interner> TraitPredicate<I> {
 }
 
 impl<I: Interner> ty::Binder<I, TraitPredicate<I>> {
+    #[inline]
     pub fn def_id(self) -> I::TraitId {
         // Ok to skip binder since trait `DefId` does not care about regions.
         self.skip_binder().def_id()
     }
 
+    #[inline]
     pub fn self_ty(self) -> ty::Binder<I, I::Ty> {
         self.map_bound(|trait_ref| trait_ref.self_ty())
     }
@@ -946,6 +949,7 @@ impl<I: Interner> ty::Binder<I, ProjectionPredicate<I>> {
     ///
     /// Note that this is not the `DefId` of the `TraitRef` containing this
     /// associated type, which is in `tcx.associated_item(projection_def_id()).container`.
+    #[inline]
     pub fn item_def_id(&self) -> I::DefId {
         // Ok to skip binder since trait `DefId` does not care about regions.
         self.skip_binder().projection_term.def_id()
@@ -1025,11 +1029,13 @@ impl<I: Interner> HostEffectPredicate<I> {
 }
 
 impl<I: Interner> ty::Binder<I, HostEffectPredicate<I>> {
+    #[inline]
     pub fn def_id(self) -> I::TraitId {
         // Ok to skip binder since trait `DefId` does not care about regions.
         self.skip_binder().def_id()
     }
 
+    #[inline]
     pub fn self_ty(self) -> ty::Binder<I, I::Ty> {
         self.map_bound(|trait_ref| trait_ref.self_ty())
     }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -225,6 +225,7 @@ impl<I: Interner> TraitPredicate<I> {
         }
     }
 
+    #[inline]
     pub fn def_id(self) -> I::TraitId {
         self.trait_ref.def_id
     }
@@ -1035,6 +1036,7 @@ impl<I: Interner> HostEffectPredicate<I> {
         Self { trait_ref: self.trait_ref.with_replaced_self_ty(interner, self_ty), ..self }
     }
 
+    #[inline]
     pub fn def_id(self) -> I::TraitId {
         self.trait_ref.def_id
     }

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -2,15 +2,12 @@
 
 set -eux
 
-python3 ../x.py build --set rust.debug=true opt-dist
-
-./build/$HOSTS/stage1-tools-bin/opt-dist linux-ci -- python3 ../x.py dist \
+# TESTING-ONLY CHANGES.
+touch github-summary.md
+python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \
-    --include-default-paths \
-    build-manifest \
-    bootstrap \
-    enzyme \
-    rustc_codegen_gcc
+    --set "rust.codegen-backends=['llvm']" \
+    rustc rust-std cargo rust-src
 
 # Use GCC for building GCC components, as it seems to behave badly when built with Clang
 # Only build GCC on full builds, not try builds


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156343)*
<!-- homu-ignore:end -->

> [!NOTE]
> This is a draft for running perf.

Small accessor functions aren't inlined across crate boundaries in all build configurations.  Even with LTO, PGO, etc., we may be limited in what gets inlined without these annotations.

In detailed profiling, the `inline` attributes being added in this PR seemed to make a difference.  Let's add them.

Notably, some of these fall within the expansion of the `newtype_index!` macro and will apply to the items it defines.

r? @traviscross
