### PR TITLE
Do not index past end of buffer when checking heuristic in error index syntax highlighter

### DIFF
--- a/compiler/rustc_driver_impl/src/highlighter.rs
+++ b/compiler/rustc_driver_impl/src/highlighter.rs
@@ -106,7 +106,7 @@ impl Highlighter {
                     // This heuristic test is to detect if the identifier is
                     // a function call. If it is, then the function identifier is
                     // colored differently.
-                    if code[*len_accum..*len_accum + len + 1].ends_with('(') {
+                    if code[*len_accum + len..].starts_with('(') {
                         style = style.fg_color(Some(Color::Ansi(FUNCTION_COLOR)));
                     }
                     // The `derive` keyword is colored differently.

--- a/tests/ui/explain/explanation-code-rendering-edge-case-regression.rs
+++ b/tests/ui/explain/explanation-code-rendering-edge-case-regression.rs
@@ -1,0 +1,3 @@
+//@ compile-flags: --explain E0602 --color always --error-format=human
+//@ check-pass
+// Ensure that we trigger the condition for #156326 without ICEing.

--- a/tests/ui/explain/explanation-code-rendering-edge-case-regression.stdout
+++ b/tests/ui/explain/explanation-code-rendering-edge-case-regression.stdout
@@ -1,0 +1,7 @@
+An unknown or invalid lint was used on the command line.
+
+Erroneous code example:
+
+rustc[2m[97m [0m[2m[97m-[0m[33mD[0m[2m[97m [0mbogus[2m[97m [0mrust_file[2m[97m.[0mrs
+
+Maybe you just misspelled the lint name or the lint doesn't exist anymore. Either way, try to update/remove it in order to fix the error.


### PR DESCRIPTION
When checking whether the current token is a function indentifier by inspecting the syntax, do not attempt to access past the end of the code buffer.

Fix rust-lang/rust#156326.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
