### PR TITLE
[perf-only] rustdoc: Unconditionally enable `--generate-link-to-definition`

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -824,7 +824,7 @@ impl Options {
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
         let show_type_layout = matches.opt_present("show-type-layout");
         let no_capture = matches.opt_present("no-capture");
-        let generate_link_to_definition = matches.opt_present("generate-link-to-definition");
+        let generate_link_to_definition = true;
         let generate_macro_expansion = matches.opt_present("generate-macro-expansion");
         let extern_html_root_takes_precedence =
             matches.opt_present("extern-html-root-takes-precedence");

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -238,18 +238,15 @@ impl SpanMapVisitor<'_> {
     }
 }
 
-// This is a reimplementation of `hir_enclosing_body_owner` which allows to fail without
-// panicking.
+// NOTE: This is less than ideal.
 fn hir_enclosing_body_owner(tcx: TyCtxt<'_>, hir_id: HirId) -> Option<LocalDefId> {
     for (_, node) in tcx.hir_parent_iter(hir_id) {
-        // FIXME: associated type impl items don't have an associated body, so we don't handle
-        // them currently.
-        if let Node::ImplItem(impl_item) = node
-            && matches!(impl_item.kind, rustc_hir::ImplItemKind::Type(_))
-        {
-            return None;
-        } else if let Some((def_id, _)) = node.associated_body() {
+        if let Some((def_id, _)) = node.associated_body() {
             return Some(def_id);
+        }
+        match node {
+            Node::Item(_) | Node::TraitItem(_) | Node::ImplItem(_) | Node::ForeignItem(_) => break,
+            _ => {}
         }
     }
     None


### PR DESCRIPTION
Compare with https://github.com/rust-lang/rust/pull/156355, https://github.com/rust-lang/rust/pull/156349.