### PR TITLE
resolve: Set correct parent and expansion for `self` declarations

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1548,13 +1548,10 @@ impl<'ra> ResolverArenas<'ra> {
         no_implicit_prelude: bool,
     ) -> Module<'ra> {
         let self_decl = match kind {
-            ModuleKind::Def(def_kind, def_id, _, _) => Some(self.new_def_decl(
-                Res::Def(def_kind, def_id),
-                vis,
-                span,
-                LocalExpnId::ROOT,
-                None,
-            )),
+            ModuleKind::Def(def_kind, def_id, _, _) => {
+                let expn_id = expn_id.as_local().unwrap_or(LocalExpnId::ROOT);
+                Some(self.new_def_decl(Res::Def(def_kind, def_id), vis, span, expn_id, parent))
+            }
             ModuleKind::Block => None,
         };
         Module(Interned::new_unchecked(self.modules.alloc(ModuleData::new(


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/rust/pull/146972 and https://github.com/rust-lang/rust/pull/154313.

The `parent` seems to not be used yet, it will ICE if used (https://github.com/rust-lang/rust/pull/156185 uses it).
The `expn_id` is only relevant to macros 2.0, I won't bother coming up with a test.