### PR TITLE
bootstrap: add bootstrap step to run intrinsic-test in CI

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -992,6 +992,140 @@ impl Step for StdarchVerify {
     }
 }
 
+/// Runs stdarch's intrinsic-test binary crate to verify that Rust's `core::arch`
+/// SIMD intrinsics produce the same results as their C counterparts.
+///
+/// First runs the `intrinsic-test` binary, which generates C wrapper programs
+/// and a Rust Cargo workspace. Then runs `cargo test` on that workspace
+/// which compiles both versions and compares their outputs on random inputs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IntrinsicTest {
+    host: TargetSelection,
+}
+
+impl Step for IntrinsicTest {
+    type Output = ();
+    const IS_HOST: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.path("library/stdarch/crates/intrinsic-test")
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        let target = run.target;
+        if !target.contains("aarch64-unknown-linux") && !target.contains("x86_64-unknown-linux") {
+            return;
+        }
+        run.builder.ensure(IntrinsicTest { host: target });
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let host = self.host;
+
+        let (input_file, skip_file, cflags, sde_runner) = if host.contains("x86_64-unknown-linux") {
+            let cpuid_def =
+                builder.src.join("library/stdarch/ci/docker/x86_64-unknown-linux-gnu/cpuid.def");
+            let sde_runner = format!(
+                "/intel-sde/sde64 -cpuid-in {} -rtm-mode full -tsx --",
+                cpuid_def.display()
+            );
+            (
+                builder.src.join("library/stdarch/intrinsics_data/x86-intel.xml"),
+                [
+                    builder
+                        .src
+                        .join("library/stdarch/crates/intrinsic-test/missing_x86_common.txt"),
+                    builder.src.join("library/stdarch/crates/intrinsic-test/missing_x86_gcc.txt"),
+                ],
+                "-I/usr/include/x86_64-linux-gnu/",
+                Some(sde_runner),
+            )
+        } else if host.contains("aarch64-unknown-linux") {
+            (
+                builder.src.join("library/stdarch/intrinsics_data/arm_intrinsics.json"),
+                [
+                    builder
+                        .src
+                        .join("library/stdarch/crates/intrinsic-test/missing_aarch64_common.txt"),
+                    builder
+                        .src
+                        .join("library/stdarch/crates/intrinsic-test/missing_aarch64_gcc.txt"),
+                ],
+                "-I/usr/aarch64-linux-gnu/include/",
+                None,
+            )
+        } else {
+            panic!("intrinsic-test only supports aarch64/x86_64 Linux, got {host}");
+        };
+
+        let out_dir = builder.out.join(host).join("intrinsic-test");
+        t!(fs::create_dir_all(&out_dir));
+
+        let crates_link = out_dir.join("crates");
+        if !crates_link.exists() {
+            t!(
+                helpers::symlink_dir(
+                    &builder.config,
+                    &builder.src.join("library/stdarch/crates"),
+                    &crates_link
+                ),
+                format!("failed to symlink stdarch crates into {}", crates_link.display())
+            );
+        }
+
+        let mut cmd = builder.tool_cmd(Tool::IntrinsicTest);
+        cmd.current_dir(&out_dir);
+        cmd.arg(&input_file);
+        cmd.arg("--target").arg(&*host.triple);
+        for skip in &skip_file {
+            cmd.arg("--skip").arg(skip);
+        }
+        cmd.arg("--sample-percentage").arg("10");
+        cmd.arg("--cc-arg-style").arg("gcc");
+        cmd.env("CC", builder.cc(host));
+        cmd.env("CFLAGS", cflags);
+        // intrinsic-test shells out to `cargo` and `rustfmt` make bootstrap's
+        // managed binaries findable by prepending their dirs to PATH.
+        let rustfmt_path = builder.config.initial_rustfmt.clone().unwrap_or_else(|| {
+            eprintln!("intrinsic-test: rustfmt is required but not available on this channel");
+            crate::exit!(1);
+        });
+
+        let mut path_dirs: Vec<PathBuf> = Vec::new();
+        if let Some(cargo_dir) = builder.initial_cargo.parent() {
+            path_dirs.push(cargo_dir.to_path_buf());
+        }
+        if let Some(rustfmt_dir) = rustfmt_path.parent() {
+            path_dirs.push(rustfmt_dir.to_path_buf());
+        }
+        let old_path = env::var_os("PATH").unwrap_or_default();
+        let new_path = env::join_paths(path_dirs.into_iter().chain(env::split_paths(&old_path)))
+            .expect("could not build PATH for intrinsic-test");
+        cmd.env("PATH", new_path);
+        cmd.run(builder);
+
+        let tested_compiler = builder.compiler(builder.top_stage, host);
+        builder.std(tested_compiler, host);
+        let rustc = builder.rustc(tested_compiler);
+
+        let manifest = out_dir.join("rust_programs/Cargo.toml");
+        let mut cargo = command(&builder.initial_cargo);
+        cargo.arg("test");
+        cargo.arg("--tests");
+        cargo.arg("--manifest-path").arg(&manifest);
+        cargo.arg("--target").arg(&*host.triple);
+        cargo.arg("--profile").arg("release");
+        cargo.env("CC", builder.cc(host));
+        cargo.env("CFLAGS", cflags);
+        cargo.env("RUSTC", rustc);
+        cargo.env("RUSTC_BOOTSTRAP", "1");
+        if let Some(runner) = sde_runner {
+            cargo.env("CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER", runner);
+        }
+        cargo.run(builder);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Clippy {
     compilers: RustcPrivateCompilers,

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -508,6 +508,7 @@ bootstrap_tool!(
     FeaturesStatusDump, "src/tools/features-status-dump", "features-status-dump";
     OptimizedDist, "src/tools/opt-dist", "opt-dist", submodules = &["src/tools/rustc-perf"];
     RunMakeSupport, "src/tools/run-make-support", "run_make_support", artifact_kind = ToolArtifactKind::Library;
+    IntrinsicTest, "library/stdarch/crates/intrinsic-test", "intrinsic-test";
 );
 
 /// These are the submodules that are required for rustbook to work due to

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_library.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_library.snap
@@ -21,3 +21,6 @@ expression: test library
 [Test] test::StdarchVerify
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::library/stdarch/crates/stdarch-verify})
+[Test] test::IntrinsicTest
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/intrinsic-test})

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -911,6 +911,7 @@ impl<'a> Builder<'a> {
                 test::Clippy,
                 test::CompiletestTest,
                 test::StdarchVerify,
+                test::IntrinsicTest,
                 test::CrateRunMakeSupport,
                 test::CrateBuildHelper,
                 test::RustdocJSStd,

--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -21,6 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libzstd-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# Install Intel SDE for AVX-512 emulation
+RUN curl -L http://ci-mirrors.rust-lang.org/sde-external-10.8.0-2026-03-15-lin.tar.xz -o /tmp/sde.tar.xz \
+  && mkdir -p /intel-sde \
+  && tar -xJf /tmp/sde.tar.xz --strip-components=1 -C /intel-sde \
+  && rm /tmp/sde.tar.xz
+
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
@@ -29,4 +35,5 @@ ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --enable-profiler \
  --enable-compiler-docs \
  --set llvm.libzstd=true"
-ENV SCRIPT="python3 ../x.py --stage 2 test"
+ENV SCRIPT="python3 ../x.py --stage 2 test && \
+            python3 ../x.py --stage 2 test library/stdarch/crates/intrinsic-test"


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156356)*
<!-- homu-ignore:end -->

This PR ports `library/stdarch/crates/intrinsic-test` crate into the bootstrap test runner as a step, so that we can run the  intrinsic-test suite via x.py test.

Changes -:
Ports `intrinsic-test` from the stdarch crate into the bootstrap system as a new  test step so it runs inside the existing
`x86_64-gnu` and `aarch64-gnu` CI jobs .
Added `intrinsic-test` in `src/bootstrap/src/core/build_steps/test.rs` .
Registers `intrinsic-test` as a bootstrap tool  in `tool.rs` .
Installs `clang`, `lld`, and Intel SDE in the respective Dockerfiles.

r? @Kobzol

try-job: x86_64-gnu