### PR TITLE
resolve: Introduce separate `(Local,Extern)ModuleData` structures for local and external modules respectively

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -9,9 +9,8 @@ use std::sync::Arc;
 
 use rustc_ast::visit::{self, AssocCtxt, Visitor, WalkItemKind};
 use rustc_ast::{
-    self as ast, AssocItem, AssocItemKind, Block, ConstItem, DUMMY_NODE_ID, Delegation, Fn,
-    ForeignItem, ForeignItemKind, Inline, Item, ItemKind, NodeId, StaticItem, StmtKind, TraitAlias,
-    TyAlias,
+    self as ast, AssocItem, AssocItemKind, Block, ConstItem, Delegation, Fn, ForeignItem,
+    ForeignItemKind, Inline, Item, ItemKind, NodeId, StaticItem, StmtKind, TraitAlias, TyAlias,
 };
 use rustc_attr_parsing::AttributeParser;
 use rustc_expand::base::{ResolverExpand, SyntaxExtension, SyntaxExtensionKind};
@@ -168,12 +167,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     let expn_id = self.cstore().expn_that_defined_untracked(self.tcx, def_id);
                     let module = self.new_extern_module(
                         parent,
-                        ModuleKind::Def(
-                            def_kind,
-                            def_id,
-                            DUMMY_NODE_ID,
-                            Some(self.tcx.item_name(def_id)),
-                        ),
+                        ModuleKind::Extern(def_kind, def_id, self.tcx.item_name(def_id)),
                         expn_id,
                         self.def_span(def_id),
                         // FIXME: Account for `#[no_implicit_prelude]` attributes.
@@ -253,11 +247,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         match vis.kind {
             ast::VisibilityKind::Public => Ok(Visibility::Public),
             ast::VisibilityKind::Inherited => {
-                Ok(match parent_scope.module.expect_local().kind {
+                Ok(match parent_scope.module.expect_local().def() {
                     // Any inherited visibility resolved directly inside an enum or trait
                     // (i.e. variants, fields, and trait items) inherits from the visibility
                     // of the enum or trait.
-                    ModuleKind::Def(DefKind::Enum | DefKind::Trait, def_id, _, _) => {
+                    Some((DefKind::Enum | DefKind::Trait, def_id)) => {
                         self.tcx.visibility(def_id).expect_local()
                     }
                     // Otherwise, the visibility is restricted to the nearest parent `mod` item.
@@ -856,7 +850,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
                 }
                 let module = self.r.new_local_module(
                     Some(parent),
-                    ModuleKind::Def(def_kind, def_id, item.id, Some(ident.name)),
+                    ModuleKind::Local(def_kind, local_def_id, item.id, Some(ident.name)),
                     expansion.to_expn_id(),
                     item.span,
                     parent.no_implicit_prelude
@@ -890,7 +884,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
 
                 let module = self.r.new_local_module(
                     Some(parent),
-                    ModuleKind::Def(def_kind, def_id, item.id, Some(ident.name)),
+                    ModuleKind::Local(def_kind, local_def_id, item.id, Some(ident.name)),
                     expansion.to_expn_id(),
                     item.span,
                     parent.no_implicit_prelude,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -51,9 +51,9 @@ use crate::late::{DiagMetadata, PatternSource, Rib};
 use crate::{
     AmbiguityError, AmbiguityKind, AmbiguityWarning, BindingError, BindingKey, Decl, DeclKind,
     DelayedVisResolutionError, Finalize, ForwardGenericParamBanReason, HasGenericParams, IdentKey,
-    LateDecl, MacroRulesScope, Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult,
-    PrivacyError, Res, ResolutionError, Resolver, Scope, ScopeSet, Segment, UseError, Used,
-    VisResolutionError, errors as errs, path_names_to_string,
+    LateDecl, MacroRulesScope, Module, ModuleOrUniformRoot, ParentScope, PathResult, PrivacyError,
+    Res, ResolutionError, Resolver, Scope, ScopeSet, Segment, UseError, Used, VisResolutionError,
+    errors as errs, path_names_to_string,
 };
 
 /// A vector of spans and replacements, a message and applicability.
@@ -240,11 +240,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             return self.report_conflict(ident, ns, new_binding, old_binding);
         }
 
-        let container = match old_binding.parent_module.unwrap().expect_local().kind {
+        let container = match old_binding.parent_module.unwrap().expect_local().def() {
             // Avoid using TyCtxt::def_kind_descr in the resolver, because it
             // indirectly *calls* the resolver, and would cause a query cycle.
-            ModuleKind::Def(kind, def_id, _, _) => kind.descr(def_id),
-            ModuleKind::Block => "block",
+            Some((def_kind, def_id)) => def_kind.descr(def_id),
+            None => "block",
         };
 
         let (name, span) =
@@ -1765,7 +1765,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         if ident.name == kw::Default
-            && let ModuleKind::Def(DefKind::Enum, def_id, _, _) = parent_scope.module.kind
+            && let Some((DefKind::Enum, def_id)) = parent_scope.module.def()
         {
             let span = self.def_span(def_id);
             let source_map = self.tcx.sess.source_map();
@@ -1893,19 +1893,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                      missing a `derive` attribute",
                 ident.name,
             );
-            let sugg_span =
-                if let ModuleKind::Def(DefKind::Enum, id, _, _) = parent_scope.module.kind {
-                    let span = self.def_span(id);
-                    if span.from_expansion() {
-                        None
-                    } else {
-                        // For enum variants sugg_span is empty but we can get the enum's Span.
-                        Some(span.shrink_to_lo())
-                    }
+            let sugg_span = if let Some((DefKind::Enum, id)) = parent_scope.module.def() {
+                let span = self.def_span(id);
+                if span.from_expansion() {
+                    None
                 } else {
-                    // For items this `Span` will be populated, everything else it'll be None.
-                    sugg_span
-                };
+                    // For enum variants sugg_span is empty but we can get the enum's Span.
+                    Some(span.shrink_to_lo())
+                }
+            } else {
+                // For items this `Span` will be populated, everything else it'll be None.
+                sugg_span
+            };
             match sugg_span {
                 Some(span) => {
                     err.span_suggestion_verbose(

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1941,8 +1941,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             && let Some((module, _)) = &self.current_trait_ref
                             && let Some(ty) = &self.diag_metadata.current_self_type
                             && Some(true) == self.diag_metadata.in_non_gat_assoc_type
-                            && let crate::ModuleKind::Def(DefKind::Trait, trait_id, _, _) =
-                                module.kind
+                            && let Some((DefKind::Trait, trait_id)) = module.def()
                         {
                             if def_id_matches_path(
                                 self.r.tcx,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -533,7 +533,7 @@ enum ModuleKind {
     /// }
     /// ```
     Block,
-    /// Any module with a name.
+    /// A local non-block module.
     ///
     /// This could be:
     ///
@@ -542,13 +542,16 @@ enum ModuleKind {
     ///   The crate root will have `None` for the symbol.
     /// * A trait or an enum (it implicitly contains associated types, methods and variant
     ///   constructors).
-    Def(DefKind, DefId, NodeId, Option<Symbol>),
+    Local(DefKind, LocalDefId, NodeId, Option<Symbol>),
+    /// An external module, non-block by definition.
+    Extern(DefKind, DefId, Symbol),
 }
 
 impl ModuleKind {
     fn opt_def_id(&self) -> Option<DefId> {
         match self {
-            ModuleKind::Def(_, def_id, _, _) => Some(*def_id),
+            ModuleKind::Local(_, def_id, _, _) => Some(def_id.to_def_id()),
+            ModuleKind::Extern(_, def_id, _) => Some(*def_id),
             _ => None,
         }
     }
@@ -557,11 +560,16 @@ impl ModuleKind {
         self.opt_def_id().expect("`Module::def_id` is called on a block module")
     }
 
-    fn is_local(&self) -> bool {
+    fn def(&self) -> Option<(DefKind, DefId)> {
         match self {
-            ModuleKind::Def(_, def_id, ..) => def_id.is_local(),
-            ModuleKind::Block => true,
+            ModuleKind::Local(def_kind, def_id, _, _) => Some((*def_kind, def_id.to_def_id())),
+            ModuleKind::Extern(def_kind, def_id, _) => Some((*def_kind, *def_id)),
+            ModuleKind::Block => None,
         }
+    }
+
+    fn is_local(&self) -> bool {
+        matches!(self, ModuleKind::Local(..) | ModuleKind::Block)
     }
 }
 
@@ -729,13 +737,10 @@ impl<'ra> ModuleData<'ra> {
         arenas: &'ra ResolverArenas<'ra>,
     ) -> Self {
         let is_foreign = !kind.is_local();
-        let self_decl = match kind {
-            ModuleKind::Def(def_kind, def_id, ..) => {
-                let expn_id = expansion.as_local().unwrap_or(LocalExpnId::ROOT);
-                Some(arenas.new_def_decl(Res::Def(def_kind, def_id), vis, span, expn_id, parent))
-            }
-            ModuleKind::Block => None,
-        };
+        let self_decl = kind.def().map(|(def_kind, def_id)| {
+            let expn_id = expansion.as_local().unwrap_or(LocalExpnId::ROOT);
+            arenas.new_def_decl(Res::Def(def_kind, def_id), vis, span, expn_id, parent)
+        });
         ModuleData {
             parent,
             kind,
@@ -757,7 +762,8 @@ impl<'ra> ModuleData<'ra> {
     fn name(&self) -> Option<Symbol> {
         match self.kind {
             ModuleKind::Block => None,
-            ModuleKind::Def(.., name) => name,
+            ModuleKind::Local(.., name) => name,
+            ModuleKind::Extern(.., name) => Some(name),
         }
     }
 
@@ -767,6 +773,10 @@ impl<'ra> ModuleData<'ra> {
 
     fn def_id(&self) -> DefId {
         self.kind.def_id()
+    }
+
+    fn def(&self) -> Option<(DefKind, DefId)> {
+        self.kind.def()
     }
 
     fn is_local(&self) -> bool {
@@ -779,14 +789,15 @@ impl<'ra> ModuleData<'ra> {
 
     fn res(&self) -> Option<Res> {
         match self.kind {
-            ModuleKind::Def(kind, def_id, _, _) => Some(Res::Def(kind, def_id)),
+            ModuleKind::Local(kind, def_id, _, _) => Some(Res::Def(kind, def_id.to_def_id())),
+            ModuleKind::Extern(kind, def_id, _) => Some(Res::Def(kind, def_id)),
             _ => None,
         }
     }
 
     fn def_kind(&self) -> Option<DefKind> {
         match self.kind {
-            ModuleKind::Def(def_kind, ..) => Some(def_kind),
+            ModuleKind::Local(def_kind, ..) | ModuleKind::Extern(def_kind, ..) => Some(def_kind),
             ModuleKind::Block => None,
         }
     }
@@ -863,7 +874,8 @@ impl<'ra> Module<'ra> {
     /// This may be the crate root.
     fn nearest_parent_mod(self) -> DefId {
         match self.kind {
-            ModuleKind::Def(DefKind::Mod, def_id, _, _) => def_id,
+            ModuleKind::Local(DefKind::Mod, def_id, _, _) => def_id.to_def_id(),
+            ModuleKind::Extern(DefKind::Mod, def_id, _) => def_id,
             _ => self.parent.expect("non-root module without parent").nearest_parent_mod(),
         }
     }
@@ -872,7 +884,8 @@ impl<'ra> Module<'ra> {
     /// This may be the crate root.
     fn nearest_parent_mod_node_id(self) -> NodeId {
         match self.kind {
-            ModuleKind::Def(DefKind::Mod, _, node_id, _) => node_id,
+            ModuleKind::Local(DefKind::Mod, _, node_id, _) => node_id,
+            ModuleKind::Extern(..) => ast::DUMMY_NODE_ID,
             _ => self.parent.expect("non-root module without parent").nearest_parent_mod_node_id(),
         }
     }
@@ -891,20 +904,16 @@ impl<'ra> Module<'ra> {
     #[track_caller]
     fn expect_local(self) -> LocalModule<'ra> {
         match self.kind {
-            ModuleKind::Def(_, def_id, _, _) if !def_id.is_local() => {
-                span_bug!(self.span, "unexpected extern module: {self:?}")
-            }
-            ModuleKind::Def(..) | ModuleKind::Block => LocalModule(self.0),
+            ModuleKind::Local(..) | ModuleKind::Block => LocalModule(self.0),
+            _ => span_bug!(self.span, "unexpected extern module: {self:?}"),
         }
     }
 
     #[track_caller]
     fn expect_extern(self) -> ExternModule<'ra> {
         match self.kind {
-            ModuleKind::Def(_, def_id, _, _) if !def_id.is_local() => ExternModule(self.0),
-            ModuleKind::Def(..) | ModuleKind::Block => {
-                span_bug!(self.span, "unexpected local module: {self:?}")
-            }
+            ModuleKind::Extern(..) => ExternModule(self.0),
+            _ => span_bug!(self.span, "unexpected local module: {self:?}"),
         }
     }
 }
@@ -1757,10 +1766,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         current_crate_outer_attr_insert_span: Span,
         arenas: &'ra ResolverArenas<'ra>,
     ) -> Resolver<'ra, 'tcx> {
-        let root_def_id = CRATE_DEF_ID.to_def_id();
         let graph_root = LocalModule::new(
             None,
-            ModuleKind::Def(DefKind::Mod, root_def_id, CRATE_NODE_ID, None),
+            ModuleKind::Local(DefKind::Mod, CRATE_DEF_ID, CRATE_NODE_ID, None),
             Visibility::Public,
             ExpnId::root(),
             crate_span,
@@ -1771,7 +1779,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let local_module_map = FxIndexMap::from_iter([(CRATE_DEF_ID, graph_root)]);
         let empty_module = LocalModule::new(
             None,
-            ModuleKind::Def(DefKind::Mod, root_def_id, CRATE_NODE_ID, None),
+            ModuleKind::Local(DefKind::Mod, CRATE_DEF_ID, CRATE_NODE_ID, None),
             Visibility::Public,
             ExpnId::root(),
             DUMMY_SP,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -43,8 +43,8 @@ use crate::hygiene::Macros20NormalizedSyntaxContext;
 use crate::imports::Import;
 use crate::{
     BindingKey, CacheCell, CmResolver, Decl, DeclKind, DeriveData, Determinacy, Finalize, IdentKey,
-    InvocationParent, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult, Res,
-    ResolutionError, Resolver, ScopeSet, Segment, Used,
+    InvocationParent, ModuleOrUniformRoot, ParentScope, PathResult, Res, ResolutionError, Resolver,
+    ScopeSet, Segment, Used,
 };
 
 /// Name declaration produced by a `macro_rules` item definition.
@@ -1181,15 +1181,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 // Silence `unused_imports` on the fallback import as well.
                 self.get_mut().record_use(ident, fallback_binding, Used::Other);
             } else {
-                let location = match parent_scope.module.kind {
-                    ModuleKind::Def(kind, def_id, _, name) => {
-                        if let Some(name) = name {
+                let location = match parent_scope.module.def() {
+                    Some((kind, def_id)) => {
+                        if let Some(name) = parent_scope.module.name() {
                             format!("{} `{name}`", kind.descr(def_id))
                         } else {
                             "the crate root".to_string()
                         }
                     }
-                    ModuleKind::Block => "this scope".to_string(),
+                    None => "this scope".to_string(),
                 };
                 self.tcx.sess.psess.buffer_lint(
                     OUT_OF_SCOPE_MACRO_CALLS,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156362)*
<!-- homu-ignore:end -->

Besides the `CommonModuleData` core they need to keep quite different data.

This is a follow up to https://github.com/rust-lang/rust/pull/155242.
The remaining piece is dismantling `CommonModuleData::lazy_resolutions`, but it would be better done separately.