### PR TITLE
stream_send_recv_stress tests: wait for threads to finish

### DIFF
--- a/library/std/tests/sync/mpmc.rs
+++ b/library/std/tests/sync/mpmc.rs
@@ -419,34 +419,48 @@ fn oneshot_multi_thread_send_recv_stress() {
 
 #[test]
 fn stream_send_recv_stress() {
-    for _ in 0..stress_factor() {
-        let (tx, rx) = channel();
+    thread::scope(|s| {
+        for _ in 0..stress_factor() {
+            let (tx, rx) = channel();
 
-        send(tx, 0);
-        recv(rx, 0);
+            send(tx, 0, s);
+            recv(rx, 0, s);
 
-        fn send(tx: Sender<Box<i32>>, i: i32) {
-            if i == 10 {
-                return;
+            fn send<'scope, 'env>(
+                tx: Sender<Box<i32>>,
+                i: i32,
+                s: &'scope thread::Scope<'scope, 'env>,
+            ) where
+                'env: 'scope,
+            {
+                if i == 10 {
+                    return;
+                }
+
+                s.spawn(move || {
+                    tx.send(Box::new(i)).unwrap();
+                    send(tx, i + 1, s);
+                });
             }
 
-            thread::spawn(move || {
-                tx.send(Box::new(i)).unwrap();
-                send(tx, i + 1);
-            });
-        }
+            fn recv<'scope, 'env>(
+                rx: Receiver<Box<i32>>,
+                i: i32,
+                s: &'scope thread::Scope<'scope, 'env>,
+            ) where
+                'env: 'scope,
+            {
+                if i == 10 {
+                    return;
+                }
 
-        fn recv(rx: Receiver<Box<i32>>, i: i32) {
-            if i == 10 {
-                return;
+                s.spawn(move || {
+                    assert!(*rx.recv().unwrap() == i);
+                    recv(rx, i + 1, s);
+                });
             }
-
-            thread::spawn(move || {
-                assert!(*rx.recv().unwrap() == i);
-                recv(rx, i + 1);
-            });
         }
-    }
+    })
 }
 
 #[test]

--- a/library/std/tests/sync/mpsc.rs
+++ b/library/std/tests/sync/mpsc.rs
@@ -382,34 +382,48 @@ fn oneshot_multi_thread_send_recv_stress() {
 
 #[test]
 fn stream_send_recv_stress() {
-    for _ in 0..stress_factor() {
-        let (tx, rx) = channel();
+    thread::scope(|s| {
+        for _ in 0..stress_factor() {
+            let (tx, rx) = channel();
 
-        send(tx, 0);
-        recv(rx, 0);
+            send(tx, 0, s);
+            recv(rx, 0, s);
 
-        fn send(tx: Sender<Box<i32>>, i: i32) {
-            if i == 10 {
-                return;
+            fn send<'scope, 'env>(
+                tx: Sender<Box<i32>>,
+                i: i32,
+                s: &'scope thread::Scope<'scope, 'env>,
+            ) where
+                'env: 'scope,
+            {
+                if i == 10 {
+                    return;
+                }
+
+                s.spawn(move || {
+                    tx.send(Box::new(i)).unwrap();
+                    send(tx, i + 1, s);
+                });
             }
 
-            thread::spawn(move || {
-                tx.send(Box::new(i)).unwrap();
-                send(tx, i + 1);
-            });
-        }
+            fn recv<'scope, 'env>(
+                rx: Receiver<Box<i32>>,
+                i: i32,
+                s: &'scope thread::Scope<'scope, 'env>,
+            ) where
+                'env: 'scope,
+            {
+                if i == 10 {
+                    return;
+                }
 
-        fn recv(rx: Receiver<Box<i32>>, i: i32) {
-            if i == 10 {
-                return;
+                s.spawn(move || {
+                    assert!(*rx.recv().unwrap() == i);
+                    recv(rx, i + 1, s);
+                });
             }
-
-            thread::spawn(move || {
-                assert!(*rx.recv().unwrap() == i);
-                recv(rx, i + 1);
-            });
         }
-    }
+    })
 }
 
 #[test]


### PR DESCRIPTION
These tests currently fail in Miri (when run with nextest) because all they do is spawn a lot of threads that will do stuff, but they don't wait for the threads to actually finish. Miri by default errors when there are background threads lingering when `main` is done (since that can indicate a leak, and since it makes it impossible to check for memory leaks). Miri gives background threads a bit of time to finish when `main` is done, but for these tests that's nowhere near enough since basically the entire test runs after `main` is done.

Outside Miri, this could also still mean that the test doesn't actually run to completion, it might get abort when `main` finishes.

So let's use `thread::scope` to ensure all threads are done before the test is considered done.