### PR TITLE
Special-case emscripten without atomics to take no-threads path

### DIFF
--- a/library/std/src/sys/sync/condvar/mod.rs
+++ b/library/std/src/sys/sync/condvar/mod.rs
@@ -1,4 +1,8 @@
 cfg_select! {
+    all(target_os = "emscripten", not(target_feature = "atomics")) => {
+        mod no_threads;
+        pub use no_threads::Condvar;
+    }
     any(
         all(target_os = "windows", not(target_vendor="win7")),
         target_os = "linux",

--- a/library/std/src/sys/sync/mutex/mod.rs
+++ b/library/std/src/sys/sync/mutex/mod.rs
@@ -1,4 +1,8 @@
 cfg_select! {
+    all(target_os = "emscripten", not(target_feature = "atomics")) => {
+        mod no_threads;
+        pub use no_threads::Mutex;
+    }
     any(
         all(target_os = "windows", not(target_vendor = "win7")),
         target_os = "linux",

--- a/library/std/src/sys/sync/once/mod.rs
+++ b/library/std/src/sys/sync/once/mod.rs
@@ -8,6 +8,10 @@
 // should help the fast path on call sites.
 
 cfg_select! {
+    all(target_os = "emscripten", not(target_feature = "atomics")) => {
+        mod no_threads;
+        pub use no_threads::{Once, OnceState};
+    }
     any(
         all(target_os = "windows", not(target_vendor="win7")),
         target_os = "linux",

--- a/library/std/src/sys/sync/rwlock/mod.rs
+++ b/library/std/src/sys/sync/rwlock/mod.rs
@@ -1,4 +1,8 @@
 cfg_select! {
+    all(target_os = "emscripten", not(target_feature = "atomics")) => {
+        mod no_threads;
+        pub use no_threads::RwLock;
+    }
     any(
         all(target_os = "windows", not(target_vendor = "win7")),
         target_os = "linux",

--- a/library/std/src/sys/sync/thread_parking/mod.rs
+++ b/library/std/src/sys/sync/thread_parking/mod.rs
@@ -1,4 +1,8 @@
 cfg_select! {
+    all(target_os = "emscripten", not(target_feature = "atomics")) => {
+        mod unsupported;
+        pub use unsupported::Parker;
+    }
     any(
         all(target_os = "windows", not(target_vendor = "win7")),
         target_os = "linux",


### PR DESCRIPTION
Fixes rust-lang/rust#156350

Emscripten's pthread stub, which is used when compiling Emscripten without pthreads/atomics, has an unsound mutex implementation. As a quick fix, explicitly make Emscripten without atomics take the no-threads path.

@hoodmane Do we support Emscripten tests in CI here? How should we test this?

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
