### PR TITLE
Fix invalid unreachable in is_known_valid_scrutinee for Reborrow

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -363,13 +363,8 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             | UpvarRef { .. }
             | VarRef { .. }
             | ZstLiteral { .. }
-            | Yield { .. } => true,
-            ExprKind::Reborrow { .. } => {
-                // FIXME(reborrow): matching on a Reborrow expression should be impossible
-                // currently. Whether this remains to be true, and if the reborrow result then is a
-                // known valid scrutinee requires further thought.
-                unreachable!("Reborrow expression in match")
-            }
+            | Yield { .. }
+            | Reborrow { .. } => true,
         }
     }
 

--- a/tests/ui/reborrow/reborrow_let_match.rs
+++ b/tests/ui/reborrow/reborrow_let_match.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+#![feature(reborrow)]
+
+use std::marker::Reborrow;
+
+#[allow(unused)]
+struct Thing<'a>(&'a ());
+
+impl<'a> Reborrow for Thing<'a> {}
+
+fn main() {
+    let x = Thing(&());
+    let _y: Thing<'_> = x;
+}


### PR DESCRIPTION
Fixes rust-lang/rust#156304 

Part of the Reborrow traits experiment rust-lang/rust#145612