### PR TITLE
remove allows_weak_linkage target spec flag

### DIFF
--- a/compiler/rustc_target/src/spec/base/cygwin.rs
+++ b/compiler/rustc_target/src/spec/base/cygwin.rs
@@ -36,7 +36,6 @@ pub(crate) fn opts() -> TargetOptions {
         families: cvs!["unix"],
         is_like_windows: true,
         binary_format: BinaryFormat::Coff,
-        allows_weak_linkage: false,
         pre_link_args,
         late_link_args,
         abi_return_struct_as_int: true,

--- a/compiler/rustc_target/src/spec/base/uefi_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/uefi_msvc.rs
@@ -39,7 +39,6 @@ pub(crate) fn opts() -> TargetOptions {
         linker_flavor: LinkerFlavor::Msvc(Lld::Yes),
         disable_redzone: true,
         exe_suffix: ".efi".into(),
-        allows_weak_linkage: false,
         panic_strategy: PanicStrategy::Abort,
         // LLVM does not emit inline assembly because the LLVM target does not get considered as…
         // "Windows".

--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -91,7 +91,6 @@ pub(crate) fn opts() -> TargetOptions {
         families: cvs!["windows"],
         is_like_windows: true,
         binary_format: BinaryFormat::Coff,
-        allows_weak_linkage: false,
         pre_link_args,
         pre_link_objects_self_contained: crt_objects::pre_mingw_self_contained(),
         link_self_contained: LinkSelfContainedDefault::InferredForMingw,

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -36,7 +36,6 @@ pub(crate) fn opts() -> TargetOptions {
         families: cvs!["windows"],
         is_like_windows: true,
         binary_format: BinaryFormat::Coff,
-        allows_weak_linkage: false,
         pre_link_args,
         pre_link_objects_self_contained: pre_mingw_self_contained(),
         link_self_contained: LinkSelfContainedDefault::InferredForMingw,

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -153,7 +153,6 @@ impl Target {
         forward!(is_like_vexos);
         forward!(binary_format);
         forward!(default_dwarf_version);
-        forward!(allows_weak_linkage);
         forward!(has_rpath);
         forward!(no_default_libraries);
         forward!(position_independent_executables);
@@ -352,7 +351,6 @@ impl ToJson for Target {
         target_option_val!(is_like_vexos);
         target_option_val!(binary_format);
         target_option_val!(default_dwarf_version);
-        target_option_val!(allows_weak_linkage);
         target_option_val!(has_rpath);
         target_option_val!(no_default_libraries);
         target_option_val!(position_independent_executables);
@@ -575,7 +573,6 @@ struct TargetSpecJson {
     is_like_vexos: Option<bool>,
     binary_format: Option<BinaryFormat>,
     default_dwarf_version: Option<u32>,
-    allows_weak_linkage: Option<bool>,
     has_rpath: Option<bool>,
     no_default_libraries: Option<bool>,
     position_independent_executables: Option<bool>,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2485,13 +2485,6 @@ pub struct TargetOptions {
     /// Default supported version of DWARF on this platform.
     /// Useful because some platforms (osx, bsd) only want up to DWARF2.
     pub default_dwarf_version: u32,
-    /// The MinGW toolchain has a known issue that prevents it from correctly
-    /// handling COFF object files with more than 2<sup>15</sup> sections. Since each weak
-    /// symbol needs its own COMDAT section, weak linkage implies a large
-    /// number sections that easily exceeds the given limit for larger
-    /// codebases. Consequently we want a way to disallow weak linkage on some
-    /// platforms.
-    pub allows_weak_linkage: bool,
     /// Whether the linker support rpaths or not. Defaults to false.
     pub has_rpath: bool,
     /// Whether to disable linking to the default libraries, typically corresponds
@@ -2878,7 +2871,6 @@ impl Default for TargetOptions {
             is_like_vexos: false,
             binary_format: BinaryFormat::Elf,
             default_dwarf_version: 4,
-            allows_weak_linkage: true,
             has_rpath: false,
             no_default_libraries: true,
             position_independent_executables: false,


### PR DESCRIPTION
The flag doesn't actually do anything. I have no idea what it's original purpose was.

It got introduced in https://github.com/rust-lang/rust/commit/59cfe904dcfbe2c3ad5396131b3d3ba6b7179fdd, but already a few months later in https://github.com/rust-lang/rust/commit/57950982b27c6ab45509c1f2db4a01fa1d2cfebb both of its uses were removed when the entire file `src/librustc_trans/closure.rs` got deleted.

It seems like back in the day we used weak linkage for closures by default and MinGW wasn't happy about that? But not much later the way we compile closures got changed, making the work-around unnecessary. The flag has then persisted unused for 10 years. A couple of Windows/UEFI targets are setting `allows_weak_linkage: false` but I assume that was just cargo-culted.

But to be sure, let's ping the folks listed for the affected targets and other Windows folks:
@dvdhrm @nicholasbishop @Berrysoft @mati865 @thomcc  @tbu- @ChrisDenton 