### PR TITLE
Support unsafe binders in borrowck, stable MIR and const-eval

### DIFF
--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -306,6 +306,11 @@ fn place_projection_conflict<'tcx>(
             debug!("place_element_conflict: DISJOINT-OR-EQ-OPAQUE");
             Overlap::EqualOrDisjoint
         }
+        (ProjectionElem::UnwrapUnsafeBinder(_), ProjectionElem::UnwrapUnsafeBinder(_)) => {
+            // casts to other types may always conflict irrespective of the type being cast to.
+            debug!("place_element_conflict: DISJOINT-OR-EQ-OPAQUE");
+            Overlap::EqualOrDisjoint
+        }
         (ProjectionElem::Field(f1, _), ProjectionElem::Field(f2, _)) => {
             if f1 == f2 {
                 // same field (e.g., `a.y` vs. `a.y`) - recur.
@@ -510,6 +515,7 @@ fn place_projection_conflict<'tcx>(
             | ProjectionElem::Index(..)
             | ProjectionElem::ConstantIndex { .. }
             | ProjectionElem::OpaqueCast { .. }
+            | ProjectionElem::UnwrapUnsafeBinder { .. }
             | ProjectionElem::Subslice { .. }
             | ProjectionElem::Downcast(..),
             _,
@@ -518,9 +524,5 @@ fn place_projection_conflict<'tcx>(
             pi1_elem,
             pi2_elem
         ),
-
-        (ProjectionElem::UnwrapUnsafeBinder(_), _) => {
-            todo!()
-        }
     }
 }

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -991,7 +991,6 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
                 // Nothing to check.
                 interp_ok(true)
             }
-            ty::UnsafeBinder(_) => todo!("FIXME(unsafe_binder)"),
             // The above should be all the primitive types. The rest is compound, we
             // check them by visiting their fields/variants.
             ty::Adt(..)
@@ -1002,6 +1001,7 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValidityVisitor<'rt, 'tcx, M> {
             | ty::Dynamic(..)
             | ty::Closure(..)
             | ty::Pat(..)
+            | ty::UnsafeBinder(_)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..) => interp_ok(false),
             // Some types only occur during typechecking, they have no layout.
@@ -1545,6 +1545,12 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
                     BackendRepr::SimdVector { .. } | BackendRepr::SimdScalableVector { .. } => unreachable!(),
                     BackendRepr::Memory { .. } => unreachable!()
                 }
+            }
+            ty::UnsafeBinder(base) => {
+                // First check that the base type is valid
+                let base = self.ecx.tcx.instantiate_bound_regions_with_erased((*base).into());
+                let inner_layout = self.ecx.layout_of(base)?;
+                self.visit_value(&val.transmute(inner_layout, self.ecx)?)?;
             }
             ty::Adt(adt, _) if adt.is_maybe_dangling() => {
                 let old_may_dangle = mem::replace(&mut self.may_dangle, true);

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -874,7 +874,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 let ty::UnsafeBinder(binder_ty) = *binder_ty.ty.kind() else {
                     self.fail(
                         location,
-                        format!("WrapUnsafeBinder does not produce a ty::UnsafeBinder"),
+                        format!("WrapUnsafeBinder does not produce a ty::UnsafeBinder, found {binder_ty:?}"),
                     );
                     return;
                 };
@@ -1434,7 +1434,9 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                 let ty::UnsafeBinder(binder_ty) = *ty.kind() else {
                     self.fail(
                         location,
-                        format!("WrapUnsafeBinder does not produce a ty::UnsafeBinder"),
+                        format!(
+                            "WrapUnsafeBinder does not produce a ty::UnsafeBinder, found {ty:?}"
+                        ),
                     );
                     return;
                 };

--- a/compiler/rustc_public/src/mir/body.rs
+++ b/compiler/rustc_public/src/mir/body.rs
@@ -534,6 +534,9 @@ pub enum Rvalue {
     /// deref operation, immediately followed by one or more projections.
     CopyForDeref(Place),
 
+    /// Wraps a value in an unsafe binder.
+    WrapUnsafeBinder(Operand, Ty),
+
     /// Computes the discriminant of the place, returning it as an integer.
     /// Returns zero for types without discriminant.
     ///
@@ -650,6 +653,7 @@ impl Rvalue {
                 AggregateKind::RawPtr(ty, mutability) => Ok(Ty::new_ptr(ty, mutability)),
             },
             Rvalue::CopyForDeref(place) => place.ty(locals),
+            Rvalue::WrapUnsafeBinder(_, ty) => Ok(*ty),
         }
     }
 }
@@ -835,6 +839,10 @@ pub enum ProjectionElem {
     /// Like an explicit cast from an opaque type to a concrete type, but without
     /// requiring an intermediate variable.
     OpaqueCast(Ty),
+
+    /// A transmute from an unsafe binder to the type that it wraps. This is a projection
+    /// of a place, so it doesn't necessarily constitute a move out of the binder.
+    UnwrapUnsafeBinder(Ty),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
@@ -1069,6 +1077,7 @@ impl ProjectionElem {
             }
             ProjectionElem::Downcast(_) => Ok(ty),
             ProjectionElem::OpaqueCast(ty) => Ok(*ty),
+            ProjectionElem::UnwrapUnsafeBinder(ty) => Ok(*ty),
         }
     }
 

--- a/compiler/rustc_public/src/mir/pretty.rs
+++ b/compiler/rustc_public/src/mir/pretty.rs
@@ -364,6 +364,9 @@ fn pretty_rvalue<W: Write>(writer: &mut W, rval: &Rvalue) -> io::Result<()> {
         Rvalue::CopyForDeref(deref) => {
             write!(writer, "CopyForDeref({deref:?})")
         }
+        Rvalue::WrapUnsafeBinder(operand, ty) => {
+            write!(writer, "wrap_binder!({operand:?}; {ty:?})")
+        }
         Rvalue::Discriminant(place) => {
             write!(writer, "discriminant({place:?})")
         }

--- a/compiler/rustc_public/src/mir/visit.rs
+++ b/compiler/rustc_public/src/mir/visit.rs
@@ -267,6 +267,10 @@ macro_rules! make_mir_visitor {
                     Rvalue::CopyForDeref(place) | Rvalue::Discriminant(place) | Rvalue::Len(place) => {
                         self.visit_place(place, PlaceContext::NON_MUTATING, location);
                     }
+                    Rvalue::WrapUnsafeBinder(operand, ty) => {
+                        self.visit_operand(operand, location);
+                        self.visit_ty(ty, location);
+                    }
                     Rvalue::Ref(region, kind, place) => {
                         self.visit_region(region, location);
                         let pcx = PlaceContext { is_mut: matches!(kind, BorrowKind::Mut { .. }) };
@@ -468,6 +472,7 @@ macro_rules! visit_place_fns {
                 ProjectionElem::Subslice { from: _, to: _, from_end: _ } => {}
                 ProjectionElem::Downcast(_idx) => {}
                 ProjectionElem::OpaqueCast(ty) => self.visit_ty(ty, location),
+                ProjectionElem::UnwrapUnsafeBinder(ty) => self.visit_ty(ty, location),
             }
         }
     };
@@ -508,6 +513,7 @@ macro_rules! visit_place_fns {
                 ProjectionElem::Subslice { from: _, to: _, from_end: _ } => {}
                 ProjectionElem::Downcast(_idx) => {}
                 ProjectionElem::OpaqueCast(ty) => self.visit_ty(ty, location),
+                ProjectionElem::UnwrapUnsafeBinder(ty) => self.visit_ty(ty, location),
             }
         }
     };

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -561,6 +561,7 @@ pub enum RigidTy {
     Ref(Region, Ty, Mutability),
     FnDef(FnDef, GenericArgs),
     FnPtr(PolyFnSig),
+    UnsafeBinder(Binder<Ty>),
     Closure(ClosureDef, GenericArgs),
     Coroutine(CoroutineDef, GenericArgs),
     CoroutineClosure(CoroutineClosureDef, GenericArgs),

--- a/compiler/rustc_public/src/unstable/convert/internal.rs
+++ b/compiler/rustc_public/src/unstable/convert/internal.rs
@@ -178,6 +178,9 @@ impl RustcInternal for RigidTy {
                 let (sig_tys, hdr) = sig.internal(tables, tcx).split();
                 rustc_ty::TyKind::FnPtr(sig_tys, hdr)
             }
+            RigidTy::UnsafeBinder(binder) => {
+                rustc_ty::TyKind::UnsafeBinder(binder.internal(tables, tcx).into())
+            }
             RigidTy::Closure(def, args) => {
                 rustc_ty::TyKind::Closure(def.0.internal(tables, tcx), args.internal(tables, tcx))
             }
@@ -736,6 +739,9 @@ impl RustcInternal for ProjectionElem {
             }
             ProjectionElem::OpaqueCast(ty) => {
                 rustc_middle::mir::PlaceElem::OpaqueCast(ty.internal(tables, tcx))
+            }
+            ProjectionElem::UnwrapUnsafeBinder(ty) => {
+                rustc_middle::mir::PlaceElem::UnwrapUnsafeBinder(ty.internal(tables, tcx))
             }
         }
     }

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -245,7 +245,10 @@ impl<'tcx> Stable<'tcx> for mir::Rvalue<'tcx> {
                 crate::mir::Rvalue::Aggregate(agg_kind.stable(tables, cx), operands)
             }
             CopyForDeref(place) => crate::mir::Rvalue::CopyForDeref(place.stable(tables, cx)),
-            WrapUnsafeBinder(..) => todo!("FIXME(unsafe_binders):"),
+            WrapUnsafeBinder(operand, ty) => crate::mir::Rvalue::WrapUnsafeBinder(
+                operand.stable(tables, cx),
+                ty.stable(tables, cx),
+            ),
         }
     }
 }
@@ -446,7 +449,9 @@ impl<'tcx> Stable<'tcx> for mir::PlaceElem<'tcx> {
             // found at https://github.com/rust-lang/rust/pull/117517#issuecomment-1811683486
             Downcast(_, idx) => crate::mir::ProjectionElem::Downcast(idx.stable(tables, cx)),
             OpaqueCast(ty) => crate::mir::ProjectionElem::OpaqueCast(ty.stable(tables, cx)),
-            UnwrapUnsafeBinder(..) => todo!("FIXME(unsafe_binders):"),
+            UnwrapUnsafeBinder(ty) => {
+                crate::mir::ProjectionElem::UnwrapUnsafeBinder(ty.stable(tables, cx))
+            }
         }
     }
 }

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -453,8 +453,9 @@ impl<'tcx> Stable<'tcx> for ty::TyKind<'tcx> {
             ty::FnPtr(sig_tys, hdr) => {
                 TyKind::RigidTy(RigidTy::FnPtr(sig_tys.with(*hdr).stable(tables, cx)))
             }
-            // FIXME(unsafe_binders):
-            ty::UnsafeBinder(_) => todo!(),
+            ty::UnsafeBinder(binder) => {
+                TyKind::RigidTy(RigidTy::UnsafeBinder(binder.stable(tables, cx)))
+            }
             ty::Dynamic(existential_predicates, region) => TyKind::RigidTy(RigidTy::Dynamic(
                 existential_predicates
                     .iter()

--- a/compiler/rustc_public/src/visitor.rs
+++ b/compiler/rustc_public/src/visitor.rs
@@ -171,6 +171,7 @@ impl Visitable for RigidTy {
             | RigidTy::CoroutineClosure(_, args)
             | RigidTy::FnDef(_, args) => args.visit(visitor),
             RigidTy::FnPtr(sig) => sig.visit(visitor),
+            RigidTy::UnsafeBinder(binder) => binder.visit(visitor),
             RigidTy::Dynamic(pred, r) => {
                 pred.visit(visitor)?;
                 r.visit(visitor)


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/rust/pull/146562

Those were the changes required to use unsafe binders in coroutines. I'm not sure how to test them, so this PR mostly gives out the code to whomever can craft those tests.

r? @oli-obk

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
