### PR TITLE
suggest removing return type on use of void

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -548,6 +548,23 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 && expected.starts_with("struct")
             {
                 ("`async` blocks are only allowed in Rust 2018 or later".to_string(), suggestion)
+            } else if item_str.as_str() == "void"
+                && let Some((FnKind::Fn(.., fun), ..)) = self.diag_metadata.current_function
+                && let ast::FnRetTy::Ty(ty) = &fun.sig.decl.output
+                && ty.span == item_span
+            {
+                // check for accidental use of `void` as a return type
+                let return_ty_span =
+                    self.r.tcx.sess.source_map().span_extend_to_prev_char(item_span, ')', true);
+
+                (
+                    "functions with no return value use `()`".to_string(),
+                    Some((
+                        return_ty_span,
+                        "omit the return type to return `()` implicitly",
+                        "".to_owned(),
+                    )),
+                )
             } else {
                 // check if we are in situation of typo like `True` instead of `true`.
                 let override_suggestion =

--- a/tests/ui/suggestions/return-void.rs
+++ b/tests/ui/suggestions/return-void.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+
+pub fn foo() -> void {} //~ ERROR cannot find type `void`
+
+pub fn bar(v: void) {} //~ ERROR cannot find type `void`

--- a/tests/ui/suggestions/return-void.stderr
+++ b/tests/ui/suggestions/return-void.stderr
@@ -1,0 +1,21 @@
+error[E0425]: cannot find type `void` in this scope
+  --> $DIR/return-void.rs:3:17
+   |
+LL | pub fn foo() -> void {}
+   |                 ^^^^ functions with no return value use `()`
+   |
+help: omit the return type to return `()` implicitly
+   |
+LL - pub fn foo() -> void {}
+LL + pub fn foo() {}
+   |
+
+error[E0425]: cannot find type `void` in this scope
+  --> $DIR/return-void.rs:5:15
+   |
+LL | pub fn bar(v: void) {}
+   |               ^^^^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/100972#issuecomment-1283286557.

This PR suggests removing the return type entirely if the user writes `-> void`, expecting it to work like C or TypeScript.
