### PR TITLE
Remove some dead code for dumping MIR for a single DefId

### DIFF
--- a/compiler/rustc_driver_impl/src/pretty.rs
+++ b/compiler/rustc_driver_impl/src/pretty.rs
@@ -301,12 +301,12 @@ pub fn print<'tcx>(sess: &Session, ppm: PpMode, ex: PrintExtra<'tcx>) {
         }
         Mir => {
             let mut out = Vec::new();
-            write_mir_pretty(ex.tcx(), None, &mut out).unwrap();
+            write_mir_pretty(ex.tcx(), &mut out).unwrap();
             String::from_utf8(out).unwrap()
         }
         MirCFG => {
             let mut out = Vec::new();
-            write_mir_graphviz(ex.tcx(), None, &mut out).unwrap();
+            write_mir_graphviz(ex.tcx(), &mut out).unwrap();
             String::from_utf8(out).unwrap()
         }
         StableMir => {

--- a/compiler/rustc_middle/src/mir/graphviz.rs
+++ b/compiler/rustc_middle/src/mir/graphviz.rs
@@ -4,24 +4,22 @@ use gsgdt::GraphvizSettings;
 use rustc_graphviz as dot;
 
 use super::generic_graph::mir_fn_to_generic_graph;
-use super::pretty::dump_mir_def_ids;
 use crate::mir::*;
 
 /// Write a graphviz DOT graph of a list of MIRs.
-pub fn write_mir_graphviz<W>(tcx: TyCtxt<'_>, single: Option<DefId>, w: &mut W) -> io::Result<()>
+pub fn write_mir_graphviz<W>(tcx: TyCtxt<'_>, w: &mut W) -> io::Result<()>
 where
     W: Write,
 {
-    let def_ids = dump_mir_def_ids(tcx, single);
-
-    let mirs = def_ids
+    let mirs = tcx
+        .mir_keys(())
         .iter()
         .filter(|&&def_id| !tcx.is_trivial_const(def_id))
         .flat_map(|&def_id| {
             if tcx.is_const_fn(def_id) {
                 vec![tcx.optimized_mir(def_id), tcx.mir_for_ctfe(def_id)]
             } else {
-                vec![tcx.instance_mir(ty::InstanceKind::Item(def_id))]
+                vec![tcx.instance_mir(ty::InstanceKind::Item(def_id.to_def_id()))]
             }
         })
         .collect::<Vec<_>>();

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -312,13 +312,9 @@ impl<'a, 'tcx> MirDumper<'a, 'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 // Whole MIR bodies
 
-/// Write out a human-readable textual representation for the given MIR, with the default
-/// [PrettyPrintMirOptions].
-pub fn write_mir_pretty<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    single: Option<DefId>,
-    w: &mut dyn io::Write,
-) -> io::Result<()> {
+/// Write out a human-readable textual representation of this crate's MIR,
+/// with the default [`PrettyPrintMirOptions`].
+pub fn write_mir_pretty<'tcx>(tcx: TyCtxt<'tcx>, w: &mut dyn io::Write) -> io::Result<()> {
     let writer = MirWriter::new(tcx);
 
     writeln!(w, "// WARNING: This output format is intended for human consumers only")?;
@@ -326,7 +322,7 @@ pub fn write_mir_pretty<'tcx>(
     writeln!(w, "// HINT: See also -Z dump-mir for MIR at specific points during compilation.")?;
 
     let mut first = true;
-    for def_id in dump_mir_def_ids(tcx, single) {
+    for &def_id in tcx.mir_keys(()) {
         if first {
             first = false;
         } else {
@@ -360,7 +356,7 @@ pub fn write_mir_pretty<'tcx>(
                 }
                 writeln!(w, ": {} = const {};", ty, Const::Val(val, ty))?;
             } else {
-                let instance_mir = tcx.instance_mir(ty::InstanceKind::Item(def_id));
+                let instance_mir = tcx.instance_mir(ty::InstanceKind::Item(def_id.to_def_id()));
                 render_body(w, instance_mir)?;
             }
         }
@@ -696,14 +692,6 @@ fn write_user_type_annotations(
         writeln!(w, "|")?;
     }
     Ok(())
-}
-
-pub fn dump_mir_def_ids(tcx: TyCtxt<'_>, single: Option<DefId>) -> Vec<DefId> {
-    if let Some(i) = single {
-        vec![i]
-    } else {
-        tcx.mir_keys(()).iter().map(|def_id| def_id.to_def_id()).collect()
-    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2073,7 +2073,8 @@ impl<'tcx> TyCtxt<'tcx> {
     ///
     /// Even if this returns `true`, constness may still be unstable!
     #[inline]
-    pub fn is_const_fn(self, def_id: DefId) -> bool {
+    pub fn is_const_fn(self, def_id: impl IntoQueryKey<DefId>) -> bool {
+        let def_id = def_id.into_query_key();
         matches!(
             self.def_kind(def_id),
             DefKind::Fn | DefKind::AssocFn | DefKind::Ctor(_, CtorKind::Fn) | DefKind::Closure

--- a/compiler/rustc_mir_transform/src/dump_mir.rs
+++ b/compiler/rustc_mir_transform/src/dump_mir.rs
@@ -25,11 +25,11 @@ pub fn emit_mir(tcx: TyCtxt<'_>) -> io::Result<()> {
     match tcx.output_filenames(()).path(OutputType::Mir) {
         OutFileName::Stdout => {
             let mut f = io::stdout();
-            write_mir_pretty(tcx, None, &mut f)?;
+            write_mir_pretty(tcx, &mut f)?;
         }
         OutFileName::Real(path) => {
             let mut f = File::create_buffered(&path)?;
-            write_mir_pretty(tcx, None, &mut f)?;
+            write_mir_pretty(tcx, &mut f)?;
             if tcx.sess.opts.json_artifact_notifications {
                 tcx.dcx().emit_artifact_notification(&path, "mir");
             }


### PR DESCRIPTION
The functions that call `dump_mir_def_ids` are themselves never called with a specific DefId; they always dump MIR for the entire crate.