### PR TITLE
enable more f16/f128 tests in Miri

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0029-sysroot_tests-disable-f16-math.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0029-sysroot_tests-disable-f16-math.patch
@@ -15,117 +15,117 @@ index c61961f8584..d7b4fa20322 100644
      name: powf,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1557,7 +1557,7 @@ fn s_nan() -> Float {
      name: exp,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1578,7 +1578,7 @@ fn s_nan() -> Float {
      name: exp2,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1598,7 +1598,7 @@ fn s_nan() -> Float {
      name: ln,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1620,7 +1620,7 @@ fn s_nan() -> Float {
      name: log,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1645,7 +1645,7 @@ fn s_nan() -> Float {
      name: log2,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1668,7 +1668,7 @@ fn s_nan() -> Float {
      name: log10,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1692,7 +1692,7 @@ fn s_nan() -> Float {
      name: asinh,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1725,7 +1725,7 @@ fn s_nan() -> Float {
      name: acosh,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1753,7 +1753,7 @@ fn s_nan() -> Float {
      name: atanh,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1779,7 +1779,7 @@ fn s_nan() -> Float {
      name: gamma,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -1814,7 +1814,7 @@ fn s_nan() -> Float {
      name: ln_gamma,
      attrs: {
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 @@ -2027,7 +2027,7 @@ fn s_nan() -> Float {
      attrs: {
          // FIXME(f16_f128): add math tests when available
          const: #[cfg(false)],
--        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
+-        f16: #[cfg(target_has_reliable_f16_math)],
 +        f16: #[cfg(false)], // FIXME(rust-lang/rustc_codegen_cranelift#1622)
-         f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+         f128: #[cfg(target_has_reliable_f128_math)],
      },
      test {
 --

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -843,7 +843,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let x = 1.0f128;
     /// let y = 2.0f128;
@@ -874,7 +874,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let x = 1.0f128;
     /// let y = 2.0f128;
@@ -906,7 +906,7 @@ impl f128 {
     /// ```
     /// #![feature(f128)]
     /// #![feature(float_minimum_maximum)]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let x = 1.0f128;
     /// let y = 2.0f128;
@@ -938,7 +938,7 @@ impl f128 {
     /// ```
     /// #![feature(f128)]
     /// #![feature(float_minimum_maximum)]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let x = 1.0f128;
     /// let y = 2.0f128;
@@ -1620,8 +1620,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let f = 3.7_f128;
     /// let g = 3.0_f128;
@@ -1649,8 +1648,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let f = 3.01_f128;
     /// let g = 4.0_f128;
@@ -1678,8 +1676,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let f = 3.3_f128;
     /// let g = -3.3_f128;
@@ -1712,8 +1709,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let f = 3.3_f128;
     /// let g = -3.3_f128;
@@ -1744,8 +1740,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let f = 3.7_f128;
     /// let g = 3.0_f128;
@@ -1774,8 +1769,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let x = 3.6_f128;
     /// let y = -3.6_f128;
@@ -1813,8 +1807,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let m = 10.0_f128;
     /// let x = 4.0_f128;
@@ -1858,8 +1851,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let a: f128 = 7.0;
     /// let b = 4.0;
@@ -1902,8 +1894,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let a: f128 = 7.0;
     /// let b = 4.0;
@@ -1945,12 +1936,11 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 2.0_f128;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
-    /// assert!(abs_difference <= f128::EPSILON);
+    /// assert!(abs_difference <= 1e-9);
     ///
     /// assert_eq!(f128::powi(f128::NAN, 0), 1.0);
     /// assert_eq!(f128::powi(0.0, 0), 1.0);
@@ -1978,8 +1968,7 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f128_math)] {
+    /// # #[cfg(any(miri, target_has_reliable_f128_math))] { // Miri uses softfloats, always works
     ///
     /// let positive = 4.0_f128;
     /// let negative = -4.0_f128;

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1448,7 +1448,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 3.5_f16;
     /// let y = -3.5_f16;
@@ -1513,7 +1513,7 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(target_has_reliable_f16_math)] {
+    /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.5_f16;
     ///
@@ -1606,7 +1606,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.7_f16;
@@ -1635,7 +1634,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.01_f16;
@@ -1664,7 +1662,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.3_f16;
@@ -1698,7 +1695,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.3_f16;
@@ -1730,7 +1726,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let f = 3.7_f16;
@@ -1760,7 +1755,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 3.6_f16;
@@ -1799,7 +1793,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let m = 10.0_f16;
@@ -1844,7 +1837,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let a: f16 = 7.0;
@@ -1888,7 +1880,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let a: f16 = 7.0;
@@ -1931,12 +1922,11 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
-    /// # #[cfg(target_has_reliable_f16)] {
+    /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 2.0_f16;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 0.1);
     ///
     /// assert_eq!(f16::powi(f16::NAN, 0), 1.0);
     /// assert_eq!(f16::powi(0.0, 0), 1.0);
@@ -1964,7 +1954,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let positive = 4.0_f16;
@@ -1999,7 +1988,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16)] {
     ///
     /// let x = 8.0f16;

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1777,7 +1777,7 @@ mod prim_ref {}
 /// However, a direct cast back is not possible. You need to use `transmute`:
 ///
 /// ```rust
-/// # #[cfg(not(miri))] { // FIXME: use strict provenance APIs once they are stable, then remove this `cfg`
+/// # #[cfg(not(miri))] { // disabled because it fails with -Zmiri-strict-provenance
 /// # let fnptr: fn(i32) -> i32 = |x| x+2;
 /// # let fnptr_addr = fnptr as usize;
 /// let fnptr = fnptr_addr as *const ();

--- a/library/coretests/tests/num/float_ieee754_flt2dec_dec2flt.rs
+++ b/library/coretests/tests/num/float_ieee754_flt2dec_dec2flt.rs
@@ -51,7 +51,7 @@ float_test! {
     name: preserve_signed_zero,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         f128: #[cfg(false)],
     },
     test {
@@ -67,7 +67,7 @@ float_test! {
     name: preserve_signed_infinity,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         f128: #[cfg(false)],
     },
     test {
@@ -83,7 +83,7 @@ float_test! {
     name: infinity_to_str,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         f128: #[cfg(false)],
     },
     test {
@@ -109,7 +109,7 @@ float_test! {
     name: nan_to_str,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         f128: #[cfg(false)],
     },
     test {
@@ -127,7 +127,7 @@ float_test! {
     name: infinity_from_str,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         f128: #[cfg(false)],
     },
     test {
@@ -152,7 +152,7 @@ float_test! {
     name: qnan_from_str,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         f128: #[cfg(false)],
     },
     test {

--- a/library/coretests/tests/num/floats.rs
+++ b/library/coretests/tests/num/floats.rs
@@ -69,11 +69,15 @@ impl TestableFloat for f16 {
     const BITS: u32 = 16;
     type Int = u16;
     type SInt = i16;
-    const APPROX: Self = 1e-3;
-    const POWF_APPROX: Self = 5e-1;
+    /// Miri adds some extra errors to float functions; make sure the tests still pass.
+    /// These values are purely used as a canary to test against and are thus not a stable guarantee Rust provides.
+    /// They serve as a way to get an idea of the real precision of floating point operations on different platforms.
+    const APPROX: Self = if cfg!(miri) { 1e-2 } else { 1e-3 };
+    const POWF_APPROX: Self = if cfg!(miri) { 1e-0 } else { 5e-1 };
     const _180_TO_RADIANS_APPROX: Self = 1e-2;
     const PI_TO_DEGREES_APPROX: Self = 0.125;
-    const EXP_APPROX: Self = 1e-2;
+    const EXP_APPROX: Self = if cfg!(miri) { 5e-1 } else { 1e-2 }; // for values on the order of 150, 4 ULP are more than 0.1...
+    const POWI_APPROX: Self = if cfg!(miri) { 1e-1 } else { Self::APPROX };
     const LN_APPROX: Self = 1e-2;
     const LOG_APPROX: Self = 1e-2;
     const LOG2_APPROX: Self = 1e-2;
@@ -440,8 +444,8 @@ pub(crate) use float_test;
 float_test! {
     name: num,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let two: Float = 2.0;
@@ -458,6 +462,7 @@ float_test! {
 float_test! {
     name: num_rem,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -471,8 +476,8 @@ float_test! {
 float_test! {
     name: nan,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -491,8 +496,8 @@ float_test! {
 float_test! {
     name: infinity,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let inf: Float = Float::INFINITY;
@@ -509,8 +514,8 @@ float_test! {
 float_test! {
     name: neg_infinity,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let neg_inf: Float = Float::NEG_INFINITY;
@@ -527,8 +532,8 @@ float_test! {
 float_test! {
     name: zero,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(0.0, Float::ZERO);
@@ -545,8 +550,8 @@ float_test! {
 float_test! {
     name: neg_zero,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let neg_zero: Float = -0.0;
@@ -565,8 +570,8 @@ float_test! {
 float_test! {
     name: one,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(1.0, Float::ONE);
@@ -583,8 +588,8 @@ float_test! {
 float_test! {
     name: is_nan,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -604,8 +609,8 @@ float_test! {
 float_test! {
     name: is_infinite,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -625,8 +630,8 @@ float_test! {
 float_test! {
     name: is_finite,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -646,8 +651,8 @@ float_test! {
 float_test! {
     name: is_normal,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -668,7 +673,7 @@ float_test! {
 float_test! {
     name: classify,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -689,6 +694,7 @@ float_test! {
 float_test! {
     name: min,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -730,6 +736,7 @@ float_test! {
 float_test! {
     name: max,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -772,6 +779,7 @@ float_test! {
 float_test! {
     name: minimum,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -803,6 +811,7 @@ float_test! {
 float_test! {
     name: maximum,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -835,6 +844,7 @@ float_test! {
 float_test! {
     name: midpoint,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -887,9 +897,9 @@ float_test! {
     name: midpoint_large_magnitude,
     attrs: {
         const: #[cfg(false)],
-        // FIXME(f16_f128): `powi` does not work in Miri for these types
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        // Needs powi
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         // test if large differences in magnitude are still correctly computed.
@@ -918,6 +928,7 @@ float_test! {
 float_test! {
     name: abs,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -936,6 +947,7 @@ float_test! {
 float_test! {
     name: copysign,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -951,6 +963,7 @@ float_test! {
     name: rem_euclid,
     attrs: {
         const: #[cfg(false)],
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -968,6 +981,7 @@ float_test! {
     name: div_euclid,
     attrs: {
         const: #[cfg(false)],
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -983,6 +997,7 @@ float_test! {
 float_test! {
     name: floor,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1012,6 +1027,7 @@ float_test! {
 float_test! {
     name: ceil,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1041,6 +1057,7 @@ float_test! {
 float_test! {
     name: round,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1071,6 +1088,7 @@ float_test! {
 float_test! {
     name: round_ties_even,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1101,6 +1119,7 @@ float_test! {
 float_test! {
     name: trunc,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1130,6 +1149,7 @@ float_test! {
 float_test! {
     name: fract,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1161,6 +1181,7 @@ float_test! {
 float_test! {
     name: signum,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1179,8 +1200,8 @@ float_test! {
 float_test! {
     name: is_sign_positive,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert!(Float::INFINITY.is_sign_positive());
@@ -1198,8 +1219,8 @@ float_test! {
 float_test! {
     name: is_sign_negative,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert!(!Float::INFINITY.is_sign_negative());
@@ -1217,8 +1238,8 @@ float_test! {
 float_test! {
     name: next_up,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(Float::NEG_INFINITY.next_up(), Float::MIN);
@@ -1248,8 +1269,8 @@ float_test! {
 float_test! {
     name: next_down,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(Float::NEG_INFINITY.next_down(), Float::NEG_INFINITY);
@@ -1281,6 +1302,7 @@ float_test! {
     name: sqrt_domain,
     attrs: {
         const: #[cfg(false)],
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1299,10 +1321,10 @@ float_test! {
     name: clamp_min_greater_than_max,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(any(miri, target_has_reliable_f16))],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(any(miri, target_has_reliable_f128))],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
     },
     test {
         let _ = Float::ONE.clamp(3.0, 1.0);
@@ -1313,10 +1335,10 @@ float_test! {
     name: clamp_min_is_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(any(miri, target_has_reliable_f16))],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(any(miri, target_has_reliable_f128))],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
     },
     test {
         let _ = Float::ONE.clamp(Float::NAN, 1.0);
@@ -1327,10 +1349,10 @@ float_test! {
     name: clamp_max_is_nan,
     attrs: {
         const: #[cfg(false)],
-        f16: #[should_panic, cfg(any(miri, target_has_reliable_f16))],
+        f16: #[should_panic, cfg(target_has_reliable_f16)],
         f32: #[should_panic],
         f64: #[should_panic],
-        f128: #[should_panic, cfg(any(miri, target_has_reliable_f128))],
+        f128: #[should_panic, cfg(target_has_reliable_f128)],
     },
     test {
         let _ = Float::ONE.clamp(3.0, Float::NAN);
@@ -1340,6 +1362,7 @@ float_test! {
 float_test! {
     name: total_cmp,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1445,6 +1468,7 @@ float_test! {
     name: total_cmp_s_nan,
     attrs: {
         const: #[cfg(false)],
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1501,6 +1525,7 @@ float_test! {
 float_test! {
     name: recip,
     attrs: {
+        // Miri only uses softfloats here, so that always works
         f16: #[cfg(any(miri, target_has_reliable_f16_math))],
         f128: #[cfg(any(miri, target_has_reliable_f128_math))],
     },
@@ -1524,9 +1549,8 @@ float_test! {
     name: powi,
     attrs: {
         const: #[cfg(false)],
-        // FIXME(f16_f128): `powi` does not work in Miri for these types
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1546,8 +1570,8 @@ float_test! {
     name: powf,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1569,8 +1593,8 @@ float_test! {
     name: exp,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_biteq!(1.0, flt(0.0).exp());
@@ -1590,8 +1614,8 @@ float_test! {
     name: exp2,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_approx_eq!(32.0, flt(5.0).exp2(), Float::EXP_APPROX);
@@ -1610,8 +1634,8 @@ float_test! {
     name: ln,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1632,8 +1656,8 @@ float_test! {
     name: log,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1657,8 +1681,8 @@ float_test! {
     name: log2,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1680,8 +1704,8 @@ float_test! {
     name: log10,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1704,8 +1728,8 @@ float_test! {
     name: asinh,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_biteq!(flt(0.0).asinh(), 0.0);
@@ -1740,8 +1764,8 @@ float_test! {
     name: acosh,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_biteq!(flt(1.0).acosh(), 0.0);
@@ -1771,8 +1795,8 @@ float_test! {
     name: atanh,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_biteq!(flt(0.0).atanh(), 0.0);
@@ -1797,8 +1821,8 @@ float_test! {
     name: gamma,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_approx_eq!(flt(1.0).gamma(), 1.0, Float::GAMMA_APPROX);
@@ -1832,8 +1856,8 @@ float_test! {
     name: ln_gamma,
     attrs: {
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         assert_approx_eq!(flt(1.0).ln_gamma().0, 0.0, Float::LNGAMMA_APPROX);
@@ -1850,8 +1874,8 @@ float_test! {
 float_test! {
     name: to_degrees,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let pi: Float = consts::PI;
@@ -1871,8 +1895,8 @@ float_test! {
 float_test! {
     name: to_radians,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let pi: Float = consts::PI;
@@ -1892,8 +1916,8 @@ float_test! {
 float_test! {
     name: to_algebraic,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let a: Float = flt(123.0);
@@ -1916,8 +1940,8 @@ float_test! {
 float_test! {
     name: to_bits_conv,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(flt(1.0), Float::RAW_1);
@@ -1943,11 +1967,11 @@ float_test! {
 float_test! {
     name: mul_add,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
+        f16: #[cfg(target_has_reliable_f16)],
         // FIXME(#140515): mingw has an incorrect fma https://sourceforge.net/p/mingw-w64/bugs/848/
         f32: #[cfg_attr(all(target_os = "windows", target_env = "gnu", not(target_abi = "llvm")), ignore)],
         f64: #[cfg_attr(all(target_os = "windows", target_env = "gnu", not(target_abi = "llvm")), ignore)],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         let nan: Float = Float::NAN;
@@ -1968,8 +1992,8 @@ float_test! {
 float_test! {
     name: from,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(Float::from(false), Float::ZERO);
@@ -1990,7 +2014,7 @@ float_test! {
     attrs: {
         f16: #[cfg(false)],
         const f16: #[cfg(false)],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(Float::from(u16::MIN), Float::ZERO);
@@ -2009,7 +2033,7 @@ float_test! {
         const f16: #[cfg(false)],
         f32: #[cfg(false)],
         const f32: #[cfg(false)],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         assert_biteq!(Float::from(u32::MIN), Float::ZERO);
@@ -2025,8 +2049,8 @@ float_test! {
 float_test! {
     name: max_exact_integer_constant,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         // The maximum integer that converts to a unique floating point
@@ -2067,8 +2091,8 @@ float_test! {
 float_test! {
     name: min_exact_integer_constant,
     attrs: {
-        f16: #[cfg(any(miri, target_has_reliable_f16))],
-        f128: #[cfg(any(miri, target_has_reliable_f128))],
+        f16: #[cfg(target_has_reliable_f16)],
+        f128: #[cfg(target_has_reliable_f128)],
     },
     test {
         // The minimum integer that converts to a unique floating point
@@ -2115,7 +2139,7 @@ float_test! {
 //         f16: #[cfg(false)],
 //         f32: #[cfg(false)],
 //         f64: #[cfg(false)],
-//         f128: #[cfg(any(miri, target_has_reliable_f128))],
+//         f128: #[cfg(target_has_reliable_f128)],
 //     },
 //     test {
 //         assert_biteq!(Float::from(u64::MIN), Float::ZERO);
@@ -2132,8 +2156,8 @@ float_test! {
     attrs: {
         // FIXME(f16_f128): add math tests when available
         const: #[cfg(false)],
-        f16: #[cfg(all(not(miri), target_has_reliable_f16_math))],
-        f128: #[cfg(all(not(miri), target_has_reliable_f128_math))],
+        f16: #[cfg(target_has_reliable_f16_math)],
+        f128: #[cfg(target_has_reliable_f128_math)],
     },
     test {
         let pi: Float = consts::PI;

--- a/library/coretests/tests/num/int_log.rs
+++ b/library/coretests/tests/num/int_log.rs
@@ -3,9 +3,9 @@
 /// Rounds the argument down to the next integer, except that we account for potential imprecision
 /// in the input, so if `f` is very close to an integer, it will round to that.
 fn round_down_imprecise(f: f32) -> u32 {
-    // Rounds up for values less than 16*EPSILON below an integer,
+    // Rounds up for values less than 32*EPSILON below an integer,
     // and rounds down for everything else.
-    (f + 16.0 * f32::EPSILON) as u32
+    (f + 32.0 * f32::EPSILON) as u32
 }
 
 #[test]
@@ -50,7 +50,6 @@ fn checked_ilog() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // FIXME test is broken on Miri: https://github.com/rust-lang/rust/issues/137591
 fn checked_ilog2() {
     assert_eq!(5u32.checked_ilog2(), Some(2));
     assert_eq!(0u64.checked_ilog2(), None);

--- a/library/coretests/tests/num/midpoint.rs
+++ b/library/coretests/tests/num/midpoint.rs
@@ -4,7 +4,7 @@
 //!  - midpoint(-a, -b) == -midpoint(a, b)
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn midpoint_obvious_impl_i8() {
     for a in i8::MIN..=i8::MAX {
         for b in i8::MIN..=i8::MAX {
@@ -14,7 +14,7 @@ fn midpoint_obvious_impl_i8() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn midpoint_obvious_impl_u8() {
     for a in u8::MIN..=u8::MAX {
         for b in u8::MIN..=u8::MAX {
@@ -24,7 +24,7 @@ fn midpoint_obvious_impl_u8() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn midpoint_order_expectation_i8() {
     for a in i8::MIN..=i8::MAX {
         for b in i8::MIN..=i8::MAX {
@@ -34,7 +34,7 @@ fn midpoint_order_expectation_i8() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn midpoint_order_expectation_u8() {
     for a in u8::MIN..=u8::MAX {
         for b in u8::MIN..=u8::MAX {
@@ -44,7 +44,7 @@ fn midpoint_order_expectation_u8() {
 }
 
 #[test]
-#[cfg(not(miri))]
+#[cfg(not(miri))] // Miri is too slow
 fn midpoint_negative_expectation() {
     for a in 0..=i8::MAX {
         for b in 0..=i8::MAX {

--- a/library/std/src/num/f128.rs
+++ b/library/std/src/num/f128.rs
@@ -34,7 +34,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 2.0_f128;
@@ -65,7 +64,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let one = 1.0f128;
@@ -97,7 +95,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let f = 2.0f128;
@@ -129,7 +126,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let one = 1.0f128;
@@ -146,7 +142,6 @@ impl f128 {
     /// Non-positive values:
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert_eq!(0_f128.ln(), f128::NEG_INFINITY);
@@ -178,7 +173,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let five = 5.0f128;
@@ -193,7 +187,6 @@ impl f128 {
     /// Non-positive values:
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert_eq!(0_f128.log(10.0), f128::NEG_INFINITY);
@@ -221,7 +214,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let two = 2.0f128;
@@ -236,7 +228,6 @@ impl f128 {
     /// Non-positive values:
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert_eq!(0_f128.log2(), f128::NEG_INFINITY);
@@ -264,7 +255,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let ten = 10.0f128;
@@ -279,7 +269,6 @@ impl f128 {
     /// Non-positive values:
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert_eq!(0_f128.log10(), f128::NEG_INFINITY);
@@ -309,7 +298,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 8.0f128;
@@ -346,7 +334,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 2.0f128;
@@ -377,7 +364,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = std::f128::consts::FRAC_PI_2;
@@ -406,7 +392,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 2.0 * std::f128::consts::PI;
@@ -438,7 +423,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = std::f128::consts::FRAC_PI_4;
@@ -471,7 +455,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let f = std::f128::consts::FRAC_PI_4;
@@ -507,7 +490,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let f = std::f128::consts::FRAC_PI_4;
@@ -542,7 +524,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let f = 1.0f128;
@@ -583,7 +564,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// // Positive angles measured counter-clockwise
@@ -626,7 +606,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = std::f128::consts::FRAC_PI_4;
@@ -663,7 +642,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 1e-8_f128;
@@ -700,7 +678,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 1e-8_f128;
@@ -716,7 +693,6 @@ impl f128 {
     /// Out-of-range values:
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// assert_eq!((-1.0_f128).ln_1p(), f128::NEG_INFINITY);
@@ -746,7 +722,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let e = std::f128::consts::E;
@@ -782,7 +757,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let e = std::f128::consts::E;
@@ -818,7 +792,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let e = std::f128::consts::E;
@@ -851,7 +824,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 1.0f128;
@@ -882,7 +854,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 1.0f128;
@@ -913,7 +884,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = std::f128::consts::FRAC_PI_6;
@@ -948,7 +918,6 @@ impl f128 {
     /// ```
     /// #![feature(f128)]
     /// #![feature(float_gamma)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 5.0f128;
@@ -984,7 +953,6 @@ impl f128 {
     /// ```
     /// #![feature(f128)]
     /// #![feature(float_gamma)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     ///
     /// let x = 2.0f128;
@@ -1020,7 +988,6 @@ impl f128 {
     /// ```
     /// #![feature(f128)]
     /// #![feature(float_erf)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     /// /// The error function relates what percent of a normal distribution lies
     /// /// within `x` standard deviations (scaled by `1/sqrt(2)`).
@@ -1060,7 +1027,6 @@ impl f128 {
     /// ```
     /// #![feature(f128)]
     /// #![feature(float_erf)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f128_math)] {
     /// let x: f128 = 0.123;
     ///

--- a/library/std/src/num/f16.rs
+++ b/library/std/src/num/f16.rs
@@ -34,12 +34,11 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 2.0_f16;
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-1);
     ///
     /// assert_eq!(f16::powf(1.0, f16::NAN), 1.0);
     /// assert_eq!(f16::powf(f16::NAN, 0.0), 1.0);
@@ -65,7 +64,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let one = 1.0f16;
@@ -75,7 +73,7 @@ impl f16 {
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -97,7 +95,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = 2.0f16;
@@ -105,7 +102,7 @@ impl f16 {
     /// // 2^2 - 4 == 0
     /// let abs_difference = (f.exp2() - 4.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-1);
     /// # }
     /// ```
     #[inline]
@@ -129,7 +126,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let one = 1.0f16;
@@ -139,14 +135,13 @@ impl f16 {
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     ///
     /// Non-positive values:
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert_eq!(0_f16.ln(), f16::NEG_INFINITY);
@@ -178,7 +173,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let five = 5.0f16;
@@ -186,14 +180,13 @@ impl f16 {
     /// // log5(5) - 1 == 0
     /// let abs_difference = (five.log(5.0) - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     ///
     /// Non-positive values:
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert_eq!(0_f16.log(10.0), f16::NEG_INFINITY);
@@ -221,7 +214,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let two = 2.0f16;
@@ -229,14 +221,13 @@ impl f16 {
     /// // log2(2) - 1 == 0
     /// let abs_difference = (two.log2() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     ///
     /// Non-positive values:
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert_eq!(0_f16.log2(), f16::NEG_INFINITY);
@@ -264,7 +255,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let ten = 10.0f16;
@@ -272,14 +262,13 @@ impl f16 {
     /// // log10(10) - 1 == 0
     /// let abs_difference = (ten.log10() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     ///
     /// Non-positive values:
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert_eq!(0_f16.log10(), f16::NEG_INFINITY);
@@ -311,7 +300,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 2.0f16;
@@ -320,7 +308,7 @@ impl f16 {
     /// // sqrt(x^2 + y^2)
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -342,14 +330,13 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = std::f16::consts::FRAC_PI_2;
     ///
     /// let abs_difference = (x.sin() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -371,14 +358,13 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 2.0 * std::f16::consts::PI;
     ///
     /// let abs_difference = (x.cos() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -403,7 +389,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = std::f16::consts::FRAC_PI_4;
@@ -436,7 +421,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = std::f16::consts::FRAC_PI_4;
@@ -444,7 +428,7 @@ impl f16 {
     /// // asin(sin(pi/2))
     /// let abs_difference = (f.sin().asin() - f).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -472,7 +456,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = std::f16::consts::FRAC_PI_4;
@@ -480,7 +463,7 @@ impl f16 {
     /// // acos(cos(pi/4))
     /// let abs_difference = (f.cos().acos() - std::f16::consts::FRAC_PI_4).abs();
     ///
-    /// assert!(abs_difference <= f16::EPSILON);
+    /// assert!(abs_difference <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -507,7 +490,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let f = 1.0f16;
@@ -548,7 +530,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// // Positive angles measured counter-clockwise
@@ -591,7 +572,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = std::f16::consts::FRAC_PI_4;
@@ -600,8 +580,8 @@ impl f16 {
     /// let abs_difference_0 = (f.0 - x.sin()).abs();
     /// let abs_difference_1 = (f.1 - x.cos()).abs();
     ///
-    /// assert!(abs_difference_0 <= f16::EPSILON);
-    /// assert!(abs_difference_1 <= f16::EPSILON);
+    /// assert!(abs_difference_0 <= 1e-2);
+    /// assert!(abs_difference_1 <= 1e-2);
     /// # }
     /// ```
     #[inline]
@@ -628,7 +608,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1e-4_f16;
@@ -665,7 +644,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1e-4_f16;
@@ -681,7 +659,6 @@ impl f16 {
     /// Out-of-range values:
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// assert_eq!((-1.0_f16).ln_1p(), f16::NEG_INFINITY);
@@ -711,7 +688,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let e = std::f16::consts::E;
@@ -747,7 +723,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let e = std::f16::consts::E;
@@ -783,7 +758,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let e = std::f16::consts::E;
@@ -816,7 +790,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
@@ -847,7 +820,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 1.0f16;
@@ -878,7 +850,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = std::f16::consts::FRAC_PI_6;
@@ -912,7 +883,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 5.0f16;
@@ -947,7 +917,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     ///
     /// let x = 2.0f16;
@@ -982,7 +951,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     /// /// The error function relates what percent of a normal distribution lies
     /// /// within `x` standard deviations (scaled by `1/sqrt(2)`).
@@ -1021,7 +989,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// # #[cfg(not(miri))]
     /// # #[cfg(target_has_reliable_f16_math)] {
     /// let x: f16 = 0.123;
     ///

--- a/src/tools/miri/Cargo.toml
+++ b/src/tools/miri/Cargo.toml
@@ -73,7 +73,7 @@ check_only = ["libffi?/check_only", "capstone?/check_only", "genmc-sys?/check_on
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ['cfg(bootstrap)']
+check-cfg = ['cfg(bootstrap)', 'cfg(target_has_reliable_f16_math)']
 
 # Be aware that this file is inside a workspace when used via the
 # submodule in the rustc repo. That means there are many cargo features

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -188,7 +188,7 @@ fn make_miri_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
             cfg.has_reliable_f128 = true;
             // We always provide the f16 intrinsics, but some are provided via the host,
             // so forward its reliability.
-            cfg.has_reliable_f16_math = cfg!(target_has_reliable_f16);
+            cfg.has_reliable_f16_math = cfg!(target_has_reliable_f16_math);
             // Many f128 operations are still missing.
             cfg.has_reliable_f128_math = false;
             cfg

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -1,5 +1,6 @@
-#![feature(rustc_private, stmt_expr_attributes)]
+#![feature(rustc_private, stmt_expr_attributes, cfg_target_has_reliable_f16_f128)]
 #![allow(
+    internal_features, // cfg_target_has_reliable_f16_f128
     clippy::manual_range_contains,
     clippy::useless_format,
     clippy::field_reassign_with_default,
@@ -181,7 +182,16 @@ fn make_miri_codegen_backend(sess: &Session) -> Box<dyn CodegenBackend> {
 
     Box::new(DummyCodegenBackend {
         target_config_override: Some(Box::new(move |sess| {
-            target_config_backend.target_config(sess)
+            let mut cfg = target_config_backend.target_config(sess);
+            // The basic types and ABI always work.
+            cfg.has_reliable_f16 = true;
+            cfg.has_reliable_f128 = true;
+            // We always provide the f16 intrinsics, but some are provided via the host,
+            // so forward its reliability.
+            cfg.has_reliable_f16_math = cfg!(target_has_reliable_f16);
+            // Many f128 operations are still missing.
+            cfg.has_reliable_f128_math = false;
+            cfg
         })),
     })
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156393)*
<!-- homu-ignore:end -->

See the individual commit messages for details.

The last commit is a drive-by comment fix that was not worth its own PR.
r? @tgross35 