### PR TITLE
Enhance drop forget ref hint

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -746,7 +746,7 @@ pub(crate) enum InvalidNullArgumentsDiag {
     #[diag(
         "calling this function with a null pointer is undefined behavior, even if the result of the function is unused"
     )]
-    #[help(
+    #[note(
         "for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>"
     )]
     NullPtrInline {
@@ -756,7 +756,7 @@ pub(crate) enum InvalidNullArgumentsDiag {
     #[diag(
         "calling this function with a null pointer is undefined behavior, even if the result of the function is unused"
     )]
-    #[help(
+    #[note(
         "for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>"
     )]
     NullPtrThroughBinding {
@@ -851,6 +851,9 @@ pub(crate) enum UseLetUnderscoreIgnoreSuggestion {
 // drop_forget_useless.rs
 #[derive(Diagnostic)]
 #[diag("calls to `std::mem::drop` with a reference instead of an owned value does nothing")]
+#[note(
+    "for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>"
+)]
 pub(crate) struct DropRefDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label("argument has type `{$arg_ty}`")]
@@ -861,6 +864,9 @@ pub(crate) struct DropRefDiag<'a> {
 
 #[derive(Diagnostic)]
 #[diag("calls to `std::mem::drop` with a value that implements `Copy` does nothing")]
+#[note(
+    "for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>"
+)]
 pub(crate) struct DropCopyDiag<'a> {
     pub arg_ty: Ty<'a>,
     #[label("argument has type `{$arg_ty}`")]
@@ -937,7 +943,7 @@ pub(crate) enum InvalidFromUtf8Diag {
 #[diag("mutation of an interior mutable `const` item with call to `{$method_name}`")]
 #[note("each usage of a `const` item creates a new temporary")]
 #[note("only the temporaries and never the original `const {$const_name}` will be modified")]
-#[help(
+#[note(
     "for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>"
 )]
 pub(crate) struct ConstItemInteriorMutationsDiag<'tcx> {
@@ -1911,10 +1917,10 @@ impl<'a> Diagnostic<'a, ()> for DropGlue<'_> {
 #[help(
     "if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`"
 )]
-#[help(
+#[note(
     "for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>"
 )]
-#[help(
+#[note(
     "for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>"
 )]
 pub(crate) struct IntegerToPtrTransmutes<'tcx> {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -977,21 +977,44 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// println!("{}", *borrow);
 /// ```
 ///
-/// Integers and other types implementing [`Copy`] are unaffected by `drop`.
+/// Integers, shared reference `&T` and other types implementing [`Copy`] are unaffected by `drop`.
 ///
 /// ```
 /// # #![allow(dropping_copy_types)]
+/// # #![allow(dropping_references)]
 /// #[derive(Copy, Clone)]
 /// struct Foo(u8);
 ///
 /// let x = 1;
+/// let ref_x = &x;
 /// let y = Foo(2);
 /// drop(x); // a copy of `x` is moved and dropped
+/// drop(ref_x); // a copy of `ref_x` is moved and dropped
 /// drop(y); // a copy of `y` is moved and dropped
 ///
-/// println!("x: {}, y: {}", x, y.0); // still available
+/// println!("x: {}, ref_x: {}, y: {}", x, ref_x, y.0); // still available
 /// ```
 ///
+/// Dropping a reference never affects the value it points to. However, calling `drop` on the reference variable behaves differently:
+/// - Shared reference `&T`: It implements [`Copy`]. It is copied into `drop`,
+///   so the original reference can still be used. The value it points to is not dropped.
+/// - Mutable reference `&mut T`: It does not implement [`Copy`]. It is moved
+///   into `drop`, so the original reference cannot be used anymore. The value it points to is not dropped.
+/// ```
+/// # #![allow(dropping_references)]
+///
+/// let mut x = 42;
+///
+/// let ref_x = &x;
+/// drop(ref_x);            // `ref_x` is copied. `x` is not affected.
+/// assert_eq!(*ref_x, 42); // `ref_x` can still be used.
+/// assert_eq!(x, 42);      // `x` can still be used directly.
+///
+/// let mut_ref_x = &mut x;
+/// drop(mut_ref_x);        // `mut_ref_x` is moved. `x` is not affected.
+/// // *mut_ref_x = 24;    // Error: use of moved value.
+/// assert_eq!(x, 42);      // `x` can still be used directly.
+/// ```
 /// [`RefCell`]: crate::cell::RefCell
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/ui/binop/can-have-side-effects-consider-operands.stderr
+++ b/tests/ui/binop/can-have-side-effects-consider-operands.stderr
@@ -6,6 +6,7 @@ LL |         () => drop(5 % 3), // No side effects
    |                    |
    |                    argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_copy_types)]` on by default
 

--- a/tests/ui/lint/const-item-interior-mutations-const-atomics.stderr
+++ b/tests/ui/lint/const-item-interior-mutations-const-atomics.stderr
@@ -8,7 +8,7 @@ LL |     let _a = A.store(true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
    = note: `#[warn(const_item_interior_mutations)]` on by default
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
@@ -26,7 +26,7 @@ LL |     let _a = A.swap(true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -43,7 +43,7 @@ LL |     let _a = A.compare_and_swap(false, true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -60,7 +60,7 @@ LL |     let _a = A.compare_exchange(false, true, Ordering::SeqCst, Ordering::Re
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -77,7 +77,7 @@ LL |     let _a = A.compare_exchange_weak(false, true, Ordering::SeqCst, Orderin
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -94,7 +94,7 @@ LL |     let _a = A.fetch_and(true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -111,7 +111,7 @@ LL |     let _a = A.fetch_nand(true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -128,7 +128,7 @@ LL |     let _a = A.fetch_or(true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -145,7 +145,7 @@ LL |     let _a = A.fetch_xor(true, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -162,7 +162,7 @@ LL |     let _a = A.fetch_not(Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -179,7 +179,7 @@ LL |     let _a = A.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(t
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -196,7 +196,7 @@ LL |     let _a = A.try_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(fal
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -213,7 +213,7 @@ LL |     let _a = A.update(Ordering::SeqCst, Ordering::Relaxed, |_| true);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicBool = AtomicBool::new(false);
@@ -230,7 +230,7 @@ LL |     let _a = A.store(std::ptr::null_mut(), Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -247,7 +247,7 @@ LL |     let _a = A.swap(std::ptr::null_mut(), Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -264,7 +264,7 @@ LL |     let _a = A.compare_and_swap(std::ptr::null_mut(), std::ptr::null_mut(),
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -288,7 +288,7 @@ LL | |     );
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -312,7 +312,7 @@ LL | |     );
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -329,7 +329,7 @@ LL |     let _a = A.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(s
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -346,7 +346,7 @@ LL |     let _a = A.try_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(std
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -363,7 +363,7 @@ LL |     let _a = A.update(Ordering::SeqCst, Ordering::Relaxed, |_| std::ptr::nu
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -380,7 +380,7 @@ LL |     let _a = A.fetch_ptr_add(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -397,7 +397,7 @@ LL |     let _a = A.fetch_ptr_sub(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -414,7 +414,7 @@ LL |     let _a = A.fetch_byte_add(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -431,7 +431,7 @@ LL |     let _a = A.fetch_byte_sub(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -448,7 +448,7 @@ LL |     let _a = A.fetch_and(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -465,7 +465,7 @@ LL |     let _a = A.fetch_or(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -482,7 +482,7 @@ LL |     let _a = A.fetch_xor(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
@@ -499,7 +499,7 @@ LL |     let _a = A.store(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -516,7 +516,7 @@ LL |     let _a = A.swap(2, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -533,7 +533,7 @@ LL |     let _a = A.compare_and_swap(2, 3, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -550,7 +550,7 @@ LL |     let _a = A.compare_exchange(3, 4, Ordering::SeqCst, Ordering::Relaxed);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -567,7 +567,7 @@ LL |     let _a = A.compare_exchange_weak(4, 5, Ordering::SeqCst, Ordering::Rela
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -584,7 +584,7 @@ LL |     let _a = A.fetch_add(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -601,7 +601,7 @@ LL |     let _a = A.fetch_sub(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -618,7 +618,7 @@ LL |     let _a = A.fetch_add(2, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -635,7 +635,7 @@ LL |     let _a = A.fetch_nand(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -652,7 +652,7 @@ LL |     let _a = A.fetch_or(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -669,7 +669,7 @@ LL |     let _a = A.fetch_xor(1, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -686,7 +686,7 @@ LL |     let _a = A.fetch_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(1
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -703,7 +703,7 @@ LL |     let _a = A.try_update(Ordering::SeqCst, Ordering::Relaxed, |_| Some(11)
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -720,7 +720,7 @@ LL |     let _a = A.update(Ordering::SeqCst, Ordering::Relaxed, |_| 12);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -737,7 +737,7 @@ LL |     let _a = A.fetch_max(20, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);
@@ -754,7 +754,7 @@ LL |     let _a = A.fetch_min(5, Ordering::SeqCst);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: AtomicU32 = AtomicU32::new(0);

--- a/tests/ui/lint/const-item-interior-mutations-const-cell.stderr
+++ b/tests/ui/lint/const-item-interior-mutations-const-cell.stderr
@@ -8,7 +8,7 @@ LL |     let _ = LazyCell::force(&A);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
    = note: `#[warn(const_item_interior_mutations)]` on by default
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
@@ -26,7 +26,7 @@ LL |     let _ = A.set(10);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceCell<i32> = OnceCell::new();
@@ -43,7 +43,7 @@ LL |     let _ = A.try_insert(20);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceCell<i32> = OnceCell::new();
@@ -60,7 +60,7 @@ LL |     let _ = A.get_or_init(|| 30);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceCell<i32> = OnceCell::new();
@@ -77,7 +77,7 @@ LL |     let _ = A.get_or_try_init(|| Ok::<_, ()>(40));
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceCell<i32> = OnceCell::new();
@@ -94,7 +94,7 @@ LL |     let _ = A.set(1);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Cell<i32> = Cell::new(0);
@@ -111,7 +111,7 @@ LL |     let _ = A.swap(&A);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Cell<i32> = Cell::new(0);
@@ -128,7 +128,7 @@ LL |     let _ = A.replace(2);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Cell<i32> = Cell::new(0);
@@ -145,7 +145,7 @@ LL |     let _ = A.get();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Cell<i32> = Cell::new(0);
@@ -162,7 +162,7 @@ LL |     let _ = A.update(|x| x + 1);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Cell<i32> = Cell::new(0);
@@ -179,7 +179,7 @@ LL |     let _ = A.replace(1);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -196,7 +196,7 @@ LL |     let _ = A.replace_with(|x| *x + 2);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -213,7 +213,7 @@ LL |     let _ = A.swap(&A);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -230,7 +230,7 @@ LL |     let _ = A.borrow();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -247,7 +247,7 @@ LL |     let _ = A.try_borrow();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -264,7 +264,7 @@ LL |     let _ = A.borrow_mut();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -281,7 +281,7 @@ LL |     let _ = A.try_borrow_mut();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RefCell<i32> = RefCell::new(0);
@@ -298,7 +298,7 @@ LL |     let _ = unsafe { A.replace(1) };
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: UnsafeCell<i32> = UnsafeCell::new(0);
@@ -315,7 +315,7 @@ LL |     let _ = A.get();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: UnsafeCell<i32> = UnsafeCell::new(0);
@@ -332,7 +332,7 @@ LL |         let _ = A.as_ref_unchecked();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: UnsafeCell<i32> = UnsafeCell::new(0);
@@ -349,7 +349,7 @@ LL |         let _ = A.as_mut_unchecked();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: UnsafeCell<i32> = UnsafeCell::new(0);
@@ -366,7 +366,7 @@ LL |     let _ = A.get();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: SyncUnsafeCell<i32> = SyncUnsafeCell::new(0);

--- a/tests/ui/lint/const-item-interior-mutations-const.stderr
+++ b/tests/ui/lint/const-item-interior-mutations-const.stderr
@@ -8,7 +8,7 @@ LL |     let _a = A.set(1);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
    = note: `#[warn(const_item_interior_mutations)]` on by default
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
@@ -26,7 +26,7 @@ LL |     let _a = A.replace(2);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Mutex<i32> = Mutex::new(0);
@@ -43,7 +43,7 @@ LL |     drop(A.lock());
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Mutex<i32> = Mutex::new(0);
@@ -60,7 +60,7 @@ LL |     drop(A.try_lock());
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Mutex<i32> = Mutex::new(0);
@@ -77,7 +77,7 @@ LL |     let _a = A.clear_poison();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Mutex<i32> = Mutex::new(0);
@@ -94,7 +94,7 @@ LL |     let _a = A.call_once(|| {});
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Once = Once::new();
@@ -111,7 +111,7 @@ LL |     let _a = A.call_once_force(|_| {});
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Once = Once::new();
@@ -128,7 +128,7 @@ LL |     let _a = A.wait();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Once = Once::new();
@@ -145,7 +145,7 @@ LL |     let _a = A.wait_force();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Once = Once::new();
@@ -162,7 +162,7 @@ LL |     let _a = A.set(1);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RwLock<i32> = RwLock::new(0);
@@ -179,7 +179,7 @@ LL |     let _a = A.replace(2);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RwLock<i32> = RwLock::new(0);
@@ -196,7 +196,7 @@ LL |     drop(A.read());
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RwLock<i32> = RwLock::new(0);
@@ -213,7 +213,7 @@ LL |     drop(A.try_read());
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RwLock<i32> = RwLock::new(0);
@@ -230,7 +230,7 @@ LL |     drop(A.write());
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RwLock<i32> = RwLock::new(0);
@@ -247,7 +247,7 @@ LL |     drop(A.try_write());
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: RwLock<i32> = RwLock::new(0);
@@ -264,7 +264,7 @@ LL |     let _a = LazyLock::force(&A);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: LazyLock<i32> = LazyLock::new(|| 0);
@@ -281,7 +281,7 @@ LL |     let _a = LazyLock::get(&A);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: LazyLock<i32> = LazyLock::new(|| 0);
@@ -298,7 +298,7 @@ LL |     let _a = A.get();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceLock<i32> = OnceLock::new();
@@ -315,7 +315,7 @@ LL |     let _a = A.wait();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceLock<i32> = OnceLock::new();
@@ -332,7 +332,7 @@ LL |     let _a = A.set(10);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceLock<i32> = OnceLock::new();
@@ -349,7 +349,7 @@ LL |     let _a = A.try_insert(20);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceLock<i32> = OnceLock::new();
@@ -366,7 +366,7 @@ LL |     let _a = A.get_or_init(|| 30);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceLock<i32> = OnceLock::new();
@@ -383,7 +383,7 @@ LL |     let _a = A.get_or_try_init(|| Ok::<_, ()>(40));
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: OnceLock<i32> = OnceLock::new();
@@ -400,7 +400,7 @@ LL |     let _a = A.wait(guard);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();
@@ -417,7 +417,7 @@ LL |     let _a = A.wait_while(guard, |x| *x == 0);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();
@@ -434,7 +434,7 @@ LL |     let _a = A.wait_timeout_ms(guard, 10);
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();
@@ -451,7 +451,7 @@ LL |     let _a = A.wait_timeout(guard, Duration::from_millis(10));
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();
@@ -468,7 +468,7 @@ LL |     let _a = A.wait_timeout_while(guard, Duration::from_millis(10), |x| *x 
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();
@@ -485,7 +485,7 @@ LL |     let _a = A.notify_one();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();
@@ -502,7 +502,7 @@ LL |     let _a = A.notify_all();
    |
    = note: each usage of a `const` item creates a new temporary
    = note: only the temporaries and never the original `const A` will be modified
-   = help: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
+   = note: for more details on interior mutability see <https://doc.rust-lang.org/reference/interior-mutability.html>
 help: for a shared instance of `A`, consider making it a `static` item instead
    |
 LL -     const A: Condvar = Condvar::new();

--- a/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189-can-not-fixed.stderr
@@ -6,6 +6,7 @@ LL |         0 => drop(y),
    |                   |
    |                   argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 note: the lint level is defined here
   --> $DIR/dropping_copy_types-issue-125189-can-not-fixed.rs:3:9
@@ -21,6 +22,7 @@ LL |         1 => drop(z),
    |                   |
    |                   argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 
 error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
@@ -31,6 +33,7 @@ LL |         2 => drop(3),
    |                   |
    |                   argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 
 error: aborting due to 3 previous errors

--- a/tests/ui/lint/dropping_copy_types-issue-125189.stderr
+++ b/tests/ui/lint/dropping_copy_types-issue-125189.stderr
@@ -6,6 +6,7 @@ LL |     drop(3.2);
    |          |
    |          argument has type `f64`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 note: the lint level is defined here
   --> $DIR/dropping_copy_types-issue-125189.rs:4:9
    |
@@ -25,6 +26,7 @@ LL |     drop(y);
    |          |
    |          argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(y);

--- a/tests/ui/lint/dropping_copy_types-macros.stderr
+++ b/tests/ui/lint/dropping_copy_types-macros.stderr
@@ -6,6 +6,7 @@ LL |     drop(writeln!(&mut msg, "test"));
    |          |
    |          argument has type `Result<(), std::fmt::Error>`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 note: the lint level is defined here
   --> $DIR/dropping_copy_types-macros.rs:4:9
    |
@@ -25,6 +26,7 @@ LL |     drop(format_args!("a"));
    |          |
    |          argument has type `Arguments<'_>`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(format_args!("a"));

--- a/tests/ui/lint/dropping_copy_types.stderr
+++ b/tests/ui/lint/dropping_copy_types.stderr
@@ -6,6 +6,7 @@ LL |     drop(s1);
    |          |
    |          argument has type `SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 note: the lint level is defined here
   --> $DIR/dropping_copy_types.rs:3:9
    |
@@ -25,6 +26,7 @@ LL |     drop(s2);
    |          |
    |          argument has type `SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(s2);
@@ -39,6 +41,7 @@ LL |     drop(s3);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: `#[warn(dropping_references)]` on by default
 help: use `let _ = ...` to ignore the expression or result
    |
@@ -54,6 +57,7 @@ LL |     drop(s4);
    |          |
    |          argument has type `SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(s4);
@@ -68,6 +72,7 @@ LL |     drop(s5);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(s5);
@@ -82,6 +87,7 @@ LL |     drop(a2);
    |          |
    |          argument has type `&AnotherStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(a2);
@@ -96,6 +102,7 @@ LL |     drop(a4);
    |          |
    |          argument has type `&AnotherStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(a4);
@@ -110,6 +117,7 @@ LL |             drop(println_and(13));
    |                  |
    |                  argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -             drop(println_and(13));
@@ -124,6 +132,7 @@ LL |         3 if drop(println_and(14)) == () => (),
    |                   |
    |                   argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 
 warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
@@ -134,6 +143,7 @@ LL |         4 => drop(2),
    |                   |
    |                   argument has type `i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 
 warning: 10 warnings emitted

--- a/tests/ui/lint/dropping_references-can-fixed.stderr
+++ b/tests/ui/lint/dropping_references-can-fixed.stderr
@@ -6,6 +6,7 @@ LL |     drop(&SomeStruct);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 note: the lint level is defined here
   --> $DIR/dropping_references-can-fixed.rs:4:9
    |
@@ -25,6 +26,7 @@ LL |     drop(&owned1);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&owned1);
@@ -39,6 +41,7 @@ LL |     drop(&&owned1);
    |          |
    |          argument has type `&&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&&owned1);
@@ -53,6 +56,7 @@ LL |     drop(&mut owned1);
    |          |
    |          argument has type `&mut SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&mut owned1);
@@ -67,6 +71,7 @@ LL |     drop(reference1);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(reference1);
@@ -81,6 +86,7 @@ LL |     drop(reference2);
    |          |
    |          argument has type `&mut SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(reference2);
@@ -95,6 +101,7 @@ LL |     drop(reference3);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(reference3);
@@ -109,6 +116,7 @@ LL |     drop(&val);
    |          |
    |          argument has type `&T`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&val);

--- a/tests/ui/lint/dropping_references.stderr
+++ b/tests/ui/lint/dropping_references.stderr
@@ -6,6 +6,7 @@ LL |     drop(&SomeStruct);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 note: the lint level is defined here
   --> $DIR/dropping_references.rs:3:9
    |
@@ -25,6 +26,7 @@ LL |     drop(&owned1);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&owned1);
@@ -39,6 +41,7 @@ LL |     drop(&&owned1);
    |          |
    |          argument has type `&&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&&owned1);
@@ -53,6 +56,7 @@ LL |     drop(&mut owned1);
    |          |
    |          argument has type `&mut SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&mut owned1);
@@ -67,6 +71,7 @@ LL |     drop(reference1);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(reference1);
@@ -81,6 +86,7 @@ LL |     drop(reference2);
    |          |
    |          argument has type `&mut SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(reference2);
@@ -95,6 +101,7 @@ LL |     drop(reference3);
    |          |
    |          argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(reference3);
@@ -109,6 +116,7 @@ LL |     drop(&val);
    |          |
    |          argument has type `&T`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     drop(&val);
@@ -123,6 +131,7 @@ LL |     std::mem::drop(&SomeStruct);
    |                    |
    |                    argument has type `&SomeStruct`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -     std::mem::drop(&SomeStruct);
@@ -137,6 +146,7 @@ LL |             drop(println_and(&13));
    |                  |
    |                  argument has type `&i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
 help: use `let _ = ...` to ignore the expression or result
    |
 LL -             drop(println_and(&13));
@@ -151,6 +161,7 @@ LL |         3 if drop(println_and(&14)) == () => (),
    |                   |
    |                   argument has type `&i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 
 warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
@@ -161,6 +172,7 @@ LL |         4 => drop(&2),
    |                   |
    |                   argument has type `&i32`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
 
 warning: 12 warnings emitted

--- a/tests/ui/lint/int_to_ptr-unsized.stderr
+++ b/tests/ui/lint/int_to_ptr-unsized.stderr
@@ -7,8 +7,8 @@ LL |     let _ref = unsafe { std::mem::transmute::<usizemetadata, &'static str>(
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
    = note: `#[warn(integer_to_ptr_transmutes)]` on by default
 
 warning: transmuting an integer to a pointer creates a pointer without provenance
@@ -20,8 +20,8 @@ LL |     let _ptr = unsafe { std::mem::transmute::<usizemetadata, *const [u8]>(0
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 
 warning: 2 warnings emitted
 

--- a/tests/ui/lint/int_to_ptr.stderr
+++ b/tests/ui/lint/int_to_ptr.stderr
@@ -7,8 +7,8 @@ LL |     let _ptr: *const u8 = unsafe { std::mem::transmute::<usize, *const u8>(
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
    = note: `#[warn(integer_to_ptr_transmutes)]` on by default
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
@@ -25,8 +25,8 @@ LL |     let _ptr: *mut u8 = unsafe { std::mem::transmute::<usize, *mut u8>(a) }
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance_mut` instead to use a previously exposed provenance
    |
 LL -     let _ptr: *mut u8 = unsafe { std::mem::transmute::<usize, *mut u8>(a) };
@@ -42,8 +42,8 @@ LL |     let _ref: &'static u8 = unsafe { std::mem::transmute::<usize, &'static 
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ref: &'static u8 = unsafe { std::mem::transmute::<usize, &'static u8>(a) };
@@ -59,8 +59,8 @@ LL |     let _ref: &'static mut u8 = unsafe { std::mem::transmute::<usize, &'sta
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance_mut` instead to use a previously exposed provenance
    |
 LL -     let _ref: &'static mut u8 = unsafe { std::mem::transmute::<usize, &'static mut u8>(a) };
@@ -76,8 +76,8 @@ LL |     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(42usize) };
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(42usize) };
@@ -93,8 +93,8 @@ LL |     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(a + a) };
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(a + a) };
@@ -110,8 +110,8 @@ LL |     let _ptr: *const u8 = unsafe { std::mem::transmute::<usize, *const u8>(
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ptr: *const u8 = unsafe { std::mem::transmute::<usize, *const u8>(a) };
@@ -127,8 +127,8 @@ LL |     let _ptr: *mut u8 = unsafe { std::mem::transmute::<usize, *mut u8>(a) }
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance_mut` instead to use a previously exposed provenance
    |
 LL -     let _ptr: *mut u8 = unsafe { std::mem::transmute::<usize, *mut u8>(a) };
@@ -144,8 +144,8 @@ LL |     let _ref: &'static u8 = unsafe { std::mem::transmute::<usize, &'static 
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ref: &'static u8 = unsafe { std::mem::transmute::<usize, &'static u8>(a) };
@@ -161,8 +161,8 @@ LL |     let _ref: &'static mut u8 = unsafe { std::mem::transmute::<usize, &'sta
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance_mut` instead to use a previously exposed provenance
    |
 LL -     let _ref: &'static mut u8 = unsafe { std::mem::transmute::<usize, &'static mut u8>(a) };
@@ -178,8 +178,8 @@ LL |     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(42usize) };
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(42usize) };
@@ -195,8 +195,8 @@ LL |     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(a + a) };
    = note: this is dangerous because dereferencing the resulting pointer is undefined behavior
    = note: exposed provenance semantics can be used to create a pointer based on some previously exposed provenance
    = help: if you truly mean to create a pointer without provenance, use `std::ptr::without_provenance_mut`
-   = help: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
-   = help: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
+   = note: for more information about transmute, see <https://doc.rust-lang.org/std/mem/fn.transmute.html#transmutation-between-pointers-and-integers>
+   = note: for more information about exposed provenance, see <https://doc.rust-lang.org/std/ptr/index.html#exposed-provenance>
 help: use `std::ptr::with_exposed_provenance` instead to use a previously exposed provenance
    |
 LL -     let _ptr = unsafe { std::mem::transmute::<usize, *const u8>(a + a) };

--- a/tests/ui/lint/invalid_null_args.stderr
+++ b/tests/ui/lint/invalid_null_args.stderr
@@ -9,7 +9,7 @@ LL | |         mem::transmute::<[u8; 4], _>([0, 0, 0, 255]),
 LL | |     );
    | |_____^
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
    = note: `#[deny(invalid_null_arguments)]` on by default
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
@@ -22,7 +22,7 @@ LL | |         mem::transmute::<[u8; 4], _>([0, 0, 0, 255]),
 LL | |     );
    | |_____^
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 note: null pointer originates from here
   --> $DIR/invalid_null_args.rs:14:20
    |
@@ -37,7 +37,7 @@ LL |     let _: &[usize] = std::slice::from_raw_parts(ptr::null(), 0);
    |                                                  |
    |                                                  null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:23:23
@@ -47,7 +47,7 @@ LL |     let _: &[usize] = std::slice::from_raw_parts(ptr::null_mut(), 0);
    |                                                  |
    |                                                  null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:25:23
@@ -57,7 +57,7 @@ LL |     let _: &[usize] = std::slice::from_raw_parts(0 as *mut _, 0);
    |                                                  |
    |                                                  null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:27:23
@@ -67,7 +67,7 @@ LL |     let _: &[usize] = std::slice::from_raw_parts(mem::transmute(0usize), 0)
    |                                                                 |
    |                                                                 null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:30:23
@@ -77,7 +77,7 @@ LL |     let _: &[usize] = std::slice::from_raw_parts_mut(ptr::null_mut(), 0);
    |                                                      |
    |                                                      null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:33:5
@@ -87,7 +87,7 @@ LL |     ptr::copy::<usize>(ptr::null(), ptr::NonNull::dangling().as_ptr(), 0);
    |                        |
    |                        null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:35:5
@@ -97,7 +97,7 @@ LL |     ptr::copy::<usize>(ptr::NonNull::dangling().as_ptr(), ptr::null_mut(), 
    |                                                           |
    |                                                           null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:38:5
@@ -107,7 +107,7 @@ LL |     ptr::copy_nonoverlapping::<usize>(ptr::null(), ptr::NonNull::dangling()
    |                                       |
    |                                       null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:40:5
@@ -121,7 +121,7 @@ LL | |         0,
 LL | |     );
    | |_____^
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:51:17
@@ -131,7 +131,7 @@ LL |     let _a: A = ptr::read(ptr::null());
    |                           |
    |                           null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:53:17
@@ -141,7 +141,7 @@ LL |     let _a: A = ptr::read(ptr::null_mut());
    |                           |
    |                           null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:56:17
@@ -151,7 +151,7 @@ LL |     let _a: A = ptr::read_unaligned(ptr::null());
    |                                     |
    |                                     null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:58:17
@@ -161,7 +161,7 @@ LL |     let _a: A = ptr::read_unaligned(ptr::null_mut());
    |                                     |
    |                                     null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:65:17
@@ -171,7 +171,7 @@ LL |     let _a: A = ptr::replace(ptr::null_mut(), v);
    |                              |
    |                              null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:68:5
@@ -181,7 +181,7 @@ LL |     ptr::swap::<A>(ptr::null_mut(), &mut v);
    |                    |
    |                    null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:70:5
@@ -191,7 +191,7 @@ LL |     ptr::swap::<A>(&mut v, ptr::null_mut());
    |                            |
    |                            null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:73:5
@@ -201,7 +201,7 @@ LL |     ptr::swap_nonoverlapping::<A>(ptr::null_mut(), &mut v, 0);
    |                                   |
    |                                   null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:75:5
@@ -211,7 +211,7 @@ LL |     ptr::swap_nonoverlapping::<A>(&mut v, ptr::null_mut(), 0);
    |                                           |
    |                                           null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:78:5
@@ -221,7 +221,7 @@ LL |     ptr::write(ptr::null_mut(), v);
    |                |
    |                null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:81:5
@@ -231,7 +231,7 @@ LL |     ptr::write_unaligned(ptr::null_mut(), v);
    |                          |
    |                          null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:87:5
@@ -241,7 +241,7 @@ LL |     ptr::write_bytes::<usize>(ptr::null_mut(), 42, 0);
    |                               |
    |                               null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:92:18
@@ -249,7 +249,7 @@ error: calling this function with a null pointer is undefined behavior, even if 
 LL |     let _a: u8 = ptr::read(const_ptr);
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 note: null pointer originates from here
   --> $DIR/invalid_null_args.rs:14:20
    |
@@ -264,7 +264,7 @@ LL |     std::slice::from_raw_parts::<()>(ptr::null(), 0);
    |                                      |
    |                                      null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:101:5
@@ -274,7 +274,7 @@ LL |     std::slice::from_raw_parts::<Zst>(ptr::null(), 0);
    |                                       |
    |                                       null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:103:5
@@ -284,7 +284,7 @@ LL |     std::slice::from_raw_parts_mut::<()>(ptr::null_mut(), 0);
    |                                          |
    |                                          null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: calling this function with a null pointer is undefined behavior, even if the result of the function is unused
   --> $DIR/invalid_null_args.rs:105:5
@@ -294,7 +294,7 @@ LL |     std::slice::from_raw_parts_mut::<Zst>(ptr::null_mut(), 0);
    |                                           |
    |                                           null pointer originates from here
    |
-   = help: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
+   = note: for more information, visit <https://doc.rust-lang.org/std/ptr/index.html> and <https://doc.rust-lang.org/reference/behavior-considered-undefined.html>
 
 error: aborting due to 28 previous errors
 

--- a/tests/ui/repeat-expr/can-have-side-effects-consider-element.stderr
+++ b/tests/ui/repeat-expr/can-have-side-effects-consider-element.stderr
@@ -6,6 +6,7 @@ LL |         () => drop([0; 1]), // No side effects
    |                    |
    |                    argument has type `[i32; 1]`
    |
+   = note: for more information about `std::mem::drop`, see <https://doc.rust-lang.org/std/mem/fn.drop.html>
    = note: use `let _ = ...` to ignore the expression or result
    = note: `#[warn(dropping_copy_types)]` on by default
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156395)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

~Replace `let _ = ...` with `let _ = drop_arg`~
~Changed some hint messages~

add a help message
try to update `std::mem::drop` documentation to make that clearer.

Fixes: rust-lang/rust#155895 