### PR TITLE
std/sys/net/xous: read NetError code from byte 4 in recv/accept paths

### DIFF
--- a/library/std/src/sys/net/connection/xous/tcplistener.rs
+++ b/library/std/src/sys/net/connection/xous/tcplistener.rs
@@ -129,12 +129,13 @@ impl TcpListener {
             0,
         ) {
             if receive_request.raw[0] != 0 {
-                // error case
-                if receive_request.raw[1] == NetError::TimedOut as u8 {
+                // Error case — code lives at byte 4 (where the send path
+                // also reads it). Byte 1 is part of the marker header.
+                if receive_request.raw[4] == NetError::TimedOut as u8 {
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "accept timed out"));
-                } else if receive_request.raw[1] == NetError::WouldBlock as u8 {
+                } else if receive_request.raw[4] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "accept would block"));
-                } else if receive_request.raw[1] == NetError::LibraryError as u8 {
+                } else if receive_request.raw[4] == NetError::LibraryError as u8 {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));

--- a/library/std/src/sys/net/connection/xous/tcpstream.rs
+++ b/library/std/src/sys/net/connection/xous/tcpstream.rs
@@ -213,11 +213,14 @@ impl TcpStream {
         } else {
             let result = receive_request.raw;
             if result[0] != 0 {
-                if result[1] == 8 {
+                // The error code lives at byte 4 of the kernel's response buffer
+                // (matches the byte the send path reads in `write` below). Byte 1
+                // is part of the marker header, not the code.
+                if result[4] == 8 {
                     // timed out
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "timeout"));
                 }
-                if result[1] == 9 {
+                if result[4] == 9 {
                     // would block
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "would block"));
                 }

--- a/library/std/src/sys/net/connection/xous/udp.rs
+++ b/library/std/src/sys/net/connection/xous/udp.rs
@@ -145,12 +145,13 @@ impl UdpSocket {
             0,
         ) {
             if receive_request.raw[0] != 0 {
-                // error case
-                if receive_request.raw[1] == NetError::TimedOut as u8 {
+                // Error case — code lives at byte 4 (where `send_message`
+                // also reads it). Byte 1 is part of the marker header.
+                if receive_request.raw[4] == NetError::TimedOut as u8 {
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "recv timed out"));
-                } else if receive_request.raw[1] == NetError::WouldBlock as u8 {
+                } else if receive_request.raw[4] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "recv would block"));
-                } else if receive_request.raw[1] == NetError::LibraryError as u8 {
+                } else if receive_request.raw[4] == NetError::LibraryError as u8 {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));


### PR DESCRIPTION
The Xous std backend's TCP **send** path reads the `NetError`
code from `send_request.raw[4]` (correct — that's where the
xous-core kernel's `respond_with_error` writes it). But the TCP
recv, UDP recv, and TcpListener accept paths all read from
`raw[1]` instead. The kernel's historical layout is
`[1, 1, 1, 1, code, 0, 0, 0]`, so byte 1 is always `1` and
`ErrorKind::TimedOut` / `ErrorKind::WouldBlock` are unreachable
from the recv side — every error falls through to the catch-all
`ErrorKind::Other("recv_slice failure")`.

This patch moves the recv-path checks to `raw[4]`, matching the
send path and the kernel's existing encoding. Three files,
identical one-byte change in each (+15 / -10 total). No new
behavior; an existing inconsistency between the send and recv
sides of the same backend is removed.

**Why this matters in practice:** any application using
`set_read_timeout()` to interleave reads and writes on a Xous
`TcpStream` (e.g. a tungstenite-based WebSocket pump) currently
can't distinguish "no data this poll" from real transport
failure. Concretely, a Signal client using a 5s read timeout saw
every WebSocket torn down within 5s of opening, because the
timeout was indistinguishable from a fatal error.

**Coordination with the kernel side:** a complementary kernel-
side change has been filed on the xous-core repo —
[betrusted-io/xous-core#877](https://github.com/betrusted-io/xous-core/pull/877)
— which mirrors the code at byte 1 in addition to byte 4 so
applications work immediately on stock Rust toolchains while
this PR cycles. After both land, the two sides agree at byte 4
and byte 1 stays mirrored only for backwards-compat with older
Rust. Either change alone fixes the user-visible symptom; both
together remove the wire-format ambiguity.

**Tests:** Tier-3 target std backends generally don't have CI
coverage in this repo, so I haven't added any. Happy to add an
in-process test that constructs a fake net-server response and
asserts the `ErrorKind` mapping if maintainers prefer.

Full disclosure: I used an AI agent to debug this problem and eventually track it here.  
