### PR TITLE
Update itertools to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
  "color-print",
  "declare_clippy_lint",
  "filetime",
- "itertools",
+ "itertools 0.12.1",
  "pulldown-cmark",
  "regex",
  "rustc_tools_util 0.4.2",
@@ -705,7 +705,7 @@ name = "clippy_config"
 version = "0.1.98"
 dependencies = [
  "clippy_utils",
- "itertools",
+ "itertools 0.12.1",
  "serde",
  "toml 0.7.8",
  "walkdir",
@@ -718,7 +718,7 @@ dependencies = [
  "chrono",
  "clap",
  "indoc",
- "itertools",
+ "itertools 0.12.1",
  "opener",
  "rustc-literal-escaper",
  "walkdir",
@@ -733,7 +733,7 @@ dependencies = [
  "clippy_config",
  "clippy_utils",
  "declare_clippy_lint",
- "itertools",
+ "itertools 0.12.1",
  "quine-mc_cluskey",
  "regex-syntax",
  "semver",
@@ -751,7 +751,7 @@ version = "0.0.1"
 dependencies = [
  "clippy_config",
  "clippy_utils",
- "itertools",
+ "itertools 0.12.1",
  "regex",
  "rustc-semver",
 ]
@@ -761,7 +761,7 @@ name = "clippy_utils"
 version = "0.1.98"
 dependencies = [
  "arrayvec",
- "itertools",
+ "itertools 0.12.1",
  "rustc_apfloat",
  "serde",
 ]
@@ -933,7 +933,7 @@ name = "coverage-dump"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.15.0",
  "leb128",
  "md-5",
  "miniz_oxide",
@@ -2125,6 +2125,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3686,7 +3695,7 @@ dependencies = [
 name = "rustc_ast_passes"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_ast",
  "rustc_ast_pretty",
@@ -3706,7 +3715,7 @@ dependencies = [
 name = "rustc_ast_pretty"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_ast",
  "rustc_lexer",
  "rustc_span",
@@ -3750,7 +3759,7 @@ name = "rustc_borrowck"
 version = "0.0.0"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.15.0",
  "polonius-engine",
  "rustc_abi",
  "rustc_data_structures",
@@ -3804,7 +3813,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "gimli 0.31.1",
- "itertools",
+ "itertools 0.15.0",
  "libc",
  "libloading 0.9.0",
  "measureme",
@@ -3840,7 +3849,7 @@ dependencies = [
  "bitflags",
  "bstr",
  "find-msvc-tools",
- "itertools",
+ "itertools 0.15.0",
  "libc",
  "object 0.37.3",
  "pathdiff",
@@ -4110,7 +4119,7 @@ dependencies = [
 name = "rustc_hir_analysis"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_arena",
  "rustc_ast",
@@ -4157,7 +4166,7 @@ dependencies = [
 name = "rustc_hir_typeck"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_ast",
  "rustc_data_structures",
@@ -4435,7 +4444,7 @@ dependencies = [
 name = "rustc_mir_build"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_apfloat",
  "rustc_arena",
@@ -4479,7 +4488,7 @@ name = "rustc_mir_transform"
 version = "0.0.0"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_arena",
  "rustc_ast",
@@ -4684,7 +4693,7 @@ name = "rustc_resolve"
 version = "0.0.0"
 dependencies = [
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "pulldown-cmark",
  "rustc_arena",
  "rustc_ast",
@@ -4846,7 +4855,7 @@ checksum = "a3b75158011a63889ba12084cf1224baad7bcad50f6ee7c842f772b74aa148ed"
 name = "rustc_trait_selection"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_ast",
  "rustc_data_structures",
@@ -4880,7 +4889,7 @@ dependencies = [
 name = "rustc_transmute"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_hir",
@@ -4894,7 +4903,7 @@ dependencies = [
 name = "rustc_ty_utils"
 version = "0.0.0"
 dependencies = [
- "itertools",
+ "itertools 0.15.0",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_errors",
@@ -4971,7 +4980,7 @@ dependencies = [
  "base64",
  "expect-test",
  "indexmap",
- "itertools",
+ "itertools 0.15.0",
  "minifier",
  "proc-macro2",
  "pulldown-cmark-escape",
@@ -5059,7 +5068,7 @@ dependencies = [
  "dirs",
  "getopts",
  "ignore",
- "itertools",
+ "itertools 0.12.1",
  "regex",
  "rustfmt-config_proc_macro",
  "semver",

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_ast = { path = "../rustc_ast" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use ast::{ForLoopKind, MatchKind};
-use itertools::{Itertools, Position};
+use itertools::Itertools;
 use rustc_ast::util::classify;
 use rustc_ast::util::literal::escape_byte_str_symbol;
 use rustc_ast::util::parser::{self, ExprPrecedence, Fixity};
@@ -170,8 +170,8 @@ impl<'a> State<'a> {
         }
         let cb = self.cbox(0);
         for (pos, field) in fields.iter().with_position() {
-            let is_first = matches!(pos, Position::First | Position::Only);
-            let is_last = matches!(pos, Position::Last | Position::Only);
+            let is_first = pos.is_first();
+            let is_last = pos.is_last();
             self.maybe_print_comment(field.span.hi());
             self.print_outer_attributes(&field.attrs);
             if is_first {

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -1,5 +1,5 @@
 use ast::StaticItem;
-use itertools::{Itertools, Position};
+use itertools::Itertools;
 use rustc_ast::{self as ast, EiiImpl, ModKind, Safety, TraitAlias};
 use rustc_span::Ident;
 
@@ -923,7 +923,7 @@ impl<'a> State<'a> {
                     self.zerobreak();
                     let ib = self.ibox(0);
                     for (pos, use_tree) in items.iter().with_position() {
-                        let is_last = matches!(pos, Position::Last | Position::Only);
+                        let is_last = pos.is_last();
                         self.print_use_tree(&use_tree.0);
                         if !is_last {
                             self.word(",");

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 either = "1.5.0"
-itertools = "0.12"
+itertools = "0.15"
 polonius-engine = "0.13.0"
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "2.4.1"
 # To avoid duplicate dependencies, this should match the version of gimli used
 # by `rustc_codegen_ssa` via its `thorin-dwp` dependency.
 gimli = "0.31"
-itertools = "0.12"
+itertools = "0.15"
 libc = "0.2"
 libloading = { version = "0.9.0" }
 measureme = "12.0.1"

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -9,7 +9,7 @@ ar_archive_writer = "0.5"
 bitflags = "2.4.1"
 bstr = "1.11.3"
 find-msvc-tools = "0.1.2"
-itertools = "0.12"
+itertools = "0.15"
 pathdiff = "0.2.0"
 regex = "1.4"
 rustc_abi = { path = "../rustc_abi" }

--- a/compiler/rustc_hir_analysis/Cargo.toml
+++ b/compiler/rustc_hir_analysis/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_arena = { path = "../rustc_arena" }
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_hir_typeck/Cargo.toml
+++ b/compiler/rustc_hir_typeck/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_mir_build/Cargo.toml
+++ b/compiler/rustc_mir_build/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_apfloat = "0.2.0"
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -9,7 +9,7 @@ use std::borrow::Borrow;
 use std::sync::Arc;
 use std::{debug_assert_matches, mem};
 
-use itertools::{Itertools, Position};
+use itertools::Itertools;
 use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
@@ -551,9 +551,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // the drop order for the first sub-branch, we lower sub-branches in reverse (#142163).
             let target_block = self.cfg.start_new_block();
             for (pos, sub_branch) in branch.sub_branches.into_iter().rev().with_position() {
-                debug_assert!(pos != Position::Only);
+                debug_assert!(!pos.is_exactly_one());
                 let schedule_drops =
-                    if pos == Position::Last { ScheduleDrops::Yes } else { ScheduleDrops::No };
+                    if pos.is_last() { ScheduleDrops::Yes } else { ScheduleDrops::No };
                 let binding_end = self.bind_and_guard_matched_candidate(
                     sub_branch,
                     fake_borrow_temps,

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 either = "1"
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_arena = { path = "../rustc_arena" }
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_resolve/Cargo.toml
+++ b/compiler/rustc_resolve/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # tidy-alphabetical-start
 indexmap = "2.4.0"
-itertools = "0.12"
+itertools = "0.15"
 pulldown-cmark = { version = "0.11", features = [
     "html",
 ], default-features = false }

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 # tidy-alphabetical-end
 
 [features]

--- a/compiler/rustc_ty_utils/Cargo.toml
+++ b/compiler/rustc_ty_utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-itertools = "0.12"
+itertools = "0.15"
 rustc_abi = { path = "../rustc_abi" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -13,7 +13,7 @@ arrayvec = { version = "0.7", default-features = false }
 askama = { version = "0.16.0", default-features = false, features = ["alloc", "config", "derive"] }
 base64 = "0.21.7"
 indexmap = { version = "2", features = ["serde"] }
-itertools = "0.12"
+itertools = "0.15"
 minifier = { version = "0.3.5", default-features = false }
 proc-macro2 = "1.0.103"
 pulldown-cmark-escape = { version = "0.11.0", features = ["simd"] }

--- a/src/librustdoc/html/render/sorted_template.rs
+++ b/src/librustdoc/html/render/sorted_template.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Write as _};
 use std::marker::PhantomData;
 use std::str::FromStr;
 
-use itertools::{Itertools as _, Position};
+use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 
 /// Append-only templates for sorted, deduplicated lists of items.
@@ -62,7 +62,7 @@ impl<F: FileFormat> fmt::Display for SortedTemplate<F> {
         write!(f, "{}", self.before)?;
         for (p, fragment) in self.fragments.iter().with_position() {
             let mut f = DeltaWriter { inner: &mut f, delta: 0 };
-            let sep = if matches!(p, Position::First | Position::Only) { "" } else { F::SEPARATOR };
+            let sep = if p.is_first() { "" } else { F::SEPARATOR };
             f.write_str(sep)?;
             f.write_str(fragment)?;
             fragment_lengths.push(f.delta);
@@ -95,7 +95,7 @@ impl<F: FileFormat> FromStr for SortedTemplate<F> {
             let (fragment, rest) =
                 s.split_at_checked(index).ok_or(Error("invalid fragment length: out of bounds"))?;
             s = rest;
-            let sep = if matches!(p, Position::First | Position::Only) { "" } else { F::SEPARATOR };
+            let sep = if p.is_first() { "" } else { F::SEPARATOR };
             let fragment = fragment
                 .strip_prefix(sep)
                 .ok_or(Error("invalid fragment length: expected to find separator here"))?;

--- a/src/tools/coverage-dump/Cargo.toml
+++ b/src/tools/coverage-dump/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.71"
-itertools = "0.12"
+itertools = "0.15"
 leb128 = "0.2.5"
 md5 = { package = "md-5" , version = "0.10.5" }
 miniz_oxide = "0.8.8"


### PR DESCRIPTION
This bumps the itertools dependency to [0.15](https://github.com/rust-itertools/itertools/blob/master/CHANGELOG.md#0150).

There’s a breaking change upstream in the shape of `itertools::Position`, so this updates the use sites of it as well, aside from submodules like clippy, which will be handled [separately](https://github.com/rust-lang/rust-clippy/pull/16805).