### PR TITLE
Fix unwanted "Available on XX-bit only" in libcore integers

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -460,6 +460,7 @@ impl i128 {
     midpoint_impl! { i128, signed }
 }
 
+#[doc(auto_cfg = false)]
 #[cfg(target_pointer_width = "16")]
 impl isize {
     int_impl! {
@@ -485,6 +486,7 @@ impl isize {
     midpoint_impl! { isize, i32, signed }
 }
 
+#[doc(auto_cfg = false)]
 #[cfg(target_pointer_width = "32")]
 impl isize {
     int_impl! {
@@ -510,6 +512,7 @@ impl isize {
     midpoint_impl! { isize, i64, signed }
 }
 
+#[doc(auto_cfg = false)]
 #[cfg(target_pointer_width = "64")]
 impl isize {
     int_impl! {
@@ -1334,6 +1337,7 @@ impl u128 {
     carrying_carryless_mul_impl! { u128, u256 }
 }
 
+#[doc(auto_cfg = false)]
 #[cfg(target_pointer_width = "16")]
 impl usize {
     uint_impl! {
@@ -1365,6 +1369,7 @@ impl usize {
     carrying_carryless_mul_impl! { usize, u32 }
 }
 
+#[doc(auto_cfg = false)]
 #[cfg(target_pointer_width = "32")]
 impl usize {
     uint_impl! {
@@ -1396,6 +1401,7 @@ impl usize {
     carrying_carryless_mul_impl! { usize, u64 }
 }
 
+#[doc(auto_cfg = false)]
 #[cfg(target_pointer_width = "64")]
 impl usize {
     uint_impl! {


### PR DESCRIPTION
Fixes rust-lang/rust#149786.

The problem came from:

<img width="754" height="734" alt="image" src="https://github.com/user-attachments/assets/c251326f-8640-420d-bc4c-a3246390ea67" />

The `doc_cfg` feature picks the `cfg` as it should. If we don't want it, we simply need to disable the feature on it. With this fix, no more `cfg` annotations:

<img width="860" height="590" alt="image" src="https://github.com/user-attachments/assets/da793590-bf43-4874-94e1-a56809938420" />

r? @Urgau 