### PR TITLE
Move `std::io::util` to `core::io`

### DIFF
--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -2,6 +2,7 @@
 
 mod borrowed_buf;
 mod error;
+mod util;
 
 #[unstable(feature = "core_io_borrowed_buf", issue = "117693")]
 pub use self::borrowed_buf::{BorrowedBuf, BorrowedCursor};
@@ -9,3 +10,8 @@ pub use self::borrowed_buf::{BorrowedBuf, BorrowedCursor};
 pub use self::error::ErrorKind;
 #[unstable(feature = "raw_os_error_ty", issue = "107792")]
 pub use self::error::RawOsError;
+#[unstable(feature = "core_io", issue = "154046")]
+pub use self::util::{Chain, Empty, Repeat, Sink, Take, empty, repeat, sink};
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+pub use self::util::{chain, take};

--- a/library/core/src/io/util.rs
+++ b/library/core/src/io/util.rs
@@ -1,0 +1,415 @@
+use crate::fmt;
+
+/// `Empty` ignores any data written via [`Write`], and will always be empty
+/// (returning zero bytes) when read via [`Read`].
+///
+/// [`Write`]: ../../std/io/trait.Write.html
+/// [`Read`]: ../../std/io/trait.Read.html
+///
+/// This struct is generally created by calling [`empty()`]. Please
+/// see the documentation of [`empty()`] for more details.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Empty;
+
+/// Creates a value that is always at EOF for reads, and ignores all data written.
+///
+/// All calls to [`write`] on the returned instance will return [`Ok(buf.len())`]
+/// and the contents of the buffer will not be inspected.
+///
+/// All calls to [`read`] from the returned reader will return [`Ok(0)`].
+///
+/// [`Ok(buf.len())`]: Ok
+/// [`Ok(0)`]: Ok
+///
+/// [`write`]: ../../std/io/trait.Write.html#tymethod.write
+/// [`read`]: ../../std/io/trait.Read.html#tymethod.read
+///
+/// # Examples
+///
+/// ```rust
+/// use std::io::{self, Write};
+///
+/// let buffer = vec![1, 2, 3, 5, 8];
+/// let num_bytes = io::empty().write(&buffer).unwrap();
+/// assert_eq!(num_bytes, 5);
+/// ```
+///
+///
+/// ```rust
+/// use std::io::{self, Read};
+///
+/// let mut buffer = String::new();
+/// io::empty().read_to_string(&mut buffer).unwrap();
+/// assert!(buffer.is_empty());
+/// ```
+#[must_use]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_stable(feature = "const_io_structs", since = "1.79.0")]
+pub const fn empty() -> Empty {
+    Empty
+}
+
+/// A reader which yields one byte over and over and over and over and over and...
+///
+/// This struct is generally created by calling [`repeat()`]. Please
+/// see the documentation of [`repeat()`] for more details.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[non_exhaustive]
+pub struct Repeat {
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub byte: u8,
+}
+
+/// Creates an instance of a reader that infinitely repeats one byte.
+///
+/// All reads from this reader will succeed by filling the specified buffer with
+/// the given byte.
+///
+/// # Examples
+///
+/// ```
+/// use std::io::{self, Read};
+///
+/// let mut buffer = [0; 3];
+/// io::repeat(0b101).read_exact(&mut buffer).unwrap();
+/// assert_eq!(buffer, [0b101, 0b101, 0b101]);
+/// ```
+#[must_use]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_stable(feature = "const_io_structs", since = "1.79.0")]
+pub const fn repeat(byte: u8) -> Repeat {
+    Repeat { byte }
+}
+
+#[stable(feature = "std_debug", since = "1.16.0")]
+impl fmt::Debug for Repeat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Repeat").finish_non_exhaustive()
+    }
+}
+
+/// A writer which will move data into the void.
+///
+/// This struct is generally created by calling [`sink()`]. Please
+/// see the documentation of [`sink()`] for more details.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Sink;
+
+/// Creates an instance of a writer which will successfully consume all data.
+///
+/// All calls to [`write`] on the returned instance will return [`Ok(buf.len())`]
+/// and the contents of the buffer will not be inspected.
+///
+/// [`write`]: ../../std/io/trait.Write.html#tymethod.write
+/// [`Ok(buf.len())`]: Ok
+///
+/// # Examples
+///
+/// ```rust
+/// use std::io::{self, Write};
+///
+/// let buffer = vec![1, 2, 3, 5, 8];
+/// let num_bytes = io::sink().write(&buffer).unwrap();
+/// assert_eq!(num_bytes, 5);
+/// ```
+#[must_use]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_stable(feature = "const_io_structs", since = "1.79.0")]
+pub const fn sink() -> Sink {
+    Sink
+}
+
+/// Adapter to chain together two readers.
+///
+/// This struct is generally created by calling [`chain`] on a reader.
+/// Please see the documentation of [`chain`] for more details.
+///
+/// [`chain`]: ../../std/io/trait.Read.html#method.chain
+#[stable(feature = "rust1", since = "1.0.0")]
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Chain<T, U> {
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub first: T,
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub second: U,
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub done_first: bool,
+}
+
+impl<T, U> Chain<T, U> {
+    /// Consumes the `Chain`, returning the wrapped readers.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut foo_file = File::open("foo.txt")?;
+    ///     let mut bar_file = File::open("bar.txt")?;
+    ///
+    ///     let chain = foo_file.chain(bar_file);
+    ///     let (foo_file, bar_file) = chain.into_inner();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
+    pub fn into_inner(self) -> (T, U) {
+        (self.first, self.second)
+    }
+
+    /// Gets references to the underlying readers in this `Chain`.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying readers as doing so may corrupt the internal state of this
+    /// `Chain`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut foo_file = File::open("foo.txt")?;
+    ///     let mut bar_file = File::open("bar.txt")?;
+    ///
+    ///     let chain = foo_file.chain(bar_file);
+    ///     let (foo_file, bar_file) = chain.get_ref();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
+    pub fn get_ref(&self) -> (&T, &U) {
+        (&self.first, &self.second)
+    }
+
+    /// Gets mutable references to the underlying readers in this `Chain`.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying readers as doing so may corrupt the internal state of this
+    /// `Chain`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut foo_file = File::open("foo.txt")?;
+    ///     let mut bar_file = File::open("bar.txt")?;
+    ///
+    ///     let mut chain = foo_file.chain(bar_file);
+    ///     let (foo_file, bar_file) = chain.get_mut();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
+    pub fn get_mut(&mut self) -> (&mut T, &mut U) {
+        (&mut self.first, &mut self.second)
+    }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+#[must_use]
+#[inline]
+pub const fn chain<T, U>(first: T, second: U) -> Chain<T, U> {
+    Chain { first, second, done_first: false }
+}
+
+/// Reader adapter which limits the bytes read from an underlying reader.
+///
+/// This struct is generally created by calling [`take`] on a reader.
+/// Please see the documentation of [`take`] for more details.
+///
+/// [`take`]: ../../std/io/trait.Read.html#method.take
+#[stable(feature = "rust1", since = "1.0.0")]
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Take<T> {
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub inner: T,
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub len: u64,
+    #[doc(hidden)]
+    #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+    pub limit: u64,
+}
+
+impl<T> Take<T> {
+    /// Returns the number of bytes that can be read before this instance will
+    /// return EOF.
+    ///
+    /// # Note
+    ///
+    /// This instance may reach `EOF` after reading fewer bytes than indicated by
+    /// this method if the underlying [`Read`] instance reaches EOF.
+    ///
+    /// [`Read`]: ../../std/io/trait.Read.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let f = File::open("foo.txt")?;
+    ///
+    ///     // read at most five bytes
+    ///     let handle = f.take(5);
+    ///
+    ///     println!("limit: {}", handle.limit());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    /// Returns the number of bytes read so far.
+    #[unstable(feature = "seek_io_take_position", issue = "97227")]
+    #[inline]
+    pub fn position(&self) -> u64 {
+        self.len - self.limit
+    }
+
+    /// Sets the number of bytes that can be read before this instance will
+    /// return EOF. This is the same as constructing a new `Take` instance, so
+    /// the amount of bytes read and the previous limit value don't matter when
+    /// calling this method.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let f = File::open("foo.txt")?;
+    ///
+    ///     // read at most five bytes
+    ///     let mut handle = f.take(5);
+    ///     handle.set_limit(10);
+    ///
+    ///     assert_eq!(handle.limit(), 10);
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "take_set_limit", since = "1.27.0")]
+    pub fn set_limit(&mut self, limit: u64) {
+        self.len = limit;
+        self.limit = limit;
+    }
+
+    /// Consumes the `Take`, returning the wrapped reader.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut file = File::open("foo.txt")?;
+    ///
+    ///     let mut buffer = [0; 5];
+    ///     let mut handle = file.take(5);
+    ///     handle.read(&mut buffer)?;
+    ///
+    ///     let file = handle.into_inner();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "io_take_into_inner", since = "1.15.0")]
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Gets a reference to the underlying reader.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying reader as doing so may corrupt the internal limit of this
+    /// `Take`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut file = File::open("foo.txt")?;
+    ///
+    ///     let mut buffer = [0; 5];
+    ///     let mut handle = file.take(5);
+    ///     handle.read(&mut buffer)?;
+    ///
+    ///     let file = handle.get_ref();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying reader.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying reader as doing so may corrupt the internal limit of this
+    /// `Take`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::io;
+    /// use std::io::prelude::*;
+    /// use std::fs::File;
+    ///
+    /// fn main() -> io::Result<()> {
+    ///     let mut file = File::open("foo.txt")?;
+    ///
+    ///     let mut buffer = [0; 5];
+    ///     let mut handle = file.take(5);
+    ///     handle.read(&mut buffer)?;
+    ///
+    ///     let file = handle.get_mut();
+    ///     Ok(())
+    /// }
+    /// ```
+    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
+#[must_use]
+#[inline]
+pub const fn take<T>(inner: T, limit: u64) -> Take<T> {
+    Take { inner, limit, len: limit }
+}

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -299,6 +299,8 @@ mod tests;
 
 #[unstable(feature = "read_buf", issue = "78485")]
 pub use core::io::{BorrowedBuf, BorrowedCursor};
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::io::{Chain, Empty, Repeat, Sink, Take, empty, repeat, sink};
 use core::slice::memchr;
 
 #[stable(feature = "bufwriter_into_parts", since = "1.56.0")]
@@ -328,7 +330,6 @@ pub use self::{
     cursor::Cursor,
     error::{Error, ErrorKind, Result},
     stdio::{Stderr, StderrLock, Stdin, StdinLock, Stdout, StdoutLock, stderr, stdin, stdout},
-    util::{Empty, Repeat, Sink, empty, repeat, sink},
 };
 use crate::mem::{MaybeUninit, take};
 use crate::ops::{Deref, DerefMut};
@@ -1183,7 +1184,7 @@ pub trait Read {
     where
         Self: Sized,
     {
-        Chain { first: self, second: next, done_first: false }
+        core::io::chain(self, next)
     }
 
     /// Creates an adapter which will read at most `limit` bytes from it.
@@ -1222,7 +1223,7 @@ pub trait Read {
     where
         Self: Sized,
     {
-        Take { inner: self, len: limit, limit }
+        core::io::take(self, limit)
     }
 
     /// Read and return a fixed array of bytes from this source.
@@ -2704,99 +2705,6 @@ pub trait BufRead: Read {
     }
 }
 
-/// Adapter to chain together two readers.
-///
-/// This struct is generally created by calling [`chain`] on a reader.
-/// Please see the documentation of [`chain`] for more details.
-///
-/// [`chain`]: Read::chain
-#[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Debug)]
-pub struct Chain<T, U> {
-    first: T,
-    second: U,
-    done_first: bool,
-}
-
-impl<T, U> Chain<T, U> {
-    /// Consumes the `Chain`, returning the wrapped readers.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut foo_file = File::open("foo.txt")?;
-    ///     let mut bar_file = File::open("bar.txt")?;
-    ///
-    ///     let chain = foo_file.chain(bar_file);
-    ///     let (foo_file, bar_file) = chain.into_inner();
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
-    pub fn into_inner(self) -> (T, U) {
-        (self.first, self.second)
-    }
-
-    /// Gets references to the underlying readers in this `Chain`.
-    ///
-    /// Care should be taken to avoid modifying the internal I/O state of the
-    /// underlying readers as doing so may corrupt the internal state of this
-    /// `Chain`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut foo_file = File::open("foo.txt")?;
-    ///     let mut bar_file = File::open("bar.txt")?;
-    ///
-    ///     let chain = foo_file.chain(bar_file);
-    ///     let (foo_file, bar_file) = chain.get_ref();
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
-    pub fn get_ref(&self) -> (&T, &U) {
-        (&self.first, &self.second)
-    }
-
-    /// Gets mutable references to the underlying readers in this `Chain`.
-    ///
-    /// Care should be taken to avoid modifying the internal I/O state of the
-    /// underlying readers as doing so may corrupt the internal state of this
-    /// `Chain`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut foo_file = File::open("foo.txt")?;
-    ///     let mut bar_file = File::open("bar.txt")?;
-    ///
-    ///     let mut chain = foo_file.chain(bar_file);
-    ///     let (foo_file, bar_file) = chain.get_mut();
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
-    pub fn get_mut(&mut self) -> (&mut T, &mut U) {
-        (&mut self.first, &mut self.second)
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Read, U: Read> Read for Chain<T, U> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -2903,170 +2811,6 @@ impl<T, U> SizeHint for Chain<T, U> {
             (Some(first), Some(second)) => first.checked_add(second),
             _ => None,
         }
-    }
-}
-
-/// Reader adapter which limits the bytes read from an underlying reader.
-///
-/// This struct is generally created by calling [`take`] on a reader.
-/// Please see the documentation of [`take`] for more details.
-///
-/// [`take`]: Read::take
-#[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Debug)]
-pub struct Take<T> {
-    inner: T,
-    len: u64,
-    limit: u64,
-}
-
-impl<T> Take<T> {
-    /// Returns the number of bytes that can be read before this instance will
-    /// return EOF.
-    ///
-    /// # Note
-    ///
-    /// This instance may reach `EOF` after reading fewer bytes than indicated by
-    /// this method if the underlying [`Read`] instance reaches EOF.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let f = File::open("foo.txt")?;
-    ///
-    ///     // read at most five bytes
-    ///     let handle = f.take(5);
-    ///
-    ///     println!("limit: {}", handle.limit());
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn limit(&self) -> u64 {
-        self.limit
-    }
-
-    /// Returns the number of bytes read so far.
-    #[unstable(feature = "seek_io_take_position", issue = "97227")]
-    pub fn position(&self) -> u64 {
-        self.len - self.limit
-    }
-
-    /// Sets the number of bytes that can be read before this instance will
-    /// return EOF. This is the same as constructing a new `Take` instance, so
-    /// the amount of bytes read and the previous limit value don't matter when
-    /// calling this method.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let f = File::open("foo.txt")?;
-    ///
-    ///     // read at most five bytes
-    ///     let mut handle = f.take(5);
-    ///     handle.set_limit(10);
-    ///
-    ///     assert_eq!(handle.limit(), 10);
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "take_set_limit", since = "1.27.0")]
-    pub fn set_limit(&mut self, limit: u64) {
-        self.len = limit;
-        self.limit = limit;
-    }
-
-    /// Consumes the `Take`, returning the wrapped reader.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut file = File::open("foo.txt")?;
-    ///
-    ///     let mut buffer = [0; 5];
-    ///     let mut handle = file.take(5);
-    ///     handle.read(&mut buffer)?;
-    ///
-    ///     let file = handle.into_inner();
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "io_take_into_inner", since = "1.15.0")]
-    pub fn into_inner(self) -> T {
-        self.inner
-    }
-
-    /// Gets a reference to the underlying reader.
-    ///
-    /// Care should be taken to avoid modifying the internal I/O state of the
-    /// underlying reader as doing so may corrupt the internal limit of this
-    /// `Take`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut file = File::open("foo.txt")?;
-    ///
-    ///     let mut buffer = [0; 5];
-    ///     let mut handle = file.take(5);
-    ///     handle.read(&mut buffer)?;
-    ///
-    ///     let file = handle.get_ref();
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
-    pub fn get_ref(&self) -> &T {
-        &self.inner
-    }
-
-    /// Gets a mutable reference to the underlying reader.
-    ///
-    /// Care should be taken to avoid modifying the internal I/O state of the
-    /// underlying reader as doing so may corrupt the internal limit of this
-    /// `Take`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::io;
-    /// use std::io::prelude::*;
-    /// use std::fs::File;
-    ///
-    /// fn main() -> io::Result<()> {
-    ///     let mut file = File::open("foo.txt")?;
-    ///
-    ///     let mut buffer = [0; 5];
-    ///     let mut handle = file.take(5);
-    ///     handle.read(&mut buffer)?;
-    ///
-    ///     let file = handle.get_mut();
-    ///     Ok(())
-    /// }
-    /// ```
-    #[stable(feature = "more_io_inner_methods", since = "1.20.0")]
-    pub fn get_mut(&mut self) -> &mut T {
-        &mut self.inner
     }
 }
 

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -5,56 +5,9 @@ mod tests;
 
 use crate::fmt;
 use crate::io::{
-    self, BorrowedCursor, BufRead, IoSlice, IoSliceMut, Read, Seek, SeekFrom, SizeHint, Write,
+    self, BorrowedCursor, BufRead, Empty, IoSlice, IoSliceMut, Read, Repeat, Seek, SeekFrom, Sink,
+    SizeHint, Write,
 };
-
-/// `Empty` ignores any data written via [`Write`], and will always be empty
-/// (returning zero bytes) when read via [`Read`].
-///
-/// This struct is generally created by calling [`empty()`]. Please
-/// see the documentation of [`empty()`] for more details.
-#[stable(feature = "rust1", since = "1.0.0")]
-#[non_exhaustive]
-#[derive(Copy, Clone, Debug, Default)]
-pub struct Empty;
-
-/// Creates a value that is always at EOF for reads, and ignores all data written.
-///
-/// All calls to [`write`] on the returned instance will return [`Ok(buf.len())`]
-/// and the contents of the buffer will not be inspected.
-///
-/// All calls to [`read`] from the returned reader will return [`Ok(0)`].
-///
-/// [`Ok(buf.len())`]: Ok
-/// [`Ok(0)`]: Ok
-///
-/// [`write`]: Write::write
-/// [`read`]: Read::read
-///
-/// # Examples
-///
-/// ```rust
-/// use std::io::{self, Write};
-///
-/// let buffer = vec![1, 2, 3, 5, 8];
-/// let num_bytes = io::empty().write(&buffer).unwrap();
-/// assert_eq!(num_bytes, 5);
-/// ```
-///
-///
-/// ```rust
-/// use std::io::{self, Read};
-///
-/// let mut buffer = String::new();
-/// io::empty().read_to_string(&mut buffer).unwrap();
-/// assert!(buffer.is_empty());
-/// ```
-#[must_use]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_stable(feature = "const_io_structs", since = "1.79.0")]
-pub const fn empty() -> Empty {
-    Empty
-}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Empty {
@@ -234,36 +187,6 @@ impl Write for &Empty {
     }
 }
 
-/// A reader which yields one byte over and over and over and over and over and...
-///
-/// This struct is generally created by calling [`repeat()`]. Please
-/// see the documentation of [`repeat()`] for more details.
-#[stable(feature = "rust1", since = "1.0.0")]
-pub struct Repeat {
-    byte: u8,
-}
-
-/// Creates an instance of a reader that infinitely repeats one byte.
-///
-/// All reads from this reader will succeed by filling the specified buffer with
-/// the given byte.
-///
-/// # Examples
-///
-/// ```
-/// use std::io::{self, Read};
-///
-/// let mut buffer = [0; 3];
-/// io::repeat(0b101).read_exact(&mut buffer).unwrap();
-/// assert_eq!(buffer, [0b101, 0b101, 0b101]);
-/// ```
-#[must_use]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_stable(feature = "const_io_structs", since = "1.79.0")]
-pub const fn repeat(byte: u8) -> Repeat {
-    Repeat { byte }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for Repeat {
     #[inline]
@@ -327,46 +250,6 @@ impl SizeHint for Repeat {
     fn upper_bound(&self) -> Option<usize> {
         None
     }
-}
-
-#[stable(feature = "std_debug", since = "1.16.0")]
-impl fmt::Debug for Repeat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Repeat").finish_non_exhaustive()
-    }
-}
-
-/// A writer which will move data into the void.
-///
-/// This struct is generally created by calling [`sink()`]. Please
-/// see the documentation of [`sink()`] for more details.
-#[stable(feature = "rust1", since = "1.0.0")]
-#[non_exhaustive]
-#[derive(Copy, Clone, Debug, Default)]
-pub struct Sink;
-
-/// Creates an instance of a writer which will successfully consume all data.
-///
-/// All calls to [`write`] on the returned instance will return [`Ok(buf.len())`]
-/// and the contents of the buffer will not be inspected.
-///
-/// [`write`]: Write::write
-/// [`Ok(buf.len())`]: Ok
-///
-/// # Examples
-///
-/// ```rust
-/// use std::io::{self, Write};
-///
-/// let buffer = vec![1, 2, 3, 5, 8];
-/// let num_bytes = io::sink().write(&buffer).unwrap();
-/// assert_eq!(num_bytes, 5);
-/// ```
-#[must_use]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_stable(feature = "const_io_structs", since = "1.79.0")]
-pub const fn sink() -> Sink {
-    Sink
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -365,6 +365,7 @@
 #![feature(ptr_mask)]
 #![feature(random)]
 #![feature(raw_os_error_ty)]
+#![feature(seek_io_take_position)]
 #![feature(slice_internals)]
 #![feature(slice_ptr_get)]
 #![feature(slice_range)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/155625)*
<!-- homu-ignore:end -->

ACP: https://github.com/rust-lang/libs-team/issues/755
Tracking issue: https://github.com/rust-lang/rust/issues/154046
Subset of: https://github.com/rust-lang/rust/pull/154684

## Description

Moves utility types and functions from `std::io::util` and `std::io` to `core::io`, leaving any IO trait implementations behind. They will be moved along with the traits themselves. Certain documentation links had to be amended.

- `Chain`
- `Empty`
- `Repeat`
- `Sink`
- `Take`
- `empty`
- `repeat`
- `sink`

---

## Notes

* This can be reviewed independently of the other PRs tracked in rust-lang/rust#154046.
* `Chain` and `Take` were previously in the main `mod.rs` file for `std::io`, but I've chosen to move them into the `util.rs` file in `core::io` instead. I think they make more sense in that file, but I'm happy to move them into `mod.rs` if that's a controversial decision.
* No AI tooling of any kind was used during the creation of this PR.
