### PR TITLE
Show intrinsics::gpu in docs

### DIFF
--- a/library/core/src/intrinsics/gpu.rs
+++ b/library/core/src/intrinsics/gpu.rs
@@ -47,7 +47,7 @@
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[unstable(feature = "gpu_launch_sized_workgroup_mem", issue = "135513")]
-#[cfg(any(target_arch = "amdgpu", target_arch = "nvptx64"))]
+#[cfg(any(doc, target_arch = "amdgpu", target_arch = "nvptx64"))]
 pub fn gpu_launch_sized_workgroup_mem<T>() -> *mut T;
 
 /// Returns a pointer to the HSA kernel dispatch packet.
@@ -63,6 +63,6 @@ pub fn gpu_launch_sized_workgroup_mem<T>() -> *mut T;
 /// [hsa.h]: https://github.com/ROCm/rocm-systems/blob/rocm-7.1.0/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa.h#L2959
 #[rustc_nounwind]
 #[rustc_intrinsic]
-#[cfg(target_arch = "amdgpu")]
+#[cfg(any(doc, target_arch = "amdgpu"))]
 #[must_use = "returns a pointer that does nothing unless used"]
 pub fn amdgpu_dispatch_ptr() -> *const ();


### PR DESCRIPTION
It was previously not visible (unless compiling docs for amdgpu, which I guess nobody does).
Follow other specific intrinsics and always include them in docs.

Now looks like this:
<img width="1220" height="446" alt="2026-05-11_10-51-05" src="https://github.com/user-attachments/assets/c3a98f0e-2803-4697-87a8-1cc8ff01815c" />

r? @ZuseZ4 (I hope you are fine with reviewing this, please re-assign if not :))

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
