### PR TITLE
Fix invalid suggestion for parenthesized break

### DIFF
--- a/compiler/rustc_hir_typeck/src/loops.rs
+++ b/compiler/rustc_hir_typeck/src/loops.rs
@@ -270,7 +270,13 @@ impl<'hir> Visitor<'hir> for CheckLoopVisitor<'hir> {
                     }
                 }
 
-                let sp_lo = e.span.with_lo(e.span.lo() + BytePos("break".len() as u32));
+                let sp_lo = if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(e.span)
+                    && let Some(break_pos) = snippet.find("break")
+                {
+                    e.span.with_lo(e.span.lo() + BytePos((break_pos + "break".len()) as u32))
+                } else {
+                    e.span.with_lo(e.span.lo() + BytePos("break".len() as u32))
+                };
                 let label_sp = match break_destination.label {
                     Some(label) => sp_lo.with_hi(label.ident.span.hi()),
                     None => sp_lo.shrink_to_lo(),

--- a/tests/ui/parser/break-in-unlabeled-block-parenthesized.rs
+++ b/tests/ui/parser/break-in-unlabeled-block-parenthesized.rs
@@ -1,0 +1,9 @@
+#![allow(unused_parens)]
+fn main() {
+    {
+        (break); //~ ERROR `break` outside of a loop or labeled block
+    };
+    {
+        ((break)); //~ ERROR `break` outside of a loop or labeled block
+    };
+}

--- a/tests/ui/parser/break-in-unlabeled-block-parenthesized.stderr
+++ b/tests/ui/parser/break-in-unlabeled-block-parenthesized.stderr
@@ -1,0 +1,27 @@
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-in-unlabeled-block-parenthesized.rs:4:9
+   |
+LL |         (break);
+   |         ^^^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL ~     'block: {
+LL ~         (break 'block);
+   |
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-in-unlabeled-block-parenthesized.rs:7:9
+   |
+LL |         ((break));
+   |         ^^^^^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL ~     'block: {
+LL ~         ((break 'block));
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0268`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Resolves rust-lang/rust#156383 

The old code incorrectly assumed `e.span` started exactly at the beginning of `break`. Fixed by locating the exact start position of `break`.