### PR TITLE
miri subtree update

### DIFF
--- a/src/tools/miri/src/shims/unix/fs.rs
+++ b/src/tools/miri/src/shims/unix/fs.rs
@@ -863,6 +863,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
         let path = this.read_path_from_c_str(path_ptr)?;
 
+        // Reject if isolation is enabled.
+        if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
+            this.reject_in_isolation("`chmod`", reject_with)?;
+            return this.set_last_error_and_return_i32(LibcError("EACCES"));
+        }
+
         let permissions = this.host_permissions_from_mode(mode.try_into().unwrap())?;
         if let Err(err) = fs::set_permissions(path, permissions) {
             return this.set_last_error_and_return_i32(IoError::HostError(err));
@@ -884,6 +890,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // The docs don't talk about what happens for non-regular files...
             throw_unsup_format!("`fchmod` is only supported on regular files")
         };
+
+        // Reject if isolation is enabled.
+        if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
+            this.reject_in_isolation("`fchmod`", reject_with)?;
+            return this.set_last_error_and_return_i32(LibcError("EACCES"));
+        }
 
         let permissions = this.host_permissions_from_mode(mode.try_into().unwrap())?;
         if let Err(err) = file.file.set_permissions(permissions) {


### PR DESCRIPTION
Subtree update of `miri` to https://github.com/rust-lang/miri/commit/39301e961f9536e22ff6fdc678c9ee6153333f1a.

Created using https://github.com/rust-lang/josh-sync.

Out-of-schedule sync to avoid nasty surprises when isolation doesn't work (but also see https://github.com/rust-lang/miri/pull/5025)

r? @ghost