### PR TITLE
compiletest: Enforce that directives are consistently used with or without a colon

### DIFF
--- a/src/tools/compiletest/src/directives.rs
+++ b/src/tools/compiletest/src/directives.rs
@@ -618,7 +618,11 @@ impl Config {
     }
 
     fn parse_pp_exact(&self, line: &DirectiveLine<'_>) -> Option<Utf8PathBuf> {
-        if let Some(s) = self.parse_name_value_directive(line, "pp-exact") {
+        // Unusually, `//@ pp-exact` can be used with or without a colon, so to avoid a panic
+        // in the parse method we need to make sure there is a colon before calling it.
+        if line.value_after_colon().is_some()
+            && let Some(s) = self.parse_name_value_directive(line, "pp-exact")
+        {
             Some(Utf8PathBuf::from(&s))
         } else if self.parse_name_directive(line, "pp-exact") {
             line.file_path.file_name().map(Utf8PathBuf::from)
@@ -648,10 +652,17 @@ impl Config {
     }
 
     fn parse_name_directive(&self, line: &DirectiveLine<'_>, directive: &str) -> bool {
-        // FIXME(Zalathar): Ideally, this should raise an error if a name-only
-        // directive is followed by a colon, since that's the wrong syntax.
-        // But we would need to fix tests that rely on the current behaviour.
-        line.name == directive
+        if line.name != directive {
+            return false;
+        }
+
+        if line.value_after_colon().is_some() {
+            let &DirectiveLine { file_path, line_number, .. } = line;
+            panic!(
+                "{file_path}:{line_number}: directive `{directive}` must not be followed by a colon"
+            );
+        }
+        true
     }
 
     fn parse_name_value_directive(
@@ -665,10 +676,9 @@ impl Config {
             return None;
         };
 
-        // FIXME(Zalathar): This silently discards directives with a matching
-        // name but no colon. Unfortunately, some directives (e.g. "pp-exact")
-        // currently rely on _not_ panicking here.
-        let value = line.value_after_colon()?;
+        let value = line.value_after_colon().unwrap_or_else(|| {
+            panic!("{file_path}:{line_number}: directive `{directive}` must be followed by a colon and value");
+        });
         debug!("{}: {}", directive, value);
         let value = expand_variables(value.to_owned(), self);
 

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -1153,7 +1153,6 @@ fn edition_order() {
 #[test]
 fn test_parse_edition_range() {
     assert_eq!(None, parse_edition_range("hello-world"));
-    assert_eq!(None, parse_edition_range("edition"));
 
     assert_eq!(Some(EditionRange::Exact(2018.into())), parse_edition_range("edition: 2018"));
     assert_eq!(Some(EditionRange::Exact(2021.into())), parse_edition_range("edition:2021"));

--- a/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
+++ b/tests/ui/const-generics/mgca/printing_valtrees_supports_non_values.rs
@@ -1,5 +1,5 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/150354>
-//@ edition 2024
+//@ edition: 2024
 
 #![allow(incomplete_features)]
 #![feature(min_generic_const_args, adt_const_params)]

--- a/tests/ui/consts/issue-miri-1910.rs
+++ b/tests/ui/consts/issue-miri-1910.rs
@@ -1,5 +1,4 @@
 //@ ignore-backends: gcc
-//@ error-pattern unable to turn pointer into raw bytes
 //@ normalize-stderr: "alloc[0-9]+\+0x[a-z0-9]+" -> "ALLOC"
 
 const C: () = unsafe {

--- a/tests/ui/consts/issue-miri-1910.stderr
+++ b/tests/ui/consts/issue-miri-1910.stderr
@@ -1,5 +1,5 @@
 error[E0080]: unable to turn pointer into integer
-  --> $DIR/issue-miri-1910.rs:8:5
+  --> $DIR/issue-miri-1910.rs:7:5
    |
 LL |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `C` failed here

--- a/tests/ui/proc-macro/edition-gated-async-move-syntax-issue89699.rs
+++ b/tests/ui/proc-macro/edition-gated-async-move-syntax-issue89699.rs
@@ -2,7 +2,7 @@
 //@ edition: 2015
 
 // Non-regression test for issue #89699, where a proc-macro emitting syntax only available in
-//@ edition 2018 and up (`async move`) is used on edition 2015
+// edition 2018 and up (`async move`) is used on edition 2015
 
 extern crate edition_gated_async_move_syntax;
 

--- a/tests/ui/rust-2021/generic-type-collision.fixed
+++ b/tests/ui/rust-2021/generic-type-collision.fixed
@@ -1,7 +1,6 @@
-//@ edition:2015
 //@ check-pass
 //@ run-rustfix
-//@ edition 2018
+//@ edition: 2018
 #![warn(rust_2021_prelude_collisions)]
 
 trait MyTrait<A> {

--- a/tests/ui/rust-2021/generic-type-collision.rs
+++ b/tests/ui/rust-2021/generic-type-collision.rs
@@ -1,7 +1,6 @@
-//@ edition:2015
 //@ check-pass
 //@ run-rustfix
-//@ edition 2018
+//@ edition: 2018
 #![warn(rust_2021_prelude_collisions)]
 
 trait MyTrait<A> {

--- a/tests/ui/rust-2021/generic-type-collision.stderr
+++ b/tests/ui/rust-2021/generic-type-collision.stderr
@@ -1,13 +1,13 @@
 warning: trait-associated function `from_iter` will become ambiguous in Rust 2021
-  --> $DIR/generic-type-collision.rs:16:5
+  --> $DIR/generic-type-collision.rs:15:5
    |
 LL |     <Vec<i32>>::from_iter(None);
    |     ^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `<Vec<i32> as MyTrait<_>>::from_iter`
    |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/prelude.html>
 note: the lint level is defined here
-  --> $DIR/generic-type-collision.rs:5:9
+  --> $DIR/generic-type-collision.rs:4:9
    |
 LL | #![warn(rust_2021_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
With the notable exception of `//@ pp-exact`, all directives expect to either always be used *with* a colon, or always be used *without* a colon. For example:

- `//@ uses-colon: value`
- `//@ no-colon` or `//@ no-colon (remark)`

Currently we just silently discard directives that use the wrong syntax, which is not great.

This PR therefore makes `parse_name_directive` and `parse_name_value_directive` panic if the wrong syntax is encountered.

The parser for `pp-exact` has been adjusted to check for the colon before deciding which parse method to call.

r? jieyouxu