### PR TITLE
LLVM 23: Specify `returnaddress` intrinsic return type

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -860,7 +860,14 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                     _ => {
                         let ty = self.type_ix(32);
                         let val = self.const_int(ty, 0);
-                        self.call_intrinsic("llvm.returnaddress", &[], &[val])
+
+                        let type_params: &[&'ll Type] = if llvm_version < (23, 0, 0) {
+                            &[]
+                        } else {
+                            &[self.type_ptr()]
+                        };
+
+                        self.call_intrinsic("llvm.returnaddress", type_params, &[val])
                     }
                 }
             }

--- a/tests/codegen-llvm/intrinsics/return_address.rs
+++ b/tests/codegen-llvm/intrinsics/return_address.rs
@@ -7,6 +7,6 @@
 #[no_mangle]
 #[inline(never)]
 pub fn call_return_address_intrinsic() -> *const () {
-    // CHECK: call ptr @llvm.returnaddress(i32 0)
+    // CHECK: call ptr @llvm.returnaddress{{(.p0)?}}(i32 0)
     core::intrinsics::return_address()
 }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/188464 made the return type of the intrinsic generic to support different pointer address spaces.

@rustbot label llvm-main