### PR TITLE
LLVM 23: Accept float (instead of hex) literals in codegen tests

### DIFF
--- a/tests/codegen-llvm/const-vector.rs
+++ b/tests/codegen-llvm/const-vector.rs
@@ -65,10 +65,10 @@ pub fn do_call() {
         // CHECK: call void @test_i8x2_arr(<2 x i8> <i8 32, i8 64>
         test_i8x2_arr(const { i8x2::from_array([32, 64]) });
 
-        // CHECK: call void @test_f32x2(<2 x float> <float 0x3FD47AE140000000, float 0x3FE47AE140000000>
+        // CHECK: call void @test_f32x2(<2 x float> <float {{0x3FD47AE140000000|3.200000e-01}}, float {{0x3FE47AE140000000|6.400000e-01}}>
         test_f32x2(const { f32x2::from_array([0.32, 0.64]) });
 
-        // CHECK: void @test_f32x2_arr(<2 x float> <float 0x3FD47AE140000000, float 0x3FE47AE140000000>
+        // CHECK: void @test_f32x2_arr(<2 x float> <float {{0x3FD47AE140000000|3.200000e-01}}, float {{0x3FE47AE140000000|6.400000e-01}}>
         test_f32x2_arr(const { f32x2::from_array([0.32, 0.64]) });
 
         // CHECK: call void @test_simd(<4 x i32> <i32 2, i32 4, i32 6, i32 8>

--- a/tests/codegen-llvm/sparc-struct-abi.rs
+++ b/tests/codegen-llvm/sparc-struct-abi.rs
@@ -31,7 +31,7 @@ pub struct BoolFloat {
 
 // CHECK: define inreg { i32, float } @structboolfloat()
 // CHECK-NEXT: start:
-// CHECK-NEXT: ret { i32, float } { i32 16777216, float 0x40091EB860000000 }
+// CHECK-NEXT: ret { i32, float } { i32 16777216, float {{0x40091EB860000000|3.140000e\+00}} }
 #[no_mangle]
 pub extern "C" fn structboolfloat() -> BoolFloat {
     BoolFloat { b: true, f: 3.14 }
@@ -70,7 +70,7 @@ pub struct FloatLongFloat {
 
 // CHECK: define inreg { float, i32, i64, float, i32 } @structfloatlongfloat()
 // CHECK-NEXT: start:
-// CHECK-NEXT: ret { float, i32, i64, float, i32 } { float 0x3FB99999A0000000, i32 undef, i64 123, float 0x40091EB860000000, i32 undef }
+// CHECK-NEXT: ret { float, i32, i64, float, i32 } { float {{0x3FB99999A0000000|1.000000e-01}}, i32 undef, i64 123, float {{0x40091EB860000000|3.140000e\+00}}, i32 undef }
 #[no_mangle]
 pub extern "C" fn structfloatlongfloat() -> FloatLongFloat {
     FloatLongFloat { f: 0.1, i: 123, g: 3.14 }
@@ -90,7 +90,7 @@ pub struct NestedStructs {
 
 // CHECK: define inreg { float, float, float, float } @structnestestructs()
 // CHECK-NEXT: start:
-// CHECK-NEXT: ret { float, float, float, float } { float 0x3FB99999A0000000, float 0x3FF19999A0000000, float 0x40019999A0000000, float 0x400A666660000000 }
+// CHECK-NEXT: ret { float, float, float, float } { float {{0x3FB99999A0000000|1.000000e-01}}, float {{0x3FF19999A0000000|1.100000e\+00}}, float {{0x40019999A0000000|2.200000e\+00}}, float {{0x400A666660000000|3.300000e\+00}} }
 #[no_mangle]
 pub extern "C" fn structnestestructs() -> NestedStructs {
     NestedStructs { a: FloatFloat { f: 0.1, g: 1.1 }, b: FloatFloat { f: 2.2, g: 3.3 } }


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/190649 changes how float constants are printed in LLVM IR.

@rustbot label llvm-main