### PR TITLE
optimize: use with_capacity_and_hasher for builtin functions in rustc…

### DIFF
--- a/compiler/rustc_codegen_gcc/src/context.rs
+++ b/compiler/rustc_codegen_gcc/src/context.rs
@@ -223,8 +223,9 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         let isize_type = usize_type;
         let bool_type = context.new_type::<bool>();
 
-        let mut functions = FxHashMap::default();
         let builtins = ["abort"];
+        let mut functions =
+            FxHashMap::with_capacity_and_hasher(builtins.len(), Default::default());
 
         for builtin in builtins.iter() {
             functions.insert(builtin.to_string(), context.get_builtin_function(builtin));

--- a/compiler/rustc_codegen_gcc/src/context.rs
+++ b/compiler/rustc_codegen_gcc/src/context.rs
@@ -224,8 +224,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         let bool_type = context.new_type::<bool>();
 
         let builtins = ["abort"];
-        let mut functions =
-            FxHashMap::with_capacity_and_hasher(builtins.len(), Default::default());
+        let mut functions = FxHashMap::with_capacity_and_hasher(builtins.len(), Default::default());
 
         for builtin in builtins.iter() {
             functions.insert(builtin.to_string(), context.get_builtin_function(builtin));


### PR DESCRIPTION
…_codegen_gcc

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Ref rust-lang/rust#137005

Found a case where builtin functions are inserted into a map with a known size. Added with_capacity to avoid reallocations.