### PR TITLE
Refactor `CheckAttrVisitor` so rustfmt can format it.

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -123,288 +123,295 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     ) {
         let attrs = self.tcx.hir_attrs(hir_id);
         for attr in attrs {
-            let mut style = None;
             match attr {
-                Attribute::Parsed(AttributeKind::ProcMacro) => {
-                    self.check_proc_macro(hir_id, target, ProcMacroKind::FunctionLike)
+                Attribute::Parsed(attr_kind) => {
+                    self.check_one_parsed_attribute(hir_id, span, target, item, attrs, attr_kind);
+                    self.check_unused_attribute(hir_id, attr, None);
                 }
-                Attribute::Parsed(AttributeKind::ProcMacroAttribute) => {
-                    self.check_proc_macro(hir_id, target, ProcMacroKind::Attribute);
-                }
-                Attribute::Parsed(AttributeKind::ProcMacroDerive { .. }) => {
-                    self.check_proc_macro(hir_id, target, ProcMacroKind::Derive)
-                }
-                Attribute::Parsed(AttributeKind::Inline(InlineAttr::Force { .. }, ..)) => {} // handled separately below
-                Attribute::Parsed(AttributeKind::Inline(kind, attr_span)) => {
-                    self.check_inline(hir_id, *attr_span, kind, target)
-                }
-                Attribute::Parsed(AttributeKind::LoopMatch(attr_span)) => {
-                    self.check_loop_match(hir_id, *attr_span, target)
-                }
-                Attribute::Parsed(AttributeKind::ConstContinue(attr_span)) => {
-                    self.check_const_continue(hir_id, *attr_span, target)
-                }
-                Attribute::Parsed(AttributeKind::AllowInternalUnsafe(attr_span) | AttributeKind::AllowInternalUnstable(.., attr_span)) => {
-                    self.check_macro_only_attr(*attr_span, span, target, attrs)
-                }
-                Attribute::Parsed(AttributeKind::RustcAllowConstFnUnstable(_, first_span)) => {
-                    self.check_rustc_allow_const_fn_unstable(hir_id, *first_span, span, target)
-                }
-                Attribute::Parsed(AttributeKind::Deprecated { span: attr_span, .. }) => {
-                    self.check_deprecated(hir_id, *attr_span, target)
-                }
-                Attribute::Parsed(AttributeKind::TargetFeature{ attr_span, ..}) => {
-                    self.check_target_feature(hir_id, *attr_span, target, attrs)
-                }
-                Attribute::Parsed(AttributeKind::RustcDumpObjectLifetimeDefaults) => {
-                    self.check_dump_object_lifetime_defaults(hir_id);
-                }
-                &Attribute::Parsed(AttributeKind::RustcPubTransparent(attr_span)) => {
-                    self.check_rustc_pub_transparent(attr_span, span, attrs)
-                }
-                Attribute::Parsed(AttributeKind::RustcAlign {..}) => {
-
-                }
-                Attribute::Parsed(AttributeKind::Naked(..)) => {
-                    self.check_naked(hir_id, target)
-                }
-                Attribute::Parsed(AttributeKind::TrackCaller(attr_span)) => {
-                    self.check_track_caller(hir_id, *attr_span, attrs, target)
-                }
-                Attribute::Parsed(AttributeKind::NonExhaustive(attr_span)) => {
-                    self.check_non_exhaustive(*attr_span, span, target, item)
-                }
-                &Attribute::Parsed(AttributeKind::FfiPure(attr_span)) => {
-                    self.check_ffi_pure(attr_span, attrs)
-                }
-                Attribute::Parsed(AttributeKind::MayDangle(attr_span)) => {
-                    self.check_may_dangle(hir_id, *attr_span)
-                }
-                &Attribute::Parsed(AttributeKind::Sanitize { on_set, off_set, rtsan: _, span: attr_span}) => {
-                    self.check_sanitize(attr_span, on_set | off_set, span, target);
-                },
-                Attribute::Parsed(AttributeKind::Link(_, attr_span)) => {
-                    self.check_link(hir_id, *attr_span, span, target)
-                },
-                Attribute::Parsed(AttributeKind::MacroExport { span, .. }) => {
-                    self.check_macro_export(hir_id, *span, target)
-                },
-                Attribute::Parsed(AttributeKind::RustcLegacyConstGenerics{attr_span, fn_indexes}) => {
-                    self.check_rustc_legacy_const_generics(item, *attr_span, fn_indexes)
-                },
-                Attribute::Parsed(AttributeKind::Doc(attr)) => self.check_doc_attrs(attr, hir_id, target),
-                Attribute::Parsed(AttributeKind::EiiImpls(impls)) => {
-                     self.check_eii_impl(impls, target)
-                },
-                Attribute::Parsed(AttributeKind::RustcMustImplementOneOf { attr_span, fn_names }) => {
-                    self.check_rustc_must_implement_one_of(*attr_span, fn_names, hir_id,target)
-                },
-                Attribute::Parsed(AttributeKind::OnUnimplemented{directive}) => {self.check_diagnostic_on_unimplemented(hir_id, directive.as_deref())},
-                Attribute::Parsed(AttributeKind::OnConst{span, ..}) => {self.check_diagnostic_on_const(*span, hir_id, target, item)},
-                Attribute::Parsed(AttributeKind::OnMove { directive }) => {
-                    self.check_diagnostic_on_move(hir_id, directive.as_deref())
-                },
-                Attribute::Parsed(
-                    // tidy-alphabetical-start
-                    AttributeKind::RustcAllowIncoherentImpl(..)
-                    | AttributeKind::AutomaticallyDerived
-                    | AttributeKind::CfgAttrTrace
-                    | AttributeKind::CfgTrace(..)
-                    | AttributeKind::CfiEncoding { .. }
-                    | AttributeKind::Cold
-                    | AttributeKind::CollapseDebugInfo(..)
-                    | AttributeKind::CompilerBuiltins
-                    | AttributeKind::Coroutine
-                    | AttributeKind::Coverage (..)
-                    | AttributeKind::CrateName { .. }
-                    | AttributeKind::CrateType(..)
-                    | AttributeKind::CustomMir(..)
-                    | AttributeKind::DebuggerVisualizer(..)
-                    | AttributeKind::DefaultLibAllocator
-                    | AttributeKind::DoNotRecommend
-                    // `#[doc]` is actually a lot more than just doc comments, so is checked below
-                    | AttributeKind::DocComment {..}
-                    | AttributeKind::EiiDeclaration { .. }
-                    | AttributeKind::ExportName { .. }
-                    | AttributeKind::ExportStable
-                    | AttributeKind::Feature(..)
-                    | AttributeKind::FfiConst
-                    | AttributeKind::Fundamental
-                    | AttributeKind::Ignore { .. }
-                    | AttributeKind::InstructionSet(..)
-                    | AttributeKind::Lang(..)
-                    | AttributeKind::LinkName { .. }
-                    | AttributeKind::LinkOrdinal { .. }
-                    | AttributeKind::LinkSection { .. }
-                    | AttributeKind::Linkage(..)
-                    | AttributeKind::MacroEscape
-                    | AttributeKind::MacroUse { .. }
-                    | AttributeKind::Marker
-                    | AttributeKind::MoveSizeLimit { .. }
-                    | AttributeKind::MustNotSupend { .. }
-                    | AttributeKind::MustUse { .. }
-                    | AttributeKind::NeedsAllocator
-                    | AttributeKind::NeedsPanicRuntime
-                    | AttributeKind::NoBuiltins
-                    | AttributeKind::NoCore { .. }
-                    | AttributeKind::NoImplicitPrelude
-                    | AttributeKind::NoLink
-                    | AttributeKind::NoMain
-                    | AttributeKind::NoMangle(..)
-                    | AttributeKind::NoStd { .. }
-                    | AttributeKind::OnUnknown { .. }
-                    | AttributeKind::OnUnmatchArgs { .. }
-                    | AttributeKind::Optimize(..)
-                    | AttributeKind::PanicRuntime
-                    | AttributeKind::PatchableFunctionEntry { .. }
-                    | AttributeKind::Path(..)
-                    | AttributeKind::PatternComplexityLimit { .. }
-                    | AttributeKind::PinV2(..)
-                    | AttributeKind::PreludeImport
-                    | AttributeKind::ProfilerRuntime
-                    | AttributeKind::RecursionLimit { .. }
-                    | AttributeKind::ReexportTestHarnessMain(..)
-                    | AttributeKind::RegisterTool(..)
-                    // handled below this loop and elsewhere
-                    | AttributeKind::Repr { .. }
-                    | AttributeKind::RustcAbi { .. }
-                    | AttributeKind::RustcAllocator
-                    | AttributeKind::RustcAllocatorZeroed
-                    | AttributeKind::RustcAllocatorZeroedVariant { .. }
-                    | AttributeKind::RustcAsPtr
-                    | AttributeKind::RustcAutodiff(..)
-                    | AttributeKind::RustcBodyStability { .. }
-                    | AttributeKind::RustcBuiltinMacro { .. }
-                    | AttributeKind::RustcCaptureAnalysis
-                    | AttributeKind::RustcCguTestAttr(..)
-                    | AttributeKind::RustcClean(..)
-                    | AttributeKind::RustcCoherenceIsCore
-                    | AttributeKind::RustcCoinductive
-                    | AttributeKind::RustcConfusables { .. }
-                    | AttributeKind::RustcConstStability { .. }
-                    | AttributeKind::RustcConstStableIndirect
-                    | AttributeKind::RustcConversionSuggestion
-                    | AttributeKind::RustcDeallocator
-                    | AttributeKind::RustcDelayedBugFromInsideQuery
-                    | AttributeKind::RustcDenyExplicitImpl
-                    | AttributeKind::RustcDeprecatedSafe2024 {..}
-                    | AttributeKind::RustcDiagnosticItem(..)
-                    | AttributeKind::RustcDoNotConstCheck
-                    | AttributeKind::RustcDocPrimitive(..)
-                    | AttributeKind::RustcDummy
-                    | AttributeKind::RustcDumpDefParents
-                    | AttributeKind::RustcDumpDefPath(..)
-                    | AttributeKind::RustcDumpHiddenTypeOfOpaques
-                    | AttributeKind::RustcDumpInferredOutlives
-                    | AttributeKind::RustcDumpItemBounds
-                    | AttributeKind::RustcDumpLayout(..)
-                    | AttributeKind::RustcDumpPredicates
-                    | AttributeKind::RustcDumpSymbolName(..)
-                    | AttributeKind::RustcDumpUserArgs
-                    | AttributeKind::RustcDumpVariances
-                    | AttributeKind::RustcDumpVariancesOfOpaques
-                    | AttributeKind::RustcDumpVtable(..)
-                    | AttributeKind::RustcDynIncompatibleTrait(..)
-                    | AttributeKind::RustcEffectiveVisibility
-                    | AttributeKind::RustcEiiForeignItem
-                    | AttributeKind::RustcEvaluateWhereClauses
-                    | AttributeKind::RustcHasIncoherentInherentImpls
-                    | AttributeKind::RustcIfThisChanged(..)
-                    | AttributeKind::RustcInheritOverflowChecks
-                    | AttributeKind::RustcInsignificantDtor
-                    | AttributeKind::RustcIntrinsic
-                    | AttributeKind::RustcIntrinsicConstStableIndirect
-                    | AttributeKind::RustcLintOptDenyFieldAccess { .. }
-                    | AttributeKind::RustcLintOptTy
-                    | AttributeKind::RustcLintQueryInstability
-                    | AttributeKind::RustcLintUntrackedQueryInformation
-                    | AttributeKind::RustcMacroTransparency(_)
-                    | AttributeKind::RustcMain
-                    | AttributeKind::RustcMir(_)
-                    | AttributeKind::RustcMustMatchExhaustively(..)
-                    | AttributeKind::RustcNeverReturnsNullPtr
-                    | AttributeKind::RustcNeverTypeOptions {..}
-                    | AttributeKind::RustcNoImplicitAutorefs
-                    | AttributeKind::RustcNoImplicitBounds
-                    | AttributeKind::RustcNoMirInline
-                    | AttributeKind::RustcNoWritable
-                    | AttributeKind::RustcNonConstTraitMethod
-                    | AttributeKind::RustcNonnullOptimizationGuaranteed
-                    | AttributeKind::RustcNounwind
-                    | AttributeKind::RustcObjcClass { .. }
-                    | AttributeKind::RustcObjcSelector { .. }
-                    | AttributeKind::RustcOffloadKernel
-                    | AttributeKind::RustcParenSugar
-                    | AttributeKind::RustcPassByValue
-                    | AttributeKind::RustcPassIndirectlyInNonRusticAbis(..)
-                    | AttributeKind::RustcPreserveUbChecks
-                    | AttributeKind::RustcProcMacroDecls
-                    | AttributeKind::RustcReallocator
-                    | AttributeKind::RustcRegions
-                    | AttributeKind::RustcReservationImpl(..)
-                    | AttributeKind::RustcScalableVector { .. }
-                    | AttributeKind::RustcShouldNotBeCalledOnConstItems
-                    | AttributeKind::RustcSimdMonomorphizeLaneLimit(..)
-                    | AttributeKind::RustcSkipDuringMethodDispatch { .. }
-                    | AttributeKind::RustcSpecializationTrait
-                    | AttributeKind::RustcStdInternalSymbol
-                    | AttributeKind::RustcStrictCoherence(..)
-                    | AttributeKind::RustcTestMarker(..)
-                    | AttributeKind::RustcThenThisWouldNeed(..)
-                    | AttributeKind::RustcTrivialFieldReads
-                    | AttributeKind::RustcUnsafeSpecializationMarker
-                    | AttributeKind::ShouldPanic { .. }
-                    | AttributeKind::Stability { .. }
-                    | AttributeKind::TestRunner(..)
-                    | AttributeKind::ThreadLocal
-                    | AttributeKind::TypeLengthLimit { .. }
-                    | AttributeKind::UnstableFeatureBound(..)
-                    | AttributeKind::UnstableRemoved(..)
-                    | AttributeKind::Used { .. }
-                    | AttributeKind::WindowsSubsystem(..)
-                    // tidy-alphabetical-end
-                ) => { /* do nothing  */ }
                 Attribute::Unparsed(attr_item) => {
-                    style = Some(attr_item.style);
                     match attr.path().as_slice() {
-                        [
-                            // ok
-                            sym::allow
-                            | sym::expect
-                            | sym::warn
-                            | sym::deny
-                            | sym::forbid,
-                            ..
-                        ] => {}
-                        [name, rest@..] => {
-                            match BUILTIN_ATTRIBUTE_MAP.get(name) {
-                                Some(_) => {
-                                    if rest.len() > 0 && AttributeParser::is_parsed_attribute(slice::from_ref(name)) {
-                                        // Check if we tried to use a builtin attribute as an attribute namespace, like `#[must_use::skip]`.
-                                        // This check is here to solve https://github.com/rust-lang/rust/issues/137590
-                                        // An error is already produced for this case elsewhere
-                                        continue
-                                    }
+                        // ok
+                        [sym::allow | sym::expect | sym::warn | sym::deny | sym::forbid, ..] => {}
 
-                                    span_bug!(
-                                        attr.span(),
-                                        "builtin attribute {name:?} not handled by `CheckAttrVisitor`"
-                                    )
+                        [name, rest @ ..] => {
+                            if let Some(_) = BUILTIN_ATTRIBUTE_MAP.get(name) {
+                                if rest.len() > 0
+                                    && AttributeParser::is_parsed_attribute(slice::from_ref(name))
+                                {
+                                    // Check if we tried to use a builtin attribute as an attribute
+                                    // namespace, like `#[must_use::skip]`. This check is here to
+                                    // solve <https://github.com/rust-lang/rust/issues/137590>.
+                                    // An error is already produced for this case elsewhere.
+                                    return;
                                 }
-                                None => (),
+
+                                span_bug!(
+                                    attr.span(),
+                                    "builtin attribute {name:?} not handled by `CheckAttrVisitor`"
+                                )
                             }
                         }
+
                         [] => unreachable!(),
                     }
+
+                    self.check_unused_attribute(hir_id, attr, Some(attr_item.style));
                 }
             }
-
-            self.check_unused_attribute(hir_id, attr, style)
         }
 
         self.check_repr(attrs, span, target, item, hir_id);
         self.check_rustc_force_inline(hir_id, attrs, target);
         self.check_mix_no_mangle_export(hir_id, attrs);
+    }
+
+    /// Called by [`Self::check_attributes()`] to check a single attribute which is
+    /// [`Attribute::Parsed`].
+    ///
+    /// This is a separate function to help with comprehensibility and rustfmt-ability.
+    fn check_one_parsed_attribute(
+        &self,
+        hir_id: HirId,
+        span: Span,
+        target: Target,
+        item: Option<ItemLike<'_>>,
+        attrs: &[Attribute],
+        attr: &AttributeKind,
+    ) {
+        match attr {
+            AttributeKind::ProcMacro => {
+                self.check_proc_macro(hir_id, target, ProcMacroKind::FunctionLike)
+            }
+            AttributeKind::ProcMacroAttribute => {
+                self.check_proc_macro(hir_id, target, ProcMacroKind::Attribute);
+            }
+            AttributeKind::ProcMacroDerive { .. } => {
+                self.check_proc_macro(hir_id, target, ProcMacroKind::Derive)
+            }
+            AttributeKind::Inline(InlineAttr::Force { .. }, ..) => {} // handled separately below
+            AttributeKind::Inline(kind, attr_span) => {
+                self.check_inline(hir_id, *attr_span, kind, target)
+            }
+            AttributeKind::LoopMatch(attr_span) => {
+                self.check_loop_match(hir_id, *attr_span, target)
+            }
+            AttributeKind::ConstContinue(attr_span) => {
+                self.check_const_continue(hir_id, *attr_span, target)
+            }
+            AttributeKind::AllowInternalUnsafe(attr_span)
+            | AttributeKind::AllowInternalUnstable(.., attr_span) => {
+                self.check_macro_only_attr(*attr_span, span, target, attrs)
+            }
+            AttributeKind::RustcAllowConstFnUnstable(_, first_span) => {
+                self.check_rustc_allow_const_fn_unstable(hir_id, *first_span, span, target)
+            }
+            AttributeKind::Deprecated { span: attr_span, .. } => {
+                self.check_deprecated(hir_id, *attr_span, target)
+            }
+            AttributeKind::TargetFeature { attr_span, .. } => {
+                self.check_target_feature(hir_id, *attr_span, target, attrs)
+            }
+            AttributeKind::RustcDumpObjectLifetimeDefaults => {
+                self.check_dump_object_lifetime_defaults(hir_id);
+            }
+            &AttributeKind::RustcPubTransparent(attr_span) => {
+                self.check_rustc_pub_transparent(attr_span, span, attrs)
+            }
+            AttributeKind::RustcAlign { .. } => {}
+            AttributeKind::Naked(..) => self.check_naked(hir_id, target),
+            AttributeKind::TrackCaller(attr_span) => {
+                self.check_track_caller(hir_id, *attr_span, attrs, target)
+            }
+            AttributeKind::NonExhaustive(attr_span) => {
+                self.check_non_exhaustive(*attr_span, span, target, item)
+            }
+            &AttributeKind::FfiPure(attr_span) => self.check_ffi_pure(attr_span, attrs),
+            AttributeKind::MayDangle(attr_span) => self.check_may_dangle(hir_id, *attr_span),
+            &AttributeKind::Sanitize { on_set, off_set, rtsan: _, span: attr_span } => {
+                self.check_sanitize(attr_span, on_set | off_set, span, target);
+            }
+            AttributeKind::Link(_, attr_span) => self.check_link(hir_id, *attr_span, span, target),
+            AttributeKind::MacroExport { span, .. } => {
+                self.check_macro_export(hir_id, *span, target)
+            }
+            AttributeKind::RustcLegacyConstGenerics { attr_span, fn_indexes } => {
+                self.check_rustc_legacy_const_generics(item, *attr_span, fn_indexes)
+            }
+            AttributeKind::Doc(attr) => self.check_doc_attrs(attr, hir_id, target),
+            AttributeKind::EiiImpls(impls) => self.check_eii_impl(impls, target),
+            AttributeKind::RustcMustImplementOneOf { attr_span, fn_names } => {
+                self.check_rustc_must_implement_one_of(*attr_span, fn_names, hir_id, target)
+            }
+            AttributeKind::OnUnimplemented { directive } => {
+                self.check_diagnostic_on_unimplemented(hir_id, directive.as_deref())
+            }
+            AttributeKind::OnConst { span, .. } => {
+                self.check_diagnostic_on_const(*span, hir_id, target, item)
+            }
+            AttributeKind::OnMove { directive } => {
+                self.check_diagnostic_on_move(hir_id, directive.as_deref())
+            }
+
+            // All of the following attributes have no specific checks.
+            // tidy-alphabetical-start
+            AttributeKind::AutomaticallyDerived => (),
+            AttributeKind::CfgAttrTrace => (),
+            AttributeKind::CfgTrace(..) => (),
+            AttributeKind::CfiEncoding { .. } => (),
+            AttributeKind::Cold => (),
+            AttributeKind::CollapseDebugInfo(..) => (),
+            AttributeKind::CompilerBuiltins => (),
+            AttributeKind::Coroutine => (),
+            AttributeKind::Coverage(..) => (),
+            AttributeKind::CrateName { .. } => (),
+            AttributeKind::CrateType(..) => (),
+            AttributeKind::CustomMir(..) => (),
+            AttributeKind::DebuggerVisualizer(..) => (),
+            AttributeKind::DefaultLibAllocator => (),
+            AttributeKind::DoNotRecommend => (),
+            // `#[doc]` is actually a lot more than just doc comments, so is checked below
+            AttributeKind::DocComment { .. } => (),
+            AttributeKind::EiiDeclaration { .. } => (),
+            AttributeKind::ExportName { .. } => (),
+            AttributeKind::ExportStable => (),
+            AttributeKind::Feature(..) => (),
+            AttributeKind::FfiConst => (),
+            AttributeKind::Fundamental => (),
+            AttributeKind::Ignore { .. } => (),
+            AttributeKind::InstructionSet(..) => (),
+            AttributeKind::Lang(..) => (),
+            AttributeKind::LinkName { .. } => (),
+            AttributeKind::LinkOrdinal { .. } => (),
+            AttributeKind::LinkSection { .. } => (),
+            AttributeKind::Linkage(..) => (),
+            AttributeKind::MacroEscape => (),
+            AttributeKind::MacroUse { .. } => (),
+            AttributeKind::Marker => (),
+            AttributeKind::MoveSizeLimit { .. } => (),
+            AttributeKind::MustNotSupend { .. } => (),
+            AttributeKind::MustUse { .. } => (),
+            AttributeKind::NeedsAllocator => (),
+            AttributeKind::NeedsPanicRuntime => (),
+            AttributeKind::NoBuiltins => (),
+            AttributeKind::NoCore { .. } => (),
+            AttributeKind::NoImplicitPrelude => (),
+            AttributeKind::NoLink => (),
+            AttributeKind::NoMain => (),
+            AttributeKind::NoMangle(..) => (),
+            AttributeKind::NoStd { .. } => (),
+            AttributeKind::OnUnknown { .. } => (),
+            AttributeKind::OnUnmatchArgs { .. } => (),
+            AttributeKind::Optimize(..) => (),
+            AttributeKind::PanicRuntime => (),
+            AttributeKind::PatchableFunctionEntry { .. } => (),
+            AttributeKind::Path(..) => (),
+            AttributeKind::PatternComplexityLimit { .. } => (),
+            AttributeKind::PinV2(..) => (),
+            AttributeKind::PreludeImport => (),
+            AttributeKind::ProfilerRuntime => (),
+            AttributeKind::RecursionLimit { .. } => (),
+            AttributeKind::ReexportTestHarnessMain(..) => (),
+            AttributeKind::RegisterTool(..) => (),
+            // handled below this loop and elsewhere
+            AttributeKind::Repr { .. } => (),
+            AttributeKind::RustcAbi { .. } => (),
+            AttributeKind::RustcAllocator => (),
+            AttributeKind::RustcAllocatorZeroed => (),
+            AttributeKind::RustcAllocatorZeroedVariant { .. } => (),
+            AttributeKind::RustcAllowIncoherentImpl(..) => (),
+            AttributeKind::RustcAsPtr => (),
+            AttributeKind::RustcAutodiff(..) => (),
+            AttributeKind::RustcBodyStability { .. } => (),
+            AttributeKind::RustcBuiltinMacro { .. } => (),
+            AttributeKind::RustcCaptureAnalysis => (),
+            AttributeKind::RustcCguTestAttr(..) => (),
+            AttributeKind::RustcClean(..) => (),
+            AttributeKind::RustcCoherenceIsCore => (),
+            AttributeKind::RustcCoinductive => (),
+            AttributeKind::RustcConfusables { .. } => (),
+            AttributeKind::RustcConstStability { .. } => (),
+            AttributeKind::RustcConstStableIndirect => (),
+            AttributeKind::RustcConversionSuggestion => (),
+            AttributeKind::RustcDeallocator => (),
+            AttributeKind::RustcDelayedBugFromInsideQuery => (),
+            AttributeKind::RustcDenyExplicitImpl => (),
+            AttributeKind::RustcDeprecatedSafe2024 { .. } => (),
+            AttributeKind::RustcDiagnosticItem(..) => (),
+            AttributeKind::RustcDoNotConstCheck => (),
+            AttributeKind::RustcDocPrimitive(..) => (),
+            AttributeKind::RustcDummy => (),
+            AttributeKind::RustcDumpDefParents => (),
+            AttributeKind::RustcDumpDefPath(..) => (),
+            AttributeKind::RustcDumpHiddenTypeOfOpaques => (),
+            AttributeKind::RustcDumpInferredOutlives => (),
+            AttributeKind::RustcDumpItemBounds => (),
+            AttributeKind::RustcDumpLayout(..) => (),
+            AttributeKind::RustcDumpPredicates => (),
+            AttributeKind::RustcDumpSymbolName(..) => (),
+            AttributeKind::RustcDumpUserArgs => (),
+            AttributeKind::RustcDumpVariances => (),
+            AttributeKind::RustcDumpVariancesOfOpaques => (),
+            AttributeKind::RustcDumpVtable(..) => (),
+            AttributeKind::RustcDynIncompatibleTrait(..) => (),
+            AttributeKind::RustcEffectiveVisibility => (),
+            AttributeKind::RustcEiiForeignItem => (),
+            AttributeKind::RustcEvaluateWhereClauses => (),
+            AttributeKind::RustcHasIncoherentInherentImpls => (),
+            AttributeKind::RustcIfThisChanged(..) => (),
+            AttributeKind::RustcInheritOverflowChecks => (),
+            AttributeKind::RustcInsignificantDtor => (),
+            AttributeKind::RustcIntrinsic => (),
+            AttributeKind::RustcIntrinsicConstStableIndirect => (),
+            AttributeKind::RustcLintOptDenyFieldAccess { .. } => (),
+            AttributeKind::RustcLintOptTy => (),
+            AttributeKind::RustcLintQueryInstability => (),
+            AttributeKind::RustcLintUntrackedQueryInformation => (),
+            AttributeKind::RustcMacroTransparency(_) => (),
+            AttributeKind::RustcMain => (),
+            AttributeKind::RustcMir(_) => (),
+            AttributeKind::RustcMustMatchExhaustively(..) => (),
+            AttributeKind::RustcNeverReturnsNullPtr => (),
+            AttributeKind::RustcNeverTypeOptions { .. } => (),
+            AttributeKind::RustcNoImplicitAutorefs => (),
+            AttributeKind::RustcNoImplicitBounds => (),
+            AttributeKind::RustcNoMirInline => (),
+            AttributeKind::RustcNoWritable => (),
+            AttributeKind::RustcNonConstTraitMethod => (),
+            AttributeKind::RustcNonnullOptimizationGuaranteed => (),
+            AttributeKind::RustcNounwind => (),
+            AttributeKind::RustcObjcClass { .. } => (),
+            AttributeKind::RustcObjcSelector { .. } => (),
+            AttributeKind::RustcOffloadKernel => (),
+            AttributeKind::RustcParenSugar => (),
+            AttributeKind::RustcPassByValue => (),
+            AttributeKind::RustcPassIndirectlyInNonRusticAbis(..) => (),
+            AttributeKind::RustcPreserveUbChecks => (),
+            AttributeKind::RustcProcMacroDecls => (),
+            AttributeKind::RustcReallocator => (),
+            AttributeKind::RustcRegions => (),
+            AttributeKind::RustcReservationImpl(..) => (),
+            AttributeKind::RustcScalableVector { .. } => (),
+            AttributeKind::RustcShouldNotBeCalledOnConstItems => (),
+            AttributeKind::RustcSimdMonomorphizeLaneLimit(..) => (),
+            AttributeKind::RustcSkipDuringMethodDispatch { .. } => (),
+            AttributeKind::RustcSpecializationTrait => (),
+            AttributeKind::RustcStdInternalSymbol => (),
+            AttributeKind::RustcStrictCoherence(..) => (),
+            AttributeKind::RustcTestMarker(..) => (),
+            AttributeKind::RustcThenThisWouldNeed(..) => (),
+            AttributeKind::RustcTrivialFieldReads => (),
+            AttributeKind::RustcUnsafeSpecializationMarker => (),
+            AttributeKind::ShouldPanic { .. } => (),
+            AttributeKind::Stability { .. } => (),
+            AttributeKind::TestRunner(..) => (),
+            AttributeKind::ThreadLocal => (),
+            AttributeKind::TypeLengthLimit { .. } => (),
+            AttributeKind::UnstableFeatureBound(..) => (),
+            AttributeKind::UnstableRemoved(..) => (),
+            AttributeKind::Used { .. } => (),
+            AttributeKind::WindowsSubsystem(..) => (),
+            // tidy-alphabetical-end
+        }
     }
 
     fn check_rustc_must_implement_one_of(


### PR DESCRIPTION
I don’t have any need for this myself, but [I heard it was annoying people](https://rust-lang.zulipchat.com/#narrow/channel/147480-t-compiler.2Fdiagnostics/topic/.60.23.5Bdiagnostic.3A.3Aon_unimplemented.5D.60.20on.20trait.20methods.3F/near/594113991) and I like fixing formatting and structure problems.

The key change is that the do-nothing cases are now individual match arms instead of an enormous or-pattern. In order to achieve this cleanly, I moved the code handling `Attribute::Parsed` into a separate function matching `AttributeKind`s rather than `Attribute`s.

This also fixes `RustcAllowIncoherentImpl` being non-alphabetical because it was spelled without a leading “|” (though that by itself could be achieved by adding the optional leading “|”).
