### PR TITLE
Add paths for linked associated items

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -14,6 +14,7 @@ use std::io::{BufWriter, Write, stdout};
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, DefIdSet};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
@@ -129,24 +130,23 @@ impl<'tcx> JsonRenderer<'tcx> {
         paths
     }
 
-    #[allow(rustc::potential_query_instability)]
     fn add_intra_doc_link_paths(&self, paths: &mut FxHashMap<types::Id, types::ItemSummary>) {
         // The link target IDs were already interned when the `links` maps were emitted.
         // This only fills missing summaries in `paths`, where JSON object order is not meaningful.
-        for link in self.cache.intra_doc_links.values().flatten() {
+        #[allow(rustc::potential_query_instability)]
+        let links = self.cache.intra_doc_links.values();
+        for link in links.flatten() {
             let Some(UrlFragment::Item(item_id)) = link.fragment.as_ref() else {
                 continue;
             };
             let item_id = *item_id;
             let id = self.id_from_item_default(item_id.into());
 
-            if paths.contains_key(&id) || item_id.is_local() && !self.index.contains_key(&id) {
+            if paths.contains_key(&id) || (item_id.is_local() && !self.index.contains_key(&id)) {
                 continue;
             }
 
-            let Some(path) = self.path_for_link_target(link.page_id, item_id) else {
-                continue;
-            };
+            let path = self.path_for_link_target(link.page_id, item_id);
             let kind = ItemType::from_def_id(item_id, self.tcx);
             paths.insert(
                 id,
@@ -159,30 +159,44 @@ impl<'tcx> JsonRenderer<'tcx> {
         }
     }
 
-    fn path_for_link_target(&self, page_id: DefId, item_id: DefId) -> Option<Vec<String>> {
-        self.path_from_cached_parent(item_id).or_else(|| {
-            let mut path = self.path_from_cached_parent(page_id)?;
-            path.push(self.tcx.opt_item_name(item_id)?.to_string());
-            Some(path)
+    fn path_for_link_target(&self, page_id: DefId, item_id: DefId) -> Vec<String> {
+        let parent_id = self.tcx.parent(item_id);
+        // Inherent items have an unnamed impl parent, while variant fields have one extra named
+        // parent between themselves and their page.
+        let (mut path, variant_id) = match self.tcx.def_kind(parent_id) {
+            DefKind::Impl { .. } => (
+                self.cached_path(page_id).expect("intra-doc link page should have a cached path"),
+                None,
+            ),
+            DefKind::Variant => {
+                (self.path_for_named_item(self.tcx.parent(parent_id)), Some(parent_id))
+            }
+            _ => (self.path_for_named_item(parent_id), None),
+        };
+
+        if let Some(variant_id) = variant_id {
+            path.push(self.tcx.item_name(variant_id).to_string());
+        }
+        path.push(self.tcx.item_name(item_id).to_string());
+        path
+    }
+
+    fn path_for_named_item(&self, item_id: DefId) -> Vec<String> {
+        self.cached_path(item_id).unwrap_or_else(|| {
+            let kind = ItemType::from_def_id(item_id, self.tcx);
+            clean::inline::get_item_path(self.tcx, item_id, kind)
+                .into_iter()
+                .map(|name| name.to_string())
+                .collect()
         })
     }
 
-    fn path_from_cached_parent(&self, item_id: DefId) -> Option<Vec<String>> {
-        let mut suffix = Vec::new();
-        let mut current = item_id;
-
-        loop {
-            if let Some((path, _)) =
-                self.cache.paths.get(&current).or_else(|| self.cache.external_paths.get(&current))
-            {
-                let mut path = path.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-                path.extend(suffix.into_iter().rev());
-                return Some(path);
-            }
-
-            suffix.push(self.tcx.opt_item_name(current)?.to_string());
-            current = self.tcx.opt_parent(current)?;
-        }
+    fn cached_path(&self, item_id: DefId) -> Option<Vec<String>> {
+        self.cache
+            .paths
+            .get(&item_id)
+            .or_else(|| self.cache.external_paths.get(&item_id))
+            .map(|(path, _)| path.iter().map(|name| name.to_string()).collect())
     }
 }
 

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -32,7 +32,9 @@ use crate::docfs::PathError;
 use crate::error::Error;
 use crate::formats::FormatRenderer;
 use crate::formats::cache::Cache;
+use crate::formats::item_type::ItemType;
 use crate::json::conversions::IntoJson;
+use crate::passes::collect_intra_doc_links::UrlFragment;
 use crate::{clean, try_err};
 
 pub(crate) struct JsonRenderer<'tcx> {
@@ -103,6 +105,84 @@ impl<'tcx> JsonRenderer<'tcx> {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    fn paths(&self) -> FxHashMap<types::Id, types::ItemSummary> {
+        let mut paths = self
+            .cache
+            .paths
+            .iter()
+            .chain(&self.cache.external_paths)
+            .map(|(&k, &(ref path, kind))| {
+                (
+                    self.id_from_item_default(k.into()),
+                    types::ItemSummary {
+                        crate_id: k.krate.as_u32(),
+                        path: path.iter().map(|s| s.to_string()).collect(),
+                        kind: kind.into_json(self),
+                    },
+                )
+            })
+            .collect();
+
+        self.add_intra_doc_link_paths(&mut paths);
+        paths
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    fn add_intra_doc_link_paths(&self, paths: &mut FxHashMap<types::Id, types::ItemSummary>) {
+        // The link target IDs were already interned when the `links` maps were emitted.
+        // This only fills missing summaries in `paths`, where JSON object order is not meaningful.
+        for link in self.cache.intra_doc_links.values().flatten() {
+            let Some(UrlFragment::Item(item_id)) = link.fragment.as_ref() else {
+                continue;
+            };
+            let item_id = *item_id;
+            let id = self.id_from_item_default(item_id.into());
+
+            if paths.contains_key(&id) || item_id.is_local() && !self.index.contains_key(&id) {
+                continue;
+            }
+
+            let Some(path) = self.path_for_link_target(link.page_id, item_id) else {
+                continue;
+            };
+            let kind = ItemType::from_def_id(item_id, self.tcx);
+            paths.insert(
+                id,
+                types::ItemSummary {
+                    crate_id: item_id.krate.as_u32(),
+                    path,
+                    kind: kind.into_json(self),
+                },
+            );
+        }
+    }
+
+    fn path_for_link_target(&self, page_id: DefId, item_id: DefId) -> Option<Vec<String>> {
+        self.path_from_cached_parent(item_id).or_else(|| {
+            let mut path = self.path_from_cached_parent(page_id)?;
+            path.push(self.tcx.opt_item_name(item_id)?.to_string());
+            Some(path)
+        })
+    }
+
+    fn path_from_cached_parent(&self, item_id: DefId) -> Option<Vec<String>> {
+        let mut suffix = Vec::new();
+        let mut current = item_id;
+
+        loop {
+            if let Some((path, _)) =
+                self.cache.paths.get(&current).or_else(|| self.cache.external_paths.get(&current))
+            {
+                let mut path = path.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+                path.extend(suffix.into_iter().rev());
+                return Some(path);
+            }
+
+            suffix.push(self.tcx.opt_item_name(current)?.to_string());
+            current = self.tcx.opt_parent(current)?;
+        }
     }
 }
 
@@ -248,26 +328,12 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         let target = conversions::target(sess);
 
         debug!("Constructing Output");
+        let paths = self.paths();
         let output_crate = types::Crate {
             root: self.id_from_item_default(e.def_id().into()),
             crate_version: self.cache.crate_version.clone(),
             includes_private: self.cache.document_private,
-            paths: self
-                .cache
-                .paths
-                .iter()
-                .chain(&self.cache.external_paths)
-                .map(|(&k, &(ref path, kind))| {
-                    (
-                        self.id_from_item_default(k.into()),
-                        types::ItemSummary {
-                            crate_id: k.krate.as_u32(),
-                            path: path.iter().map(|s| s.to_string()).collect(),
-                            kind: kind.into_json(&self),
-                        },
-                    )
-                })
-                .collect(),
+            paths,
             external_crates: self
                 .cache
                 .extern_locations

--- a/tests/rustdoc-json/intra-doc-links/non_page.rs
+++ b/tests/rustdoc-json/intra-doc-links/non_page.rs
@@ -6,6 +6,9 @@
 //! [`Trait::AssocType`]
 //! [`Trait::ASSOC_CONST`]
 //! [`Trait::method`]
+//! [`std::vec::Vec::push`]
+//! [`std::io::ErrorKind::NotFound`]
+//! [`usize::MAX`]
 
 //@ set struct_field = "$.index[?(@.name=='struct_field')].id"
 //@ set Variant = "$.index[?(@.name=='Variant')].id"
@@ -18,6 +21,16 @@
 //@ is "$.index[?(@.name=='non_page')].links['`Trait::AssocType`']" $AssocType
 //@ is "$.index[?(@.name=='non_page')].links['`Trait::ASSOC_CONST`']" $ASSOC_CONST
 //@ is "$.index[?(@.name=='non_page')].links['`Trait::method`']" $method
+
+// Regression test for <https://github.com/rust-lang/rust/issues/152511>:
+// link target IDs for associated items need matching `paths` entries.
+//@ has "$.paths[*].path" '["non_page", "Struct", "struct_field"]'
+//@ has "$.paths[*].path" '["non_page", "Trait", "AssocType"]'
+//@ has "$.paths[*].path" '["non_page", "Trait", "ASSOC_CONST"]'
+//@ has "$.paths[*].path" '["non_page", "Trait", "method"]'
+//@ has "$.paths[*].path" '["alloc", "vec", "Vec", "push"]'
+//@ has "$.paths[*].path" '["core", "io", "error", "ErrorKind", "NotFound"]'
+//@ has "$.paths[*].path" '["std", "usize", "MAX"]'
 
 pub struct Struct {
     pub struct_field: i32,

--- a/tests/rustdoc-json/intra-doc-links/non_page.rs
+++ b/tests/rustdoc-json/intra-doc-links/non_page.rs
@@ -3,6 +3,7 @@
 
 //! [`Struct::struct_field`]
 //! [`Enum::Variant`]
+//! [`Enum::StructVariant::field`]
 //! [`Trait::AssocType`]
 //! [`Trait::ASSOC_CONST`]
 //! [`Trait::method`]
@@ -25,6 +26,7 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/152511>:
 // link target IDs for associated items need matching `paths` entries.
 //@ has "$.paths[*].path" '["non_page", "Struct", "struct_field"]'
+//@ has "$.paths[*].path" '["non_page", "Enum", "StructVariant", "field"]'
 //@ has "$.paths[*].path" '["non_page", "Trait", "AssocType"]'
 //@ has "$.paths[*].path" '["non_page", "Trait", "ASSOC_CONST"]'
 //@ has "$.paths[*].path" '["non_page", "Trait", "method"]'
@@ -38,6 +40,7 @@ pub struct Struct {
 
 pub enum Enum {
     Variant(),
+    StructVariant { field: i32 },
 }
 
 pub trait Trait {

--- a/tests/rustdoc-json/intra-doc-links/non_page.rs
+++ b/tests/rustdoc-json/intra-doc-links/non_page.rs
@@ -25,14 +25,23 @@
 
 // Regression test for <https://github.com/rust-lang/rust/issues/152511>:
 // link target IDs for associated items need matching `paths` entries.
-//@ has "$.paths[*].path" '["non_page", "Struct", "struct_field"]'
-//@ has "$.paths[*].path" '["non_page", "Enum", "StructVariant", "field"]'
-//@ has "$.paths[*].path" '["non_page", "Trait", "AssocType"]'
-//@ has "$.paths[*].path" '["non_page", "Trait", "ASSOC_CONST"]'
-//@ has "$.paths[*].path" '["non_page", "Trait", "method"]'
-//@ has "$.paths[*].path" '["alloc", "vec", "Vec", "push"]'
-//@ has "$.paths[*].path" '["core", "io", "error", "ErrorKind", "NotFound"]'
-//@ has "$.paths[*].path" '["std", "usize", "MAX"]'
+//@ jq_set crate = '.index[] | select(.name == "non_page")'
+//@ jq_set struct_field_link = '$crate.links["`Struct::struct_field`"]'
+//@ jq_set variant_field_link = '$crate.links["`Enum::StructVariant::field`"]'
+//@ jq_set assoc_type_link = '$crate.links["`Trait::AssocType`"]'
+//@ jq_set assoc_const_link = '$crate.links["`Trait::ASSOC_CONST`"]'
+//@ jq_set method_link = '$crate.links["`Trait::method`"]'
+//@ jq_set vec_push_link = '$crate.links["`std::vec::Vec::push`"]'
+//@ jq_set error_kind_link = '$crate.links["`std::io::ErrorKind::NotFound`"]'
+//@ jq_set usize_max_link = '$crate.links["`usize::MAX`"]'
+//@ jq_is '.paths["\($struct_field_link)"].path' '["non_page", "Struct", "struct_field"]'
+//@ jq_is '.paths["\($variant_field_link)"].path' '["non_page", "Enum", "StructVariant", "field"]'
+//@ jq_is '.paths["\($assoc_type_link)"].path' '["non_page", "Trait", "AssocType"]'
+//@ jq_is '.paths["\($assoc_const_link)"].path' '["non_page", "Trait", "ASSOC_CONST"]'
+//@ jq_is '.paths["\($method_link)"].path' '["non_page", "Trait", "method"]'
+//@ jq_is '.paths["\($vec_push_link)"].path' '["alloc", "vec", "Vec", "push"]'
+//@ jq_is '.paths["\($error_kind_link)"].path' '["core", "io", "error", "ErrorKind", "NotFound"]'
+//@ jq_is '.paths["\($usize_max_link)"].path' '["std", "usize", "MAX"]'
 
 pub struct Struct {
     pub struct_field: i32,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156474)*
<!-- homu-ignore:end -->

rustdoc-json emits intra-doc links to associated items using the associated item's id. For external associated items, that id is not present in `index`, and it was also missing from `paths`.

This PR backfills missing `paths` summaries for intra-doc link targets from the resolved page item and cached parent paths. Local targets are only added when already present in `index`, preserving jsondoclint's local-path invariant.

Fixes rust-lang/rust#152511