### PR TITLE
[rustdoc] Reduce sidebar items links width to allow selecting the text

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -739,10 +739,23 @@ ul.block, .block li, .block ul {
 	display: block;
 	padding: 0.25rem; /* 4px */
 	margin-right: 0.25rem;
+	background-clip: border-box;
 	/* extend click target to far edge of screen (mile wide bar) */
 	border-left: solid var(--sidebar-elems-left-padding) transparent;
 	margin-left: calc(-0.25rem - var(--sidebar-elems-left-padding));
-	background-clip: border-box;
+}
+
+.sidebar li {
+	margin-left: calc(-0.25rem - var(--sidebar-elems-left-padding));
+	padding-left: calc(0.25rem + var(--sidebar-elems-left-padding));
+}
+.sidebar li:hover  {
+	background-color: var(--sidebar-current-link-background-color);
+}
+.sidebar li a {
+	padding-left: 0;
+	border-left: 0;
+	margin-left: 0;
 }
 
 .hide-toc #rustdoc-toc, .hide-toc .in-crate {

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -188,13 +188,15 @@ assert-property: (".sidebar .sidebar-crate h2 a", {
 
 // Check that the sidebar links touch the left side of the box
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
-assert-position: (".sidebar .block a", {"x": -4})
+assert-position: (".sidebar .block li", {"x": -4})
+assert-position: (".sidebar .block li a", {"x": 24})
 assert-position: (".sidebar-crate > h2 > a", {"x": -3})
 
 // Check that the main sidebar links touch the left side of the box
 // but the crate name doesn't, because the logo takes that space
 go-to: "file://" + |DOC_PATH| + "/huge_logo/index.html"
-assert-position: (".sidebar .block a", {"x": -4})
+assert-position: (".sidebar .block li", {"x": -4})
+assert-position: (".sidebar .block li a", {"x": 24})
 // when side-by-side, it's not line wrapped
 assert-position-false: (".sidebar-crate > h2 > a", {"x": -3})
 // when line-wrapped, see that it becomes flush-left again


### PR DESCRIPTION
Currently:

https://github.com/user-attachments/assets/9c36c440-bd48-4d9e-acd3-cde08e3a2f28

With this PR:

https://github.com/user-attachments/assets/55460934-a44c-43e0-8161-6570f4c36df2

r? @lolbinarycat 