### PR TITLE
Split `Components` iterator to prefixed and non-prefixed versions and optimize `Components` for non-prefix path based platforms

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -700,14 +700,14 @@ impl<'a> Components<'a> {
             Some(FirstComponent::AbsolutePath) => {
                 self.first_comp = None;
                 if dir_front {
-                    self.advance_through_trailing_sep_front();
+                    self.normalize_front();
                 }
                 return Some(Component::RootDir);
             }
             Some(FirstComponent::Prefix) => {
                 self.first_comp = None;
                 if dir_front {
-                    self.advance_through_trailing_sep_front();
+                    self.normalize_front();
                 }
 
                 // SAFETY: Our front has the length of our Prefix component encoded at the start,
@@ -735,107 +735,74 @@ impl<'a> Components<'a> {
     /// Normalizes away trailing separators and current directory ('.') components
     /// in the forward direction.
     #[inline]
-    fn advance_through_trailing_sep_front(&mut self) {
-        // `Some(false)` is used to denote that
-        // we haven't seen a '.' component *yet*,
-        // `Some(true)` means we have seen a '.' component,
-        // and `None` means that the component is not '.'
-        let mut curr_dir = Some(false);
-        // We rebound to the original index for path components
-        // like '..' or 'abc.'
-        let mut rebound_ind: Option<usize> = None;
-        loop {
-            if self.front == self.back {
-                if let Some(front_ind) = rebound_ind {
-                    self.front = front_ind;
-                }
-                break;
-            }
-
-            if is_sep_byte(self.path[self.front]) {
-                if let Some(curr_dir_present) = curr_dir
-                    && curr_dir_present
-                {
-                    curr_dir = Some(false);
-                    rebound_ind = None;
+    fn normalize_front(&mut self) {
+        let path = &self.path[self.front..self.back];
+        // ".a", ".." needs to rebound back to index
+        // before the "." character
+        let mut cur_dir_present = false;
+        match path.iter().position(|b| {
+            if !is_sep_byte(*b) {
+                if *b == b'.' && !cur_dir_present {
+                    cur_dir_present = true;
+                    false
+                } else {
+                    true
                 }
             } else {
-                if self.path[self.front] == b'.' {
-                    if let Some(curr_dir_present) = curr_dir {
-                        if !curr_dir_present {
-                            curr_dir = Some(true);
-                            rebound_ind = Some(self.front);
-                        } else {
-                            curr_dir = None;
-                        }
-                    } else {
-                        if let Some(front_ind) = rebound_ind {
-                            self.front = front_ind;
-                        }
-                        break;
-                    }
+                cur_dir_present = false;
+                false
+            }
+        }) {
+            None => self.front = self.back,
+            Some(i) => {
+                if cur_dir_present {
+                    self.front += i - 1;
                 } else {
-                    if let Some(front_ind) = rebound_ind {
-                        self.front = front_ind;
-                    }
-                    break;
+                    self.front += i;
                 }
             }
-
-            self.front += 1;
         }
     }
 
     /// Normalizes away trailing separators and current directory ('.') components
     /// in the backward direction.
     #[inline]
-    fn advance_through_trailing_sep_back(&mut self) {
-        // `Some(false)` is used to denote that
-        // we haven't seen a '.' component *yet*,
-        // `Some(true)` means we have seen a '.' component,
-        // and `None` means that the component is not '.'
-        let mut curr_dir = Some(false);
-        // We rebound to the original index for path components
-        // like '..' or 'abc.'
-        let mut rebound_ind: Option<usize> = None;
-        loop {
-            if self.back == self.front {
-                if let Some(back_ind) = rebound_ind {
-                    self.back = back_ind;
-                }
-                break;
-            }
-
-            if is_sep_byte(self.path[self.back - 1]) {
-                if let Some(curr_dir_present) = curr_dir
-                    && curr_dir_present
-                {
-                    curr_dir = Some(false);
-                    rebound_ind = None;
+    fn normalize_back(&mut self) {
+        let path = &self.path[self.front..self.back];
+        // "a.", ".." needs to rebound back to index
+        // before the "." character
+        let mut cur_dir_present = false;
+        match path.iter().rposition(|b| {
+            if !is_sep_byte(*b) {
+                if *b == b'.' && !cur_dir_present {
+                    cur_dir_present = true;
+                    false
+                } else {
+                    true
                 }
             } else {
-                if self.path[self.back - 1] == b'.' {
-                    if let Some(curr_dir_present) = curr_dir {
-                        if !curr_dir_present {
-                            curr_dir = Some(true);
-                            rebound_ind = Some(self.back);
-                        } else {
-                            curr_dir = None;
-                        }
-                    } else {
-                        if let Some(back_ind) = rebound_ind {
-                            self.back = back_ind;
-                        }
-                        break;
-                    }
+                cur_dir_present = false;
+                false
+            }
+        }) {
+            None => {
+                // For cases like "./a", where our path
+                // will observe "." at the end, and we need to return
+                // that we observed "." component instead of
+                // returning an empty path.
+                if cur_dir_present {
+                    self.back = self.front + 1;
                 } else {
-                    if let Some(back_ind) = rebound_ind {
-                        self.back = back_ind;
-                    }
-                    break;
+                    self.back = self.front;
                 }
             }
-            self.back -= 1;
+            Some(i) => {
+                if cur_dir_present {
+                    self.back -= path.len() - i - 2;
+                } else {
+                    self.back -= path.len() - i - 1;
+                }
+            }
         }
     }
 
@@ -942,7 +909,7 @@ impl<'a> Components<'a> {
         let curr_front = self.front;
         // Normalizes trailing seps and curr dirs in preparation for
         // next front component
-        self.advance_through_trailing_sep_front();
+        self.normalize_front();
 
         // SAFETY: Our curr_front index always stops a byte after the ascii
         // separator byte or at self.back (should there be no ascii separator
@@ -968,7 +935,7 @@ impl<'a> Components<'a> {
         let curr_back = self.back;
         // Normalizes trailing seps and curr dirs in preparation for
         // next back component
-        self.advance_through_trailing_sep_back();
+        self.normalize_back();
 
         // Our curr_back is at the byte before an ascii separator byte or self.front,
         // (should there be no ascii separator in traversal), so we can always
@@ -1111,8 +1078,6 @@ impl<'a> PartialEq for Components<'a> {
     #[inline]
     fn eq(&self, other: &Components<'a>) -> bool {
         // Fast path for exact matches, e.g. for hashmap lookups.
-        // Don't explicitly compare the prefix or has_physical_root fields since they'll
-        // either be covered by the `path` buffer or are only relevant for `prefix_verbatim()`.
         if self.path.len() == other.path.len()
             && self.front == other.front
             && self.back == other.back
@@ -1168,24 +1133,20 @@ fn compare_components(left: Components<'_>, right: Components<'_>) -> cmp::Order
     // - backtrack to find separator before mismatch to avoid ambiguous parsings of '.' or '..' characters
     // - if found update state to only do a component-wise comparison on the remainder,
     //   otherwise do it on the full path
-    //
-    // The fast path isn't taken for paths with a PrefixComponent to avoid backtracking into
-    // the middle of one
-    // possible future improvement: a [u8]::first_mismatch simd implementation
 
-    let (left_path_len, left_path) = if left.first_comp.is_some() {
-        (left.back, &left.path[..left.back])
+    let left_path = if matches!(left.first_comp, Some(FirstComponent::Prefix)) {
+        &left.path[..left.back]
     } else {
-        (left.back - left.front, &left.path[left.front..left.back])
+        &left.path[left.front..left.back]
     };
-    let (right_path_len, right_path) = if right.first_comp.is_some() {
-        (right.back, &right.path[..right.back])
+    let right_path = if matches!(right.first_comp, Some(FirstComponent::Prefix)) {
+        &right.path[..right.back]
     } else {
-        (right.back - right.front, &right.path[right.front..right.back])
+        &right.path[right.front..right.back]
     };
     match left_path.iter().zip(right_path).position(|(&a, &b)| a != b) {
         // Left path and right path are exactly the same
-        None if left_path_len == right_path_len => return cmp::Ordering::Equal,
+        None if left_path.len() == right_path.len() => return cmp::Ordering::Equal,
         // FIXME: This should check the character that they conflict on so you
         // can return Ordering::Greater or Ordering::Less if the conflicting
         // characters is not a slash ("/") or current directory character (".")

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -696,36 +696,40 @@ impl<'a> Components<'a> {
     ///   return `None`.
     #[inline]
     fn consume_first_component(&mut self, dir_front: bool) -> Option<Component<'a>> {
-        if let Some(first_comp) = self.first_comp {
-            // Our first
-            self.first_comp = None;
-            if !matches!(first_comp, FirstComponent::RelativePath) {
+        match self.first_comp {
+            Some(FirstComponent::AbsolutePath) => {
+                self.first_comp = None;
                 if dir_front {
                     self.advance_through_trailing_sep_front();
                 }
-                if first_comp == FirstComponent::AbsolutePath {
-                    return Some(Component::RootDir);
-                } else {
-                    // Our front has the length of our Prefix component encoded at the start,
-                    // so this slice is guaranteed to contain the Prefix component if it's
-                    // unconsumed.
-                    let subslice =
-                        unsafe { OsStr::from_encoded_bytes_unchecked(&self.path[0..self.front]) };
-                    // This prefix is guaranteed to be made since we confirmed
-                    // our first component is a Prefix
-                    let prefix = parse_prefix(subslice).unwrap();
-                    return Some(Component::Prefix(PrefixComponent {
-                        raw: subslice,
-                        parsed: prefix,
-                    }));
+                return Some(Component::RootDir);
+            }
+            Some(FirstComponent::Prefix) => {
+                self.first_comp = None;
+                if dir_front {
+                    self.advance_through_trailing_sep_front();
                 }
-            } else {
+
+                // SAFETY: Our front has the length of our Prefix component encoded at the start,
+                // so this slice is guaranteed to contain the Prefix component if it's
+                // unconsumed.
+                let subslice =
+                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path[0..self.front]) };
+                // This prefix is guaranteed to be made since we confirmed
+                // our first component is a Prefix
+                let prefix = parse_prefix(subslice).unwrap();
+
+                Some(Component::Prefix(PrefixComponent { raw: subslice, parsed: prefix }))
+            }
+            Some(FirstComponent::RelativePath) => {
+                self.first_comp = None;
                 if dir_front {
                     return self.parse_next_component();
                 }
+                None
             }
+            None => None,
         }
-        None
     }
 
     /// Normalizes away trailing separators and current directory ('.') components
@@ -863,22 +867,6 @@ impl<'a> Components<'a> {
         }
     }
 
-    /// Parse a u8 slice into an OsStr, which is encoded into a `Component`
-    #[inline]
-    fn parse_single_component(&self, slice: &'a [u8]) -> Option<Component<'a>> {
-        match slice {
-            [] => return None,
-            [b'.'] => Some(Component::CurDir),
-            [b'.', b'.'] => Some(Component::ParentDir),
-            _ => {
-                // SAFETY: Our sliced path is guaranteed to capture the entire component
-                // due to delimiting on ascii separators from front and back.
-                let path_osstr = unsafe { OsStr::from_encoded_bytes_unchecked(slice) };
-                Some(Component::Normal(path_osstr))
-            }
-        }
-    }
-
     /// Extracts a slice corresponding to the portion of the path remaining for iteration.
     ///
     /// # Examples
@@ -903,6 +891,16 @@ impl<'a> Components<'a> {
                     }
                 }
                 FirstComponent::Prefix => {
+                    // We don't want to trim away separators from a Prefix
+                    // component
+                    if self.front == self.back {
+                        // SAFETY: If the first component is not consumed, then
+                        // front index encodes the whole length of the Prefix
+                        // component
+                        return unsafe { Path::from_u8_slice(&self.path[..self.front]) };
+                    }
+                    // SAFETY: Our back index is guaranteed to delimit at an ascii
+                    // separator byte, so this should present a valid path
                     return unsafe {
                         Path::from_u8_slice(&self.path[..self.back]).trim_trailing_sep()
                     };
@@ -915,6 +913,26 @@ impl<'a> Components<'a> {
         // where front is a byte after an ascii separator and back is at an ascii
         // separator, so this will always produce a valid path.
         unsafe { Path::from_u8_slice(&self.path[self.front..self.back]).trim_trailing_sep() }
+    }
+
+    /// Parse a u8 slice into an OsStr, which is encoded into a `Component`
+    #[inline]
+    fn parse_single_component(&self, slice: &'a [u8]) -> Option<Component<'a>> {
+        match slice {
+            [] => return None,
+            [b'.'] => Some(Component::CurDir),
+            [b'.', b'.'] => Some(Component::ParentDir),
+            _ => {
+                let root_slice = [MAIN_SEPARATOR as u8];
+                if slice == root_slice {
+                    return Some(Component::RootDir);
+                }
+                // SAFETY: Our sliced path is guaranteed to capture the entire component
+                // due to delimiting on ascii separators from front and back.
+                let path_osstr = unsafe { OsStr::from_encoded_bytes_unchecked(slice) };
+                Some(Component::Normal(path_osstr))
+            }
+        }
     }
 
     /// Parses the next component in `Components<'_>` from the left
@@ -1065,14 +1083,10 @@ impl<'a> Iterator for Components<'a> {
     fn next(&mut self) -> Option<Component<'a>> {
         // We reach this case when we no longer have anymore paths
         // to consume (return `None`), or if our front idx was initially
-        // equal to back idx (e.g. if we had `C:`, `.`, `/`)
-        if self.front >= self.back {
+        // equal to back idx (e.g. if we had `C:`, `.`, `/`), or if we
+        // had a front component initially
+        if self.front >= self.back || self.first_comp.is_some() {
             return self.consume_first_component(true);
-        }
-
-        // Consume our first component if we haven't already.
-        if let Some(comp) = self.consume_first_component(true) {
-            return Some(comp);
         }
 
         self.parse_next_component()
@@ -1083,8 +1097,8 @@ impl<'a> Iterator for Components<'a> {
 impl<'a> DoubleEndedIterator for Components<'a> {
     fn next_back(&mut self) -> Option<Component<'a>> {
         // We reach here when we no longer have anymore paths
-        // to consume, we're dealing with relative paths and
-        // need to output "", or we need to output Prefix component
+        // to consume, or we need to output Prefix component
+        // (anything else falls through this conditional)
         if self.back <= self.front {
             return self.consume_first_component(false);
         }
@@ -1107,9 +1121,22 @@ impl<'a> PartialEq for Components<'a> {
             && self.front == other.front
             && self.back == other.back
         {
-            // possible future improvement: this could bail out earlier if there were a
-            // reverse memcmp/bcmp comparing back to front
-            if self.path == other.path {
+            // If either `self` or `other` have a prefix (indicated by `first_comp`)
+            // we need to start at index 0 (because prefix length is encoded in
+            // `front`)
+            let path = if matches!(self.first_comp, Some(FirstComponent::Prefix)) {
+                &self.path[..self.back]
+            } else {
+                &self.path[self.front..self.back]
+            };
+
+            let other_path = if matches!(other.first_comp, Some(FirstComponent::Prefix)) {
+                &other.path[..other.back]
+            } else {
+                &other.path[other.front..other.back]
+            };
+
+            if path == other_path {
                 return true;
             }
         }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -391,20 +391,6 @@ fn validate_extension(extension: &OsStr) {
 // The core iterators
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Component parsing works by a double-ended state machine; the cursors at the
-/// front and back of the path each keep track of what parts of the path have
-/// been consumed so far.
-///
-/// Going front to back, a path is made up of a prefix, a starting
-/// directory component, and a body (of normal components)
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-enum State {
-    Prefix = 0,   // c:
-    StartDir = 1, // / or . or nothing
-    Body = 2,     // foo/bar/baz
-    Done = 3,
-}
-
 /// A structure wrapping a Windows path prefix as well as its unparsed string
 /// representation.
 ///
@@ -597,6 +583,18 @@ impl AsRef<Path> for Component<'_> {
     }
 }
 
+/// This is what the first component of our path is
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum FirstComponent {
+    /// For all paths starting with `/`
+    AbsolutePath,
+    /// For paths without root path like `.`, `..`, `a/`
+    RelativePath,
+    /// For Window specific paths like (`C:`, `\\?\UNC\server\share`,
+    /// `\\.\COM42`, etc.)
+    Prefix,
+}
+
 /// An iterator over the [`Component`]s of a [`Path`].
 ///
 /// This `struct` is created by the [`components`] method on [`Path`].
@@ -615,25 +613,26 @@ impl AsRef<Path> for Component<'_> {
 /// ```
 ///
 /// [`components`]: Path::components
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Components<'a> {
     // The path left to parse components from
     path: &'a [u8],
-
-    // The prefix as it was originally parsed, if any
-    prefix: Option<Prefix<'a>>,
-
-    // true if path *physically* has a root separator; for most Windows
+    // The iterator is double-ended, and these two indices keep track of how to
+    // subslice the path to present the unconsumed components accordingly
+    // If `front` starts off as non-zero on creating a `Components<'_>` iterator, a
+    // prefix is present. `back` may not equal to `path.len()` if trailing separators
+    // are present.
+    front: usize,
+    back: usize,
+    // True if path *physically* has a root separator; for most Windows
     // prefixes, it may have a "logical" root separator for the purposes of
     // normalization, e.g., \\server\share == \\server\share\.
     has_physical_root: bool,
-
-    // The iterator is double-ended, and these two states keep track of what has
-    // been produced from either end
-    front: State,
-    back: State,
+    // The first component parsed, be it a relative path (""), an absolute path ("/"),
+    // or a Prefix, which is Windows Specific
+    first_comp: Option<FirstComponent>,
 }
 
 /// An iterator over the [`Component`]s of a [`Path`], as [`OsStr`] slices.
@@ -665,49 +664,219 @@ impl fmt::Debug for Components<'_> {
 }
 
 impl<'a> Components<'a> {
-    // how long is the prefix, if any?
-    #[inline]
-    fn prefix_len(&self) -> usize {
-        if !HAS_PREFIXES {
-            return 0;
+    /// Is the *original* path rooted?
+    fn has_root(&self) -> bool {
+        if self.has_physical_root {
+            return true;
         }
-        self.prefix.as_ref().map(Prefix::len).unwrap_or(0)
-    }
 
-    #[inline]
-    fn prefix_verbatim(&self) -> bool {
-        if !HAS_PREFIXES {
-            return false;
+        // SAFETY: This u8 slice is the entire original path unmodified. The caller to
+        // `Path::components` should have given us a valid `Path`.
+        if HAS_PREFIXES
+            && let Some(p) = parse_prefix(unsafe { OsStr::from_encoded_bytes_unchecked(self.path) })
+        {
+            if p.has_implicit_root() {
+                return true;
+            }
         }
-        self.prefix.as_ref().map(Prefix::is_verbatim).unwrap_or(false)
+        false
     }
 
-    /// how much of the prefix is left from the point of view of iteration?
+    /// This is a helper function for consuming the  physical first component in
+    /// either `Components::next`/`Components::next_back`.
+    ///
+    /// There are four cases we can have here:
+    /// - We have an unconsumed absolute component (`/`). We should just output `/`
+    ///   in this case.
+    /// - We have an unconsumed prefix component (Windows specific, e.g. `C:`).
+    ///   We should just return that prefix component
+    /// - We have a relative directory, we should just parse the component as
+    ///   normal for the front direction only (due to 0 indexing front index)
+    /// - We don't have a start component (frequent case), which means we just
+    ///   return `None`.
     #[inline]
-    fn prefix_remaining(&self) -> usize {
-        if !HAS_PREFIXES {
-            return 0;
+    fn consume_first_component(&mut self, dir_front: bool) -> Option<Component<'a>> {
+        if let Some(first_comp) = self.first_comp {
+            // Our first
+            self.first_comp = None;
+            if !matches!(first_comp, FirstComponent::RelativePath) {
+                if dir_front {
+                    self.advance_through_trailing_sep_front();
+                }
+                if first_comp == FirstComponent::AbsolutePath {
+                    return Some(Component::RootDir);
+                } else {
+                    // Our front has the length of our Prefix component encoded at the start,
+                    // so this slice is guaranteed to contain the Prefix component if it's
+                    // unconsumed.
+                    let subslice =
+                        unsafe { OsStr::from_encoded_bytes_unchecked(&self.path[0..self.front]) };
+                    // This prefix is guaranteed to be made since we confirmed
+                    // our first component is a Prefix
+                    let prefix = parse_prefix(subslice).unwrap();
+                    return Some(Component::Prefix(PrefixComponent {
+                        raw: subslice,
+                        parsed: prefix,
+                    }));
+                }
+            } else {
+                if dir_front {
+                    return self.parse_next_component();
+                }
+            }
         }
-        if self.front == State::Prefix { self.prefix_len() } else { 0 }
+        None
     }
 
-    // Given the iteration so far, how much of the pre-State::Body path is left?
+    /// Normalizes away trailing separators and current directory ('.') components
+    /// in the forward direction.
     #[inline]
-    fn len_before_body(&self) -> usize {
-        let root = if self.front <= State::StartDir && self.has_physical_root { 1 } else { 0 };
-        let cur_dir = if self.front <= State::StartDir && self.include_cur_dir() { 1 } else { 0 };
-        self.prefix_remaining() + root + cur_dir
+    fn advance_through_trailing_sep_front(&mut self) {
+        // `Some(false)` is used to denote that
+        // we haven't seen a '.' component *yet*,
+        // `Some(true)` means we have seen a '.' component,
+        // and `None` means that the component is not '.'
+        let mut curr_dir = Some(false);
+        // We rebound to the original index for path components
+        // like '..' or 'abc.'
+        let mut rebound_ind: Option<usize> = None;
+        loop {
+            if self.front == self.back {
+                if let Some(front_ind) = rebound_ind {
+                    self.front = front_ind;
+                }
+                break;
+            }
+
+            if is_sep_byte(self.path[self.front]) {
+                if let Some(curr_dir_present) = curr_dir
+                    && curr_dir_present
+                {
+                    curr_dir = Some(false);
+                    rebound_ind = None;
+                }
+            } else {
+                if self.path[self.front] == b'.' {
+                    if let Some(curr_dir_present) = curr_dir {
+                        if !curr_dir_present {
+                            curr_dir = Some(true);
+                            rebound_ind = Some(self.front);
+                        } else {
+                            curr_dir = None;
+                        }
+                    } else {
+                        if let Some(front_ind) = rebound_ind {
+                            self.front = front_ind;
+                        }
+                        break;
+                    }
+                } else {
+                    if let Some(front_ind) = rebound_ind {
+                        self.front = front_ind;
+                    }
+                    break;
+                }
+            }
+
+            self.front += 1;
+        }
     }
 
-    // is the iteration complete?
+    /// Normalizes away trailing separators and current directory ('.') components
+    /// in the backward direction.
     #[inline]
-    fn finished(&self) -> bool {
-        self.front == State::Done || self.back == State::Done || self.front > self.back
+    fn advance_through_trailing_sep_back(&mut self) {
+        // `Some(false)` is used to denote that
+        // we haven't seen a '.' component *yet*,
+        // `Some(true)` means we have seen a '.' component,
+        // and `None` means that the component is not '.'
+        let mut curr_dir = Some(false);
+        // We rebound to the original index for path components
+        // like '..' or 'abc.'
+        let mut rebound_ind: Option<usize> = None;
+        loop {
+            if self.back == self.front {
+                if let Some(back_ind) = rebound_ind {
+                    self.back = back_ind;
+                }
+                break;
+            }
+
+            if is_sep_byte(self.path[self.back - 1]) {
+                if let Some(curr_dir_present) = curr_dir
+                    && curr_dir_present
+                {
+                    curr_dir = Some(false);
+                    rebound_ind = None;
+                }
+            } else {
+                if self.path[self.back - 1] == b'.' {
+                    if let Some(curr_dir_present) = curr_dir {
+                        if !curr_dir_present {
+                            curr_dir = Some(true);
+                            rebound_ind = Some(self.back);
+                        } else {
+                            curr_dir = None;
+                        }
+                    } else {
+                        if let Some(back_ind) = rebound_ind {
+                            self.back = back_ind;
+                        }
+                        break;
+                    }
+                } else {
+                    if let Some(back_ind) = rebound_ind {
+                        self.back = back_ind;
+                    }
+                    break;
+                }
+            }
+            self.back -= 1;
+        }
     }
 
+    /// Increments our front pointer until we find the
+    /// next separator byte or have reached the component
+    /// that back index is pointing at.
     #[inline]
-    fn is_sep_byte(&self, b: u8) -> bool {
-        if self.prefix_verbatim() { is_verbatim_sep(b) } else { is_sep_byte(b) }
+    fn find_next_separator_front(&mut self) {
+        while self.front < self.back {
+            if is_sep_byte(self.path[self.front]) {
+                self.front += 1;
+                break;
+            }
+            self.front += 1;
+        }
+    }
+
+    /// Decrements our back pointer until we find the
+    /// next separator byte or have reached the component
+    /// that front index is pointing to.
+    #[inline]
+    fn find_next_separator_back(&mut self) {
+        while self.back > self.front {
+            if is_sep_byte(self.path[self.back - 1]) {
+                self.back -= 1;
+                break;
+            }
+            self.back -= 1;
+        }
+    }
+
+    /// Parse a u8 slice into an OsStr, which is encoded into a `Component`
+    #[inline]
+    fn parse_single_component(&self, slice: &'a [u8]) -> Option<Component<'a>> {
+        match slice {
+            [] => return None,
+            [b'.'] => Some(Component::CurDir),
+            [b'.', b'.'] => Some(Component::ParentDir),
+            _ => {
+                // SAFETY: Our sliced path is guaranteed to capture the entire component
+                // due to delimiting on ascii separators from front and back.
+                let path_osstr = unsafe { OsStr::from_encoded_bytes_unchecked(slice) };
+                Some(Component::Normal(path_osstr))
+            }
+        }
     }
 
     /// Extracts a slice corresponding to the portion of the path remaining for iteration.
@@ -726,103 +895,76 @@ impl<'a> Components<'a> {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn as_path(&self) -> &'a Path {
-        let mut comps = self.clone();
-        if comps.front == State::Body {
-            comps.trim_left();
-        }
-        if comps.back == State::Body {
-            comps.trim_right();
-        }
-        unsafe { Path::from_u8_slice(comps.path) }
-    }
-
-    /// Is the *original* path rooted?
-    fn has_root(&self) -> bool {
-        if self.has_physical_root {
-            return true;
-        }
-        if HAS_PREFIXES && let Some(p) = self.prefix {
-            if p.has_implicit_root() {
-                return true;
+        if let Some(first_comp) = self.first_comp {
+            match first_comp {
+                FirstComponent::AbsolutePath => {
+                    if self.back == 0 {
+                        return Path::new("/");
+                    }
+                }
+                FirstComponent::Prefix => {
+                    return unsafe {
+                        Path::from_u8_slice(&self.path[..self.back]).trim_trailing_sep()
+                    };
+                }
+                FirstComponent::RelativePath => {}
             }
         }
-        false
+
+        // SAFETY: front and back index are delimited by ascii separator bytes,
+        // where front is a byte after an ascii separator and back is at an ascii
+        // separator, so this will always produce a valid path.
+        unsafe { Path::from_u8_slice(&self.path[self.front..self.back]).trim_trailing_sep() }
     }
 
-    /// Should the normalized path include a leading . ?
-    fn include_cur_dir(&self) -> bool {
-        if self.has_root() {
-            return false;
-        }
-        let slice = &self.path[self.prefix_remaining()..];
-        match slice {
-            [b'.'] => true,
-            [b'.', b, ..] => self.is_sep_byte(*b),
-            _ => false,
-        }
-    }
+    /// Parses the next component in `Components<'_>` from the left
+    fn parse_next_component(&mut self) -> Option<Component<'a>> {
+        // Our current `self.front` index at this point is the start
+        // of the component name
+        let before_front = self.front;
+        // We trace our `self.front` idx down the path until
+        // we hit a separator.
+        self.find_next_separator_front();
+        let curr_front = self.front;
+        // Normalizes trailing seps and curr dirs in preparation for
+        // next front component
+        self.advance_through_trailing_sep_front();
 
-    // parse a given byte sequence following the OsStr encoding into the
-    // corresponding path component
-    unsafe fn parse_single_component<'b>(&self, comp: &'b [u8]) -> Option<Component<'b>> {
-        match comp {
-            b"." if HAS_PREFIXES && self.prefix_verbatim() => Some(Component::CurDir),
-            b"." => None, // . components are normalized away, except at
-            // the beginning of a path, which is treated
-            // separately via `include_cur_dir`
-            b".." => Some(Component::ParentDir),
-            b"" => None,
-            _ => Some(Component::Normal(unsafe { OsStr::from_encoded_bytes_unchecked(comp) })),
-        }
-    }
-
-    // parse a component from the left, saying how many bytes to consume to
-    // remove the component
-    fn parse_next_component(&self) -> (usize, Option<Component<'a>>) {
-        debug_assert!(self.front == State::Body);
-        let (extra, comp) = match self.path.iter().position(|b| self.is_sep_byte(*b)) {
-            None => (0, self.path),
-            Some(i) => (1, &self.path[..i]),
+        // SAFETY: Our curr_front index always stops a byte after the ascii
+        // separator byte or at self.back (should there be no ascii separator
+        // in traversal), so we can always construct a valid u8 path slice
+        let sliced_path = if curr_front > 0 && is_sep_byte(self.path[curr_front - 1]) {
+            &self.path[before_front..curr_front - 1]
+        } else {
+            &self.path[before_front..curr_front]
         };
-        // SAFETY: `comp` is a valid substring, since it is split on a separator.
-        (comp.len() + extra, unsafe { self.parse_single_component(comp) })
+        self.parse_single_component(sliced_path)
     }
 
-    // parse a component from the right, saying how many bytes to consume to
-    // remove the component
-    fn parse_next_component_back(&self) -> (usize, Option<Component<'a>>) {
-        debug_assert!(self.back == State::Body);
-        let start = self.len_before_body();
-        let (extra, comp) = match self.path[start..].iter().rposition(|b| self.is_sep_byte(*b)) {
-            None => (0, &self.path[start..]),
-            Some(i) => (1, &self.path[start + i + 1..]),
+    /// Parses the next back component in `Components<'_>` from the
+    /// right
+    fn parse_next_back_component(&mut self) -> Option<Component<'a>> {
+        // Our current `self.back` index at this point encompasses
+        // the parent path
+        let before_back = self.back;
+        // We trace our `self.back` idx up the path until we reach a
+        // separator byte. This prepares the path we return on the next
+        // call to this function.
+        self.find_next_separator_back();
+        let curr_back = self.back;
+        // Normalizes trailing seps and curr dirs in preparation for
+        // next back component
+        self.advance_through_trailing_sep_back();
+
+        // Our curr_back is at the byte before an ascii separator byte or self.front,
+        // (should there be no ascii separator in traversal), so we can always
+        // construct a valid u8 path slice
+        let sliced_path = if is_sep_byte(self.path[curr_back]) {
+            &self.path[curr_back + 1..before_back]
+        } else {
+            &self.path[curr_back..before_back]
         };
-        // SAFETY: `comp` is a valid substring, since it is split on a separator.
-        (comp.len() + extra, unsafe { self.parse_single_component(comp) })
-    }
-
-    // trim away repeated separators (i.e., empty components) on the left
-    fn trim_left(&mut self) {
-        while !self.path.is_empty() {
-            let (size, comp) = self.parse_next_component();
-            if comp.is_some() {
-                return;
-            } else {
-                self.path = &self.path[size..];
-            }
-        }
-    }
-
-    // trim away repeated separators (i.e., empty components) on the right
-    fn trim_right(&mut self) {
-        while self.path.len() > self.len_before_body() {
-            let (size, comp) = self.parse_next_component_back();
-            if comp.is_some() {
-                return;
-            } else {
-                self.path = &self.path[..self.path.len() - size];
-            }
-        }
+        self.parse_single_component(sliced_path)
     }
 }
 
@@ -921,101 +1063,33 @@ impl<'a> Iterator for Components<'a> {
     type Item = Component<'a>;
 
     fn next(&mut self) -> Option<Component<'a>> {
-        while !self.finished() {
-            match self.front {
-                // most likely case first
-                State::Body if !self.path.is_empty() => {
-                    let (size, comp) = self.parse_next_component();
-                    self.path = &self.path[size..];
-                    if comp.is_some() {
-                        return comp;
-                    }
-                }
-                State::Body => {
-                    self.front = State::Done;
-                }
-                State::StartDir => {
-                    self.front = State::Body;
-                    if self.has_physical_root {
-                        debug_assert!(!self.path.is_empty());
-                        self.path = &self.path[1..];
-                        return Some(Component::RootDir);
-                    } else if HAS_PREFIXES && let Some(p) = self.prefix {
-                        if p.has_implicit_root() && !p.is_verbatim() {
-                            return Some(Component::RootDir);
-                        }
-                    } else if self.include_cur_dir() {
-                        debug_assert!(!self.path.is_empty());
-                        self.path = &self.path[1..];
-                        return Some(Component::CurDir);
-                    }
-                }
-                _ if const { !HAS_PREFIXES } => unreachable!(),
-                State::Prefix if self.prefix_len() == 0 => {
-                    self.front = State::StartDir;
-                }
-                State::Prefix => {
-                    self.front = State::StartDir;
-                    debug_assert!(self.prefix_len() <= self.path.len());
-                    let raw = &self.path[..self.prefix_len()];
-                    self.path = &self.path[self.prefix_len()..];
-                    return Some(Component::Prefix(PrefixComponent {
-                        raw: unsafe { OsStr::from_encoded_bytes_unchecked(raw) },
-                        parsed: self.prefix.unwrap(),
-                    }));
-                }
-                State::Done => unreachable!(),
-            }
+        // We reach this case when we no longer have anymore paths
+        // to consume (return `None`), or if our front idx was initially
+        // equal to back idx (e.g. if we had `C:`, `.`, `/`)
+        if self.front >= self.back {
+            return self.consume_first_component(true);
         }
-        None
+
+        // Consume our first component if we haven't already.
+        if let Some(comp) = self.consume_first_component(true) {
+            return Some(comp);
+        }
+
+        self.parse_next_component()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> DoubleEndedIterator for Components<'a> {
     fn next_back(&mut self) -> Option<Component<'a>> {
-        while !self.finished() {
-            match self.back {
-                State::Body if self.path.len() > self.len_before_body() => {
-                    let (size, comp) = self.parse_next_component_back();
-                    self.path = &self.path[..self.path.len() - size];
-                    if comp.is_some() {
-                        return comp;
-                    }
-                }
-                State::Body => {
-                    self.back = State::StartDir;
-                }
-                State::StartDir => {
-                    self.back = if HAS_PREFIXES { State::Prefix } else { State::Done };
-                    if self.has_physical_root {
-                        self.path = &self.path[..self.path.len() - 1];
-                        return Some(Component::RootDir);
-                    } else if HAS_PREFIXES && let Some(p) = self.prefix {
-                        if p.has_implicit_root() && !p.is_verbatim() {
-                            return Some(Component::RootDir);
-                        }
-                    } else if self.include_cur_dir() {
-                        self.path = &self.path[..self.path.len() - 1];
-                        return Some(Component::CurDir);
-                    }
-                }
-                _ if !HAS_PREFIXES => unreachable!(),
-                State::Prefix if self.prefix_len() > 0 => {
-                    self.back = State::Done;
-                    return Some(Component::Prefix(PrefixComponent {
-                        raw: unsafe { OsStr::from_encoded_bytes_unchecked(self.path) },
-                        parsed: self.prefix.unwrap(),
-                    }));
-                }
-                State::Prefix => {
-                    self.back = State::Done;
-                    return None;
-                }
-                State::Done => unreachable!(),
-            }
+        // We reach here when we no longer have anymore paths
+        // to consume, we're dealing with relative paths and
+        // need to output "", or we need to output Prefix component
+        if self.back <= self.front {
+            return self.consume_first_component(false);
         }
-        None
+
+        self.parse_next_back_component()
     }
 }
 
@@ -1026,16 +1100,12 @@ impl FusedIterator for Components<'_> {}
 impl<'a> PartialEq for Components<'a> {
     #[inline]
     fn eq(&self, other: &Components<'a>) -> bool {
-        let Components { path: _, front: _, back: _, has_physical_root: _, prefix: _ } = self;
-
         // Fast path for exact matches, e.g. for hashmap lookups.
         // Don't explicitly compare the prefix or has_physical_root fields since they'll
         // either be covered by the `path` buffer or are only relevant for `prefix_verbatim()`.
         if self.path.len() == other.path.len()
             && self.front == other.front
-            && self.back == State::Body
-            && other.back == State::Body
-            && self.prefix_verbatim() == other.prefix_verbatim()
+            && self.back == other.back
         {
             // possible future improvement: this could bail out earlier if there were a
             // reverse memcmp/bcmp comparing back to front
@@ -1068,7 +1138,7 @@ impl Ord for Components<'_> {
     }
 }
 
-fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
+fn compare_components(left: Components<'_>, right: Components<'_>) -> cmp::Ordering {
     // Fast path for long shared prefixes
     //
     // - compare raw bytes to find first mismatch
@@ -1078,23 +1148,27 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
     //
     // The fast path isn't taken for paths with a PrefixComponent to avoid backtracking into
     // the middle of one
-    if left.prefix.is_none() && right.prefix.is_none() && left.front == right.front {
-        // possible future improvement: a [u8]::first_mismatch simd implementation
-        let first_difference = match left.path.iter().zip(right.path).position(|(&a, &b)| a != b) {
-            None if left.path.len() == right.path.len() => return cmp::Ordering::Equal,
-            None => left.path.len().min(right.path.len()),
-            Some(diff) => diff,
-        };
+    // possible future improvement: a [u8]::first_mismatch simd implementation
 
-        if let Some(previous_sep) =
-            left.path[..first_difference].iter().rposition(|&b| left.is_sep_byte(b))
-        {
-            let mismatched_component_start = previous_sep + 1;
-            left.path = &left.path[mismatched_component_start..];
-            left.front = State::Body;
-            right.path = &right.path[mismatched_component_start..];
-            right.front = State::Body;
-        }
+    let (left_path_len, left_path) = if left.first_comp.is_some() {
+        (left.back, &left.path[..left.back])
+    } else {
+        (left.back - left.front, &left.path[left.front..left.back])
+    };
+    let (right_path_len, right_path) = if right.first_comp.is_some() {
+        (right.back, &right.path[..right.back])
+    } else {
+        (right.back - right.front, &right.path[right.front..right.back])
+    };
+    match left_path.iter().zip(right_path).position(|(&a, &b)| a != b) {
+        // Left path and right path are exactly the same
+        None if left_path_len == right_path_len => return cmp::Ordering::Equal,
+        // FIXME: This should check the character that they conflict on so you
+        // can return Ordering::Greater or Ordering::Less if the conflicting
+        // characters is not a slash ("/") or current directory character (".")
+        // Some(pos) => {
+        // }
+        _ => {}
     }
 
     Iterator::cmp(left, right)
@@ -1344,11 +1418,11 @@ impl PathBuf {
         let mut need_sep = buf.last().map(|c| !is_sep_byte(*c)).unwrap_or(false);
 
         // in the special case of `C:` on Windows, do *not* add a separator
-        let comps = self.components();
+        let parsed_prefix = parse_prefix(&self.inner);
 
-        if comps.prefix_len() > 0
-            && comps.prefix_len() == comps.path.len()
-            && comps.prefix.unwrap().is_drive()
+        if let Some(prefix) = parsed_prefix
+            && prefix.len() == self.inner.len()
+            && prefix.is_drive()
         {
             need_sep = false
         }
@@ -1367,7 +1441,11 @@ impl PathBuf {
             self.inner.clear();
 
         // verbatim paths need . and .. removed
-        } else if comps.prefix_verbatim() && !path.inner.is_empty() {
+        } else if let Some(prefix) = parsed_prefix
+            && prefix.is_verbatim()
+            && !path.inner.is_empty()
+        {
+            let comps = self.components();
             let mut buf: Vec<_> = comps.collect();
             for c in path.components() {
                 match c {
@@ -1408,7 +1486,9 @@ impl PathBuf {
 
         // `path` has a root but no prefix, e.g., `\windows` (Windows only)
         } else if path.has_root() {
-            let prefix_len = self.components().prefix_remaining();
+            // On creating a components iterator, if front index
+            // is non-zero we have a prefix.
+            let prefix_len = self.components().front;
             self.inner.truncate(prefix_len);
 
         // `path` is a pure relative path
@@ -2575,7 +2655,7 @@ impl Path {
     }
 
     pub(crate) fn prefix(&self) -> Option<Prefix<'_>> {
-        self.components().prefix
+        parse_prefix(&self.inner)
     }
 
     /// Returns `true` if the `Path` has a root.
@@ -3242,16 +3322,85 @@ impl Path {
     /// [`CurDir`]: Component::CurDir
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn components(&self) -> Components<'_> {
-        let prefix = parse_prefix(self.as_os_str());
-        Components {
-            path: self.as_u8_slice(),
-            prefix,
-            has_physical_root: has_physical_root(self.as_u8_slice(), prefix),
-            // use a platform-specific initial state to avoid one turn of
-            // the state-machine when the platform doesn't have a Prefix.
-            front: const { if HAS_PREFIXES { State::Prefix } else { State::StartDir } },
-            back: State::Body,
+        /// Normalizes the trailing portion of given path
+        /// and returns the number of bytes that it occupied
+        #[inline]
+        fn trailing_path_length(path_bytes: &[u8]) -> usize {
+            let path_len = path_bytes.len();
+            // this won't panic because "" does not have
+            // a trailing separator
+            let mut idx = path_len;
+
+            // `Some(false)` is used to denote that
+            // we haven't seen a '.' component *yet*,
+            // `Some(true)` means we have seen a '.' component,
+            // and `None` means that the component is not '.'
+            let mut curr_dir = false;
+            // We rebound to the original index for path components
+            // like '..' or 'abc.'
+            let mut rebound_idx: Option<usize> = None;
+            while idx > 0 {
+                if is_sep_byte(path_bytes[idx - 1]) {
+                    if curr_dir {
+                        rebound_idx = None;
+                        curr_dir = false;
+                    }
+                } else {
+                    if path_bytes[idx - 1] == b'.' {
+                        if !curr_dir {
+                            rebound_idx = Some(idx);
+                            curr_dir = true;
+                        } else {
+                            if let Some(r_idx) = rebound_idx {
+                                curr_dir = false;
+                                idx = r_idx;
+                            }
+                            break;
+                        }
+                    } else {
+                        if let Some(r_idx) = rebound_idx {
+                            curr_dir = false;
+                            idx = r_idx;
+                        }
+                        break;
+                    }
+                }
+                idx -= 1;
+            }
+
+            // If our path is `./a/b/c`, this `.` is not normalized
+            // away because it's treated as its own component
+            if curr_dir {
+                idx += 1;
+            }
+            path_len - idx
         }
+
+        let os_str_path = self.as_os_str();
+        let path_bytes = os_str_path.as_encoded_bytes();
+        let trailing_seps = trailing_path_length(path_bytes);
+
+        // Windows specific component
+        let prefix = parse_prefix(os_str_path);
+        let prefix_exist = prefix.map(|_| true).unwrap_or(false);
+
+        let mut has_root = false;
+        let first_comp = if prefix_exist {
+            Some(FirstComponent::Prefix)
+        } else if has_physical_root(path_bytes, prefix) {
+            has_root = true;
+            Some(FirstComponent::AbsolutePath)
+        } else {
+            Some(FirstComponent::RelativePath)
+        };
+
+        // If we have a prefix, we encode that index into front
+        let front = prefix.map(|prefix| prefix.len()).unwrap_or(0);
+        // Set our back pointer to the last separator byte (without trailing)
+        // or last byte
+        let back = path_bytes.len() - trailing_seps;
+
+        Components { path: path_bytes, has_physical_root: has_root, front, back, first_comp }
     }
 
     /// Produces an iterator over the path's components viewed as [`OsStr`]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -683,7 +683,7 @@ impl<'a> Components<'a> {
     }
 
     /// This is a helper function for consuming the  physical first component in
-    /// either `Components::next`/`Components::next_back`.
+    /// `Components::next`.
     ///
     /// There are four cases we can have here:
     /// - We have an unconsumed absolute component (`/`). We should just output `/`
@@ -695,21 +695,16 @@ impl<'a> Components<'a> {
     /// - We don't have a start component (frequent case), which means we just
     ///   return `None`.
     #[inline]
-    fn consume_first_component(&mut self, dir_front: bool) -> Option<Component<'a>> {
+    fn consume_first_component_front(&mut self) -> Option<Component<'a>> {
         match self.first_comp {
             Some(FirstComponent::AbsolutePath) => {
                 self.first_comp = None;
-                if dir_front {
-                    self.normalize_front();
-                }
+                self.normalize_front();
                 return Some(Component::RootDir);
             }
             Some(FirstComponent::Prefix) => {
                 self.first_comp = None;
-                if dir_front {
-                    self.normalize_front();
-                }
-
+                self.normalize_front();
                 // SAFETY: Our front has the length of our Prefix component encoded at the start,
                 // so this slice is guaranteed to contain the Prefix component if it's
                 // unconsumed.
@@ -723,9 +718,45 @@ impl<'a> Components<'a> {
             }
             Some(FirstComponent::RelativePath) => {
                 self.first_comp = None;
-                if dir_front {
-                    return self.parse_next_component();
-                }
+                self.parse_next_component()
+            }
+            None => None,
+        }
+    }
+
+    /// This is a helper function for consuming the  physical first component in
+    /// `Components::next_back`.
+    ///
+    /// There are four cases we can have here:
+    /// - We have an unconsumed absolute component (`/`). We should just output `/`
+    ///   in this case.
+    /// - We have an unconsumed prefix component (Windows specific, e.g. `C:`).
+    ///   We should just return that prefix component
+    /// - We have a relative directory, we should just return None.
+    /// - We don't have a start component (frequent case), which means we just
+    ///   return `None`.
+    #[inline]
+    fn consume_first_component_back(&mut self) -> Option<Component<'a>> {
+        match self.first_comp {
+            Some(FirstComponent::AbsolutePath) => {
+                self.first_comp = None;
+                return Some(Component::RootDir);
+            }
+            Some(FirstComponent::Prefix) => {
+                self.first_comp = None;
+                // SAFETY: Our front has the length of our Prefix component encoded at the start,
+                // so this slice is guaranteed to contain the Prefix component if it's
+                // unconsumed.
+                let subslice =
+                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path[0..self.front]) };
+                // This prefix is guaranteed to be made since we confirmed
+                // our first component is a Prefix
+                let prefix = parse_prefix(subslice).unwrap();
+
+                Some(Component::Prefix(PrefixComponent { raw: subslice, parsed: prefix }))
+            }
+            Some(FirstComponent::RelativePath) => {
+                self.first_comp = None;
                 None
             }
             None => None,
@@ -845,6 +876,7 @@ impl<'a> Components<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn as_path(&self) -> &'a Path {
         match self.first_comp {
             Some(FirstComponent::AbsolutePath) => {
@@ -898,6 +930,7 @@ impl<'a> Components<'a> {
     }
 
     /// Parses the next component in `Components<'_>` from the left
+    #[inline]
     fn parse_next_component(&mut self) -> Option<Component<'a>> {
         // Our current `self.front` index at this point is the start
         // of the component name
@@ -923,6 +956,7 @@ impl<'a> Components<'a> {
 
     /// Parses the next back component in `Components<'_>` from the
     /// right
+    #[inline]
     fn parse_next_back_component(&mut self) -> Option<Component<'a>> {
         // Our current `self.back` index at this point encompasses
         // the parent path
@@ -1042,13 +1076,14 @@ impl FusedIterator for Iter<'_> {}
 impl<'a> Iterator for Components<'a> {
     type Item = Component<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Component<'a>> {
         // We reach this case when we no longer have anymore paths
         // to consume (return `None`), or if our front idx was initially
         // equal to back idx (e.g. if we had `C:`, `.`, `/`), or if we
         // had a front component initially
         if self.front >= self.back || self.first_comp.is_some() {
-            return self.consume_first_component(true);
+            return self.consume_first_component_front();
         }
 
         self.parse_next_component()
@@ -1057,12 +1092,13 @@ impl<'a> Iterator for Components<'a> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> DoubleEndedIterator for Components<'a> {
+    #[inline]
     fn next_back(&mut self) -> Option<Component<'a>> {
         // We reach here when we no longer have anymore paths
         // to consume, or we need to output Prefix component
         // (anything else falls through this conditional)
         if self.back <= self.front {
-            return self.consume_first_component(false);
+            return self.consume_first_component_back();
         }
 
         self.parse_next_back_component()

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -613,7 +613,7 @@ enum FirstComponent {
 /// ```
 ///
 /// [`components`]: Path::components
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Components<'a> {
@@ -811,7 +811,8 @@ impl<'a> Components<'a> {
     /// that back index is pointing at.
     #[inline]
     fn find_next_separator_front(&mut self) {
-        match self.path[self.front..self.back].iter().position(|b| is_sep_byte(*b)) {
+        let path = &self.path[self.front..self.back];
+        match path.iter().position(|b| is_sep_byte(*b)) {
             None => self.front = self.back,
             Some(i) => self.front += i + 1,
         }
@@ -823,7 +824,6 @@ impl<'a> Components<'a> {
     #[inline]
     fn find_next_separator_back(&mut self) {
         let path = &self.path[self.front..self.back];
-
         match path.iter().rposition(|b| is_sep_byte(*b)) {
             None => self.back = self.front,
             Some(i) => self.back -= path.len() - i,
@@ -846,32 +846,31 @@ impl<'a> Components<'a> {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn as_path(&self) -> &'a Path {
-        if let Some(first_comp) = self.first_comp {
-            match first_comp {
-                FirstComponent::AbsolutePath => {
-                    if self.back == 0 {
-                        return Path::new("/");
-                    }
+        match self.first_comp {
+            Some(FirstComponent::AbsolutePath) => {
+                // If back index is at 0 (e.g parsing backward
+                // through "/foo") and we have an unconsumed
+                // Root component, Components::as_path needs to
+                // return "/" path
+                if self.back == 0 {
+                    return Path::new("/");
                 }
-                FirstComponent::Prefix => {
-                    // We don't want to trim away separators from a Prefix
-                    // component
-                    if self.front == self.back {
-                        // SAFETY: If the first component is not consumed, then
-                        // front index encodes the whole length of the Prefix
-                        // component
-                        return unsafe { Path::from_u8_slice(&self.path[..self.front]) };
-                    }
-                    // SAFETY: Our back index is guaranteed to delimit at an ascii
-                    // separator byte, so this should present a valid path
-                    return unsafe {
-                        Path::from_u8_slice(&self.path[..self.back]).trim_trailing_sep()
-                    };
-                }
-                FirstComponent::RelativePath => {}
             }
+            Some(FirstComponent::Prefix) => {
+                // We don't want to trim away separators from a Prefix
+                // component
+                if self.front == self.back {
+                    // SAFETY: If the first component is not consumed, then
+                    // front index encodes the whole length of the Prefix
+                    // component
+                    return unsafe { Path::from_u8_slice(&self.path[..self.front]) };
+                }
+                // SAFETY: Our back index is guaranteed to delimit at an ascii
+                // separator byte, so this should present a valid path
+                return unsafe { Path::from_u8_slice(&self.path[..self.back]).trim_trailing_sep() };
+            }
+            _ => {}
         }
-
         // SAFETY: front and back index are delimited by ascii separator bytes,
         // where front is a byte after an ascii separator and back is at an ascii
         // separator, so this will always produce a valid path.
@@ -3306,63 +3305,8 @@ impl Path {
     /// [`CurDir`]: Component::CurDir
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn components(&self) -> Components<'_> {
-        /// Normalizes the trailing portion of given path
-        /// and returns the number of bytes that it occupied
-        #[inline]
-        fn trailing_path_length(path_bytes: &[u8]) -> usize {
-            let path_len = path_bytes.len();
-            // this won't panic because "" does not have
-            // a trailing separator
-            let mut idx = path_len;
-
-            // `Some(false)` is used to denote that
-            // we haven't seen a '.' component *yet*,
-            // `Some(true)` means we have seen a '.' component,
-            // and `None` means that the component is not '.'
-            let mut curr_dir = false;
-            // We rebound to the original index for path components
-            // like '..' or 'abc.'
-            let mut rebound_idx: Option<usize> = None;
-            while idx > 0 {
-                if is_sep_byte(path_bytes[idx - 1]) {
-                    if curr_dir {
-                        rebound_idx = None;
-                        curr_dir = false;
-                    }
-                } else {
-                    if path_bytes[idx - 1] == b'.' {
-                        if !curr_dir {
-                            rebound_idx = Some(idx);
-                            curr_dir = true;
-                        } else {
-                            if let Some(r_idx) = rebound_idx {
-                                curr_dir = false;
-                                idx = r_idx;
-                            }
-                            break;
-                        }
-                    } else {
-                        if let Some(r_idx) = rebound_idx {
-                            curr_dir = false;
-                            idx = r_idx;
-                        }
-                        break;
-                    }
-                }
-                idx -= 1;
-            }
-
-            // If our path is `./a/b/c`, this `.` is not normalized
-            // away because it's treated as its own component
-            if curr_dir {
-                idx += 1;
-            }
-            path_len - idx
-        }
-
         let os_str_path = self.as_os_str();
         let path_bytes = os_str_path.as_encoded_bytes();
-        let trailing_seps = trailing_path_length(path_bytes);
 
         // Windows specific component
         let prefix = parse_prefix(os_str_path);
@@ -3380,11 +3324,15 @@ impl Path {
 
         // If we have a prefix, we encode that index into front
         let front = prefix.map(|prefix| prefix.len()).unwrap_or(0);
-        // Set our back pointer to the last separator byte (without trailing)
-        // or last byte
-        let back = path_bytes.len() - trailing_seps;
+        let back = path_bytes.len();
 
-        Components { path: path_bytes, has_physical_root: has_root, front, back, first_comp }
+        let mut components =
+            Components { path: path_bytes, has_physical_root: has_root, front, back, first_comp };
+
+        // Normalize any trailing separators or cur dir (".") components away
+        components.normalize_back();
+
+        components
     }
 
     /// Produces an iterator over the path's components viewed as [`OsStr`]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1125,33 +1125,51 @@ impl Ord for Components<'_> {
     }
 }
 
-fn compare_components(left: Components<'_>, right: Components<'_>) -> cmp::Ordering {
+fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
     // Fast path for long shared prefixes
     //
     // - compare raw bytes to find first mismatch
     // - backtrack to find separator before mismatch to avoid ambiguous parsings of '.' or '..' characters
     // - if found update state to only do a component-wise comparison on the remainder,
     //   otherwise do it on the full path
-
-    let left_path = if matches!(left.first_comp, Some(FirstComponent::Prefix)) {
-        &left.path[..left.back]
-    } else {
-        &left.path[left.front..left.back]
-    };
-    let right_path = if matches!(right.first_comp, Some(FirstComponent::Prefix)) {
-        &right.path[..right.back]
-    } else {
-        &right.path[right.front..right.back]
-    };
-    match left_path.iter().zip(right_path).position(|(&a, &b)| a != b) {
-        // Left path and right path are exactly the same
-        None if left_path.len() == right_path.len() => return cmp::Ordering::Equal,
-        // FIXME: This should check the character that they conflict on so you
-        // can return Ordering::Greater or Ordering::Less if the conflicting
-        // characters is not a slash ("/") or current directory character (".")
-        // Some(pos) => {
-        // }
-        _ => {}
+    //
+    // The fast path isn't taken for paths with a PrefixComponent to avoid backtracking into
+    // the middle of one. If both left and right are at 0, that means no prefix was encoded
+    // into this
+    // possible future improvement: a [u8]::first_mismatch simd implementation
+    // Optimization: can check if the differing character is not a '/' or '.'
+    // and then return either `Ordering::Greater` or `Ordering::Less`
+    if left.front == 0 && right.front == 0 {
+        // Note: Benchmarking details shows that using `left.back.min(right.back)`
+        // causes this function to run slower than using a variable that stores
+        // the `left.back` and `right.back` information (which `back` field
+        // encodes the length of the `Components<'_>` unconsumed path)
+        let left_back = left.back;
+        let right_back = right.back;
+        let first_difference = match left.path[..left.back]
+            .iter()
+            .zip(&right.path[..right.back])
+            .position(|(&a, &b)| a != b)
+        {
+            None if left.back == right.back => return cmp::Ordering::Equal,
+            None => left_back.min(right_back),
+            Some(diff) => diff,
+        };
+        if let Some(previous_sep) =
+            left.path[..first_difference].iter().rposition(|&b| is_sep_byte(b))
+        {
+            // We should always set first_comp to `None` since we got past
+            // the first character (could be root dir or a part of a relative path)
+            // we normalize both `Components<'_>` because we want both to start
+            // at a non-separator character and start comparing from there
+            // (e.g. comparing "/a" with "///a")
+            left.first_comp = None;
+            left.front = previous_sep;
+            left.normalize_front();
+            right.first_comp = None;
+            right.front = previous_sep;
+            right.normalize_front();
+        }
     }
 
     Iterator::cmp(left, right)

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1165,47 +1165,191 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
     // Fast path for long shared prefixes
     //
     // - compare raw bytes to find first mismatch
-    // - backtrack to find separator before mismatch to avoid ambiguous parsings of '.' or '..' characters
-    // - if found update state to only do a component-wise comparison on the remainder,
-    //   otherwise do it on the full path
+    // - if mismatch is between non-separator bytes, return comparison between bytes
+    // - if mismatch is between a non-separator byte and a separator byte, normalize
+    // the conflicting byte with the separator byte to make sure that the conflict
+    // is not due to path not being normalized
+    // - otherwise if we see a '.' (which could be from `..`, a current directory, or something
+    // that we should normalize), defer to comparison via `Iterator::cmp`. Before handing it off
+    // to `Iterator::cmp`, backtrack to find separator before mismatch to avoid ambiguous parsings
+    // of '.' or '..' characters.
     //
-    // The fast path isn't taken for paths with a PrefixComponent to avoid backtracking into
-    // the middle of one. If both left and right are at 0, that means no prefix was encoded
-    // into this
-    // possible future improvement: a [u8]::first_mismatch simd implementation
-    // Optimization: can check if the differing character is not a '/' or '.'
-    // and then return either `Ordering::Greater` or `Ordering::Less`
-    if left.front == 0 && right.front == 0 {
-        // Note: Benchmarking details shows that using `left.back.min(right.back)`
-        // causes this function to run slower than using a variable that stores
-        // the `left.back` and `right.back` information (which `back` field
-        // encodes the length of the `Components<'_>` unconsumed path)
-        let left_back = left.back;
-        let right_back = right.back;
-        let first_difference = match left.path[..left.back]
+    // The faster path isn't taken for paths with a PrefixComponent to avoid backtracking
+    // into the middle of one.
+
+    // If we have a `FirstComponent` on both left and right `Components`,
+    // an optimization we can take is that if our left path is absolute
+    // and right path is relative (or vice versa), just compare the first
+    // byte (or return Greater/Less if relative path is empty string) since
+    // we know these two bytes are different
+    if let Some(left_first_comp) = left.first_comp
+        && let Some(right_first_comp) = right.first_comp
+    {
+        match (left_first_comp, right_first_comp) {
+            (FirstComponent::AbsolutePath, FirstComponent::RelativePath) => {
+                if right.back > 0 {
+                    return left.path[0].cmp(&right.path[0]);
+                }
+                return cmp::Ordering::Greater;
+            }
+            (FirstComponent::RelativePath, FirstComponent::AbsolutePath) => {
+                if left.back > 0 {
+                    return left.path[0].cmp(&right.path[0]);
+                }
+                return cmp::Ordering::Less;
+            }
+            (FirstComponent::AbsolutePath, FirstComponent::AbsolutePath)
+            | (FirstComponent::RelativePath, FirstComponent::RelativePath) => {}
+            _ => return Iterator::cmp(left, right),
+        }
+    }
+
+    let mut left_front = left.front;
+    let mut right_front = right.front;
+    let left_back = left.back;
+    let right_back = right.back;
+
+    loop {
+        match left.path[left_front..left_back]
             .iter()
-            .zip(&right.path[..right.back])
+            .zip(right.path[right_front..right_back].iter())
             .position(|(&a, &b)| a != b)
         {
-            None if left.back == right.back => return cmp::Ordering::Equal,
-            None => left_back.min(right_back),
-            Some(diff) => diff,
-        };
-        if let Some(previous_sep) =
-            left.path[..first_difference].iter().rposition(|&b| is_sep_byte(b))
-        {
-            // We should always set first_comp to `None` since we got past
-            // the first character (could be root dir or a part of a relative path)
-            // we normalize both `Components<'_>` because we want both to start
-            // at a non-separator character and start comparing from there
-            // (e.g. comparing "/a" with "///a")
-            left.first_comp = None;
-            left.front = previous_sep;
-            left.normalize_front();
-            right.first_comp = None;
-            right.front = previous_sep;
-            right.normalize_front();
+            None if left_back - left_front == right_back - right_front => {
+                return cmp::Ordering::Equal;
+            }
+            None => {
+                let mut cur_dir_present = false;
+                if left_back - left_front > right_back - right_front {
+                    // For path comparison between /foo/bar. vs /foo/bar, we
+                    // can't treat this '.' as a current directory component
+                    // to be normalized
+                    if right_back > 0
+                        && left.path[right_back] == b'.'
+                        && left.path[right_back - 1] != MAIN_SEPARATOR as u8
+                    {
+                        return cmp::Ordering::Greater;
+                    }
+
+                    match left.path[right_back..left_back].iter().position(|b| {
+                        if !is_sep_byte(*b) {
+                            if *b == b'.' && !cur_dir_present {
+                                cur_dir_present = true;
+                                false
+                            } else {
+                                true
+                            }
+                        } else {
+                            cur_dir_present = false;
+                            false
+                        }
+                    }) {
+                        None => return cmp::Ordering::Equal,
+                        Some(_) => return cmp::Ordering::Greater,
+                    }
+                } else {
+                    // For path comparison between /foo/bar vs /foo/bar., we
+                    // can't treat this '.' as a current directory component
+                    // to be normalized
+                    if left_back > 0
+                        && right.path[left_back] == b'.'
+                        && right.path[left_back - 1] != MAIN_SEPARATOR as u8
+                    {
+                        return cmp::Ordering::Less;
+                    }
+                    match right.path[left_back..right_back].iter().position(|b| {
+                        if !is_sep_byte(*b) {
+                            if *b == b'.' && !cur_dir_present {
+                                cur_dir_present = true;
+                                false
+                            } else {
+                                true
+                            }
+                        } else {
+                            cur_dir_present = false;
+                            false
+                        }
+                    }) {
+                        None => return cmp::Ordering::Equal,
+                        Some(_) => return cmp::Ordering::Less,
+                    }
+                }
+            }
+            Some(ind) => {
+                left_front += ind;
+                right_front += ind;
+                let left_byte = left.path[left_front];
+                let right_byte = right.path[right_front];
+                if left_byte == MAIN_SEPARATOR as u8 && right_byte != MAIN_SEPARATOR as u8 {
+                    let mut cur_dir_present = false;
+                    match left.path[left_front..left_back].iter().position(|b| {
+                        if !is_sep_byte(*b) {
+                            if *b == b'.' && !cur_dir_present {
+                                cur_dir_present = true;
+                                false
+                            } else {
+                                true
+                            }
+                        } else {
+                            cur_dir_present = false;
+                            false
+                        }
+                    }) {
+                        None => return cmp::Ordering::Less,
+                        Some(i) => {
+                            if cur_dir_present {
+                                left_front += i - 1;
+                            } else {
+                                left_front += i;
+                            }
+                        }
+                    }
+                } else if left_byte != MAIN_SEPARATOR as u8 && right_byte == MAIN_SEPARATOR as u8 {
+                    let mut cur_dir_present = false;
+                    match right.path[right_front..right_back].iter().position(|b| {
+                        if !is_sep_byte(*b) {
+                            if *b == b'.' && !cur_dir_present {
+                                cur_dir_present = true;
+                                false
+                            } else {
+                                true
+                            }
+                        } else {
+                            cur_dir_present = false;
+                            false
+                        }
+                    }) {
+                        None => return cmp::Ordering::Greater,
+                        Some(i) => {
+                            if cur_dir_present {
+                                right_front += i - 1;
+                            } else {
+                                right_front += i;
+                            }
+                        }
+                    }
+                } else {
+                    if left_byte == b'.' || right_byte == b'.' {
+                        break;
+                    }
+                    return left_byte.cmp(&right_byte);
+                }
+            }
         }
+    }
+
+    // Start from the last separator before handing it off to be processed
+    // and compared by `Components::next`
+    if let Some(left_previous_sep) = left.path[..left_front].iter().rposition(|&b| is_sep_byte(b))
+        && let Some(right_prev_sep) =
+            right.path[..right_front].iter().rposition(|&b| is_sep_byte(b))
+    {
+        left.first_comp = None;
+        left.front = left_previous_sep;
+        left.normalize_front();
+        right.first_comp = None;
+        right.front = right_prev_sep;
+        right.normalize_front();
     }
 
     Iterator::cmp(left, right)

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -844,12 +844,9 @@ impl<'a> Components<'a> {
     /// that back index is pointing at.
     #[inline]
     fn find_next_separator_front(&mut self) {
-        while self.front < self.back {
-            if is_sep_byte(self.path[self.front]) {
-                self.front += 1;
-                break;
-            }
-            self.front += 1;
+        match self.path[self.front..self.back].iter().position(|b| is_sep_byte(*b)) {
+            None => self.front = self.back,
+            Some(i) => self.front += i + 1,
         }
     }
 
@@ -858,12 +855,11 @@ impl<'a> Components<'a> {
     /// that front index is pointing to.
     #[inline]
     fn find_next_separator_back(&mut self) {
-        while self.back > self.front {
-            if is_sep_byte(self.path[self.back - 1]) {
-                self.back -= 1;
-                break;
-            }
-            self.back -= 1;
+        let path = &self.path[self.front..self.back];
+
+        match path.iter().rposition(|b| is_sep_byte(*b)) {
+            None => self.back = self.front,
+            Some(i) => self.back -= path.len() - i,
         }
     }
 

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2515,7 +2515,8 @@ impl ToOwned for Path {
 impl PartialEq for PathBuf {
     #[inline]
     fn eq(&self, other: &PathBuf) -> bool {
-        self.components() == other.components()
+        self.as_os_str() == other.as_os_str()
+            || Iterator::eq(self.components().rev(), other.components().rev())
     }
 }
 
@@ -4040,7 +4041,8 @@ impl fmt::Display for Display<'_> {
 impl PartialEq for Path {
     #[inline]
     fn eq(&self, other: &Path) -> bool {
-        self.components() == other.components()
+        self.as_os_str() == other.as_os_str()
+            || Iterator::eq(self.components().rev(), other.components().rev())
     }
 }
 

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -617,21 +617,20 @@ enum FirstComponent {
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Components<'a> {
-    // The path left to parse components from
-    path: &'a [u8],
-    // The iterator is double-ended, and these two indices keep track of how to
-    // subslice the path to present the unconsumed components accordingly
-    // If `front` starts off as non-zero on creating a `Components<'_>` iterator, a
-    // prefix is present. `back` may not equal to `path.len()` if trailing separators
-    // are present.
+    /// The path left to parse components from
+    path_bytes: &'a [u8],
+    /// A tracking index to consume components from the front. If `front` starts off
+    /// as non-zero on creating a `Components<'_>` iterator, a prefix is present.
     front: usize,
+    /// A tracking index to consume components from the back.`back` may not equal to
+    /// `path.len()` if trailing separators are present.
     back: usize,
-    // True if path *physically* has a root separator; for most Windows
-    // prefixes, it may have a "logical" root separator for the purposes of
-    // normalization, e.g., \\server\share == \\server\share\.
+    /// True if path *physically* has a root separator; for most Windows
+    /// prefixes, it may have a "logical" root separator for the purposes of
+    /// normalization, e.g., \\server\share == \\server\share\.
     has_physical_root: bool,
-    // The first component parsed, be it a relative path (""), an absolute path ("/"),
-    // or a Prefix, which is Windows Specific
+    /// The first component parsed, be it a relative path (""), an absolute path ("/"),
+    /// or a Prefix, which is Windows Specific
     first_comp: Option<FirstComponent>,
 }
 
@@ -664,7 +663,7 @@ impl fmt::Debug for Components<'_> {
 }
 
 impl<'a> Components<'a> {
-    /// Is the *original* path rooted?
+    /// This is the canonical implementation of `Path::has_root`
     fn has_root(&self) -> bool {
         if self.has_physical_root {
             return true;
@@ -672,12 +671,11 @@ impl<'a> Components<'a> {
 
         // SAFETY: This u8 slice is the entire original path unmodified. The caller to
         // `Path::components` should have given us a valid `Path`.
-        if HAS_PREFIXES
-            && let Some(p) = parse_prefix(unsafe { OsStr::from_encoded_bytes_unchecked(self.path) })
+        if self.first_comp == Some(FirstComponent::Prefix)
+            && let Some(p) =
+                parse_prefix(unsafe { OsStr::from_encoded_bytes_unchecked(self.path_bytes) })
         {
-            if p.has_implicit_root() {
-                return true;
-            }
+            return p.has_implicit_root();
         }
         false
     }
@@ -694,7 +692,6 @@ impl<'a> Components<'a> {
     ///   normal for the front direction only (due to 0 indexing front index)
     /// - We don't have a start component (frequent case), which means we just
     ///   return `None`.
-    #[inline]
     fn consume_first_component_front(&mut self) -> Option<Component<'a>> {
         match self.first_comp {
             Some(FirstComponent::AbsolutePath) => {
@@ -709,7 +706,7 @@ impl<'a> Components<'a> {
                 // so this slice is guaranteed to contain the Prefix component if it's
                 // unconsumed.
                 let subslice =
-                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path[0..self.front]) };
+                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path_bytes[0..self.front]) };
                 // This prefix is guaranteed to be made since we confirmed
                 // our first component is a Prefix
                 let prefix = parse_prefix(subslice).unwrap();
@@ -735,7 +732,6 @@ impl<'a> Components<'a> {
     /// - We have a relative directory, we should just return None.
     /// - We don't have a start component (frequent case), which means we just
     ///   return `None`.
-    #[inline]
     fn consume_first_component_back(&mut self) -> Option<Component<'a>> {
         match self.first_comp {
             Some(FirstComponent::AbsolutePath) => {
@@ -748,26 +744,26 @@ impl<'a> Components<'a> {
                 // so this slice is guaranteed to contain the Prefix component if it's
                 // unconsumed.
                 let subslice =
-                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path[0..self.front]) };
+                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path_bytes[0..self.front]) };
                 // This prefix is guaranteed to be made since we confirmed
                 // our first component is a Prefix
                 let prefix = parse_prefix(subslice).unwrap();
 
                 Some(Component::Prefix(PrefixComponent { raw: subslice, parsed: prefix }))
             }
-            Some(FirstComponent::RelativePath) => {
-                self.first_comp = None;
-                None
-            }
-            None => None,
+            // Back does not need to set `first_comp` to `None` on relative components because
+            // as it parses the path ahead of time from previous calls to `Components::next_back`.
+            // Front will not be affected by this not being set to None either because it will
+            // parse an empty path, which `Components::parse_single_component` will return `None`
+            // as a result.
+            _ => None,
         }
     }
 
     /// Normalizes away trailing separators and current directory ('.') components
     /// in the forward direction.
-    #[inline]
     fn normalize_front(&mut self) {
-        let path = &self.path[self.front..self.back];
+        let path = &self.path_bytes[self.front..self.back];
         // ".a", ".." needs to rebound back to index
         // before the "." character
         let mut cur_dir_present = false;
@@ -797,9 +793,8 @@ impl<'a> Components<'a> {
 
     /// Normalizes away trailing separators and current directory ('.') components
     /// in the backward direction.
-    #[inline]
     fn normalize_back(&mut self) {
-        let path = &self.path[self.front..self.back];
+        let path = &self.path_bytes[self.front..self.back];
         // "a.", ".." needs to rebound back to index
         // before the "." character
         let mut cur_dir_present = false;
@@ -840,10 +835,9 @@ impl<'a> Components<'a> {
     /// Increments our front pointer until we find the
     /// next separator byte or have reached the component
     /// that back index is pointing at.
-    #[inline]
-    fn find_next_separator_front(&mut self) {
-        let path = &self.path[self.front..self.back];
-        match path.iter().position(|b| is_sep_byte(*b)) {
+    fn seek_next_separator_front(&mut self) {
+        let path_bytes = &self.path_bytes[self.front..self.back];
+        match path_bytes.iter().position(|b| is_sep_byte(*b)) {
             None => self.front = self.back,
             Some(i) => self.front += i + 1,
         }
@@ -852,12 +846,11 @@ impl<'a> Components<'a> {
     /// Decrements our back pointer until we find the
     /// next separator byte or have reached the component
     /// that front index is pointing to.
-    #[inline]
-    fn find_next_separator_back(&mut self) {
-        let path = &self.path[self.front..self.back];
-        match path.iter().rposition(|b| is_sep_byte(*b)) {
+    fn seek_next_separator_back(&mut self) {
+        let path_bytes = &self.path_bytes[self.front..self.back];
+        match path_bytes.iter().rposition(|b| is_sep_byte(*b)) {
             None => self.back = self.front,
-            Some(i) => self.back -= path.len() - i,
+            Some(i) => self.back -= path_bytes.len() - i,
         }
     }
 
@@ -895,29 +888,30 @@ impl<'a> Components<'a> {
                     // SAFETY: If the first component is not consumed, then
                     // front index encodes the whole length of the Prefix
                     // component
-                    return unsafe { Path::from_u8_slice(&self.path[..self.front]) };
+                    return unsafe { Path::from_u8_slice(&self.path_bytes[..self.front]) };
                 }
                 // SAFETY: Our back index is guaranteed to delimit at an ascii
                 // separator byte, so this should present a valid path
-                return unsafe { Path::from_u8_slice(&self.path[..self.back]).trim_trailing_sep() };
+                return unsafe {
+                    Path::from_u8_slice(&self.path_bytes[..self.back]).trim_trailing_sep()
+                };
             }
             _ => {}
         }
         // SAFETY: front and back index are delimited by ascii separator bytes,
         // where front is a byte after an ascii separator and back is at an ascii
         // separator, so this will always produce a valid path.
-        unsafe { Path::from_u8_slice(&self.path[self.front..self.back]).trim_trailing_sep() }
+        unsafe { Path::from_u8_slice(&self.path_bytes[self.front..self.back]).trim_trailing_sep() }
     }
 
     /// Parse a u8 slice into an OsStr, which is encoded into a `Component`
-    #[inline]
     fn parse_single_component(&self, slice: &'a [u8]) -> Option<Component<'a>> {
         match slice {
             [] => return None,
             [b'.'] => Some(Component::CurDir),
             [b'.', b'.'] => Some(Component::ParentDir),
             _ => {
-                let root_slice = [MAIN_SEPARATOR as u8];
+                let root_slice = MAIN_SEPARATOR_STR.as_bytes();
                 if slice == root_slice {
                     return Some(Component::RootDir);
                 }
@@ -930,14 +924,13 @@ impl<'a> Components<'a> {
     }
 
     /// Parses the next component in `Components<'_>` from the left
-    #[inline]
     fn parse_next_component(&mut self) -> Option<Component<'a>> {
         // Our current `self.front` index at this point is the start
         // of the component name
         let before_front = self.front;
         // We trace our `self.front` idx down the path until
         // we hit a separator.
-        self.find_next_separator_front();
+        self.seek_next_separator_front();
         let curr_front = self.front;
         // Normalizes trailing seps and curr dirs in preparation for
         // next front component
@@ -946,17 +939,16 @@ impl<'a> Components<'a> {
         // SAFETY: Our curr_front index always stops a byte after the ascii
         // separator byte or at self.back (should there be no ascii separator
         // in traversal), so we can always construct a valid u8 path slice
-        let sliced_path = if curr_front > 0 && is_sep_byte(self.path[curr_front - 1]) {
-            &self.path[before_front..curr_front - 1]
+        let sliced_path = if curr_front > 0 && is_sep_byte(self.path_bytes[curr_front - 1]) {
+            &self.path_bytes[before_front..curr_front - 1]
         } else {
-            &self.path[before_front..curr_front]
+            &self.path_bytes[before_front..curr_front]
         };
         self.parse_single_component(sliced_path)
     }
 
     /// Parses the next back component in `Components<'_>` from the
     /// right
-    #[inline]
     fn parse_next_back_component(&mut self) -> Option<Component<'a>> {
         // Our current `self.back` index at this point encompasses
         // the parent path
@@ -964,7 +956,7 @@ impl<'a> Components<'a> {
         // We trace our `self.back` idx up the path until we reach a
         // separator byte. This prepares the path we return on the next
         // call to this function.
-        self.find_next_separator_back();
+        self.seek_next_separator_back();
         let curr_back = self.back;
         // Normalizes trailing seps and curr dirs in preparation for
         // next back component
@@ -973,10 +965,10 @@ impl<'a> Components<'a> {
         // Our curr_back is at the byte before an ascii separator byte or self.front,
         // (should there be no ascii separator in traversal), so we can always
         // construct a valid u8 path slice
-        let sliced_path = if is_sep_byte(self.path[curr_back]) {
-            &self.path[curr_back + 1..before_back]
+        let sliced_path = if is_sep_byte(self.path_bytes[curr_back]) {
+            &self.path_bytes[curr_back + 1..before_back]
         } else {
-            &self.path[curr_back..before_back]
+            &self.path_bytes[curr_back..before_back]
         };
         self.parse_single_component(sliced_path)
     }
@@ -1076,32 +1068,30 @@ impl FusedIterator for Iter<'_> {}
 impl<'a> Iterator for Components<'a> {
     type Item = Component<'a>;
 
-    #[inline]
     fn next(&mut self) -> Option<Component<'a>> {
         // We reach this case when we no longer have anymore paths
         // to consume (return `None`), or if our front idx was initially
         // equal to back idx (e.g. if we had `C:`, `.`, `/`), or if we
         // had a front component initially
         if self.front >= self.back || self.first_comp.is_some() {
-            return self.consume_first_component_front();
+            self.consume_first_component_front()
+        } else {
+            self.parse_next_component()
         }
-
-        self.parse_next_component()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> DoubleEndedIterator for Components<'a> {
-    #[inline]
     fn next_back(&mut self) -> Option<Component<'a>> {
         // We reach here when we no longer have anymore paths
         // to consume, or we need to output Prefix component
         // (anything else falls through this conditional)
         if self.back <= self.front {
-            return self.consume_first_component_back();
+            self.consume_first_component_back()
+        } else {
+            self.parse_next_back_component()
         }
-
-        self.parse_next_back_component()
     }
 }
 
@@ -1113,7 +1103,7 @@ impl<'a> PartialEq for Components<'a> {
     #[inline]
     fn eq(&self, other: &Components<'a>) -> bool {
         // Fast path for exact matches, e.g. for hashmap lookups.
-        if self.path.len() == other.path.len()
+        if self.path_bytes.len() == other.path_bytes.len()
             && self.front == other.front
             && self.back == other.back
         {
@@ -1121,15 +1111,15 @@ impl<'a> PartialEq for Components<'a> {
             // we need to start at index 0 (because prefix length is encoded in
             // `front`)
             let path = if matches!(self.first_comp, Some(FirstComponent::Prefix)) {
-                &self.path[..self.back]
+                &self.path_bytes[..self.back]
             } else {
-                &self.path[self.front..self.back]
+                &self.path_bytes[self.front..self.back]
             };
 
             let other_path = if matches!(other.first_comp, Some(FirstComponent::Prefix)) {
-                &other.path[..other.back]
+                &other.path_bytes[..other.back]
             } else {
-                &other.path[other.front..other.back]
+                &other.path_bytes[other.front..other.back]
             };
 
             if path == other_path {
@@ -1162,39 +1152,26 @@ impl Ord for Components<'_> {
 }
 
 fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
-    // Fast path for long shared prefixes
-    //
-    // - compare raw bytes to find first mismatch
-    // - if mismatch is between non-separator bytes, return comparison between bytes
-    // - if mismatch is between a non-separator byte and a separator byte, normalize
-    // the conflicting byte with the separator byte to make sure that the conflict
-    // is not due to path not being normalized
-    // - otherwise if we see a '.' (which could be from `..`, a current directory, or something
-    // that we should normalize), defer to comparison via `Iterator::cmp`. Before handing it off
-    // to `Iterator::cmp`, backtrack to find separator before mismatch to avoid ambiguous parsings
-    // of '.' or '..' characters.
-    //
-    // The faster path isn't taken for paths with a PrefixComponent to avoid backtracking
-    // into the middle of one.
-
     // If we have a `FirstComponent` on both left and right `Components`,
     // an optimization we can take is that if our left path is absolute
     // and right path is relative (or vice versa), just compare the first
     // byte (or return Greater/Less if relative path is empty string) since
     // we know these two bytes are different
+    // The faster path isn't taken for paths with a PrefixComponent to avoid
+    // backtracking into the middle of one.
     if let Some(left_first_comp) = left.first_comp
         && let Some(right_first_comp) = right.first_comp
     {
         match (left_first_comp, right_first_comp) {
             (FirstComponent::AbsolutePath, FirstComponent::RelativePath) => {
                 if right.back > 0 {
-                    return left.path[0].cmp(&right.path[0]);
+                    return left.path_bytes[0].cmp(&right.path_bytes[0]);
                 }
                 return cmp::Ordering::Greater;
             }
             (FirstComponent::RelativePath, FirstComponent::AbsolutePath) => {
                 if left.back > 0 {
-                    return left.path[0].cmp(&right.path[0]);
+                    return left.path_bytes[0].cmp(&right.path_bytes[0]);
                 }
                 return cmp::Ordering::Less;
             }
@@ -1210,14 +1187,18 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
     let right_back = right.back;
 
     loop {
-        match left.path[left_front..left_back]
-            .iter()
-            .zip(right.path[right_front..right_back].iter())
-            .position(|(&a, &b)| a != b)
+        // Compare raw bytes to find first mismatch
+        match crate::iter::zip(
+            left.path_bytes[left_front..left_back].iter(),
+            right.path_bytes[right_front..right_back].iter(),
+        )
+        .position(|(&a, &b)| a != b)
         {
             None if left_back - left_front == right_back - right_front => {
                 return cmp::Ordering::Equal;
             }
+            // left/right path is strictly bigger than right/left path; normalize
+            // left/right path to see if it truly is equal to right/left path
             None => {
                 let mut cur_dir_present = false;
                 if left_back - left_front > right_back - right_front {
@@ -1225,13 +1206,13 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
                     // can't treat this '.' as a current directory component
                     // to be normalized
                     if right_back > 0
-                        && left.path[right_back] == b'.'
-                        && left.path[right_back - 1] != MAIN_SEPARATOR as u8
+                        && left.path_bytes[right_back] == b'.'
+                        && left.path_bytes[right_back - 1] != MAIN_SEPARATOR as u8
                     {
                         return cmp::Ordering::Greater;
                     }
 
-                    match left.path[right_back..left_back].iter().position(|b| {
+                    match left.path_bytes[right_back..left_back].iter().position(|b| {
                         if !is_sep_byte(*b) {
                             if *b == b'.' && !cur_dir_present {
                                 cur_dir_present = true;
@@ -1252,12 +1233,12 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
                     // can't treat this '.' as a current directory component
                     // to be normalized
                     if left_back > 0
-                        && right.path[left_back] == b'.'
-                        && right.path[left_back - 1] != MAIN_SEPARATOR as u8
+                        && right.path_bytes[left_back] == b'.'
+                        && right.path_bytes[left_back - 1] != MAIN_SEPARATOR as u8
                     {
                         return cmp::Ordering::Less;
                     }
-                    match right.path[left_back..right_back].iter().position(|b| {
+                    match right.path_bytes[left_back..right_back].iter().position(|b| {
                         if !is_sep_byte(*b) {
                             if *b == b'.' && !cur_dir_present {
                                 cur_dir_present = true;
@@ -1275,14 +1256,19 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
                     }
                 }
             }
+            // Mismatched byte found
             Some(ind) => {
                 left_front += ind;
                 right_front += ind;
-                let left_byte = left.path[left_front];
-                let right_byte = right.path[right_front];
+                let left_byte = left.path_bytes[left_front];
+                let right_byte = right.path_bytes[right_front];
+
+                // mismatch between a separator byte and a non-separator byte, normalize
+                // separator byte to make sure that the conflict is not due to path not
+                // being normalized
                 if left_byte == MAIN_SEPARATOR as u8 && right_byte != MAIN_SEPARATOR as u8 {
                     let mut cur_dir_present = false;
-                    match left.path[left_front..left_back].iter().position(|b| {
+                    match left.path_bytes[left_front..left_back].iter().position(|b| {
                         if !is_sep_byte(*b) {
                             if *b == b'.' && !cur_dir_present {
                                 cur_dir_present = true;
@@ -1304,9 +1290,13 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
                             }
                         }
                     }
-                } else if left_byte != MAIN_SEPARATOR as u8 && right_byte == MAIN_SEPARATOR as u8 {
+                }
+                // mismatch between a non-separator byte and a separator byte, normalize
+                // separator byte to make sure that the conflict is not due to path not
+                // being normalized
+                else if left_byte != MAIN_SEPARATOR as u8 && right_byte == MAIN_SEPARATOR as u8 {
                     let mut cur_dir_present = false;
-                    match right.path[right_front..right_back].iter().position(|b| {
+                    match right.path_bytes[right_front..right_back].iter().position(|b| {
                         if !is_sep_byte(*b) {
                             if *b == b'.' && !cur_dir_present {
                                 cur_dir_present = true;
@@ -1328,7 +1318,11 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
                             }
                         }
                     }
-                } else {
+                }
+                // if mismatch is between non-separator bytes, return comparison between bytes
+                else {
+                    // if we see a '.' (which could be from `..`, a current directory, or something
+                    // that we should normalize), defer to comparison via `Iterator::cmp`.
                     if left_byte == b'.' || right_byte == b'.' {
                         break;
                     }
@@ -1339,10 +1333,12 @@ fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cm
     }
 
     // Start from the last separator before handing it off to be processed
-    // and compared by `Components::next`
-    if let Some(left_previous_sep) = left.path[..left_front].iter().rposition(|&b| is_sep_byte(b))
+    // and compared by `Components::next`.This also avoids ambiguous parsings
+    // of '.' or '..' characters.
+    if let Some(left_previous_sep) =
+        left.path_bytes[..left_front].iter().rposition(|&b| is_sep_byte(b))
         && let Some(right_prev_sep) =
-            right.path[..right_front].iter().rposition(|&b| is_sep_byte(b))
+            right.path_bytes[..right_front].iter().rposition(|&b| is_sep_byte(b))
     {
         left.first_comp = None;
         left.front = left_previous_sep;
@@ -1598,83 +1594,96 @@ impl PathBuf {
         let buf = self.inner.as_encoded_bytes();
         let mut need_sep = buf.last().map(|c| !is_sep_byte(*c)).unwrap_or(false);
 
-        // in the special case of `C:` on Windows, do *not* add a separator
-        let parsed_prefix = parse_prefix(&self.inner);
-
-        if let Some(prefix) = parsed_prefix
-            && prefix.len() == self.inner.len()
-            && prefix.is_drive()
-        {
-            need_sep = false
-        }
-
-        let need_clear = if cfg!(target_os = "cygwin") {
-            // If path is absolute and its prefix is none, it is like `/foo`,
-            // and will be handled below.
-            path.prefix().is_some()
-        } else {
-            // On Unix: prefix is always None.
-            path.is_absolute() || path.prefix().is_some()
-        };
-
-        // absolute `path` replaces `self`
-        if need_clear {
-            self.inner.clear();
-
-        // verbatim paths need . and .. removed
-        } else if let Some(prefix) = parsed_prefix
-            && prefix.is_verbatim()
-            && !path.inner.is_empty()
-        {
+        if HAS_PREFIXES {
             let comps = self.components();
-            let mut buf: Vec<_> = comps.collect();
-            for c in path.components() {
-                match c {
-                    Component::RootDir => {
-                        buf.truncate(1);
-                        buf.push(c);
-                    }
-                    Component::CurDir => (),
-                    Component::ParentDir => {
-                        if let Some(Component::Normal(_)) = buf.last() {
-                            buf.pop();
+            // in the special case of `C:` on Windows, do *not* add a separator
+            let parsed_prefix = parse_prefix(&self.inner);
+
+            if let Some(prefix) = parsed_prefix
+                && prefix.len() == self.inner.len()
+                && prefix.is_drive()
+            {
+                need_sep = false
+            }
+
+            let need_clear = if cfg!(target_os = "cygwin") {
+                // If path is absolute and its prefix is none, it is like `/foo`,
+                // and will be handled below.
+                path.prefix().is_some()
+            } else {
+                // On Unix: prefix is always None.
+                path.is_absolute() || path.prefix().is_some()
+            };
+
+            // absolute `path` replaces `self`
+            if need_clear {
+                self.inner.clear();
+            // verbatim paths need . and .. removed
+            } else if let Some(prefix) = parsed_prefix
+                && prefix.is_verbatim()
+                && !path.inner.is_empty()
+            {
+                let mut buf: Vec<_> = comps.collect();
+                for c in path.components() {
+                    match c {
+                        Component::RootDir => {
+                            buf.truncate(1);
+                            buf.push(c);
                         }
+                        Component::CurDir => (),
+                        Component::ParentDir => {
+                            if let Some(Component::Normal(_)) = buf.last() {
+                                buf.pop();
+                            }
+                        }
+                        _ => buf.push(c),
                     }
-                    _ => buf.push(c),
                 }
-            }
 
-            let mut res = OsString::new();
-            let mut need_sep = false;
+                let mut res = OsString::new();
+                let mut need_sep = false;
 
-            for c in buf {
-                if need_sep && c != Component::RootDir {
-                    res.push(MAIN_SEPARATOR_STR);
-                }
-                res.push(c.as_os_str());
-
-                need_sep = match c {
-                    Component::RootDir => false,
-                    Component::Prefix(prefix) => {
-                        !prefix.parsed.is_drive() && prefix.parsed.len() > 0
+                for c in buf {
+                    if need_sep && c != Component::RootDir {
+                        res.push(MAIN_SEPARATOR_STR);
                     }
-                    _ => true,
+                    res.push(c.as_os_str());
+
+                    need_sep = match c {
+                        Component::RootDir => false,
+                        Component::Prefix(prefix) => {
+                            !prefix.parsed.is_drive() && prefix.parsed.len() > 0
+                        }
+                        _ => true,
+                    }
                 }
+
+                self.inner = res;
+                return;
+
+            // `path` has a root but no prefix, e.g., `\windows` (Windows only)
+            } else if path.has_root() {
+                // On creating a components iterator, if front index
+                // is non-zero we have a prefix.
+                let prefix_len = comps.front;
+                self.inner.truncate(prefix_len);
+
+            // `path` is a pure relative path
+            } else if need_sep {
+                self.inner.push(MAIN_SEPARATOR_STR);
             }
+        } else {
+            let need_clear = path.is_absolute();
 
-            self.inner = res;
-            return;
-
-        // `path` has a root but no prefix, e.g., `\windows` (Windows only)
-        } else if path.has_root() {
-            // On creating a components iterator, if front index
-            // is non-zero we have a prefix.
-            let prefix_len = self.components().front;
-            self.inner.truncate(prefix_len);
-
-        // `path` is a pure relative path
-        } else if need_sep {
-            self.inner.push(MAIN_SEPARATOR_STR);
+            // absolute `path` replaces `self`
+            if need_clear {
+                self.inner.clear();
+            } else if path.has_root() {
+                self.inner.truncate(0);
+            // `path` is a pure relative path
+            } else if need_sep {
+                self.inner.push(MAIN_SEPARATOR_STR);
+            }
         }
 
         self.inner.push(path);
@@ -3510,11 +3519,10 @@ impl Path {
         let prefix = parse_prefix(os_str_path);
         let prefix_exist = prefix.map(|_| true).unwrap_or(false);
 
-        let mut has_root = false;
+        let has_physical_root = has_physical_root(path_bytes, prefix);
         let first_comp = if prefix_exist {
             Some(FirstComponent::Prefix)
-        } else if has_physical_root(path_bytes, prefix) {
-            has_root = true;
+        } else if has_physical_root {
             Some(FirstComponent::AbsolutePath)
         } else {
             Some(FirstComponent::RelativePath)
@@ -3524,8 +3532,7 @@ impl Path {
         let front = prefix.map(|prefix| prefix.len()).unwrap_or(0);
         let back = path_bytes.len();
 
-        let mut components =
-            Components { path: path_bytes, has_physical_root: has_root, front, back, first_comp };
+        let mut components = Components { path_bytes, has_physical_root, front, back, first_comp };
 
         // Normalize any trailing separators or cur dir (".") components away
         components.normalize_back();

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -93,7 +93,7 @@ use crate::ops::{self, Deref};
 use crate::rc::Rc;
 use crate::str::FromStr;
 use crate::sync::Arc;
-use crate::sys::path::{HAS_PREFIXES, is_sep_byte, is_verbatim_sep, parse_prefix};
+use crate::sys::path as path_imp;
 use crate::{cmp, fmt, fs, io, sys};
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -198,7 +198,7 @@ pub enum Prefix<'a> {
 
 impl<'a> Prefix<'a> {
     #[inline]
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         use self::Prefix::*;
         fn os_str_len(s: &OsStr) -> usize {
             s.as_encoded_bytes().len()
@@ -237,16 +237,6 @@ impl<'a> Prefix<'a> {
         use self::Prefix::*;
         matches!(*self, Verbatim(_) | VerbatimDisk(_) | VerbatimUNC(..))
     }
-
-    #[inline]
-    fn is_drive(&self) -> bool {
-        matches!(*self, Prefix::Disk(_))
-    }
-
-    #[inline]
-    fn has_implicit_root(&self) -> bool {
-        !self.is_drive()
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -268,7 +258,7 @@ impl<'a> Prefix<'a> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_path_separators", issue = "153106")]
 pub const fn is_separator(c: char) -> bool {
-    c.is_ascii() && is_sep_byte(c as u8)
+    c.is_ascii() && path_imp::is_sep_byte(c as u8)
 }
 
 /// All path separators recognized on the current platform, represented as [`char`]s; for example,
@@ -323,11 +313,11 @@ where
 // Cross-platform, iterator-independent parsing
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Says whether the first byte after the prefix is a separator.
-fn has_physical_root(s: &[u8], prefix: Option<Prefix<'_>>) -> bool {
-    let path = if let Some(p) = prefix { &s[p.len()..] } else { s };
-    !path.is_empty() && is_sep_byte(path[0])
-}
+// /// Says whether the first byte after the prefix is a separator.
+// fn has_physical_root(s: &[u8], prefix: Option<Prefix<'_>>) -> bool {
+//     let path = if let Some(p) = prefix { &s[p.len()..] } else { s };
+//     !path.is_empty() && is_sep_byte(path[0])
+// }
 
 // basic workhorse for splitting stem and extension
 fn rsplit_file_at_dot(file: &OsStr) -> (Option<&OsStr>, Option<&OsStr>) {
@@ -381,7 +371,7 @@ fn split_file_at_dot(file: &OsStr) -> (&OsStr, Option<&OsStr>) {
 /// Checks whether the string is valid as a file extension, or panics otherwise.
 fn validate_extension(extension: &OsStr) {
     for &b in extension.as_encoded_bytes() {
-        if is_sep_byte(b) {
+        if path_imp::is_sep_byte(b) {
             panic!("extension cannot contain path separators: {extension:?}");
         }
     }
@@ -428,10 +418,10 @@ fn validate_extension(extension: &OsStr) {
 #[derive(Copy, Clone, Eq, Debug)]
 pub struct PrefixComponent<'a> {
     /// The prefix as an unparsed `OsStr` slice.
-    raw: &'a OsStr,
+    pub(crate) raw: &'a OsStr,
 
     /// The parsed prefix data.
-    parsed: Prefix<'a>,
+    pub(crate) parsed: Prefix<'a>,
 }
 
 impl<'a> PrefixComponent<'a> {
@@ -583,18 +573,6 @@ impl AsRef<Path> for Component<'_> {
     }
 }
 
-/// This is what the first component of our path is
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum FirstComponent {
-    /// For all paths starting with `/`
-    AbsolutePath,
-    /// For paths without root path like `.`, `..`, `a/`
-    RelativePath,
-    /// For Window specific paths like (`C:`, `\\?\UNC\server\share`,
-    /// `\\.\COM42`, etc.)
-    Prefix,
-}
-
 /// An iterator over the [`Component`]s of a [`Path`].
 ///
 /// This `struct` is created by the [`components`] method on [`Path`].
@@ -616,23 +594,7 @@ enum FirstComponent {
 #[derive(Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Components<'a> {
-    /// The path left to parse components from
-    path_bytes: &'a [u8],
-    /// A tracking index to consume components from the front. If `front` starts off
-    /// as non-zero on creating a `Components<'_>` iterator, a prefix is present.
-    front: usize,
-    /// A tracking index to consume components from the back.`back` may not equal to
-    /// `path.len()` if trailing separators are present.
-    back: usize,
-    /// True if path *physically* has a root separator; for most Windows
-    /// prefixes, it may have a "logical" root separator for the purposes of
-    /// normalization, e.g., \\server\share == \\server\share\.
-    has_physical_root: bool,
-    /// The first component parsed, be it a relative path (""), an absolute path ("/"),
-    /// or a Prefix, which is Windows Specific
-    first_comp: Option<FirstComponent>,
-}
+pub struct Components<'a>(pub(crate) path_imp::Components<'a>);
 
 /// An iterator over the [`Component`]s of a [`Path`], as [`OsStr`] slices.
 ///
@@ -663,197 +625,6 @@ impl fmt::Debug for Components<'_> {
 }
 
 impl<'a> Components<'a> {
-    /// This is the canonical implementation of `Path::has_root`
-    fn has_root(&self) -> bool {
-        if self.has_physical_root {
-            return true;
-        }
-
-        // SAFETY: This u8 slice is the entire original path unmodified. The caller to
-        // `Path::components` should have given us a valid `Path`.
-        if self.first_comp == Some(FirstComponent::Prefix)
-            && let Some(p) =
-                parse_prefix(unsafe { OsStr::from_encoded_bytes_unchecked(self.path_bytes) })
-        {
-            return p.has_implicit_root();
-        }
-        false
-    }
-
-    /// This is a helper function for consuming the  physical first component in
-    /// `Components::next`.
-    ///
-    /// There are four cases we can have here:
-    /// - We have an unconsumed absolute component (`/`). We should just output `/`
-    ///   in this case.
-    /// - We have an unconsumed prefix component (Windows specific, e.g. `C:`).
-    ///   We should just return that prefix component
-    /// - We have a relative directory, we should just parse the component as
-    ///   normal for the front direction only (due to 0 indexing front index)
-    /// - We don't have a start component (frequent case), which means we just
-    ///   return `None`.
-    fn consume_first_component_front(&mut self) -> Option<Component<'a>> {
-        match self.first_comp {
-            Some(FirstComponent::AbsolutePath) => {
-                self.first_comp = None;
-                self.normalize_front();
-                return Some(Component::RootDir);
-            }
-            Some(FirstComponent::Prefix) => {
-                self.first_comp = None;
-                self.normalize_front();
-                // SAFETY: Our front has the length of our Prefix component encoded at the start,
-                // so this slice is guaranteed to contain the Prefix component if it's
-                // unconsumed.
-                let subslice =
-                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path_bytes[0..self.front]) };
-                // This prefix is guaranteed to be made since we confirmed
-                // our first component is a Prefix
-                let prefix = parse_prefix(subslice).unwrap();
-
-                Some(Component::Prefix(PrefixComponent { raw: subslice, parsed: prefix }))
-            }
-            Some(FirstComponent::RelativePath) => {
-                self.first_comp = None;
-                self.parse_next_component()
-            }
-            None => None,
-        }
-    }
-
-    /// This is a helper function for consuming the  physical first component in
-    /// `Components::next_back`.
-    ///
-    /// There are four cases we can have here:
-    /// - We have an unconsumed absolute component (`/`). We should just output `/`
-    ///   in this case.
-    /// - We have an unconsumed prefix component (Windows specific, e.g. `C:`).
-    ///   We should just return that prefix component
-    /// - We have a relative directory, we should just return None.
-    /// - We don't have a start component (frequent case), which means we just
-    ///   return `None`.
-    fn consume_first_component_back(&mut self) -> Option<Component<'a>> {
-        match self.first_comp {
-            Some(FirstComponent::AbsolutePath) => {
-                self.first_comp = None;
-                return Some(Component::RootDir);
-            }
-            Some(FirstComponent::Prefix) => {
-                self.first_comp = None;
-                // SAFETY: Our front has the length of our Prefix component encoded at the start,
-                // so this slice is guaranteed to contain the Prefix component if it's
-                // unconsumed.
-                let subslice =
-                    unsafe { OsStr::from_encoded_bytes_unchecked(&self.path_bytes[0..self.front]) };
-                // This prefix is guaranteed to be made since we confirmed
-                // our first component is a Prefix
-                let prefix = parse_prefix(subslice).unwrap();
-
-                Some(Component::Prefix(PrefixComponent { raw: subslice, parsed: prefix }))
-            }
-            // Back does not need to set `first_comp` to `None` on relative components because
-            // as it parses the path ahead of time from previous calls to `Components::next_back`.
-            // Front will not be affected by this not being set to None either because it will
-            // parse an empty path, which `Components::parse_single_component` will return `None`
-            // as a result.
-            _ => None,
-        }
-    }
-
-    /// Normalizes away trailing separators and current directory ('.') components
-    /// in the forward direction.
-    fn normalize_front(&mut self) {
-        let path = &self.path_bytes[self.front..self.back];
-        // ".a", ".." needs to rebound back to index
-        // before the "." character
-        let mut cur_dir_present = false;
-        match path.iter().position(|b| {
-            if !is_sep_byte(*b) {
-                if *b == b'.' && !cur_dir_present {
-                    cur_dir_present = true;
-                    false
-                } else {
-                    true
-                }
-            } else {
-                cur_dir_present = false;
-                false
-            }
-        }) {
-            None => self.front = self.back,
-            Some(i) => {
-                if cur_dir_present {
-                    self.front += i - 1;
-                } else {
-                    self.front += i;
-                }
-            }
-        }
-    }
-
-    /// Normalizes away trailing separators and current directory ('.') components
-    /// in the backward direction.
-    fn normalize_back(&mut self) {
-        let path = &self.path_bytes[self.front..self.back];
-        // "a.", ".." needs to rebound back to index
-        // before the "." character
-        let mut cur_dir_present = false;
-        match path.iter().rposition(|b| {
-            if !is_sep_byte(*b) {
-                if *b == b'.' && !cur_dir_present {
-                    cur_dir_present = true;
-                    false
-                } else {
-                    true
-                }
-            } else {
-                cur_dir_present = false;
-                false
-            }
-        }) {
-            None => {
-                // For cases like "./a", where our path
-                // will observe "." at the end, and we need to return
-                // that we observed "." component instead of
-                // returning an empty path.
-                if cur_dir_present {
-                    self.back = self.front + 1;
-                } else {
-                    self.back = self.front;
-                }
-            }
-            Some(i) => {
-                if cur_dir_present {
-                    self.back -= path.len() - i - 2;
-                } else {
-                    self.back -= path.len() - i - 1;
-                }
-            }
-        }
-    }
-
-    /// Increments our front pointer until we find the
-    /// next separator byte or have reached the component
-    /// that back index is pointing at.
-    fn seek_next_separator_front(&mut self) {
-        let path_bytes = &self.path_bytes[self.front..self.back];
-        match path_bytes.iter().position(|b| is_sep_byte(*b)) {
-            None => self.front = self.back,
-            Some(i) => self.front += i + 1,
-        }
-    }
-
-    /// Decrements our back pointer until we find the
-    /// next separator byte or have reached the component
-    /// that front index is pointing to.
-    fn seek_next_separator_back(&mut self) {
-        let path_bytes = &self.path_bytes[self.front..self.back];
-        match path_bytes.iter().rposition(|b| is_sep_byte(*b)) {
-            None => self.back = self.front,
-            Some(i) => self.back -= path_bytes.len() - i,
-        }
-    }
-
     /// Extracts a slice corresponding to the portion of the path remaining for iteration.
     ///
     /// # Examples
@@ -871,106 +642,13 @@ impl<'a> Components<'a> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn as_path(&self) -> &'a Path {
-        match self.first_comp {
-            Some(FirstComponent::AbsolutePath) => {
-                // If back index is at 0 (e.g parsing backward
-                // through "/foo") and we have an unconsumed
-                // Root component, Components::as_path needs to
-                // return "/" path
-                if self.back == 0 {
-                    return Path::new("/");
-                }
-            }
-            Some(FirstComponent::Prefix) => {
-                // We don't want to trim away separators from a Prefix
-                // component
-                if self.front == self.back {
-                    // SAFETY: If the first component is not consumed, then
-                    // front index encodes the whole length of the Prefix
-                    // component
-                    return unsafe { Path::from_u8_slice(&self.path_bytes[..self.front]) };
-                }
-                // SAFETY: Our back index is guaranteed to delimit at an ascii
-                // separator byte, so this should present a valid path
-                return unsafe {
-                    Path::from_u8_slice(&self.path_bytes[..self.back]).trim_trailing_sep()
-                };
-            }
-            _ => {}
-        }
-        // SAFETY: front and back index are delimited by ascii separator bytes,
-        // where front is a byte after an ascii separator and back is at an ascii
-        // separator, so this will always produce a valid path.
-        unsafe { Path::from_u8_slice(&self.path_bytes[self.front..self.back]).trim_trailing_sep() }
+        self.0.as_path()
     }
 
-    /// Parse a u8 slice into an OsStr, which is encoded into a `Component`
-    fn parse_single_component(&self, slice: &'a [u8]) -> Option<Component<'a>> {
-        match slice {
-            [] => return None,
-            [b'.'] => Some(Component::CurDir),
-            [b'.', b'.'] => Some(Component::ParentDir),
-            _ => {
-                let root_slice = MAIN_SEPARATOR_STR.as_bytes();
-                if slice == root_slice {
-                    return Some(Component::RootDir);
-                }
-                // SAFETY: Our sliced path is guaranteed to capture the entire component
-                // due to delimiting on ascii separators from front and back.
-                let path_osstr = unsafe { OsStr::from_encoded_bytes_unchecked(slice) };
-                Some(Component::Normal(path_osstr))
-            }
-        }
-    }
-
-    /// Parses the next component in `Components<'_>` from the left
-    fn parse_next_component(&mut self) -> Option<Component<'a>> {
-        // Our current `self.front` index at this point is the start
-        // of the component name
-        let before_front = self.front;
-        // We trace our `self.front` idx down the path until
-        // we hit a separator.
-        self.seek_next_separator_front();
-        let curr_front = self.front;
-        // Normalizes trailing seps and curr dirs in preparation for
-        // next front component
-        self.normalize_front();
-
-        // SAFETY: Our curr_front index always stops a byte after the ascii
-        // separator byte or at self.back (should there be no ascii separator
-        // in traversal), so we can always construct a valid u8 path slice
-        let sliced_path = if curr_front > 0 && is_sep_byte(self.path_bytes[curr_front - 1]) {
-            &self.path_bytes[before_front..curr_front - 1]
-        } else {
-            &self.path_bytes[before_front..curr_front]
-        };
-        self.parse_single_component(sliced_path)
-    }
-
-    /// Parses the next back component in `Components<'_>` from the
-    /// right
-    fn parse_next_back_component(&mut self) -> Option<Component<'a>> {
-        // Our current `self.back` index at this point encompasses
-        // the parent path
-        let before_back = self.back;
-        // We trace our `self.back` idx up the path until we reach a
-        // separator byte. This prepares the path we return on the next
-        // call to this function.
-        self.seek_next_separator_back();
-        let curr_back = self.back;
-        // Normalizes trailing seps and curr dirs in preparation for
-        // next back component
-        self.normalize_back();
-
-        // Our curr_back is at the byte before an ascii separator byte or self.front,
-        // (should there be no ascii separator in traversal), so we can always
-        // construct a valid u8 path slice
-        let sliced_path = if is_sep_byte(self.path_bytes[curr_back]) {
-            &self.path_bytes[curr_back + 1..before_back]
-        } else {
-            &self.path_bytes[curr_back..before_back]
-        };
-        self.parse_single_component(sliced_path)
+    /// This is the canonical implementation of `Path::has_root`
+    #[inline]
+    fn has_root(&self) -> bool {
+        self.0.has_root()
     }
 }
 
@@ -1068,30 +746,17 @@ impl FusedIterator for Iter<'_> {}
 impl<'a> Iterator for Components<'a> {
     type Item = Component<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Component<'a>> {
-        // We reach this case when we no longer have anymore paths
-        // to consume (return `None`), or if our front idx was initially
-        // equal to back idx (e.g. if we had `C:`, `.`, `/`), or if we
-        // had a front component initially
-        if self.front >= self.back || self.first_comp.is_some() {
-            self.consume_first_component_front()
-        } else {
-            self.parse_next_component()
-        }
+        self.0.next()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> DoubleEndedIterator for Components<'a> {
+    #[inline]
     fn next_back(&mut self) -> Option<Component<'a>> {
-        // We reach here when we no longer have anymore paths
-        // to consume, or we need to output Prefix component
-        // (anything else falls through this conditional)
-        if self.back <= self.front {
-            self.consume_first_component_back()
-        } else {
-            self.parse_next_back_component()
-        }
+        self.0.next_back()
     }
 }
 
@@ -1102,33 +767,7 @@ impl FusedIterator for Components<'_> {}
 impl<'a> PartialEq for Components<'a> {
     #[inline]
     fn eq(&self, other: &Components<'a>) -> bool {
-        // Fast path for exact matches, e.g. for hashmap lookups.
-        if self.path_bytes.len() == other.path_bytes.len()
-            && self.front == other.front
-            && self.back == other.back
-        {
-            // If either `self` or `other` have a prefix (indicated by `first_comp`)
-            // we need to start at index 0 (because prefix length is encoded in
-            // `front`)
-            let path = if matches!(self.first_comp, Some(FirstComponent::Prefix)) {
-                &self.path_bytes[..self.back]
-            } else {
-                &self.path_bytes[self.front..self.back]
-            };
-
-            let other_path = if matches!(other.first_comp, Some(FirstComponent::Prefix)) {
-                &other.path_bytes[..other.back]
-            } else {
-                &other.path_bytes[other.front..other.back]
-            };
-
-            if path == other_path {
-                return true;
-            }
-        }
-
-        // compare back to front since absolute paths often share long prefixes
-        Iterator::eq(self.clone().rev(), other.clone().rev())
+        self.0 == other.0
     }
 }
 
@@ -1139,7 +778,7 @@ impl Eq for Components<'_> {}
 impl<'a> PartialOrd for Components<'a> {
     #[inline]
     fn partial_cmp(&self, other: &Components<'a>) -> Option<cmp::Ordering> {
-        Some(compare_components(self.clone(), other.clone()))
+        Some(path_imp::compare_components(self.0.clone(), other.0.clone()))
     }
 }
 
@@ -1147,208 +786,8 @@ impl<'a> PartialOrd for Components<'a> {
 impl Ord for Components<'_> {
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        compare_components(self.clone(), other.clone())
+        path_imp::compare_components(self.0.clone(), other.0.clone())
     }
-}
-
-fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
-    // If we have a `FirstComponent` on both left and right `Components`,
-    // an optimization we can take is that if our left path is absolute
-    // and right path is relative (or vice versa), just compare the first
-    // byte (or return Greater/Less if relative path is empty string) since
-    // we know these two bytes are different
-    // The faster path isn't taken for paths with a PrefixComponent to avoid
-    // backtracking into the middle of one.
-    if let Some(left_first_comp) = left.first_comp
-        && let Some(right_first_comp) = right.first_comp
-    {
-        match (left_first_comp, right_first_comp) {
-            (FirstComponent::AbsolutePath, FirstComponent::RelativePath) => {
-                if right.back > 0 {
-                    return left.path_bytes[0].cmp(&right.path_bytes[0]);
-                }
-                return cmp::Ordering::Greater;
-            }
-            (FirstComponent::RelativePath, FirstComponent::AbsolutePath) => {
-                if left.back > 0 {
-                    return left.path_bytes[0].cmp(&right.path_bytes[0]);
-                }
-                return cmp::Ordering::Less;
-            }
-            (FirstComponent::AbsolutePath, FirstComponent::AbsolutePath)
-            | (FirstComponent::RelativePath, FirstComponent::RelativePath) => {}
-            _ => return Iterator::cmp(left, right),
-        }
-    }
-
-    let mut left_front = left.front;
-    let mut right_front = right.front;
-    let left_back = left.back;
-    let right_back = right.back;
-
-    loop {
-        // Compare raw bytes to find first mismatch
-        match crate::iter::zip(
-            left.path_bytes[left_front..left_back].iter(),
-            right.path_bytes[right_front..right_back].iter(),
-        )
-        .position(|(&a, &b)| a != b)
-        {
-            None if left_back - left_front == right_back - right_front => {
-                return cmp::Ordering::Equal;
-            }
-            // left/right path is strictly bigger than right/left path; normalize
-            // left/right path to see if it truly is equal to right/left path
-            None => {
-                let mut cur_dir_present = false;
-                if left_back - left_front > right_back - right_front {
-                    // For path comparison between /foo/bar. vs /foo/bar, we
-                    // can't treat this '.' as a current directory component
-                    // to be normalized
-                    if right_back > 0
-                        && left.path_bytes[right_back] == b'.'
-                        && left.path_bytes[right_back - 1] != MAIN_SEPARATOR as u8
-                    {
-                        return cmp::Ordering::Greater;
-                    }
-
-                    match left.path_bytes[right_back..left_back].iter().position(|b| {
-                        if !is_sep_byte(*b) {
-                            if *b == b'.' && !cur_dir_present {
-                                cur_dir_present = true;
-                                false
-                            } else {
-                                true
-                            }
-                        } else {
-                            cur_dir_present = false;
-                            false
-                        }
-                    }) {
-                        None => return cmp::Ordering::Equal,
-                        Some(_) => return cmp::Ordering::Greater,
-                    }
-                } else {
-                    // For path comparison between /foo/bar vs /foo/bar., we
-                    // can't treat this '.' as a current directory component
-                    // to be normalized
-                    if left_back > 0
-                        && right.path_bytes[left_back] == b'.'
-                        && right.path_bytes[left_back - 1] != MAIN_SEPARATOR as u8
-                    {
-                        return cmp::Ordering::Less;
-                    }
-                    match right.path_bytes[left_back..right_back].iter().position(|b| {
-                        if !is_sep_byte(*b) {
-                            if *b == b'.' && !cur_dir_present {
-                                cur_dir_present = true;
-                                false
-                            } else {
-                                true
-                            }
-                        } else {
-                            cur_dir_present = false;
-                            false
-                        }
-                    }) {
-                        None => return cmp::Ordering::Equal,
-                        Some(_) => return cmp::Ordering::Less,
-                    }
-                }
-            }
-            // Mismatched byte found
-            Some(ind) => {
-                left_front += ind;
-                right_front += ind;
-                let left_byte = left.path_bytes[left_front];
-                let right_byte = right.path_bytes[right_front];
-
-                // mismatch between a separator byte and a non-separator byte, normalize
-                // separator byte to make sure that the conflict is not due to path not
-                // being normalized
-                if left_byte == MAIN_SEPARATOR as u8 && right_byte != MAIN_SEPARATOR as u8 {
-                    let mut cur_dir_present = false;
-                    match left.path_bytes[left_front..left_back].iter().position(|b| {
-                        if !is_sep_byte(*b) {
-                            if *b == b'.' && !cur_dir_present {
-                                cur_dir_present = true;
-                                false
-                            } else {
-                                true
-                            }
-                        } else {
-                            cur_dir_present = false;
-                            false
-                        }
-                    }) {
-                        None => return cmp::Ordering::Less,
-                        Some(i) => {
-                            if cur_dir_present {
-                                left_front += i - 1;
-                            } else {
-                                left_front += i;
-                            }
-                        }
-                    }
-                }
-                // mismatch between a non-separator byte and a separator byte, normalize
-                // separator byte to make sure that the conflict is not due to path not
-                // being normalized
-                else if left_byte != MAIN_SEPARATOR as u8 && right_byte == MAIN_SEPARATOR as u8 {
-                    let mut cur_dir_present = false;
-                    match right.path_bytes[right_front..right_back].iter().position(|b| {
-                        if !is_sep_byte(*b) {
-                            if *b == b'.' && !cur_dir_present {
-                                cur_dir_present = true;
-                                false
-                            } else {
-                                true
-                            }
-                        } else {
-                            cur_dir_present = false;
-                            false
-                        }
-                    }) {
-                        None => return cmp::Ordering::Greater,
-                        Some(i) => {
-                            if cur_dir_present {
-                                right_front += i - 1;
-                            } else {
-                                right_front += i;
-                            }
-                        }
-                    }
-                }
-                // if mismatch is between non-separator bytes, return comparison between bytes
-                else {
-                    // if we see a '.' (which could be from `..`, a current directory, or something
-                    // that we should normalize), defer to comparison via `Iterator::cmp`.
-                    if left_byte == b'.' || right_byte == b'.' {
-                        break;
-                    }
-                    return left_byte.cmp(&right_byte);
-                }
-            }
-        }
-    }
-
-    // Start from the last separator before handing it off to be processed
-    // and compared by `Components::next`.This also avoids ambiguous parsings
-    // of '.' or '..' characters.
-    if let Some(left_previous_sep) =
-        left.path_bytes[..left_front].iter().rposition(|&b| is_sep_byte(b))
-        && let Some(right_prev_sep) =
-            right.path_bytes[..right_front].iter().rposition(|&b| is_sep_byte(b))
-    {
-        left.first_comp = None;
-        left.front = left_previous_sep;
-        left.normalize_front();
-        right.first_comp = None;
-        right.front = right_prev_sep;
-        right.normalize_front();
-    }
-
-    Iterator::cmp(left, right)
 }
 
 /// An iterator over [`Path`] and its ancestors.
@@ -1463,7 +902,7 @@ impl FusedIterator for Ancestors<'_> {}
 #[cfg_attr(not(test), rustc_diagnostic_item = "PathBuf")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct PathBuf {
-    inner: OsString,
+    pub(crate) inner: OsString,
 }
 
 impl PathBuf {
@@ -1586,107 +1025,7 @@ impl PathBuf {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_confusables("append", "put")]
     pub fn push<P: AsRef<Path>>(&mut self, path: P) {
-        self._push(path.as_ref())
-    }
-
-    fn _push(&mut self, path: &Path) {
-        // in general, a separator is needed if the rightmost byte is not a separator
-        let buf = self.inner.as_encoded_bytes();
-        let mut need_sep = buf.last().map(|c| !is_sep_byte(*c)).unwrap_or(false);
-
-        if HAS_PREFIXES {
-            let comps = self.components();
-            // in the special case of `C:` on Windows, do *not* add a separator
-            let parsed_prefix = parse_prefix(&self.inner);
-
-            if let Some(prefix) = parsed_prefix
-                && prefix.len() == self.inner.len()
-                && prefix.is_drive()
-            {
-                need_sep = false
-            }
-
-            let need_clear = if cfg!(target_os = "cygwin") {
-                // If path is absolute and its prefix is none, it is like `/foo`,
-                // and will be handled below.
-                path.prefix().is_some()
-            } else {
-                // On Unix: prefix is always None.
-                path.is_absolute() || path.prefix().is_some()
-            };
-
-            // absolute `path` replaces `self`
-            if need_clear {
-                self.inner.clear();
-            // verbatim paths need . and .. removed
-            } else if let Some(prefix) = parsed_prefix
-                && prefix.is_verbatim()
-                && !path.inner.is_empty()
-            {
-                let mut buf: Vec<_> = comps.collect();
-                for c in path.components() {
-                    match c {
-                        Component::RootDir => {
-                            buf.truncate(1);
-                            buf.push(c);
-                        }
-                        Component::CurDir => (),
-                        Component::ParentDir => {
-                            if let Some(Component::Normal(_)) = buf.last() {
-                                buf.pop();
-                            }
-                        }
-                        _ => buf.push(c),
-                    }
-                }
-
-                let mut res = OsString::new();
-                let mut need_sep = false;
-
-                for c in buf {
-                    if need_sep && c != Component::RootDir {
-                        res.push(MAIN_SEPARATOR_STR);
-                    }
-                    res.push(c.as_os_str());
-
-                    need_sep = match c {
-                        Component::RootDir => false,
-                        Component::Prefix(prefix) => {
-                            !prefix.parsed.is_drive() && prefix.parsed.len() > 0
-                        }
-                        _ => true,
-                    }
-                }
-
-                self.inner = res;
-                return;
-
-            // `path` has a root but no prefix, e.g., `\windows` (Windows only)
-            } else if path.has_root() {
-                // On creating a components iterator, if front index
-                // is non-zero we have a prefix.
-                let prefix_len = comps.front;
-                self.inner.truncate(prefix_len);
-
-            // `path` is a pure relative path
-            } else if need_sep {
-                self.inner.push(MAIN_SEPARATOR_STR);
-            }
-        } else {
-            let need_clear = path.is_absolute();
-
-            // absolute `path` replaces `self`
-            if need_clear {
-                self.inner.clear();
-            } else if path.has_root() {
-                self.inner.truncate(0);
-            // `path` is a pure relative path
-            } else if need_sep {
-                self.inner.push(MAIN_SEPARATOR_STR);
-            }
-        }
-
-        self.inner.push(path);
+        path_imp::push(self, path.as_ref())
     }
 
     /// Truncates `self` to [`self.parent`].
@@ -2516,7 +1855,7 @@ impl PartialEq for PathBuf {
     #[inline]
     fn eq(&self, other: &PathBuf) -> bool {
         self.as_os_str() == other.as_os_str()
-            || Iterator::eq(self.components().rev(), other.components().rev())
+            || path_imp::eq_components(self.components().0, other.components().0)
     }
 }
 
@@ -2566,7 +1905,7 @@ impl Eq for PathBuf {}
 impl PartialOrd for PathBuf {
     #[inline]
     fn partial_cmp(&self, other: &PathBuf) -> Option<cmp::Ordering> {
-        Some(compare_components(self.components(), other.components()))
+        Some(path_imp::compare_components(self.components().0, other.components().0))
     }
 }
 
@@ -2574,7 +1913,7 @@ impl PartialOrd for PathBuf {
 impl Ord for PathBuf {
     #[inline]
     fn cmp(&self, other: &PathBuf) -> cmp::Ordering {
-        compare_components(self.components(), other.components())
+        path_imp::compare_components(self.components().0, other.components().0)
     }
 }
 
@@ -2648,7 +1987,7 @@ pub struct NormalizeError;
 impl Path {
     // The following (private!) function allows construction of a path from a u8
     // slice, which is only safe when it is known to follow the OsStr encoding.
-    unsafe fn from_u8_slice(s: &[u8]) -> &Path {
+    pub(crate) unsafe fn from_u8_slice(s: &[u8]) -> &Path {
         unsafe { Path::new(OsStr::from_encoded_bytes_unchecked(s)) }
     }
     // The following (private!) function reveals the byte encoding used for OsStr.
@@ -2843,10 +2182,6 @@ impl Path {
     #[inline]
     pub fn is_relative(&self) -> bool {
         !self.is_absolute()
-    }
-
-    pub(crate) fn prefix(&self) -> Option<Prefix<'_>> {
-        parse_prefix(&self.inner)
     }
 
     /// Returns `true` if the `Path` has a root.
@@ -3254,7 +2589,7 @@ impl Path {
     #[must_use]
     #[inline]
     pub fn has_trailing_sep(&self) -> bool {
-        self.as_os_str().as_encoded_bytes().last().copied().is_some_and(is_sep_byte)
+        self.as_os_str().as_encoded_bytes().last().copied().is_some_and(path_imp::is_sep_byte)
     }
 
     /// Ensures that a path has a trailing [separator](MAIN_SEPARATOR),
@@ -3308,7 +2643,7 @@ impl Path {
         if self.has_trailing_sep() && (!self.has_root() || self.parent().is_some()) {
             let mut bytes = self.inner.as_encoded_bytes();
             while let Some((last, init)) = bytes.split_last()
-                && is_sep_byte(*last)
+                && path_imp::is_sep_byte(*last)
             {
                 bytes = init;
             }
@@ -3513,32 +2848,7 @@ impl Path {
     /// [`CurDir`]: Component::CurDir
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn components(&self) -> Components<'_> {
-        let os_str_path = self.as_os_str();
-        let path_bytes = os_str_path.as_encoded_bytes();
-
-        // Windows specific component
-        let prefix = parse_prefix(os_str_path);
-        let prefix_exist = prefix.map(|_| true).unwrap_or(false);
-
-        let has_physical_root = has_physical_root(path_bytes, prefix);
-        let first_comp = if prefix_exist {
-            Some(FirstComponent::Prefix)
-        } else if has_physical_root {
-            Some(FirstComponent::AbsolutePath)
-        } else {
-            Some(FirstComponent::RelativePath)
-        };
-
-        // If we have a prefix, we encode that index into front
-        let front = prefix.map(|prefix| prefix.len()).unwrap_or(0);
-        let back = path_bytes.len();
-
-        let mut components = Components { path_bytes, has_physical_root, front, back, first_comp };
-
-        // Normalize any trailing separators or cur dir (".") components away
-        components.normalize_back();
-
-        components
+        Components(path_imp::components(self))
     }
 
     /// Produces an iterator over the path's components viewed as [`OsStr`]
@@ -4042,7 +3352,7 @@ impl PartialEq for Path {
     #[inline]
     fn eq(&self, other: &Path) -> bool {
         self.as_os_str() == other.as_os_str()
-            || Iterator::eq(self.components().rev(), other.components().rev())
+            || path_imp::eq_components(self.components().0, other.components().0)
     }
 }
 
@@ -4083,7 +3393,7 @@ impl cmp::PartialEq<Path> for String {
 impl Hash for Path {
     fn hash<H: Hasher>(&self, h: &mut H) {
         let bytes = self.as_u8_slice();
-        let (prefix_len, verbatim) = match parse_prefix(&self.inner) {
+        let (prefix_len, verbatim) = match path_imp::parse_prefix(&self.inner) {
             Some(prefix) => {
                 prefix.hash(h);
                 (prefix.len(), prefix.is_verbatim())
@@ -4099,7 +3409,11 @@ impl Hash for Path {
         let mut chunk_bits: usize = 0;
 
         for i in 0..bytes.len() {
-            let is_sep = if verbatim { is_verbatim_sep(bytes[i]) } else { is_sep_byte(bytes[i]) };
+            let is_sep = if verbatim {
+                path_imp::is_verbatim_sep(bytes[i])
+            } else {
+                path_imp::is_sep_byte(bytes[i])
+            };
             if is_sep {
                 if i > component_start {
                     let to_hash = &bytes[component_start..i];
@@ -4117,7 +3431,7 @@ impl Hash for Path {
                 if !verbatim {
                     component_start += match tail {
                         [b'.'] => 1,
-                        [b'.', sep, ..] if is_sep_byte(*sep) => 1,
+                        [b'.', sep, ..] if path_imp::is_sep_byte(*sep) => 1,
                         _ => 0,
                     };
                 }
@@ -4142,7 +3456,7 @@ impl Eq for Path {}
 impl PartialOrd for Path {
     #[inline]
     fn partial_cmp(&self, other: &Path) -> Option<cmp::Ordering> {
-        Some(compare_components(self.components(), other.components()))
+        Some(path_imp::compare_components(self.components().0, other.components().0))
     }
 }
 
@@ -4150,7 +3464,7 @@ impl PartialOrd for Path {
 impl Ord for Path {
     #[inline]
     fn cmp(&self, other: &Path) -> cmp::Ordering {
-        compare_components(self.components(), other.components())
+        path_imp::compare_components(self.components().0, other.components().0)
     }
 }
 

--- a/library/std/src/sys/path/cygwin.rs
+++ b/library/std/src/sys/path/cygwin.rs
@@ -18,8 +18,6 @@ pub const fn is_verbatim_sep(b: u8) -> bool {
 
 pub use super::windows_prefix::parse_prefix;
 
-pub const HAS_PREFIXES: bool = true;
-
 unsafe extern "C" {
     // Doc: https://cygwin.com/cygwin-api/func-cygwin-conv-path.html
     // Src: https://github.com/cygwin/cygwin/blob/718a15ba50e0d01c79800bd658c2477f9a603540/winsup/cygwin/path.cc#L3902
@@ -55,7 +53,7 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
         Ok(PathBuf::from(OsString::from_vec(buffer)))
     })
     .map(|path| {
-        if path.prefix().is_some() {
+        if path.components().0.prefix().is_some() {
             return path;
         }
 
@@ -81,7 +79,7 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
 
 pub(crate) fn is_absolute(path: &Path) -> bool {
     if path.as_os_str().as_encoded_bytes().starts_with(b"\\") {
-        path.has_root() && path.prefix().is_some()
+        path.has_root() && path.components().0.prefix().is_some()
     } else {
         path.has_root()
     }

--- a/library/std/src/sys/path/mod.rs
+++ b/library/std/src/sys/path/mod.rs
@@ -21,27 +21,39 @@ cfg_select! {
     target_os = "windows" => {
         mod windows;
         mod windows_prefix;
+        mod prefixed_paths;
         pub use windows::*;
+        pub use prefixed_paths::*;
     }
     all(target_vendor = "fortanix", target_env = "sgx") => {
         mod sgx;
+        mod nonprefixed_paths;
         pub use sgx::*;
+        pub use nonprefixed_paths::*;
     }
     target_os = "solid_asp3" => {
         mod unsupported_backslash;
+        mod prefixed_paths;
         pub use unsupported_backslash::*;
+        pub use prefixed_paths::*;
     }
     target_os = "uefi" => {
         mod uefi;
+        mod prefixed_paths;
         pub use uefi::*;
+        pub use prefixed_paths::*;
     }
     target_os = "cygwin" => {
         mod cygwin;
+        mod prefixed_paths;
         mod windows_prefix;
         pub use cygwin::*;
+        pub use prefixed_paths::*;
     }
     _ => {
         mod unix;
+        mod nonprefixed_paths;
         pub use unix::*;
+        pub use nonprefixed_paths::*;
     }
 }

--- a/library/std/src/sys/path/nonprefixed_paths.rs
+++ b/library/std/src/sys/path/nonprefixed_paths.rs
@@ -1,0 +1,451 @@
+//! This file constructs an implementation of the `Components` iterator that does not
+//! consider prefix components and provides different implementation to specific functions
+//! that utilize this version of `Components`.
+
+use crate::cmp;
+use crate::ffi::OsStr;
+use crate::iter::FusedIterator;
+use crate::path::{Component, MAIN_SEPARATOR, MAIN_SEPARATOR_STR, Path, PathBuf};
+use crate::sys::path::is_sep_byte;
+
+/// This tracks the current state of the iterator, or more specifically,
+/// the bytes we have left to consume from our path.
+///
+/// We use:
+///    - 'Absolute' to denote that our current path_bytes is considered an
+///       an absolute path
+///    - `Relative` to denote that our current path_bytes is considered a
+///       relative path
+///    - `Done` to denote that our current path_bytes is empty
+///
+/// All of these states allow us to parse the path components
+/// appropriately within `Components::next`/`Components::next_back`.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+enum State {
+    Absolute = 1, // A root component (i.e. '/')
+    Relative = 2, // A relative component ('foo')
+    Done = 3,     // Iterator is fully consumed
+}
+
+#[derive(Clone)]
+pub struct Components<'a> {
+    // The path left to parse components from
+    path: &'a [u8],
+    // The current state of the iterator
+    state: State,
+}
+
+impl<'a> Components<'a> {
+    /// Checks if all bytes of our path have been consumed
+    #[inline]
+    fn is_done(&self) -> bool {
+        self.state == State::Done
+    }
+
+    /// This is the canonical implementation of `Path::has_root`
+    #[inline]
+    pub(crate) fn has_root(&self) -> bool {
+        self.state == State::Absolute
+    }
+
+    /// Normalizes away trailing separators and current directory ('.') components
+    /// in the forward direction. Returns the 0-index `self.path` should start at
+    /// to subslice at in the front direction.
+    fn normalize_front(&mut self, mut front: usize) -> usize {
+        let mut cur_dir_present = false;
+        match self.path[front..].iter().position(|b| {
+            if !is_sep_byte(*b) {
+                if *b == b'.' && !cur_dir_present {
+                    cur_dir_present = true;
+                    false
+                } else {
+                    true
+                }
+            } else {
+                cur_dir_present = false;
+                false
+            }
+        }) {
+            None => {
+                self.state = State::Done;
+                return self.path.len();
+            }
+            Some(i) => {
+                if cur_dir_present {
+                    front += i - 1;
+                } else {
+                    front += i;
+                }
+            }
+        }
+        front
+    }
+
+    /// Normalizes away trailing separators and current directory ('.') components
+    /// in the backward direction. Returns the 1-index `self.path` should start at
+    /// to find next separator in the back direction.
+    fn normalize_back(&mut self) -> usize {
+        let mut cur_dir_present = false;
+        match self.path.iter().rposition(|b| {
+            if !is_sep_byte(*b) {
+                if *b == b'.' && !cur_dir_present {
+                    cur_dir_present = true;
+                    false
+                } else {
+                    true
+                }
+            } else {
+                cur_dir_present = false;
+                false
+            }
+        }) {
+            None => {
+                // For cases like "./a", where our path
+                // will observe "." at the end, and we need to return
+                // that we observed "." component instead of
+                // returning an empty path.
+                if cur_dir_present {
+                    return 1;
+                } else {
+                    self.state = State::Done;
+                    return 0;
+                }
+            }
+            Some(i) => {
+                if cur_dir_present {
+                    return i + 2;
+                } else {
+                    return i + 1;
+                }
+            }
+        }
+    }
+
+    /// Extracts a slice corresponding to the portion of the path remaining for iteration.
+    pub fn as_path(&self) -> &'a Path {
+        // Normalize bytes from the right
+        let mut cur_dir_present = false;
+        let (done, back) = match self.path.iter().rposition(|b| {
+            if !is_sep_byte(*b) {
+                if *b == b'.' && !cur_dir_present {
+                    cur_dir_present = true;
+                    false
+                } else {
+                    true
+                }
+            } else {
+                cur_dir_present = false;
+                false
+            }
+        }) {
+            None => {
+                // For cases like "./a", where our path
+                // will observe "." at the end, and we need to return
+                // that we observed "." component instead of
+                // returning an empty path.
+                if cur_dir_present {
+                    (false, 1)
+                } else {
+                    // self.is_done = true;
+                    (true, 0)
+                }
+            }
+            Some(i) => {
+                if cur_dir_present {
+                    (false, i + 2)
+                } else {
+                    (false, i + 1)
+                }
+            }
+        };
+
+        if done && self.has_root() {
+            return Path::new("/");
+        }
+        // SAFETY: Back should be at a separator byte (or index 0 if
+        // no separator byte exist), which slicing path_bytes at that index
+        // should give us a valid slice
+        unsafe { Path::from_u8_slice(&self.path[..back]) }
+    }
+
+    /// Parse a u8 slice into an OsStr, which is encoded into a `Component`
+    fn parse_single_component(&self, slice: &'a [u8]) -> Option<Component<'a>> {
+        match slice {
+            [] => return None,
+            [b'.'] => Some(Component::CurDir),
+            [b'.', b'.'] => Some(Component::ParentDir),
+            _ => {
+                let root_slice = MAIN_SEPARATOR_STR.as_bytes();
+                if slice == root_slice {
+                    return Some(Component::RootDir);
+                }
+                // SAFETY: Our sliced path is guaranteed to capture the entire component
+                // due to delimiting on ascii separators from front and back.
+                let path_osstr = unsafe { OsStr::from_encoded_bytes_unchecked(slice) };
+                Some(Component::Normal(path_osstr))
+            }
+        }
+    }
+
+    /// Parses the next component in `Components<'_>` from the left. This returns both the index
+    /// of the separator byte it saw (if None, it's the whole remaining slice) and the parsed
+    /// component.
+    fn parse_next_component(&mut self) -> (usize, Option<Component<'a>>) {
+        let (front_ind, comp) = match self.path.iter().position(|b| is_sep_byte(*b)) {
+            None => (self.path.len(), self.path),
+            Some(i) => (i + 1, &self.path[..i]),
+        };
+
+        (front_ind, self.parse_single_component(comp))
+    }
+
+    /// Parses the next back component in `Components<'_>` from the right. This returns both the index
+    /// of the separator byte it saw (if None, it's 0) and the parsed component.
+    fn parse_next_back_component(&mut self, back: usize) -> (usize, Option<Component<'a>>) {
+        let (back_ind, comp) = match self.path[..back].iter().rposition(|b| is_sep_byte(*b)) {
+            None => {
+                self.state = State::Done;
+                (0, &self.path[..back])
+            }
+            Some(i) => (i, &self.path[i + 1..back]),
+        };
+
+        (back_ind, self.parse_single_component(comp))
+    }
+}
+
+impl<'a> Iterator for Components<'a> {
+    type Item = Component<'a>;
+
+    fn next(&mut self) -> Option<Component<'a>> {
+        // Changing this to a pure match case body with State::Absolute,
+        // State::Relative, State::Done causes performance degradation
+        // with `Components` ordering. Unsure why, but writing the code like
+        // this maintains performance on par with the prefixed version.
+        if !self.is_done() {
+            match self.state {
+                State::Absolute => {
+                    let end_ind = self.normalize_front(0);
+                    self.path = if self.is_done() {
+                        &[]
+                    } else {
+                        self.state = State::Relative;
+                        &self.path[end_ind..]
+                    };
+
+                    return Some(Component::RootDir);
+                }
+                _ => {
+                    let (front_ind, comp) = self.parse_next_component();
+                    let normalized_front_ind = self.normalize_front(front_ind);
+                    self.path =
+                        if self.is_done() { &[] } else { &self.path[normalized_front_ind..] };
+                    return comp;
+                }
+            }
+        }
+        None
+    }
+}
+
+impl<'a> DoubleEndedIterator for Components<'a> {
+    fn next_back(&mut self) -> Option<Component<'a>> {
+        match self.state {
+            State::Done => None,
+            State::Absolute => {
+                let back = self.normalize_back();
+                // Since we normalize upfront, we only return the
+                // root component when our path bytes are fully consumed
+                // Otherwise, we treat this as the same as a relative component
+                if self.is_done() {
+                    self.path = &[];
+                    Some(Component::RootDir)
+                } else {
+                    let (back_ind, comp) = self.parse_next_back_component(back);
+                    self.path = &self.path[..back_ind];
+                    comp
+                }
+            }
+            State::Relative => {
+                let back = self.normalize_back();
+                let (back_ind, comp) = self.parse_next_back_component(back);
+                self.path = &self.path[..back_ind];
+                comp
+            }
+        }
+    }
+}
+
+#[stable(feature = "fused", since = "1.26.0")]
+impl FusedIterator for Components<'_> {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a> PartialEq for Components<'a> {
+    #[inline]
+    fn eq(&self, other: &Components<'a>) -> bool {
+        // Fast path for exact matches, e.g. for hashmap lookups.
+        if self.path == other.path {
+            return true;
+        }
+
+        eq_components(self.clone(), other.clone())
+    }
+}
+
+/// Prefix-less `Components` equality
+pub fn eq_components(mut left: Components<'_>, mut right: Components<'_>) -> bool {
+    // Fast path
+    //
+    // - check if we have empty paths
+    // - compare raw bytes from right to left to find first mismatch
+    // - backtrack to find separator after mismatch to avoid ambiguous parsings of '.' or '..' characters
+    // - if found update state to only do a component-wise comparison in the back direction
+    //   on the remainder, otherwise do it on the full path
+
+    // One of them is an empty path
+    if left.is_done() != right.is_done() {
+        return false;
+    }
+
+    // Both are empty paths
+    if left.is_done() && right.is_done() {
+        return true;
+    }
+
+    let mut left_iter = left.path.iter();
+    let mut right_iter = right.path.iter();
+    let mut bytes_consumed = 0;
+
+    // From benchmarking, this is faster than using:
+    // left_iter.rev().zip(right_iter.rev()).position(|&a, &b| a != b)
+    let (left_diff, right_diff) = 'diff: {
+        while let Some(left_byte) = left_iter.next_back()
+            && let Some(right_byte) = right_iter.next_back()
+        {
+            bytes_consumed += 1;
+            let left_byte = *left_byte;
+            let right_byte = *right_byte;
+            if left_byte != right_byte {
+                // If left byte and right byte are not any of these bytes
+                // this mismatch means they are not equal
+                if left_byte != MAIN_SEPARATOR as u8
+                    && left_byte != b'.'
+                    && right_byte != MAIN_SEPARATOR as u8
+                    && right_byte != b'.'
+                {
+                    return false;
+                } else {
+                }
+                break 'diff (left.path.len() - bytes_consumed, right.path.len() - bytes_consumed);
+            }
+        }
+
+        (left.path.len() - bytes_consumed, right.path.len() - bytes_consumed)
+    };
+
+    // Cases like "foo/./bar" == "foo/bar", "foobar/bar" == "foobar", needs to consider
+    // whether left_diff/right_diff is at a separator byte or not.
+    if left.path[left_diff] != MAIN_SEPARATOR as u8 {
+        if let Some(next_sep) = left.path[left_diff..].iter().position(|&b| is_sep_byte(b)) {
+            left.path = &left.path[..left_diff + next_sep];
+            right.path = &right.path[..right_diff + next_sep];
+        }
+    } else if right.path[right_diff] != MAIN_SEPARATOR as u8 {
+        if let Some(next_sep) = right.path[right_diff..].iter().position(|&b| is_sep_byte(b)) {
+            left.path = &left.path[..left_diff + next_sep];
+            right.path = &right.path[..right_diff + next_sep];
+        }
+    } else {
+        // We exclude the separator byte; if we happen to exclude the root dir component
+        // for one of the paths (e.g. "///foo" == "/foo") that's fine, our
+        // Component iterator state will still tell us that the path is an absolute
+        // path, and then both would return `Component::RootDir`
+        left.path = &left.path[..left_diff];
+        right.path = &right.path[..right_diff];
+    }
+
+    // compare back to front since absolute paths often share long prefixes
+    Iterator::eq(left.rev(), right.rev())
+}
+
+impl Eq for Components<'_> {}
+
+impl<'a> PartialOrd for Components<'a> {
+    #[inline]
+    fn partial_cmp(&self, other: &Components<'a>) -> Option<cmp::Ordering> {
+        Some(compare_components(self.clone(), other.clone()))
+    }
+}
+
+impl Ord for Components<'_> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        compare_components(self.clone(), other.clone())
+    }
+}
+
+/// Prefix-less `Components` comparison
+pub fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
+    // Fast path for long shared prefixes
+    //
+    // - compare raw bytes to find first mismatch
+    // - backtrack to find separator before mismatch to avoid ambiguous parsings of '.' or '..' characters
+    // - if found update state to only do a component-wise comparison on the remainder,
+    //   otherwise do it on the full path
+
+    let first_difference = match left.path.iter().zip(right.path).position(|(&a, &b)| a != b) {
+        None if left.path.len() == right.path.len() => return cmp::Ordering::Equal,
+        None => left.path.len().min(right.path.len()),
+        Some(diff) => diff,
+    };
+
+    if let Some(previous_sep) = left.path[..first_difference].iter().rposition(|&b| is_sep_byte(b))
+    {
+        // If our state initially started as an absolute path, the root component
+        // is guaranteed to be sliced away, so treat the state as if it were a
+        // relative component
+        let mismatched_component_start = previous_sep + 1;
+        left.path = &left.path[left.normalize_front(mismatched_component_start)..];
+        left.state = State::Relative;
+        right.path = &right.path[right.normalize_front(mismatched_component_start)..];
+        right.state = State::Relative;
+    }
+
+    Iterator::cmp(left, right)
+}
+
+/// Prefix-less `Components` construction implementation
+pub fn components(path: &Path) -> Components<'_> {
+    let os_str_path = path.as_os_str();
+    let path = os_str_path.as_encoded_bytes();
+
+    let state = if path.is_empty() {
+        State::Done
+    } else if is_sep_byte(path[0]) {
+        State::Absolute
+    } else {
+        State::Relative
+    };
+
+    Components { path, state }
+}
+
+/// Internal prefix-less helper method for `PathBuf::push`
+pub fn push(self_path: &mut PathBuf, other_path: &Path) {
+    // in general, a separator is needed if the rightmost byte is not a separator
+    let buf = self_path.inner.as_encoded_bytes();
+    let need_sep = buf.last().map(|c| !is_sep_byte(*c)).unwrap_or(false);
+    let need_clear = other_path.is_absolute();
+
+    // absolute `path` replaces `self`
+    if need_clear {
+        self_path.inner.clear();
+    } else if other_path.has_root() {
+        self_path.inner.truncate(0);
+    // `path` is a pure relative path
+    } else if need_sep {
+        self_path.inner.push(MAIN_SEPARATOR_STR);
+    }
+
+    self_path.inner.push(other_path);
+}

--- a/library/std/src/sys/path/prefixed_paths.rs
+++ b/library/std/src/sys/path/prefixed_paths.rs
@@ -1,0 +1,480 @@
+//! This file constructs an implementation of the `Components` iterator that handles
+//! prefix components and provides different implementation to specific functions
+//! that utilize this version of `Components`.
+
+use crate::cmp;
+use crate::ffi::{OsStr, OsString};
+use crate::iter::FusedIterator;
+use crate::path::{Component, MAIN_SEPARATOR_STR, Path, PathBuf, Prefix, PrefixComponent};
+use crate::sys::path::{is_sep_byte, is_verbatim_sep, parse_prefix};
+
+// Extra internal methods implemented on `Prefix`
+impl<'a> Prefix<'a> {
+    #[inline]
+    fn is_drive(&self) -> bool {
+        matches!(*self, Prefix::Disk(_))
+    }
+
+    #[inline]
+    fn has_implicit_root(&self) -> bool {
+        !self.is_drive()
+    }
+}
+
+/// Component parsing works by a double-ended state machine; the cursors at the
+/// front and back of the path each keep track of what parts of the path have
+/// been consumed so far.
+///
+/// Going front to back, a path is made up of a prefix, a starting
+/// directory component, and a body (of normal components)
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+enum State {
+    Prefix = 0,   // c:
+    StartDir = 1, // / or . or nothing
+    Body = 2,     // foo/bar/baz
+    Done = 3,
+}
+
+#[derive(Clone)]
+pub struct Components<'a> {
+    // The path left to parse components from
+    path: &'a [u8],
+
+    // The prefix as it was originally parsed, if any
+    prefix: Option<Prefix<'a>>,
+
+    // true if path *physically* has a root separator; for most Windows
+    // prefixes, it may have a "logical" root separator for the purposes of
+    // normalization, e.g., \\server\share == \\server\share\.
+    has_physical_root: bool,
+
+    // The iterator is double-ended, and these two states keep track of what has
+    // been produced from either end
+    front: State,
+    back: State,
+}
+
+impl<'a> Components<'a> {
+    // how long is the prefix, if any?
+    #[inline]
+    fn prefix_len(&self) -> usize {
+        self.prefix.as_ref().map(Prefix::len).unwrap_or(0)
+    }
+
+    #[inline]
+    fn prefix_verbatim(&self) -> bool {
+        self.prefix.as_ref().map(Prefix::is_verbatim).unwrap_or(false)
+    }
+
+    /// how much of the prefix is left from the point of view of iteration?
+    #[inline]
+    fn prefix_remaining(&self) -> usize {
+        if self.front == State::Prefix { self.prefix_len() } else { 0 }
+    }
+
+    // Given the iteration so far, how much of the pre-State::Body path is left?
+    #[inline]
+    fn len_before_body(&self) -> usize {
+        let root = if self.front <= State::StartDir && self.has_physical_root { 1 } else { 0 };
+        let cur_dir = if self.front <= State::StartDir && self.include_cur_dir() { 1 } else { 0 };
+        self.prefix_remaining() + root + cur_dir
+    }
+
+    // is the iteration complete?
+    #[inline]
+    fn finished(&self) -> bool {
+        self.front == State::Done || self.back == State::Done || self.front > self.back
+    }
+
+    #[inline]
+    fn is_sep_byte(&self, b: u8) -> bool {
+        if self.prefix_verbatim() { is_verbatim_sep(b) } else { is_sep_byte(b) }
+    }
+
+    /// Extracts a slice corresponding to the portion of the path remaining for iteration.
+    pub fn as_path(&self) -> &'a Path {
+        let mut comps = self.clone();
+        if comps.front == State::Body {
+            comps.trim_left();
+        }
+        if comps.back == State::Body {
+            comps.trim_right();
+        }
+        unsafe { Path::from_u8_slice(comps.path) }
+    }
+
+    /// Obtain prefix component from `Components` iterator
+    /// if it exists
+    pub(crate) fn prefix(&self) -> Option<Prefix<'_>> {
+        self.prefix
+    }
+
+    /// Is the *original* path rooted?
+    pub(crate) fn has_root(&self) -> bool {
+        if self.has_physical_root {
+            return true;
+        }
+        if let Some(p) = self.prefix {
+            if p.has_implicit_root() {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Should the normalized path include a leading . ?
+    fn include_cur_dir(&self) -> bool {
+        if self.has_root() {
+            return false;
+        }
+        let slice = &self.path[self.prefix_remaining()..];
+        match slice {
+            [b'.'] => true,
+            [b'.', b, ..] => self.is_sep_byte(*b),
+            _ => false,
+        }
+    }
+
+    // parse a given byte sequence following the OsStr encoding into the
+    // corresponding path component
+    unsafe fn parse_single_component<'b>(&self, comp: &'b [u8]) -> Option<Component<'b>> {
+        match comp {
+            b"." if self.prefix_verbatim() => Some(Component::CurDir),
+            b"." => None, // . components are normalized away, except at
+            // the beginning of a path, which is treated
+            // separately via `include_cur_dir`
+            b".." => Some(Component::ParentDir),
+            b"" => None,
+            _ => Some(Component::Normal(unsafe { OsStr::from_encoded_bytes_unchecked(comp) })),
+        }
+    }
+
+    // parse a component from the left, saying how many bytes to consume to
+    // remove the component
+    fn parse_next_component(&self) -> (usize, Option<Component<'a>>) {
+        debug_assert!(self.front == State::Body);
+        let (extra, comp) = match self.path.iter().position(|b| self.is_sep_byte(*b)) {
+            None => (0, self.path),
+            Some(i) => (1, &self.path[..i]),
+        };
+        // SAFETY: `comp` is a valid substring, since it is split on a separator.
+        (comp.len() + extra, unsafe { self.parse_single_component(comp) })
+    }
+
+    // parse a component from the right, saying how many bytes to consume to
+    // remove the component
+    fn parse_next_component_back(&self) -> (usize, Option<Component<'a>>) {
+        debug_assert!(self.back == State::Body);
+        let start = self.len_before_body();
+        let (extra, comp) = match self.path[start..].iter().rposition(|b| self.is_sep_byte(*b)) {
+            None => (0, &self.path[start..]),
+            Some(i) => (1, &self.path[start + i + 1..]),
+        };
+        // SAFETY: `comp` is a valid substring, since it is split on a separator.
+        (comp.len() + extra, unsafe { self.parse_single_component(comp) })
+    }
+
+    // trim away repeated separators (i.e., empty components) on the left
+    fn trim_left(&mut self) {
+        while !self.path.is_empty() {
+            let (size, comp) = self.parse_next_component();
+            if comp.is_some() {
+                return;
+            } else {
+                self.path = &self.path[size..];
+            }
+        }
+    }
+
+    // trim away repeated separators (i.e., empty components) on the right
+    fn trim_right(&mut self) {
+        while self.path.len() > self.len_before_body() {
+            let (size, comp) = self.parse_next_component_back();
+            if comp.is_some() {
+                return;
+            } else {
+                self.path = &self.path[..self.path.len() - size];
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for Components<'a> {
+    type Item = Component<'a>;
+
+    fn next(&mut self) -> Option<Component<'a>> {
+        while !self.finished() {
+            match self.front {
+                // most likely case first
+                State::Body if !self.path.is_empty() => {
+                    let (size, comp) = self.parse_next_component();
+                    self.path = &self.path[size..];
+                    if comp.is_some() {
+                        return comp;
+                    }
+                }
+                State::Body => {
+                    self.front = State::Done;
+                }
+                State::StartDir => {
+                    self.front = State::Body;
+                    if self.has_physical_root {
+                        debug_assert!(!self.path.is_empty());
+                        self.path = &self.path[1..];
+                        return Some(Component::RootDir);
+                    } else if let Some(p) = self.prefix {
+                        if p.has_implicit_root() && !p.is_verbatim() {
+                            return Some(Component::RootDir);
+                        }
+                    } else if self.include_cur_dir() {
+                        debug_assert!(!self.path.is_empty());
+                        self.path = &self.path[1..];
+                        return Some(Component::CurDir);
+                    }
+                }
+                State::Prefix if self.prefix_len() == 0 => {
+                    self.front = State::StartDir;
+                }
+                State::Prefix => {
+                    self.front = State::StartDir;
+                    debug_assert!(self.prefix_len() <= self.path.len());
+                    let raw = &self.path[..self.prefix_len()];
+                    self.path = &self.path[self.prefix_len()..];
+                    return Some(Component::Prefix(PrefixComponent {
+                        raw: unsafe { OsStr::from_encoded_bytes_unchecked(raw) },
+                        parsed: self.prefix.unwrap(),
+                    }));
+                }
+                State::Done => unreachable!(),
+            }
+        }
+        None
+    }
+}
+
+impl<'a> DoubleEndedIterator for Components<'a> {
+    fn next_back(&mut self) -> Option<Component<'a>> {
+        while !self.finished() {
+            match self.back {
+                State::Body if self.path.len() > self.len_before_body() => {
+                    let (size, comp) = self.parse_next_component_back();
+                    self.path = &self.path[..self.path.len() - size];
+                    if comp.is_some() {
+                        return comp;
+                    }
+                }
+                State::Body => {
+                    self.back = State::StartDir;
+                }
+                State::StartDir => {
+                    self.back = State::Prefix;
+                    if self.has_physical_root {
+                        self.path = &self.path[..self.path.len() - 1];
+                        return Some(Component::RootDir);
+                    } else if let Some(p) = self.prefix {
+                        if p.has_implicit_root() && !p.is_verbatim() {
+                            return Some(Component::RootDir);
+                        }
+                    } else if self.include_cur_dir() {
+                        self.path = &self.path[..self.path.len() - 1];
+                        return Some(Component::CurDir);
+                    }
+                }
+                State::Prefix if self.prefix_len() > 0 => {
+                    self.back = State::Done;
+                    return Some(Component::Prefix(PrefixComponent {
+                        raw: unsafe { OsStr::from_encoded_bytes_unchecked(self.path) },
+                        parsed: self.prefix.unwrap(),
+                    }));
+                }
+                State::Prefix => {
+                    self.back = State::Done;
+                    return None;
+                }
+                State::Done => unreachable!(),
+            }
+        }
+        None
+    }
+}
+
+impl FusedIterator for Components<'_> {}
+
+impl<'a> PartialEq for Components<'a> {
+    #[inline]
+    fn eq(&self, other: &Components<'a>) -> bool {
+        let Components { path: _, front: _, back: _, has_physical_root: _, prefix: _ } = self;
+
+        // Fast path for exact matches, e.g. for hashmap lookups.
+        // Don't explicitly compare the prefix or has_physical_root fields since they'll
+        // either be covered by the `path` buffer or are only relevant for `prefix_verbatim()`.
+        if self.path.len() == other.path.len()
+            && self.front == other.front
+            && self.back == State::Body
+            && other.back == State::Body
+            && self.prefix_verbatim() == other.prefix_verbatim()
+        {
+            // possible future improvement: this could bail out earlier if there were a
+            // reverse memcmp/bcmp comparing back to front
+            if self.path == other.path {
+                return true;
+            }
+        }
+
+        eq_components(self.clone(), other.clone())
+    }
+}
+
+/// Prefixed `Components` equality
+pub fn eq_components(left: Components<'_>, right: Components<'_>) -> bool {
+    // compare back to front since absolute paths often share long prefixes
+    Iterator::eq(left.rev(), right.rev())
+}
+
+impl Eq for Components<'_> {}
+
+impl<'a> PartialOrd for Components<'a> {
+    #[inline]
+    fn partial_cmp(&self, other: &Components<'a>) -> Option<cmp::Ordering> {
+        Some(compare_components(self.clone(), other.clone()))
+    }
+}
+
+impl Ord for Components<'_> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        compare_components(self.clone(), other.clone())
+    }
+}
+
+/// Prefixed `Components` comparison
+pub fn compare_components(mut left: Components<'_>, mut right: Components<'_>) -> cmp::Ordering {
+    // Fast path for long shared prefixes
+    //
+    // - compare raw bytes to find first mismatch
+    // - backtrack to find separator before mismatch to avoid ambiguous parsings of '.' or '..' characters
+    // - if found update state to only do a component-wise comparison on the remainder,
+    //   otherwise do it on the full path
+    //
+    // The fast path isn't taken for paths with a PrefixComponent to avoid backtracking into
+    // the middle of one
+
+    if left.prefix.is_none() && right.prefix.is_none() && left.front == right.front {
+        // possible future improvement: a [u8]::first_mismatch simd implementation
+        let first_difference = match left.path.iter().zip(right.path).position(|(&a, &b)| a != b) {
+            None if left.path.len() == right.path.len() => return cmp::Ordering::Equal,
+            None => left.path.len().min(right.path.len()),
+            Some(diff) => diff,
+        };
+
+        if let Some(previous_sep) =
+            left.path[..first_difference].iter().rposition(|&b| left.is_sep_byte(b))
+        {
+            let mismatched_component_start = previous_sep + 1;
+            left.path = &left.path[mismatched_component_start..];
+            left.front = State::Body;
+            right.path = &right.path[mismatched_component_start..];
+            right.front = State::Body;
+        }
+    }
+
+    Iterator::cmp(left, right)
+}
+
+/// Says whether the first byte after the prefix is a separator.
+fn has_physical_root(s: &[u8], prefix: Option<Prefix<'_>>) -> bool {
+    let path = if let Some(p) = prefix { &s[p.len()..] } else { s };
+    !path.is_empty() && is_sep_byte(path[0])
+}
+
+/// Prefixed `Components` construction implementation
+pub fn components(path: &Path) -> Components<'_> {
+    let prefix = parse_prefix(path.as_os_str());
+    Components {
+        path: path.as_u8_slice(),
+        prefix,
+        has_physical_root: has_physical_root(path.as_u8_slice(), prefix),
+        front: State::Prefix,
+        back: State::Body,
+    }
+}
+
+/// Internal prefixed helper method for `PathBuf::push`
+pub fn push(self_path: &mut PathBuf, other_path: &Path) {
+    // in general, a separator is needed if the rightmost byte is not a separator
+    let buf = self_path.inner.as_encoded_bytes();
+    let mut need_sep = buf.last().map(|c| !is_sep_byte(*c)).unwrap_or(false);
+
+    // in the special case of `C:` on Windows, do *not* add a separator
+    let comps = self_path.components().0;
+
+    if comps.prefix_len() > 0
+        && comps.prefix_len() == comps.path.len()
+        && comps.prefix.unwrap().is_drive()
+    {
+        need_sep = false
+    }
+
+    let need_clear = if cfg!(target_os = "cygwin") {
+        // If path is absolute and its prefix is none, it is like `/foo`,
+        // and will be handled below.
+        parse_prefix(other_path.as_os_str()).is_some()
+    } else {
+        // On Unix: prefix is always None.
+        other_path.is_absolute() || parse_prefix(other_path.as_os_str()).is_some()
+    };
+
+    // absolute `path` replaces `self`
+    if need_clear {
+        self_path.inner.clear();
+
+    // verbatim paths need . and .. removed
+    } else if comps.prefix_verbatim() && !other_path.as_os_str().is_empty() {
+        let mut buf: Vec<_> = comps.collect();
+        for c in other_path.components() {
+            match c {
+                Component::RootDir => {
+                    buf.truncate(1);
+                    buf.push(c);
+                }
+                Component::CurDir => (),
+                Component::ParentDir => {
+                    if let Some(Component::Normal(_)) = buf.last() {
+                        buf.pop();
+                    }
+                }
+                _ => buf.push(c),
+            }
+        }
+
+        let mut res = OsString::new();
+        let mut need_sep = false;
+
+        for c in buf {
+            if need_sep && c != Component::RootDir {
+                res.push(MAIN_SEPARATOR_STR);
+            }
+            res.push(c.as_os_str());
+
+            need_sep = match c {
+                Component::RootDir => false,
+                Component::Prefix(prefix) => !prefix.parsed.is_drive() && prefix.parsed.len() > 0,
+                _ => true,
+            }
+        }
+
+        self_path.inner = res;
+        return;
+
+    // `path` has a root but no prefix, e.g., `\windows` (Windows only)
+    } else if other_path.has_root() {
+        let prefix_len = self_path.components().0.prefix_remaining();
+        self_path.inner.truncate(prefix_len);
+
+    // `path` is a pure relative path
+    } else if need_sep {
+        self_path.inner.push(MAIN_SEPARATOR_STR);
+    }
+
+    self_path.inner.push(other_path);
+}

--- a/library/std/src/sys/path/sgx.rs
+++ b/library/std/src/sys/path/sgx.rs
@@ -14,12 +14,10 @@ pub fn parse_prefix(_: &OsStr) -> Option<Prefix<'_>> {
     None
 }
 
-pub const HAS_PREFIXES: bool = false;
-
 pub(crate) fn absolute(_path: &Path) -> io::Result<PathBuf> {
     unsupported()
 }
 
 pub(crate) fn is_absolute(path: &Path) -> bool {
-    path.has_root() && path.prefix().is_some()
+    path.has_root()
 }

--- a/library/std/src/sys/path/uefi.rs
+++ b/library/std/src/sys/path/uefi.rs
@@ -19,8 +19,6 @@ pub fn parse_prefix(_: &OsStr) -> Option<Prefix<'_>> {
     None
 }
 
-pub const HAS_PREFIXES: bool = true;
-
 /// UEFI paths can be of 4 types:
 ///
 /// 1. Absolute Shell Path: Uses shell mappings (eg: `FS0:`). Does not exist if UEFI shell not present.

--- a/library/std/src/sys/path/unix.rs
+++ b/library/std/src/sys/path/unix.rs
@@ -14,8 +14,6 @@ pub fn parse_prefix(_: &OsStr) -> Option<Prefix<'_>> {
     None
 }
 
-pub const HAS_PREFIXES: bool = false;
-
 /// Make a POSIX path absolute without changing its semantics.
 pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
     // This is mostly a wrapper around collecting `Path::components`, with
@@ -58,9 +56,5 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
 }
 
 pub(crate) fn is_absolute(path: &Path) -> bool {
-    if cfg!(any(unix, target_os = "hermit", target_os = "wasi", target_os = "motor")) {
-        path.has_root()
-    } else {
-        path.has_root() && path.prefix().is_some()
-    }
+    path.has_root()
 }

--- a/library/std/src/sys/path/unsupported_backslash.rs
+++ b/library/std/src/sys/path/unsupported_backslash.rs
@@ -15,12 +15,10 @@ pub fn parse_prefix(_: &OsStr) -> Option<Prefix<'_>> {
     None
 }
 
-pub const HAS_PREFIXES: bool = true;
-
 pub(crate) fn absolute(_path: &Path) -> io::Result<PathBuf> {
     unsupported()
 }
 
 pub(crate) fn is_absolute(path: &Path) -> bool {
-    path.has_root() && path.prefix().is_some()
+    path.has_root() && path.components().0.prefix().is_some()
 }

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -11,8 +11,6 @@ pub use super::windows_prefix::parse_prefix;
 
 path_separator_bytes!(b'\\', b'/');
 
-pub const HAS_PREFIXES: bool = true;
-
 /// A null terminated wide string.
 #[repr(transparent)]
 pub struct WCStr([u16]);
@@ -209,7 +207,7 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
 }
 
 pub(crate) fn is_absolute(path: &Path) -> bool {
-    path.has_root() && path.prefix().is_some()
+    path.has_root() && path.components().0.prefix().is_some()
 }
 
 /// Test that the path is absolute, fully qualified and unchanged when processed by the Windows API.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156496)*
<!-- homu-ignore:end -->

This PR entirely changes how `Components<'_>` is implemented. ~~Currently, the `Components<'_>` iterator 'consumes' components through mutating its path field to a subslice that presents the left over unconsumed path components (this consumed path component is what's returned in `Components::next` or `Components::next_back`). However, this PR keeps the path field alive/unmodified and uses front and back indexing strategy to extract consumed/unconsumed components.~~ This `Components<'_>` implementation still uses a subslicing approach similar to the original implementation, but it's highly optimized for non-Windows platform, given that there's no `Prefix<'_>` components to check with.

Ideally, at least from a few benchmarking test I've done locally, this `Components<'_>` implementation should perform similarly with the original one when it comes to `Components::next`/`Components` ordering comparisons (the original one was already highly optimized as is). Where this non-Windows implementation shine though is improving `Components::as_path` (as a result certain things benefit from this like `Ancestors` iterator, `std::fs::create_dir_all`, etc.) and `Components::next_back` (and as a result `Path` equality). 

There are a lot of different things I've done to make sure that `Components` equality is improved dramatically. For example, just like what `Components` comparison does with checking if we see a mismatched byte in the forward direction and setting our `Components` iterator to the nearest separator, we do the same thing with `Components` equality in the opposite direction (this actually is one of the significant reason why this implementation of `Components` equality is really, *really* faster now). Additionally, there are other optimizations I do here, like doing less boolean checks or usize comparisons within `Components::next_back` and normalizing any separator/curr directory bytes upfront (the original implementation had a lot of conditional checks that could be way more simplified; the prefix checking also didn't benefit non-Windows platform). With the way I have `State` enum implemented in this `Components` iterator, I can do other small optimizations like checking for empty paths, so that I can return `true` or `false` immediately. 

Because the implementation I'm going for is specific to non-Windows/non-prefix-supporting platforms, I chose to split the `Components` iterator implementation to two different version that is re-exported accordingly to individual platforms (this leads to `HAS_PREFIXES` constant being redundant and unnecessary). I'm open to discussion on how to organize the code here better, naming stuff, etc. Some prefix-specific things have been refactored to be exclusively on platforms that utilize prefix components.

So far, I've been benchmarking it locally. I formerly did it with Criterion, but now I've just been benchmarking manually through hyperfine. What I've been testing was how fast can this implementation of`Components::next`/`Components::next_back` run paths like "a1..aN/a1..aN" vs "b/a1..aN/a1..aN/" (where N is some number of a's I put for each component, and you can assume that there are some X path components in the path); I also played around with the mismatching component placed at the end of the path versus beginning, and benchmarked running the same path equality/comparisons 10000 times to see the result cumulatively. You can try hyperfining the code in this [repo](https://github.com/asder8215/components_redesign/blob/components_subslice/src/main.rs); I'll get around to consolidating those benchmarks in Criterion a bit later and then posting results in the comments below.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
