### PR TITLE
bootstrap: remap windows-style OUT_DIR paths

### DIFF
--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1079,6 +1079,12 @@ impl Builder<'_> {
                         format!("{}={map_to}", self.build.src.display()),
                         // remap OUT_DIR so they don't leak into artifacts.
                         format!("{}={map_to}/out", self.build.out.display()),
+                        // on windows, rustc may use forward slashes internally
+                        #[cfg(windows)]
+                        format!(
+                            "{}={map_to}\\out",
+                            self.build.out.display().to_string().replace('/', "\\")
+                        ),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);
@@ -1101,6 +1107,12 @@ impl Builder<'_> {
                         format!("{}={map_to}", self.build.src.display()),
                         // remap OUT_DIR so they don't leak into artifacts.
                         format!("{}={map_to}/out", self.build.out.display()),
+                        // on windows, rustc may use forward slashes internally
+                        #[cfg(windows)]
+                        format!(
+                            "{}={map_to}\\out",
+                            self.build.out.display().to_string().replace('/', "\\")
+                        ),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

### problem:
on windows, some paths embedded into debuginfo / metadata may internally use `\` separators, while the existing `RUSTC_DEBUGINFO_MAP` remapping only covers the `/` form of `self.build.out`.

### fix:
add an additional remap entry for the windows style `\` variant of `self.build.out`.

### result:
improves path remapping consistency on windows, in turn helping with reproducibility.

r? @bjorn3 
