### PR TITLE
debuginfo: create_scope_map.rs: change discriminators map capacity to…

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/create_scope_map.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/create_scope_map.rs
@@ -40,7 +40,8 @@ pub(crate) fn compute_mir_scopes<'ll, 'tcx>(
         None
     };
     let mut instantiated = DenseBitSet::new_empty(mir.source_scopes.len());
-    let mut discriminators = FxHashMap::default();
+    let mut discriminators =
+        FxHashMap::with_capacity_and_hasher(mir.source_scopes.len(), Default::default());
     // Instantiate all scopes.
     for scope in mir.source_scopes.indices() {
         make_mir_scope(


### PR DESCRIPTION
… match mir.source_scopes length

Aligns discriminators FxHashMap capacity with other scope-related data structures (vars, instantiated) using mir.source_scopes.len().

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
