### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -373,6 +373,10 @@ impl CodegenBackend for LlvmCodegenBackend {
         print!("{stats}");
     }
 
+    fn print_statistics_json(&self) -> String {
+        llvm::build_string(|s| unsafe { llvm::LLVMRustPrintStatisticsJSON(s) }).unwrap()
+    }
+
     fn link(
         &self,
         sess: &Session,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2114,6 +2114,9 @@ unsafe extern "C" {
     /// Prints the statistics collected by `-Zprint-codegen-stats`.
     pub(crate) fn LLVMRustPrintStatistics(OutStr: &RustString);
 
+    /// Save the statistics collected by `-Zprint-codegen-stats-json`
+    pub(crate) fn LLVMRustPrintStatisticsJSON(OutStr: &RustString);
+
     pub(crate) fn LLVMRustInlineAsmVerify(
         Ty: &Type,
         Constraints: *const c_uchar, // See "PTR_LEN_STR".

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -120,7 +120,7 @@ unsafe fn configure_llvm(sess: &Session) {
         // Use non-zero `import-instr-limit` multiplier for cold callsites.
         add("-import-cold-multiplier=0.1", false);
 
-        if sess.print_llvm_stats() {
+        if sess.print_llvm_stats() || sess.print_llvm_stats_json().is_some() {
             add("-stats", false);
         }
 

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -131,6 +131,10 @@ pub trait CodegenBackend {
 
     fn print_statistics(&self) {}
 
+    fn print_statistics_json(&self) -> String {
+        String::new()
+    }
+
     /// This is called on the returned [`CompiledModules`] from [`join_codegen`](Self::join_codegen).
     fn link(
         &self,

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -70,6 +70,22 @@ impl Linker {
             codegen_backend.print_statistics()
         }
 
+        if let Some(out_path) = sess.print_llvm_stats_json() {
+            let llvm_stats_json = codegen_backend.print_statistics_json();
+
+            if !llvm_stats_json.is_empty() {
+                if let Err(e) = std::fs::write(&out_path, llvm_stats_json) {
+                    sess.dcx().err(format!("failed to write stats to {}: {}", out_path, e));
+                }
+            } else {
+                sess.dcx().warn(format!(
+                    "requested to print LLVM statistics to JSON file {}, but the codegen backend \
+                    did not provide any statistics",
+                    out_path,
+                ));
+            }
+        }
+
         sess.timings.end_section(sess.dcx(), TimingSection::Codegen);
 
         if sess.opts.incremental.is_some()

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -155,6 +155,11 @@ extern "C" void LLVMRustPrintStatistics(RustStringRef OutBuf) {
   llvm::PrintStatistics(OS);
 }
 
+extern "C" void LLVMRustPrintStatisticsJSON(RustStringRef OutBuf) {
+  auto OS = RawRustStringOstream(OutBuf);
+  llvm::PrintStatisticsJSON(OS);
+}
+
 // Some of the functions here rely on LLVM modules that may not always be
 // available. As such, we only try to build it in the first place, if
 // llvm.offload is enabled.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2544,6 +2544,9 @@ options! {
     #[rustc_lint_opt_deny_field_access("use `Session::print_codegen_stats` instead of this field")]
     print_codegen_stats: bool = (false, parse_bool, [UNTRACKED],
         "print codegen statistics (default: no)"),
+    #[rustc_lint_opt_deny_field_access("use `Session::print_llvm_stats_json` instead of this field")]
+    print_codegen_stats_json: Option<String> = (None, parse_opt_string, [UNTRACKED],
+        "print codegen statistics in JSON to a file (default: no)"),
     print_llvm_passes: bool = (false, parse_bool, [UNTRACKED],
         "print the LLVM optimization passes being run (default: no)"),
     print_mono_items: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -599,6 +599,10 @@ impl Session {
         self.opts.unstable_opts.print_codegen_stats
     }
 
+    pub fn print_llvm_stats_json(&self) -> Option<&String> {
+        self.opts.unstable_opts.print_codegen_stats_json.as_ref()
+    }
+
     pub fn verify_llvm_ir(&self) -> bool {
         self.opts.unstable_opts.verify_llvm_ir || option_env!("RUSTC_VERIFY_LLVM_IR").is_some()
     }

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -867,7 +867,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for IllegalSelfTypeVisitor<'tcx> {
             ty::ConstKind::Unevaluated(proj) if self.tcx.features().min_generic_const_args() => {
                 match self.allow_self_projections {
                     AllowSelfProjections::Yes
-                        if let trait_def_id = self.tcx.parent(proj.def)
+                        if matches!(self.tcx.def_kind(proj.def), DefKind::AssocConst { .. })
+                            && let trait_def_id = self.tcx.parent(proj.def)
                             && self.tcx.def_kind(trait_def_id) == DefKind::Trait =>
                     {
                         let trait_ref = ty::TraitRef::from_assoc(self.tcx, trait_def_id, proj.args);

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -1079,6 +1079,12 @@ impl Builder<'_> {
                         format!("{}={map_to}", self.build.src.display()),
                         // remap OUT_DIR so they don't leak into artifacts.
                         format!("{}={map_to}/out", self.build.out.display()),
+                        // on windows, rustc may use forward slashes internally
+                        #[cfg(windows)]
+                        format!(
+                            "{}={map_to}\\out",
+                            self.build.out.display().to_string().replace('/', "\\")
+                        ),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);
@@ -1101,6 +1107,12 @@ impl Builder<'_> {
                         format!("{}={map_to}", self.build.src.display()),
                         // remap OUT_DIR so they don't leak into artifacts.
                         format!("{}={map_to}/out", self.build.out.display()),
+                        // on windows, rustc may use forward slashes internally
+                        #[cfg(windows)]
+                        format!(
+                            "{}={map_to}\\out",
+                            self.build.out.display().to_string().replace('/', "\\")
+                        ),
                     ]
                     .join("\t");
                     cargo.env("RUSTC_DEBUGINFO_MAP", map);

--- a/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
@@ -1,11 +1,12 @@
 //! Regression test for <https://github.com/rust-lang/rust/issues/156293>
-//@ edition: 2024
 //@ check-pass
 
-#![feature(min_generic_const_args, transmutability)]
+#![feature(min_generic_const_args)]
+
+trait Bar<const N: bool = false> {}
 
 trait Foo {
-    type AssocB: std::mem::TransmuteFrom<()>;
+    type AssocB: Bar;
 }
 
 fn main() {}

--- a/tests/ui/traits/associated_type_bound/generic-const-args-transmutability.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-transmutability.rs
@@ -1,0 +1,11 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/156293>
+//@ edition: 2024
+//@ check-pass
+
+#![feature(min_generic_const_args, transmutability)]
+
+trait Foo {
+    type AssocB: std::mem::TransmuteFrom<()>;
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156472 (Add support for Zprint-codegen-stats-json)
 - rust-lang/rust#156504 (bootstrap: remap windows-style OUT_DIR paths)
 - rust-lang/rust#156325 (Don't treat const param default as projection)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156472,156504,156325)
<!-- homu-ignore:end -->

