### PR TITLE
Avoid synthetic auto-trait ICE with next solver in rustdoc

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -21,6 +21,14 @@ pub(crate) fn synthesize_auto_trait_impls<'tcx>(
     item_def_id: DefId,
 ) -> Vec<clean::Item> {
     let tcx = cx.tcx;
+    // FIXME(-Znext-solver): `AutoTraitFinder` still uses old-solver-only selection APIs.
+    // Do not synthesize rustdoc's auto-trait impls for display while the new solver is global.
+    if tcx.next_trait_solver_globally() {
+        cx.sess().dcx().fatal(
+            "rustdoc does not support generating auto-trait impls for display with `-Znext-solver=globally`",
+        );
+    }
+
     let typing_env = ty::TypingEnv::non_body_analysis(tcx, item_def_id);
     let ty = tcx.type_of(item_def_id).instantiate_identity().skip_norm_wip();
 

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/next-solver-globally.rs
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/next-solver-globally.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: -Znext-solver=globally
+//@ failure-status: 1
+
+//~? ERROR rustdoc does not support generating auto-trait impls for display with `-Znext-solver=globally`
+
+// Regression test for https://github.com/rust-lang/rust/issues/156487.
+struct A;
+fn main() {}

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/next-solver-globally.stderr
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/next-solver-globally.stderr
@@ -1,0 +1,4 @@
+error: rustdoc does not support generating auto-trait impls for display with `-Znext-solver=globally`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#156487

`AutoTraitFinder` still uses old-solver-only selection APIs. When rustdoc runs with `-Znext-solver=globally`, synthetic auto-trait impl generation reaches that path with the new solver enabled and ICEs in trait selection.