### PR TITLE
Explicitly request copying `rustc-dev` artifacts for rustfmt/clippy and add rustc libs path for rustc-private tools under `download-rustc`

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1999,12 +1999,16 @@ impl Step for Sysroot {
             }
 
             // Copy the compiler into the correct sysroot.
-            // NOTE(#108767): We intentionally don't copy `rustc-dev` artifacts until they're requested with `builder.ensure(Rustc)`.
-            // This fixes an issue where we'd have multiple copies of libc in the sysroot with no way to tell which to load.
-            // There are a few quirks of bootstrap that interact to make this reliable:
+            //
+            // FIXME(#156525): investigate if this is still needed.
+            //
+            // NOTE(#108767): We intentionally don't copy `rustc-dev` artifacts until they're
+            // requested with `builder.ensure(Rustc)`. This fixes an issue where we'd have multiple
+            // copies of libc in the sysroot with no way to tell which to load. There are a few
+            // quirks of bootstrap that interact to make this reliable:
             // 1. The order `Step`s are run is hard-coded in `builder.rs` and not configurable. This
-            //    avoids e.g. reordering `test::UiFulldeps` before `test::Ui` and causing the latter to
-            //    fail because of duplicate metadata.
+            //    avoids e.g. reordering `test::UiFulldeps` before `test::Ui` and causing the latter
+            //    to fail because of duplicate metadata.
             // 2. The sysroot is deleted and recreated between each invocation, so running `x test
             //    ui-fulldeps && x test ui` can't cause failures.
             let mut filtered_files = Vec::new();

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -510,7 +510,7 @@ impl Step for Rustfmt {
         let compilers = RustcPrivateCompilers::new(builder, stage, host);
         let rustfmt_build = builder.ensure(tool::Rustfmt::from_compilers(compilers));
 
-        let mut rustfmt = tool::prepare_tool_cargo(
+        let mut cargo = tool::prepare_tool_cargo(
             builder,
             rustfmt_build.build_compiler,
             Mode::ToolRustcPrivate,
@@ -521,10 +521,10 @@ impl Step for Rustfmt {
             &[],
         );
 
-        rustfmt.args(["--bin", "rustfmt", "--"]);
-        rustfmt.args(builder.config.args());
+        cargo.args(["--bin", "rustfmt", "--"]);
+        cargo.args(builder.config.args());
 
-        rustfmt.into_cmd().run(builder);
+        cargo.into_cmd().run(builder);
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -579,6 +579,11 @@ impl Step for Rustfmt {
         let build_compiler = self.compilers.build_compiler();
         let target = self.compilers.target();
 
+        // FIXME(#156525): `compile::Sysroot::run` intentionally do not copy `rustc-dev` artifacts
+        // until they're requested with `builder.ensure(Rustc)`, relevant for `download-rustc`
+        // flows.
+        builder.ensure(compile::Rustc::new(build_compiler, target));
+
         let mut cargo = tool::prepare_tool_cargo(
             builder,
             build_compiler,
@@ -940,6 +945,11 @@ impl Step for Clippy {
         // and it must also be used by clippy's test runner to build tests and their dependencies.
         let target_compiler = self.compilers.target_compiler();
         let build_compiler = self.compilers.build_compiler();
+
+        // FIXME(#156525): `compile::Sysroot::run` intentionally do not copy `rustc-dev` artifacts
+        // until they're requested with `builder.ensure(Rustc)`, relevant for `download-rustc`
+        // flows.
+        builder.ensure(compile::Rustc::new(build_compiler, target));
 
         let mut cargo = tool::prepare_tool_cargo(
             builder,

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -224,6 +224,12 @@ pub fn prepare_tool_cargo(
     // avoid rebuilding when running tests.
     cargo.env("SYSROOT", builder.sysroot(compiler));
 
+    // Make sure we explicitly add rustc_private libs to path centrally here so that
+    // RustcPrivate tools can pick them up.
+    if mode == Mode::ToolRustcPrivate {
+        cargo.add_rustc_lib_path(builder);
+    }
+
     // if tools are using lzma we want to force the build script to build its
     // own copy
     cargo.env("LZMA_API_STATIC", "1");


### PR DESCRIPTION
## Summary

[#t-infra/bootstrap > x run rustfmt works but x test rustfmt fails to compile](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/x.20run.20rustfmt.20works.20but.20x.20test.20rustfmt.20fails.20to.20compile/with/594752284) reported that `./x test rustfmt --stage={1,2}` no longer works with `download-rustc`.

* This seems to be due to us removing some manual `builder.ensure(Rustc)`s around the times of stage 0 rejiggling.
* Because `compile::Sysroot::run` has a quirky non-trivial behavior regarding `rustc-dev` artifact copying under `download-rustc`, tracing back to sysroot dep resolution troubles (cf. rust-lang/rust#108767), we need to explicitly `ensure(Rustc)` to opt-in to `rustc-dev` artifact copying under `download-rustc`.
* For the short-term, let's insert manual `ensure`s to force `rustc-dev` artifact copying under `download-rustc` to unblock rustfmt/clippy contributors who want to use `download-rustc` (to avoid having to build the compiler).

Additionally, I needed to explicitly add rustc libs path for `RustcPrivate` tools, or else it seems like the ci-rustc sysroot is not always correctly set.

## Testing

Use a dummy config: `bootstrap.rustfmt.toml`

```toml
profile = "tools"
change-id = "ignore"

[rust]
# Force download-rustc, needed because we modify bootstrap which makes
# `if-unchanged` ineligible.
download-rustc = true
```

Run:

* `./x test rustfmt --config=bootstrap.rustfmt.toml --stage=1`
* `./x test rustfmt --config=bootstrap.rustfmt.toml --stage=2`
* `./x test clippy --config=bootstrap.rustfmt.toml --stage=1`
* `./x test clippy --config=bootstrap.rustfmt.toml --stage=2`

When reviewing, also check that if you revert the commit / this PR, that invocations above fail (which is the case against `main` for me).

Tested also without `download-rustc` to make sure `./x test {rustfmt,clippy} --stage={1,2}` still works.

## Notes

This is by no means a proper fix, but it should unblock local tool profile workflows trying to use `download-rustc` with {rustfmt,clippy}. I don't think it's worth blocking over that.

Efforts for a more proper fix should be tracked by rust-lang/rust#156525, I left FIXMEs pointing to that.