### PR TITLE
Add CI check when building sysroot with GCC backend and running libcore tests with it

### DIFF
--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -1352,7 +1352,10 @@ fn try_intrinsic<'a, 'b, 'gcc, 'tcx>(
     dest: PlaceRef<'tcx, RValue<'gcc>>,
 ) {
     if !bx.sess().panic_strategy().unwinds() {
-        bx.call(bx.type_void(), None, None, try_func, &[data], None, None);
+        let param_type = bx.u8_type.make_pointer();
+        let fn_type =
+            bx.context.new_function_pointer_type(None, bx.type_void(), &[param_type], false);
+        bx.call(fn_type, None, None, try_func, &[data], None, None);
         // Return 0 unconditionally from the intrinsic call;
         // we can never unwind.
         OperandValue::Immediate(bx.const_i32(0)).store(bx, dest);

--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
@@ -1,3 +1,6 @@
+# This Dockerfile builds sysroot crates with the GCC backend and then run libcore tests
+# with it.
+
 FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -41,5 +44,4 @@ ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --set rust.codegen-backends=[\\\"gcc\\\"]"
 ENV SCRIPT="python3 ../x.py \
   --stage 1 \
-  test library/coretests \
-  --set rust.codegen-backends=[\\\"gcc\\\"]"
+  test library/coretests"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  bzip2 \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  libssl-dev \
+  pkg-config \
+  xz-utils \
+  mingw-w64 \
+  zlib1g-dev \
+  libzstd-dev \
+  # libgccjit dependencies
+  flex \
+  libmpfr-dev \
+  libgmp-dev \
+  libmpc3 \
+  libmpc-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV NO_DEBUG_ASSERTIONS="1"
+ENV RUSTFLAGS="-Cpanic=abort -Zpanic-abort-tests"
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
+ --enable-sanitizers \
+ --enable-profiler \
+ --enable-compiler-docs \
+ --set llvm.libzstd=true \
+ --set rust.codegen-backends=[\\\"gcc\\\"]"
+ENV SCRIPT="python3 ../x.py \
+  --stage 1 \
+  test library/coretests \
+  --set rust.codegen-backends=[\\\"gcc\\\"]"

--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc/Dockerfile
@@ -1,3 +1,6 @@
+# This Dockerfile builds sysroot with the LLVM backendsthen run tests with the
+# GCC backend.
+
 FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -145,6 +145,9 @@ pr:
   - name: x86_64-gnu-gcc
     doc_url: https://rustc-dev-guide.rust-lang.org/tests/codegen-backend-tests/cg_gcc.html
     <<: *job-linux-4c
+  - name: x86_64-gnu-gcc-core-tests
+    doc_url: https://rustc-dev-guide.rust-lang.org/tests/codegen-backend-tests/cg_gcc.html
+    <<: *job-linux-4c
 
 # Jobs that run when you perform a try build (@bors try)
 # These jobs automatically inherit envs.try, to avoid repeating
@@ -359,6 +362,10 @@ auto:
     <<: *job-linux-4c
 
   - name: x86_64-gnu-gcc
+    doc_url: https://rustc-dev-guide.rust-lang.org/tests/codegen-backend-tests/cg_gcc.html
+    <<: *job-linux-4c
+
+  - name: x86_64-gnu-gcc-core-tests
     doc_url: https://rustc-dev-guide.rust-lang.org/tests/codegen-backend-tests/cg_gcc.html
     <<: *job-linux-4c
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156549)*
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rustc_codegen_gcc/issues/882.

Is it what you had in mind @Kobzol?

r? @Kobzol 