### PR TITLE
search_graph: emit `-Zself-profile` events at key call sites

### DIFF
--- a/compiler/rustc_middle/src/ty/context/impl_interner.rs
+++ b/compiler/rustc_middle/src/ty/context/impl_interner.rs
@@ -143,6 +143,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         // See trait-system-refactor-initiative#234.
     }
 
+    fn solver_event(self, label: &'static str) {
+        let _guard = self.sess.prof.generic_activity(label);
+    }
+
     fn expand_abstract_consts<T: TypeFoldable<TyCtxt<'tcx>>>(self, t: T) -> T {
         self.expand_abstract_consts(t)
     }

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -187,6 +187,9 @@ pub trait Interner:
     /// (in theory) only happen when concurrent.
     fn assert_evaluation_is_concurrent(&self);
 
+    /// Forwarded from `search_graph::Cx::solver_event`. Defaults to a no-op.
+    fn solver_event(self, _label: &'static str) {}
+
     fn expand_abstract_consts<T: TypeFoldable<Self>>(self, t: T) -> T;
 
     type GenericsOf: GenericsOf<Self>;
@@ -580,5 +583,9 @@ impl<I: Interner> search_graph::Cx for I {
     }
     fn assert_evaluation_is_concurrent(&self) {
         self.assert_evaluation_is_concurrent()
+    }
+
+    fn solver_event(self, label: &'static str) {
+        I::solver_event(self, label)
     }
 }

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -55,6 +55,10 @@ pub trait Cx: Copy {
     fn with_global_cache<R>(self, f: impl FnOnce(&mut GlobalCache<Self>) -> R) -> R;
 
     fn assert_evaluation_is_concurrent(&self);
+
+    /// Record a solver event for `-Zself-profile`. Defaults to a no-op so
+    /// non-rustc implementors (e.g. the search-graph fuzzer) need no changes.
+    fn solver_event(self, _label: &'static str) {}
 }
 
 pub trait Delegate: Sized {
@@ -777,7 +781,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
         // - A
         //     - BA cycle
         //     - CB :x:
-        if let Some(result) = self.lookup_provisional_cache(input, step_kind_from_parent) {
+        if let Some(result) = self.lookup_provisional_cache(cx, input, step_kind_from_parent) {
             return result;
         }
 
@@ -809,6 +813,8 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
             debug_assert!(validate_cache.is_none(), "global cache and cycle on stack: {input:?}");
             return result;
         }
+
+        cx.solver_event("search_graph::evaluate_goal");
 
         // Unfortunate, it looks like we actually have to compute this goal.
         self.stack.push(StackEntry {
@@ -896,6 +902,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
         }
 
         debug!("encountered stack overflow");
+        cx.solver_event("search_graph::handle_overflow");
         D::stack_overflow_result(cx, input)
     }
 
@@ -1079,6 +1086,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
 
     fn lookup_provisional_cache(
         &mut self,
+        cx: X,
         input: X::Input,
         step_kind_from_parent: PathKind,
     ) -> Option<X::Result> {
@@ -1122,6 +1130,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
                     UpdateParentGoalCtxt::ProvisionalCacheHit,
                 );
                 debug!(?head_index, ?path_from_head, "provisional cache hit");
+                cx.solver_event("search_graph::provisional_cache_hit");
                 return Some(result);
             }
         }
@@ -1246,6 +1255,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
             );
 
             debug!(?required_depth, "global cache hit");
+            cx.solver_event("search_graph::global_cache_hit");
             Some(result)
         })
     }
@@ -1265,6 +1275,7 @@ impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D, X> {
         // in case we're in the first fixpoint iteration for this goal.
         let path_kind = Self::cycle_path_kind(&self.stack, step_kind_from_parent, head_index);
         debug!(?path_kind, "encountered cycle with depth {head_index:?}");
+        cx.solver_event("search_graph::cycle_on_stack");
         let mut usages = HeadUsages::default();
         usages.add_usage(path_kind);
         let head = CycleHead { paths_to_head: step_kind_from_parent.into(), usages };


### PR DESCRIPTION
The new trait solver is invisible to `-Zself-profile`.
This adds a `solver_event` hook (no-op default; `TyCtxt` forwards to `sess.prof`) called at `search_graph::{evaluate_goal, global_cache_hit, provisional_cache_hit, cycle_on_stack, handle_overflow}`.

## Test plan
- `./x.py build compiler/rustc --stage 1` clean
- `./x.py build library --stage 1` clean
- `cargo +stage1 check -Zself-profile=DIR` on mathypad-core produces solver events visible via `summarize`

r? @lcnr