### PR TITLE
compiler: fix duplicated "the" in two doc-comments

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/var_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/var_name.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use crate::region_infer::RegionInferenceContext;
 
 impl<'tcx> RegionInferenceContext<'tcx> {
-    /// Find the the name and span of the variable corresponding to the given region.
+    /// Find the name and span of the variable corresponding to the given region.
     /// The returned var will also be ensured to actually be used in `body`.
     pub(crate) fn get_var_name_and_span_for_region(
         &self,

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -145,7 +145,7 @@ impl<T: Copy + Debug + Hash + Eq> AsRef<[T]> for SmallCopyList<T> {
 /// | never                   | no    | no                                                                                                                   |
 /// | always                  | yes   | yes                                                                                                                  |
 /// | [defid in storage]      | no    | only if any of the defids in the list is in the opaque type storage OR if TypingMode::PostAnalysis                   |
-/// | opaque with hidden type | no    | only if any of the the opaques in the opaque type storage has a hidden type in this list AND if TypingMode::Analysis |
+/// | opaque with hidden type | no    | only if any of the opaques in the opaque type storage has a hidden type in this list AND if TypingMode::Analysis |
 ///
 /// - "bail" is implemented with [`should_bail`](Self::should_bail).
 ///   If true, we're abandoning our attempt to canonicalize in [`TypingMode::ErasedNotCoherence`],


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in compiler doc-comments:
- `compiler/rustc_type_ir/src/solve/mod.rs` — "only if any of the the opaques in the opaque type storage has a hidden type" → "...any of the opaques in..."
- `compiler/rustc_borrowck/src/diagnostics/var_name.rs` — "/// Find the the name and span of the variable corresponding to the given region." → "/// Find the name and span of the variable corresponding to the given region."

No code/behavior change.