### PR TITLE
Resolving Windows environment test failures

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2334,6 +2334,9 @@ fn test_fs_set_times_follows_symlink() {
     use crate::os::windows::fs::FileTimesExt;
 
     let tmp = tmpdir();
+    if !got_symlink_permission(&tmp) {
+        return;
+    }
 
     // Create a target file
     let target = tmp.join("target");
@@ -2432,6 +2435,9 @@ fn test_fs_set_times_nofollow() {
     use crate::os::windows::fs::FileTimesExt;
 
     let tmp = tmpdir();
+    if !got_symlink_permission(&tmp) {
+        return;
+    }
 
     // Create a target file and a symlink to it
     let target = tmp.join("target");


### PR DESCRIPTION
This resolves an issue where the `fs::tests::test_fs_set_times follows symlink` and `fs::tests::test_fs_set_times_nofollow` tests failed locally due to permission issues in a Windows environment.

The code has been modified so that these tests do not proceed if permissions are not granted.

Since these tests can be passed with the necessary permissions via CI before merging, I believe it is appropriate for them to pass locally due to permission issues rather than fail.

Close rust-lang/rust#156558 