### PR TITLE
tests: extend remap-path-prefix-std to all stdlib rlibs

### DIFF
--- a/tests/run-make/remap-path-prefix-std/rmake.rs
+++ b/tests/run-make/remap-path-prefix-std/rmake.rs
@@ -1,5 +1,6 @@
 // This test makes sure that we do not leak paths to the checkout
-// (i.e. /checkout in CI) in the distributed `libstd` debuginfo.
+// (ie. /checkout in CI) in the distributed standard library debuginfo.
+// It checks all rlibs found in the target libdir, not just libstd.
 //
 // This test only runs on Linux and dist builder (or with `rust.remap-debuginfo = true`
 // set in your `bootstrap.toml`).
@@ -24,30 +25,70 @@ fn main() {
         path
     };
 
-    // Find all the `libstd-.*.rlib` files under the libdir
-    let libstd_rlibs = shallow_find_files(&target_libdir, |p| {
+    // Find all rlib files under the libdir (the full standard library set)
+    let all_rlibs = shallow_find_files(&target_libdir, |p| {
         if let Some(filename) = p.file_name()
             && let filename = filename.to_string_lossy()
+            && let Some(ext) = p.extension()
+            && filename.starts_with("lib")
+            && ext == "rlib"
+            && filename.contains('-')
         {
-            filename.starts_with("libstd-") && filename.ends_with(".rlib")
+            true
         } else {
             false
         }
     });
 
-    // Assert that there is only one rlib for the `libstd`
-    let [libstd_rlib] = &libstd_rlibs[..] else {
-        unreachable!("multiple libstd rlib: {libstd_rlibs:?} in {target_libdir:?}");
-    };
+    // There must be at least one rlib (libstd itself, plus many others)
+    assert!(!all_rlibs.is_empty(), "no rlibs found in target libdir {target_libdir:?}");
 
-    // Symlink the libstd rlib here to avoid absolute paths from llvm-dwarfdump own output
-    // and not from the debuginfo it-self
-    rfs::symlink_file(libstd_rlib, "libstd.rlib");
+    for rlib in &all_rlibs {
+        // Use a stable symlink name based on the crate part (before the '-<hash>' suffix).
+        // e.g. "libstd-92abaa9b58c011c1.rlib" → "libstd.rlib"
+        let filename = rlib.file_name().unwrap().to_string_lossy();
+        let link_name = match filename.split_once('-') {
+            Some((prefix, _)) => format!("{prefix}.rlib"),
+            None => filename.to_string(),
+        };
 
-    // Check that there is only `/rustc/` paths and no `/checkout`, `/home`, or whatever
-    llvm_dwarfdump()
-        .input("libstd.rlib")
-        .run()
-        .assert_stdout_contains("/rustc/")
-        .assert_stdout_not_contains(source_root().to_string_lossy());
+        // Symlink the original rlib to avoid absolute paths from dwarfdump itself
+        rfs::symlink_file(rlib, &link_name);
+
+        // Check that no distributed rlib leaks the checkout/source root path.
+        let completed = llvm_dwarfdump().input(&link_name).run_unchecked();
+        if !completed.status().success() {
+            eprintln!("dwarfdump failed on {link_name}: exit status {:?}", completed.status());
+            panic!("llvm-dwarfdump failed for {link_name}");
+        }
+
+        let stdout = completed.stdout_utf8();
+        let source_root = source_root();
+        let root = source_root.to_string_lossy();
+
+        if let Some((i, _)) =
+            stdout.lines().enumerate().find(|(_, line)| line.contains(root.as_ref()))
+        {
+            let lines: Vec<_> = stdout.lines().collect();
+
+            let start = i.saturating_sub(2);
+            let end = (i + 3).min(lines.len());
+
+            eprintln!("leaked source-root path found in {link_name}:");
+
+            for line in &lines[start..end] {
+                eprintln!("{line}");
+            }
+
+            panic!("found leaked source-root path in {link_name}");
+        }
+
+        // Check that remapped paths are present if the rlib has debug info.
+        if stdout.contains("DW_TAG_compile_unit") {
+            assert!(
+                stdout.contains("/rustc/") || stdout.contains("/rust/deps"),
+                "Expected remapped paths in dwarfdump output for {link_name}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156570)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

### problem:
the current `remap-path-prefix-std` run-make test validates path remapping for `libstd.rlib`, which leaves the rest of the distributed `stdlib` artifacts unchecked.

### fix:
generalizing the test to go over over all distributed `.rlib` files found in the target `sysroot libdir` instead of checking only the `libstd`.

### result:
improves reproducibility coverage for distributed `stdlib` artifacts.

r? @Urgau 

