### PR TITLE
Disable `main_needs_argc_argv` for Wasm

### DIFF
--- a/compiler/rustc_target/src/spec/base/wasm.rs
+++ b/compiler/rustc_target/src/spec/base/wasm.rs
@@ -118,6 +118,13 @@ pub(crate) fn options() -> TargetOptions {
         // with unwinding.
         llvm_args: cvs!["-wasm-use-legacy-eh=false"],
 
+        // WASI's `sys::args::init` function ignores its arguments; instead,
+        // `args::args()` makes the WASI API calls itself.
+        //
+        // Other Wasm targets make no use of `std::env` entirely.
+        // Emscripten enables it explicitly.
+        main_needs_argc_argv: false,
+
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
@@ -28,6 +28,7 @@ pub(crate) fn target() -> Target {
         crt_static_respected: true,
         crt_static_default: true,
         crt_static_allows_dylibs: true,
+        main_needs_argc_argv: true,
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         families: cvs!["unix", "wasm"],

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
@@ -41,10 +41,6 @@ pub(crate) fn target() -> Target {
     // without a main function.
     options.crt_static_allows_dylibs = true;
 
-    // WASI's `sys::args::init` function ignores its arguments; instead,
-    // `args::args()` makes the WASI API calls itself.
-    options.main_needs_argc_argv = false;
-
     // And, WASI mangles the name of "main" to distinguish between different
     // signatures.
     options.entry_name = "__main_void".into();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -52,10 +52,6 @@ pub(crate) fn target() -> Target {
     // without a main function.
     options.crt_static_allows_dylibs = true;
 
-    // WASI's `sys::args::init` function ignores its arguments; instead,
-    // `args::args()` makes the WASI API calls itself.
-    options.main_needs_argc_argv = false;
-
     // And, WASI mangles the name of "main" to distinguish between different
     // signatures.
     options.entry_name = "__main_void".into();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
@@ -46,10 +46,6 @@ pub(crate) fn target() -> Target {
     // without a main function.
     options.crt_static_allows_dylibs = true;
 
-    // WASI's `sys::args::init` function ignores its arguments; instead,
-    // `args::args()` makes the WASI API calls itself.
-    options.main_needs_argc_argv = false;
-
     // And, WASI mangles the name of "main" to distinguish between different
     // signatures.
     options.entry_name = "__main_void".into();


### PR DESCRIPTION
AFAIU this explains to the "Rust Runtime" that `main()` doesn't need `argc`/`argv`. Newer Wasm targets have explicitly disabled this, this PR changes it so that the base Wasm configuration affecting all Wasm targets disables this now.

This affects the following targets:
- `wasm32-unknown-unknown`
- `wasm32v1-none`
- `wasm64-unknown-unknown`

The only Wasm target where `main_needs_argc_argv` is still enabled is `wasm32-unknown-emscripten`. @hoodmane let me know and I can remove it there as well.

Credit goes to @Spxg for stumbling on this.

r? @alexcrichton