### PR TITLE
Add unwinder_private_data_size for wasm64 target

### DIFF
--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -72,7 +72,7 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))]
 pub const unwinder_private_data_size: usize = 2;
 
-#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+#[cfg(all(target_family = "wasm", target_os = "emscripten"))]
 pub const unwinder_private_data_size: usize = 20;
 
 #[cfg(all(target_arch = "wasm32", any(target_os = "linux", target_os = "wasi")))]


### PR DESCRIPTION
Fixes missing unwinder_private_data_size for the wasm64 architecture

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
