### PR TITLE
Test EII UI tests with prefer-dynamic

### DIFF
--- a/tests/ui/eii/default/auxiliary/decl_with_default.rs
+++ b/tests/ui/eii/default/auxiliary/decl_with_default.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/default/auxiliary/decl_with_default_panics.rs
+++ b/tests/ui/eii/default/auxiliary/decl_with_default_panics.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ needs-unwind
 //@ exec-env:RUST_BACKTRACE=1
 #![crate_type = "rlib"]

--- a/tests/ui/eii/default/auxiliary/impl1.rs
+++ b/tests/ui/eii/default/auxiliary/impl1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/default/call_default.rs
+++ b/tests/ui/eii/default/call_default.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default.rs
 //@ run-pass
 //@ check-run-results

--- a/tests/ui/eii/default/call_default_panics.rs
+++ b/tests/ui/eii/default/call_default_panics.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default_panics.rs
 //@ edition: 2021
 //@ run-pass

--- a/tests/ui/eii/default/call_impl.rs
+++ b/tests/ui/eii/default/call_impl.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default.rs
 //@ aux-build: impl1.rs
 //@ run-pass

--- a/tests/ui/eii/duplicate/auxiliary/impl1.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/auxiliary/impl2.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl2.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/auxiliary/impl3.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl3.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/auxiliary/impl4.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl4.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/duplicate1.rs
+++ b/tests/ui/eii/duplicate/duplicate1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: impl1.rs
 //@ aux-build: impl2.rs
 //@ ignore-backends: gcc

--- a/tests/ui/eii/duplicate/duplicate1.stderr
+++ b/tests/ui/eii/duplicate/duplicate1.stderr
@@ -1,10 +1,10 @@
 error: multiple implementations of `#[eii1]`
-  --> $DIR/auxiliary/impl1.rs:10:1
+  --> $DIR/auxiliary/impl1.rs:9:1
    |
 LL | fn other(x: u64) {
    | ^^^^^^^^^^^^^^^^ first implemented here in crate `impl1`
    |
-  ::: $DIR/auxiliary/impl2.rs:10:1
+  ::: $DIR/auxiliary/impl2.rs:9:1
    |
 LL | fn other(x: u64) {
    | ---------------- also implemented here in crate `impl2`

--- a/tests/ui/eii/duplicate/duplicate2.rs
+++ b/tests/ui/eii/duplicate/duplicate2.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: impl1.rs
 //@ aux-build: impl2.rs
 //@ aux-build: impl3.rs

--- a/tests/ui/eii/duplicate/duplicate2.stderr
+++ b/tests/ui/eii/duplicate/duplicate2.stderr
@@ -1,10 +1,10 @@
 error: multiple implementations of `#[eii1]`
-  --> $DIR/auxiliary/impl1.rs:10:1
+  --> $DIR/auxiliary/impl1.rs:9:1
    |
 LL | fn other(x: u64) {
    | ^^^^^^^^^^^^^^^^ first implemented here in crate `impl1`
    |
-  ::: $DIR/auxiliary/impl2.rs:10:1
+  ::: $DIR/auxiliary/impl2.rs:9:1
    |
 LL | fn other(x: u64) {
    | ---------------- also implemented here in crate `impl2`

--- a/tests/ui/eii/duplicate/duplicate3.rs
+++ b/tests/ui/eii/duplicate/duplicate3.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: impl1.rs
 //@ aux-build: impl2.rs
 //@ aux-build: impl3.rs

--- a/tests/ui/eii/duplicate/duplicate3.stderr
+++ b/tests/ui/eii/duplicate/duplicate3.stderr
@@ -1,10 +1,10 @@
 error: multiple implementations of `#[eii1]`
-  --> $DIR/auxiliary/impl1.rs:10:1
+  --> $DIR/auxiliary/impl1.rs:9:1
    |
 LL | fn other(x: u64) {
    | ^^^^^^^^^^^^^^^^ first implemented here in crate `impl1`
    |
-  ::: $DIR/auxiliary/impl2.rs:10:1
+  ::: $DIR/auxiliary/impl2.rs:9:1
    |
 LL | fn other(x: u64) {
    | ---------------- also implemented here in crate `impl2`

--- a/tests/ui/eii/static/auxiliary/cross_crate_def.rs
+++ b/tests/ui/eii/static/auxiliary/cross_crate_def.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156577)*
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#125418

Remove `no-prefer-dynamic` from the EII UI tests now that rust-lang/rust#153648 fixed exporting EII declaration aliases from dylibs.

Fixes rust-lang/rust#151271.

Tested with:

```sh
python3 x.py test tests/ui/eii --force-rerun
```