### PR TITLE
Correctly handle associated items in rustdoc macro expansion

### DIFF
--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -1,5 +1,8 @@
-use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt, walk_ty};
-use rustc_ast::{Crate, Expr, Item, Pat, Stmt, Ty};
+use rustc_ast::visit::{
+    AssocCtxt, Visitor, walk_assoc_item, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt,
+    walk_ty,
+};
+use rustc_ast::{AssocItem, Crate, Expr, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -159,6 +162,16 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             self.handle_new_span(ty.span, || rustc_ast_pretty::pprust::ty_to_string(ty));
         } else {
             walk_ty(self, ty);
+        }
+    }
+
+    fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) -> Self::Result {
+        if item.span.from_expansion() {
+            self.handle_new_span(item.span, || {
+                rustc_ast_pretty::pprust::assoc_item_to_string(item)
+            });
+        } else {
+            walk_assoc_item(self, item, ctxt);
         }
     }
 }

--- a/tests/rustdoc-html/macro-expansion/assoc-items-decl-macro.rs
+++ b/tests/rustdoc-html/macro-expansion/assoc-items-decl-macro.rs
@@ -1,0 +1,24 @@
+// Ensure assoc items work for decl macros.
+// Regression test for <https://github.com/rust-lang/rust/issues/156075>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+#![feature(decl_macro)]
+
+//@ has 'src/foo/assoc-items-decl-macro.rs.html'
+
+pub macro first() {
+    type P1 = bool;
+    fn u1() {}
+}
+
+trait C1 {
+    type P1;
+    fn u1();
+}
+
+impl C1 for u32 {
+    //@ matches - '//*[@class="expansion"]/*[@class="expanded"]' 'type P1 = bool;\nfn u1\(\) {}'
+    first!();
+}

--- a/tests/rustdoc-html/macro-expansion/assoc-items-macro.rs
+++ b/tests/rustdoc-html/macro-expansion/assoc-items-macro.rs
@@ -1,0 +1,25 @@
+// Ensure assoc items work for macro rules.
+// Regression test for <https://github.com/rust-lang/rust/issues/156075>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/assoc-items-macro.rs.html'
+
+macro_rules! first {
+    () => {
+        type P1 = bool;
+        fn u1() {}
+    }
+}
+
+trait C1 {
+    type P1;
+    fn u1();
+}
+
+impl C1 for u32 {
+    //@ matches - '//*[@class="expansion"]/*[@class="expanded"]' 'type P1 = bool;\nfn u1\(\) {}'
+    first!();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#156075.

The bug was simply that it didn't cover associated items.

r? @Urgau 