### PR TITLE
Improve diagnostics for ambiguous binops with as _

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -821,8 +821,10 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 let predicate = fcx.resolve_vars_if_possible(obligation.predicate);
                 let cast_span = self.cast_span;
 
-                if let ObligationCauseCode::BinOp { rhs_span, .. } = obligation.cause.code()
-                    && rhs_span.contains(cast_span)
+                if let ObligationCauseCode::BinOp { lhs_hir_id, rhs_span, .. } =
+                    obligation.cause.code()
+                    && (fcx.tcx.hir_span(*lhs_hir_id).contains(cast_span)
+                        || rhs_span.contains(cast_span))
                     && matches!(
                         predicate.kind().skip_binder(),
                         ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -821,14 +821,21 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 let predicate = fcx.resolve_vars_if_possible(obligation.predicate);
                 let cast_span = self.cast_span;
 
-                if let ObligationCauseCode::BinOp { lhs_hir_id, rhs_span, .. } =
+                let ObligationCauseCode::BinOp { lhs_hir_id, rhs_hir_id, rhs_span, .. } =
                     obligation.cause.code()
-                    && (fcx.tcx.hir_span(*lhs_hir_id).contains(cast_span)
-                        || rhs_span.contains(cast_span))
-                    && matches!(
-                        predicate.kind().skip_binder(),
-                        ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
-                    )
+                else {
+                    return None;
+                };
+                let lhs_ty = fcx.resolve_vars_if_possible(fcx.node_ty(*lhs_hir_id));
+                let rhs_ty = fcx.resolve_vars_if_possible(fcx.node_ty(*rhs_hir_id));
+
+                if (fcx.tcx.hir_span(*lhs_hir_id).contains(cast_span)
+                    && lhs_ty.contains(self.cast_ty))
+                    || (rhs_span.contains(cast_span) && rhs_ty.contains(self.cast_ty))
+                        && matches!(
+                            predicate.kind().skip_binder(),
+                            ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
+                        )
                 {
                     obligation.cause.span = cast_span;
                     obligation.predicate = predicate;

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -842,15 +842,12 @@ impl<'a, 'tcx> CastCheck<'tcx> {
 
                     let ocx = ObligationCtxt::new_with_diagnostics(&fcx.infcx);
                     ocx.register_obligation(obligation);
-                    ocx.evaluate_obligations_error_on_ambiguity()
-                        .into_iter()
-                        .filter(|error| {
-                            matches!(
-                                error.code,
-                                traits::FulfillmentErrorCode::Ambiguity { overflow: None }
-                            )
-                        })
-                        .next()
+                    ocx.evaluate_obligations_error_on_ambiguity().into_iter().find(|error| {
+                        matches!(
+                            error.code,
+                            traits::FulfillmentErrorCode::Ambiguity { overflow: None }
+                        )
+                    })
                 } else {
                     None
                 }

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -754,7 +754,17 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     pub(crate) fn check(mut self, fcx: &FnCtxt<'a, 'tcx>) {
         let expr_span = self.expr_span_for_type_resolution(fcx);
         self.expr_ty = fcx.structurally_resolve_type(expr_span, self.expr_ty);
-        self.cast_ty = fcx.structurally_resolve_type(self.cast_span, self.cast_ty);
+        self.cast_ty = fcx.resolve_vars_with_obligations(self.cast_ty);
+        if self.cast_ty.is_ty_var() {
+            self.cast_ty =
+                if let Some(guar) = fcx.try_report_ambiguous_binop_for_infer_cast(self.cast_span) {
+                    let err = Ty::new_error(fcx.tcx, guar);
+                    fcx.demand_suptype(self.cast_span, err, self.cast_ty);
+                    err
+                } else {
+                    fcx.type_must_be_known_at_this_point(self.cast_span, self.cast_ty)
+                };
+        }
 
         debug!("check_cast({}, {:?} as {:?})", self.expr.hir_id, self.expr_ty, self.cast_ty);
 

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -34,6 +34,7 @@ use rustc_errors::{Applicability, Diag, ErrorGuaranteed};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, ExprKind};
 use rustc_infer::infer::DefineOpaqueTypes;
+use rustc_infer::traits::ObligationCauseCode;
 use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::mir::Mutability;
 use rustc_middle::ty::adjustment::AllowTwoPhase;
@@ -46,6 +47,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_session::lint;
 use rustc_span::{DUMMY_SP, Span, sym};
 use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::traits::{self, ObligationCtxt};
 use tracing::{debug, instrument};
 
 use super::FnCtxt;
@@ -756,14 +758,13 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         self.expr_ty = fcx.structurally_resolve_type(expr_span, self.expr_ty);
         self.cast_ty = fcx.resolve_vars_with_obligations(self.cast_ty);
         if self.cast_ty.is_ty_var() {
-            self.cast_ty =
-                if let Some(guar) = fcx.try_report_ambiguous_binop_for_infer_cast(self.cast_span) {
-                    let err = Ty::new_error(fcx.tcx, guar);
-                    fcx.demand_suptype(self.cast_span, err, self.cast_ty);
-                    err
-                } else {
-                    fcx.type_must_be_known_at_this_point(self.cast_span, self.cast_ty)
-                };
+            self.cast_ty = if let Some(guar) = self.try_report_ambiguous_binop_for_infer_cast(fcx) {
+                let err = Ty::new_error(fcx.tcx, guar);
+                fcx.demand_suptype(self.cast_span, err, self.cast_ty);
+                err
+            } else {
+                fcx.type_must_be_known_at_this_point(self.cast_span, self.cast_ty)
+            };
         }
 
         debug!("check_cast({}, {:?} as {:?})", self.expr.hir_id, self.expr_ty, self.cast_ty);
@@ -804,6 +805,56 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             };
         }
     }
+
+    /// Prefer a pending operator ambiguity over a generic `as _` inference failure.
+    #[cold]
+    fn try_report_ambiguous_binop_for_infer_cast(
+        &self,
+        fcx: &FnCtxt<'a, 'tcx>,
+    ) -> Option<ErrorGuaranteed> {
+        let errors: Vec<_> = fcx
+            .fulfillment_cx
+            .borrow()
+            .pending_obligations()
+            .into_iter()
+            .filter_map(|mut obligation| {
+                let predicate = fcx.resolve_vars_if_possible(obligation.predicate);
+                let cast_span = self.cast_span;
+
+                if let ObligationCauseCode::BinOp { rhs_span, .. } = obligation.cause.code()
+                    && rhs_span.contains(cast_span)
+                    && matches!(
+                        predicate.kind().skip_binder(),
+                        ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
+                    )
+                {
+                    obligation.cause.span = cast_span;
+                    obligation.predicate = predicate;
+
+                    let ocx = ObligationCtxt::new_with_diagnostics(&fcx.infcx);
+                    ocx.register_obligation(obligation);
+                    ocx.evaluate_obligations_error_on_ambiguity()
+                        .into_iter()
+                        .filter(|error| {
+                            matches!(
+                                error.code,
+                                traits::FulfillmentErrorCode::Ambiguity { overflow: None }
+                            )
+                        })
+                        .next()
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if errors.is_empty() {
+            None
+        } else {
+            Some(fcx.err_ctxt().report_fulfillment_errors(errors))
+        }
+    }
+
     /// Checks a cast, and report an error if one exists. In some cases, this
     /// can return Ok and create type errors in the fcx rather than returning
     /// directly. coercion-cast is handled in check instead of here.

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -34,6 +34,7 @@ use rustc_errors::{Applicability, Diag, ErrorGuaranteed};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, ExprKind};
 use rustc_infer::infer::DefineOpaqueTypes;
+use rustc_infer::traits::ObligationCauseCode;
 use rustc_macros::{TypeFoldable, TypeVisitable};
 use rustc_middle::mir::Mutability;
 use rustc_middle::ty::adjustment::AllowTwoPhase;
@@ -46,6 +47,7 @@ use rustc_middle::{bug, span_bug};
 use rustc_session::lint;
 use rustc_span::{DUMMY_SP, Span, sym};
 use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::traits::{self, ObligationCtxt, TraitEngine};
 use tracing::{debug, instrument};
 
 use super::FnCtxt;
@@ -799,7 +801,16 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     pub(crate) fn check(mut self, fcx: &FnCtxt<'a, 'tcx>) {
         let expr_span = self.expr_span_for_type_resolution(fcx);
         self.expr_ty = fcx.structurally_resolve_type(expr_span, self.expr_ty);
-        self.cast_ty = fcx.structurally_resolve_type(self.cast_span, self.cast_ty);
+        self.cast_ty = fcx.resolve_vars_with_obligations(self.cast_ty);
+        if self.cast_ty.is_ty_var() {
+            self.cast_ty = if let Some(guar) = self.try_report_ambiguous_binop_for_infer_cast(fcx) {
+                let err = Ty::new_error(fcx.tcx, guar);
+                fcx.demand_suptype(self.cast_span, err, self.cast_ty);
+                err
+            } else {
+                fcx.type_must_be_known_at_this_point(self.cast_span, self.cast_ty)
+            };
+        }
 
         debug!("check_cast({}, {:?} as {:?})", self.expr.hir_id, self.expr_ty, self.cast_ty);
 
@@ -839,6 +850,64 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             };
         }
     }
+
+    /// Prefer a pending operator ambiguity over a generic `as _` inference failure.
+    #[cold]
+    fn try_report_ambiguous_binop_for_infer_cast(
+        &self,
+        fcx: &FnCtxt<'a, 'tcx>,
+    ) -> Option<ErrorGuaranteed> {
+        let errors: Vec<_> = fcx
+            .fulfillment_cx
+            .borrow()
+            .pending_obligations()
+            .into_iter()
+            .filter_map(|mut obligation| {
+                let predicate = fcx.resolve_vars_if_possible(obligation.predicate);
+                if !matches!(
+                    predicate.kind().skip_binder(),
+                    ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
+                ) {
+                    return None;
+                }
+                let cast_span = self.cast_span;
+
+                let ObligationCauseCode::BinOp { lhs_hir_id, rhs_hir_id, rhs_span, .. } =
+                    obligation.cause.code()
+                else {
+                    return None;
+                };
+                let lhs_ty = fcx.resolve_vars_if_possible(fcx.node_ty(*lhs_hir_id));
+                let rhs_ty = fcx.resolve_vars_if_possible(fcx.node_ty(*rhs_hir_id));
+
+                if (fcx.tcx.hir_span(*lhs_hir_id).contains(cast_span)
+                    && lhs_ty.contains(self.cast_ty))
+                    || (rhs_span.contains(cast_span) && rhs_ty.contains(self.cast_ty))
+                {
+                    obligation.cause.span = cast_span;
+                    obligation.predicate = predicate;
+
+                    let ocx = ObligationCtxt::new_with_diagnostics(&fcx.infcx);
+                    ocx.register_obligation(obligation);
+                    ocx.evaluate_obligations_error_on_ambiguity().into_iter().find(|error| {
+                        matches!(
+                            error.code,
+                            traits::FulfillmentErrorCode::Ambiguity { overflow: None }
+                        )
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if errors.is_empty() {
+            None
+        } else {
+            Some(fcx.err_ctxt().report_fulfillment_errors(errors.into()))
+        }
+    }
+
     /// Checks a cast, and report an error if one exists. In some cases, this
     /// can return Ok and create type errors in the fcx rather than returning
     /// directly. coercion-cast is handled in check instead of here.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -37,7 +37,7 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_trait_selection::error_reporting::infer::need_type_info::TypeAnnotationNeeded;
 use rustc_trait_selection::traits::{
-    self, NormalizeExt, ObligationCauseCode, ObligationCtxt, StructurallyNormalizeExt,
+    self, NormalizeExt, ObligationCauseCode, StructurallyNormalizeExt,
 };
 use tracing::{debug, instrument};
 
@@ -1541,54 +1541,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let err = Ty::new_error(self.tcx, guar);
         self.demand_suptype(sp, err, ty);
         err
-    }
-
-    /// Prefer a pending operator ambiguity over a generic `as _` inference failure.
-    #[cold]
-    pub(crate) fn try_report_ambiguous_binop_for_infer_cast(
-        &self,
-        sp: Span,
-    ) -> Option<ErrorGuaranteed> {
-        let errors: Vec<_> = self
-            .fulfillment_cx
-            .borrow()
-            .pending_obligations()
-            .into_iter()
-            .filter_map(|mut obligation| {
-                let predicate = self.resolve_vars_if_possible(obligation.predicate);
-
-                if let ObligationCauseCode::BinOp { rhs_span, .. } = obligation.cause.code()
-                    && rhs_span.contains(sp)
-                    && matches!(
-                        predicate.kind().skip_binder(),
-                        ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
-                    )
-                {
-                    obligation.cause.span = sp;
-                    obligation.predicate = predicate;
-
-                    let ocx = ObligationCtxt::new_with_diagnostics(&self.infcx);
-                    ocx.register_obligation(obligation);
-                    ocx.evaluate_obligations_error_on_ambiguity()
-                        .into_iter()
-                        .filter(|error| {
-                            matches!(
-                                error.code,
-                                traits::FulfillmentErrorCode::Ambiguity { overflow: None }
-                            )
-                        })
-                        .next()
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        if errors.is_empty() {
-            None
-        } else {
-            Some(self.err_ctxt().report_fulfillment_errors(errors))
-        }
     }
 
     pub(crate) fn structurally_resolve_const(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -37,7 +37,7 @@ use rustc_span::def_id::LocalDefId;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_trait_selection::error_reporting::infer::need_type_info::TypeAnnotationNeeded;
 use rustc_trait_selection::traits::{
-    self, NormalizeExt, ObligationCauseCode, StructurallyNormalizeExt,
+    self, NormalizeExt, ObligationCauseCode, ObligationCtxt, StructurallyNormalizeExt,
 };
 use tracing::{debug, instrument};
 
@@ -1541,6 +1541,57 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let err = Ty::new_error(self.tcx, guar);
         self.demand_suptype(sp, err, ty);
         err
+    }
+
+    /// Prefer a pending operator ambiguity over a generic `as _` inference failure.
+    #[cold]
+    pub(crate) fn try_report_ambiguous_binop_for_infer_cast(
+        &self,
+        sp: Span,
+    ) -> Option<ErrorGuaranteed> {
+        let errors: Vec<_> = self
+            .fulfillment_cx
+            .borrow()
+            .pending_obligations()
+            .into_iter()
+            .filter_map(|mut obligation| {
+                let rhs_span = match obligation.cause.code() {
+                    ObligationCauseCode::BinOp { rhs_span, .. } => *rhs_span,
+                    _ => return None,
+                };
+
+                let predicate = self.resolve_vars_if_possible(obligation.predicate);
+                if !rhs_span.contains(sp)
+                    || !matches!(
+                        predicate.kind().skip_binder(),
+                        ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
+                    )
+                {
+                    return None;
+                }
+
+                obligation.cause.span = sp;
+                obligation.predicate = predicate;
+
+                let ocx = ObligationCtxt::new_with_diagnostics(&self.infcx);
+                ocx.register_obligation(obligation);
+                ocx.evaluate_obligations_error_on_ambiguity()
+                    .into_iter()
+                    .filter(|error| {
+                        matches!(
+                            error.code,
+                            traits::FulfillmentErrorCode::Ambiguity { overflow: None }
+                        )
+                    })
+                    .next()
+            })
+            .collect();
+
+        if errors.is_empty() {
+            None
+        } else {
+            Some(self.err_ctxt().report_fulfillment_errors(errors))
+        }
     }
 
     pub(crate) fn structurally_resolve_const(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1555,35 +1555,32 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .pending_obligations()
             .into_iter()
             .filter_map(|mut obligation| {
-                let rhs_span = match obligation.cause.code() {
-                    ObligationCauseCode::BinOp { rhs_span, .. } => *rhs_span,
-                    _ => return None,
-                };
-
                 let predicate = self.resolve_vars_if_possible(obligation.predicate);
-                if !rhs_span.contains(sp)
-                    || !matches!(
+
+                if let ObligationCauseCode::BinOp { rhs_span, .. } = obligation.cause.code()
+                    && rhs_span.contains(sp)
+                    && matches!(
                         predicate.kind().skip_binder(),
                         ty::PredicateKind::Clause(ty::ClauseKind::Trait(_))
                     )
                 {
-                    return None;
+                    obligation.cause.span = sp;
+                    obligation.predicate = predicate;
+
+                    let ocx = ObligationCtxt::new_with_diagnostics(&self.infcx);
+                    ocx.register_obligation(obligation);
+                    ocx.evaluate_obligations_error_on_ambiguity()
+                        .into_iter()
+                        .filter(|error| {
+                            matches!(
+                                error.code,
+                                traits::FulfillmentErrorCode::Ambiguity { overflow: None }
+                            )
+                        })
+                        .next()
+                } else {
+                    None
                 }
-
-                obligation.cause.span = sp;
-                obligation.predicate = predicate;
-
-                let ocx = ObligationCtxt::new_with_diagnostics(&self.infcx);
-                ocx.register_obligation(obligation);
-                ocx.evaluate_obligations_error_on_ambiguity()
-                    .into_iter()
-                    .filter(|error| {
-                        matches!(
-                            error.code,
-                            traits::FulfillmentErrorCode::Ambiguity { overflow: None }
-                        )
-                    })
-                    .next()
             })
             .collect();
 

--- a/tests/ui/inference/multiple-impl-apply.rs
+++ b/tests/ui/inference/multiple-impl-apply.rs
@@ -55,8 +55,19 @@ impl PartialEq<Value> for u32 {
     }
 }
 
-fn partial_eq_with_infer_cast() {
-    // https://github.com/rust-lang/rust/issues/156004
+impl PartialEq<u32> for Value {
+    fn eq(&self, _: &u32) -> bool {
+        false
+    }
+}
+
+// https://github.com/rust-lang/rust/issues/156004
+fn partial_eq_with_infer_cast_on_rhs() {
     let n: u32 = 17;
     let _ = n == 42usize as _; //~ ERROR E0283
+}
+
+fn partial_eq_with_infer_cast_on_lhs() {
+    let n: u32 = 17;
+    let _ = 42usize as _ == n; //~ ERROR E0283
 }

--- a/tests/ui/inference/multiple-impl-apply.rs
+++ b/tests/ui/inference/multiple-impl-apply.rs
@@ -71,3 +71,13 @@ fn partial_eq_with_infer_cast_on_lhs() {
     let n: u32 = 17;
     let _ = 42usize as _ == n; //~ ERROR E0283
 }
+
+fn unrelated_infer_cast_in_lhs() {
+    let n: u32 = 17;
+    let _ = (
+        {
+            let _ = 42usize as _; //~ ERROR E0282
+            Default::default()
+        }
+    ) == n;
+}

--- a/tests/ui/inference/multiple-impl-apply.rs
+++ b/tests/ui/inference/multiple-impl-apply.rs
@@ -46,3 +46,17 @@ fn main() {
 fn magic_foo(arg: Baz) -> Foo {
     arg.into()
 }
+
+struct Value;
+
+impl PartialEq<Value> for u32 {
+    fn eq(&self, _: &Value) -> bool {
+        false
+    }
+}
+
+fn partial_eq_with_infer_cast() {
+    // https://github.com/rust-lang/rust/issues/156004
+    let n: u32 = 17;
+    let _ = n == 42usize as _; //~ ERROR E0282
+}

--- a/tests/ui/inference/multiple-impl-apply.rs
+++ b/tests/ui/inference/multiple-impl-apply.rs
@@ -58,5 +58,5 @@ impl PartialEq<Value> for u32 {
 fn partial_eq_with_infer_cast() {
     // https://github.com/rust-lang/rust/issues/156004
     let n: u32 = 17;
-    let _ = n == 42usize as _; //~ ERROR E0282
+    let _ = n == 42usize as _; //~ ERROR E0283
 }

--- a/tests/ui/inference/multiple-impl-apply.rs
+++ b/tests/ui/inference/multiple-impl-apply.rs
@@ -55,8 +55,47 @@ impl PartialEq<Value> for u32 {
     }
 }
 
-fn partial_eq_with_infer_cast() {
-    // https://github.com/rust-lang/rust/issues/156004
+impl PartialEq<u32> for Value {
+    fn eq(&self, _: &u32) -> bool {
+        false
+    }
+}
+
+// https://github.com/rust-lang/rust/issues/156004
+fn partial_eq_with_infer_cast_on_rhs() {
     let n: u32 = 17;
-    let _ = n == 42usize as _; //~ ERROR E0282
+    let _ = n == 42usize as _; //~ ERROR E0283
+}
+
+fn partial_eq_with_infer_cast_on_lhs() {
+    let n: u32 = 17;
+    let _ = 42usize as _ == n; //~ ERROR E0283
+}
+
+fn unrelated_infer_cast_in_lhs() {
+    let n: u32 = 17;
+    let _ = (
+        {
+            let _ = 42usize as _; //~ ERROR E0282
+            Default::default()
+        }
+    ) == n;
+}
+
+struct AddRhs;
+
+impl std::ops::Add<AddRhs> for u32 {
+    type Output = ();
+
+    fn add(self, _: AddRhs) {}
+}
+
+impl std::ops::Add<AddRhs> for i32 {
+    type Output = ();
+
+    fn add(self, _: AddRhs) {}
+}
+
+fn add_with_infer_cast_on_lhs() {
+    let _: () = 42usize as _ + AddRhs; //~ ERROR E0283
 }

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -44,6 +44,26 @@ LL | impl PartialEq<u32> for Value {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
-error: aborting due to 3 previous errors
+error[E0283]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:79:32
+   |
+LL |       let _ = (
+   |  _____________-
+LL | |         {
+LL | |             let _ = 42usize as _;
+   | |                                ^ cannot infer type
+LL | |             Default::default()
+LL | |         }
+LL | |     ) == n;
+   | |_____-    -
+   |
+note: multiple `impl`s satisfying `_: PartialEq<u32>` found
+  --> $DIR/multiple-impl-apply.rs:58:1
+   |
+LL | impl PartialEq<u32> for Value {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -18,13 +18,19 @@ help: consider giving `y` an explicit type
 LL |     let y: /* Type */ = x.into();
    |          ++++++++++++
 
-error[E0282]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/multiple-impl-apply.rs:61:29
    |
 LL |     let _ = n == 42usize as _;
    |                             ^ cannot infer type
+   |
+note: multiple `impl`s satisfying `u32: PartialEq<_>` found
+  --> $DIR/multiple-impl-apply.rs:52:1
+   |
+LL | impl PartialEq<Value> for u32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0282, E0283.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -18,6 +18,13 @@ help: consider giving `y` an explicit type
 LL |     let y: /* Type */ = x.into();
    |          ++++++++++++
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:61:29
+   |
+LL |     let _ = n == 42usize as _;
+   |                             ^ cannot infer type
 
-For more information about this error, try `rustc --explain E0283`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0283.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -44,26 +44,18 @@ LL | impl PartialEq<u32> for Value {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
-error[E0283]: type annotations needed
-  --> $DIR/multiple-impl-apply.rs:79:32
+error[E0282]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:79:17
    |
-LL |       let _ = (
-   |  _____________-
-LL | |         {
-LL | |             let _ = 42usize as _;
-   | |                                ^ cannot infer type
-LL | |             Default::default()
-LL | |         }
-LL | |     ) == n;
-   | |_____-    -
+LL |             let _ = 42usize as _;
+   |                 ^              - type must be known at this point
    |
-note: multiple `impl`s satisfying `_: PartialEq<u32>` found
-  --> $DIR/multiple-impl-apply.rs:58:1
+help: consider giving this pattern a type
    |
-LL | impl PartialEq<u32> for Value {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
+LL |             let _: /* Type */ = 42usize as _;
+   |                  ++++++++++++
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0283`.
+Some errors have detailed explanations: E0282, E0283.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -31,13 +31,19 @@ LL | impl PartialEq<Value> for u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
-error[E0282]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/multiple-impl-apply.rs:72:24
    |
 LL |     let _ = 42usize as _ == n;
    |                        ^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: PartialEq<u32>` found
+  --> $DIR/multiple-impl-apply.rs:58:1
+   |
+LL | impl PartialEq<u32> for Value {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0282, E0283.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -19,7 +19,7 @@ LL |     let y: /* Type */ = x.into();
    |          ++++++++++++
 
 error[E0283]: type annotations needed
-  --> $DIR/multiple-impl-apply.rs:61:29
+  --> $DIR/multiple-impl-apply.rs:67:29
    |
 LL |     let _ = n == 42usize as _;
    |                             ^ cannot infer type
@@ -31,6 +31,13 @@ LL | impl PartialEq<Value> for u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:72:24
+   |
+LL |     let _ = 42usize as _ == n;
+   |                        ^ cannot infer type
 
-For more information about this error, try `rustc --explain E0283`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0282, E0283.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/inference/multiple-impl-apply.stderr
+++ b/tests/ui/inference/multiple-impl-apply.stderr
@@ -18,13 +18,59 @@ help: consider giving `y` an explicit type
 LL |     let y: /* Type */ = x.into();
    |          ++++++++++++
 
-error[E0282]: type annotations needed
-  --> $DIR/multiple-impl-apply.rs:61:29
+error[E0283]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:67:29
    |
 LL |     let _ = n == 42usize as _;
    |                             ^ cannot infer type
+   |
+note: multiple `impl`s satisfying `u32: PartialEq<_>` found
+  --> $DIR/multiple-impl-apply.rs:52:1
+   |
+LL | impl PartialEq<Value> for u32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
 
-error: aborting due to 2 previous errors
+error[E0283]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:72:24
+   |
+LL |     let _ = 42usize as _ == n;
+   |                        ^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: PartialEq<u32>` found
+  --> $DIR/multiple-impl-apply.rs:58:1
+   |
+LL | impl PartialEq<u32> for Value {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: and another `impl` found in the `core` crate: `impl PartialEq for u32;`
+
+error[E0282]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:79:17
+   |
+LL |             let _ = 42usize as _;
+   |                 ^              - type must be known at this point
+   |
+help: consider giving this pattern a type
+   |
+LL |             let _: /* Type */ = 42usize as _;
+   |                  ++++++++++++
+
+error[E0283]: type annotations needed
+  --> $DIR/multiple-impl-apply.rs:100:28
+   |
+LL |     let _: () = 42usize as _ + AddRhs;
+   |                            ^ cannot infer type
+   |
+note: multiple `impl`s satisfying `_: Add<AddRhs>` found
+  --> $DIR/multiple-impl-apply.rs:87:1
+   |
+LL | impl std::ops::Add<AddRhs> for u32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+LL | impl std::ops::Add<AddRhs> for i32 {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0282, E0283.
 For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156591)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#156004

`as _` inside the RHS of an overloaded binary operation can leave the cast target unresolved while there is still a pending operator obligation that knows the more useful ambiguity.

This PR keeps the normal resolved-cast path unchanged, such that when the cast target is still a type variable, cast checking now looks for a pending `BinOp` obligation whose RHS contains the cast span and replays that obligation in a fresh diagnostic fulfillment context. If the replayed obligation is actually ambiguous, rustc reports the existing fulfillment ambiguity, including the competing impl candidates.

Best reviewed commit-by-commit.
