### PR TITLE
Avoid rustfix suggestions for macro-expanded unused imports

### DIFF
--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -486,6 +486,9 @@ impl Resolver<'_, '_> {
 
             let remove_whole_use = remove_spans.len() == 1 && remove_spans[0] == unused.item_span;
             let num_to_remove = ms.primary_spans().len();
+            // Only offer rustfix suggestions for spans that point at directly editable code.
+            let can_suggest_removal =
+                remove_spans.iter().all(|span| span.can_be_used_for_suggestions());
 
             // If we are in the `--test` mode, suppress a help that adds the `#[cfg(test)]`
             // attribute; however, if not, suggest adding the attribute. There is no way to
@@ -516,11 +519,13 @@ impl Resolver<'_, '_> {
                 unused.use_tree_id,
                 ms,
                 move |dcx, level, sess| {
-                    let sugg = if remove_whole_use {
-                        errors::UnusedImportsSugg::RemoveWholeUse { span: remove_spans[0] }
-                    } else {
-                        errors::UnusedImportsSugg::RemoveImports { remove_spans, num_to_remove }
-                    };
+                    let sugg = can_suggest_removal.then(|| {
+                        if remove_whole_use {
+                            errors::UnusedImportsSugg::RemoveWholeUse { span: remove_spans[0] }
+                        } else {
+                            errors::UnusedImportsSugg::RemoveImports { remove_spans, num_to_remove }
+                        }
+                    });
                     let test_module_span = test_module_span.map(|span| {
                         sess.downcast_ref::<rustc_session::Session>()
                             .expect("expected a `Session`")

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -1742,7 +1742,7 @@ pub(crate) struct ElidedLifetimesInPaths {
 )]
 pub(crate) struct UnusedImports {
     #[subdiagnostic]
-    pub sugg: UnusedImportsSugg,
+    pub sugg: Option<UnusedImportsSugg>,
     #[help("if this is a test module, consider adding a `#[cfg(test)]` to the containing module")]
     pub test_module_span: Option<Span>,
 

--- a/tests/ui/imports/unused-import-in-macro-expansion-rustfix.fixed
+++ b/tests/ui/imports/unused-import-in-macro-expansion-rustfix.fixed
@@ -1,0 +1,22 @@
+//@ edition:2024
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+//@ check-pass
+
+mod m {
+    macro_rules! define_new_macro {
+        ($name:ident) => {
+            macro_rules! $name {
+                () => {};
+            }
+            pub(crate) use $name;
+        };
+    }
+
+    define_new_macro!(item_used);
+    define_new_macro!(item_unused);
+}
+
+fn main() {
+    m::item_used!();
+}

--- a/tests/ui/imports/unused-import-in-macro-expansion-rustfix.fixed
+++ b/tests/ui/imports/unused-import-in-macro-expansion-rustfix.fixed
@@ -1,3 +1,4 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/147855>
 //@ edition:2024
 //@ run-rustfix
 //@ rustfix-only-machine-applicable

--- a/tests/ui/imports/unused-import-in-macro-expansion-rustfix.fixed
+++ b/tests/ui/imports/unused-import-in-macro-expansion-rustfix.fixed
@@ -1,5 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/147855>
-//@ edition:2024
+//@ edition:2021
 //@ run-rustfix
 //@ rustfix-only-machine-applicable
 //@ check-pass

--- a/tests/ui/imports/unused-import-in-macro-expansion-rustfix.rs
+++ b/tests/ui/imports/unused-import-in-macro-expansion-rustfix.rs
@@ -1,0 +1,22 @@
+//@ edition:2024
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+//@ check-pass
+
+mod m {
+    macro_rules! define_new_macro {
+        ($name:ident) => {
+            macro_rules! $name {
+                () => {};
+            }
+            pub(crate) use $name;
+        };
+    }
+
+    define_new_macro!(item_used);
+    define_new_macro!(item_unused);
+}
+
+fn main() {
+    m::item_used!();
+}

--- a/tests/ui/imports/unused-import-in-macro-expansion-rustfix.rs
+++ b/tests/ui/imports/unused-import-in-macro-expansion-rustfix.rs
@@ -1,3 +1,4 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/147855>
 //@ edition:2024
 //@ run-rustfix
 //@ rustfix-only-machine-applicable

--- a/tests/ui/imports/unused-import-in-macro-expansion-rustfix.rs
+++ b/tests/ui/imports/unused-import-in-macro-expansion-rustfix.rs
@@ -1,5 +1,5 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/147855>
-//@ edition:2024
+//@ edition:2021
 //@ run-rustfix
 //@ rustfix-only-machine-applicable
 //@ check-pass


### PR DESCRIPTION
Avoid emitting rustfix suggestions for unused imports when the removal span is not directly editable.

Closes rust-lang/rust#147855
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
