### PR TITLE
Assert redundant incremental check

### DIFF
--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -91,6 +91,8 @@ pub struct OnDiskCache {
     // we try to map an `ExpnHash` to its value in the current
     // compilation session.
     foreign_expn_data: UnhashMap<ExpnHash, u32>,
+
+    fresh: bool,
 }
 
 // This type is used only for serialization and deserialization.
@@ -175,6 +177,7 @@ impl OnDiskCache {
             expn_data: footer.expn_data,
             foreign_expn_data: footer.foreign_expn_data,
             hygiene_context: Default::default(),
+            fresh: false,
         })
     }
 
@@ -190,7 +193,12 @@ impl OnDiskCache {
             expn_data: UnhashMap::default(),
             foreign_expn_data: UnhashMap::default(),
             hygiene_context: Default::default(),
+            fresh: true,
         }
+    }
+
+    pub fn is_fresh(&self) -> bool {
+        self.fresh
     }
 
     /// Release the serialized backing `Mmap`.

--- a/compiler/rustc_query_impl/src/execution.rs
+++ b/compiler/rustc_query_impl/src/execution.rs
@@ -19,7 +19,7 @@ use tracing::warn;
 use crate::dep_graph::{DepNode, DepNodeIndex};
 use crate::handle_cycle_error;
 use crate::job::{QueryJobInfo, QueryJobMap, create_cycle_error, find_cycle_in_stack};
-use crate::plumbing::{current_query_job, loadable_from_disk, next_job_id, start_query};
+use crate::plumbing::{current_query_job, loadable_from_disk_incr, next_job_id, start_query};
 use crate::query_impl::for_each_query_vtable;
 
 #[inline]
@@ -604,7 +604,7 @@ fn ensure_can_skip_execution<'tcx, C: QueryCache>(
                 // for this key.
                 EnsureMode::Done => {
                     query.will_cache_on_disk_for_key(key)
-                        && loadable_from_disk(tcx, serialized_dep_node_index)
+                        && loadable_from_disk_incr(tcx, serialized_dep_node_index)
                 }
             }
         }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -175,7 +175,8 @@ pub(crate) fn promote_from_disk_inner<'tcx, C: QueryCache>(
 
 pub(crate) fn loadable_from_disk<'tcx>(tcx: TyCtxt<'tcx>, id: SerializedDepNodeIndex) -> bool {
     if let Some(cache) = tcx.query_system.on_disk_cache.as_ref() {
-        cache.loadable_from_disk(id)
+        assert!(cache.loadable_from_disk(id));
+        true
     } else {
         false
     }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -173,8 +173,9 @@ pub(crate) fn promote_from_disk_inner<'tcx, C: QueryCache>(
     }
 }
 
-pub(crate) fn loadable_from_disk<'tcx>(tcx: TyCtxt<'tcx>, id: SerializedDepNodeIndex) -> bool {
-    if let Some(cache) = tcx.query_system.on_disk_cache.as_ref() {
+pub(crate) fn loadable_from_disk_incr<'tcx>(tcx: TyCtxt<'tcx>, id: SerializedDepNodeIndex) -> bool {
+    let cache = tcx.query_system.on_disk_cache.as_ref().unwrap();
+    if !cache.is_fresh() {
         assert!(cache.loadable_from_disk(id));
         true
     } else {


### PR DESCRIPTION
So to incrementally execute `tcx.ensure_done().query()` we first do query graph coloring to determine if nothing has changed and maybe color our query green. In that case for `ensure_ok` we skip further execution and return. However for `ensure_done` we do this check:

https://github.com/rust-lang/rust/blob/7c3c88f42ad444f4688b865591d84660be4ece2f/compiler/rustc_query_impl/src/execution.rs#L601-L608

Which in turn looks up a serialized query value:

https://github.com/rust-lang/rust/blob/7c3c88f42ad444f4688b865591d84660be4ece2f/compiler/rustc_middle/src/query/on_disk_cache.rs#L338-L343

However, we only serialize query values if the pure (I've checked) function `will_cache_on_disk_for_key_fn` from above returns true:

https://github.com/rust-lang/rust/blob/7c3c88f42ad444f4688b865591d84660be4ece2f/compiler/rustc_query_impl/src/plumbing.rs#L95-L99

As such `loadable_from_disk` should be able to simply check if `tcx.query_system.on_disk_cache` is loaded and assume query value is present, assuming that `will_cache_on_disk_for_key_fn` returned true.