### PR TITLE
Make const param default test reproduce original ICE

### DIFF
--- a/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
@@ -3,7 +3,7 @@
 
 #![feature(min_generic_const_args)]
 
-trait Bar<const N: bool = false> {}
+trait Bar<const N: usize = const { 1 + 1 }> {}
 
 trait Foo {
     type AssocB: Bar;


### PR DESCRIPTION
As discussed in [comment](https://github.com/rust-lang/rust/pull/156325#discussion_r3247360505).

ICE using old logic: 
[old-logic-ice.txt](https://github.com/user-attachments/files/27797628/old-logic-ice.txt)

r? BoxyUwU

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
