### PR TITLE
coverage: Reduce and clarify the context-mismatch test case

### DIFF
--- a/tests/coverage/macros/context-mismatch-issue-147339.cov-map
+++ b/tests/coverage/macros/context-mismatch-issue-147339.cov-map
@@ -1,40 +1,20 @@
-Function name: context_mismatch_issue_147339::a (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
+Function name: context_mismatch_issue_147339::_function (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 14, 11, 00, 26, 00, 02, 11, 00, 12]
 Number of files: 1
 - file 0 => $DIR/context-mismatch-issue-147339.rs
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
-- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
-Highest counter ID seen: (none)
-
-Function name: context_mismatch_issue_147339::b (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
-Number of files: 1
-- file 0 => $DIR/context-mismatch-issue-147339.rs
-Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
-- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
-Highest counter ID seen: (none)
-
-Function name: context_mismatch_issue_147339::c (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
-Number of files: 1
-- file 0 => $DIR/context-mismatch-issue-147339.rs
-Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
-- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
+- Code(Zero) at (prev + 20, 17) to (start + 0, 38)
+- Code(Zero) at (prev + 2, 17) to (start + 0, 18)
 Highest counter ID seen: (none)
 
 Function name: context_mismatch_issue_147339::main
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 14, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 1f, 01, 00, 0a, 01, 00, 0c, 00, 0d]
 Number of files: 1
 - file 0 => $DIR/context-mismatch-issue-147339.rs
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 20, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 31, 1) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
 Highest counter ID seen: c0
 

--- a/tests/coverage/macros/context-mismatch-issue-147339.coverage
+++ b/tests/coverage/macros/context-mismatch-issue-147339.coverage
@@ -6,23 +6,27 @@
    LL|       |//
    LL|       |// Reported in <https://github.com/rust-lang/rust/issues/147339>.
    LL|       |
-   LL|       |macro_rules! foo {
-   LL|       |    ($($m:ident $($f:ident $v:tt)+),*) => {
-   LL|       |        $($(macro_rules! $f { () => { $v } })+)*
-   LL|      0|        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
-  ------------------
-  | Unexecuted instantiation: context_mismatch_issue_147339::a
-  ------------------
-  | Unexecuted instantiation: context_mismatch_issue_147339::b
-  ------------------
-  | Unexecuted instantiation: context_mismatch_issue_147339::c
-  ------------------
-   LL|       |    }
+   LL|       |macro_rules! outer_macro {
+   LL|       |    (
+   LL|       |        $v:tt
+   LL|       |    ) => {
+   LL|       |        macro_rules! _other_macro_that_mentions_v {
+   LL|       |            () => {
+   LL|       |                $v
+   LL|       |            };
+   LL|       |        }
+   LL|       |        macro_rules! inner_macro {
+   LL|       |            () => {
+   LL|      0|                fn _function() -> i32 {
+   LL|       |                    $v
+   LL|      0|                }
+   LL|       |            };
+   LL|       |        }
+   LL|       |    };
    LL|       |}
    LL|       |
-   LL|       |foo!(m a 1 b 2, n c 3);
-   LL|       |m!();
-   LL|       |n!();
+   LL|       |outer_macro!(1);
+   LL|       |inner_macro!();
    LL|       |
    LL|      1|fn main() {}
 

--- a/tests/coverage/macros/context-mismatch-issue-147339.rs
+++ b/tests/coverage/macros/context-mismatch-issue-147339.rs
@@ -6,15 +6,26 @@
 //
 // Reported in <https://github.com/rust-lang/rust/issues/147339>.
 
-macro_rules! foo {
-    ($($m:ident $($f:ident $v:tt)+),*) => {
-        $($(macro_rules! $f { () => { $v } })+)*
-        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
-    }
+macro_rules! outer_macro {
+    (
+        $v:tt
+    ) => {
+        macro_rules! _other_macro_that_mentions_v {
+            () => {
+                $v
+            };
+        }
+        macro_rules! inner_macro {
+            () => {
+                fn _function() -> i32 {
+                    $v
+                }
+            };
+        }
+    };
 }
 
-foo!(m a 1 b 2, n c 3);
-m!();
-n!();
+outer_macro!(1);
+inner_macro!();
 
 fn main() {}


### PR DESCRIPTION
Most of the complexity in this test case isn't needed to reproduce the condition observed in https://github.com/rust-lang/rust/issues/147339.

I have checked that this reduced test case still triggers the context-mismatch in `extract_refined_covspans`.