### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3867,6 +3867,19 @@ pub struct Fn {
     pub eii_impls: ThinVec<EiiImpl>,
 }
 
+impl Fn {
+    pub fn is_pin_drop_sugar(&self) -> bool {
+        self.ident.name == sym::drop
+            && self
+                .sig
+                .decl
+                .inputs
+                .first()
+                .and_then(|param| param.to_self())
+                .is_some_and(|eself| matches!(eself.node, SelfKind::Pinned(None, Mutability::Mut)))
+    }
+}
+
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub struct EiiImpl {
     pub node_id: NodeId,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1192,6 +1192,52 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
+    fn resolve_pin_drop_sugar_impl_item(
+        &self,
+        i: &AssocItem,
+        ident: Ident,
+        span: Span,
+    ) -> (Ident, Result<DefId, ErrorGuaranteed>) {
+        let trait_item_def_id = self
+            .get_partial_res(i.id)
+            .and_then(|r| r.expect_full_res().opt_def_id())
+            .ok_or_else(|| {
+                self.dcx().span_delayed_bug(span, "could not resolve trait item being implemented")
+            });
+
+        let is_pin_drop_sugar = match &i.kind {
+            AssocItemKind::Fn(fn_kind) => fn_kind.is_pin_drop_sugar(),
+            _ => false,
+        };
+        let def_id = match trait_item_def_id {
+            Ok(def_id) => def_id,
+            Err(guar) => return (ident, Err(guar)),
+        };
+        if !is_pin_drop_sugar {
+            return (ident, Ok(def_id));
+        }
+
+        let is_drop_pin_drop = self
+            .tcx
+            .lang_items()
+            .drop_trait()
+            .is_some_and(|drop_trait| self.tcx.parent(def_id) == drop_trait);
+        if is_drop_pin_drop {
+            // Associated item collection still derives the impl item's name from HIR.
+            return (Ident::new(sym::pin_drop, ident.span), Ok(def_id));
+        }
+
+        let guar = self
+            .dcx()
+            .struct_span_err(
+                i.span,
+                "method `drop` with `&pin mut self` is only supported for the `Drop` trait",
+            )
+            .with_span_label(i.span, "not a `Drop::pin_drop` implementation")
+            .emit();
+        (ident, Err(guar))
+    }
+
     fn lower_impl_item(
         &mut self,
         i: &AssocItem,
@@ -1309,26 +1355,19 @@ impl<'hir> LoweringContext<'_, 'hir> {
         };
 
         let span = self.lower_span(i.span);
+        let (effective_ident, impl_kind) = if is_in_trait_impl {
+            let (effective_ident, trait_item_def_id) =
+                self.resolve_pin_drop_sugar_impl_item(i, ident, span);
+            (effective_ident, ImplItemImplKind::Trait { defaultness, trait_item_def_id })
+        } else {
+            (ident, ImplItemImplKind::Inherent { vis_span: self.lower_span(i.vis.span) })
+        };
+
         let item = hir::ImplItem {
             owner_id: hir_id.expect_owner(),
-            ident: self.lower_ident(ident),
+            ident: self.lower_ident(effective_ident),
             generics,
-            impl_kind: if is_in_trait_impl {
-                ImplItemImplKind::Trait {
-                    defaultness,
-                    trait_item_def_id: self
-                        .get_partial_res(i.id)
-                        .and_then(|r| r.expect_full_res().opt_def_id())
-                        .ok_or_else(|| {
-                            self.dcx().span_delayed_bug(
-                                span,
-                                "could not resolve trait item being implemented",
-                            )
-                        }),
-                }
-            } else {
-                ImplItemImplKind::Inherent { vis_span: self.lower_span(i.vis.span) }
-            },
+            impl_kind,
             kind,
             span,
             has_delayed_lints: !self.delayed_lints.is_empty(),

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -14,6 +14,7 @@ use rustc_middle::ty::{
 use rustc_span::{ErrorGuaranteed, Span, kw};
 
 use crate::collect::ItemCtxt;
+use crate::errors::DelegationSelfTypeNotSpecified;
 use crate::hir_ty_lowering::HirTyLowerer;
 
 type RemapTable = FxHashMap<u32, u32>;
@@ -284,6 +285,12 @@ fn get_delegation_self_ty_or_err(tcx: TyCtxt<'_>, delegation_id: LocalDefId) -> 
             ctx.lower_ty(tcx.hir_node(id).expect_ty())
         })
         .unwrap_or_else(|| {
+            // It is possible to attempt to get self type when it is used in signature
+            // (i.e., `fn default() -> Self`), so emit error here in addition to possible
+            // `mismatched types` error (see #156388).
+            let err = DelegationSelfTypeNotSpecified { span: tcx.def_span(delegation_id) };
+            tcx.dcx().emit_err(err);
+
             Ty::new_error_with_message(
                 tcx,
                 tcx.def_span(delegation_id),

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1671,6 +1671,14 @@ pub(crate) struct UnsupportedDelegation<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag("delegation self type is not specified")]
+#[help("consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`")]
+pub(crate) struct DelegationSelfTypeNotSpecified {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("method should be `async` or return a future, but it is synchronous")]
 pub(crate) struct MethodShouldReturnFuture {
     #[primary_span]

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -222,14 +222,8 @@ where
         let span = self.source_info.span;
 
         let pin_obj_bb = bb.unwrap_or_else(|| {
-            self.elaborator.patch().new_block(BasicBlockData::new(
-                Some(Terminator {
-                    // Temporary terminator, will be replaced by patch
-                    source_info: self.source_info,
-                    kind: TerminatorKind::Return,
-                }),
-                false,
-            ))
+            // Temporary terminator, will be replaced by patch
+            self.new_block(unwind, TerminatorKind::Return)
         });
 
         let (fut_ty, drop_fn_def_id, trait_args) = if call_destructor_only {
@@ -594,8 +588,7 @@ where
                 succ,
                 unwind,
                 dropline,
-                // Using `self.path` here to condition the drop on
-                // our own drop flag.
+                // Using `self.path` here to condition the drop on our own drop flag.
                 path: self.path,
             }
             .complete_drop(succ, unwind)
@@ -767,18 +760,14 @@ where
 
         let do_drop_bb = self.drop_subpath(interior, interior_path, succ, unwind, dropline);
 
-        let setup_bbd = BasicBlockData::new_stmts(
+        self.new_block_with_statements(
+            unwind,
             vec![self.assign(
                 Place::from(ptr_local),
                 Rvalue::Cast(CastKind::Transmute, Operand::Copy(nonnull_place), ptr_ty),
             )],
-            Some(Terminator {
-                kind: TerminatorKind::Goto { target: do_drop_bb },
-                source_info: self.source_info,
-            }),
-            unwind.is_cleanup(),
-        );
-        self.elaborator.patch().new_block(setup_bbd)
+            TerminatorKind::Goto { target: do_drop_bb },
+        )
     }
 
     #[instrument(level = "debug", ret)]
@@ -788,13 +777,7 @@ where
         args: GenericArgsRef<'tcx>,
     ) -> BasicBlock {
         if adt.variants().is_empty() {
-            return self.elaborator.patch().new_block(BasicBlockData::new(
-                Some(Terminator {
-                    source_info: self.source_info,
-                    kind: TerminatorKind::Unreachable,
-                }),
-                self.unwind.is_cleanup(),
-            ));
+            return self.new_block(self.unwind, TerminatorKind::Unreachable);
         }
 
         let skip_contents = adt.is_union() || adt.is_manually_drop();
@@ -972,21 +955,17 @@ where
         let discr_ty = adt.repr().discr_type().to_ty(self.tcx());
         let discr = Place::from(self.new_temp(discr_ty));
         let discr_rv = Rvalue::Discriminant(self.place);
-        let switch_block = BasicBlockData::new_stmts(
+        let switch_block = self.new_block_with_statements(
+            unwind,
             vec![self.assign(discr, discr_rv)],
-            Some(Terminator {
-                source_info: self.source_info,
-                kind: TerminatorKind::SwitchInt {
-                    discr: Operand::Move(discr),
-                    targets: SwitchTargets::new(
-                        values.iter().copied().zip(blocks.iter().copied()),
-                        *blocks.last().unwrap(),
-                    ),
-                },
-            }),
-            unwind.is_cleanup(),
+            TerminatorKind::SwitchInt {
+                discr: Operand::Move(discr),
+                targets: SwitchTargets::new(
+                    values.iter().copied().zip(blocks.iter().copied()),
+                    *blocks.last().unwrap(),
+                ),
+            },
         );
-        let switch_block = self.elaborator.patch().new_block(switch_block);
         self.drop_flag_test_block(switch_block, succ, unwind)
     }
 
@@ -1001,7 +980,8 @@ where
         let ref_place = self.new_temp(ref_ty);
         let unit_temp = Place::from(self.new_temp(tcx.types.unit));
 
-        let result = BasicBlockData::new_stmts(
+        self.new_block_with_statements(
+            unwind,
             vec![self.assign(
                 Place::from(ref_place),
                 Rvalue::Ref(
@@ -1010,28 +990,17 @@ where
                     self.place,
                 ),
             )],
-            Some(Terminator {
-                kind: TerminatorKind::Call {
-                    func: Operand::function_handle(
-                        tcx,
-                        drop_fn,
-                        [ty.into()],
-                        self.source_info.span,
-                    ),
-                    args: [Spanned { node: Operand::Move(Place::from(ref_place)), span: DUMMY_SP }]
-                        .into(),
-                    destination: unit_temp,
-                    target: Some(succ),
-                    unwind: unwind.into_action(),
-                    call_source: CallSource::Misc,
-                    fn_span: self.source_info.span,
-                },
-                source_info: self.source_info,
-            }),
-            unwind.is_cleanup(),
-        );
-
-        self.elaborator.patch().new_block(result)
+            TerminatorKind::Call {
+                func: Operand::function_handle(tcx, drop_fn, [ty.into()], self.source_info.span),
+                args: [Spanned { node: Operand::Move(Place::from(ref_place)), span: DUMMY_SP }]
+                    .into(),
+                destination: unit_temp,
+                target: Some(succ),
+                unwind: unwind.into_action(),
+                call_source: CallSource::Misc,
+                fn_span: self.source_info.span,
+            },
+        )
     }
 
     #[instrument(level = "debug", skip(self), ret)]
@@ -1078,7 +1047,8 @@ where
         let can_go = Place::from(self.new_temp(tcx.types.bool));
         let one = self.constant_usize(1);
 
-        let drop_block = BasicBlockData::new_stmts(
+        let drop_block = self.new_block_with_statements(
+            unwind,
             vec![
                 self.assign(
                     ptr,
@@ -1089,27 +1059,18 @@ where
                     Rvalue::BinaryOp(BinOp::Add, Box::new((move_(cur.into()), one))),
                 ),
             ],
-            Some(Terminator {
-                source_info: self.source_info,
-                // this gets overwritten by drop elaboration.
-                kind: TerminatorKind::Unreachable,
-            }),
-            unwind.is_cleanup(),
+            // this gets overwritten by drop elaboration.
+            TerminatorKind::Unreachable,
         );
-        let drop_block = self.elaborator.patch().new_block(drop_block);
 
-        let loop_block = BasicBlockData::new_stmts(
+        let loop_block = self.new_block_with_statements(
+            unwind,
             vec![self.assign(
                 can_go,
                 Rvalue::BinaryOp(BinOp::Eq, Box::new((copy(Place::from(cur)), copy(len.into())))),
             )],
-            Some(Terminator {
-                source_info: self.source_info,
-                kind: TerminatorKind::if_(move_(can_go), succ, drop_block),
-            }),
-            unwind.is_cleanup(),
+            TerminatorKind::if_(move_(can_go), succ, drop_block),
         );
-        let loop_block = self.elaborator.patch().new_block(loop_block);
 
         let place = tcx.mk_place_deref(ptr);
         if !unwind.is_cleanup() && self.check_if_can_async_drop(ety, false) {
@@ -1213,7 +1174,15 @@ where
         let slice_ptr_ty = Ty::new_mut_ptr(tcx, slice_ty);
         let slice_ptr = self.new_temp(slice_ptr_ty);
 
-        let mut delegate_block = BasicBlockData::new_stmts(
+        let array_place = mem::replace(
+            &mut self.place,
+            Place::from(slice_ptr).project_deeper(&[PlaceElem::Deref], tcx),
+        );
+        let slice_block = self.drop_loop_trio_for_slice(ety);
+        self.place = array_place;
+
+        self.new_block_with_statements(
+            self.unwind,
             vec![
                 self.assign(Place::from(array_ptr), Rvalue::RawPtr(RawPtrKind::Mut, self.place)),
                 self.assign(
@@ -1228,22 +1197,8 @@ where
                     ),
                 ),
             ],
-            None,
-            self.unwind.is_cleanup(),
-        );
-
-        let array_place = mem::replace(
-            &mut self.place,
-            Place::from(slice_ptr).project_deeper(&[PlaceElem::Deref], tcx),
-        );
-        let slice_block = self.drop_loop_trio_for_slice(ety);
-        self.place = array_place;
-
-        delegate_block.terminator = Some(Terminator {
-            source_info: self.source_info,
-            kind: TerminatorKind::Goto { target: slice_block },
-        });
-        self.elaborator.patch().new_block(delegate_block)
+            TerminatorKind::Goto { target: slice_block },
+        )
     }
 
     /// Creates a trio of drop-loops of `place`, which drops its contents, even
@@ -1272,7 +1227,8 @@ where
         };
 
         let zero = self.constant_usize(0);
-        let block = BasicBlockData::new_stmts(
+        let drop_block = self.new_block_with_statements(
+            unwind,
             vec![
                 self.assign(
                     len.into(),
@@ -1283,14 +1239,9 @@ where
                 ),
                 self.assign(cur.into(), Rvalue::Use(zero, WithRetag::Yes)),
             ],
-            Some(Terminator {
-                source_info: self.source_info,
-                kind: TerminatorKind::Goto { target: loop_block },
-            }),
-            unwind.is_cleanup(),
+            TerminatorKind::Goto { target: loop_block },
         );
 
-        let drop_block = self.elaborator.patch().new_block(block);
         // FIXME(#34708): handle partially-dropped array/slice elements.
         let reset_block = self.drop_flag_reset_block(DropFlagMode::Deep, drop_block, unwind);
         self.drop_flag_test_block(reset_block, self.succ, unwind)
@@ -1334,13 +1285,7 @@ where
                     self.source_info.span,
                     "open drop for unsafe binder shouldn't be encountered",
                 );
-                self.elaborator.patch().new_block(BasicBlockData::new(
-                    Some(Terminator {
-                        source_info: self.source_info,
-                        kind: TerminatorKind::Unreachable,
-                    }),
-                    self.unwind.is_cleanup(),
-                ))
+                self.new_block(self.unwind, TerminatorKind::Unreachable)
             }
 
             _ => span_bug!(self.source_info.span, "open drop from non-ADT `{:?}`", ty),
@@ -1375,21 +1320,19 @@ where
 
     #[instrument(level = "debug", skip(self), ret)]
     fn elaborated_drop_block(&mut self) -> BasicBlock {
-        let blk = self.drop_block_simple(self.succ, self.unwind);
+        let blk = self.new_block(
+            self.unwind,
+            TerminatorKind::Drop {
+                place: self.place,
+                target: self.succ,
+                unwind: self.unwind.into_action(),
+                replace: false,
+                drop: self.dropline,
+                async_fut: None,
+            },
+        );
         self.elaborate_drop(blk);
         blk
-    }
-
-    fn drop_block_simple(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
-        let block = TerminatorKind::Drop {
-            place: self.place,
-            target,
-            unwind: unwind.into_action(),
-            replace: false,
-            drop: self.dropline,
-            async_fut: None,
-        };
-        self.new_block(unwind, block)
     }
 
     fn drop_block(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
@@ -1405,15 +1348,17 @@ where
                 false,
             )
         } else {
-            let block = TerminatorKind::Drop {
-                place: self.place,
-                target,
-                unwind: unwind.into_action(),
-                replace: false,
-                drop: None,
-                async_fut: None,
-            };
-            self.new_block(unwind, block)
+            self.new_block(
+                unwind,
+                TerminatorKind::Drop {
+                    place: self.place,
+                    target,
+                    unwind: unwind.into_action(),
+                    replace: false,
+                    drop: None,
+                    async_fut: None,
+                },
+            )
         }
     }
 

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -207,6 +207,7 @@ where
     // We keep async drop unexpanded to poll-loop here, to expand it later, at StateTransform -
     //   into states expand.
     // call_destructor_only - to call only AsyncDrop::drop, not full async_drop_in_place glue
+    #[instrument(level = "debug", skip(self), ret)]
     fn build_async_drop(
         &mut self,
         place: Place<'tcx>,
@@ -565,6 +566,7 @@ where
             .collect()
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_subpath(
         &mut self,
         place: Place<'tcx>,
@@ -574,8 +576,6 @@ where
         dropline: Option<BasicBlock>,
     ) -> BasicBlock {
         if let Some(path) = path {
-            debug!("drop_subpath: for std field {:?}", place);
-
             DropCtxt {
                 elaborator: self.elaborator,
                 source_info: self.source_info,
@@ -587,8 +587,6 @@ where
             }
             .elaborated_drop_block()
         } else {
-            debug!("drop_subpath: for rest field {:?}", place);
-
             DropCtxt {
                 elaborator: self.elaborator,
                 source_info: self.source_info,
@@ -614,6 +612,7 @@ where
     /// `dropline_ladder` is a similar list of steps in reverse order,
     /// which is called if the matching step of the drop glue will contain async drop
     /// (expanded later to Yield) and the containing coroutine will be dropped at this point.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_halfladder(
         &mut self,
         unwind_ladder: &[Unwind],
@@ -679,6 +678,7 @@ where
     ///
     /// NOTE: this does not clear the master drop flag, so you need
     /// to point succ/unwind on a `drop_ladder_bottom`.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_ladder(
         &mut self,
         fields: Vec<(Place<'tcx>, Option<D::Path>)>,
@@ -686,7 +686,6 @@ where
         unwind: Unwind,
         dropline: Option<BasicBlock>,
     ) -> (BasicBlock, Unwind, Option<BasicBlock>) {
-        debug!("drop_ladder({:?}, {:?})", self, fields);
         assert!(
             if unwind.is_cleanup() { dropline.is_none() } else { true },
             "Dropline is set for cleanup drop ladder"
@@ -723,9 +722,8 @@ where
         )
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn open_drop_for_tuple(&mut self, tys: &[Ty<'tcx>]) -> BasicBlock {
-        debug!("open_drop_for_tuple({:?}, {:?})", self, tys);
-
         let fields = tys
             .iter()
             .enumerate()
@@ -994,8 +992,8 @@ where
         self.drop_flag_test_block(switch_block, succ, unwind)
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn destructor_call_block_sync(&mut self, (succ, unwind): (BasicBlock, Unwind)) -> BasicBlock {
-        debug!("destructor_call_block_sync({:?}, {:?})", self, succ);
         let tcx = self.tcx();
         let drop_trait = tcx.require_lang_item(LangItem::Drop, DUMMY_SP);
         let drop_fn = tcx.associated_item_def_ids(drop_trait)[0];
@@ -1038,11 +1036,11 @@ where
         self.elaborator.patch().new_block(result)
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn destructor_call_block(
         &mut self,
         (succ, unwind, dropline): (BasicBlock, Unwind, Option<BasicBlock>),
     ) -> BasicBlock {
-        debug!("destructor_call_block({:?}, {:?})", self, succ);
         let ty = self.place_ty(self.place);
         if !unwind.is_cleanup() && self.check_if_can_async_drop(ty, true) {
             self.build_async_drop(self.place, ty, None, succ, unwind, dropline, true)
@@ -1140,13 +1138,13 @@ where
         loop_block
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn open_drop_for_array(
         &mut self,
         array_ty: Ty<'tcx>,
         ety: Ty<'tcx>,
         opt_size: Option<u64>,
     ) -> BasicBlock {
-        debug!("open_drop_for_array({:?}, {:?}, {:?})", array_ty, ety, opt_size);
         let tcx = self.tcx();
 
         if let Some(size) = opt_size {
@@ -1250,8 +1248,8 @@ where
 
     /// Creates a trio of drop-loops of `place`, which drops its contents, even
     /// in the case of 1 panic or in the case of coroutine drop
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_loop_trio_for_slice(&mut self, ety: Ty<'tcx>) -> BasicBlock {
-        debug!("drop_loop_trio_for_slice({:?})", ety);
         let tcx = self.tcx();
         let len = self.new_temp(tcx.types.usize);
         let cur = self.new_temp(tcx.types.usize);
@@ -1349,24 +1347,21 @@ where
         }
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn complete_drop(&mut self, succ: BasicBlock, unwind: Unwind) -> BasicBlock {
-        debug!("complete_drop(succ={:?}, unwind={:?})", succ, unwind);
-
         let drop_block = self.drop_block(succ, unwind);
-
         self.drop_flag_test_block(drop_block, succ, unwind)
     }
 
     /// Creates a block that resets the drop flag. If `mode` is deep, all children drop flags will
     /// also be cleared.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_flag_reset_block(
         &mut self,
         mode: DropFlagMode,
         succ: BasicBlock,
         unwind: Unwind,
     ) -> BasicBlock {
-        debug!("drop_flag_reset_block({:?},{:?})", self, mode);
-
         if unwind.is_cleanup() {
             // The drop flag isn't read again on the unwind path, so don't
             // bother setting it.
@@ -1378,8 +1373,8 @@ where
         block
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn elaborated_drop_block(&mut self) -> BasicBlock {
-        debug!("elaborated_drop_block({:?})", self);
         let blk = self.drop_block_simple(self.succ, self.unwind);
         self.elaborate_drop(blk);
         blk
@@ -1432,6 +1427,7 @@ where
     /// Depending on the required `DropStyle`, this might be a generated block with an `if`
     /// terminator (for dynamic/open drops), or it might be `on_set` or `on_unset` itself, in case
     /// the drop can be statically determined.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_flag_test_block(
         &mut self,
         on_set: BasicBlock,
@@ -1439,11 +1435,6 @@ where
         unwind: Unwind,
     ) -> BasicBlock {
         let style = self.elaborator.drop_style(self.path, DropFlagMode::Shallow);
-        debug!(
-            "drop_flag_test_block({:?},{:?},{:?},{:?}) - {:?}",
-            self, on_set, on_unset, unwind, style
-        );
-
         match style {
             DropStyle::Dead => on_unset,
             DropStyle::Static => on_set,
@@ -1455,6 +1446,7 @@ where
         }
     }
 
+    #[instrument(level = "trace", skip(self), ret)]
     fn new_block(&mut self, unwind: Unwind, k: TerminatorKind<'tcx>) -> BasicBlock {
         self.elaborator.patch().new_block(BasicBlockData::new(
             Some(Terminator { source_info: self.source_info, kind: k }),
@@ -1462,6 +1454,7 @@ where
         ))
     }
 
+    #[instrument(level = "trace", skip(self, statements), ret)]
     fn new_block_with_statements(
         &mut self,
         unwind: Unwind,

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -798,7 +798,7 @@ where
         }
 
         let skip_contents = adt.is_union() || adt.is_manually_drop();
-        let contents_drop = if skip_contents {
+        let (contents_succ, contents_unwind, contents_dropline) = if skip_contents {
             if adt.has_dtor(self.tcx()) && self.elaborator.get_drop_flag(self.path).is_some() {
                 // the top-level drop flag is usually cleared by open_drop_for_adt_contents
                 // types with destructors would still need an empty drop ladder to clear it
@@ -817,21 +817,19 @@ where
         if adt.has_dtor(self.tcx()) {
             let destructor_block = if adt.is_box() {
                 // we need to drop the inside of the box before running the destructor
-                let succ = self.destructor_call_block_sync((contents_drop.0, contents_drop.1));
-                let unwind = contents_drop
-                    .1
-                    .map(|unwind| self.destructor_call_block_sync((unwind, Unwind::InCleanup)));
-                let dropline = contents_drop
-                    .2
-                    .map(|dropline| self.destructor_call_block_sync((dropline, contents_drop.1)));
+                let succ = self.destructor_call_block_sync(contents_succ, contents_unwind);
+                let unwind = contents_unwind
+                    .map(|unwind| self.destructor_call_block_sync(unwind, Unwind::InCleanup));
+                let dropline = contents_dropline
+                    .map(|dropline| self.destructor_call_block_sync(dropline, contents_unwind));
                 self.open_drop_for_box_contents(adt, args, succ, unwind, dropline)
             } else {
-                self.destructor_call_block(contents_drop)
+                self.destructor_call_block(contents_succ, contents_unwind, contents_dropline)
             };
 
-            self.drop_flag_test_block(destructor_block, contents_drop.0, contents_drop.1)
+            self.drop_flag_test_block(destructor_block, contents_succ, contents_unwind)
         } else {
-            contents_drop.0
+            contents_succ
         }
     }
 
@@ -993,7 +991,7 @@ where
     }
 
     #[instrument(level = "debug", skip(self), ret)]
-    fn destructor_call_block_sync(&mut self, (succ, unwind): (BasicBlock, Unwind)) -> BasicBlock {
+    fn destructor_call_block_sync(&mut self, succ: BasicBlock, unwind: Unwind) -> BasicBlock {
         let tcx = self.tcx();
         let drop_trait = tcx.require_lang_item(LangItem::Drop, DUMMY_SP);
         let drop_fn = tcx.associated_item_def_ids(drop_trait)[0];
@@ -1039,13 +1037,15 @@ where
     #[instrument(level = "debug", skip(self), ret)]
     fn destructor_call_block(
         &mut self,
-        (succ, unwind, dropline): (BasicBlock, Unwind, Option<BasicBlock>),
+        succ: BasicBlock,
+        unwind: Unwind,
+        dropline: Option<BasicBlock>,
     ) -> BasicBlock {
         let ty = self.place_ty(self.place);
         if !unwind.is_cleanup() && self.check_if_can_async_drop(ty, true) {
             self.build_async_drop(self.place, ty, None, succ, unwind, dropline, true)
         } else {
-            self.destructor_call_block_sync((succ, unwind))
+            self.destructor_call_block_sync(succ, unwind)
         }
     }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3591,6 +3591,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                         this.check_trait_item(
                                             item.id,
                                             *ident,
+                                            *ident,
                                             &item.kind,
                                             ValueNS,
                                             item.span,
@@ -3635,7 +3636,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 );
                 self.resolve_define_opaques(define_opaque);
             }
-            AssocItemKind::Fn(Fn { ident, generics, define_opaque, .. }) => {
+            AssocItemKind::Fn(fn_kind @ Fn { ident, generics, define_opaque, .. }) => {
                 debug!("resolve_implementation AssocItemKind::Fn");
                 // We also need a new scope for the impl item type parameters.
                 self.with_generic_param_rib(
@@ -3645,10 +3646,16 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     LifetimeBinderKind::Function,
                     generics.span,
                     |this| {
+                        let effective_ident = if is_in_trait_impl && fn_kind.is_pin_drop_sugar() {
+                            Ident::new(sym::pin_drop, ident.span)
+                        } else {
+                            *ident
+                        };
                         // If this is a trait impl, ensure the method
                         // exists in trait
                         this.check_trait_item(
                             item.id,
+                            effective_ident,
                             *ident,
                             &item.kind,
                             ValueNS,
@@ -3680,6 +3687,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             this.check_trait_item(
                                 item.id,
                                 *ident,
+                                *ident,
                                 &item.kind,
                                 TypeNS,
                                 item.span,
@@ -3705,6 +3713,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         this.check_trait_item(
                             item.id,
                             delegation.ident,
+                            delegation.ident,
                             &item.kind,
                             ValueNS,
                             item.span,
@@ -3729,6 +3738,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         &mut self,
         id: NodeId,
         mut ident: Ident,
+        mut reported_ident: Ident,
         kind: &AssocItemKind,
         ns: Namespace,
         span: Span,
@@ -3742,6 +3752,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             return;
         };
         ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
+        reported_ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
         let key = BindingKey::new(IdentKey::new(ident), ns);
         let mut decl = self.r.resolution(module, key).and_then(|r| r.best_decl());
         debug!(?decl);
@@ -3777,10 +3788,10 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
         let Some(decl) = decl else {
             // We could not find the method: report an error.
-            let candidate = self.find_similarly_named_assoc_item(ident.name, kind);
+            let candidate = self.find_similarly_named_assoc_item(reported_ident.name, kind);
             let path = &self.current_trait_ref.as_ref().unwrap().1.path;
             let path_names = path_names_to_string(path);
-            self.report_error(span, err(ident, path_names, candidate));
+            self.report_error(span, err(reported_ident, path_names, candidate));
             feed_visibility(self, module.def_id());
             return;
         };

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -308,7 +308,10 @@ impl str {
     pub fn replace<P: Pattern>(&self, from: P, to: &str) -> String {
         // Fast path for replacing a single ASCII character with another.
         if let Some(from_byte) = match from.as_utf8_pattern() {
-            Some(Utf8Pattern::StringPattern([from_byte])) => Some(*from_byte),
+            Some(Utf8Pattern::StringPattern(s)) => match s.as_bytes() {
+                [from_byte] => Some(*from_byte),
+                _ => None,
+            },
             Some(Utf8Pattern::CharPattern(c)) => c.as_ascii().map(|ascii_char| ascii_char.to_u8()),
             _ => None,
         } {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2654,7 +2654,7 @@ impl<'b> Pattern for &'b String {
 
     #[inline]
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-        Some(Utf8Pattern::StringPattern(self.as_bytes()))
+        Some(Utf8Pattern::StringPattern(self.as_str()))
     }
 }
 

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -161,7 +161,7 @@ pub trait Pattern: Sized {
         }
     }
 
-    /// Returns the pattern as utf-8 bytes if possible.
+    /// Returns the pattern as UTF-8 if possible.
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
         None
     }
@@ -172,7 +172,9 @@ pub trait Pattern: Sized {
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Utf8Pattern<'a> {
     /// Type returned by String and str types.
-    StringPattern(&'a [u8]),
+    /// This stores `str` rather than bytes so callers cannot describe
+    /// non-UTF-8 string patterns through this API.
+    StringPattern(&'a str),
     /// Type returned by char types.
     CharPattern(char),
 }
@@ -1049,7 +1051,7 @@ impl<'b> Pattern for &'b str {
 
     #[inline]
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-        Some(Utf8Pattern::StringPattern(self.as_bytes()))
+        Some(Utf8Pattern::StringPattern(*self))
     }
 }
 

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -689,7 +689,7 @@ pub fn home_dir() -> Option<PathBuf> {
 /// [GetTempPath]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
 /// [appledoc]: https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/Articles/RaceConditions.html#//apple_ref/doc/uid/TP40002585-SW10
 ///
-/// ```no_run
+/// ```
 /// use std::env;
 ///
 /// fn main() {

--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -1,5 +1,8 @@
-use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt, walk_ty};
-use rustc_ast::{Crate, Expr, Item, Pat, Stmt, Ty};
+use rustc_ast::visit::{
+    AssocCtxt, Visitor, walk_assoc_item, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt,
+    walk_ty,
+};
+use rustc_ast::{AssocItem, Crate, Expr, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -159,6 +162,16 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             self.handle_new_span(ty.span, || rustc_ast_pretty::pprust::ty_to_string(ty));
         } else {
             walk_ty(self, ty);
+        }
+    }
+
+    fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) -> Self::Result {
+        if item.span.from_expansion() {
+            self.handle_new_span(item.span, || {
+                rustc_ast_pretty::pprust::assoc_item_to_string(item)
+            });
+        } else {
+            walk_assoc_item(self, item, ctxt);
         }
     }
 }

--- a/tests/rustdoc-html/macro-expansion/assoc-items-decl-macro.rs
+++ b/tests/rustdoc-html/macro-expansion/assoc-items-decl-macro.rs
@@ -1,0 +1,24 @@
+// Ensure assoc items work for decl macros.
+// Regression test for <https://github.com/rust-lang/rust/issues/156075>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+#![feature(decl_macro)]
+
+//@ has 'src/foo/assoc-items-decl-macro.rs.html'
+
+pub macro first() {
+    type P1 = bool;
+    fn u1() {}
+}
+
+trait C1 {
+    type P1;
+    fn u1();
+}
+
+impl C1 for u32 {
+    //@ matches - '//*[@class="expansion"]/*[@class="expanded"]' 'type P1 = bool;\nfn u1\(\) {}'
+    first!();
+}

--- a/tests/rustdoc-html/macro-expansion/assoc-items-macro.rs
+++ b/tests/rustdoc-html/macro-expansion/assoc-items-macro.rs
@@ -1,0 +1,25 @@
+// Ensure assoc items work for macro rules.
+// Regression test for <https://github.com/rust-lang/rust/issues/156075>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/assoc-items-macro.rs.html'
+
+macro_rules! first {
+    () => {
+        type P1 = bool;
+        fn u1() {}
+    }
+}
+
+trait C1 {
+    type P1;
+    fn u1();
+}
+
+impl C1 for u32 {
+    //@ matches - '//*[@class="expansion"]/*[@class="expanded"]' 'type P1 = bool;\nfn u1\(\) {}'
+    first!();
+}

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
@@ -1,3 +1,5 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
 #![feature(fn_delegation)]
 
 trait Bound<T> {}
@@ -19,12 +21,16 @@ reuse <usize as Trait>::static_method::<'static, Vec<i32>, false> as bar2;
 
 reuse Trait::static_method as error { self - 123 }
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 reuse Trait::<'static, i32, 123>::static_method as error2;
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 
 reuse <String as Trait>::static_method as error5;
 //~^ ERROR: the trait bound `String: Trait<'a, T, X>` is not satisfied

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
@@ -1,21 +1,53 @@
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:22:14
+   |
+LL | reuse Trait::static_method as error { self - 123 }
+   |              ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:25:35
+   |
+LL | reuse Trait::<'static, i32, 123>::static_method as error2;
+   |                                   ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:28:35
+   |
+LL | reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
+   |                                   ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:31:14
+   |
+LL | reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
+   |              ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:33:49
+  --> $DIR/free-to-trait-static-reuse.rs:39:49
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    |                                                 ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-static-reuse.rs:32:1
+  --> $DIR/free-to-trait-static-reuse.rs:38:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:15:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait`
-  --> $DIR/free-to-trait-static-reuse.rs:7:11
+  --> $DIR/free-to-trait-static-reuse.rs:9:11
    |
 LL | trait Trait<'a, T, const X: usize>
    |       ----- required by a bound in this trait
@@ -24,13 +56,13 @@ LL |     Self: Bound<T>,
    |           ^^^^^^^^ required by this bound in `Trait`
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:20:14
+  --> $DIR/free-to-trait-static-reuse.rs:22:14
    |
 LL | reuse Trait::static_method as error { self - 123 }
    |              ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +71,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:22:35
+  --> $DIR/free-to-trait-static-reuse.rs:25:35
    |
 LL | reuse Trait::<'static, i32, 123>::static_method as error2;
    |                                   ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +86,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:24:35
+  --> $DIR/free-to-trait-static-reuse.rs:28:35
    |
 LL | reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
    |                                   ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +101,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:26:14
+  --> $DIR/free-to-trait-static-reuse.rs:31:14
    |
 LL | reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
    |              ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +116,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `String: Trait<'a, T, X>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:29:8
+  --> $DIR/free-to-trait-static-reuse.rs:35:8
    |
 LL | reuse <String as Trait>::static_method as error5;
    |        ^^^^^^ the trait `Trait<'a, T, X>` is not implemented for `String`
    |
 help: the following other types implement trait `Trait<'a, T, X>`
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize`
@@ -99,23 +131,23 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Struct`
 
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:36:8
+  --> $DIR/free-to-trait-static-reuse.rs:42:8
    |
 LL | reuse <Struct as Trait>::static_method as error6;
    |        ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-static-reuse.rs:32:1
+  --> $DIR/free-to-trait-static-reuse.rs:38:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:15:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait::static_method`
-  --> $DIR/free-to-trait-static-reuse.rs:7:11
+  --> $DIR/free-to-trait-static-reuse.rs:9:11
    |
 LL |     Self: Bound<T>,
    |           ^^^^^^^^ required by this bound in `Trait::static_method`
@@ -123,7 +155,7 @@ LL | {
 LL |     fn static_method<'c: 'c, U, const B: bool>(x: usize) {}
    |        ------------- required by a bound in this associated function
 
-error: aborting due to 7 previous errors
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0277, E0283.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/delegation/self-ty-ice-156388.rs
+++ b/tests/ui/delegation/self-ty-ice-156388.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
+#![feature(fn_delegation)]
+
+reuse Default::default;
+//~^ ERROR: delegation self type is not specified
+
+fn main() {}

--- a/tests/ui/delegation/self-ty-ice-156388.stderr
+++ b/tests/ui/delegation/self-ty-ice-156388.stderr
@@ -1,0 +1,10 @@
+error: delegation self type is not specified
+  --> $DIR/self-ty-ice-156388.rs:5:16
+   |
+LL | reuse Default::default;
+   |                ^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -1,3 +1,5 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
 #![feature(fn_delegation)]
 
 trait Trait {
@@ -14,6 +16,7 @@ fn foo(x: i32) -> i32 { x }
 fn bar<T: Default>(_: T) {
     reuse Trait::static_method {
     //~^ ERROR mismatched types
+    //~| ERROR: delegation self type is not specified
         let _ = T::Default();
         //~^ ERROR can't use generic parameters from outer item
     }

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -1,18 +1,18 @@
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/target-expr.rs:17:17
+  --> $DIR/target-expr.rs:20:17
    |
 LL | fn bar<T: Default>(_: T) {
    |        - type parameter from outer item
 LL |     reuse Trait::static_method {
    |                  ------------- generic parameter used in this inner delegated function
-LL |
+...
 LL |         let _ = T::Default();
    |                 ^ use of generic parameter from outer item
    |
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0434]: can't capture dynamic environment in a fn item
-  --> $DIR/target-expr.rs:25:17
+  --> $DIR/target-expr.rs:28:17
    |
 LL |         let x = y;
    |                 ^
@@ -20,7 +20,7 @@ LL |         let x = y;
    = help: use the `|| { ... }` closure form instead
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/target-expr.rs:32:5
+  --> $DIR/target-expr.rs:35:5
    |
 LL | fn main() {
    |    ---- this function can't have a `self` parameter
@@ -29,29 +29,38 @@ LL |     self.0;
    |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/target-expr.rs:34:13
+  --> $DIR/target-expr.rs:37:13
    |
 LL |     let z = x;
    |             ^
    |
 help: the binding `x` is available in a different scope in the same function
-  --> $DIR/target-expr.rs:25:13
+  --> $DIR/target-expr.rs:28:13
    |
 LL |         let x = y;
    |             ^
 
+error: delegation self type is not specified
+  --> $DIR/target-expr.rs:17:18
+   |
+LL |     reuse Trait::static_method {
+   |                  ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
 error[E0308]: mismatched types
-  --> $DIR/target-expr.rs:15:32
+  --> $DIR/target-expr.rs:17:32
    |
 LL |       reuse Trait::static_method {
    |  ________________________________^
+LL | |
 LL | |
 LL | |         let _ = T::Default();
 LL | |
 LL | |     }
    | |_____^ expected `i32`, found `()`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0308, E0401, E0424, E0425, E0434.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/delegation/unsupported.current.stderr
+++ b/tests/ui/delegation/unsupported.current.stderr
@@ -1,41 +1,49 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:29:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:29:25
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:29:25
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:32:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:32:24
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:32:24
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 2 previous errors
+error: delegation self type is not specified
+  --> $DIR/unsupported.rs:54:18
+   |
+LL |     reuse Trait::foo;
+   |                  ^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/delegation/unsupported.next.stderr
+++ b/tests/ui/delegation/unsupported.next.stderr
@@ -1,41 +1,49 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:29:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:29:25
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:29:25
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:32:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:32:24
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:32:24
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 2 previous errors
+error: delegation self type is not specified
+  --> $DIR/unsupported.rs:54:18
+   |
+LL |     reuse Trait::foo;
+   |                  ^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/delegation/unsupported.rs
+++ b/tests/ui/delegation/unsupported.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
@@ -51,6 +52,7 @@ mod effects {
     }
 
     reuse Trait::foo;
+    //~^ ERROR: delegation self type is not specified
 }
 
 fn main() {}

--- a/tests/ui/eii/auxiliary/other_crate_privacy1.rs
+++ b/tests/ui/eii/auxiliary/other_crate_privacy1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/auxiliary/other_crate_privacy2.rs
+++ b/tests/ui/eii/auxiliary/other_crate_privacy2.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/default/auxiliary/decl_with_default.rs
+++ b/tests/ui/eii/default/auxiliary/decl_with_default.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/default/auxiliary/decl_with_default_panics.rs
+++ b/tests/ui/eii/default/auxiliary/decl_with_default_panics.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ needs-unwind
 //@ exec-env:RUST_BACKTRACE=1
 #![crate_type = "rlib"]

--- a/tests/ui/eii/default/auxiliary/impl1.rs
+++ b/tests/ui/eii/default/auxiliary/impl1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/default/call_default.rs
+++ b/tests/ui/eii/default/call_default.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default.rs
 //@ run-pass
 //@ check-run-results

--- a/tests/ui/eii/default/call_default_panics.rs
+++ b/tests/ui/eii/default/call_default_panics.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default_panics.rs
 //@ edition: 2021
 //@ run-pass

--- a/tests/ui/eii/default/call_impl.rs
+++ b/tests/ui/eii/default/call_impl.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl_with_default.rs
 //@ aux-build: impl1.rs
 //@ run-pass

--- a/tests/ui/eii/duplicate/auxiliary/decl.rs
+++ b/tests/ui/eii/duplicate/auxiliary/decl.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/duplicate/auxiliary/impl1.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/auxiliary/impl2.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl2.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/auxiliary/impl3.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl3.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/auxiliary/impl4.rs
+++ b/tests/ui/eii/duplicate/auxiliary/impl4.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: decl.rs
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]

--- a/tests/ui/eii/duplicate/duplicate1.rs
+++ b/tests/ui/eii/duplicate/duplicate1.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: impl1.rs
 //@ aux-build: impl2.rs
 //@ ignore-backends: gcc

--- a/tests/ui/eii/duplicate/duplicate1.stderr
+++ b/tests/ui/eii/duplicate/duplicate1.stderr
@@ -1,10 +1,10 @@
 error: multiple implementations of `#[eii1]`
-  --> $DIR/auxiliary/impl1.rs:10:1
+  --> $DIR/auxiliary/impl1.rs:9:1
    |
 LL | fn other(x: u64) {
    | ^^^^^^^^^^^^^^^^ first implemented here in crate `impl1`
    |
-  ::: $DIR/auxiliary/impl2.rs:10:1
+  ::: $DIR/auxiliary/impl2.rs:9:1
    |
 LL | fn other(x: u64) {
    | ---------------- also implemented here in crate `impl2`

--- a/tests/ui/eii/duplicate/duplicate2.rs
+++ b/tests/ui/eii/duplicate/duplicate2.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: impl1.rs
 //@ aux-build: impl2.rs
 //@ aux-build: impl3.rs

--- a/tests/ui/eii/duplicate/duplicate2.stderr
+++ b/tests/ui/eii/duplicate/duplicate2.stderr
@@ -1,10 +1,10 @@
 error: multiple implementations of `#[eii1]`
-  --> $DIR/auxiliary/impl1.rs:10:1
+  --> $DIR/auxiliary/impl1.rs:9:1
    |
 LL | fn other(x: u64) {
    | ^^^^^^^^^^^^^^^^ first implemented here in crate `impl1`
    |
-  ::: $DIR/auxiliary/impl2.rs:10:1
+  ::: $DIR/auxiliary/impl2.rs:9:1
    |
 LL | fn other(x: u64) {
    | ---------------- also implemented here in crate `impl2`

--- a/tests/ui/eii/duplicate/duplicate3.rs
+++ b/tests/ui/eii/duplicate/duplicate3.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 //@ aux-build: impl1.rs
 //@ aux-build: impl2.rs
 //@ aux-build: impl3.rs

--- a/tests/ui/eii/duplicate/duplicate3.stderr
+++ b/tests/ui/eii/duplicate/duplicate3.stderr
@@ -1,10 +1,10 @@
 error: multiple implementations of `#[eii1]`
-  --> $DIR/auxiliary/impl1.rs:10:1
+  --> $DIR/auxiliary/impl1.rs:9:1
    |
 LL | fn other(x: u64) {
    | ^^^^^^^^^^^^^^^^ first implemented here in crate `impl1`
    |
-  ::: $DIR/auxiliary/impl2.rs:10:1
+  ::: $DIR/auxiliary/impl2.rs:9:1
    |
 LL | fn other(x: u64) {
    | ---------------- also implemented here in crate `impl2`

--- a/tests/ui/eii/linking/auxiliary/codegen_cross_crate_other_crate.rs
+++ b/tests/ui/eii/linking/auxiliary/codegen_cross_crate_other_crate.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/privacy2.stderr
+++ b/tests/ui/eii/privacy2.stderr
@@ -11,13 +11,13 @@ LL |     codegen::decl1(42);
    |              ^^^^^ private function
    |
 note: the function `decl1` is defined here
-  --> $DIR/auxiliary/other_crate_privacy2.rs:7:1
+  --> $DIR/auxiliary/other_crate_privacy2.rs:6:1
    |
 LL | fn decl1(x: u64);
    | ^^^^^^^^^^^^^^^^^
 
 error: `#[eii2]` required, but not found
-  --> $DIR/auxiliary/other_crate_privacy2.rs:9:7
+  --> $DIR/auxiliary/other_crate_privacy2.rs:8:7
    |
 LL | #[eii(eii2)]
    |       ^^^^ expected because `#[eii2]` was declared here in crate `other_crate_privacy2`
@@ -25,7 +25,7 @@ LL | #[eii(eii2)]
    = help: expected at least one implementation in crate `privacy2` or any of its dependencies
 
 error: `#[eii3]` required, but not found
-  --> $DIR/auxiliary/other_crate_privacy2.rs:13:11
+  --> $DIR/auxiliary/other_crate_privacy2.rs:12:11
    |
 LL |     #[eii(eii3)]
    |           ^^^^ expected because `#[eii3]` was declared here in crate `other_crate_privacy2`

--- a/tests/ui/eii/static/auxiliary/cross_crate_decl.rs
+++ b/tests/ui/eii/static/auxiliary/cross_crate_decl.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/static/auxiliary/cross_crate_def.rs
+++ b/tests/ui/eii/static/auxiliary/cross_crate_def.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 

--- a/tests/ui/eii/type_checking/auxiliary/cross_crate_eii_declaration.rs
+++ b/tests/ui/eii/type_checking/auxiliary/cross_crate_eii_declaration.rs
@@ -1,4 +1,3 @@
-//@ no-prefer-dynamic
 #![crate_type = "rlib"]
 #![feature(extern_item_impls)]
 #![feature(decl_macro)]

--- a/tests/ui/eii/type_checking/cross_crate_wrong_ty.stderr
+++ b/tests/ui/eii/type_checking/cross_crate_wrong_ty.stderr
@@ -6,7 +6,7 @@ LL | #[unsafe(cross_crate_eii_declaration::foo)]
 LL | fn other() -> u64 {
    | ^^^^^^^^^^^^^^^^^ expected 1 parameter, found 0
    |
-  ::: $DIR/auxiliary/cross_crate_eii_declaration.rs:13:5
+  ::: $DIR/auxiliary/cross_crate_eii_declaration.rs:12:5
    |
 LL |     pub safe fn bar(x: u64) -> u64;
    |     ------------------------------- requires 1 parameter

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -17,6 +17,14 @@ impl Drop for Foo {
     //~^ ERROR use of unstable library feature `pin_ergonomics` [E0658]
 }
 
+struct Sugar;
+
+impl Drop for Sugar {
+    //~^ ERROR not all trait items implemented, missing: `drop`
+    fn drop(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+    //~^ ERROR use of unstable library feature `pin_ergonomics` [E0658]
+}
+
 fn foo(mut x: Pin<&mut Foo>) {
     Foo::foo_sugar(x.as_mut());
     Foo::foo_sugar_const(x.as_ref());

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -29,7 +29,17 @@ LL |     fn pin_drop(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:23:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:24:14
+   |
+LL |     fn drop(&pin mut self) {}
+   |              ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:31:14
    |
 LL |     let _y: &pin mut Foo = x;
    |              ^^^
@@ -39,7 +49,7 @@ LL |     let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:27:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:35:14
    |
 LL |     let _y: &pin const Foo = x;
    |              ^^^
@@ -49,7 +59,7 @@ LL |     let _y: &pin const Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:30:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:38:18
    |
 LL | fn foo_sugar(_: &pin mut Foo) {}
    |                  ^^^
@@ -59,7 +69,7 @@ LL | fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:42:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:50:18
    |
 LL | fn baz_sugar(_: &pin const Foo) {}
    |                  ^^^
@@ -69,7 +79,7 @@ LL | fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:45:31
+  --> $DIR/feature-gate-pin_ergonomics.rs:53:31
    |
 LL |     let mut x: Pin<&mut _> = &pin mut Foo;
    |                               ^^^
@@ -79,7 +89,7 @@ LL |     let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:50:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:58:23
    |
 LL |     let x: Pin<&_> = &pin const Foo;
    |                       ^^^
@@ -89,7 +99,7 @@ LL |     let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:57:6
+  --> $DIR/feature-gate-pin_ergonomics.rs:65:6
    |
 LL |     &pin mut x: &pin mut i32,
    |      ^^^
@@ -99,7 +109,7 @@ LL |     &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:57:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:65:18
    |
 LL |     &pin mut x: &pin mut i32,
    |                  ^^^
@@ -109,7 +119,7 @@ LL |     &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:60:6
+  --> $DIR/feature-gate-pin_ergonomics.rs:68:6
    |
 LL |     &pin const y: &'a pin const i32,
    |      ^^^
@@ -119,7 +129,7 @@ LL |     &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:60:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:68:23
    |
 LL |     &pin const y: &'a pin const i32,
    |                       ^^^
@@ -129,7 +139,7 @@ LL |     &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:63:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:71:9
    |
 LL |     ref pin mut z: i32,
    |         ^^^
@@ -139,7 +149,7 @@ LL |     ref pin mut z: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:64:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:72:9
    |
 LL |     ref pin const w: i32,
    |         ^^^
@@ -149,7 +159,7 @@ LL |     ref pin const w: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:76:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:84:23
    |
 LL |         fn foo_sugar(&pin mut self) {}
    |                       ^^^
@@ -159,7 +169,7 @@ LL |         fn foo_sugar(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:77:29
+  --> $DIR/feature-gate-pin_ergonomics.rs:85:29
    |
 LL |         fn foo_sugar_const(&pin const self) {}
    |                             ^^^
@@ -169,7 +179,7 @@ LL |         fn foo_sugar_const(&pin const self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:81:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:89:22
    |
 LL |         fn pin_drop(&pin mut self) {}
    |                      ^^^
@@ -179,7 +189,7 @@ LL |         fn pin_drop(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:87:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:95:18
    |
 LL |         let _y: &pin mut Foo = x;
    |                  ^^^
@@ -189,7 +199,7 @@ LL |         let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:90:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:98:22
    |
 LL |     fn foo_sugar(_: &pin mut Foo) {}
    |                      ^^^
@@ -199,7 +209,7 @@ LL |     fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:102:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:110:22
    |
 LL |     fn baz_sugar(_: &pin const Foo) {}
    |                      ^^^
@@ -209,7 +219,7 @@ LL |     fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:105:35
+  --> $DIR/feature-gate-pin_ergonomics.rs:113:35
    |
 LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    |                                   ^^^
@@ -219,7 +229,7 @@ LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:110:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:118:27
    |
 LL |         let x: Pin<&_> = &pin const Foo;
    |                           ^^^
@@ -229,7 +239,7 @@ LL |         let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:117:10
+  --> $DIR/feature-gate-pin_ergonomics.rs:125:10
    |
 LL |         &pin mut x: &pin mut i32,
    |          ^^^
@@ -239,7 +249,7 @@ LL |         &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:117:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:125:22
    |
 LL |         &pin mut x: &pin mut i32,
    |                      ^^^
@@ -249,7 +259,7 @@ LL |         &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:120:10
+  --> $DIR/feature-gate-pin_ergonomics.rs:128:10
    |
 LL |         &pin const y: &'a pin const i32,
    |          ^^^
@@ -259,7 +269,7 @@ LL |         &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:120:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:128:27
    |
 LL |         &pin const y: &'a pin const i32,
    |                           ^^^
@@ -269,7 +279,7 @@ LL |         &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:123:13
+  --> $DIR/feature-gate-pin_ergonomics.rs:131:13
    |
 LL |         ref pin mut z: i32,
    |             ^^^
@@ -279,7 +289,7 @@ LL |         ref pin mut z: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:124:13
+  --> $DIR/feature-gate-pin_ergonomics.rs:132:13
    |
 LL |         ref pin const w: i32,
    |             ^^^
@@ -308,6 +318,16 @@ LL |     fn pin_drop(&pin mut self) {}
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: use of unstable library feature `pin_ergonomics`
+  --> $DIR/feature-gate-pin_ergonomics.rs:24:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0046]: not all trait items implemented, missing: `drop`
   --> $DIR/feature-gate-pin_ergonomics.rs:14:1
    |
@@ -316,8 +336,16 @@ LL | impl Drop for Foo {
    |
    = help: implement the missing item: `fn drop(&mut self) { todo!() }`
 
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/feature-gate-pin_ergonomics.rs:22:1
+   |
+LL | impl Drop for Sugar {
+   | ^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
+
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:34:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:42:9
    |
 LL | fn bar(x: Pin<&mut Foo>) {
    |        - move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -327,7 +355,7 @@ LL |     foo(x);
    |         ^ value used here after move
    |
 note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:20:15
+  --> $DIR/feature-gate-pin_ergonomics.rs:28:15
    |
 LL | fn foo(mut x: Pin<&mut Foo>) {
    |    ---        ^^^^^^^^^^^^^ this parameter takes ownership of the value
@@ -335,7 +363,7 @@ LL | fn foo(mut x: Pin<&mut Foo>) {
    |    in this function
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:39:5
+  --> $DIR/feature-gate-pin_ergonomics.rs:47:5
    |
 LL | fn baz(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -354,7 +382,7 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 34 previous errors
+error: aborting due to 37 previous errors
 
 Some errors have detailed explanations: E0046, E0382, E0658.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/pin-ergonomics/pinned-drop-check.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-check.rs
@@ -25,11 +25,11 @@ mod pin_drop_only {
     struct Bar;
 
     impl Drop for Foo {
-        fn pin_drop(&pin mut self) {} // ok, only `pin_drop` is implemented
+        fn pin_drop(&pin mut self) {} // ok, non-`#[pin_v2]` can also implement `pin_drop`
     }
 
     impl Drop for Bar {
-        fn pin_drop(&pin mut self) {} // ok, non-`#[pin_v2]` can also implement `pin_drop`
+        fn pin_drop(&pin mut self) {} // ok, `#[pin_v2]` implements `pin_drop`
     }
 }
 
@@ -60,16 +60,67 @@ mod neither {
     impl Drop for Bar {} //~ ERROR not all trait items implemented, missing one of: `drop`, `pin_drop` [E0046]
 }
 
-mod drop_wrong_type {
+mod drop_sugar {
     struct Foo;
     #[pin_v2]
     struct Bar;
 
     impl Drop for Foo {
-        fn drop(&pin mut self) {} //~ ERROR method `drop` has an incompatible type for trait [E0053]
+        fn drop(&pin mut self) {} // ok, sugar for `pin_drop`
     }
+
     impl Drop for Bar {
-        fn drop(&pin mut self) {}
+        fn drop(&pin mut self) {} // ok, sugar for `pin_drop`
+    }
+}
+
+mod drop_pin_const_wrong_type {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&pin const self) {} //~ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn drop(&pin const self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+        //~| ERROR `Bar` must implement `pin_drop`
+    }
+}
+
+mod drop_with_lifetime_wrong_type {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop<'a>(&'a pin mut self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn drop<'a>(&'a pin mut self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+        //~| ERROR `Bar` must implement `pin_drop`
+    }
+}
+
+mod drop_explicit_pin_wrong_type {
+    use std::pin::Pin;
+
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(self: Pin<&mut Self>) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn drop(self: Pin<&mut Self>) {}
         //~^ ERROR method `drop` has an incompatible type for trait [E0053]
         //~| ERROR `Bar` must implement `pin_drop`
     }
@@ -121,6 +172,33 @@ mod explicit_call_drop {
         fn pin_drop(&pin mut self) {
             Drop::drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
         }
+    }
+}
+
+mod explicit_call_drop_sugar {
+    struct Foo;
+
+    impl Drop for Foo {
+        fn drop(&pin mut self) {
+            Drop::drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+            Drop::pin_drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+        }
+    }
+}
+
+mod sugar_and_pin_drop {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&pin mut self) {}
+        fn pin_drop(&pin mut self) {} //~ ERROR duplicate definitions with name `pin_drop`
+    }
+
+    impl Drop for Bar {
+        fn drop(&pin mut self) {}
+        fn pin_drop(&pin mut self) {} //~ ERROR duplicate definitions with name `pin_drop`
     }
 }
 

--- a/tests/ui/pin-ergonomics/pinned-drop-check.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-check.stderr
@@ -1,3 +1,27 @@
+error[E0201]: duplicate definitions with name `pin_drop`:
+  --> $DIR/pinned-drop-check.rs:196:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ------------------------- previous definition here
+LL |         fn pin_drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
+   |
+  --> $SRC_DIR/core/src/ops/drop.rs:LL:COL
+   |
+   = note: item in trait
+
+error[E0201]: duplicate definitions with name `pin_drop`:
+  --> $DIR/pinned-drop-check.rs:201:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ------------------------- previous definition here
+LL |         fn pin_drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
+   |
+  --> $SRC_DIR/core/src/ops/drop.rs:LL:COL
+   |
+   = note: item in trait
+
 error: `Bar` must implement `pin_drop`
   --> $DIR/pinned-drop-check.rs:18:9
    |
@@ -55,56 +79,157 @@ LL |     impl Drop for Bar {}
    |     ^^^^^^^^^^^^^^^^^ missing one of `drop`, `pin_drop` in implementation
 
 error: `Bar` must implement `pin_drop`
-  --> $DIR/pinned-drop-check.rs:72:9
+  --> $DIR/pinned-drop-check.rs:87:9
    |
-LL |         fn drop(&pin mut self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+LL |         fn drop(&pin const self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: structurally pinned types must keep `Pin`'s safety contract
 note: `Bar` is marked `#[pin_v2]` here
-  --> $DIR/pinned-drop-check.rs:65:5
+  --> $DIR/pinned-drop-check.rs:79:5
    |
 LL |     #[pin_v2]
    |     ^^^^^^^^^
 help: implement `pin_drop` instead
    |
-LL |         fn pin_drop(&pin mut self) {}
-   |            ++++
+LL -         fn drop(&pin const self) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
 help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
    |
 LL -     #[pin_v2]
    |
 
 error[E0053]: method `drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:69:17
+  --> $DIR/pinned-drop-check.rs:83:17
    |
-LL |         fn drop(&pin mut self) {}
-   |                 ^^^^^^^^^^^^^ expected `&mut drop_wrong_type::Foo`, found `Pin<&mut drop_wrong_type::Foo>`
+LL |         fn drop(&pin const self) {}
+   |                 ^^^^^^^^^^^^^^^ expected `&mut drop_pin_const_wrong_type::Foo`, found `Pin<&drop_pin_const_wrong_type::Foo>`
    |
-   = note: expected signature `fn(&mut drop_wrong_type::Foo)`
-              found signature `fn(Pin<&mut drop_wrong_type::Foo>)`
+   = note: expected signature `fn(&mut drop_pin_const_wrong_type::Foo)`
+              found signature `fn(Pin<&drop_pin_const_wrong_type::Foo>)`
 help: change the self-receiver type to match the trait
    |
-LL -         fn drop(&pin mut self) {}
+LL -         fn drop(&pin const self) {}
 LL +         fn drop(&mut self) {}
    |
 
 error[E0053]: method `drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:72:17
+  --> $DIR/pinned-drop-check.rs:87:17
    |
-LL |         fn drop(&pin mut self) {}
-   |                 ^^^^^^^^^^^^^ expected `&mut drop_wrong_type::Bar`, found `Pin<&mut drop_wrong_type::Bar>`
+LL |         fn drop(&pin const self) {}
+   |                 ^^^^^^^^^^^^^^^ expected `&mut drop_pin_const_wrong_type::Bar`, found `Pin<&drop_pin_const_wrong_type::Bar>`
    |
-   = note: expected signature `fn(&mut drop_wrong_type::Bar)`
-              found signature `fn(Pin<&mut drop_wrong_type::Bar>)`
+   = note: expected signature `fn(&mut drop_pin_const_wrong_type::Bar)`
+              found signature `fn(Pin<&drop_pin_const_wrong_type::Bar>)`
 help: change the self-receiver type to match the trait
    |
-LL -         fn drop(&pin mut self) {}
+LL -         fn drop(&pin const self) {}
+LL +         fn drop(&mut self) {}
+   |
+
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:104:9
+   |
+LL |         fn drop<'a>(&'a pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:95:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL -         fn drop<'a>(&'a pin mut self) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:99:21
+   |
+LL |         fn drop<'a>(&'a pin mut self) {}
+   |                     ^^^^^^^^^^^^^^^^ expected `&mut drop_with_lifetime_wrong_type::Foo`, found `Pin<&mut Foo>`
+   |
+   = note: expected signature `fn(&mut drop_with_lifetime_wrong_type::Foo)`
+              found signature `fn(Pin<&mut drop_with_lifetime_wrong_type::Foo>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop<'a>(&'a pin mut self) {}
+LL +         fn drop<'a>(&mut self) {}
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:104:21
+   |
+LL |         fn drop<'a>(&'a pin mut self) {}
+   |                     ^^^^^^^^^^^^^^^^ expected `&mut drop_with_lifetime_wrong_type::Bar`, found `Pin<&mut Bar>`
+   |
+   = note: expected signature `fn(&mut drop_with_lifetime_wrong_type::Bar)`
+              found signature `fn(Pin<&mut drop_with_lifetime_wrong_type::Bar>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop<'a>(&'a pin mut self) {}
+LL +         fn drop<'a>(&mut self) {}
+   |
+
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:123:9
+   |
+LL |         fn drop(self: Pin<&mut Self>) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:114:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL -         fn drop(self: Pin<&mut Self>) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:118:23
+   |
+LL |         fn drop(self: Pin<&mut Self>) {}
+   |                       ^^^^^^^^^^^^^^ expected `&mut drop_explicit_pin_wrong_type::Foo`, found `Pin<&mut Foo>`
+   |
+   = note: expected signature `fn(&mut drop_explicit_pin_wrong_type::Foo)`
+              found signature `fn(Pin<&mut drop_explicit_pin_wrong_type::Foo>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop(self: Pin<&mut Self>) {}
+LL +         fn drop(&mut self) {}
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:123:23
+   |
+LL |         fn drop(self: Pin<&mut Self>) {}
+   |                       ^^^^^^^^^^^^^^ expected `&mut drop_explicit_pin_wrong_type::Bar`, found `Pin<&mut Bar>`
+   |
+   = note: expected signature `fn(&mut drop_explicit_pin_wrong_type::Bar)`
+              found signature `fn(Pin<&mut drop_explicit_pin_wrong_type::Bar>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop(self: Pin<&mut Self>) {}
 LL +         fn drop(&mut self) {}
    |
 
 error[E0053]: method `pin_drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:84:21
+  --> $DIR/pinned-drop-check.rs:135:21
    |
 LL |         fn pin_drop(&mut self) {}
    |                     ^^^^^^^^^ expected `Pin<&mut pin_drop_wrong_type::Foo>`, found `&mut pin_drop_wrong_type::Foo`
@@ -118,7 +243,7 @@ LL +         fn pin_drop(self: Pin<&mut pin_drop_wrong_type::Foo>) {}
    |
 
 error[E0053]: method `pin_drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:88:21
+  --> $DIR/pinned-drop-check.rs:139:21
    |
 LL |         fn pin_drop(&mut self) {}
    |                     ^^^^^^^^^ expected `Pin<&mut pin_drop_wrong_type::Bar>`, found `&mut pin_drop_wrong_type::Bar`
@@ -132,14 +257,14 @@ LL +         fn pin_drop(self: Pin<&mut pin_drop_wrong_type::Bar>) {}
    |
 
 error: `Bar` must implement `pin_drop`
-  --> $DIR/pinned-drop-check.rs:103:9
+  --> $DIR/pinned-drop-check.rs:154:9
    |
 LL |         fn drop(&mut self) {
    |         ^^^^^^^^^^^^^^^^^^
    |
    = help: structurally pinned types must keep `Pin`'s safety contract
 note: `Bar` is marked `#[pin_v2]` here
-  --> $DIR/pinned-drop-check.rs:94:5
+  --> $DIR/pinned-drop-check.rs:145:5
    |
 LL |     #[pin_v2]
    |     ^^^^^^^^^
@@ -154,30 +279,42 @@ LL -     #[pin_v2]
    |
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:99:13
+  --> $DIR/pinned-drop-check.rs:150:13
    |
 LL |             Drop::pin_drop(todo!());
    |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:105:13
+  --> $DIR/pinned-drop-check.rs:156:13
    |
 LL |             Drop::pin_drop(todo!());
    |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:117:13
+  --> $DIR/pinned-drop-check.rs:168:13
    |
 LL |             Drop::drop(todo!());
    |             ^^^^^^^^^^ explicit destructor calls not allowed
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:122:13
+  --> $DIR/pinned-drop-check.rs:173:13
    |
 LL |             Drop::drop(todo!());
    |             ^^^^^^^^^^ explicit destructor calls not allowed
 
-error: aborting due to 15 previous errors
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:183:13
+   |
+LL |             Drop::drop(todo!());
+   |             ^^^^^^^^^^ explicit destructor calls not allowed
 
-Some errors have detailed explanations: E0040, E0046, E0053.
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:184:13
+   |
+LL |             Drop::pin_drop(todo!());
+   |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
+
+error: aborting due to 25 previous errors
+
+Some errors have detailed explanations: E0040, E0046, E0053, E0201.
 For more information about an error, try `rustc --explain E0040`.

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-no-core.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-no-core.rs
@@ -1,0 +1,78 @@
+//@ check-pass
+
+#![no_std]
+#![no_core]
+#![no_main]
+#![feature(no_core, pin_ergonomics, lang_items)]
+#![allow(incomplete_features)]
+
+#[lang = "pointee_sized"]
+trait PointeeSized {}
+
+#[lang = "meta_sized"]
+trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+trait Sized: MetaSized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "legacy_receiver"]
+trait LegacyReceiver: PointeeSized {}
+
+#[lang = "deref"]
+trait Deref: PointeeSized {
+    #[lang = "deref_target"]
+    type Target: PointeeSized;
+
+    fn deref(&self) -> &Self::Target;
+}
+
+#[lang = "deref_mut"]
+trait DerefMut: Deref + PointeeSized {
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+
+#[lang = "pin"]
+struct Pin<T> {
+    pointer: T,
+}
+
+impl<T: PointeeSized> LegacyReceiver for &T {}
+impl<T: PointeeSized> LegacyReceiver for &mut T {}
+impl<Ptr: LegacyReceiver> LegacyReceiver for Pin<Ptr> {}
+
+impl<Ptr: Deref> Deref for Pin<Ptr> {
+    type Target = Ptr::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.pointer
+    }
+}
+
+impl<Ptr: DerefMut> DerefMut for Pin<Ptr> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.pointer
+    }
+}
+
+impl<T: PointeeSized> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+struct LocalDrop;
+
+impl Drop for LocalDrop {
+    fn drop(&pin mut self) {}
+}
+
+#[lang = "drop"]
+trait Drop {
+    fn drop(&mut self) {}
+    fn pin_drop(self: Pin<&mut Self>) {}
+}

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.rs
@@ -1,0 +1,62 @@
+//@ edition:2024
+
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+use std::pin::Pin;
+
+struct S;
+
+trait NeedsPinDrop {
+    fn pin_drop(self: Pin<&mut Self>);
+}
+
+impl NeedsPinDrop for S {
+    //~^ ERROR not all trait items implemented, missing: `pin_drop` [E0046]
+    fn drop(&pin mut self) {}
+    //~^ ERROR method `drop` with `&pin mut self` is only supported for the `Drop` trait
+}
+
+trait HasDrop {
+    fn drop(self: Pin<&mut Self>);
+}
+
+impl HasDrop for S {
+    //~^ ERROR not all trait items implemented, missing: `drop` [E0046]
+    fn drop(&pin mut self) {}
+    //~^ ERROR method `drop` is not a member of trait `HasDrop` [E0407]
+}
+
+trait HasPinnedDropReceiver {
+    fn drop(self: &pin mut Self);
+}
+
+impl HasPinnedDropReceiver for S {
+    //~^ ERROR not all trait items implemented, missing: `drop` [E0046]
+    fn drop(&pin mut self) {}
+    //~^ ERROR method `drop` is not a member of trait `HasPinnedDropReceiver` [E0407]
+}
+
+struct Inherent;
+
+impl Inherent {
+    fn drop(&pin mut self) {}
+}
+
+mod local_drop_trait {
+    use std::pin::Pin;
+
+    struct S;
+
+    trait Drop {
+        fn pin_drop(self: Pin<&mut Self>);
+    }
+
+    impl Drop for S {
+        //~^ ERROR not all trait items implemented, missing: `pin_drop` [E0046]
+        fn drop(&pin mut self) {}
+        //~^ ERROR method `drop` with `&pin mut self` is only supported for the `Drop` trait
+    }
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.stderr
@@ -1,0 +1,70 @@
+error[E0407]: method `drop` is not a member of trait `HasDrop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:26:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^----^^^^^^^^^^^^^^^^^^
+   |     |  |
+   |     |  help: there is an associated function with a similar name: `drop`
+   |     not a member of trait `HasDrop`
+
+error[E0407]: method `drop` is not a member of trait `HasPinnedDropReceiver`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:36:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^----^^^^^^^^^^^^^^^^^^
+   |     |  |
+   |     |  help: there is an associated function with a similar name: `drop`
+   |     not a member of trait `HasPinnedDropReceiver`
+
+error: method `drop` with `&pin mut self` is only supported for the `Drop` trait
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:16:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ not a `Drop::pin_drop` implementation
+
+error: method `drop` with `&pin mut self` is only supported for the `Drop` trait
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:57:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ not a `Drop::pin_drop` implementation
+
+error[E0046]: not all trait items implemented, missing: `pin_drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:14:1
+   |
+LL |     fn pin_drop(self: Pin<&mut Self>);
+   |     ---------------------------------- `pin_drop` from trait
+...
+LL | impl NeedsPinDrop for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `pin_drop` in implementation
+
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:24:1
+   |
+LL |     fn drop(self: Pin<&mut Self>);
+   |     ------------------------------ `drop` from trait
+...
+LL | impl HasDrop for S {
+   | ^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:34:1
+   |
+LL |     fn drop(self: &pin mut Self);
+   |     ----------------------------- `drop` from trait
+...
+LL | impl HasPinnedDropReceiver for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+
+error[E0046]: not all trait items implemented, missing: `pin_drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:55:5
+   |
+LL |         fn pin_drop(self: Pin<&mut Self>);
+   |         ---------------------------------- `pin_drop` from trait
+...
+LL |     impl Drop for S {
+   |     ^^^^^^^^^^^^^^^ missing `pin_drop` in implementation
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0046, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+//@ edition:2024
+
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+struct Unpinned;
+
+#[pin_v2]
+struct Pinned;
+
+struct Qualified;
+struct CoreQualified;
+
+impl Drop for Unpinned {
+    fn drop(&pin mut self) {}
+}
+
+impl Drop for Pinned {
+    fn drop(&pin mut self) {}
+}
+
+impl std::ops::Drop for Qualified {
+    fn drop(&pin mut self) {}
+}
+
+impl core::ops::Drop for CoreQualified {
+    fn drop(&pin mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
@@ -3,7 +3,7 @@
 
 #![feature(min_generic_const_args)]
 
-trait Bar<const N: bool = false> {}
+trait Bar<const N: usize = const { 1 + 1 }> {}
 
 trait Foo {
     type AssocB: Bar;


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156493 (actually run the temp_dir doctest)
 - rust-lang/rust#156452 (Implement pinned drop sugar)
 - rust-lang/rust#156600 (Make const param default test reproduce original ICE)
 - rust-lang/rust#156556 (Require UTF-8 in `Utf8Pattern::StringPattern`)
 - rust-lang/rust#156565 (delegation: emit error when self type is not specified and accessed)
 - rust-lang/rust#156577 (Test EII UI tests with prefer-dynamic)
 - rust-lang/rust#156586 (Use DropCtxt::new_block and new_block_with_statements systematically.)
 - rust-lang/rust#156587 (Correctly handle associated items in rustdoc macro expansion)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156493,156452,156600,156556,156565,156577,156586,156587)
<!-- homu-ignore:end -->

