### PR TITLE
Consider structurally impossible Sized predicates in MIR

### DIFF
--- a/compiler/rustc_mir_transform/src/impossible_predicates.rs
+++ b/compiler/rustc_mir_transform/src/impossible_predicates.rs
@@ -27,18 +27,57 @@
 //!    it's usually never invoked in this way.
 
 use rustc_middle::mir::{Body, START_BLOCK, TerminatorKind};
-use rustc_middle::ty::{TyCtxt, TypeFlags, TypeVisitableExt, Unnormalized};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeFlags, TypeVisitableExt, Unnormalized};
 use rustc_span::def_id::DefId;
 use rustc_trait_selection::traits;
 use tracing::trace;
 
 use crate::pass_manager::MirPass;
 
+fn is_structurally_unsized<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
+    match ty.kind() {
+        ty::Str | ty::Slice(_) | ty::Dynamic(_, _) | ty::Foreign(_) => true,
+        ty::Tuple(tys) => tys.last().is_some_and(|ty| is_structurally_unsized(tcx, *ty)),
+        ty::Adt(def, args) => {
+            def.sizedness_constraint(tcx, ty::SizedTraitKind::Sized).is_some_and(|ty| {
+                is_structurally_unsized(tcx, ty.instantiate(tcx, args).skip_norm_wip())
+            })
+        }
+        _ => false,
+    }
+}
+
+fn has_structurally_impossible_sized_predicate<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    sized_trait: DefId,
+    predicate: ty::Clause<'tcx>,
+) -> bool {
+    let Some(trait_predicate) = predicate.as_trait_clause() else {
+        return false;
+    };
+    let trait_predicate = trait_predicate.skip_binder();
+
+    trait_predicate.polarity == ty::PredicatePolarity::Positive
+        && trait_predicate.def_id() == sized_trait
+        && is_structurally_unsized(tcx, trait_predicate.self_ty())
+}
+
 pub(crate) struct ImpossiblePredicates;
 
-pub(crate) fn has_impossible_predicates(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+pub(crate) fn has_impossible_predicates<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
     let predicates = tcx.predicates_of(def_id).instantiate_identity(tcx);
     tracing::trace!(?predicates);
+
+    // Some `Sized` predicates that mention local generics are still impossible
+    // for every instantiation, e.g. `dyn Trait<T>: Sized`.
+    if let Some(sized_trait) = tcx.lang_items().sized_trait() {
+        if predicates.predicates.iter().copied().map(Unnormalized::skip_norm_wip).any(|predicate| {
+            has_structurally_impossible_sized_predicate(tcx, sized_trait, predicate)
+        }) {
+            return true;
+        }
+    }
+
     let predicates =
         predicates.predicates.into_iter().map(Unnormalized::skip_norm_wip).filter(|p| {
             !p.has_type_flags(

--- a/tests/ui/const_prop/issue-102553.rs
+++ b/tests/ui/const_prop/issue-102553.rs
@@ -1,5 +1,5 @@
-//@ compile-flags: --crate-type=lib -Zmir-opt-level=3
-//@ build-pass
+//@ compile-flags: --crate-type=lib
+//@ check-pass
 
 pub trait Widget<E> {
     fn boxed<'w>(self) -> Box<dyn WidgetDyn<E> + 'w>
@@ -20,23 +20,5 @@ impl<E> Widget<E> for dyn WidgetDyn<E> + '_ {
         // trigger an ICE because it can never be called from actual code
         // (due to the trivially false where-clause predicate).
         Box::new(self)
-    }
-}
-
-// Regression test for https://github.com/rust-lang/rust/issues/156051.
-trait WidgetSize<E> {
-    fn size<'w>(self) -> usize
-    where
-        Self: Sized + 'w;
-}
-
-trait WidgetSizeDyn<E> {}
-
-impl<E> WidgetSize<E> for dyn WidgetSizeDyn<E> + '_ {
-    fn size<'w>(self) -> usize
-    where
-        Self: Sized + 'w,
-    {
-        core::mem::size_of::<Self>()
     }
 }

--- a/tests/ui/const_prop/issue-102553.rs
+++ b/tests/ui/const_prop/issue-102553.rs
@@ -1,5 +1,5 @@
-//@ compile-flags: --crate-type=lib
-//@ check-pass
+//@ compile-flags: --crate-type=lib -Zmir-opt-level=3
+//@ build-pass
 
 pub trait Widget<E> {
     fn boxed<'w>(self) -> Box<dyn WidgetDyn<E> + 'w>
@@ -20,5 +20,23 @@ impl<E> Widget<E> for dyn WidgetDyn<E> + '_ {
         // trigger an ICE because it can never be called from actual code
         // (due to the trivially false where-clause predicate).
         Box::new(self)
+    }
+}
+
+// Regression test for https://github.com/rust-lang/rust/issues/156051.
+trait WidgetSize<E> {
+    fn size<'w>(self) -> usize
+    where
+        Self: Sized + 'w;
+}
+
+trait WidgetSizeDyn<E> {}
+
+impl<E> WidgetSize<E> for dyn WidgetSizeDyn<E> + '_ {
+    fn size<'w>(self) -> usize
+    where
+        Self: Sized + 'w,
+    {
+        core::mem::size_of::<Self>()
     }
 }

--- a/tests/ui/const_prop/mir-opt-impossible-sized-predicates.rs
+++ b/tests/ui/const_prop/mir-opt-impossible-sized-predicates.rs
@@ -1,0 +1,21 @@
+// Regression test for https://github.com/rust-lang/rust/issues/156051.
+
+//@ compile-flags: --crate-type=lib -Zmir-opt-level=3
+//@ build-pass
+
+trait WidgetSize<E> {
+    fn size<'w>(self) -> usize
+    where
+        Self: Sized + 'w;
+}
+
+trait WidgetSizeDyn<E> {}
+
+impl<E> WidgetSize<E> for dyn WidgetSizeDyn<E> + '_ {
+    fn size<'w>(self) -> usize
+    where
+        Self: Sized + 'w,
+    {
+        core::mem::size_of::<Self>()
+    }
+}


### PR DESCRIPTION
Fixes rust-lang/rust#156051

`ImpossiblePredicates` filters predicates mentioning local generics before invoking the trait solver, which avoids normalization and solver work in generic contexts, thereby skipping predicates such as `dyn Trait<T>: Sized`, even though they are impossible for every substitution.

This PR adds a narrow structural fast path for positive `Sized` predicates whose self type is known-unsized without normalization, letting the pass clear unreachable bodies before later MIR opts can evaluate `SizedTypeProperties` constants such as `size_of::<Self>()`.
