### PR TITLE
Compile libraries with cf-protection=branch on x64

### DIFF
--- a/library/compiler-builtins/compiler-builtins/build.rs
+++ b/library/compiler-builtins/compiler-builtins/build.rs
@@ -245,15 +245,6 @@ mod c {
             build.flag_if_supported("-fomit-frame-pointer");
             build.define("VISIBILITY_HIDDEN", None);
 
-            // Enable CET Indirect Branch Tracking on x86_64. Emits ENDBR64
-            // at indirect branch targets and adds the IBT ELF property note.
-            // Without this, these objects prevent IBT enforcement in any
-            // binary they are linked into (the linker ANDs the property
-            // across all objects).
-            if cfg.target_arch == "x86_64" {
-                build.flag_if_supported("-fcf-protection=branch");
-            }
-
             if let "aarch64" | "arm64ec" = cfg.target_arch.as_str() {
                 // FIXME(llvm20): Older GCCs on A64 fail to build with
                 // -Werror=implicit-function-declaration due to a compiler-rt bug.

--- a/library/compiler-builtins/compiler-builtins/build.rs
+++ b/library/compiler-builtins/compiler-builtins/build.rs
@@ -245,6 +245,15 @@ mod c {
             build.flag_if_supported("-fomit-frame-pointer");
             build.define("VISIBILITY_HIDDEN", None);
 
+            // Enable CET Indirect Branch Tracking on x86_64. Emits ENDBR64
+            // at indirect branch targets and adds the IBT ELF property note.
+            // Without this, these objects prevent IBT enforcement in any
+            // binary they are linked into (the linker ANDs the property
+            // across all objects).
+            if cfg.target_arch == "x86_64" {
+                build.flag_if_supported("-fcf-protection=branch");
+            }
+
             if let "aarch64" | "arm64ec" = cfg.target_arch.as_str() {
                 // FIXME(llvm20): Older GCCs on A64 fail to build with
                 // -Werror=implicit-function-declaration due to a compiler-rt bug.

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -713,7 +713,7 @@ pub fn std_cargo(
     // and because the linker ANDs the property across all objects, any binary
     // linking Rust code loses IBT protection -- even if all other code was
     // compiled with -fcf-protection=branch.
-    if target.contains("x86_64") {
+    if target.contains("x86_64") && builder.unstable_features() {
         cargo.rustflag("-Zcf-protection=branch");
     }
 

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -701,6 +701,22 @@ pub fn std_cargo(
         cargo.rustflag("-Cforce-unwind-tables=yes");
     }
 
+    // Enable CET Indirect Branch Tracking (IBT) for x86_64 targets. This emits
+    // ENDBR64 instructions at indirect branch targets and adds the
+    // GNU_PROPERTY_X86_FEATURE_1_IBT ELF note to each object file. On CPUs that
+    // support CET (Intel Tiger Lake+, AMD Zen 4+), the kernel enforces that
+    // indirect calls/jumps land on ENDBR64, blocking ROP/JOP attacks. On older
+    // CPUs, ENDBR64 executes as a NOP with a minor cost (4 bytes, one decode
+    // slot per function entry).
+    //
+    // Without this, the prebuilt standard library objects lack the IBT property,
+    // and because the linker ANDs the property across all objects, any binary
+    // linking Rust code loses IBT protection -- even if all other code was
+    // compiled with -fcf-protection=branch.
+    if target.contains("x86_64") {
+        cargo.rustflag("-Zcf-protection=branch");
+    }
+
     let html_root =
         format!("-Zcrate-attr=doc(html_root_url=\"{}/\")", builder.doc_rust_lang_org_channel(),);
     cargo.rustflag(&html_root);

--- a/tests/ui/lto/thin-lto-inlines2.rs
+++ b/tests/ui/lto/thin-lto-inlines2.rs
@@ -23,8 +23,15 @@ fn main() {
     println!("{} {}", foo(), bar::bar());
 
     unsafe {
-        let foo = foo as usize as *const u8;
+        let mut foo = foo as usize as *const u8;
         let bar = bar::bar as usize as *const u8;
+
+        // cf-protection puts a NOP-like instruction, ENDBR64, at the start
+        // of each function, but that's not present for the inlined version.
+        // Skip that if present.
+        if std::slice::from_raw_parts(foo, 4) == [0xf3, 0x0f, 0x1e, 0xfa] {
+            foo = foo.add(4);
+        }
 
         assert_eq!(*foo, *bar);
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156612)*
<!-- homu-ignore:end -->

The CET control-flow enforcement technology feature on x64 prevents control-flow hijacking via corrupted vtables and similar.  It requires a special NOP at all entry points that are targeted by indirect branches/calls.

For an executable to be protected, all object files linked into it have to have support. Until now, any rust object file would disable support for the entire executable. This adds the flag (if available) so that rust system libraries do not poison the protection when linked in.

Note: This doesn't do anything for shadow stack support. The two features can be enabled separately, so it's valuable in itself.

tracking issue: https://github.com/rust-lang/rust/issues/93754

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
