### PR TITLE
rustdoc: add test case for `-Drustdoc::` and `--cap-lints`

### DIFF
--- a/tests/rustdoc-ui/lints/unescaped_backticks.deny_cli.stderr
+++ b/tests/rustdoc-ui/lints/unescaped_backticks.deny_cli.stderr
@@ -1,5 +1,5 @@
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:190:70
+  --> $DIR/unescaped_backticks.rs:192:70
    |
 LL | /// if you want your MIR to be modified by the full MIR pipeline, or `#![custom_mir(dialect =
    |                                                                      ^
@@ -15,7 +15,7 @@ LL | /// if you want your MIR to be modified by the full MIR pipeline, or \`#![c
    |                                                                      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:235:13
+  --> $DIR/unescaped_backticks.rs:237:13
    |
 LL |         //! `#![rustc_expected_cgu_reuse(module="spike", cfg="rpass2", kind="post-lto")]
    |             ^
@@ -30,7 +30,7 @@ LL |         //! \`#![rustc_expected_cgu_reuse(module="spike", cfg="rpass2", kin
    |             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:240:13
+  --> $DIR/unescaped_backticks.rs:242:13
    |
 LL |         /// `cfg=...
    |             ^
@@ -45,7 +45,7 @@ LL |         /// \`cfg=...
    |             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:244:42
+  --> $DIR/unescaped_backticks.rs:246:42
    |
 LL |         /// `cfg=... and not `#[cfg_attr]`
    |                                          ^
@@ -60,7 +60,7 @@ LL |         /// `cfg=... and not `#[cfg_attr]\`
    |                                          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:196:93
+  --> $DIR/unescaped_backticks.rs:198:93
    |
 LL |     /// Constructs a `TyKind::Error` type and registers a `span_delayed_bug` with the given `msg to
    |                                                                                             ^
@@ -75,7 +75,7 @@ LL |     /// Constructs a `TyKind::Error` type and registers a `span_delayed_bug
    |                                                                                             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:205:34
+  --> $DIR/unescaped_backticks.rs:207:34
    |
 LL |         /// in `nt_to_tokenstream`
    |                                  ^
@@ -90,7 +90,7 @@ LL |         /// in `nt_to_tokenstream\`
    |                                  +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:211:62
+  --> $DIR/unescaped_backticks.rs:213:62
    |
 LL |     /// that `Option<Symbol>` only takes up 4 bytes, because `newtype_index! reserves
    |                                                              ^
@@ -105,7 +105,7 @@ LL |     /// that `Option<Symbol>` only takes up 4 bytes, because \`newtype_inde
    |                                                              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:219:52
+  --> $DIR/unescaped_backticks.rs:221:52
    |
 LL |     /// also avoids the need to import `OpenOptions`.
    |                                                    ^
@@ -120,7 +120,7 @@ LL |     /// also avoids the need to import `OpenOptions\`.
    |                                                    +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:224:47
+  --> $DIR/unescaped_backticks.rs:226:47
    |
 LL |     /// `ChunkedBitSet`. Has no effect if `row` does not exist.
    |                                               ^
@@ -135,7 +135,7 @@ LL |     /// `ChunkedBitSet`. Has no effect if `row\` does not exist.
    |                                               +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:250:12
+  --> $DIR/unescaped_backticks.rs:252:12
    |
 LL |     /// RWU`s can get very large, so it uses a more compact representation.
    |            ^
@@ -150,7 +150,7 @@ LL |     /// RWU\`s can get very large, so it uses a more compact representation
    |            +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:257:15
+  --> $DIR/unescaped_backticks.rs:259:15
    |
 LL |     /// in `U2`.
    |               ^
@@ -165,7 +165,7 @@ LL |     /// in `U2\`.
    |               +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:274:42
+  --> $DIR/unescaped_backticks.rs:276:42
    |
 LL |     /// because it contains `[type error]`. Yuck! (See issue #29857 for
    |                                          ^
@@ -180,7 +180,7 @@ LL |     /// because it contains `[type error]\`. Yuck! (See issue #29857 for
    |                                          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:284:53
+  --> $DIR/unescaped_backticks.rs:286:53
    |
 LL |     /// well as the second instance of `A: AutoTrait`) to suppress
    |                                                     ^
@@ -195,7 +195,7 @@ LL |     /// well as the second instance of `A: AutoTrait\`) to suppress
    |                                                     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:294:40
+  --> $DIR/unescaped_backticks.rs:296:40
    |
 LL |     /// `'a` with `'b` and not `'static`. But it will have to do for
    |                                        ^
@@ -207,7 +207,7 @@ LL |     /// `'a` with `'b` and not `'static\`. But it will have to do for
    |                                        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:303:54
+  --> $DIR/unescaped_backticks.rs:305:54
    |
 LL | /// `None`. Otherwise, it will return `Some(Dispatch)`.
    |                                                      ^
@@ -222,7 +222,7 @@ LL | /// `None`. Otherwise, it will return `Some(Dispatch)\`.
    |                                                      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:307:13
+  --> $DIR/unescaped_backticks.rs:309:13
    |
 LL | /// or `None` if it isn't.
    |             ^
@@ -234,7 +234,7 @@ LL | /// or `None\` if it isn't.
    |             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:311:14
+  --> $DIR/unescaped_backticks.rs:313:14
    |
 LL | /// `on_event` should be called.
    |              ^
@@ -249,7 +249,7 @@ LL | /// `on_event\` should be called.
    |              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:316:29
+  --> $DIR/unescaped_backticks.rs:318:29
    |
 LL | /// [`rebuild_interest_cache`][rebuild] is called after the value of the max
    |                             ^
@@ -264,7 +264,7 @@ LL | /// [`rebuild_interest_cache\`][rebuild] is called after the value of the m
    |                             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:326:5
+  --> $DIR/unescaped_backticks.rs:328:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -280,7 +280,7 @@ LL | |     /// level changes.
            to this: `None`. Otherwise, it will return `Some(Dispatch)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:326:5
+  --> $DIR/unescaped_backticks.rs:328:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -294,7 +294,7 @@ LL | |     /// level changes.
            to this: or `None\` if it isn't.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:326:5
+  --> $DIR/unescaped_backticks.rs:328:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -310,7 +310,7 @@ LL | |     /// level changes.
            to this: `on_event\` should be called.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:326:5
+  --> $DIR/unescaped_backticks.rs:328:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -326,7 +326,7 @@ LL | |     /// level changes.
            to this: [`rebuild_interest_cache\`][rebuild] is called after the value of the max
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:352:56
+  --> $DIR/unescaped_backticks.rs:354:56
    |
 LL |     /// instead and use [`CloneCounterObserver::counter`] to increment.
    |                                                        ^
@@ -338,7 +338,7 @@ LL |     /// instead and use [`CloneCounterObserver::counter\`] to increment.
    |                                                        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:15:5
+  --> $DIR/unescaped_backticks.rs:17:5
    |
 LL | /// `
    |     ^
@@ -350,7 +350,7 @@ LL | /// \`
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:22:7
+  --> $DIR/unescaped_backticks.rs:24:7
    |
 LL | /// \`
    |       ^
@@ -365,7 +365,7 @@ LL | /// \\`
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:29:6
+  --> $DIR/unescaped_backticks.rs:31:6
    |
 LL | /// [`link1]
    |      ^
@@ -380,7 +380,7 @@ LL | /// [\`link1]
    |      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:33:11
+  --> $DIR/unescaped_backticks.rs:35:11
    |
 LL | /// [link2`]
    |           ^
@@ -395,7 +395,7 @@ LL | /// [link2\`]
    |           +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:37:6
+  --> $DIR/unescaped_backticks.rs:39:6
    |
 LL | /// [`link_long](link_long)
    |      ^
@@ -410,7 +410,7 @@ LL | /// [\`link_long](link_long)
    |      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:41:6
+  --> $DIR/unescaped_backticks.rs:43:6
    |
 LL | /// [`broken-link]
    |      ^
@@ -425,7 +425,7 @@ LL | /// [\`broken-link]
    |      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:48:8
+  --> $DIR/unescaped_backticks.rs:50:8
    |
 LL | /// <x:`>
    |        ^
@@ -440,7 +440,7 @@ LL | /// <x:\`>
    |        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:58:6
+  --> $DIR/unescaped_backticks.rs:60:6
    |
 LL | /// 🦀`🦀
    |       ^
@@ -459,7 +459,7 @@ LL | /// 🦀\`🦀
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:62:5
+  --> $DIR/unescaped_backticks.rs:64:5
    |
 LL | /// `foo(
    |     ^
@@ -474,7 +474,7 @@ LL | /// \`foo(
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:68:14
+  --> $DIR/unescaped_backticks.rs:70:14
    |
 LL | /// `foo `bar`
    |              ^
@@ -489,7 +489,7 @@ LL | /// `foo `bar\`
    |              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:74:5
+  --> $DIR/unescaped_backticks.rs:76:5
    |
 LL | /// `foo(
    |     ^
@@ -504,7 +504,7 @@ LL | /// \`foo(
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:79:83
+  --> $DIR/unescaped_backticks.rs:81:83
    |
 LL | /// Addition is commutative, which means that add(a, b)` is the same as `add(b, a)`.
    |                                                                                   ^
@@ -519,7 +519,7 @@ LL | /// Addition is commutative, which means that add(a, b)` is the same as `ad
    |                                                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:83:51
+  --> $DIR/unescaped_backticks.rs:85:51
    |
 LL | /// or even to add a number `n` to 42 (`add(42, b)`)!
    |                                                   ^
@@ -534,7 +534,7 @@ LL | /// or even to add a number `n` to 42 (`add(42, b)\`)!
    |                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:87:83
+  --> $DIR/unescaped_backticks.rs:89:83
    |
 LL | /// Addition is commutative, which means that `add(a, b) is the same as `add(b, a)`.
    |                                                                                   ^
@@ -549,7 +549,7 @@ LL | /// Addition is commutative, which means that `add(a, b) is the same as `ad
    |                                                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:91:51
+  --> $DIR/unescaped_backticks.rs:93:51
    |
 LL | /// or even to add a number `n` to 42 (`add(42, n)`)!
    |                                                   ^
@@ -564,7 +564,7 @@ LL | /// or even to add a number `n` to 42 (`add(42, n)\`)!
    |                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:95:83
+  --> $DIR/unescaped_backticks.rs:97:83
    |
 LL | /// Addition is commutative, which means that `add(a, b)` is the same as add(b, a)`.
    |                                                                                   ^
@@ -579,7 +579,7 @@ LL | /// Addition is commutative, which means that `add(a, b)` is the same as ad
    |                                                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:99:50
+  --> $DIR/unescaped_backticks.rs:101:50
    |
 LL | /// or even to add a number `n` to 42 (add(42, n)`)!
    |                                                  ^
@@ -594,7 +594,7 @@ LL | /// or even to add a number `n` to 42 (add(42, n)\`)!
    |                                                  +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:103:74
+  --> $DIR/unescaped_backticks.rs:105:74
    |
 LL | /// Addition is commutative, which means that `add(a, b)` is the same as `add(b, a).
    |                                                                          ^
@@ -609,7 +609,7 @@ LL | /// Addition is commutative, which means that `add(a, b)` is the same as \`
    |                                                                          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:107:51
+  --> $DIR/unescaped_backticks.rs:109:51
    |
 LL | /// or even to add a number `n` to 42 (`add(42, n)`)!
    |                                                   ^
@@ -624,7 +624,7 @@ LL | /// or even to add a number `n` to 42 (`add(42, n)\`)!
    |                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:111:10
+  --> $DIR/unescaped_backticks.rs:113:10
    |
 LL | #[doc = "`"]
    |          ^
@@ -635,7 +635,7 @@ LL | #[doc = "`"]
            to this: \`
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:118:26
+  --> $DIR/unescaped_backticks.rs:120:26
    |
 LL | #[doc = concat!("\\", "`")]
    |                          ^
@@ -648,7 +648,7 @@ LL | #[doc = concat!("\\", "`")]
            to this: \\`
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:122:9
+  --> $DIR/unescaped_backticks.rs:124:9
    |
 LL | #[doc = "Addition is commutative, which means that add(a, b)` is the same as `add(b, a)`."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -661,7 +661,7 @@ LL | #[doc = "Addition is commutative, which means that add(a, b)` is the same a
            to this: Addition is commutative, which means that add(a, b)` is the same as `add(b, a)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:126:9
+  --> $DIR/unescaped_backticks.rs:128:9
    |
 LL | #[doc = "Addition is commutative, which means that `add(a, b) is the same as `add(b, a)`."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -674,7 +674,7 @@ LL | #[doc = "Addition is commutative, which means that `add(a, b) is the same a
            to this: Addition is commutative, which means that `add(a, b) is the same as `add(b, a)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:130:9
+  --> $DIR/unescaped_backticks.rs:132:9
    |
 LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same as add(b, a)`."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -687,7 +687,7 @@ LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same 
            to this: Addition is commutative, which means that `add(a, b)` is the same as add(b, a)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:134:9
+  --> $DIR/unescaped_backticks.rs:136:9
    |
 LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same as `add(b, a)."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -700,7 +700,7 @@ LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same 
            to this: Addition is commutative, which means that `add(a, b)` is the same as \`add(b, a).
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:139:5
+  --> $DIR/unescaped_backticks.rs:141:5
    |
 LL | /// `foo
    |     ^
@@ -715,7 +715,7 @@ LL | /// \`foo
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:143:7
+  --> $DIR/unescaped_backticks.rs:145:7
    |
 LL | /// # `(heading
    |       ^
@@ -730,7 +730,7 @@ LL | /// # \`(heading
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:145:17
+  --> $DIR/unescaped_backticks.rs:147:17
    |
 LL | /// ## heading2)`
    |                 ^
@@ -745,7 +745,7 @@ LL | /// ## heading2)\`
    |                 +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:148:11
+  --> $DIR/unescaped_backticks.rs:150:11
    |
 LL | /// multi `(
    |           ^
@@ -760,7 +760,7 @@ LL | /// multi \`(
    |           +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:154:10
+  --> $DIR/unescaped_backticks.rs:156:10
    |
 LL | /// para)`(graph
    |          ^
@@ -779,7 +779,7 @@ LL | /// para)\`(graph
    |          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:157:10
+  --> $DIR/unescaped_backticks.rs:159:10
    |
 LL | /// para)`(graph2
    |          ^
@@ -798,7 +798,7 @@ LL | /// para)\`(graph2
    |          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:160:12
+  --> $DIR/unescaped_backticks.rs:162:12
    |
 LL | /// 1. foo)`
    |            ^
@@ -813,7 +813,7 @@ LL | /// 1. foo)\`
    |            +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:162:8
+  --> $DIR/unescaped_backticks.rs:164:8
    |
 LL | /// 2. `(bar
    |        ^
@@ -828,7 +828,7 @@ LL | /// 2. \`(bar
    |        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:164:11
+  --> $DIR/unescaped_backticks.rs:166:11
    |
 LL | /// * baz)`
    |           ^
@@ -843,7 +843,7 @@ LL | /// * baz)\`
    |           +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:166:7
+  --> $DIR/unescaped_backticks.rs:168:7
    |
 LL | /// * `(quux
    |       ^
@@ -858,7 +858,7 @@ LL | /// * \`(quux
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:169:5
+  --> $DIR/unescaped_backticks.rs:171:5
    |
 LL | /// `#![this_is_actually_an_image(and(not), an = "attribute")]
    |     ^
@@ -873,7 +873,7 @@ LL | /// \`#![this_is_actually_an_image(and(not), an = "attribute")]
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:172:62
+  --> $DIR/unescaped_backticks.rs:174:62
    |
 LL | /// #![this_is_actually_an_image(and(not), an = "attribute")]`
    |                                                              ^
@@ -888,7 +888,7 @@ LL | /// #![this_is_actually_an_image(and(not), an = "attribute")]\`
    |                                                              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:177:7
+  --> $DIR/unescaped_backticks.rs:179:7
    |
 LL | /// | `table( | )head` |
    |       ^
@@ -903,7 +903,7 @@ LL | /// | \`table( | )head` |
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:177:22
+  --> $DIR/unescaped_backticks.rs:179:22
    |
 LL | /// | `table( | )head` |
    |                      ^
@@ -918,7 +918,7 @@ LL | /// | `table( | )head\` |
    |                      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:181:12
+  --> $DIR/unescaped_backticks.rs:183:12
    |
 LL | /// | table`( | )`body |
    |            ^
@@ -933,7 +933,7 @@ LL | /// | table\`( | )`body |
    |            +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:181:18
+  --> $DIR/unescaped_backticks.rs:183:18
    |
 LL | /// | table`( | )`body |
    |                  ^

--- a/tests/rustdoc-ui/lints/unescaped_backticks.deny_cli.stderr
+++ b/tests/rustdoc-ui/lints/unescaped_backticks.deny_cli.stderr
@@ -1,14 +1,10 @@
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:187:70
+  --> $DIR/unescaped_backticks.rs:190:70
    |
 LL | /// if you want your MIR to be modified by the full MIR pipeline, or `#![custom_mir(dialect =
    |                                                                      ^
    |
-note: the lint level is defined here
-  --> $DIR/unescaped_backticks.rs:1:9
-   |
-LL | #![deny(rustdoc::unescaped_backticks)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: requested on the command line with `-D rustdoc::unescaped-backticks`
 help: the closing backtick of an inline code may be missing
    |
 LL | /// "runtime", phase = "optimized")]` if you don't.
@@ -19,7 +15,7 @@ LL | /// if you want your MIR to be modified by the full MIR pipeline, or \`#![c
    |                                                                      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:232:13
+  --> $DIR/unescaped_backticks.rs:235:13
    |
 LL |         //! `#![rustc_expected_cgu_reuse(module="spike", cfg="rpass2", kind="post-lto")]
    |             ^
@@ -34,7 +30,7 @@ LL |         //! \`#![rustc_expected_cgu_reuse(module="spike", cfg="rpass2", kin
    |             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:237:13
+  --> $DIR/unescaped_backticks.rs:240:13
    |
 LL |         /// `cfg=...
    |             ^
@@ -49,7 +45,7 @@ LL |         /// \`cfg=...
    |             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:241:42
+  --> $DIR/unescaped_backticks.rs:244:42
    |
 LL |         /// `cfg=... and not `#[cfg_attr]`
    |                                          ^
@@ -64,7 +60,7 @@ LL |         /// `cfg=... and not `#[cfg_attr]\`
    |                                          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:193:93
+  --> $DIR/unescaped_backticks.rs:196:93
    |
 LL |     /// Constructs a `TyKind::Error` type and registers a `span_delayed_bug` with the given `msg to
    |                                                                                             ^
@@ -79,7 +75,7 @@ LL |     /// Constructs a `TyKind::Error` type and registers a `span_delayed_bug
    |                                                                                             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:202:34
+  --> $DIR/unescaped_backticks.rs:205:34
    |
 LL |         /// in `nt_to_tokenstream`
    |                                  ^
@@ -94,7 +90,7 @@ LL |         /// in `nt_to_tokenstream\`
    |                                  +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:208:62
+  --> $DIR/unescaped_backticks.rs:211:62
    |
 LL |     /// that `Option<Symbol>` only takes up 4 bytes, because `newtype_index! reserves
    |                                                              ^
@@ -109,7 +105,7 @@ LL |     /// that `Option<Symbol>` only takes up 4 bytes, because \`newtype_inde
    |                                                              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:216:52
+  --> $DIR/unescaped_backticks.rs:219:52
    |
 LL |     /// also avoids the need to import `OpenOptions`.
    |                                                    ^
@@ -124,7 +120,7 @@ LL |     /// also avoids the need to import `OpenOptions\`.
    |                                                    +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:221:47
+  --> $DIR/unescaped_backticks.rs:224:47
    |
 LL |     /// `ChunkedBitSet`. Has no effect if `row` does not exist.
    |                                               ^
@@ -139,7 +135,7 @@ LL |     /// `ChunkedBitSet`. Has no effect if `row\` does not exist.
    |                                               +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:247:12
+  --> $DIR/unescaped_backticks.rs:250:12
    |
 LL |     /// RWU`s can get very large, so it uses a more compact representation.
    |            ^
@@ -154,7 +150,7 @@ LL |     /// RWU\`s can get very large, so it uses a more compact representation
    |            +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:254:15
+  --> $DIR/unescaped_backticks.rs:257:15
    |
 LL |     /// in `U2`.
    |               ^
@@ -169,7 +165,7 @@ LL |     /// in `U2\`.
    |               +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:271:42
+  --> $DIR/unescaped_backticks.rs:274:42
    |
 LL |     /// because it contains `[type error]`. Yuck! (See issue #29857 for
    |                                          ^
@@ -184,7 +180,7 @@ LL |     /// because it contains `[type error]\`. Yuck! (See issue #29857 for
    |                                          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:281:53
+  --> $DIR/unescaped_backticks.rs:284:53
    |
 LL |     /// well as the second instance of `A: AutoTrait`) to suppress
    |                                                     ^
@@ -199,7 +195,7 @@ LL |     /// well as the second instance of `A: AutoTrait\`) to suppress
    |                                                     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:291:40
+  --> $DIR/unescaped_backticks.rs:294:40
    |
 LL |     /// `'a` with `'b` and not `'static`. But it will have to do for
    |                                        ^
@@ -211,7 +207,7 @@ LL |     /// `'a` with `'b` and not `'static\`. But it will have to do for
    |                                        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:300:54
+  --> $DIR/unescaped_backticks.rs:303:54
    |
 LL | /// `None`. Otherwise, it will return `Some(Dispatch)`.
    |                                                      ^
@@ -226,7 +222,7 @@ LL | /// `None`. Otherwise, it will return `Some(Dispatch)\`.
    |                                                      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:304:13
+  --> $DIR/unescaped_backticks.rs:307:13
    |
 LL | /// or `None` if it isn't.
    |             ^
@@ -238,7 +234,7 @@ LL | /// or `None\` if it isn't.
    |             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:308:14
+  --> $DIR/unescaped_backticks.rs:311:14
    |
 LL | /// `on_event` should be called.
    |              ^
@@ -253,7 +249,7 @@ LL | /// `on_event\` should be called.
    |              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:313:29
+  --> $DIR/unescaped_backticks.rs:316:29
    |
 LL | /// [`rebuild_interest_cache`][rebuild] is called after the value of the max
    |                             ^
@@ -268,7 +264,7 @@ LL | /// [`rebuild_interest_cache\`][rebuild] is called after the value of the m
    |                             +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:323:5
+  --> $DIR/unescaped_backticks.rs:326:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -284,7 +280,7 @@ LL | |     /// level changes.
            to this: `None`. Otherwise, it will return `Some(Dispatch)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:323:5
+  --> $DIR/unescaped_backticks.rs:326:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -298,7 +294,7 @@ LL | |     /// level changes.
            to this: or `None\` if it isn't.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:323:5
+  --> $DIR/unescaped_backticks.rs:326:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -314,7 +310,7 @@ LL | |     /// level changes.
            to this: `on_event\` should be called.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:323:5
+  --> $DIR/unescaped_backticks.rs:326:5
    |
 LL | /     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
 ...  |
@@ -330,7 +326,7 @@ LL | |     /// level changes.
            to this: [`rebuild_interest_cache\`][rebuild] is called after the value of the max
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:349:56
+  --> $DIR/unescaped_backticks.rs:352:56
    |
 LL |     /// instead and use [`CloneCounterObserver::counter`] to increment.
    |                                                        ^
@@ -342,7 +338,7 @@ LL |     /// instead and use [`CloneCounterObserver::counter\`] to increment.
    |                                                        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:12:5
+  --> $DIR/unescaped_backticks.rs:15:5
    |
 LL | /// `
    |     ^
@@ -354,7 +350,7 @@ LL | /// \`
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:19:7
+  --> $DIR/unescaped_backticks.rs:22:7
    |
 LL | /// \`
    |       ^
@@ -369,7 +365,7 @@ LL | /// \\`
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:26:6
+  --> $DIR/unescaped_backticks.rs:29:6
    |
 LL | /// [`link1]
    |      ^
@@ -384,7 +380,7 @@ LL | /// [\`link1]
    |      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:30:11
+  --> $DIR/unescaped_backticks.rs:33:11
    |
 LL | /// [link2`]
    |           ^
@@ -399,7 +395,7 @@ LL | /// [link2\`]
    |           +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:34:6
+  --> $DIR/unescaped_backticks.rs:37:6
    |
 LL | /// [`link_long](link_long)
    |      ^
@@ -414,7 +410,7 @@ LL | /// [\`link_long](link_long)
    |      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:38:6
+  --> $DIR/unescaped_backticks.rs:41:6
    |
 LL | /// [`broken-link]
    |      ^
@@ -429,7 +425,7 @@ LL | /// [\`broken-link]
    |      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:45:8
+  --> $DIR/unescaped_backticks.rs:48:8
    |
 LL | /// <x:`>
    |        ^
@@ -444,7 +440,7 @@ LL | /// <x:\`>
    |        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:55:6
+  --> $DIR/unescaped_backticks.rs:58:6
    |
 LL | /// 🦀`🦀
    |       ^
@@ -463,7 +459,7 @@ LL | /// 🦀\`🦀
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:59:5
+  --> $DIR/unescaped_backticks.rs:62:5
    |
 LL | /// `foo(
    |     ^
@@ -478,7 +474,7 @@ LL | /// \`foo(
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:65:14
+  --> $DIR/unescaped_backticks.rs:68:14
    |
 LL | /// `foo `bar`
    |              ^
@@ -493,7 +489,7 @@ LL | /// `foo `bar\`
    |              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:71:5
+  --> $DIR/unescaped_backticks.rs:74:5
    |
 LL | /// `foo(
    |     ^
@@ -508,7 +504,7 @@ LL | /// \`foo(
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:76:83
+  --> $DIR/unescaped_backticks.rs:79:83
    |
 LL | /// Addition is commutative, which means that add(a, b)` is the same as `add(b, a)`.
    |                                                                                   ^
@@ -523,7 +519,7 @@ LL | /// Addition is commutative, which means that add(a, b)` is the same as `ad
    |                                                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:80:51
+  --> $DIR/unescaped_backticks.rs:83:51
    |
 LL | /// or even to add a number `n` to 42 (`add(42, b)`)!
    |                                                   ^
@@ -538,7 +534,7 @@ LL | /// or even to add a number `n` to 42 (`add(42, b)\`)!
    |                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:84:83
+  --> $DIR/unescaped_backticks.rs:87:83
    |
 LL | /// Addition is commutative, which means that `add(a, b) is the same as `add(b, a)`.
    |                                                                                   ^
@@ -553,7 +549,7 @@ LL | /// Addition is commutative, which means that `add(a, b) is the same as `ad
    |                                                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:88:51
+  --> $DIR/unescaped_backticks.rs:91:51
    |
 LL | /// or even to add a number `n` to 42 (`add(42, n)`)!
    |                                                   ^
@@ -568,7 +564,7 @@ LL | /// or even to add a number `n` to 42 (`add(42, n)\`)!
    |                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:92:83
+  --> $DIR/unescaped_backticks.rs:95:83
    |
 LL | /// Addition is commutative, which means that `add(a, b)` is the same as add(b, a)`.
    |                                                                                   ^
@@ -583,7 +579,7 @@ LL | /// Addition is commutative, which means that `add(a, b)` is the same as ad
    |                                                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:96:50
+  --> $DIR/unescaped_backticks.rs:99:50
    |
 LL | /// or even to add a number `n` to 42 (add(42, n)`)!
    |                                                  ^
@@ -598,7 +594,7 @@ LL | /// or even to add a number `n` to 42 (add(42, n)\`)!
    |                                                  +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:100:74
+  --> $DIR/unescaped_backticks.rs:103:74
    |
 LL | /// Addition is commutative, which means that `add(a, b)` is the same as `add(b, a).
    |                                                                          ^
@@ -613,7 +609,7 @@ LL | /// Addition is commutative, which means that `add(a, b)` is the same as \`
    |                                                                          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:104:51
+  --> $DIR/unescaped_backticks.rs:107:51
    |
 LL | /// or even to add a number `n` to 42 (`add(42, n)`)!
    |                                                   ^
@@ -628,7 +624,7 @@ LL | /// or even to add a number `n` to 42 (`add(42, n)\`)!
    |                                                   +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:108:10
+  --> $DIR/unescaped_backticks.rs:111:10
    |
 LL | #[doc = "`"]
    |          ^
@@ -639,7 +635,7 @@ LL | #[doc = "`"]
            to this: \`
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:115:26
+  --> $DIR/unescaped_backticks.rs:118:26
    |
 LL | #[doc = concat!("\\", "`")]
    |                          ^
@@ -652,7 +648,7 @@ LL | #[doc = concat!("\\", "`")]
            to this: \\`
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:119:9
+  --> $DIR/unescaped_backticks.rs:122:9
    |
 LL | #[doc = "Addition is commutative, which means that add(a, b)` is the same as `add(b, a)`."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -665,7 +661,7 @@ LL | #[doc = "Addition is commutative, which means that add(a, b)` is the same a
            to this: Addition is commutative, which means that add(a, b)` is the same as `add(b, a)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:123:9
+  --> $DIR/unescaped_backticks.rs:126:9
    |
 LL | #[doc = "Addition is commutative, which means that `add(a, b) is the same as `add(b, a)`."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -678,7 +674,7 @@ LL | #[doc = "Addition is commutative, which means that `add(a, b) is the same a
            to this: Addition is commutative, which means that `add(a, b) is the same as `add(b, a)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:127:9
+  --> $DIR/unescaped_backticks.rs:130:9
    |
 LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same as add(b, a)`."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -691,7 +687,7 @@ LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same 
            to this: Addition is commutative, which means that `add(a, b)` is the same as add(b, a)\`.
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:131:9
+  --> $DIR/unescaped_backticks.rs:134:9
    |
 LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same as `add(b, a)."]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -704,7 +700,7 @@ LL | #[doc = "Addition is commutative, which means that `add(a, b)` is the same 
            to this: Addition is commutative, which means that `add(a, b)` is the same as \`add(b, a).
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:136:5
+  --> $DIR/unescaped_backticks.rs:139:5
    |
 LL | /// `foo
    |     ^
@@ -719,7 +715,7 @@ LL | /// \`foo
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:140:7
+  --> $DIR/unescaped_backticks.rs:143:7
    |
 LL | /// # `(heading
    |       ^
@@ -734,7 +730,7 @@ LL | /// # \`(heading
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:142:17
+  --> $DIR/unescaped_backticks.rs:145:17
    |
 LL | /// ## heading2)`
    |                 ^
@@ -749,7 +745,7 @@ LL | /// ## heading2)\`
    |                 +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:145:11
+  --> $DIR/unescaped_backticks.rs:148:11
    |
 LL | /// multi `(
    |           ^
@@ -764,7 +760,7 @@ LL | /// multi \`(
    |           +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:151:10
+  --> $DIR/unescaped_backticks.rs:154:10
    |
 LL | /// para)`(graph
    |          ^
@@ -783,7 +779,7 @@ LL | /// para)\`(graph
    |          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:154:10
+  --> $DIR/unescaped_backticks.rs:157:10
    |
 LL | /// para)`(graph2
    |          ^
@@ -802,7 +798,7 @@ LL | /// para)\`(graph2
    |          +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:157:12
+  --> $DIR/unescaped_backticks.rs:160:12
    |
 LL | /// 1. foo)`
    |            ^
@@ -817,7 +813,7 @@ LL | /// 1. foo)\`
    |            +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:159:8
+  --> $DIR/unescaped_backticks.rs:162:8
    |
 LL | /// 2. `(bar
    |        ^
@@ -832,7 +828,7 @@ LL | /// 2. \`(bar
    |        +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:161:11
+  --> $DIR/unescaped_backticks.rs:164:11
    |
 LL | /// * baz)`
    |           ^
@@ -847,7 +843,7 @@ LL | /// * baz)\`
    |           +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:163:7
+  --> $DIR/unescaped_backticks.rs:166:7
    |
 LL | /// * `(quux
    |       ^
@@ -862,7 +858,7 @@ LL | /// * \`(quux
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:166:5
+  --> $DIR/unescaped_backticks.rs:169:5
    |
 LL | /// `#![this_is_actually_an_image(and(not), an = "attribute")]
    |     ^
@@ -877,7 +873,7 @@ LL | /// \`#![this_is_actually_an_image(and(not), an = "attribute")]
    |     +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:169:62
+  --> $DIR/unescaped_backticks.rs:172:62
    |
 LL | /// #![this_is_actually_an_image(and(not), an = "attribute")]`
    |                                                              ^
@@ -892,7 +888,7 @@ LL | /// #![this_is_actually_an_image(and(not), an = "attribute")]\`
    |                                                              +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:174:7
+  --> $DIR/unescaped_backticks.rs:177:7
    |
 LL | /// | `table( | )head` |
    |       ^
@@ -907,7 +903,7 @@ LL | /// | \`table( | )head` |
    |       +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:174:22
+  --> $DIR/unescaped_backticks.rs:177:22
    |
 LL | /// | `table( | )head` |
    |                      ^
@@ -922,7 +918,7 @@ LL | /// | `table( | )head\` |
    |                      +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:178:12
+  --> $DIR/unescaped_backticks.rs:181:12
    |
 LL | /// | table`( | )`body |
    |            ^
@@ -937,7 +933,7 @@ LL | /// | table\`( | )`body |
    |            +
 
 error: unescaped backtick
-  --> $DIR/unescaped_backticks.rs:178:18
+  --> $DIR/unescaped_backticks.rs:181:18
    |
 LL | /// | table`( | )`body |
    |                  ^

--- a/tests/rustdoc-ui/lints/unescaped_backticks.rs
+++ b/tests/rustdoc-ui/lints/unescaped_backticks.rs
@@ -1,4 +1,7 @@
-#![deny(rustdoc::unescaped_backticks)]
+//@revisions: deny_cli allow_cli
+//@[deny_cli] compile-flags: -Drustdoc::unescaped_backticks
+//@[allow_cli] compile-flags: -Arustdoc::unescaped_backticks
+//@[allow_cli] check-pass
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(rustdoc::invalid_html_tags)]
 #![allow(rustdoc::redundant_explicit_links)]
@@ -10,40 +13,40 @@ pub fn empty() {}
 pub fn empty2() {}
 
 /// `
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn single() {}
 
 /// \`
 pub fn escaped() {}
 
 /// \\`
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn not_escaped() {}
 
 /// \\\`
 pub fn not_not_escaped() {}
 
 /// [`link1]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn link1() {}
 
 /// [link2`]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn link2() {}
 
 /// [`link_long](link_long)
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn link_long() {}
 
 /// [`broken-link]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn broken_link() {}
 
 /// <xx:`>
 pub fn url() {}
 
 /// <x:`>
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn not_url() {}
 
 /// <h1>`</h1>
@@ -53,131 +56,131 @@ pub fn html_tag() {}
 pub fn html_escape() {}
 
 /// 🦀`🦀
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn unicode() {}
 
 /// `foo(
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// paragraph
 pub fn paragraph() {}
 
 /// `foo `bar`
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// paragraph
 pub fn paragraph2() {}
 
 /// `foo(
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// not paragraph
 pub fn not_paragraph() {}
 
 /// Addition is commutative, which means that add(a, b)` is the same as `add(b, a)`.
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// You could use this function to add 42 to a number `n` (add(n, 42)`),
 /// or even to add a number `n` to 42 (`add(42, b)`)!
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn add1(a: i32, b: i32) -> i32 { a + b }
 
 /// Addition is commutative, which means that `add(a, b) is the same as `add(b, a)`.
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// You could use this function to add 42 to a number `n` (`add(n, 42)),
 /// or even to add a number `n` to 42 (`add(42, n)`)!
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn add2(a: i32, b: i32) -> i32 { a + b }
 
 /// Addition is commutative, which means that `add(a, b)` is the same as add(b, a)`.
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// You could use this function to add 42 to a number `n` (`add(n, 42)`),
 /// or even to add a number `n` to 42 (add(42, n)`)!
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn add3(a: i32, b: i32) -> i32 { a + b }
 
 /// Addition is commutative, which means that `add(a, b)` is the same as `add(b, a).
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// You could use this function to add 42 to a number `n` (`add(n, 42)),
 /// or even to add a number `n` to 42 (`add(42, n)`)!
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn add4(a: i32, b: i32) -> i32 { a + b }
 
 #[doc = "`"]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn attr() {}
 
 #[doc = concat!("\\", "`")]
 pub fn attr_escaped() {}
 
 #[doc = concat!("\\\\", "`")]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn attr_not_escaped() {}
 
 #[doc = "Addition is commutative, which means that add(a, b)` is the same as `add(b, a)`."]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn attr_add1(a: i32, b: i32) -> i32 { a + b }
 
 #[doc = "Addition is commutative, which means that `add(a, b) is the same as `add(b, a)`."]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn attr_add2(a: i32, b: i32) -> i32 { a + b }
 
 #[doc = "Addition is commutative, which means that `add(a, b)` is the same as add(b, a)`."]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn attr_add3(a: i32, b: i32) -> i32 { a + b }
 
 #[doc = "Addition is commutative, which means that `add(a, b)` is the same as `add(b, a)."]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn attr_add4(a: i32, b: i32) -> i32 { a + b }
 
 /// ``double backticks``
 /// `foo
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 pub fn double_backticks() {}
 
 /// # `(heading
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// ## heading2)`
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// multi `(
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// line
 /// ) heading
 /// =
 ///
 /// para)`(graph
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// para)`(graph2
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// 1. foo)`
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// 2. `(bar
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// * baz)`
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// * `(quux
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// `#![this_is_actually_an_image(and(not), an = "attribute")]
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// #![this_is_actually_an_image(and(not), an = "attribute")]`
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// [this_is_actually_an_image(and(not), an = "attribute")]: `.png
 ///
 /// | `table( | )head` |
-//~^ ERROR unescaped backtick
-//~| ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
+//[deny_cli]~| ERROR unescaped backtick
 /// |---------|--------|
 /// | table`( | )`body |
-//~^ ERROR unescaped backtick
-//~| ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
+//[deny_cli]~| ERROR unescaped backtick
 pub fn complicated_markdown() {}
 
 /// The `custom_mir` attribute tells the compiler to treat the function as being custom MIR. This
@@ -185,13 +188,13 @@ pub fn complicated_markdown() {}
 /// another function. The `dialect` and `phase` parameters indicate which [version of MIR][dialect
 /// docs] you are inserting here. Generally you'll want to use `#![custom_mir(dialect = "built")]`
 /// if you want your MIR to be modified by the full MIR pipeline, or `#![custom_mir(dialect =
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// "runtime", phase = "optimized")] if you don't.
 pub mod mir {}
 
 pub mod rustc {
     /// Constructs a `TyKind::Error` type and registers a `span_delayed_bug` with the given `msg to
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     /// ensure it gets used.
     pub fn ty_error_with_message() {}
 
@@ -200,13 +203,13 @@ pub mod rustc {
         /// if we parsed no predicates (e.g. `struct Foo where {}
         /// This allows us to accurately pretty-print
         /// in `nt_to_tokenstream`
-        //~^ ERROR unescaped backtick
+        //[deny_cli]~^ ERROR unescaped backtick
         pub has_where_token: bool,
     }
 
     /// A symbol is an interned or gensymed string. The use of `newtype_index!` means
     /// that `Option<Symbol>` only takes up 4 bytes, because `newtype_index! reserves
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     /// the last 256 values for tagging purposes.
     pub struct Symbol();
 
@@ -214,12 +217,12 @@ pub mod rustc {
     /// readable code. Instead of `OpenOptions::new().read(true).open("foo.txt")`
     /// you can write `File::with_options().read(true).open("foo.txt"). This
     /// also avoids the need to import `OpenOptions`.
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     pub fn with_options() {}
 
     /// Subtracts `set from `row`. `set` can be either `BitSet` or
     /// `ChunkedBitSet`. Has no effect if `row` does not exist.
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     ///
     /// Returns true if the row was changed.
     pub fn subtract_row() {}
@@ -230,29 +233,29 @@ pub mod rustc {
         //! perturb the reuse results.
         //!
         //! `#![rustc_expected_cgu_reuse(module="spike", cfg="rpass2", kind="post-lto")]
-        //~^ ERROR unescaped backtick
+        //[deny_cli]~^ ERROR unescaped backtick
         //! allows for doing a more fine-grained check to see if pre- or post-lto data
         //! was re-used.
 
         /// `cfg=...
-        //~^ ERROR unescaped backtick
+        //[deny_cli]~^ ERROR unescaped backtick
         pub fn foo() {}
 
         /// `cfg=... and not `#[cfg_attr]`
-        //~^ ERROR unescaped backtick
+        //[deny_cli]~^ ERROR unescaped backtick
         pub fn bar() {}
     }
 
     /// Conceptually, this is like a `Vec<Vec<RWU>>`. But the number of
     /// RWU`s can get very large, so it uses a more compact representation.
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     pub struct RWUTable {}
 
     /// Like [Self::canonicalize_query], but preserves distinct universes. For
     /// example, canonicalizing `&'?0: Trait<'?1>`, where `'?0` is in `U1` and
     /// `'?1` is in `U3` would be canonicalized to have ?0` in `U1` and `'?1`
     /// in `U2`.
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     ///
     /// This is used for Chalk integration.
     pub fn canonicalize_query_preserving_universes() {}
@@ -269,7 +272,7 @@ pub mod rustc {
     /// `<MyType<[type error]> as Trait>::Foo`. We are supposed to report
     /// an error for this obligation, but we legitimately should not,
     /// because it contains `[type error]`. Yuck! (See issue #29857 for
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     /// one case where this arose.)
     pub fn normalize_to_error() {}
 
@@ -279,7 +282,7 @@ pub mod rustc {
     /// encountered a problem (later on) with `A: AutoTrait. So we
     /// currently set a flag on the stack node for `B: AutoTrait` (as
     /// well as the second instance of `A: AutoTrait`) to suppress
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     /// caching.
     pub struct TraitObligationStack;
 
@@ -289,7 +292,7 @@ pub mod rustc {
     /// actually stricter than necessary: ideally, we'd support bounds
     /// like `for<'a: 'b`>` that might then allow us to approximate
     /// `'a` with `'b` and not `'static`. But it will have to do for
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     /// now.
     pub fn add_incompatible_universe(){}
 }
@@ -298,20 +301,20 @@ pub mod rustc {
 /// which returns an `Option<Dispatch>`. If all [`Dispatch`] clones that point
 /// at the `Subscriber` have been dropped, [`WeakDispatch::upgrade`] will return
 /// `None`. Otherwise, it will return `Some(Dispatch)`.
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// Returns some reference to this `[`Subscriber`] value if it is of type `T`,
 /// or `None` if it isn't.
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// Called before the filtered [`Layer]'s [`on_event`], to determine if
 /// `on_event` should be called.
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 ///
 /// Therefore, if the `Filter will change the value returned by this
 /// method, it is responsible for ensuring that
 /// [`rebuild_interest_cache`][rebuild] is called after the value of the max
-//~^ ERROR unescaped backtick
+//[deny_cli]~^ ERROR unescaped backtick
 /// level changes.
 pub mod tracing {}
 
@@ -321,10 +324,10 @@ macro_rules! id {
 
 id! {
     /// The Subscriber` may be accessed by calling [`WeakDispatch::upgrade`],
-    //~^ ERROR unescaped backtick
-    //~| ERROR unescaped backtick
-    //~| ERROR unescaped backtick
-    //~| ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
+    //[deny_cli]~| ERROR unescaped backtick
+    //[deny_cli]~| ERROR unescaped backtick
+    //[deny_cli]~| ERROR unescaped backtick
     /// which returns an `Option<Dispatch>`. If all [`Dispatch`] clones that point
     /// at the `Subscriber` have been dropped, [`WeakDispatch::upgrade`] will return
     /// `None`. Otherwise, it will return `Some(Dispatch)`.
@@ -347,7 +350,7 @@ pub mod trillium_server_common {
     /// One-indexed, because the first CloneCounter is included. If you don't
     /// want the original to count, construct a [``CloneCounterObserver`]
     /// instead and use [`CloneCounterObserver::counter`] to increment.
-    //~^ ERROR unescaped backtick
+    //[deny_cli]~^ ERROR unescaped backtick
     pub struct CloneCounter;
 
     /// This is used by the above.

--- a/tests/rustdoc-ui/lints/unescaped_backticks.rs
+++ b/tests/rustdoc-ui/lints/unescaped_backticks.rs
@@ -1,4 +1,6 @@
-//@revisions: deny_cli allow_cli
+//@revisions: deny_cli allow_cli capped
+//@[capped] compile-flags: --cap-lints=allow
+//@[capped] check-pass
 //@[deny_cli] compile-flags: -Drustdoc::unescaped_backticks
 //@[allow_cli] compile-flags: -Arustdoc::unescaped_backticks
 //@[allow_cli] check-pass


### PR DESCRIPTION
This works, but I couldn't find any test cases for it.
