### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3867,6 +3867,19 @@ pub struct Fn {
     pub eii_impls: ThinVec<EiiImpl>,
 }
 
+impl Fn {
+    pub fn is_pin_drop_sugar(&self) -> bool {
+        self.ident.name == sym::drop
+            && self
+                .sig
+                .decl
+                .inputs
+                .first()
+                .and_then(|param| param.to_self())
+                .is_some_and(|eself| matches!(eself.node, SelfKind::Pinned(None, Mutability::Mut)))
+    }
+}
+
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub struct EiiImpl {
     pub node_id: NodeId,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1192,6 +1192,52 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
+    fn resolve_pin_drop_sugar_impl_item(
+        &self,
+        i: &AssocItem,
+        ident: Ident,
+        span: Span,
+    ) -> (Ident, Result<DefId, ErrorGuaranteed>) {
+        let trait_item_def_id = self
+            .get_partial_res(i.id)
+            .and_then(|r| r.expect_full_res().opt_def_id())
+            .ok_or_else(|| {
+                self.dcx().span_delayed_bug(span, "could not resolve trait item being implemented")
+            });
+
+        let is_pin_drop_sugar = match &i.kind {
+            AssocItemKind::Fn(fn_kind) => fn_kind.is_pin_drop_sugar(),
+            _ => false,
+        };
+        let def_id = match trait_item_def_id {
+            Ok(def_id) => def_id,
+            Err(guar) => return (ident, Err(guar)),
+        };
+        if !is_pin_drop_sugar {
+            return (ident, Ok(def_id));
+        }
+
+        let is_drop_pin_drop = self
+            .tcx
+            .lang_items()
+            .drop_trait()
+            .is_some_and(|drop_trait| self.tcx.parent(def_id) == drop_trait);
+        if is_drop_pin_drop {
+            // Associated item collection still derives the impl item's name from HIR.
+            return (Ident::new(sym::pin_drop, ident.span), Ok(def_id));
+        }
+
+        let guar = self
+            .dcx()
+            .struct_span_err(
+                i.span,
+                "method `drop` with `&pin mut self` is only supported for the `Drop` trait",
+            )
+            .with_span_label(i.span, "not a `Drop::pin_drop` implementation")
+            .emit();
+        (ident, Err(guar))
+    }
+
     fn lower_impl_item(
         &mut self,
         i: &AssocItem,
@@ -1309,26 +1355,19 @@ impl<'hir> LoweringContext<'_, 'hir> {
         };
 
         let span = self.lower_span(i.span);
+        let (effective_ident, impl_kind) = if is_in_trait_impl {
+            let (effective_ident, trait_item_def_id) =
+                self.resolve_pin_drop_sugar_impl_item(i, ident, span);
+            (effective_ident, ImplItemImplKind::Trait { defaultness, trait_item_def_id })
+        } else {
+            (ident, ImplItemImplKind::Inherent { vis_span: self.lower_span(i.vis.span) })
+        };
+
         let item = hir::ImplItem {
             owner_id: hir_id.expect_owner(),
-            ident: self.lower_ident(ident),
+            ident: self.lower_ident(effective_ident),
             generics,
-            impl_kind: if is_in_trait_impl {
-                ImplItemImplKind::Trait {
-                    defaultness,
-                    trait_item_def_id: self
-                        .get_partial_res(i.id)
-                        .and_then(|r| r.expect_full_res().opt_def_id())
-                        .ok_or_else(|| {
-                            self.dcx().span_delayed_bug(
-                                span,
-                                "could not resolve trait item being implemented",
-                            )
-                        }),
-                }
-            } else {
-                ImplItemImplKind::Inherent { vis_span: self.lower_span(i.vis.span) }
-            },
+            impl_kind,
             kind,
             span,
             has_delayed_lints: !self.delayed_lints.is_empty(),

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -66,7 +66,10 @@ unsafe fn configure_llvm(sess: &Session) {
 
     let cg_opts = sess.opts.cg.llvm_args.iter().map(AsRef::as_ref);
     let tg_opts = sess.target.llvm_args.iter().map(AsRef::as_ref);
-    let sess_args = cg_opts.chain(tg_opts);
+    // Target-spec args are passed to LLVM before user `-Cllvm-args`. LLVM's
+    // `cl::opt` parser is last-wins, so this lets `-Cllvm-args=...` override
+    // a value already set in the target spec (e.g. `-wasm-use-legacy-eh`).
+    let sess_args = tg_opts.chain(cg_opts);
 
     let user_specified_args: FxHashSet<_> =
         sess_args.clone().map(|s| llvm_arg_to_arg_name(s)).filter(|s| !s.is_empty()).collect();

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1088,6 +1088,93 @@ impl<'hir> Generics<'hir> {
             bound_span.with_lo(bounds[bound_pos - 1].span().hi())
         }
     }
+
+    /// Computes the span representing the removal of a generic parameter at `param_index`.
+    ///
+    /// This function identifies the correct slice of source code to delete so that the
+    /// remaining generic list remains syntactically valid (handling commas and brackets).
+    ///
+    /// ### Examples
+    ///
+    /// 1. **With a following parameter:** (Includes the trailing comma)
+    ///    - Input: `<T, U>` (index 0)
+    ///    - Produces span for: `T, `
+    ///
+    /// 2. **With a previous parameter:** (Includes the leading comma and bounds)
+    ///    - Input: `<T: Clone, U>` (index 1)
+    ///    - Produces span for: `, U`
+    ///
+    /// 3. **The only parameter:** (Includes the angle brackets)
+    ///    - Input: `<T>` (index 0)
+    ///    - Produces span for: `<T>`
+    ///
+    /// 4. **Parameter with where-clause bounds:**
+    ///    - Input: `fn foo<T, U>() where T: Copy` (index 0)
+    ///    - Produces span for: `T, ` (The where-clause remains for other logic to handle).
+    pub fn span_for_param_removal(&self, param_index: usize) -> Span {
+        if param_index >= self.params.len() {
+            return self.span.shrink_to_hi();
+        }
+
+        let is_param_explicit = |par: &&GenericParam<'_>| match par.kind {
+            GenericParamKind::Type { .. }
+            | GenericParamKind::Const { .. }
+            | GenericParamKind::Lifetime { kind: LifetimeParamKind::Explicit } => true,
+            _ => false,
+        };
+
+        // Find the span of the type parameter.
+        if let Some(next) = self.params[param_index + 1..].iter().find(is_param_explicit) {
+            self.params[param_index].span.until(next.span)
+        } else if let Some(prev) = self.params[..param_index].iter().rfind(is_param_explicit) {
+            let mut prev_span = prev.span;
+            // Consider the span of the bounds with the previous generic parameter when there is.
+            if let Some(prev_bounds_span) = self.span_for_param_bounds(prev) {
+                prev_span = prev_span.to(prev_bounds_span);
+            }
+
+            // Consider the span of the bounds with the current generic parameter when there is.
+            prev_span.shrink_to_hi().to(
+                if let Some(cur_bounds_span) = self.span_for_param_bounds(&self.params[param_index])
+                {
+                    cur_bounds_span
+                } else {
+                    self.params[param_index].span
+                },
+            )
+        } else {
+            // Remove also angle brackets <> when there is just ONE generic parameter.
+            self.span
+        }
+    }
+
+    /// Returns the span of the `WherePredicate` associated with the given `GenericParam`, if any.
+    ///
+    /// This looks specifically for predicates in the `where` clause that were generated
+    /// from the parameter definition (e.g., `T` in `where T: Bound`).
+    ///
+    /// ### Example
+    ///
+    /// - Input: `param` representing `T`
+    /// - Context: `where T: Clone + Default, U: Copy`
+    /// - Returns: Span of `T: Clone + Default`
+    fn span_for_param_bounds(&self, param: &GenericParam<'hir>) -> Option<Span> {
+        self.predicates
+            .iter()
+            .find(|pred| {
+                if let WherePredicateKind::BoundPredicate(WhereBoundPredicate {
+                    origin: PredicateOrigin::GenericParam,
+                    bounded_ty,
+                    ..
+                }) = pred.kind
+                {
+                    bounded_ty.span == param.span
+                } else {
+                    false
+                }
+            })
+            .map(|pred| pred.span)
+    }
 }
 
 /// A single predicate in a where-clause.

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -14,6 +14,7 @@ use rustc_middle::ty::{
 use rustc_span::{ErrorGuaranteed, Span, kw};
 
 use crate::collect::ItemCtxt;
+use crate::errors::DelegationSelfTypeNotSpecified;
 use crate::hir_ty_lowering::HirTyLowerer;
 
 type RemapTable = FxHashMap<u32, u32>;
@@ -284,6 +285,12 @@ fn get_delegation_self_ty_or_err(tcx: TyCtxt<'_>, delegation_id: LocalDefId) -> 
             ctx.lower_ty(tcx.hir_node(id).expect_ty())
         })
         .unwrap_or_else(|| {
+            // It is possible to attempt to get self type when it is used in signature
+            // (i.e., `fn default() -> Self`), so emit error here in addition to possible
+            // `mismatched types` error (see #156388).
+            let err = DelegationSelfTypeNotSpecified { span: tcx.def_span(delegation_id) };
+            tcx.dcx().emit_err(err);
+
             Ty::new_error_with_message(
                 tcx,
                 tcx.def_span(delegation_id),

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -15,6 +15,8 @@ pub(crate) mod wrong_number_of_generic_args;
 mod precise_captures;
 pub(crate) use precise_captures::*;
 
+pub(crate) mod remove_or_use_generic;
+
 #[derive(Diagnostic)]
 #[diag("ambiguous associated {$assoc_kind} `{$assoc_ident}` in bounds of `{$qself}`")]
 pub(crate) struct AmbiguousAssocItem<'a> {

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1671,6 +1671,14 @@ pub(crate) struct UnsupportedDelegation<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag("delegation self type is not specified")]
+#[help("consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`")]
+pub(crate) struct DelegationSelfTypeNotSpecified {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("method should be `async` or return a future, but it is synchronous")]
 pub(crate) struct MethodShouldReturnFuture {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/errors/remove_or_use_generic.rs
+++ b/compiler/rustc_hir_analysis/src/errors/remove_or_use_generic.rs
@@ -1,0 +1,211 @@
+use std::ops::ControlFlow;
+
+use rustc_errors::{Applicability, Diag};
+use rustc_hir::def::DefKind;
+use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::intravisit::{self, Visitor, walk_lifetime};
+use rustc_hir::{GenericArg, HirId, LifetimeKind, Path, QPath, TyKind};
+use rustc_middle::hir::nested_filter::All;
+use rustc_middle::ty::{GenericParamDef, GenericParamDefKind, TyCtxt};
+
+use crate::hir::def::Res;
+
+/// Use a Visitor to find usages of the type or lifetime parameter
+struct ParamUsageVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    /// The `DefId` of the generic parameter we are looking for.
+    param_def_id: DefId,
+    found: bool,
+}
+
+impl<'tcx> Visitor<'tcx> for ParamUsageVisitor<'tcx> {
+    type NestedFilter = All;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    type Result = ControlFlow<()>;
+
+    fn visit_path(&mut self, path: &Path<'tcx>, _id: HirId) -> Self::Result {
+        if let Some(res_def_id) = path.res.opt_def_id() {
+            if res_def_id == self.param_def_id {
+                self.found = true;
+                return ControlFlow::Break(());
+            }
+        }
+        intravisit::walk_path(self, path)
+    }
+
+    fn visit_lifetime(&mut self, lifetime: &'tcx rustc_hir::Lifetime) -> Self::Result {
+        if let LifetimeKind::Param(id) = lifetime.kind {
+            if let Some(local_def_id) = self.param_def_id.as_local() {
+                if id == local_def_id {
+                    self.found = true;
+                    return ControlFlow::Break(());
+                }
+            }
+        }
+        walk_lifetime(self, lifetime)
+    }
+}
+
+/// Adds a suggestion to a diagnostic to either remove an unused generic parameter, or use it.
+///
+/// # Examples
+///
+/// - `impl<T> Struct { ... }` where `T` is unused -> suggests removing `T` or using it.
+/// - `impl<T> Struct { // T used in here }` where `T` is used in the body but not in the self type -> suggests adding `T` to the self type and struct definition.
+/// - `impl<T> Struct { ... }` where the struct has a generic parameter with a default -> suggests adding `T` to the self type.
+pub(crate) fn suggest_to_remove_or_use_generic(
+    tcx: TyCtxt<'_>,
+    diag: &mut Diag<'_>,
+    impl_def_id: LocalDefId,
+    param: &GenericParamDef,
+    is_lifetime: bool,
+) {
+    let node = tcx.hir_node_by_def_id(impl_def_id);
+    let hir_impl = node.expect_item().expect_impl();
+
+    let Some((index, _)) = hir_impl
+        .generics
+        .params
+        .iter()
+        .enumerate()
+        .find(|(_, par)| par.def_id.to_def_id() == param.def_id)
+    else {
+        return;
+    };
+
+    // Get the Struct/ADT definition ID from the self type
+    let struct_def_id = if let TyKind::Path(QPath::Resolved(_, path)) = hir_impl.self_ty.kind
+        && let Res::Def(DefKind::Struct | DefKind::Enum | DefKind::Union, def_id) = path.res
+    {
+        def_id
+    } else {
+        return;
+    };
+
+    // Count how many generic parameters are defined in the struct definition
+    let generics = tcx.generics_of(struct_def_id);
+    let total_params = generics
+        .own_params
+        .iter()
+        .filter(|p| {
+            if is_lifetime {
+                matches!(p.kind, GenericParamDefKind::Lifetime)
+            } else {
+                matches!(p.kind, GenericParamDefKind::Type { .. })
+            }
+        })
+        .count();
+
+    // Count how many arguments are currently provided in the impl
+    let mut provided_params = 0;
+    let mut last_segment_args = None;
+
+    if let TyKind::Path(QPath::Resolved(_, path)) = hir_impl.self_ty.kind
+        && let Some(seg) = path.segments.last()
+        && let Some(args) = seg.args
+    {
+        last_segment_args = Some(args);
+        provided_params = args
+            .args
+            .iter()
+            .filter(|arg| match arg {
+                GenericArg::Lifetime(_) => is_lifetime,
+                GenericArg::Type(_) => !is_lifetime,
+                _ => false,
+            })
+            .count();
+    }
+
+    let mut visitor = ParamUsageVisitor { tcx, param_def_id: param.def_id, found: false };
+    for item_ref in hir_impl.items {
+        let _ = visitor.visit_impl_item_ref(item_ref);
+        if visitor.found {
+            break;
+        }
+    }
+    let is_param_used = visitor.found;
+
+    let mut suggestions = vec![];
+
+    // Option A: Remove (Only if not used in body)
+    if !is_param_used {
+        suggestions.push((hir_impl.generics.span_for_param_removal(index), String::new()));
+    }
+
+    // Option B: Suggest adding only if there's an available parameter in the struct definition
+    // or the parameter is already used somewhere, then we suggest adding to the impl struct and the struct definition
+    if provided_params < total_params || is_param_used {
+        if let Some(args) = last_segment_args {
+            // Struct already has <...>, append to it
+            suggestions.push((args.span().unwrap().shrink_to_hi(), format!(", {}", param.name)));
+        } else if let TyKind::Path(QPath::Resolved(_, path)) = hir_impl.self_ty.kind {
+            // Struct has no <...> yet, add it
+            let seg = path.segments.last().unwrap();
+            suggestions.push((seg.ident.span.shrink_to_hi(), format!("<{}>", param.name)));
+        }
+        if is_param_used {
+            // If the parameter is used in the body, we also want to suggest adding it to the struct definition if it's not already there
+            let struct_span = tcx.def_span(struct_def_id);
+            let last_param_span = if let Some(local_def_id) = struct_def_id.as_local() {
+                let hir_struct = tcx.hir_node_by_def_id(local_def_id).expect_item().expect_struct();
+                hir_struct.1.params.last().map(|param| param.span)
+            } else {
+                let generics = tcx.generics_of(struct_def_id);
+                generics.own_params.last().map(|param| tcx.def_span(param.def_id))
+            };
+
+            if let Some(last_param_span) = last_param_span {
+                suggestions.push((last_param_span.shrink_to_hi(), format!(", {}", param.name)));
+            } else {
+                suggestions.push((struct_span.shrink_to_hi(), format!("<{}>", param.name)));
+            }
+        }
+    }
+
+    if suggestions.is_empty() {
+        return;
+    }
+
+    let parameter_type = if is_lifetime { "lifetime" } else { "type" };
+    if is_param_used {
+        let msg = format!(
+            "use the {} parameter `{}` in the `{}` type and use it in the type definition",
+            parameter_type,
+            param.name,
+            tcx.def_path_str(struct_def_id)
+        );
+        diag.multipart_suggestion(
+            msg,
+            vec![
+                (suggestions[0].0, suggestions[0].1.clone()),
+                (suggestions[1].0, suggestions[1].1.clone()),
+            ],
+            Applicability::MaybeIncorrect,
+        );
+    } else {
+        let msg = if suggestions.len() == 2 {
+            format!("either remove the unused {} parameter `{}`", parameter_type, param.name)
+        } else {
+            format!("remove the unused {} parameter `{}`", parameter_type, param.name)
+        };
+        diag.span_suggestion(
+            suggestions[0].0,
+            msg,
+            suggestions[0].1.clone(),
+            Applicability::MaybeIncorrect,
+        );
+        if suggestions.len() == 2 {
+            let msg = format!("or use it");
+            diag.span_suggestion(
+                suggestions[1].0,
+                msg,
+                suggestions[1].1.clone(),
+                Applicability::MaybeIncorrect,
+            );
+        }
+    };
+}

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -21,6 +21,7 @@ use rustc_span::{ErrorGuaranteed, kw};
 
 use crate::constrained_generic_params as cgp;
 use crate::errors::UnconstrainedGenericParameter;
+use crate::errors::remove_or_use_generic::suggest_to_remove_or_use_generic;
 
 mod min_specialization;
 
@@ -177,6 +178,7 @@ pub(crate) fn enforce_impl_lifetime_params_are_constrained(
                             );
                         }
                     }
+                    suggest_to_remove_or_use_generic(tcx, &mut diag, impl_def_id, param, true);
                     res = Err(diag.emit());
                 }
             }
@@ -242,6 +244,7 @@ pub(crate) fn enforce_impl_non_lifetime_params_are_constrained(
                 const_param_note2: const_param_note,
             });
             diag.code(E0207);
+            suggest_to_remove_or_use_generic(tcx, &mut diag, impl_def_id, &param, false);
             res = Err(diag.emit());
         }
     }

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -222,14 +222,8 @@ where
         let span = self.source_info.span;
 
         let pin_obj_bb = bb.unwrap_or_else(|| {
-            self.elaborator.patch().new_block(BasicBlockData::new(
-                Some(Terminator {
-                    // Temporary terminator, will be replaced by patch
-                    source_info: self.source_info,
-                    kind: TerminatorKind::Return,
-                }),
-                false,
-            ))
+            // Temporary terminator, will be replaced by patch
+            self.new_block(unwind, TerminatorKind::Return)
         });
 
         let (fut_ty, drop_fn_def_id, trait_args) = if call_destructor_only {
@@ -594,8 +588,7 @@ where
                 succ,
                 unwind,
                 dropline,
-                // Using `self.path` here to condition the drop on
-                // our own drop flag.
+                // Using `self.path` here to condition the drop on our own drop flag.
                 path: self.path,
             }
             .complete_drop(succ, unwind)
@@ -767,18 +760,14 @@ where
 
         let do_drop_bb = self.drop_subpath(interior, interior_path, succ, unwind, dropline);
 
-        let setup_bbd = BasicBlockData::new_stmts(
+        self.new_block_with_statements(
+            unwind,
             vec![self.assign(
                 Place::from(ptr_local),
                 Rvalue::Cast(CastKind::Transmute, Operand::Copy(nonnull_place), ptr_ty),
             )],
-            Some(Terminator {
-                kind: TerminatorKind::Goto { target: do_drop_bb },
-                source_info: self.source_info,
-            }),
-            unwind.is_cleanup(),
-        );
-        self.elaborator.patch().new_block(setup_bbd)
+            TerminatorKind::Goto { target: do_drop_bb },
+        )
     }
 
     #[instrument(level = "debug", ret)]
@@ -788,13 +777,7 @@ where
         args: GenericArgsRef<'tcx>,
     ) -> BasicBlock {
         if adt.variants().is_empty() {
-            return self.elaborator.patch().new_block(BasicBlockData::new(
-                Some(Terminator {
-                    source_info: self.source_info,
-                    kind: TerminatorKind::Unreachable,
-                }),
-                self.unwind.is_cleanup(),
-            ));
+            return self.new_block(self.unwind, TerminatorKind::Unreachable);
         }
 
         let skip_contents = adt.is_union() || adt.is_manually_drop();
@@ -972,21 +955,17 @@ where
         let discr_ty = adt.repr().discr_type().to_ty(self.tcx());
         let discr = Place::from(self.new_temp(discr_ty));
         let discr_rv = Rvalue::Discriminant(self.place);
-        let switch_block = BasicBlockData::new_stmts(
+        let switch_block = self.new_block_with_statements(
+            unwind,
             vec![self.assign(discr, discr_rv)],
-            Some(Terminator {
-                source_info: self.source_info,
-                kind: TerminatorKind::SwitchInt {
-                    discr: Operand::Move(discr),
-                    targets: SwitchTargets::new(
-                        values.iter().copied().zip(blocks.iter().copied()),
-                        *blocks.last().unwrap(),
-                    ),
-                },
-            }),
-            unwind.is_cleanup(),
+            TerminatorKind::SwitchInt {
+                discr: Operand::Move(discr),
+                targets: SwitchTargets::new(
+                    values.iter().copied().zip(blocks.iter().copied()),
+                    *blocks.last().unwrap(),
+                ),
+            },
         );
-        let switch_block = self.elaborator.patch().new_block(switch_block);
         self.drop_flag_test_block(switch_block, succ, unwind)
     }
 
@@ -1001,7 +980,8 @@ where
         let ref_place = self.new_temp(ref_ty);
         let unit_temp = Place::from(self.new_temp(tcx.types.unit));
 
-        let result = BasicBlockData::new_stmts(
+        self.new_block_with_statements(
+            unwind,
             vec![self.assign(
                 Place::from(ref_place),
                 Rvalue::Ref(
@@ -1010,28 +990,17 @@ where
                     self.place,
                 ),
             )],
-            Some(Terminator {
-                kind: TerminatorKind::Call {
-                    func: Operand::function_handle(
-                        tcx,
-                        drop_fn,
-                        [ty.into()],
-                        self.source_info.span,
-                    ),
-                    args: [Spanned { node: Operand::Move(Place::from(ref_place)), span: DUMMY_SP }]
-                        .into(),
-                    destination: unit_temp,
-                    target: Some(succ),
-                    unwind: unwind.into_action(),
-                    call_source: CallSource::Misc,
-                    fn_span: self.source_info.span,
-                },
-                source_info: self.source_info,
-            }),
-            unwind.is_cleanup(),
-        );
-
-        self.elaborator.patch().new_block(result)
+            TerminatorKind::Call {
+                func: Operand::function_handle(tcx, drop_fn, [ty.into()], self.source_info.span),
+                args: [Spanned { node: Operand::Move(Place::from(ref_place)), span: DUMMY_SP }]
+                    .into(),
+                destination: unit_temp,
+                target: Some(succ),
+                unwind: unwind.into_action(),
+                call_source: CallSource::Misc,
+                fn_span: self.source_info.span,
+            },
+        )
     }
 
     #[instrument(level = "debug", skip(self), ret)]
@@ -1078,7 +1047,8 @@ where
         let can_go = Place::from(self.new_temp(tcx.types.bool));
         let one = self.constant_usize(1);
 
-        let drop_block = BasicBlockData::new_stmts(
+        let drop_block = self.new_block_with_statements(
+            unwind,
             vec![
                 self.assign(
                     ptr,
@@ -1089,27 +1059,18 @@ where
                     Rvalue::BinaryOp(BinOp::Add, Box::new((move_(cur.into()), one))),
                 ),
             ],
-            Some(Terminator {
-                source_info: self.source_info,
-                // this gets overwritten by drop elaboration.
-                kind: TerminatorKind::Unreachable,
-            }),
-            unwind.is_cleanup(),
+            // this gets overwritten by drop elaboration.
+            TerminatorKind::Unreachable,
         );
-        let drop_block = self.elaborator.patch().new_block(drop_block);
 
-        let loop_block = BasicBlockData::new_stmts(
+        let loop_block = self.new_block_with_statements(
+            unwind,
             vec![self.assign(
                 can_go,
                 Rvalue::BinaryOp(BinOp::Eq, Box::new((copy(Place::from(cur)), copy(len.into())))),
             )],
-            Some(Terminator {
-                source_info: self.source_info,
-                kind: TerminatorKind::if_(move_(can_go), succ, drop_block),
-            }),
-            unwind.is_cleanup(),
+            TerminatorKind::if_(move_(can_go), succ, drop_block),
         );
-        let loop_block = self.elaborator.patch().new_block(loop_block);
 
         let place = tcx.mk_place_deref(ptr);
         if !unwind.is_cleanup() && self.check_if_can_async_drop(ety, false) {
@@ -1213,7 +1174,15 @@ where
         let slice_ptr_ty = Ty::new_mut_ptr(tcx, slice_ty);
         let slice_ptr = self.new_temp(slice_ptr_ty);
 
-        let mut delegate_block = BasicBlockData::new_stmts(
+        let array_place = mem::replace(
+            &mut self.place,
+            Place::from(slice_ptr).project_deeper(&[PlaceElem::Deref], tcx),
+        );
+        let slice_block = self.drop_loop_trio_for_slice(ety);
+        self.place = array_place;
+
+        self.new_block_with_statements(
+            self.unwind,
             vec![
                 self.assign(Place::from(array_ptr), Rvalue::RawPtr(RawPtrKind::Mut, self.place)),
                 self.assign(
@@ -1228,22 +1197,8 @@ where
                     ),
                 ),
             ],
-            None,
-            self.unwind.is_cleanup(),
-        );
-
-        let array_place = mem::replace(
-            &mut self.place,
-            Place::from(slice_ptr).project_deeper(&[PlaceElem::Deref], tcx),
-        );
-        let slice_block = self.drop_loop_trio_for_slice(ety);
-        self.place = array_place;
-
-        delegate_block.terminator = Some(Terminator {
-            source_info: self.source_info,
-            kind: TerminatorKind::Goto { target: slice_block },
-        });
-        self.elaborator.patch().new_block(delegate_block)
+            TerminatorKind::Goto { target: slice_block },
+        )
     }
 
     /// Creates a trio of drop-loops of `place`, which drops its contents, even
@@ -1272,7 +1227,8 @@ where
         };
 
         let zero = self.constant_usize(0);
-        let block = BasicBlockData::new_stmts(
+        let drop_block = self.new_block_with_statements(
+            unwind,
             vec![
                 self.assign(
                     len.into(),
@@ -1283,14 +1239,9 @@ where
                 ),
                 self.assign(cur.into(), Rvalue::Use(zero, WithRetag::Yes)),
             ],
-            Some(Terminator {
-                source_info: self.source_info,
-                kind: TerminatorKind::Goto { target: loop_block },
-            }),
-            unwind.is_cleanup(),
+            TerminatorKind::Goto { target: loop_block },
         );
 
-        let drop_block = self.elaborator.patch().new_block(block);
         // FIXME(#34708): handle partially-dropped array/slice elements.
         let reset_block = self.drop_flag_reset_block(DropFlagMode::Deep, drop_block, unwind);
         self.drop_flag_test_block(reset_block, self.succ, unwind)
@@ -1334,13 +1285,7 @@ where
                     self.source_info.span,
                     "open drop for unsafe binder shouldn't be encountered",
                 );
-                self.elaborator.patch().new_block(BasicBlockData::new(
-                    Some(Terminator {
-                        source_info: self.source_info,
-                        kind: TerminatorKind::Unreachable,
-                    }),
-                    self.unwind.is_cleanup(),
-                ))
+                self.new_block(self.unwind, TerminatorKind::Unreachable)
             }
 
             _ => span_bug!(self.source_info.span, "open drop from non-ADT `{:?}`", ty),
@@ -1375,21 +1320,19 @@ where
 
     #[instrument(level = "debug", skip(self), ret)]
     fn elaborated_drop_block(&mut self) -> BasicBlock {
-        let blk = self.drop_block_simple(self.succ, self.unwind);
+        let blk = self.new_block(
+            self.unwind,
+            TerminatorKind::Drop {
+                place: self.place,
+                target: self.succ,
+                unwind: self.unwind.into_action(),
+                replace: false,
+                drop: self.dropline,
+                async_fut: None,
+            },
+        );
         self.elaborate_drop(blk);
         blk
-    }
-
-    fn drop_block_simple(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
-        let block = TerminatorKind::Drop {
-            place: self.place,
-            target,
-            unwind: unwind.into_action(),
-            replace: false,
-            drop: self.dropline,
-            async_fut: None,
-        };
-        self.new_block(unwind, block)
     }
 
     fn drop_block(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
@@ -1405,15 +1348,17 @@ where
                 false,
             )
         } else {
-            let block = TerminatorKind::Drop {
-                place: self.place,
-                target,
-                unwind: unwind.into_action(),
-                replace: false,
-                drop: None,
-                async_fut: None,
-            };
-            self.new_block(unwind, block)
+            self.new_block(
+                unwind,
+                TerminatorKind::Drop {
+                    place: self.place,
+                    target,
+                    unwind: unwind.into_action(),
+                    replace: false,
+                    drop: None,
+                    async_fut: None,
+                },
+            )
         }
     }
 

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -207,6 +207,7 @@ where
     // We keep async drop unexpanded to poll-loop here, to expand it later, at StateTransform -
     //   into states expand.
     // call_destructor_only - to call only AsyncDrop::drop, not full async_drop_in_place glue
+    #[instrument(level = "debug", skip(self), ret)]
     fn build_async_drop(
         &mut self,
         place: Place<'tcx>,
@@ -565,6 +566,7 @@ where
             .collect()
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_subpath(
         &mut self,
         place: Place<'tcx>,
@@ -574,8 +576,6 @@ where
         dropline: Option<BasicBlock>,
     ) -> BasicBlock {
         if let Some(path) = path {
-            debug!("drop_subpath: for std field {:?}", place);
-
             DropCtxt {
                 elaborator: self.elaborator,
                 source_info: self.source_info,
@@ -587,8 +587,6 @@ where
             }
             .elaborated_drop_block()
         } else {
-            debug!("drop_subpath: for rest field {:?}", place);
-
             DropCtxt {
                 elaborator: self.elaborator,
                 source_info: self.source_info,
@@ -614,6 +612,7 @@ where
     /// `dropline_ladder` is a similar list of steps in reverse order,
     /// which is called if the matching step of the drop glue will contain async drop
     /// (expanded later to Yield) and the containing coroutine will be dropped at this point.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_halfladder(
         &mut self,
         unwind_ladder: &[Unwind],
@@ -679,6 +678,7 @@ where
     ///
     /// NOTE: this does not clear the master drop flag, so you need
     /// to point succ/unwind on a `drop_ladder_bottom`.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_ladder(
         &mut self,
         fields: Vec<(Place<'tcx>, Option<D::Path>)>,
@@ -686,7 +686,6 @@ where
         unwind: Unwind,
         dropline: Option<BasicBlock>,
     ) -> (BasicBlock, Unwind, Option<BasicBlock>) {
-        debug!("drop_ladder({:?}, {:?})", self, fields);
         assert!(
             if unwind.is_cleanup() { dropline.is_none() } else { true },
             "Dropline is set for cleanup drop ladder"
@@ -723,9 +722,8 @@ where
         )
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn open_drop_for_tuple(&mut self, tys: &[Ty<'tcx>]) -> BasicBlock {
-        debug!("open_drop_for_tuple({:?}, {:?})", self, tys);
-
         let fields = tys
             .iter()
             .enumerate()
@@ -994,8 +992,8 @@ where
         self.drop_flag_test_block(switch_block, succ, unwind)
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn destructor_call_block_sync(&mut self, (succ, unwind): (BasicBlock, Unwind)) -> BasicBlock {
-        debug!("destructor_call_block_sync({:?}, {:?})", self, succ);
         let tcx = self.tcx();
         let drop_trait = tcx.require_lang_item(LangItem::Drop, DUMMY_SP);
         let drop_fn = tcx.associated_item_def_ids(drop_trait)[0];
@@ -1038,11 +1036,11 @@ where
         self.elaborator.patch().new_block(result)
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn destructor_call_block(
         &mut self,
         (succ, unwind, dropline): (BasicBlock, Unwind, Option<BasicBlock>),
     ) -> BasicBlock {
-        debug!("destructor_call_block({:?}, {:?})", self, succ);
         let ty = self.place_ty(self.place);
         if !unwind.is_cleanup() && self.check_if_can_async_drop(ty, true) {
             self.build_async_drop(self.place, ty, None, succ, unwind, dropline, true)
@@ -1140,13 +1138,13 @@ where
         loop_block
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn open_drop_for_array(
         &mut self,
         array_ty: Ty<'tcx>,
         ety: Ty<'tcx>,
         opt_size: Option<u64>,
     ) -> BasicBlock {
-        debug!("open_drop_for_array({:?}, {:?}, {:?})", array_ty, ety, opt_size);
         let tcx = self.tcx();
 
         if let Some(size) = opt_size {
@@ -1250,8 +1248,8 @@ where
 
     /// Creates a trio of drop-loops of `place`, which drops its contents, even
     /// in the case of 1 panic or in the case of coroutine drop
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_loop_trio_for_slice(&mut self, ety: Ty<'tcx>) -> BasicBlock {
-        debug!("drop_loop_trio_for_slice({:?})", ety);
         let tcx = self.tcx();
         let len = self.new_temp(tcx.types.usize);
         let cur = self.new_temp(tcx.types.usize);
@@ -1349,24 +1347,21 @@ where
         }
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn complete_drop(&mut self, succ: BasicBlock, unwind: Unwind) -> BasicBlock {
-        debug!("complete_drop(succ={:?}, unwind={:?})", succ, unwind);
-
         let drop_block = self.drop_block(succ, unwind);
-
         self.drop_flag_test_block(drop_block, succ, unwind)
     }
 
     /// Creates a block that resets the drop flag. If `mode` is deep, all children drop flags will
     /// also be cleared.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_flag_reset_block(
         &mut self,
         mode: DropFlagMode,
         succ: BasicBlock,
         unwind: Unwind,
     ) -> BasicBlock {
-        debug!("drop_flag_reset_block({:?},{:?})", self, mode);
-
         if unwind.is_cleanup() {
             // The drop flag isn't read again on the unwind path, so don't
             // bother setting it.
@@ -1378,8 +1373,8 @@ where
         block
     }
 
+    #[instrument(level = "debug", skip(self), ret)]
     fn elaborated_drop_block(&mut self) -> BasicBlock {
-        debug!("elaborated_drop_block({:?})", self);
         let blk = self.drop_block_simple(self.succ, self.unwind);
         self.elaborate_drop(blk);
         blk
@@ -1432,6 +1427,7 @@ where
     /// Depending on the required `DropStyle`, this might be a generated block with an `if`
     /// terminator (for dynamic/open drops), or it might be `on_set` or `on_unset` itself, in case
     /// the drop can be statically determined.
+    #[instrument(level = "debug", skip(self), ret)]
     fn drop_flag_test_block(
         &mut self,
         on_set: BasicBlock,
@@ -1439,11 +1435,6 @@ where
         unwind: Unwind,
     ) -> BasicBlock {
         let style = self.elaborator.drop_style(self.path, DropFlagMode::Shallow);
-        debug!(
-            "drop_flag_test_block({:?},{:?},{:?},{:?}) - {:?}",
-            self, on_set, on_unset, unwind, style
-        );
-
         match style {
             DropStyle::Dead => on_unset,
             DropStyle::Static => on_set,
@@ -1455,6 +1446,7 @@ where
         }
     }
 
+    #[instrument(level = "trace", skip(self), ret)]
     fn new_block(&mut self, unwind: Unwind, k: TerminatorKind<'tcx>) -> BasicBlock {
         self.elaborator.patch().new_block(BasicBlockData::new(
             Some(Terminator { source_info: self.source_info, kind: k }),
@@ -1462,6 +1454,7 @@ where
         ))
     }
 
+    #[instrument(level = "trace", skip(self, statements), ret)]
     fn new_block_with_statements(
         &mut self,
         unwind: Unwind,

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -798,7 +798,7 @@ where
         }
 
         let skip_contents = adt.is_union() || adt.is_manually_drop();
-        let contents_drop = if skip_contents {
+        let (contents_succ, contents_unwind, contents_dropline) = if skip_contents {
             if adt.has_dtor(self.tcx()) && self.elaborator.get_drop_flag(self.path).is_some() {
                 // the top-level drop flag is usually cleared by open_drop_for_adt_contents
                 // types with destructors would still need an empty drop ladder to clear it
@@ -817,21 +817,19 @@ where
         if adt.has_dtor(self.tcx()) {
             let destructor_block = if adt.is_box() {
                 // we need to drop the inside of the box before running the destructor
-                let succ = self.destructor_call_block_sync((contents_drop.0, contents_drop.1));
-                let unwind = contents_drop
-                    .1
-                    .map(|unwind| self.destructor_call_block_sync((unwind, Unwind::InCleanup)));
-                let dropline = contents_drop
-                    .2
-                    .map(|dropline| self.destructor_call_block_sync((dropline, contents_drop.1)));
+                let succ = self.destructor_call_block_sync(contents_succ, contents_unwind);
+                let unwind = contents_unwind
+                    .map(|unwind| self.destructor_call_block_sync(unwind, Unwind::InCleanup));
+                let dropline = contents_dropline
+                    .map(|dropline| self.destructor_call_block_sync(dropline, contents_unwind));
                 self.open_drop_for_box_contents(adt, args, succ, unwind, dropline)
             } else {
-                self.destructor_call_block(contents_drop)
+                self.destructor_call_block(contents_succ, contents_unwind, contents_dropline)
             };
 
-            self.drop_flag_test_block(destructor_block, contents_drop.0, contents_drop.1)
+            self.drop_flag_test_block(destructor_block, contents_succ, contents_unwind)
         } else {
-            contents_drop.0
+            contents_succ
         }
     }
 
@@ -993,7 +991,7 @@ where
     }
 
     #[instrument(level = "debug", skip(self), ret)]
-    fn destructor_call_block_sync(&mut self, (succ, unwind): (BasicBlock, Unwind)) -> BasicBlock {
+    fn destructor_call_block_sync(&mut self, succ: BasicBlock, unwind: Unwind) -> BasicBlock {
         let tcx = self.tcx();
         let drop_trait = tcx.require_lang_item(LangItem::Drop, DUMMY_SP);
         let drop_fn = tcx.associated_item_def_ids(drop_trait)[0];
@@ -1039,13 +1037,15 @@ where
     #[instrument(level = "debug", skip(self), ret)]
     fn destructor_call_block(
         &mut self,
-        (succ, unwind, dropline): (BasicBlock, Unwind, Option<BasicBlock>),
+        succ: BasicBlock,
+        unwind: Unwind,
+        dropline: Option<BasicBlock>,
     ) -> BasicBlock {
         let ty = self.place_ty(self.place);
         if !unwind.is_cleanup() && self.check_if_can_async_drop(ty, true) {
             self.build_async_drop(self.place, ty, None, succ, unwind, dropline, true)
         } else {
-            self.destructor_call_block_sync((succ, unwind))
+            self.destructor_call_block_sync(succ, unwind)
         }
     }
 

--- a/compiler/rustc_passes/src/eii.rs
+++ b/compiler/rustc_passes/src/eii.rs
@@ -18,8 +18,8 @@ enum CheckingMode {
 }
 
 fn get_checking_mode(tcx: TyCtxt<'_>) -> CheckingMode {
-    // if any of the crate types is not rlib or dylib, we must check for existence.
-    if tcx.crate_types().iter().any(|i| !matches!(i, CrateType::Rlib | CrateType::Dylib)) {
+    // if any of the crate types is not rlib, we must check for existence.
+    if tcx.crate_types().iter().any(|i| !matches!(i, CrateType::Rlib)) {
         CheckingMode::CheckExistence
     } else {
         CheckingMode::CheckDuplicates

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3591,6 +3591,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                         this.check_trait_item(
                                             item.id,
                                             *ident,
+                                            *ident,
                                             &item.kind,
                                             ValueNS,
                                             item.span,
@@ -3635,7 +3636,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 );
                 self.resolve_define_opaques(define_opaque);
             }
-            AssocItemKind::Fn(Fn { ident, generics, define_opaque, .. }) => {
+            AssocItemKind::Fn(fn_kind @ Fn { ident, generics, define_opaque, .. }) => {
                 debug!("resolve_implementation AssocItemKind::Fn");
                 // We also need a new scope for the impl item type parameters.
                 self.with_generic_param_rib(
@@ -3645,10 +3646,16 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     LifetimeBinderKind::Function,
                     generics.span,
                     |this| {
+                        let effective_ident = if is_in_trait_impl && fn_kind.is_pin_drop_sugar() {
+                            Ident::new(sym::pin_drop, ident.span)
+                        } else {
+                            *ident
+                        };
                         // If this is a trait impl, ensure the method
                         // exists in trait
                         this.check_trait_item(
                             item.id,
+                            effective_ident,
                             *ident,
                             &item.kind,
                             ValueNS,
@@ -3680,6 +3687,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                             this.check_trait_item(
                                 item.id,
                                 *ident,
+                                *ident,
                                 &item.kind,
                                 TypeNS,
                                 item.span,
@@ -3705,6 +3713,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                         this.check_trait_item(
                             item.id,
                             delegation.ident,
+                            delegation.ident,
                             &item.kind,
                             ValueNS,
                             item.span,
@@ -3729,6 +3738,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         &mut self,
         id: NodeId,
         mut ident: Ident,
+        mut reported_ident: Ident,
         kind: &AssocItemKind,
         ns: Namespace,
         span: Span,
@@ -3742,6 +3752,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             return;
         };
         ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
+        reported_ident.span.normalize_to_macros_2_0_and_adjust(module.expansion);
         let key = BindingKey::new(IdentKey::new(ident), ns);
         let mut decl = self.r.resolution(module, key).and_then(|r| r.best_decl());
         debug!(?decl);
@@ -3777,10 +3788,10 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
         let Some(decl) = decl else {
             // We could not find the method: report an error.
-            let candidate = self.find_similarly_named_assoc_item(ident.name, kind);
+            let candidate = self.find_similarly_named_assoc_item(reported_ident.name, kind);
             let path = &self.current_trait_ref.as_ref().unwrap().1.path;
             let path_names = path_names_to_string(path);
-            self.report_error(span, err(ident, path_names, candidate));
+            self.report_error(span, err(reported_ident, path_names, candidate));
             feed_visibility(self, module.def_id());
             return;
         };

--- a/compiler/rustc_target/src/spec/base/wasm.rs
+++ b/compiler/rustc_target/src/spec/base/wasm.rs
@@ -118,6 +118,13 @@ pub(crate) fn options() -> TargetOptions {
         // with unwinding.
         llvm_args: cvs!["-wasm-use-legacy-eh=false"],
 
+        // WASI's `sys::args::init` function ignores its arguments; instead,
+        // `args::args()` makes the WASI API calls itself.
+        //
+        // Other Wasm targets make no use of `std::env` entirely.
+        // Emscripten enables it explicitly.
+        main_needs_argc_argv: false,
+
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_unknown_emscripten.rs
@@ -28,6 +28,7 @@ pub(crate) fn target() -> Target {
         crt_static_respected: true,
         crt_static_default: true,
         crt_static_allows_dylibs: true,
+        main_needs_argc_argv: true,
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         families: cvs!["unix", "wasm"],

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1.rs
@@ -41,10 +41,6 @@ pub(crate) fn target() -> Target {
     // without a main function.
     options.crt_static_allows_dylibs = true;
 
-    // WASI's `sys::args::init` function ignores its arguments; instead,
-    // `args::args()` makes the WASI API calls itself.
-    options.main_needs_argc_argv = false;
-
     // And, WASI mangles the name of "main" to distinguish between different
     // signatures.
     options.entry_name = "__main_void".into();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -52,10 +52,6 @@ pub(crate) fn target() -> Target {
     // without a main function.
     options.crt_static_allows_dylibs = true;
 
-    // WASI's `sys::args::init` function ignores its arguments; instead,
-    // `args::args()` makes the WASI API calls itself.
-    options.main_needs_argc_argv = false;
-
     // And, WASI mangles the name of "main" to distinguish between different
     // signatures.
     options.entry_name = "__main_void".into();

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
@@ -46,10 +46,6 @@ pub(crate) fn target() -> Target {
     // without a main function.
     options.crt_static_allows_dylibs = true;
 
-    // WASI's `sys::args::init` function ignores its arguments; instead,
-    // `args::args()` makes the WASI API calls itself.
-    options.main_needs_argc_argv = false;
-
     // And, WASI mangles the name of "main" to distinguish between different
     // signatures.
     options.entry_name = "__main_void".into();

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -308,7 +308,10 @@ impl str {
     pub fn replace<P: Pattern>(&self, from: P, to: &str) -> String {
         // Fast path for replacing a single ASCII character with another.
         if let Some(from_byte) = match from.as_utf8_pattern() {
-            Some(Utf8Pattern::StringPattern([from_byte])) => Some(*from_byte),
+            Some(Utf8Pattern::StringPattern(s)) => match s.as_bytes() {
+                [from_byte] => Some(*from_byte),
+                _ => None,
+            },
             Some(Utf8Pattern::CharPattern(c)) => c.as_ascii().map(|ascii_char| ascii_char.to_u8()),
             _ => None,
         } {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2654,7 +2654,7 @@ impl<'b> Pattern for &'b String {
 
     #[inline]
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-        Some(Utf8Pattern::StringPattern(self.as_bytes()))
+        Some(Utf8Pattern::StringPattern(self.as_str()))
     }
 }
 

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -161,7 +161,7 @@ pub trait Pattern: Sized {
         }
     }
 
-    /// Returns the pattern as utf-8 bytes if possible.
+    /// Returns the pattern as UTF-8 if possible.
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
         None
     }
@@ -172,7 +172,9 @@ pub trait Pattern: Sized {
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Utf8Pattern<'a> {
     /// Type returned by String and str types.
-    StringPattern(&'a [u8]),
+    /// This stores `str` rather than bytes so callers cannot describe
+    /// non-UTF-8 string patterns through this API.
+    StringPattern(&'a str),
     /// Type returned by char types.
     CharPattern(char),
 }
@@ -1049,7 +1051,7 @@ impl<'b> Pattern for &'b str {
 
     #[inline]
     fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-        Some(Utf8Pattern::StringPattern(self.as_bytes()))
+        Some(Utf8Pattern::StringPattern(*self))
     }
 }
 

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -689,7 +689,7 @@ pub fn home_dir() -> Option<PathBuf> {
 /// [GetTempPath]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha
 /// [appledoc]: https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/Articles/RaceConditions.html#//apple_ref/doc/uid/TP40002585-SW10
 ///
-/// ```no_run
+/// ```
 /// use std::env;
 ///
 /// fn main() {

--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -1,5 +1,8 @@
-use rustc_ast::visit::{Visitor, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt, walk_ty};
-use rustc_ast::{Crate, Expr, Item, Pat, Stmt, Ty};
+use rustc_ast::visit::{
+    AssocCtxt, Visitor, walk_assoc_item, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt,
+    walk_ty,
+};
+use rustc_ast::{AssocItem, Crate, Expr, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -159,6 +162,16 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             self.handle_new_span(ty.span, || rustc_ast_pretty::pprust::ty_to_string(ty));
         } else {
             walk_ty(self, ty);
+        }
+    }
+
+    fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) -> Self::Result {
+        if item.span.from_expansion() {
+            self.handle_new_span(item.span, || {
+                rustc_ast_pretty::pprust::assoc_item_to_string(item)
+            });
+        } else {
+            walk_assoc_item(self, item, ctxt);
         }
     }
 }

--- a/tests/assembly-llvm/wasm_legacy_eh.rs
+++ b/tests/assembly-llvm/wasm_legacy_eh.rs
@@ -1,0 +1,80 @@
+//@ only-wasm32
+//@ assembly-output: emit-asm
+//@ compile-flags: -C target-feature=+exception-handling
+//@ compile-flags: -C panic=unwind
+//@ compile-flags: -C llvm-args=-wasm-use-legacy-eh=true
+
+// Verifies that user-supplied `-Cllvm-args` can override an LLVM argument that
+// was set in the target spec. The `wasm32-unknown-unknown` target spec pins
+// `-wasm-use-legacy-eh=false`; this test asserts that passing the opposite
+// value via `-Cllvm-args` switches code generation back to the legacy
+// exception-handling instructions.
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+extern "C-unwind" {
+    fn may_panic();
+}
+
+extern "C" {
+    fn log_number(number: usize);
+}
+
+struct LogOnDrop;
+
+impl Drop for LogOnDrop {
+    fn drop(&mut self) {
+        unsafe {
+            log_number(0);
+        }
+    }
+}
+
+// CHECK-LABEL: test_cleanup:
+#[no_mangle]
+pub fn test_cleanup() {
+    let _log_on_drop = LogOnDrop;
+    unsafe {
+        may_panic();
+    }
+
+    // CHECK-NOT: try_table
+    // CHECK-NOT: catch_all_ref
+    // CHECK-NOT: throw_ref
+    // CHECK-NOT: call
+    // CHECK: try
+    // CHECK: call may_panic
+    // CHECK: catch_all
+    // CHECK: rethrow
+    // CHECK: end_try
+}
+
+// CHECK-LABEL: test_rtry:
+#[no_mangle]
+pub fn test_rtry() {
+    unsafe {
+        core::intrinsics::catch_unwind(
+            |_| {
+                may_panic();
+            },
+            core::ptr::null_mut(),
+            |data, exception| {
+                log_number(data as usize);
+                log_number(exception as usize);
+            },
+        );
+    }
+
+    // CHECK-NOT: try_table
+    // CHECK-NOT: catch_all_ref
+    // CHECK-NOT: throw_ref
+    // CHECK-NOT: call
+    // CHECK: try
+    // CHECK: call may_panic
+    // CHECK: catch
+    // CHECK: call log_number
+    // CHECK: call log_number
+    // CHECK-NOT: rethrow
+    // CHECK: end_try
+}

--- a/tests/coverage/macros/context-mismatch-issue-147339.cov-map
+++ b/tests/coverage/macros/context-mismatch-issue-147339.cov-map
@@ -1,40 +1,20 @@
-Function name: context_mismatch_issue_147339::a (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
+Function name: context_mismatch_issue_147339::_function (unused)
+Raw bytes (14): 0x[01, 01, 00, 02, 00, 14, 11, 00, 26, 00, 02, 11, 00, 12]
 Number of files: 1
 - file 0 => $DIR/context-mismatch-issue-147339.rs
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
-- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
-Highest counter ID seen: (none)
-
-Function name: context_mismatch_issue_147339::b (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
-Number of files: 1
-- file 0 => $DIR/context-mismatch-issue-147339.rs
-Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
-- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
-Highest counter ID seen: (none)
-
-Function name: context_mismatch_issue_147339::c (unused)
-Raw bytes (14): 0x[01, 01, 00, 02, 00, 0c, 27, 00, 35, 00, 00, 3b, 00, 3c]
-Number of files: 1
-- file 0 => $DIR/context-mismatch-issue-147339.rs
-Number of expressions: 0
-Number of file 0 mappings: 2
-- Code(Zero) at (prev + 12, 39) to (start + 0, 53)
-- Code(Zero) at (prev + 0, 59) to (start + 0, 60)
+- Code(Zero) at (prev + 20, 17) to (start + 0, 38)
+- Code(Zero) at (prev + 2, 17) to (start + 0, 18)
 Highest counter ID seen: (none)
 
 Function name: context_mismatch_issue_147339::main
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 14, 01, 00, 0a, 01, 00, 0c, 00, 0d]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 1f, 01, 00, 0a, 01, 00, 0c, 00, 0d]
 Number of files: 1
 - file 0 => $DIR/context-mismatch-issue-147339.rs
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 20, 1) to (start + 0, 10)
+- Code(Counter(0)) at (prev + 31, 1) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 12) to (start + 0, 13)
 Highest counter ID seen: c0
 

--- a/tests/coverage/macros/context-mismatch-issue-147339.coverage
+++ b/tests/coverage/macros/context-mismatch-issue-147339.coverage
@@ -6,23 +6,27 @@
    LL|       |//
    LL|       |// Reported in <https://github.com/rust-lang/rust/issues/147339>.
    LL|       |
-   LL|       |macro_rules! foo {
-   LL|       |    ($($m:ident $($f:ident $v:tt)+),*) => {
-   LL|       |        $($(macro_rules! $f { () => { $v } })+)*
-   LL|      0|        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
-  ------------------
-  | Unexecuted instantiation: context_mismatch_issue_147339::a
-  ------------------
-  | Unexecuted instantiation: context_mismatch_issue_147339::b
-  ------------------
-  | Unexecuted instantiation: context_mismatch_issue_147339::c
-  ------------------
-   LL|       |    }
+   LL|       |macro_rules! outer_macro {
+   LL|       |    (
+   LL|       |        $v:tt
+   LL|       |    ) => {
+   LL|       |        macro_rules! _other_macro_that_mentions_v {
+   LL|       |            () => {
+   LL|       |                $v
+   LL|       |            };
+   LL|       |        }
+   LL|       |        macro_rules! inner_macro {
+   LL|       |            () => {
+   LL|      0|                fn _function() -> i32 {
+   LL|       |                    $v
+   LL|      0|                }
+   LL|       |            };
+   LL|       |        }
+   LL|       |    };
    LL|       |}
    LL|       |
-   LL|       |foo!(m a 1 b 2, n c 3);
-   LL|       |m!();
-   LL|       |n!();
+   LL|       |outer_macro!(1);
+   LL|       |inner_macro!();
    LL|       |
    LL|      1|fn main() {}
 

--- a/tests/coverage/macros/context-mismatch-issue-147339.rs
+++ b/tests/coverage/macros/context-mismatch-issue-147339.rs
@@ -6,15 +6,26 @@
 //
 // Reported in <https://github.com/rust-lang/rust/issues/147339>.
 
-macro_rules! foo {
-    ($($m:ident $($f:ident $v:tt)+),*) => {
-        $($(macro_rules! $f { () => { $v } })+)*
-        $(macro_rules! $m { () => { $(fn $f() -> i32 { $v })+ } })*
-    }
+macro_rules! outer_macro {
+    (
+        $v:tt
+    ) => {
+        macro_rules! _other_macro_that_mentions_v {
+            () => {
+                $v
+            };
+        }
+        macro_rules! inner_macro {
+            () => {
+                fn _function() -> i32 {
+                    $v
+                }
+            };
+        }
+    };
 }
 
-foo!(m a 1 b 2, n c 3);
-m!();
-n!();
+outer_macro!(1);
+inner_macro!();
 
 fn main() {}

--- a/tests/rustdoc-html/macro-expansion/assoc-items-decl-macro.rs
+++ b/tests/rustdoc-html/macro-expansion/assoc-items-decl-macro.rs
@@ -1,0 +1,24 @@
+// Ensure assoc items work for decl macros.
+// Regression test for <https://github.com/rust-lang/rust/issues/156075>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+#![feature(decl_macro)]
+
+//@ has 'src/foo/assoc-items-decl-macro.rs.html'
+
+pub macro first() {
+    type P1 = bool;
+    fn u1() {}
+}
+
+trait C1 {
+    type P1;
+    fn u1();
+}
+
+impl C1 for u32 {
+    //@ matches - '//*[@class="expansion"]/*[@class="expanded"]' 'type P1 = bool;\nfn u1\(\) {}'
+    first!();
+}

--- a/tests/rustdoc-html/macro-expansion/assoc-items-macro.rs
+++ b/tests/rustdoc-html/macro-expansion/assoc-items-macro.rs
@@ -1,0 +1,25 @@
+// Ensure assoc items work for macro rules.
+// Regression test for <https://github.com/rust-lang/rust/issues/156075>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/assoc-items-macro.rs.html'
+
+macro_rules! first {
+    () => {
+        type P1 = bool;
+        fn u1() {}
+    }
+}
+
+trait C1 {
+    type P1;
+    fn u1();
+}
+
+impl C1 for u32 {
+    //@ matches - '//*[@class="expansion"]/*[@class="expanded"]' 'type P1 = bool;\nfn u1\(\) {}'
+    first!();
+}

--- a/tests/rustdoc-ui/not-wf-ambiguous-normalization.stderr
+++ b/tests/rustdoc-ui/not-wf-ambiguous-normalization.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
   --> $DIR/not-wf-ambiguous-normalization.rs:14:6
    |
 LL | impl<T> Allocator for DefaultAllocator {
-   |      ^ unconstrained type parameter
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `T`
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/unconstrained-param-in-impl-ambiguity.stderr
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/unconstrained-param-in-impl-ambiguity.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `Q` is not constrained by the impl trait, self 
   --> $DIR/unconstrained-param-in-impl-ambiguity.rs:7:13
    |
 LL | unsafe impl<Q: Trait> Send for Inner {}
-   |             ^ unconstrained type parameter
+   |            -^--------
+   |            ||
+   |            |unconstrained type parameter
+   |            help: remove the unused type parameter `Q`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-inherent-types/hr-do-not-blame-outlives-static-ice.stderr
+++ b/tests/ui/associated-inherent-types/hr-do-not-blame-outlives-static-ice.stderr
@@ -3,6 +3,13 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Foo<fn(&())> {
    |      ^^ unconstrained lifetime parameter
+   |
+help: use the lifetime parameter `'a` in the `Foo` type and use it in the type definition
+   |
+LL ~ struct Foo<T, 'a>(T);
+LL |
+LL ~ impl<'a> Foo<fn(&()), 'a> {
+   |
 
 error[E0308]: mismatched types
   --> $DIR/hr-do-not-blame-outlives-static-ice.rs:13:11

--- a/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.stderr
+++ b/tests/ui/associated-inherent-types/inherent-assoc-ty-mismatch-issue-153539.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `X` is not constrained by the impl trait, self 
   --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:9:6
    |
 LL | impl<X> S<'_> {
-   |      ^ unconstrained type parameter
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `X`
 
 error[E0308]: mismatched types
   --> $DIR/inherent-assoc-ty-mismatch-issue-153539.rs:17:5

--- a/tests/ui/associated-inherent-types/next-solver-opaque-inherent-fn-ptr-issue-155204.stderr
+++ b/tests/ui/associated-inherent-types/next-solver-opaque-inherent-fn-ptr-issue-155204.stderr
@@ -27,7 +27,10 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
   --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:7:6
    |
 LL | impl<T> Windows<fn(&())> {
-   |      ^ unconstrained type parameter
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `T`
 
 error[E0282]: type annotations needed
   --> $DIR/next-solver-opaque-inherent-fn-ptr-issue-155204.rs:12:22

--- a/tests/ui/associated-inherent-types/next-solver-opaque-inherent-no-ice.stderr
+++ b/tests/ui/associated-inherent-types/next-solver-opaque-inherent-no-ice.stderr
@@ -24,7 +24,10 @@ error[E0207]: the const parameter `X` is not constrained by the impl trait, self
   --> $DIR/next-solver-opaque-inherent-no-ice.rs:6:6
    |
 LL | impl<const X: y> Foo {
-   |      ^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `X`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/associated-types/issue-26262.stderr
+++ b/tests/ui/associated-types/issue-26262.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: Tr> S<T::Assoc> {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `S` type and use it in the type definition
+   |
+LL ~ struct S<T, T>(T);
+LL |
+LL | trait Tr { type Assoc; fn test(); }
+LL |
+LL ~ impl<T: Tr> S<T::Assoc, T> {
+   |
 
 error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, self type, or predicates
   --> $DIR/issue-26262.rs:17:6

--- a/tests/ui/associated-types/unconstrained-lifetime-assoc-type.stderr
+++ b/tests/ui/associated-types/unconstrained-lifetime-assoc-type.stderr
@@ -3,6 +3,15 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Fun for Holder {
    |      ^^ unconstrained lifetime parameter
+   |
+help: use the lifetime parameter `'a` in the `Holder` type and use it in the type definition
+   |
+LL ~ struct Holder<'a> {
+LL |     x: String,
+LL | }
+LL |
+LL ~ impl<'a> Fun for Holder<'a> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/issues/issue-78654.full.stderr
+++ b/tests/ui/async-await/issues/issue-78654.full.stderr
@@ -8,7 +8,10 @@ error[E0207]: the const parameter `H` is not constrained by the impl trait, self
   --> $DIR/issue-78654.rs:9:6
    |
 LL | impl<const H: feature> Foo {
-   |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `H`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/async-await/issues/issue-78654.min.stderr
+++ b/tests/ui/async-await/issues/issue-78654.min.stderr
@@ -8,7 +8,10 @@ error[E0207]: the const parameter `H` is not constrained by the impl trait, self
   --> $DIR/issue-78654.rs:9:6
    |
 LL | impl<const H: feature> Foo {
-   |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `H`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/const-generics/adt_const_params/unsized-anon-const-err-2.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsized-anon-const-err-2.stderr
@@ -37,7 +37,10 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
   --> $DIR/unsized-anon-const-err-2.rs:13:6
    |
 LL | impl<const N: i32> Copy for S<A> {}
-   |      ^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `N`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
@@ -46,7 +49,10 @@ error[E0207]: the const parameter `M` is not constrained by the impl trait, self
   --> $DIR/unsized-anon-const-err-2.rs:16:6
    |
 LL | impl<const M: usize> Copy for S<A> {}
-   |      ^^^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `M`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.stderr
@@ -24,7 +24,10 @@ error[E0207]: the const parameter `NUM` is not constrained by the impl trait, se
   --> $DIR/post-analysis-user-facing-param-env.rs:5:10
    |
 LL | impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
-   |          ^^^^^^^^^^^^^^^^ unconstrained const parameter
+   |        --^^^^^^^^^^^^^^^^
+   |        | |
+   |        | unconstrained const parameter
+   |        help: remove the unused type parameter `NUM`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
+++ b/tests/ui/const-generics/ice-unexpected-inference-var-122549.stderr
@@ -71,6 +71,14 @@ LL | impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}> {
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
+help: use the type parameter `N` in the `ConstChunksExact` type and use it in the type definition
+   |
+LL ~ struct ConstChunksExact<'rem, T: 'a, const N: usize, N> {}
+LL |
+LL |
+LL |
+LL ~ impl<'a, T, const N: usize> Iterator for ConstChunksExact<'a, T, {}, N> {
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/const-generics/issues/issue-68366.full.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.full.stderr
@@ -14,7 +14,10 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
   --> $DIR/issue-68366.rs:12:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
-   |       ^^^^^^^^^^^^^^ unconstrained const parameter
+   |      -^^^^^^^^^^^^^^-
+   |      ||
+   |      |unconstrained const parameter
+   |      help: remove the unused type parameter `N`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
@@ -23,7 +26,10 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
   --> $DIR/issue-68366.rs:19:6
    |
 LL | impl<const N: usize> Foo {}
-   |      ^^^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `N`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -23,7 +23,10 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
   --> $DIR/issue-68366.rs:12:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
-   |       ^^^^^^^^^^^^^^ unconstrained const parameter
+   |      -^^^^^^^^^^^^^^-
+   |      ||
+   |      |unconstrained const parameter
+   |      help: remove the unused type parameter `N`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
@@ -32,7 +35,10 @@ error[E0207]: the const parameter `N` is not constrained by the impl trait, self
   --> $DIR/issue-68366.rs:19:6
    |
 LL | impl<const N: usize> Foo {}
-   |      ^^^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `N`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/const-generics/normalizing_with_unconstrained_impl_params.stderr
+++ b/tests/ui/const-generics/normalizing_with_unconstrained_impl_params.stderr
@@ -53,6 +53,14 @@ LL | impl<'a, T: std::fmt::Debug, const N: usize> Iterator for ConstChunksExact<
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
+help: use the type parameter `N` in the `ConstChunksExact` type and use it in the type definition
+   |
+LL ~ struct ConstChunksExact<'a, T: '_, const assert: usize, N> {}
+LL |
+LL |
+LL |
+LL ~ impl<'a, T: std::fmt::Debug, const N: usize> Iterator for ConstChunksExact<'a, T, {}, N> {
+   |
 
 error[E0308]: mismatched types
   --> $DIR/normalizing_with_unconstrained_impl_params.rs:6:27

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.rs
@@ -1,3 +1,5 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
 #![feature(fn_delegation)]
 
 trait Bound<T> {}
@@ -19,12 +21,16 @@ reuse <usize as Trait>::static_method::<'static, Vec<i32>, false> as bar2;
 
 reuse Trait::static_method as error { self - 123 }
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 reuse Trait::<'static, i32, 123>::static_method as error2;
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
 //~^ ERROR: type annotations needed
+//~| ERROR: delegation self type is not specified
 
 reuse <String as Trait>::static_method as error5;
 //~^ ERROR: the trait bound `String: Trait<'a, T, X>` is not satisfied

--- a/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
+++ b/tests/ui/delegation/generics/free-to-trait-static-reuse.stderr
@@ -1,21 +1,53 @@
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:22:14
+   |
+LL | reuse Trait::static_method as error { self - 123 }
+   |              ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:25:35
+   |
+LL | reuse Trait::<'static, i32, 123>::static_method as error2;
+   |                                   ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:28:35
+   |
+LL | reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
+   |                                   ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: delegation self type is not specified
+  --> $DIR/free-to-trait-static-reuse.rs:31:14
+   |
+LL | reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
+   |              ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:33:49
+  --> $DIR/free-to-trait-static-reuse.rs:39:49
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    |                                                 ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-static-reuse.rs:32:1
+  --> $DIR/free-to-trait-static-reuse.rs:38:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:15:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait`
-  --> $DIR/free-to-trait-static-reuse.rs:7:11
+  --> $DIR/free-to-trait-static-reuse.rs:9:11
    |
 LL | trait Trait<'a, T, const X: usize>
    |       ----- required by a bound in this trait
@@ -24,13 +56,13 @@ LL |     Self: Bound<T>,
    |           ^^^^^^^^ required by this bound in `Trait`
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:20:14
+  --> $DIR/free-to-trait-static-reuse.rs:22:14
    |
 LL | reuse Trait::static_method as error { self - 123 }
    |              ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +71,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:22:35
+  --> $DIR/free-to-trait-static-reuse.rs:25:35
    |
 LL | reuse Trait::<'static, i32, 123>::static_method as error2;
    |                                   ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +86,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:24:35
+  --> $DIR/free-to-trait-static-reuse.rs:28:35
    |
 LL | reuse Trait::<'static, i32, 123>::static_method::<'static, String, false> as error3;
    |                                   ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'static, i32, 123>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +101,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/free-to-trait-static-reuse.rs:26:14
+  --> $DIR/free-to-trait-static-reuse.rs:31:14
    |
 LL | reuse Trait::static_method::<'static, Vec<i32>, false> as error4 { self + 4 }
    |              ^^^^^^^^^^^^^ cannot infer type
    |
 note: multiple `impl`s satisfying `_: Trait<'a, T, X>` found
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +116,13 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `String: Trait<'a, T, X>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:29:8
+  --> $DIR/free-to-trait-static-reuse.rs:35:8
    |
 LL | reuse <String as Trait>::static_method as error5;
    |        ^^^^^^ the trait `Trait<'a, T, X>` is not implemented for `String`
    |
 help: the following other types implement trait `Trait<'a, T, X>`
-  --> $DIR/free-to-trait-static-reuse.rs:12:1
+  --> $DIR/free-to-trait-static-reuse.rs:14:1
    |
 LL | impl<'a, T, const X: usize> Trait<'a, T, X> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize`
@@ -99,23 +131,23 @@ LL | impl<'a, T, const X: usize> Trait<'a, T, X> for Struct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Struct`
 
 error[E0277]: the trait bound `Struct: Bound<T>` is not satisfied
-  --> $DIR/free-to-trait-static-reuse.rs:36:8
+  --> $DIR/free-to-trait-static-reuse.rs:42:8
    |
 LL | reuse <Struct as Trait>::static_method as error6;
    |        ^^^^^^ unsatisfied trait bound
    |
 help: the trait `Bound<T>` is not implemented for `Struct`
-  --> $DIR/free-to-trait-static-reuse.rs:32:1
+  --> $DIR/free-to-trait-static-reuse.rs:38:1
    |
 LL | struct Struct;
    | ^^^^^^^^^^^^^
 help: the trait `Bound<T>` is implemented for `usize`
-  --> $DIR/free-to-trait-static-reuse.rs:13:1
+  --> $DIR/free-to-trait-static-reuse.rs:15:1
    |
 LL | impl<T> Bound<T> for usize {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `Trait::static_method`
-  --> $DIR/free-to-trait-static-reuse.rs:7:11
+  --> $DIR/free-to-trait-static-reuse.rs:9:11
    |
 LL |     Self: Bound<T>,
    |           ^^^^^^^^ required by this bound in `Trait::static_method`
@@ -123,7 +155,7 @@ LL | {
 LL |     fn static_method<'c: 'c, U, const B: bool>(x: usize) {}
    |        ------------- required by a bound in this associated function
 
-error: aborting due to 7 previous errors
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0277, E0283.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/delegation/self-ty-ice-156388.rs
+++ b/tests/ui/delegation/self-ty-ice-156388.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
+#![feature(fn_delegation)]
+
+reuse Default::default;
+//~^ ERROR: delegation self type is not specified
+
+fn main() {}

--- a/tests/ui/delegation/self-ty-ice-156388.stderr
+++ b/tests/ui/delegation/self-ty-ice-156388.stderr
@@ -1,0 +1,10 @@
+error: delegation self type is not specified
+  --> $DIR/self-ty-ice-156388.rs:5:16
+   |
+LL | reuse Default::default;
+   |                ^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -1,3 +1,5 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
 #![feature(fn_delegation)]
 
 trait Trait {
@@ -14,6 +16,7 @@ fn foo(x: i32) -> i32 { x }
 fn bar<T: Default>(_: T) {
     reuse Trait::static_method {
     //~^ ERROR mismatched types
+    //~| ERROR: delegation self type is not specified
         let _ = T::Default();
         //~^ ERROR can't use generic parameters from outer item
     }

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -1,18 +1,18 @@
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/target-expr.rs:17:17
+  --> $DIR/target-expr.rs:20:17
    |
 LL | fn bar<T: Default>(_: T) {
    |        - type parameter from outer item
 LL |     reuse Trait::static_method {
    |                  ------------- generic parameter used in this inner delegated function
-LL |
+...
 LL |         let _ = T::Default();
    |                 ^ use of generic parameter from outer item
    |
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0434]: can't capture dynamic environment in a fn item
-  --> $DIR/target-expr.rs:25:17
+  --> $DIR/target-expr.rs:28:17
    |
 LL |         let x = y;
    |                 ^
@@ -20,7 +20,7 @@ LL |         let x = y;
    = help: use the `|| { ... }` closure form instead
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/target-expr.rs:32:5
+  --> $DIR/target-expr.rs:35:5
    |
 LL | fn main() {
    |    ---- this function can't have a `self` parameter
@@ -29,29 +29,38 @@ LL |     self.0;
    |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/target-expr.rs:34:13
+  --> $DIR/target-expr.rs:37:13
    |
 LL |     let z = x;
    |             ^
    |
 help: the binding `x` is available in a different scope in the same function
-  --> $DIR/target-expr.rs:25:13
+  --> $DIR/target-expr.rs:28:13
    |
 LL |         let x = y;
    |             ^
 
+error: delegation self type is not specified
+  --> $DIR/target-expr.rs:17:18
+   |
+LL |     reuse Trait::static_method {
+   |                  ^^^^^^^^^^^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
 error[E0308]: mismatched types
-  --> $DIR/target-expr.rs:15:32
+  --> $DIR/target-expr.rs:17:32
    |
 LL |       reuse Trait::static_method {
    |  ________________________________^
+LL | |
 LL | |
 LL | |         let _ = T::Default();
 LL | |
 LL | |     }
    | |_____^ expected `i32`, found `()`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0308, E0401, E0424, E0425, E0434.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/delegation/unsupported.current.stderr
+++ b/tests/ui/delegation/unsupported.current.stderr
@@ -1,41 +1,49 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:29:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:29:25
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:29:25
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:32:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:32:24
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:32:24
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 2 previous errors
+error: delegation self type is not specified
+  --> $DIR/unsupported.rs:54:18
+   |
+LL |     reuse Trait::foo;
+   |                  ^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/delegation/unsupported.next.stderr
+++ b/tests/ui/delegation/unsupported.next.stderr
@@ -1,41 +1,49 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:29:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:29:25
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:28:5: 28:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:29:25
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:30:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`
-  --> $DIR/unsupported.rs:32:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:32:24
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:31:5: 31:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:32:24
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
+note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+  --> $DIR/unsupported.rs:33:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 2 previous errors
+error: delegation self type is not specified
+  --> $DIR/unsupported.rs:54:18
+   |
+LL |     reuse Trait::foo;
+   |                  ^^^
+   |
+   = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/tests/ui/delegation/unsupported.rs
+++ b/tests/ui/delegation/unsupported.rs
@@ -1,3 +1,4 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
@@ -51,6 +52,7 @@ mod effects {
     }
 
     reuse Trait::foo;
+    //~^ ERROR: delegation self type is not specified
 }
 
 fn main() {}

--- a/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
+++ b/tests/ui/dropck/unconstrained_const_param_on_drop.stderr
@@ -22,7 +22,10 @@ error[E0207]: the const parameter `UNUSED` is not constrained by the impl trait,
   --> $DIR/unconstrained_const_param_on_drop.rs:3:6
    |
 LL | impl<const UNUSED: usize> Drop for Foo {}
-   |      ^^^^^^^^^^^^^^^^^^^ unconstrained const parameter
+   |     -^^^^^^^^^^^^^^^^^^^-
+   |     ||
+   |     |unconstrained const parameter
+   |     help: remove the unused type parameter `UNUSED`
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/tests/ui/eii/dylib_needs_impl.rs
+++ b/tests/ui/eii/dylib_needs_impl.rs
@@ -1,0 +1,7 @@
+//@ no-prefer-dynamic
+//@ needs-crate-type: dylib
+#![crate_type = "dylib"]
+#![feature(extern_item_impls)]
+
+#[eii(eii1)] //~ ERROR `#[eii1]` required, but not found
+fn decl1(x: u64);

--- a/tests/ui/eii/dylib_needs_impl.stderr
+++ b/tests/ui/eii/dylib_needs_impl.stderr
@@ -1,0 +1,10 @@
+error: `#[eii1]` required, but not found
+  --> $DIR/dylib_needs_impl.rs:6:7
+   |
+LL | #[eii(eii1)]
+   |       ^^^^ expected because `#[eii1]` was declared here in crate `dylib_needs_impl`
+   |
+   = help: expected at least one implementation in crate `dylib_needs_impl` or any of its dependencies
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/error-codes/E0207.stderr
+++ b/tests/ui/error-codes/E0207.stderr
@@ -3,6 +3,13 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: Default> Foo {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Foo` type and use it in the type definition
+   |
+LL ~ struct Foo<T>;
+LL |
+LL ~ impl<T: Default> Foo<T> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -17,6 +17,14 @@ impl Drop for Foo {
     //~^ ERROR use of unstable library feature `pin_ergonomics` [E0658]
 }
 
+struct Sugar;
+
+impl Drop for Sugar {
+    //~^ ERROR not all trait items implemented, missing: `drop`
+    fn drop(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+    //~^ ERROR use of unstable library feature `pin_ergonomics` [E0658]
+}
+
 fn foo(mut x: Pin<&mut Foo>) {
     Foo::foo_sugar(x.as_mut());
     Foo::foo_sugar_const(x.as_ref());

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -29,7 +29,17 @@ LL |     fn pin_drop(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:23:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:24:14
+   |
+LL |     fn drop(&pin mut self) {}
+   |              ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:31:14
    |
 LL |     let _y: &pin mut Foo = x;
    |              ^^^
@@ -39,7 +49,7 @@ LL |     let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:27:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:35:14
    |
 LL |     let _y: &pin const Foo = x;
    |              ^^^
@@ -49,7 +59,7 @@ LL |     let _y: &pin const Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:30:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:38:18
    |
 LL | fn foo_sugar(_: &pin mut Foo) {}
    |                  ^^^
@@ -59,7 +69,7 @@ LL | fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:42:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:50:18
    |
 LL | fn baz_sugar(_: &pin const Foo) {}
    |                  ^^^
@@ -69,7 +79,7 @@ LL | fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:45:31
+  --> $DIR/feature-gate-pin_ergonomics.rs:53:31
    |
 LL |     let mut x: Pin<&mut _> = &pin mut Foo;
    |                               ^^^
@@ -79,7 +89,7 @@ LL |     let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:50:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:58:23
    |
 LL |     let x: Pin<&_> = &pin const Foo;
    |                       ^^^
@@ -89,7 +99,7 @@ LL |     let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:57:6
+  --> $DIR/feature-gate-pin_ergonomics.rs:65:6
    |
 LL |     &pin mut x: &pin mut i32,
    |      ^^^
@@ -99,7 +109,7 @@ LL |     &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:57:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:65:18
    |
 LL |     &pin mut x: &pin mut i32,
    |                  ^^^
@@ -109,7 +119,7 @@ LL |     &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:60:6
+  --> $DIR/feature-gate-pin_ergonomics.rs:68:6
    |
 LL |     &pin const y: &'a pin const i32,
    |      ^^^
@@ -119,7 +129,7 @@ LL |     &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:60:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:68:23
    |
 LL |     &pin const y: &'a pin const i32,
    |                       ^^^
@@ -129,7 +139,7 @@ LL |     &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:63:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:71:9
    |
 LL |     ref pin mut z: i32,
    |         ^^^
@@ -139,7 +149,7 @@ LL |     ref pin mut z: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:64:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:72:9
    |
 LL |     ref pin const w: i32,
    |         ^^^
@@ -149,7 +159,7 @@ LL |     ref pin const w: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:76:23
+  --> $DIR/feature-gate-pin_ergonomics.rs:84:23
    |
 LL |         fn foo_sugar(&pin mut self) {}
    |                       ^^^
@@ -159,7 +169,7 @@ LL |         fn foo_sugar(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:77:29
+  --> $DIR/feature-gate-pin_ergonomics.rs:85:29
    |
 LL |         fn foo_sugar_const(&pin const self) {}
    |                             ^^^
@@ -169,7 +179,7 @@ LL |         fn foo_sugar_const(&pin const self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:81:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:89:22
    |
 LL |         fn pin_drop(&pin mut self) {}
    |                      ^^^
@@ -179,7 +189,7 @@ LL |         fn pin_drop(&pin mut self) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:87:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:95:18
    |
 LL |         let _y: &pin mut Foo = x;
    |                  ^^^
@@ -189,7 +199,7 @@ LL |         let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:90:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:98:22
    |
 LL |     fn foo_sugar(_: &pin mut Foo) {}
    |                      ^^^
@@ -199,7 +209,7 @@ LL |     fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:102:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:110:22
    |
 LL |     fn baz_sugar(_: &pin const Foo) {}
    |                      ^^^
@@ -209,7 +219,7 @@ LL |     fn baz_sugar(_: &pin const Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:105:35
+  --> $DIR/feature-gate-pin_ergonomics.rs:113:35
    |
 LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    |                                   ^^^
@@ -219,7 +229,7 @@ LL |         let mut x: Pin<&mut _> = &pin mut Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:110:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:118:27
    |
 LL |         let x: Pin<&_> = &pin const Foo;
    |                           ^^^
@@ -229,7 +239,7 @@ LL |         let x: Pin<&_> = &pin const Foo;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:117:10
+  --> $DIR/feature-gate-pin_ergonomics.rs:125:10
    |
 LL |         &pin mut x: &pin mut i32,
    |          ^^^
@@ -239,7 +249,7 @@ LL |         &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:117:22
+  --> $DIR/feature-gate-pin_ergonomics.rs:125:22
    |
 LL |         &pin mut x: &pin mut i32,
    |                      ^^^
@@ -249,7 +259,7 @@ LL |         &pin mut x: &pin mut i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:120:10
+  --> $DIR/feature-gate-pin_ergonomics.rs:128:10
    |
 LL |         &pin const y: &'a pin const i32,
    |          ^^^
@@ -259,7 +269,7 @@ LL |         &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:120:27
+  --> $DIR/feature-gate-pin_ergonomics.rs:128:27
    |
 LL |         &pin const y: &'a pin const i32,
    |                           ^^^
@@ -269,7 +279,7 @@ LL |         &pin const y: &'a pin const i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:123:13
+  --> $DIR/feature-gate-pin_ergonomics.rs:131:13
    |
 LL |         ref pin mut z: i32,
    |             ^^^
@@ -279,7 +289,7 @@ LL |         ref pin mut z: i32,
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:124:13
+  --> $DIR/feature-gate-pin_ergonomics.rs:132:13
    |
 LL |         ref pin const w: i32,
    |             ^^^
@@ -308,6 +318,16 @@ LL |     fn pin_drop(&pin mut self) {}
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: use of unstable library feature `pin_ergonomics`
+  --> $DIR/feature-gate-pin_ergonomics.rs:24:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0046]: not all trait items implemented, missing: `drop`
   --> $DIR/feature-gate-pin_ergonomics.rs:14:1
    |
@@ -316,8 +336,16 @@ LL | impl Drop for Foo {
    |
    = help: implement the missing item: `fn drop(&mut self) { todo!() }`
 
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/feature-gate-pin_ergonomics.rs:22:1
+   |
+LL | impl Drop for Sugar {
+   | ^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+   |
+   = help: implement the missing item: `fn drop(&mut self) { todo!() }`
+
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:34:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:42:9
    |
 LL | fn bar(x: Pin<&mut Foo>) {
    |        - move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -327,7 +355,7 @@ LL |     foo(x);
    |         ^ value used here after move
    |
 note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:20:15
+  --> $DIR/feature-gate-pin_ergonomics.rs:28:15
    |
 LL | fn foo(mut x: Pin<&mut Foo>) {
    |    ---        ^^^^^^^^^^^^^ this parameter takes ownership of the value
@@ -335,7 +363,7 @@ LL | fn foo(mut x: Pin<&mut Foo>) {
    |    in this function
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:39:5
+  --> $DIR/feature-gate-pin_ergonomics.rs:47:5
    |
 LL | fn baz(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -354,7 +382,7 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 34 previous errors
+error: aborting due to 37 previous errors
 
 Some errors have detailed explanations: E0046, E0382, E0658.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/generic-associated-types/bugs/issue-87735.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-87735.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `U` is not constrained by the impl trait, self 
    |
 LL | impl<'b, T, U> AsRef2 for Foo<T>
    |             ^ unconstrained type parameter
+   |
+help: use the type parameter `U` in the `Foo` type and use it in the type definition
+   |
+LL ~ struct Foo<T, U>(T);
+LL | #[derive(Debug)]
+LL | struct FooRef<'a, U>(&'a [U]);
+LL |
+LL ~ impl<'b, T, U> AsRef2 for Foo<T, U>
+   |
 
 error[E0309]: the parameter type `U` may not live long enough
   --> $DIR/issue-87735.rs:34:3

--- a/tests/ui/generic-associated-types/bugs/issue-88526.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-88526.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `I` is not constrained by the impl trait, self 
   --> $DIR/issue-88526.rs:25:13
    |
 LL | impl<'q, Q, I, F> A for TestB<Q, F>
-   |             ^ unconstrained type parameter
+   |             ^--
+   |             |
+   |             unconstrained type parameter
+   |             help: remove the unused type parameter `I`
 
 error[E0309]: the parameter type `F` may not live long enough
   --> $DIR/issue-88526.rs:16:5

--- a/tests/ui/generics/unconstrained-param-default-available.rs
+++ b/tests/ui/generics/unconstrained-param-default-available.rs
@@ -1,0 +1,18 @@
+//! Test that making use of parameter is suggested when a parameter with default type is available
+
+struct S<U = i32> {
+    _u: U,
+}
+impl<V> MyTrait for S {}
+//~^ ERROR the type parameter `V` is not constrained by the impl trait, self type, or predicates
+
+struct S2<T, U = i32> {
+    _t: T,
+    _u: U,
+}
+impl<T, V> MyTrait for S2<T> {}
+//~^ ERROR the type parameter `V` is not constrained by the impl trait, self type, or predicates
+
+trait MyTrait {}
+
+fn main() {}

--- a/tests/ui/generics/unconstrained-param-default-available.stderr
+++ b/tests/ui/generics/unconstrained-param-default-available.stderr
@@ -1,0 +1,35 @@
+error[E0207]: the type parameter `V` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-param-default-available.rs:6:6
+   |
+LL | impl<V> MyTrait for S {}
+   |      ^ unconstrained type parameter
+   |
+help: either remove the unused type parameter `V`
+   |
+LL - impl<V> MyTrait for S {}
+LL + impl MyTrait for S {}
+   |
+help: or use it
+   |
+LL | impl<V> MyTrait for S<V> {}
+   |                      +++
+
+error[E0207]: the type parameter `V` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-param-default-available.rs:13:9
+   |
+LL | impl<T, V> MyTrait for S2<T> {}
+   |         ^ unconstrained type parameter
+   |
+help: either remove the unused type parameter `V`
+   |
+LL - impl<T, V> MyTrait for S2<T> {}
+LL + impl<T> MyTrait for S2<T> {}
+   |
+help: or use it
+   |
+LL | impl<T, V> MyTrait for S2<T, V> {}
+   |                            +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/generics/unconstrained-type-params-inherent-impl.stderr
+++ b/tests/ui/generics/unconstrained-type-params-inherent-impl.stderr
@@ -2,13 +2,19 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
   --> $DIR/unconstrained-type-params-inherent-impl.rs:11:6
    |
 LL | impl<T> MyType {
-   |      ^ unconstrained type parameter
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `T`
 
 error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
   --> $DIR/unconstrained-type-params-inherent-impl.rs:20:9
    |
 LL | impl<T, U> MyType1<T> {
-   |         ^ unconstrained type parameter
+   |       --^
+   |       | |
+   |       | unconstrained type parameter
+   |       help: remove the unused type parameter `U`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generics/unconstrained-used-param.rs
+++ b/tests/ui/generics/unconstrained-used-param.rs
@@ -1,0 +1,23 @@
+//! Test that making use of parameter is suggested when the parameter is used in the impl
+//! but not in the trait or self type
+
+struct S;
+impl<T> S {
+//~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+   fn foo(&self, x: T) {
+       // use T here
+   }
+}
+
+
+struct S2<F> {
+    _f: F,
+}
+impl<F, T> S2<F> {
+//~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+   fn foo(&self, x: T) {
+       // use T here
+   }
+}
+
+fn main() {}

--- a/tests/ui/generics/unconstrained-used-param.stderr
+++ b/tests/ui/generics/unconstrained-used-param.stderr
@@ -1,0 +1,29 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-used-param.rs:5:6
+   |
+LL | impl<T> S {
+   |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `S` type and use it in the type definition
+   |
+LL ~ struct S<T>;
+LL ~ impl<T> S<T> {
+   |
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-used-param.rs:16:9
+   |
+LL | impl<F, T> S2<F> {
+   |         ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `S2` type and use it in the type definition
+   |
+LL ~ struct S2<F, T> {
+LL |     _f: F,
+LL | }
+LL ~ impl<F, T> S2<F, T> {
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0207`.

--- a/tests/ui/issues/issue-16562.stderr
+++ b/tests/ui/issues/issue-16562.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
   --> $DIR/issue-16562.rs:10:6
    |
 LL | impl<T, M: MatrixShape> Collection for Col<M, usize> {
-   |      ^ unconstrained type parameter
+   |      ^--
+   |      |
+   |      unconstrained type parameter
+   |      help: remove the unused type parameter `T`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-22886.stderr
+++ b/tests/ui/issues/issue-22886.stderr
@@ -3,6 +3,13 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> Iterator for Newtype {
    |      ^^ unconstrained lifetime parameter
+   |
+help: use the lifetime parameter `'a` in the `Newtype` type and use it in the type definition
+   |
+LL ~ struct Newtype<'a>(Option<Box<usize>>);
+LL |
+LL ~ impl<'a> Iterator for Newtype<'a> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-35139.stderr
+++ b/tests/ui/issues/issue-35139.stderr
@@ -3,6 +3,13 @@ error[E0207]: the lifetime parameter `'a` is not constrained by the impl trait, 
    |
 LL | impl<'a> MethodType for MTFn {
    |      ^^ unconstrained lifetime parameter
+   |
+help: use the lifetime parameter `'a` in the `MTFn` type and use it in the type definition
+   |
+LL ~ pub struct MTFn<'a>;
+LL |
+LL ~ impl<'a> MethodType for MTFn<'a> {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pin-ergonomics/pinned-drop-check.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-check.rs
@@ -25,11 +25,11 @@ mod pin_drop_only {
     struct Bar;
 
     impl Drop for Foo {
-        fn pin_drop(&pin mut self) {} // ok, only `pin_drop` is implemented
+        fn pin_drop(&pin mut self) {} // ok, non-`#[pin_v2]` can also implement `pin_drop`
     }
 
     impl Drop for Bar {
-        fn pin_drop(&pin mut self) {} // ok, non-`#[pin_v2]` can also implement `pin_drop`
+        fn pin_drop(&pin mut self) {} // ok, `#[pin_v2]` implements `pin_drop`
     }
 }
 
@@ -60,16 +60,67 @@ mod neither {
     impl Drop for Bar {} //~ ERROR not all trait items implemented, missing one of: `drop`, `pin_drop` [E0046]
 }
 
-mod drop_wrong_type {
+mod drop_sugar {
     struct Foo;
     #[pin_v2]
     struct Bar;
 
     impl Drop for Foo {
-        fn drop(&pin mut self) {} //~ ERROR method `drop` has an incompatible type for trait [E0053]
+        fn drop(&pin mut self) {} // ok, sugar for `pin_drop`
     }
+
     impl Drop for Bar {
-        fn drop(&pin mut self) {}
+        fn drop(&pin mut self) {} // ok, sugar for `pin_drop`
+    }
+}
+
+mod drop_pin_const_wrong_type {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&pin const self) {} //~ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn drop(&pin const self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+        //~| ERROR `Bar` must implement `pin_drop`
+    }
+}
+
+mod drop_with_lifetime_wrong_type {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop<'a>(&'a pin mut self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn drop<'a>(&'a pin mut self) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+        //~| ERROR `Bar` must implement `pin_drop`
+    }
+}
+
+mod drop_explicit_pin_wrong_type {
+    use std::pin::Pin;
+
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(self: Pin<&mut Self>) {}
+        //~^ ERROR method `drop` has an incompatible type for trait [E0053]
+    }
+
+    impl Drop for Bar {
+        fn drop(self: Pin<&mut Self>) {}
         //~^ ERROR method `drop` has an incompatible type for trait [E0053]
         //~| ERROR `Bar` must implement `pin_drop`
     }
@@ -121,6 +172,33 @@ mod explicit_call_drop {
         fn pin_drop(&pin mut self) {
             Drop::drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
         }
+    }
+}
+
+mod explicit_call_drop_sugar {
+    struct Foo;
+
+    impl Drop for Foo {
+        fn drop(&pin mut self) {
+            Drop::drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+            Drop::pin_drop(todo!()); //~ ERROR explicit use of destructor method [E0040]
+        }
+    }
+}
+
+mod sugar_and_pin_drop {
+    struct Foo;
+    #[pin_v2]
+    struct Bar;
+
+    impl Drop for Foo {
+        fn drop(&pin mut self) {}
+        fn pin_drop(&pin mut self) {} //~ ERROR duplicate definitions with name `pin_drop`
+    }
+
+    impl Drop for Bar {
+        fn drop(&pin mut self) {}
+        fn pin_drop(&pin mut self) {} //~ ERROR duplicate definitions with name `pin_drop`
     }
 }
 

--- a/tests/ui/pin-ergonomics/pinned-drop-check.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-check.stderr
@@ -1,3 +1,27 @@
+error[E0201]: duplicate definitions with name `pin_drop`:
+  --> $DIR/pinned-drop-check.rs:196:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ------------------------- previous definition here
+LL |         fn pin_drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
+   |
+  --> $SRC_DIR/core/src/ops/drop.rs:LL:COL
+   |
+   = note: item in trait
+
+error[E0201]: duplicate definitions with name `pin_drop`:
+  --> $DIR/pinned-drop-check.rs:201:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ------------------------- previous definition here
+LL |         fn pin_drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definition
+   |
+  --> $SRC_DIR/core/src/ops/drop.rs:LL:COL
+   |
+   = note: item in trait
+
 error: `Bar` must implement `pin_drop`
   --> $DIR/pinned-drop-check.rs:18:9
    |
@@ -55,56 +79,157 @@ LL |     impl Drop for Bar {}
    |     ^^^^^^^^^^^^^^^^^ missing one of `drop`, `pin_drop` in implementation
 
 error: `Bar` must implement `pin_drop`
-  --> $DIR/pinned-drop-check.rs:72:9
+  --> $DIR/pinned-drop-check.rs:87:9
    |
-LL |         fn drop(&pin mut self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^
+LL |         fn drop(&pin const self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: structurally pinned types must keep `Pin`'s safety contract
 note: `Bar` is marked `#[pin_v2]` here
-  --> $DIR/pinned-drop-check.rs:65:5
+  --> $DIR/pinned-drop-check.rs:79:5
    |
 LL |     #[pin_v2]
    |     ^^^^^^^^^
 help: implement `pin_drop` instead
    |
-LL |         fn pin_drop(&pin mut self) {}
-   |            ++++
+LL -         fn drop(&pin const self) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
 help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
    |
 LL -     #[pin_v2]
    |
 
 error[E0053]: method `drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:69:17
+  --> $DIR/pinned-drop-check.rs:83:17
    |
-LL |         fn drop(&pin mut self) {}
-   |                 ^^^^^^^^^^^^^ expected `&mut drop_wrong_type::Foo`, found `Pin<&mut drop_wrong_type::Foo>`
+LL |         fn drop(&pin const self) {}
+   |                 ^^^^^^^^^^^^^^^ expected `&mut drop_pin_const_wrong_type::Foo`, found `Pin<&drop_pin_const_wrong_type::Foo>`
    |
-   = note: expected signature `fn(&mut drop_wrong_type::Foo)`
-              found signature `fn(Pin<&mut drop_wrong_type::Foo>)`
+   = note: expected signature `fn(&mut drop_pin_const_wrong_type::Foo)`
+              found signature `fn(Pin<&drop_pin_const_wrong_type::Foo>)`
 help: change the self-receiver type to match the trait
    |
-LL -         fn drop(&pin mut self) {}
+LL -         fn drop(&pin const self) {}
 LL +         fn drop(&mut self) {}
    |
 
 error[E0053]: method `drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:72:17
+  --> $DIR/pinned-drop-check.rs:87:17
    |
-LL |         fn drop(&pin mut self) {}
-   |                 ^^^^^^^^^^^^^ expected `&mut drop_wrong_type::Bar`, found `Pin<&mut drop_wrong_type::Bar>`
+LL |         fn drop(&pin const self) {}
+   |                 ^^^^^^^^^^^^^^^ expected `&mut drop_pin_const_wrong_type::Bar`, found `Pin<&drop_pin_const_wrong_type::Bar>`
    |
-   = note: expected signature `fn(&mut drop_wrong_type::Bar)`
-              found signature `fn(Pin<&mut drop_wrong_type::Bar>)`
+   = note: expected signature `fn(&mut drop_pin_const_wrong_type::Bar)`
+              found signature `fn(Pin<&drop_pin_const_wrong_type::Bar>)`
 help: change the self-receiver type to match the trait
    |
-LL -         fn drop(&pin mut self) {}
+LL -         fn drop(&pin const self) {}
+LL +         fn drop(&mut self) {}
+   |
+
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:104:9
+   |
+LL |         fn drop<'a>(&'a pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:95:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL -         fn drop<'a>(&'a pin mut self) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:99:21
+   |
+LL |         fn drop<'a>(&'a pin mut self) {}
+   |                     ^^^^^^^^^^^^^^^^ expected `&mut drop_with_lifetime_wrong_type::Foo`, found `Pin<&mut Foo>`
+   |
+   = note: expected signature `fn(&mut drop_with_lifetime_wrong_type::Foo)`
+              found signature `fn(Pin<&mut drop_with_lifetime_wrong_type::Foo>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop<'a>(&'a pin mut self) {}
+LL +         fn drop<'a>(&mut self) {}
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:104:21
+   |
+LL |         fn drop<'a>(&'a pin mut self) {}
+   |                     ^^^^^^^^^^^^^^^^ expected `&mut drop_with_lifetime_wrong_type::Bar`, found `Pin<&mut Bar>`
+   |
+   = note: expected signature `fn(&mut drop_with_lifetime_wrong_type::Bar)`
+              found signature `fn(Pin<&mut drop_with_lifetime_wrong_type::Bar>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop<'a>(&'a pin mut self) {}
+LL +         fn drop<'a>(&mut self) {}
+   |
+
+error: `Bar` must implement `pin_drop`
+  --> $DIR/pinned-drop-check.rs:123:9
+   |
+LL |         fn drop(self: Pin<&mut Self>) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: structurally pinned types must keep `Pin`'s safety contract
+note: `Bar` is marked `#[pin_v2]` here
+  --> $DIR/pinned-drop-check.rs:114:5
+   |
+LL |     #[pin_v2]
+   |     ^^^^^^^^^
+help: implement `pin_drop` instead
+   |
+LL -         fn drop(self: Pin<&mut Self>) {}
+LL +         fn pin_drop(&pin mut self) {}
+   |
+help: remove the `#[pin_v2]` attribute if it is not intended for structurally pinning
+   |
+LL -     #[pin_v2]
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:118:23
+   |
+LL |         fn drop(self: Pin<&mut Self>) {}
+   |                       ^^^^^^^^^^^^^^ expected `&mut drop_explicit_pin_wrong_type::Foo`, found `Pin<&mut Foo>`
+   |
+   = note: expected signature `fn(&mut drop_explicit_pin_wrong_type::Foo)`
+              found signature `fn(Pin<&mut drop_explicit_pin_wrong_type::Foo>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop(self: Pin<&mut Self>) {}
+LL +         fn drop(&mut self) {}
+   |
+
+error[E0053]: method `drop` has an incompatible type for trait
+  --> $DIR/pinned-drop-check.rs:123:23
+   |
+LL |         fn drop(self: Pin<&mut Self>) {}
+   |                       ^^^^^^^^^^^^^^ expected `&mut drop_explicit_pin_wrong_type::Bar`, found `Pin<&mut Bar>`
+   |
+   = note: expected signature `fn(&mut drop_explicit_pin_wrong_type::Bar)`
+              found signature `fn(Pin<&mut drop_explicit_pin_wrong_type::Bar>)`
+help: change the self-receiver type to match the trait
+   |
+LL -         fn drop(self: Pin<&mut Self>) {}
 LL +         fn drop(&mut self) {}
    |
 
 error[E0053]: method `pin_drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:84:21
+  --> $DIR/pinned-drop-check.rs:135:21
    |
 LL |         fn pin_drop(&mut self) {}
    |                     ^^^^^^^^^ expected `Pin<&mut pin_drop_wrong_type::Foo>`, found `&mut pin_drop_wrong_type::Foo`
@@ -118,7 +243,7 @@ LL +         fn pin_drop(self: Pin<&mut pin_drop_wrong_type::Foo>) {}
    |
 
 error[E0053]: method `pin_drop` has an incompatible type for trait
-  --> $DIR/pinned-drop-check.rs:88:21
+  --> $DIR/pinned-drop-check.rs:139:21
    |
 LL |         fn pin_drop(&mut self) {}
    |                     ^^^^^^^^^ expected `Pin<&mut pin_drop_wrong_type::Bar>`, found `&mut pin_drop_wrong_type::Bar`
@@ -132,14 +257,14 @@ LL +         fn pin_drop(self: Pin<&mut pin_drop_wrong_type::Bar>) {}
    |
 
 error: `Bar` must implement `pin_drop`
-  --> $DIR/pinned-drop-check.rs:103:9
+  --> $DIR/pinned-drop-check.rs:154:9
    |
 LL |         fn drop(&mut self) {
    |         ^^^^^^^^^^^^^^^^^^
    |
    = help: structurally pinned types must keep `Pin`'s safety contract
 note: `Bar` is marked `#[pin_v2]` here
-  --> $DIR/pinned-drop-check.rs:94:5
+  --> $DIR/pinned-drop-check.rs:145:5
    |
 LL |     #[pin_v2]
    |     ^^^^^^^^^
@@ -154,30 +279,42 @@ LL -     #[pin_v2]
    |
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:99:13
+  --> $DIR/pinned-drop-check.rs:150:13
    |
 LL |             Drop::pin_drop(todo!());
    |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:105:13
+  --> $DIR/pinned-drop-check.rs:156:13
    |
 LL |             Drop::pin_drop(todo!());
    |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:117:13
+  --> $DIR/pinned-drop-check.rs:168:13
    |
 LL |             Drop::drop(todo!());
    |             ^^^^^^^^^^ explicit destructor calls not allowed
 
 error[E0040]: explicit use of destructor method
-  --> $DIR/pinned-drop-check.rs:122:13
+  --> $DIR/pinned-drop-check.rs:173:13
    |
 LL |             Drop::drop(todo!());
    |             ^^^^^^^^^^ explicit destructor calls not allowed
 
-error: aborting due to 15 previous errors
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:183:13
+   |
+LL |             Drop::drop(todo!());
+   |             ^^^^^^^^^^ explicit destructor calls not allowed
 
-Some errors have detailed explanations: E0040, E0046, E0053.
+error[E0040]: explicit use of destructor method
+  --> $DIR/pinned-drop-check.rs:184:13
+   |
+LL |             Drop::pin_drop(todo!());
+   |             ^^^^^^^^^^^^^^ explicit destructor calls not allowed
+
+error: aborting due to 25 previous errors
+
+Some errors have detailed explanations: E0040, E0046, E0053, E0201.
 For more information about an error, try `rustc --explain E0040`.

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-no-core.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-no-core.rs
@@ -1,0 +1,78 @@
+//@ check-pass
+
+#![no_std]
+#![no_core]
+#![no_main]
+#![feature(no_core, pin_ergonomics, lang_items)]
+#![allow(incomplete_features)]
+
+#[lang = "pointee_sized"]
+trait PointeeSized {}
+
+#[lang = "meta_sized"]
+trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+trait Sized: MetaSized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "legacy_receiver"]
+trait LegacyReceiver: PointeeSized {}
+
+#[lang = "deref"]
+trait Deref: PointeeSized {
+    #[lang = "deref_target"]
+    type Target: PointeeSized;
+
+    fn deref(&self) -> &Self::Target;
+}
+
+#[lang = "deref_mut"]
+trait DerefMut: Deref + PointeeSized {
+    fn deref_mut(&mut self) -> &mut Self::Target;
+}
+
+#[lang = "pin"]
+struct Pin<T> {
+    pointer: T,
+}
+
+impl<T: PointeeSized> LegacyReceiver for &T {}
+impl<T: PointeeSized> LegacyReceiver for &mut T {}
+impl<Ptr: LegacyReceiver> LegacyReceiver for Pin<Ptr> {}
+
+impl<Ptr: Deref> Deref for Pin<Ptr> {
+    type Target = Ptr::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.pointer
+    }
+}
+
+impl<Ptr: DerefMut> DerefMut for Pin<Ptr> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.pointer
+    }
+}
+
+impl<T: PointeeSized> Deref for &mut T {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+struct LocalDrop;
+
+impl Drop for LocalDrop {
+    fn drop(&pin mut self) {}
+}
+
+#[lang = "drop"]
+trait Drop {
+    fn drop(&mut self) {}
+    fn pin_drop(self: Pin<&mut Self>) {}
+}

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.rs
@@ -1,0 +1,62 @@
+//@ edition:2024
+
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+use std::pin::Pin;
+
+struct S;
+
+trait NeedsPinDrop {
+    fn pin_drop(self: Pin<&mut Self>);
+}
+
+impl NeedsPinDrop for S {
+    //~^ ERROR not all trait items implemented, missing: `pin_drop` [E0046]
+    fn drop(&pin mut self) {}
+    //~^ ERROR method `drop` with `&pin mut self` is only supported for the `Drop` trait
+}
+
+trait HasDrop {
+    fn drop(self: Pin<&mut Self>);
+}
+
+impl HasDrop for S {
+    //~^ ERROR not all trait items implemented, missing: `drop` [E0046]
+    fn drop(&pin mut self) {}
+    //~^ ERROR method `drop` is not a member of trait `HasDrop` [E0407]
+}
+
+trait HasPinnedDropReceiver {
+    fn drop(self: &pin mut Self);
+}
+
+impl HasPinnedDropReceiver for S {
+    //~^ ERROR not all trait items implemented, missing: `drop` [E0046]
+    fn drop(&pin mut self) {}
+    //~^ ERROR method `drop` is not a member of trait `HasPinnedDropReceiver` [E0407]
+}
+
+struct Inherent;
+
+impl Inherent {
+    fn drop(&pin mut self) {}
+}
+
+mod local_drop_trait {
+    use std::pin::Pin;
+
+    struct S;
+
+    trait Drop {
+        fn pin_drop(self: Pin<&mut Self>);
+    }
+
+    impl Drop for S {
+        //~^ ERROR not all trait items implemented, missing: `pin_drop` [E0046]
+        fn drop(&pin mut self) {}
+        //~^ ERROR method `drop` with `&pin mut self` is only supported for the `Drop` trait
+    }
+}
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.stderr
@@ -1,0 +1,70 @@
+error[E0407]: method `drop` is not a member of trait `HasDrop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:26:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^----^^^^^^^^^^^^^^^^^^
+   |     |  |
+   |     |  help: there is an associated function with a similar name: `drop`
+   |     not a member of trait `HasDrop`
+
+error[E0407]: method `drop` is not a member of trait `HasPinnedDropReceiver`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:36:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^----^^^^^^^^^^^^^^^^^^
+   |     |  |
+   |     |  help: there is an associated function with a similar name: `drop`
+   |     not a member of trait `HasPinnedDropReceiver`
+
+error: method `drop` with `&pin mut self` is only supported for the `Drop` trait
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:16:5
+   |
+LL |     fn drop(&pin mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ not a `Drop::pin_drop` implementation
+
+error: method `drop` with `&pin mut self` is only supported for the `Drop` trait
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:57:9
+   |
+LL |         fn drop(&pin mut self) {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ not a `Drop::pin_drop` implementation
+
+error[E0046]: not all trait items implemented, missing: `pin_drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:14:1
+   |
+LL |     fn pin_drop(self: Pin<&mut Self>);
+   |     ---------------------------------- `pin_drop` from trait
+...
+LL | impl NeedsPinDrop for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `pin_drop` in implementation
+
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:24:1
+   |
+LL |     fn drop(self: Pin<&mut Self>);
+   |     ------------------------------ `drop` from trait
+...
+LL | impl HasDrop for S {
+   | ^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+
+error[E0046]: not all trait items implemented, missing: `drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:34:1
+   |
+LL |     fn drop(self: &pin mut Self);
+   |     ----------------------------- `drop` from trait
+...
+LL | impl HasPinnedDropReceiver for S {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
+
+error[E0046]: not all trait items implemented, missing: `pin_drop`
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:55:5
+   |
+LL |         fn pin_drop(self: Pin<&mut Self>);
+   |         ---------------------------------- `pin_drop` from trait
+...
+LL |     impl Drop for S {
+   |     ^^^^^^^^^^^^^^^ missing `pin_drop` in implementation
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0046, E0407.
+For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+//@ edition:2024
+
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+struct Unpinned;
+
+#[pin_v2]
+struct Pinned;
+
+struct Qualified;
+struct CoreQualified;
+
+impl Drop for Unpinned {
+    fn drop(&pin mut self) {}
+}
+
+impl Drop for Pinned {
+    fn drop(&pin mut self) {}
+}
+
+impl std::ops::Drop for Qualified {
+    fn drop(&pin mut self) {}
+}
+
+impl core::ops::Drop for CoreQualified {
+    fn drop(&pin mut self) {}
+}
+
+fn main() {}

--- a/tests/ui/suggestions/auxiliary/generics_other_crate.rs
+++ b/tests/ui/suggestions/auxiliary/generics_other_crate.rs
@@ -1,0 +1,4 @@
+//! This file is used to test suggestions for generics in other crates.
+
+pub struct External;
+pub struct ExternalGeneric<T>(T);

--- a/tests/ui/suggestions/unconstrained-params.rs
+++ b/tests/ui/suggestions/unconstrained-params.rs
@@ -1,0 +1,54 @@
+//@ aux-build:generics_other_crate.rs
+
+extern crate generics_other_crate;
+use generics_other_crate::External;
+
+struct Local;
+struct Defaulted<T = u32>(T);
+
+// Case 1: Unused parameter -> suggests removing T
+impl<T> Local {}
+//~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+//~| HELP: remove the unused type parameter `T`
+
+// Case 2: T used in body but not in self type
+// -> suggests adding T to self type and struct definition
+impl<T> Local {
+    //~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+    //~| HELP: use the type parameter `T` in the `Local` type and use it in the type definition
+    fn check() {
+        let _: T;
+    }
+}
+
+
+// Case 3: Struct has a generic parameter with a default
+// -> suggests adding T to the self type
+impl<T> Defaulted {}
+//~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+//~| HELP: either remove the unused type parameter `T`
+//~| HELP: or use it
+
+// Case 4: Generated from a macro
+macro_rules! make_impl {
+    ($t:ident) => {
+        impl<$t> Local {}
+        //~^ HELP: remove the unused type parameter `U`
+    }
+}
+make_impl!(U);
+//~^ ERROR the type parameter `U` is not constrained by the impl trait, self type, or predicates
+
+// Case 5: Type defined in another crate
+impl<T> External {
+    //~^ ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
+    //~| ERROR: cannot define inherent `impl` for a type outside of the crate where the type is defined [E0116]
+    //~| HELP: use the type parameter `T` in the `External` type and use it in the type definition
+    //~| HELP: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+    fn check() {
+        let _: T;
+    }
+}
+
+
+fn main() {}

--- a/tests/ui/suggestions/unconstrained-params.stderr
+++ b/tests/ui/suggestions/unconstrained-params.stderr
@@ -1,0 +1,68 @@
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-params.rs:10:6
+   |
+LL | impl<T> Local {}
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `T`
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-params.rs:16:6
+   |
+LL | impl<T> Local {
+   |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Local` type and use it in the type definition
+   |
+LL ~ struct Local<T>;
+LL | struct Defaulted<T = u32>(T);
+...
+LL | // -> suggests adding T to self type and struct definition
+LL ~ impl<T> Local<T> {
+   |
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-params.rs:27:6
+   |
+LL | impl<T> Defaulted {}
+   |      ^ unconstrained type parameter
+   |
+help: either remove the unused type parameter `T`
+   |
+LL - impl<T> Defaulted {}
+LL + impl Defaulted {}
+   |
+help: or use it
+   |
+LL | impl<T> Defaulted<T> {}
+   |                  +++
+
+error[E0207]: the type parameter `U` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-params.rs:39:12
+   |
+LL |         impl<$t> Local {}
+   |             ---- help: remove the unused type parameter `U`
+...
+LL | make_impl!(U);
+   |            ^ unconstrained type parameter
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/unconstrained-params.rs:43:6
+   |
+LL | impl<T> External {
+   |      ^ unconstrained type parameter
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/unconstrained-params.rs:43:1
+   |
+LL | impl<T> External {
+   | ^^^^^^^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+   = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0116, E0207.
+For more information about an error, try `rustc --explain E0116`.

--- a/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
+++ b/tests/ui/traits/associated_type_bound/generic-const-args-default.rs
@@ -3,7 +3,7 @@
 
 #![feature(min_generic_const_args)]
 
-trait Bar<const N: bool = false> {}
+trait Bar<const N: usize = const { 1 + 1 }> {}
 
 trait Foo {
     type AssocB: Bar;

--- a/tests/ui/traits/error-reporting/leaking-vars-in-cause-code-2.stderr
+++ b/tests/ui/traits/error-reporting/leaking-vars-in-cause-code-2.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `U` is not constrained by the impl trait, self 
   --> $DIR/leaking-vars-in-cause-code-2.rs:19:9
    |
 LL | impl<T, U> Trait<()> for B<T>
-   |         ^ unconstrained type parameter
+   |       --^
+   |       | |
+   |       | unconstrained type parameter
+   |       help: remove the unused type parameter `U`
 
 error[E0277]: the trait bound `(): IncompleteGuidance` is not satisfied
   --> $DIR/leaking-vars-in-cause-code-2.rs:29:19

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization-2.current.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization-2.current.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Thing` type and use it in the type definition
+   |
+LL ~ struct Thing<T>;
+LL |
+...
+LL | }
+LL ~ impl<T: ?Sized> Every for Thing<T> {
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unconstrained-projection-normalization-2.rs:16:18

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization-2.next.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization-2.next.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Thing` type and use it in the type definition
+   |
+LL ~ struct Thing<T>;
+LL |
+...
+LL | }
+LL ~ impl<T: ?Sized> Every for Thing<T> {
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unconstrained-projection-normalization-2.rs:16:18

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization.current.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization.current.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Thing` type and use it in the type definition
+   |
+LL ~ struct Thing<T>;
+LL |
+...
+LL | }
+LL ~ impl<T: ?Sized> Every for Thing<T> {
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unconstrained-projection-normalization.rs:15:18

--- a/tests/ui/traits/normalize/unconstrained-projection-normalization.next.stderr
+++ b/tests/ui/traits/normalize/unconstrained-projection-normalization.next.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: ?Sized> Every for Thing {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Thing` type and use it in the type definition
+   |
+LL ~ struct Thing<T>;
+LL |
+...
+LL | }
+LL ~ impl<T: ?Sized> Every for Thing<T> {
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unconstrained-projection-normalization.rs:15:18

--- a/tests/ui/type-alias-impl-trait/ice-failed-to-resolve-instance-for-110696.stderr
+++ b/tests/ui/type-alias-impl-trait/ice-failed-to-resolve-instance-for-110696.stderr
@@ -3,6 +3,15 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
    |
 LL | impl<T: MyFrom<Phantom2<DummyT<U>>>, U> MyIndex<DummyT<T>> for Scope<U> {
    |      ^ unconstrained type parameter
+   |
+help: use the type parameter `T` in the `Scope` type and use it in the type definition
+   |
+LL ~ struct Scope<T, T>(Phantom2<DummyT<T>>);
+LL |
+...
+LL |
+LL ~ impl<T: MyFrom<Phantom2<DummyT<U>>>, U> MyIndex<DummyT<T>> for Scope<U, T> {
+   |
 
 error: item does not constrain `DummyT::{opaque#0}`
   --> $DIR/ice-failed-to-resolve-instance-for-110696.rs:30:8

--- a/tests/ui/type-alias-impl-trait/issue-74244.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-74244.stderr
@@ -2,7 +2,10 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
   --> $DIR/issue-74244.rs:9:6
    |
 LL | impl<T> Allocator for DefaultAllocator {
-   |      ^ unconstrained type parameter
+   |     -^-
+   |     ||
+   |     |unconstrained type parameter
+   |     help: remove the unused type parameter `T`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#148788 (Unconstrained parameter fix)
 - rust-lang/rust#156319 (Require EIIs to be defined when we compile a rust dylib)
 - rust-lang/rust#156452 (Implement pinned drop sugar)
 - rust-lang/rust#156554 (Allow user-provided `llvm_args` to override target spec arguments)
 - rust-lang/rust#156571 (Disable `main_needs_argc_argv` for Wasm)
 - rust-lang/rust#156600 (Make const param default test reproduce original ICE)
 - rust-lang/rust#156493 (actually run the temp_dir doctest)
 - rust-lang/rust#156556 (Require UTF-8 in `Utf8Pattern::StringPattern`)
 - rust-lang/rust#156565 (delegation: emit error when self type is not specified and accessed)
 - rust-lang/rust#156586 (Use DropCtxt::new_block and new_block_with_statements systematically.)
 - rust-lang/rust#156587 (Correctly handle associated items in rustdoc macro expansion)
 - rust-lang/rust#156604 (coverage: Reduce and clarify the context-mismatch test case)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=148788,156319,156452,156554,156571,156600,156493,156556,156565,156586,156587,156604)
<!-- homu-ignore:end -->

