### PR TITLE
rustdoc: test ignoring rustc lints in CLI

### DIFF
--- a/tests/rustdoc-ui/lints/deny-cmd.deny.stderr
+++ b/tests/rustdoc-ui/lints/deny-cmd.deny.stderr
@@ -1,5 +1,5 @@
 error: missing documentation for a struct
-  --> $DIR/deny-cmd.rs:7:1
+  --> $DIR/deny-cmd.rs:8:1
    |
 LL | pub struct Foo;
    | ^^^^^^^^^^^^^^

--- a/tests/rustdoc-ui/lints/deny-cmd.deny.stderr
+++ b/tests/rustdoc-ui/lints/deny-cmd.deny.stderr
@@ -1,0 +1,10 @@
+error: missing documentation for a struct
+  --> $DIR/deny-cmd.rs:7:1
+   |
+LL | pub struct Foo;
+   | ^^^^^^^^^^^^^^
+   |
+   = note: requested on the command line with `-D missing-docs`
+
+error: aborting due to 1 previous error
+

--- a/tests/rustdoc-ui/lints/deny-cmd.rs
+++ b/tests/rustdoc-ui/lints/deny-cmd.rs
@@ -1,0 +1,8 @@
+//@ revisions: deny allow
+//@[deny] compile-flags: -Dmissing_docs
+//@[allow] compile-flags: -Amissing_docs
+//@[allow] check-pass
+//! docs for crate
+
+pub struct Foo;
+//[deny]~^ ERROR missing_docs

--- a/tests/rustdoc-ui/lints/deny-cmd.rs
+++ b/tests/rustdoc-ui/lints/deny-cmd.rs
@@ -2,7 +2,8 @@
 //@[deny] compile-flags: -Dmissing_docs
 //@[allow] compile-flags: -Amissing_docs
 //@[allow] check-pass
-//! docs for crate
+
+//! Verify that the `-D` flag, passed to rustdoc, works as expected
 
 pub struct Foo;
 //[deny]~^ ERROR missing_docs


### PR DESCRIPTION
This works, but I couldn't find any tests for it.