### PR TITLE
core: Add core::ffi::c_intptr_t and core::ffi::c_uintptr_t

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -422,6 +422,8 @@ declare_features! (
     (unstable, avx10_target_feature, "1.88.0", Some(138843)),
     /// Target features on bpf.
     (unstable, bpf_target_feature, "1.54.0", Some(150247)),
+    /// Allows using size_t/ssize_t/uintptr_t/intptr_t/ptrdiff_t.
+    (unstable, c_size_t, "CURRENT_RUSTC_VERSION", Some(88345)),
     /// Allows using C-variadics.
     (unstable, c_variadic, "1.34.0", Some(44930)),
     /// Allows defining c-variadic functions on targets where this feature has not yet

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -545,6 +545,7 @@ symbols! {
         builtin_syntax,
         bundle,
         c_dash_variadic,
+        c_size_t,
         c_str_literals,
         c_unwind,
         c_variadic,

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -32,13 +32,15 @@ mod va_list;
 pub use self::va_list::{VaArgSafe, VaList};
 
 mod primitives;
+#[unstable(feature = "c_size_t", issue = "88345")]
+pub use self::primitives::{
+    IntPtr, TaggedPointer, c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t,
+};
 #[stable(feature = "core_ffi_c", since = "1.64.0")]
 pub use self::primitives::{
     c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
     c_ulong, c_ulonglong, c_ushort,
 };
-#[unstable(feature = "c_size_t", issue = "88345")]
-pub use self::primitives::{c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t};
 
 // N.B., for LLVM to recognize the void pointer type and by extension
 //     functions like malloc(), we need to have it represented as i8* in

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -38,7 +38,7 @@ pub use self::primitives::{
     c_ulong, c_ulonglong, c_ushort,
 };
 #[unstable(feature = "c_size_t", issue = "88345")]
-pub use self::primitives::{c_ptrdiff_t, c_size_t, c_ssize_t};
+pub use self::primitives::{c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t};
 
 // N.B., for LLVM to recognize the void pointer type and by extension
 //     functions like malloc(), we need to have it represented as i8* in

--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -174,6 +174,26 @@ pub type c_ptrdiff_t = isize;
 #[unstable(feature = "c_size_t", issue = "88345")]
 pub type c_ssize_t = isize;
 
+/// Equivalent to C's `intptr_t` type.
+///
+/// This type have the same size with a pointer. The C standard technically only
+/// requires that this type be a signed integer type just capable of holding a
+/// pointer.
+#[unstable(feature = "c_size_t", issue = "88345")]
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct c_intptr_t(pub *const ());
+
+/// Equivalent to C's `uintptr_t` type.
+///
+/// This type have the same size with a pointer. The C standard technically only
+/// requires that this type be an unsigned integer type just capable of holding
+/// a pointer.
+#[unstable(feature = "c_size_t", issue = "88345")]
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct c_uintptr_t(pub *const ());
+
 mod c_int_definition {
     crate::cfg_select! {
         any(target_arch = "avr", target_arch = "msp430") => {

--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -3,6 +3,8 @@
 //! This module is intentionally standalone to facilitate parsing when retrieving
 //! core C types.
 
+use crate::mem::{self};
+
 macro_rules! type_alias {
     {
       $Docfile:tt, $Alias:ident = $Real:ty;
@@ -181,8 +183,8 @@ pub type c_ssize_t = isize;
 /// pointer.
 #[unstable(feature = "c_size_t", issue = "88345")]
 #[repr(transparent)]
-#[derive(Debug)]
-pub struct c_intptr_t(pub *const ());
+#[derive(Copy, Clone, Debug)]
+pub struct c_intptr_t(*const ());
 
 /// Equivalent to C's `uintptr_t` type.
 ///
@@ -191,8 +193,111 @@ pub struct c_intptr_t(pub *const ());
 /// a pointer.
 #[unstable(feature = "c_size_t", issue = "88345")]
 #[repr(transparent)]
-#[derive(Debug)]
-pub struct c_uintptr_t(pub *const ());
+#[derive(Copy, Clone, Debug)]
+pub struct c_uintptr_t(*const ());
+
+/// Trait for types that can be used to represent C's `intptr_t` and `uintptr_t` types.
+///
+/// For handle interchange of rust `pointer` type and C's `intptr_t` and `uintptr_t` types.
+#[unstable(feature = "c_size_t", issue = "88345")]
+#[rustc_const_unstable(feature = "c_size_t", issue = "88345")]
+pub const trait TaggedPointer {
+    /// Creates a new instance of IntPtr from a pointer.
+    #[unstable(feature = "c_size_t", issue = "88345")]
+    fn new(ptr: *const ()) -> Self;
+    /// Returns the pointer contained in IntPtr.
+    #[unstable(feature = "c_size_t", issue = "88345")]
+    fn ptr(&self) -> *const ();
+}
+
+/// Trait for retrieving the integer representation of a TaggedPointer.
+///
+#[unstable(feature = "c_size_t", issue = "88345")]
+pub trait IntPtr: TaggedPointer {
+    /// The integer type that can hold the tagged pointer value.
+    type Number;
+
+    /// Returns the integer representation of the pointer contained in IntPtr.
+    #[unstable(feature = "c_size_t", issue = "88345")]
+    fn integer(&self) -> Self::Number;
+}
+
+#[unstable(feature = "c_size_t", issue = "88345")]
+#[rustc_const_unstable(feature = "c_size_t", issue = "88345")]
+impl const TaggedPointer for c_intptr_t {
+    fn new(ptr: *const ()) -> Self {
+        Self(ptr)
+    }
+
+    fn ptr(&self) -> *const () {
+        self.0
+    }
+}
+
+#[unstable(feature = "c_size_t", issue = "88345")]
+impl IntPtr for c_intptr_t {
+    type Number = c_intptr_definition::c_intptr_t;
+
+    fn integer(&self) -> Self::Number {
+        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the
+        // integer representing the pointer without exposing the provenance. Note that this is *not*
+        // a stable guarantee about transmute semantics, it relies on sysroot crates having special status.
+        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the
+        // provenance).
+        unsafe { mem::transmute(self.0.cast::<()>()) }
+    }
+}
+
+#[unstable(feature = "c_size_t", issue = "88345")]
+#[rustc_const_unstable(feature = "c_size_t", issue = "88345")]
+impl const TaggedPointer for c_uintptr_t {
+    fn new(ptr: *const ()) -> Self {
+        Self(ptr)
+    }
+
+    fn ptr(&self) -> *const () {
+        self.0
+    }
+}
+
+#[unstable(feature = "c_size_t", issue = "88345")]
+impl IntPtr for c_uintptr_t {
+    type Number = c_intptr_definition::c_uintptr_t;
+
+    fn integer(&self) -> Self::Number {
+        // A pointer-to-integer transmute currently has exactly the right semantics: it returns the
+        // integer representing the pointer without exposing the provenance. Note that this is *not*
+        // a stable guarantee about transmute semantics, it relies on sysroot crates having special status.
+        // SAFETY: Pointer-to-integer transmutes are valid (if you are okay with losing the
+        // provenance).
+        unsafe { mem::transmute(self.0.cast::<()>()) }
+    }
+}
+
+mod c_intptr_definition {
+    crate::cfg_select! {
+        target_pointer_width = "16" => {
+            pub(super) type c_intptr_t = i16;
+            pub(super) type c_uintptr_t = u16;
+        }
+        target_pointer_width = "32" => {
+            pub(super) type c_intptr_t = i32;
+            pub(super) type c_uintptr_t = u32;
+        }
+        target_pointer_width = "64" => {
+            pub(super) type c_intptr_t = i64;
+            pub(super) type c_uintptr_t = u64;
+        }
+        _ => {
+            /// 128-bit width pointer.
+            ///
+            /// The C standard only requires that these types be large enough to hold a pointer,
+            /// so we'll use the i128/u128 integer types in Rust.
+            pub(super) type c_intptr_t = i128;
+            pub(super) type c_uintptr_t = u128;
+        }
+    }
+}
 
 mod c_int_definition {
     crate::cfg_select! {

--- a/library/coretests/tests/ffi.rs
+++ b/library/coretests/tests/ffi.rs
@@ -1,1 +1,2 @@
 mod cstr;
+mod intptr;

--- a/library/coretests/tests/ffi/intptr.rs
+++ b/library/coretests/tests/ffi/intptr.rs
@@ -1,0 +1,17 @@
+#![deny(fuzzy_provenance_casts)]
+#![deny(lossy_provenance_casts)]
+
+use core::ffi::{c_intptr_t, c_uintptr_t};
+
+#[test]
+fn test_intptr_unitptr() {
+    // These types should have the same size as a pointer.
+    assert_eq!(core::mem::size_of::<c_intptr_t>(), core::mem::size_of::<*const ()>());
+    assert_eq!(core::mem::size_of::<c_uintptr_t>(), core::mem::size_of::<*const ()>());
+
+    let ptr = core::ptr::with_exposed_provenance(16_usize);
+    let ptr_uintptr_t = c_uintptr_t(ptr);
+    let ptr_back = ptr_uintptr_t.0;
+    assert_eq!(ptr_back.addr(), 16_usize);
+    assert_eq!(ptr, ptr_back);
+}

--- a/library/coretests/tests/ffi/intptr.rs
+++ b/library/coretests/tests/ffi/intptr.rs
@@ -1,7 +1,11 @@
 #![deny(fuzzy_provenance_casts)]
 #![deny(lossy_provenance_casts)]
 
-use core::ffi::{c_intptr_t, c_uintptr_t};
+use core::ffi::{IntPtr, TaggedPointer, c_intptr_t, c_uintptr_t};
+
+extern "C" fn c_ffi_function_on_uintptr(v: c_uintptr_t) {
+    assert_eq!((v.integer() as usize) & 0xFF_usize, 16_usize);
+}
 
 #[test]
 fn test_intptr_unitptr() {
@@ -10,8 +14,10 @@ fn test_intptr_unitptr() {
     assert_eq!(core::mem::size_of::<c_uintptr_t>(), core::mem::size_of::<*const ()>());
 
     let ptr = core::ptr::with_exposed_provenance(16_usize);
-    let ptr_uintptr_t = c_uintptr_t(ptr);
-    let ptr_back = ptr_uintptr_t.0;
+    let ptr_uintptr_t = c_uintptr_t::new(ptr);
+    let ptr_back = ptr_uintptr_t.ptr();
+    c_ffi_function_on_uintptr(ptr_uintptr_t);
     assert_eq!(ptr_back.addr(), 16_usize);
+    assert_eq!((ptr_uintptr_t.integer() as usize) & 0xFF_usize, 16_usize);
     assert_eq!(ptr, ptr_back);
 }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -11,6 +11,7 @@
 #![feature(bool_to_result)]
 #![feature(borrowed_buf_init)]
 #![feature(bstr)]
+#![feature(c_size_t)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(char_internals)]
 #![feature(clone_to_uninit)]

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -179,7 +179,7 @@ pub use core::ffi::{
     c_ulong, c_ulonglong, c_ushort,
 };
 #[unstable(feature = "c_size_t", issue = "88345")]
-pub use core::ffi::{c_ptrdiff_t, c_size_t, c_ssize_t};
+pub use core::ffi::{c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t};
 
 #[doc(inline)]
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -166,6 +166,10 @@ pub mod c_str;
 
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub use core::ffi::c_void;
+#[unstable(feature = "c_size_t", issue = "88345")]
+pub use core::ffi::{
+    IntPtr, TaggedPointer, c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t,
+};
 #[unstable(
     feature = "c_variadic",
     reason = "the `c_variadic` feature has not been properly tested on \
@@ -178,8 +182,6 @@ pub use core::ffi::{
     c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
     c_ulong, c_ulonglong, c_ushort,
 };
-#[unstable(feature = "c_size_t", issue = "88345")]
-pub use core::ffi::{c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t};
 
 #[doc(inline)]
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]

--- a/src/doc/unstable-book/src/language-features/c-size-t.md
+++ b/src/doc/unstable-book/src/language-features/c-size-t.md
@@ -12,10 +12,10 @@ The `c_size_t` feature allows to enable C FFI types `size_t` `ssize_t` `intptr_t
 ```rust
 #![feature(c_size_t)]
 
-use std::ffi::{c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t};
+use std::ffi::{TaggedPointer, c_uintptr_t};
 
 fn main() {
     let ptr = core::ptr::with_exposed_provenance(16_usize);
-    let _ptr_uintptr_t = c_uintptr_t(ptr);
+    let _ptr_uintptr_t = c_uintptr_t::new(ptr);
 }
 ```

--- a/src/doc/unstable-book/src/language-features/c-size-t.md
+++ b/src/doc/unstable-book/src/language-features/c-size-t.md
@@ -1,0 +1,21 @@
+# `c_size_t`
+
+The tracking issue for this feature is: [#88345]
+
+[#88345]: https://github.com/rust-lang/rust/issues/88345
+-----
+
+The `c_size_t` feature allows to enable C FFI types `size_t` `ssize_t` `intptr_t` `uintptr_t` `ptrdiff_t`.
+
+## Example
+
+```rust
+#![feature(c_size_t)]
+
+use std::ffi::{c_intptr_t, c_ptrdiff_t, c_size_t, c_ssize_t, c_uintptr_t};
+
+fn main() {
+    let ptr = core::ptr::with_exposed_provenance(16_usize);
+    let _ptr_uintptr_t = c_uintptr_t(ptr);
+}
+```

--- a/tests/ui/feature-gates/feature-gate-c-size-t.rs
+++ b/tests/ui/feature-gates/feature-gate-c-size-t.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+use std::ffi::{c_intptr_t};
+//~^ ERROR use of unstable library feature `c_size_t`

--- a/tests/ui/feature-gates/feature-gate-c-size-t.stderr
+++ b/tests/ui/feature-gates/feature-gate-c-size-t.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature `c_size_t`
+  --> $DIR/feature-gate-c-size-t.rs:3:16
+   |
+LL | use std::ffi::{c_intptr_t};
+   |                ^^^^^^^^^^
+   |
+   = note: see issue #88345 <https://github.com/rust-lang/rust/issues/88345> for more information
+   = help: add `#![feature(c_size_t)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156626)*
<!-- homu-ignore:end -->

In summary, I want to give the following conclusion:
1.  `usize`, `isize` should be the same with C23's  `size_t` `ssize_t` as @tgross35  said at [comment](https://github.com/rust-lang/rust/pull/156626#issuecomment-4464452358).
And from https://internals.rust-lang.org/t/pre-rfc-usize-semantics/19444/156
2.  (`c_intptr_t`, `c_uintptr_t`) be defined as one alias of (`i8`, `u8`), (`i16`, `u16`), (`i32`, `u32`), (`i64`, `u64`), (`i128`, `u128`)  in `core::ffi` is enough.
3. c_ptrdiff_t is very special, [can be either `ssize_t` or `intptr_t`](https://stackoverflow.com/questions/51820579/when-could-sizeofsize-t-and-sizeofptrdiff-t-differ/51836957#51836957) 

4. Add function expose_addr  to pointer Trait for retrieve the raw integer value for the tagged-pointer.
  ```
  impl *const T {
      fn addr(self) -> usize;
      fn expose_addr (self) -> c_uintptr_t;
      // ...
  }
  
  fn cast_between_pointer_uintptr() {
      let my_val = 42;
      let ptr = &my_val as *const i32;
  
      // Convert pointer to isize
      let tagged_ptr_integer = ptr as c_uintptr_t;
      let ptr2 = tagged_ptr_integer as *const i32;
  }
  ```
  maybe the `as` operator is enough.
  And avoid cast pointer from/to usize/isize by stablize [Tracking Issue for strict_provenance_lints](https://github.com/rust-lang/rust/issues/130351)

5. Add a  function to convert `c_uintptr_t`, `c_intptr_t` back to pointer.  Maybe the `as` operator is enough.

6. `ptraddr_t` is just a alias of `usize`, do not know if this need to be in core::ffi, not part of C standard yet, but Rust is a language for safety, add it into core::ffi seems make sense.

7. The usage of usize/isize is guard by [strict_provenance](https://dev-doc.rust-lang.org/beta/unstable-book/language-features/strict-provenance.html#strict_provenance)

Tracking issue: https://github.com/rust-lang/rust/issues/88345

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
