### PR TITLE
Stabilize `core::range::{legacy, RangeFull, RangeTo}`

### DIFF
--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -23,6 +23,8 @@ mod iter;
 #[stable(feature = "new_range_api_legacy", since = "CURRENT_RUSTC_VERSION")]
 pub mod legacy;
 
+use core::ops::Bound::{self, Excluded, Included, Unbounded};
+
 #[doc(inline)]
 #[stable(feature = "new_range_from_api", since = "1.96.0")]
 pub use iter::RangeFromIter;
@@ -33,19 +35,13 @@ pub use iter::RangeInclusiveIter;
 #[stable(feature = "new_range_api", since = "1.96.0")]
 pub use iter::RangeIter;
 
-// FIXME(#125687): re-exports temporarily removed
-// Because re-exports of stable items (Bound, RangeBounds, RangeFull, RangeTo)
-// can't be made unstable.
-//
-// #[doc(inline)]
-// #[unstable(feature = "new_range_api", issue = "125687")]
-// pub use crate::iter::Step;
-// #[doc(inline)]
-// #[unstable(feature = "new_range_api", issue = "125687")]
-// pub use crate::ops::{Bound, IntoBounds, OneSidedRange, RangeBounds, RangeFull, RangeTo};
 use crate::iter::Step;
-use crate::ops::Bound::{self, Excluded, Included, Unbounded};
+// FIXME(one_sided_range): These types should move into this module.
+// FIXME(range_into_bounds): Ditto. Also consider re-exporting `RangeBounds` and related.
 use crate::ops::{IntoBounds, OneSidedRange, OneSidedRangeBound, RangeBounds};
+#[doc(inline)]
+#[stable(feature = "new_range_api_exports", since = "CURRENT_RUSTC_VERSION")]
+pub use crate::ops::{RangeFull, RangeTo};
 
 /// A (half-open) range bounded inclusively below and exclusively above.
 ///

--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -20,7 +20,7 @@ use crate::hash::Hash;
 
 mod iter;
 
-#[unstable(feature = "new_range_api_legacy", issue = "125687")]
+#[stable(feature = "new_range_api_legacy", since = "CURRENT_RUSTC_VERSION")]
 pub mod legacy;
 
 #[doc(inline)]

--- a/library/core/src/range/legacy.rs
+++ b/library/core/src/range/legacy.rs
@@ -7,4 +7,5 @@
 //! The types here are equivalent to those in [`core::ops`].
 
 #[doc(inline)]
+#[stable(feature = "new_range_api_legacy", since = "CURRENT_RUSTC_VERSION")]
 pub use crate::ops::{Range, RangeFrom, RangeInclusive, RangeToInclusive};

--- a/tests/ui/did_you_mean/sugg-stable-import-first-issue-140240.stderr
+++ b/tests/ui/did_you_mean/sugg-stable-import-first-issue-140240.stderr
@@ -10,9 +10,9 @@ LL + use std::collections::btree_map::Range;
    |
 LL + use std::collections::btree_set::Range;
    |
-LL + use std::ops::Range;
-   |
 LL + use std::range::Range;
+   |
+LL + use std::range::legacy::Range;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/new-range/disabled.rs
+++ b/tests/ui/new-range/disabled.rs
@@ -1,6 +1,5 @@
+//! Without the `new_range` feature enabled, `..` syntax resolves to the legacy types.
 //@ check-pass
-
-#![feature(new_range_api_legacy)]
 
 fn main() {
     // Unchanged

--- a/tests/ui/new-range/disabled.rs
+++ b/tests/ui/new-range/disabled.rs
@@ -6,9 +6,8 @@ fn main() {
     let a: core::ops::RangeFull = ..;
     let b: core::ops::RangeTo<u8> = ..2;
 
-    // FIXME(#125687): re-exports temporarily removed
-    // let _: core::range::RangeFull = a;
-    // let _: core::range::RangeTo<u8> = b;
+    let _: core::range::RangeFull = a;
+    let _: core::range::RangeTo<u8> = b;
 
     // Changed
     let a: core::range::legacy::RangeFrom<u8> = 1..;

--- a/tests/ui/new-range/enabled.rs
+++ b/tests/ui/new-range/enabled.rs
@@ -8,9 +8,8 @@ fn main() {
     let a: core::ops::RangeFull = ..;
     let b: core::ops::RangeTo<u8> = ..2;
 
-    // FIXME(#125687): re-exports temporarily removed
-    // let _: core::range::RangeFull = a;
-    // let _: core::range::RangeTo<u8> = b;
+    let _: core::range::RangeFull = a;
+    let _: core::range::RangeTo<u8> = b;
 
     // Changed
     let a: core::range::RangeFrom<u8> = 1..;

--- a/tests/ui/new-range/enabled.rs
+++ b/tests/ui/new-range/enabled.rs
@@ -1,3 +1,4 @@
+//! With the `new_range` feature enabled, `..` syntax resolves to the new range types.
 //@ check-pass
 
 #![feature(new_range)]

--- a/tests/ui/range/new_range_stability.rs
+++ b/tests/ui/range/new_range_stability.rs
@@ -7,6 +7,7 @@ use std::range::{
     RangeFrom,
     RangeFromIter,
     Range,
+    legacy,
 };
 
 fn range_inclusive(mut r: RangeInclusive<usize>) {
@@ -59,9 +60,5 @@ fn range(mut r: Range<usize>) {
     // Left unstable
     i.remainder(); //~ ERROR unstable
 }
-
-// Unstable module
-
-use std::range::legacy; //~ ERROR unstable
 
 fn main() {}

--- a/tests/ui/range/new_range_stability.stderr
+++ b/tests/ui/range/new_range_stability.stderr
@@ -1,15 +1,5 @@
-error[E0658]: use of unstable library feature `new_range_api_legacy`
-  --> $DIR/new_range_stability.rs:65:5
-   |
-LL | use std::range::legacy;
-   |     ^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #125687 <https://github.com/rust-lang/rust/issues/125687> for more information
-   = help: add `#![feature(new_range_api_legacy)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: use of unstable library feature `new_range_remainder`
-  --> $DIR/new_range_stability.rs:23:7
+  --> $DIR/new_range_stability.rs:24:7
    |
 LL |     i.remainder();
    |       ^^^^^^^^^
@@ -19,7 +9,7 @@ LL |     i.remainder();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `new_range_remainder`
-  --> $DIR/new_range_stability.rs:44:7
+  --> $DIR/new_range_stability.rs:45:7
    |
 LL |     i.remainder();
    |       ^^^^^^^^^
@@ -29,7 +19,7 @@ LL |     i.remainder();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `new_range_remainder`
-  --> $DIR/new_range_stability.rs:60:7
+  --> $DIR/new_range_stability.rs:61:7
    |
 LL |     i.remainder();
    |       ^^^^^^^^^
@@ -38,6 +28,6 @@ LL |     i.remainder();
    = help: add `#![feature(new_range_remainder)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Stabilize `core::range::legacy` and the re-exports of unchanged range types, so all range types can now be imported from within `core::range`. Newly stable API:

```rust
use core::range::RangeFull;
use core::range::RangeTo;
use core::range::legacy::{Range, RangeFrom, RangeInclusive, RangeToInclusive};
```

Compared to what is in the comment, I made a few exclusions:

1. At https://github.com/rust-lang/rust/issues/125687#issuecomment-3619110815, @sendittothenewts suggested not to stabilize `core::range::RangeBounds` in case we want to reuse that name for a replacement based on `IntoBounds`. I have excluded it here so we can discuss further. `range_into_bounds` tracking issue: https://github.com/rust-lang/rust/issues/136903
2.   `one_sided_range` types should probably just move into this module rather than being exported, since they are unstable. Added an unresolved question at https://github.com/rust-lang/rust/issues/69780.
3. Similarly, `step_trait ` is unstable so we could just move `crate::iter::Step` if `core::range` is a better home. Added an unresolved question at https://github.com/rust-lang/rust/issues/42168.

Since this is the last thing in `new_range_api` that isn't tracked elsewhere:

Closes: https://github.com/rust-lang/rust/issues/125687

<!-- homu-ignore:start -->
Cc @pitaj
<!-- homu-ignore:end -->
