### PR TITLE
library: Fix std compilation for espidf target in unix::process

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -494,8 +494,17 @@ impl ChildExt for process::Child {
         self.handle.send_process_group_signal(signal)
     }
 
+    #[cfg(not(target_os = "espidf"))]
     fn kill_process_group(&mut self) -> io::Result<()> {
         self.handle.send_process_group_signal(libc::SIGKILL)
+    }
+
+    #[cfg(target_os = "espidf")]
+    fn kill_process_group(&mut self) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "process groups are not supported on espidf",
+        ))
     }
 }
 


### PR DESCRIPTION
Fixes a regression on the riscv32imac-esp-espidf target caused by commit 7bf5fe7bf84f5b94e5970de18543abac0579209c (linked issue rust-lang/rust#156537) . The unix_kill_process_group feature attempts to use libc::SIGKILL, which is not supported on the espidf target.

Discussed in `esp-idf-sys` issue: https://github.com/esp-rs/esp-idf-sys/issues/419