### PR TITLE
Remove broken dilos apt repo

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -27,9 +27,6 @@ RUN apt-get update && apt-get build-dep -y clang llvm && apt-get install -y --no
   g++-9-arm-linux-gnueabi \
   g++-11-riscv64-linux-gnu
 
-RUN apt-key adv --batch --yes --keyserver keyserver.ubuntu.com --recv-keys 74DA7924C5513486
-RUN add-apt-repository -y 'deb https://apt.dilos.org/dilos dilos2 main'
-
 ENV \
     AR_x86_64_unknown_fuchsia=x86_64-unknown-fuchsia-ar \
     CC_x86_64_unknown_fuchsia=x86_64-unknown-fuchsia-clang \


### PR DESCRIPTION
CI is currently down because apt is unable to access the repo at dilos.org. It is failing inside the fortanix install script which tries to run apt-get with the error:

```
5.679 E: Failed to fetch https://apt.dilos.org/dilos/dists/dilos2/InRelease  403  Forbidden [IP: 116.202.240.188 443]
```

These lines in the Dockerfile were added when Solaris builds were merged into dist-various-2 in https://github.com/rust-lang/rust/pull/45001. However, Solaris builds were split off in https://github.com/rust-lang/rust/pull/138699. In that PR, these lines adding the dilos repository weren't removed.

AFAICT, these are no longer necessary.
