### PR TITLE
Call visitor only in one place in bodies of folds for RangeInclusive

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1325,18 +1325,33 @@ impl<T: TrustedStep> RangeInclusiveIteratorImpl for ops::RangeInclusive<T> {
         }
 
         let mut accum = init;
+        let mut i: T = self.start;
+        // We use loop with postcondition because
+        // it allows us to finish loop even when `self.end` is `T::MAX`.
+        // Precondition is checked before loop at the beginning of the function.
+        loop {
+            let current = i;
+            let is_last: bool = i == self.end;
 
-        while self.start < self.end {
-            // SAFETY: just checked precondition
-            let n = unsafe { Step::forward_unchecked(self.start, 1) };
-            let n = mem::replace(&mut self.start, n);
-            accum = f(accum, n)?;
-        }
+            // Need to update both fields before calling function
+            // because we can eagerly exit due to panic or ? operator.
 
-        self.exhausted = true;
+            // Writing to `self.exhausted` at every iteration is cheaper than branching.
+            // Especially because we need to write neighbouring field _anyway_.
+            self.exhausted = is_last;
+            // This should compile to conditional move for simple types.
+            self.start = if is_last {
+                current
+            } else {
+                // SAFETY: just checked precondition
+                i = unsafe { Step::forward_unchecked(i, 1) };
+                i
+            };
 
-        if self.start == self.end {
-            accum = f(accum, self.start)?;
+            accum = f(accum, current)?;
+            if is_last {
+                break;
+            }
         }
 
         try { accum }
@@ -1365,23 +1380,33 @@ impl<T: TrustedStep> RangeInclusiveIteratorImpl for ops::RangeInclusive<T> {
         F: FnMut(B, T) -> R,
         R: Try<Output = B>,
     {
+        // Code of this implementation is almost the same as `spec_try_fold`
+        // except it updates self.end and decrements counter.
+        // See it for comments for justification of code structure
+
         if self.is_empty() {
             return try { init };
         }
 
         let mut accum = init;
+        let mut i: T = self.end;
+        loop {
+            let current = i;
+            let is_last: bool = i == self.start;
 
-        while self.start < self.end {
-            // SAFETY: just checked precondition
-            let n = unsafe { Step::backward_unchecked(self.end, 1) };
-            let n = mem::replace(&mut self.end, n);
-            accum = f(accum, n)?;
-        }
+            self.exhausted = is_last;
+            self.end = if is_last {
+                current
+            } else {
+                // SAFETY: just checked precondition
+                i = unsafe { Step::backward_unchecked(i, 1) };
+                i
+            };
 
-        self.exhausted = true;
-
-        if self.start == self.end {
-            accum = f(accum, self.start)?;
+            accum = f(accum, current)?;
+            if is_last {
+                break;
+            }
         }
 
         try { accum }

--- a/library/coretests/tests/ascii_char.rs
+++ b/library/coretests/tests/ascii_char.rs
@@ -38,3 +38,46 @@ fn test_extend() {
     s.extend(Char::CapitalA..=Char::CapitalC);
     assert_eq!(s, String::from("abcABC"));
 }
+
+#[test]
+fn test_range_inclusive_try_fold() {
+    // Visit every value once.
+    let mut it = Char::MIN..=Char::MAX;
+    let mut expected: u32 = 0;
+    it.try_fold((), |_, x| {
+        assert!(expected <= u32::from(Char::MAX));
+        assert_eq!(expected, u32::from(x));
+        expected += 1;
+        Some(())
+    });
+
+    let mut it = Char::MIN..=Char::MAX;
+    it.try_fold((), |_, x| (x < Char::CapitalA).then_some(()));
+    assert!(!it.is_empty());
+    assert_eq!(it.next(), Some(Char::CapitalB));
+
+    let mut it = Char::MIN..=Char::MAX;
+    it.try_fold((), |_, x| (x != Char::MAX).then_some(()));
+    assert!(it.is_empty());
+    assert_eq!(it.next(), None);
+
+    // Visit every value once.
+    let mut it = Char::MIN..=Char::MAX;
+    let mut expected: i32 = u8::from(Char::MAX).into();
+    it.try_rfold((), |_, x| {
+        assert!(expected >= 0);
+        assert_eq!(expected, i32::from(u8::from(x)));
+        expected -= 1;
+        Some(())
+    });
+
+    let mut it = Char::MIN..=Char::MAX;
+    it.try_rfold((), |_, x| (x > Char::CapitalB).then_some(()));
+    assert!(!it.is_empty());
+    assert_eq!(it.next_back(), Some(Char::CapitalA));
+
+    let mut it = Char::MIN..=Char::MAX;
+    it.try_rfold((), |_, x| (x != Char::MIN).then_some(()));
+    assert!(it.is_empty());
+    assert_eq!(it.next(), None);
+}

--- a/library/coretests/tests/iter/range.rs
+++ b/library/coretests/tests/iter/range.rs
@@ -422,6 +422,64 @@ fn test_range_inclusive_folds() {
     assert!(it.is_empty());
     assert_eq!(it.try_rfold(0, |a, b| Some(a + b)), Some(0));
     assert!(it.is_empty());
+
+    // No endless loop.
+    let mut it = 0u8..=u8::MAX;
+    assert_eq!(it.try_fold(0u32, |a, b| Some(a + u32::from(b))), Some(32640));
+    assert!(it.is_empty());
+    assert_eq!(it.try_fold(0, |a, b| Some(a + b)), Some(0));
+    assert!(it.is_empty());
+
+    // No endless loop.
+    let mut it = i8::MIN..=i8::MAX;
+    assert_eq!(it.try_rfold(0i32, |a, b| Some(a + i32::from(b))), Some(-128));
+    assert!(it.is_empty());
+    assert_eq!(it.try_rfold(0, |a, b| Some(a + b)), Some(0));
+    assert!(it.is_empty());
+
+    // Visit every value exactly once in order.
+    let mut expected: Option<u8> = Some(0);
+    let mut it = 0u8..=u8::MAX;
+    it.try_fold((), |_, x| {
+        assert!(expected.is_some());
+        assert_eq!(Some(x), expected);
+        expected = expected.and_then(|e| e.checked_add(1));
+        Some(())
+    });
+
+    // Visit every value exactly once in reverse order.
+    let mut expected: Option<u8> = Some(u8::MAX);
+    let mut it = 0u8..=u8::MAX;
+    it.try_rfold((), |_, x| {
+        assert!(expected.is_some());
+        assert_eq!(Some(x), expected);
+        expected = expected.and_then(|e| e.checked_sub(1));
+        Some(())
+    });
+
+    // Early stop updates state correctly.
+    let mut it = 0..=100;
+    it.try_fold((), |_, x| (x < 10).then_some(()));
+    assert!(!it.is_empty());
+    assert_eq!(it.next(), Some(11));
+
+    // Early stop updates state correctly at the end.
+    let mut it = 0..=100;
+    it.try_fold((), |_, x| (x < 100).then_some(()));
+    assert!(it.is_empty());
+    assert_eq!(it.next(), None);
+
+    // Early stop updates state correctly.
+    let mut it = 0..=100;
+    it.try_rfold((), |_, x| (x > 10).then_some(()));
+    assert!(!it.is_empty());
+    assert_eq!(it.next_back(), Some(9));
+
+    // Early stop updates state correctly at the end.
+    let mut it = 0..=100;
+    it.try_rfold((), |_, x| (x != 0).then_some(()));
+    assert!(it.is_empty());
+    assert_eq!(it.next(), None);
 }
 
 #[test]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156654)*
<!-- homu-ignore:end -->

Prior attempt: eb5b09688696562d08ebb35e34ded723e6e44277

I rewrote the loops in `spec_try_fold` and `spec_try_rfold` to call argument function only inside a loop body instead of having extra single call after the loop.

I expect this change to make the loop body a single callsite for lambdas passed into closed range iterators (`x..=y`). In such cases, it would encourage LLVM to inline the lambda and remove the instantiation of its function. Also, it would reduce code of `try_fold` calls where LLVM previously inlined the lambda body twice.

I handled the danger of overflow or underflow by switching from `while` loops to loops with postcondition.

I also checked manually that the LLVM do not fail to optimize loops.

Example test (compiled using `rustc +stage1 .\sum.rs --crate-type=dylib -O --emit=llvm-ir`):

```rust
pub fn mysum(a:u32, b: u32)->u32{
    (a..=b).sum()
}
```

Output was successfully folded into arithmetic progression formula without loops:

```llvm
define noundef i32 @mysum(i32 noundef %a, i32 noundef %b) {
bb28.i.i:
  %_0.i.not.i.i = icmp ugt i32 %a, %b
  br i1 %_0.i.not.i.i, label %_<fun_exit>.exit, label %bb4.preheader.i.i

bb4.preheader.i.i:                                ; preds = %bb28.i.i
  %_0.i510.i.i = icmp eq i32 %a, %b
  br i1 %_0.i510.i.i, label %bb16.i.i, label %bb9.preheader.i.i

bb9.preheader.i.i:                                ; preds = %bb4.preheader.i.i
  %0 = xor i32 %a, -1
  %1 = add i32 %b, %0
  %2 = add i32 %a, 1
  %3 = mul i32 %1, %2
  %4 = add i32 %3, %a
  %5 = zext i32 %1 to i33
  %reass.sub = sub i32 %b, %a
  %6 = add i32 %reass.sub, -2
  %7 = zext i32 %6 to i33
  %8 = mul i33 %5, %7
  %9 = lshr i33 %8, 1
  %10 = trunc nuw i33 %9 to i32
  %11 = add i32 %4, %10
  br label %bb16.i.i

bb16.i.i:                                         ; preds = %bb9.preheader.i.i, %bb4.preheader.i.i
  %i.sroa.0.0.lcssa.i.i = phi i32 [ %b, %bb9.preheader.i.i ], [ %a, %bb4.preheader.i.i ]
  %accum.sroa.0.0.lcssa.i.i = phi i32 [ %11, %bb9.preheader.i.i ], [ 0, %bb4.preheader.i.i ]
  %_4.0.i.i8.i.i = add i32 %accum.sroa.0.0.lcssa.i.i, %i.sroa.0.0.lcssa.i.i
  br label %_<fun_exit>.exit

_<fun_exit>.exit: ; preds = %bb28.i.i, %bb16.i.i
  %_0.sroa.0.0.i.i = phi i32 [ %_4.0.i.i8.i.i, %bb16.i.i ], [ 0, %bb28.i.i ]
  ret i32 %_0.sroa.0.0.i.i
}
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
