### PR TITLE
Avoid const generic recovery after doc comment in type

### DIFF
--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -972,7 +972,10 @@ impl<'a> Parser<'a> {
                     GenericArg::Type(ty)
                 }
                 Err(err) => {
-                    if let Some(snapshot) = snapshot
+                    let stopped_at_doc_comment = matches!(self.token.kind, token::DocComment(..));
+
+                    if !stopped_at_doc_comment
+                        && let Some(snapshot) = snapshot
                         && let Some(expr) =
                             self.recover_unbraced_const_arg_that_can_begin_ty(snapshot)
                     {

--- a/tests/ui/parser/doc-comment-in-generic-tuple-type.rs
+++ b/tests/ui/parser/doc-comment-in-generic-tuple-type.rs
@@ -1,3 +1,4 @@
+// Regression test for https://github.com/rust-lang/rust/issues/122463
 struct Foo {
     a: Vec<(
         /// Docstring

--- a/tests/ui/parser/doc-comment-in-generic-tuple-type.rs
+++ b/tests/ui/parser/doc-comment-in-generic-tuple-type.rs
@@ -1,0 +1,10 @@
+struct Foo {
+    a: Vec<(
+        /// Docstring
+        //~^ ERROR expected type, found doc comment
+        f32,
+        f32,
+    )>,
+}
+
+fn main() {}

--- a/tests/ui/parser/doc-comment-in-generic-tuple-type.stderr
+++ b/tests/ui/parser/doc-comment-in-generic-tuple-type.stderr
@@ -1,5 +1,5 @@
 error: expected type, found doc comment `/// Docstring`
-  --> $DIR/doc-comment-in-generic-tuple-type.rs:3:9
+  --> $DIR/doc-comment-in-generic-tuple-type.rs:4:9
    |
 LL | struct Foo {
    |        --- while parsing this struct

--- a/tests/ui/parser/doc-comment-in-generic-tuple-type.stderr
+++ b/tests/ui/parser/doc-comment-in-generic-tuple-type.stderr
@@ -1,0 +1,11 @@
+error: expected type, found doc comment `/// Docstring`
+  --> $DIR/doc-comment-in-generic-tuple-type.rs:3:9
+   |
+LL | struct Foo {
+   |        --- while parsing this struct
+LL |     a: Vec<(
+LL |         /// Docstring
+   |         ^^^^^^^^^^^^^ expected type
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes rust-lang/rust#122463.

When parsing a generic argument, rustc may snapshot the parser state and retry a failed type parse as an unbraced const generic argument. For `Vec<(/// doc
f32, f32)>`, that recovery produces a misleading follow-up E0747 after the useful “expected type, found doc comment” diagnostic.

This skips that const-generic recovery path when type parsing stopped at a doc comment, and adds a regression test for the compiler diagnostic.