### PR TITLE
Evaluate Unevaluated const inside `Const::Ty` in valtree conversion

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -29,8 +29,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     /// This is a convenience helper for `immediate_const_vector`. It has the precondition
-    /// that the given `constant` is an `Const::Unevaluated` and must be convertible to
-    /// a `ValTree`. If you want a more general version of this, talk to `wg-const-eval` on zulip.
+    /// that the given `constant` is a `Const::Unevaluated`, or a `Const::Ty` containing a
+    /// `ty::ConstKind::Value` or `ty::ConstKind::Unevaluated`, and must be convertible to a
+    /// `ValTree`. If you want a more general version of this, talk to `wg-const-eval` on zulip.
     ///
     /// Note that this function is cursed, since usually MIR consts should not be evaluated to
     /// valtrees!
@@ -44,6 +45,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // A constant that came from a const generic but was then used as an argument to
                 // old-style simd_shuffle (passing as argument instead of as a generic param).
                 ty::ConstKind::Value(cv) => return Ok(Ok(cv.valtree)),
+                ty::ConstKind::Unevaluated(uv) => uv,
                 other => span_bug!(constant.span, "{other:#?}"),
             },
             // We should never encounter `Const::Val` unless MIR opts (like const prop) evaluate

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -847,10 +847,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         assert!(!constant.const_.ty().has_param());
         let (uv, ty) = match constant.const_ {
             mir::Const::Unevaluated(uv, ty) => (uv.shrink(), ty),
-            mir::Const::Ty(_, c) => match c.kind() {
+            mir::Const::Ty(ty, c) => match c.kind() {
                 // A constant that came from a const generic but was then used as an argument to
                 // old-style simd_shuffle (passing as argument instead of as a generic param).
                 ty::ConstKind::Value(cv) => return Ok((cv.valtree, cv.ty)),
+                ty::ConstKind::Unevaluated(uv) => (uv, ty),
                 other => span_bug!(constant.span, "{other:#?}"),
             },
             mir::Const::Val(mir::ConstValue::Scalar(mir::interpret::Scalar::Int(val)), ty) => {

--- a/tests/ui/loop-match/type-const-const-continue-ice.rs
+++ b/tests/ui/loop-match/type-const-const-continue-ice.rs
@@ -1,0 +1,25 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/156410>
+
+#![feature(min_generic_const_args)]
+#![feature(loop_match)]
+
+trait T {
+    type const N: usize;
+    fn a() {
+        let mut s;
+        #[loop_match]
+        loop {
+            s = 'b: {
+                match s {
+                    _ => {
+                        #[const_continue]
+                        break 'b Self::N
+                        //~^ ERROR could not determine the target branch for this `#[const_continue]`
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/loop-match/type-const-const-continue-ice.stderr
+++ b/tests/ui/loop-match/type-const-const-continue-ice.stderr
@@ -1,0 +1,8 @@
+error: could not determine the target branch for this `#[const_continue]`
+  --> $DIR/type-const-const-continue-ice.rs:16:34
+   |
+LL |                         break 'b Self::N
+   |                                  ^^^^^^^ this value is too generic
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Handle `ConstKind::Unevaluated` inside `Const::Ty`.

Closes rust-lang/rust#156410

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
