### PR TITLE
change `other uses of const` to `raw pointers` in const keyword docs

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -238,7 +238,7 @@ mod break_keyword {}
 ///
 /// Turning a `fn` into a `const fn` has no effect on run-time uses of that function.
 ///
-/// ## Other uses of `const`
+/// ## raw pointers
 ///
 /// The `const` keyword is also used in raw pointers in combination with `mut`, as seen in `*const
 /// T` and `*mut T`. More about `const` as used in raw pointers can be read at the Rust docs for the [pointer primitive].


### PR DESCRIPTION
this section only talks about how `const` is used in raw pointers and doesn't give any other uses, so in my opinion it would be a bit clearer if the section was named `raw pointers` or something similar.