### PR TITLE
perf(compilation): Directly construct `Take` and `Chain`

### DIFF
--- a/library/core/src/io/mod.rs
+++ b/library/core/src/io/mod.rs
@@ -15,6 +15,3 @@ pub use self::error::ErrorKind;
 pub use self::error::RawOsError;
 #[unstable(feature = "core_io", issue = "154046")]
 pub use self::util::{Chain, Empty, Repeat, Sink, Take, empty, repeat, sink};
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-pub use self::util::{chain, take};

--- a/library/core/src/io/util.rs
+++ b/library/core/src/io/util.rs
@@ -132,7 +132,6 @@ pub const fn sink() -> Sink {
 /// [`chain`]: ../../std/io/trait.Read.html#method.chain
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct Chain<T, U> {
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
@@ -224,14 +223,6 @@ impl<T, U> Chain<T, U> {
     }
 }
 
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-#[must_use]
-#[inline]
-pub const fn chain<T, U>(first: T, second: U) -> Chain<T, U> {
-    Chain { first, second, done_first: false }
-}
-
 /// Reader adapter which limits the bytes read from an underlying reader.
 ///
 /// This struct is generally created by calling [`take`] on a reader.
@@ -240,7 +231,6 @@ pub const fn chain<T, U>(first: T, second: U) -> Chain<T, U> {
 /// [`take`]: ../../std/io/trait.Read.html#method.take
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct Take<T> {
     #[doc(hidden)]
     #[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
@@ -404,12 +394,4 @@ impl<T> Take<T> {
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }
-}
-
-#[doc(hidden)]
-#[unstable(feature = "core_io_internals", reason = "exposed only for libstd", issue = "none")]
-#[must_use]
-#[inline]
-pub const fn take<T>(inner: T, limit: u64) -> Take<T> {
-    Take { inner, limit, len: limit }
 }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1184,7 +1184,7 @@ pub trait Read {
     where
         Self: Sized,
     {
-        core::io::chain(self, next)
+        Chain { first: self, second: next, done_first: false }
     }
 
     /// Creates an adapter which will read at most `limit` bytes from it.
@@ -1223,7 +1223,7 @@ pub trait Read {
     where
         Self: Sized,
     {
-        core::io::take(self, limit)
+        Take { inner: self, len: limit, limit }
     }
 
     /// Read and return a fixed array of bytes from this source.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

# Objective

Performance regression in compilation discovered found [here](https://github.com/rust-lang/rust/pull/156506#issuecomment-4435773606) was narrowed down to the movement of utility types from `std::io` to `core::io` [here](https://github.com/rust-lang/rust/pull/156431#issuecomment-4472474235). Likely culprit is the introduction of `core::io::take` and `core::io::chain` to construction `Take` and `Chain` within `Read::take` and `Read::chain`. If this does not address the compilation difference, then it must be the unchanged methods which are not `#[inline]`, such as `Chain::into_inner`, etc.

Have not replicated the compilation performance difference locally, happy to amend/delete this PR if a perf-run shows it has no effect.,

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.