### PR TITLE
Manually load GDB visualizers on windows for GDB tests

### DIFF
--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -260,6 +260,19 @@ impl TestCx<'_> {
                             "add-auto-load-safe-path {}\n",
                             self.output_base_dir().as_str().replace(r"\", r"\\")
                         ));
+
+                        // GDB visualizer scripts aren't properly embedded on `*-windows-gnu`
+                        // at the moment (see: issue #156687), so we need to load them in
+                        // manually.
+                        #[cfg(target_os = "windows")]
+                        {
+                            script_str.push_str(&format!(
+                                "source {}\n",
+                                self.config
+                                    .src_root
+                                    .join("src/etc/gdb_load_rust_pretty_printers.py")
+                            ));
+                        }
                     }
                 }
                 _ => {


### PR DESCRIPTION
`*-windows-gnu` does not embed the visualizer scripts at the moment, so many of the debug info tests fail/can't be run. This change manually loads the visualizers, but does *not* re-enable any tests since that's a huge can of worms. They can be handled on a case-by-case basis eventually, or more than likely it'll resolve itself as I rework the test suite

Resolves https://github.com/rust-lang/rust/issues/128981

r? @Kobzol 