### PR TITLE
Add doc aliases for crate names whose functionality we've added

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -229,6 +229,7 @@ pub macro assert_matches {
 /// };
 /// ```
 #[stable(feature = "cfg_select", since = "1.95.0")]
+#[doc(alias = "cfg_if", alias = "cfg-if")]
 #[rustc_diagnostic_item = "cfg_select"]
 #[rustc_builtin_macro]
 pub macro cfg_select($($tt:tt)*) {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1570,6 +1570,7 @@ impl<T> SizedTypeProperties for T {}
 #[diagnostic::on_unmatch_args(
     note = "this macro expects a container type and a (nested) field path, like `offset_of!(Type, field)`"
 )]
+#[doc(alias = "memoffset")]
 #[allow_internal_unstable(builtin_syntax, core_intrinsics)]
 pub macro offset_of($Container:ty, $($fields:expr)+ $(,)?) {
     // The `{}` is for better error messages

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -640,6 +640,7 @@ impl Error for JoinPathsError {
 /// ```
 #[must_use]
 #[stable(feature = "env", since = "1.0.0")]
+#[doc(alias = "home")]
 pub fn home_dir() -> Option<PathBuf> {
     paths_imp::home_dir()
 }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1265,6 +1265,7 @@ impl File {
     #[doc(alias = "futimens")]
     #[doc(alias = "futimes")]
     #[doc(alias = "SetFileTime")]
+    #[doc(alias = "filetime")]
     pub fn set_times(&self, times: FileTimes) -> io::Result<()> {
         self.inner.set_times(times.0)
     }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1242,7 +1242,7 @@ pub trait IsTerminal: crate::sealed::Sealed {
     ///
     /// [changes]: io#platform-specific-behavior
     /// [`Stdin`]: crate::io::Stdin
-    #[doc(alias = "isatty")]
+    #[doc(alias = "isatty", alias = "atty")]
     #[stable(feature = "is_terminal", since = "1.70.0")]
     fn is_terminal(&self) -> bool;
 }


### PR DESCRIPTION
Add doc aliases for the names of crates whose functionality we've added to the
standard library.

This helps people find this functionality by crate name.
