### PR TITLE
feat: improve integer parsing performance

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1735,7 +1735,9 @@ macro_rules! from_str_int_impl {
             #[doc = concat!("assert!(", stringify!($int_ty), "::from_ascii_radix(b\"1 \", 10).is_err());")]
             /// ```
             #[unstable(feature = "int_from_ascii", issue = "134821")]
-            #[inline]
+            // `inline(always)` so the body's `radix`-dependent `ilog` bound
+            // and fast-prefix size const-fold at literal-radix call sites.
+            #[inline(always)]
             pub const fn from_ascii_radix(src: &[u8], radix: u32) -> Result<$int_ty, ParseIntError> {
                 use self::IntErrorKind::*;
                 use self::ParseIntError as PIE;

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1518,6 +1518,29 @@ pub enum FpCategory {
     Normal,
 }
 
+/// Largest `k` such that `radix.pow(k) <= 2.pow(bits)` — the largest digit
+/// count for which the unchecked `result = result * radix + d` accumulator is
+/// guaranteed not to overflow an integer of magnitude `2.pow(bits) - 1`.
+/// `radix` must be in `2..=36`.
+///
+/// Implemented as a macro because a `const fn` defeats cross-crate inlining.
+macro_rules! max_safe_digits {
+    ($bits:expr, $radix:expr) => {{
+        let bits: u32 = $bits;
+        let radix_u128 = ($radix) as u128;
+        if bits < 128 {
+            (1u128 << bits).ilog(radix_u128)
+        } else {
+            // 2.pow(128) doesn't fit u128. `u128::MAX.ilog(radix)` agrees with
+            // the true answer except when `radix` exactly tiles 128 bits
+            // (power of two dividing 128), where it undercounts by 1.
+            let base = u128::MAX.ilog(radix_u128);
+            let exact_tile = ($radix).is_power_of_two() && 128 % ($radix).ilog2() == 0;
+            base + exact_tile as u32
+        }
+    }};
+}
+
 /// Determines if a string of text of that length of that radix could be guaranteed to be
 /// stored in the given type T.
 /// Note that if the radix is known to the compiler, it is just the check of digits.len that
@@ -1526,7 +1549,8 @@ pub enum FpCategory {
 #[inline(always)]
 #[unstable(issue = "none", feature = "std_internals")]
 pub const fn can_not_overflow<T>(radix: u32, is_signed_ty: bool, digits: &[u8]) -> bool {
-    radix <= 16 && digits.len() <= size_of::<T>() * 2 - is_signed_ty as usize
+    let bits = (size_of::<T>() * 8 - is_signed_ty as usize) as u32;
+    digits.len() <= max_safe_digits!(bits, radix) as usize
 }
 
 #[cfg_attr(not(panic = "immediate-abort"), inline(never))]
@@ -1747,7 +1771,42 @@ macro_rules! from_str_int_impl {
                     };
                 }
 
-                if can_not_overflow::<$int_ty>(radix, is_signed_ty, digits) {
+                // Capture the original-input overflow decision *before* the
+                // u64 fast-prefix consumes any digits — consuming a safe
+                // prefix only shrinks the remaining-digit count, so an
+                // originally-safe input stays safe.
+                let no_overflow = can_not_overflow::<$int_ty>(radix, is_signed_ty, digits);
+
+                // u64 fast-prefix for types wider than `u64` (i.e. `i128`/`u128`):
+                // 128-bit multiply/add are several times slower than 64-bit on
+                // 64-bit hardware, so parse as many leading digits as fit in
+                // `u64`, then promote and let the main loop finish the rest.
+                if size_of::<$int_ty>() > size_of::<u64>() && !digits.is_empty() {
+                    let prefix_max = max_safe_digits!(64u32, radix) as usize;
+                    // `usize::min` is `const fn` but gated by an unstable
+                    // feature this function can't depend on yet.
+                    let take = if digits.len() < prefix_max { digits.len() } else { prefix_max };
+                    let (mut head, tail) = digits.split_at(take);
+                    let mut r64: u64 = 0;
+                    while let [c, rest @ ..] = head {
+                        let d = unwrap_or_PIE!((*c as char).to_digit(radix), InvalidDigit);
+                        // `head.len() <= prefix_max` keeps `r64` within `u64`.
+                        r64 = r64 * radix as u64 + d as u64;
+                        head = rest;
+                    }
+                    // For unsigned `$int_ty`, `is_positive` is always `true`
+                    // (the `-` arm of the sign match requires `is_signed_ty`),
+                    // so the negative branch is dead and gets eliminated.
+                    // For `i128`, `r64 < 2^64` so the negation cannot overflow.
+                    result = if is_positive {
+                        r64 as $int_ty
+                    } else {
+                        (r64 as $int_ty).wrapping_neg()
+                    };
+                    digits = tail;
+                }
+
+                if no_overflow {
                     // If the len of the str is short compared to the range of the type
                     // we are parsing into, then we can be certain that an overflow will not occur.
                     // This bound is when `radix.pow(digits.len()) - 1 <= T::MAX` but the condition

--- a/library/coretests/tests/num/mod.rs
+++ b/library/coretests/tests/num/mod.rs
@@ -213,8 +213,11 @@ fn test_can_not_overflow() {
     for base in 2..=36 {
         let num = <u128>::MAX;
         let max_len_string = format_radix(num, base as u128);
-        // base 16 fits perfectly for u128 and won't overflow:
-        assert_eq!(can_overflow::<u128>(base, &max_len_string), base != 16);
+        // Powers of two that divide 128 (2, 4, 16) produce a max-length
+        // string equal to u128::MAX itself, so the precise overflow check
+        // sees it as safe.
+        let fits_exactly = matches!(base, 2 | 4 | 16);
+        assert_eq!(can_overflow::<u128>(base, &max_len_string), !fits_exactly);
     }
 }
 


### PR DESCRIPTION
Const functions have improved significantly. Rather than the rough approximation of `can_not_overflow` that was introduced earlier (rust-lang/rust#95399), we can be accurate on digits that can lead to the fast path.

There is also a slight specialisation for `u128` to improve its parsing performance specifically as we can reduce the u128 multiplications that are done for fewer digits.

(I've done additional fuzz testing on both implementations to ensure there's no regressions. And full disclosure: this PR was designed by Claude and I while I was having a bath yesterday using the `/remote-control` )

## Benchmarks Arm64

  Apple M3 Max, ./x bench library/coretests --test-args=from_str, against main. New u128/i128 and long-string benches added in this PR.

  38 wins (≥5% faster), 1 regression (≥5% slower), 16 within ±5%. Best −55%, worst +13%.

```
  Selected wins (≥15%):

  bench_i8_from_str_radix_2          27525 → 12384   −55.0%
  bench_i64_from_str_radix_2         22842 → 11993   −47.5%
  bench_i16_from_str_radix_2         22292 → 11857   −46.8%
  bench_i128_from_str_radix_36       45014 → 27791   −38.3%
  bench_i16_from_str                 28609 → 17713   −38.1%
  bench_i32_from_str_radix_2         19408 → 12095   −37.7%
  bench_i16_from_str_radix_10        28303 → 18160   −35.8%
  bench_u64_from_str_radix_36        27969 → 19613   −29.9%
  bench_i128_from_str_radix_10_long 159379 → 113716  −28.7%    ← long-string
  bench_i128_from_str_radix_2        20049 → 14421   −28.1%
  bench_i64_from_str_radix_10        25465 → 18990   −25.4%
  bench_u128_from_str_radix_10_long 124595 → 102374  −17.8%    ← long-string
  bench_i128_from_str_radix_16       31002 → 25582   −17.5%
  bench_i64_from_str_radix_10_long   97396 → 81480   −16.3%    ← long-string
  bench_u128_from_str_radix_36       30580 → 25816   −15.6%

Sole regression:

  bench_i32_from_str_radix_36        23811 → 26923   +13.1%
```

The regression is structural - it's always that i32 / radix 36 combo.

## Benchmarks x86

On x86_64 (AMD Ryzen 9 5950X): all 55 benches stayed within ±1.5%.
x86 already looks about as optimum as can be.

I've included the results of some additional benchmarks in here `_long` that exercise the longer path more. I could include them in the PR but one could have too many benchmarks.



That said, if you prefer minimal changes in this PR and just want most of the performance wins, it seems changing `#[inline]` to `#[inline(always)]` here will give you most of the perf wins with a one line change:

```rust
#[inline(always)]
pub const fn from_ascii_radix(src: &[u8], radix: u32) -> Result<$int_ty, ParseIntError> {
```

```
  ┌────────────────────┬──────┬─────────────┬─────────┬─────────────────┐
  │       Option       │ Wins │ Regressions │ i32_r36 │     u16_r2      │
  ├────────────────────┼──────┼─────────────┼─────────┼─────────────────┤
  │ Just inline-always │ 22   │ 2           │ +17.2%  │ +9.8%           │
  ├────────────────────┼──────┼─────────────┼─────────┼─────────────────┤
  │ Full PR            │ 38   │ 1           │ +13.1%  │ +1.1% (noise)   │
  └────────────────────┴──────┴─────────────┴─────────┴─────────────────┘
```

I'll leave the choice up to you. I guess there must be some compile time cost to executing the const function, but there is an elegance that we have the maximum number hitting the unchecked path as possible.