### PR TITLE
Update list of platforms vulnerable to TOCTOU in `remove_dir_all`

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -3145,8 +3145,8 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// not be used in security-sensitive contexts:
 /// - **Miri**: Even when emulating targets where the underlying implementation will protect against
 ///   TOCTOU races, Miri will not do so.
-/// - **Redox OS**: This function does not protect against TOCTOU races, as Redox does not implement
-///   the required platform support to do so.
+/// - **QNX**, **Redox OS**, **VxWorks**: This function does not protect against TOCTOU races, as
+///   the underlying platform does not implement the required platform support to do so.
 ///
 /// [TOCTOU]: self#time-of-check-to-time-of-use-toctou
 /// [changes]: io#platform-specific-behavior


### PR DESCRIPTION
Neither platform can reasonably protect against TOCTOU in `remove_dir_all`:

* VxWorks doesn't always have the required API (depending on how it's built), and its security model prevents untrusted processes from existing.
* QNX itself is broken and prevents the use of `openat()`: in QNX 7.1, `O_NOFOLLOW` is straight up ignored, and in QNX 8.0 `openat()` works *but* there is a TOCTOU in the kernel itself.