### PR TITLE
delegation: visit path under elided-infer lifetime rib

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3905,7 +3905,11 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             self.visit_ty(&qself.ty);
         }
 
-        self.visit_path(&delegation.path);
+        // Create lifetimes not with `LifetimeRibKind::Generics` but with `LifetimeRibKind::Elided`,
+        // as we are not processing generic params but generic args in a future function call (#156342).
+        self.with_lifetime_rib(LifetimeRibKind::Elided(LifetimeRes::Infer), |this| {
+            this.visit_path(&delegation.path);
+        });
 
         self.r.delegation_infos.insert(
             self.r.current_owner.def_id,

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -114,8 +114,7 @@ mod test_3 {
     //~| ERROR: method takes 1 lifetime argument but 0 lifetime arguments were supplied
 
     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
-    //~^ ERROR: missing lifetime specifiers [E0106]
-    //~| ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
+    //~^ ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR: trait takes 2 generic arguments but 5 generic arguments were supplied
     //~| ERROR: method takes 2 generic arguments but 5 generic arguments were supplied
     //~| ERROR: method takes 1 lifetime argument but 0 lifetime arguments were supplied

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -59,17 +59,6 @@ help: consider introducing lifetime `'a` here
 LL |     reuse foo'a, ::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |              +++
 
-error[E0106]: missing lifetime specifiers
-  --> $DIR/generics-gen-args-errors.rs:116:19
-   |
-LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
-   |                   ^^^^^ expected 3 lifetime parameters
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     reuse Trait::<Trait<'a, 'a, 'a>, Clone, _, 'static, dyn Send, _>::foo'a, ::<1, 2, 3, _, 6> as bar7;
-   |                        ++++++++++++                                      +++
-
 error[E0423]: expected value, found struct `String`
   --> $DIR/generics-gen-args-errors.rs:13:33
    |
@@ -697,7 +686,7 @@ error[E0747]: constant provided when a type was expected
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |                 ^^
 
-error: aborting due to 58 previous errors
+error: aborting due to 57 previous errors
 
-Some errors have detailed explanations: E0106, E0107, E0121, E0261, E0401, E0423, E0425, E0747.
-For more information about an error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0107, E0121, E0261, E0401, E0423, E0425, E0747.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/wrong-lifetime-rib-ice-156342.rs
+++ b/tests/ui/delegation/wrong-lifetime-rib-ice-156342.rs
@@ -1,0 +1,17 @@
+#![feature(fn_delegation)]
+#![feature(type_info)]
+
+use std::mem::type_info::Trait;
+
+impl Trait {
+//~^ ERROR: cannot define inherent `impl` for a type outside of the crate where the type is defined
+    reuse None::<&()>;
+    //~^ ERROR: expected function, found unit variant `None`
+}
+
+fn foo<T>() {}
+
+reuse foo::<&&&&&&&&&&()> as foo1;
+reuse foo::<&std::borrow::Cow<'_, &()>> as foo2;
+
+fn main() {}

--- a/tests/ui/delegation/wrong-lifetime-rib-ice-156342.stderr
+++ b/tests/ui/delegation/wrong-lifetime-rib-ice-156342.stderr
@@ -1,0 +1,19 @@
+error[E0423]: expected function, found unit variant `None`
+  --> $DIR/wrong-lifetime-rib-ice-156342.rs:8:11
+   |
+LL |     reuse None::<&()>;
+   |           ^^^^^^^^^^^ not a function
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/wrong-lifetime-rib-ice-156342.rs:6:1
+   |
+LL | impl Trait {
+   | ^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
+   = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0116, E0423.
+For more information about an error, try `rustc --explain E0116`.


### PR DESCRIPTION
Up to this moment we processed delegation path under `LifetimeRibKind::Generics` which is not correct as we are processing generic args of a future call, not generic params. In this PR we visit path under 
`LifetimeRibKind::Elided(LifetimeRes::Infer)`.

Fixes rust-lang/rust#156342. Part of rust-lang/rust#118212.

r? @petrochenkov