### PR TITLE
rustc_driver: do not inline docs from `_impl` crate

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1,4 +1,5 @@
 // This crate is intentionally empty and a re-export of `rustc_driver_impl` to allow the code in
 // `rustc_driver_impl` to be compiled in parallel with other crates.
 
+#[doc(no_inline)]
 pub use rustc_driver_impl::*;


### PR DESCRIPTION
The inlined docs from `_impl` crate will not have the source code shown/linked but search results for functions such as `init_rustc_env_logger` show the one from the `rustc_driver` crate (without source code). It makes sense to only keep the `_impl` crate's docs in this case.

(compare https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver/fn.init_rustc_env_logger.html and https://doc.rust-lang.org/nightly/nightly-rustc/rustc_driver_impl/fn.init_rustc_env_logger.html)

cc @jyn514 :)