### PR TITLE
Pre-insert layouts of basic integers for consteval perf

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -134,31 +134,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     #[inline(always)]
     pub fn layout_of(&self, ty: Ty<'tcx>) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
         let _trace = enter_trace_span!(M, layouting::layout_of, ty = ?ty.kind());
-        if ty == self.tcx.types.usize {
-            self.layout_of_usize()
-        } else if ty == self.tcx.types.u16 {
-            Ok(TyAndLayout { ty: self.tcx.types.u16, layout: self.tcx.layouts.u16 })
-        } else if ty == self.tcx.types.i16 {
-            Ok(TyAndLayout { ty: self.tcx.types.i16, layout: self.tcx.layouts.i16 })
-        } else if ty == self.tcx.types.u32 {
-            Ok(TyAndLayout { ty: self.tcx.types.u32, layout: self.tcx.layouts.u32 })
-        } else if ty == self.tcx.types.i32 {
-            Ok(TyAndLayout { ty: self.tcx.types.i32, layout: self.tcx.layouts.i32 })
-        } else if ty == self.tcx.types.u64 {
-            Ok(TyAndLayout { ty: self.tcx.types.u64, layout: self.tcx.layouts.u64 })
-        } else if ty == self.tcx.types.i64 {
-            Ok(TyAndLayout { ty: self.tcx.types.i64, layout: self.tcx.layouts.i64 })
-        } else if ty == self.tcx.types.f16 {
-            Ok(TyAndLayout { ty: self.tcx.types.f16, layout: self.tcx.layouts.f16 })
-        } else if ty == self.tcx.types.f32 {
-            Ok(TyAndLayout { ty: self.tcx.types.f32, layout: self.tcx.layouts.f32 })
-        } else if ty == self.tcx.types.f64 {
-            Ok(TyAndLayout { ty: self.tcx.types.f64, layout: self.tcx.layouts.f64 })
-        } else if ty == self.tcx.types.f128 {
-            Ok(TyAndLayout { ty: self.tcx.types.f128, layout: self.tcx.layouts.f128 })
-        } else {
-            LayoutOf::layout_of(self, ty)
-        }
+        LayoutOf::layout_of(self, ty)
     }
 
     pub fn layout_of_usize(&self) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -1,5 +1,3 @@
-use std::cell::Cell;
-
 use either::{Left, Right};
 use rustc_abi::{Align, HasDataLayout, Size, TargetDataLayout};
 use rustc_hir::def_id::DefId;
@@ -46,8 +44,6 @@ pub struct InterpCx<'tcx, M: Machine<'tcx>> {
 
     /// The recursion limit (cached from `tcx.recursion_limit(())`)
     pub recursion_limit: Limit,
-
-    pub(super) usize_layout: Cell<Option<TyAndLayout<'tcx>>>,
 }
 
 impl<'tcx, M: Machine<'tcx>> HasDataLayout for InterpCx<'tcx, M> {
@@ -142,13 +138,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     }
 
     pub fn layout_of_usize(&self) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
-        if let Some(layout) = self.usize_layout.get() {
-            return Ok(layout);
-        };
-
-        let layout = self.layout_of(self.tcx.types.usize)?;
-        self.usize_layout.set(Some(layout));
-        Ok(layout)
+        Ok(TyAndLayout { ty: self.tcx.types.usize, layout: self.tcx.layouts.usize })
     }
 
     /// This inherent method takes priority over the trait method with the same name in FnAbiOf,
@@ -274,7 +264,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             typing_env,
             memory: Memory::new(),
             recursion_limit: tcx.recursion_limit(),
-            usize_layout: Cell::new(None),
         }
     }
 

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -133,8 +133,30 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// See [LayoutOf::layout_of] for the original documentation.
     #[inline(always)]
     pub fn layout_of(&self, ty: Ty<'tcx>) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
+        static FILE: std::sync::OnceLock<std::fs::File> =
+            std::sync::OnceLock::<std::fs::File>::new();
+
+        let mut file: &_ = FILE.get_or_init(|| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .append(true)
+                .open("/tmp/ty-layout-trace.txt")
+                .unwrap()
+        });
+
+        let start = std::time::Instant::now();
         let _trace = enter_trace_span!(M, layouting::layout_of, ty = ?ty.kind());
-        LayoutOf::layout_of(self, ty)
+        let layout = LayoutOf::layout_of(self, ty);
+        let timing = start.elapsed().as_nanos();
+
+        use std::io::Write as _;
+
+        file.lock().unwrap();
+        writeln!(file, "{timing:12}\t{:?}", ty).unwrap();
+        file.unlock().unwrap();
+
+        layout
     }
 
     pub fn layout_of_usize(&self) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -133,30 +133,24 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// See [LayoutOf::layout_of] for the original documentation.
     #[inline(always)]
     pub fn layout_of(&self, ty: Ty<'tcx>) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
-        static FILE: std::sync::OnceLock<std::fs::File> =
-            std::sync::OnceLock::<std::fs::File>::new();
-
-        let mut file: &_ = FILE.get_or_init(|| {
-            std::fs::OpenOptions::new()
-                .create(true)
-                .write(true)
-                .append(true)
-                .open("/tmp/ty-layout-trace.txt")
-                .unwrap()
-        });
-
-        let start = std::time::Instant::now();
         let _trace = enter_trace_span!(M, layouting::layout_of, ty = ?ty.kind());
-        let layout = LayoutOf::layout_of(self, ty);
-        let timing = start.elapsed().as_nanos();
-
-        use std::io::Write as _;
-
-        file.lock().unwrap();
-        writeln!(file, "{timing:12}\t{:?}", ty).unwrap();
-        file.unlock().unwrap();
-
-        layout
+        if ty == self.tcx.types.usize {
+            self.layout_of_usize()
+        } else if ty == self.tcx.types.u16 {
+            Ok(TyAndLayout { ty: self.tcx.types.u16, layout: self.tcx.layouts.u16 })
+        } else if ty == self.tcx.types.i16 {
+            Ok(TyAndLayout { ty: self.tcx.types.i16, layout: self.tcx.layouts.i16 })
+        } else if ty == self.tcx.types.u32 {
+            Ok(TyAndLayout { ty: self.tcx.types.u32, layout: self.tcx.layouts.u32 })
+        } else if ty == self.tcx.types.i32 {
+            Ok(TyAndLayout { ty: self.tcx.types.i32, layout: self.tcx.layouts.i32 })
+        } else if ty == self.tcx.types.u64 {
+            Ok(TyAndLayout { ty: self.tcx.types.u64, layout: self.tcx.layouts.u64 })
+        } else if ty == self.tcx.types.i64 {
+            Ok(TyAndLayout { ty: self.tcx.types.i64, layout: self.tcx.layouts.i64 })
+        } else {
+            LayoutOf::layout_of(self, ty)
+        }
     }
 
     pub fn layout_of_usize(&self) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -148,6 +148,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Ok(TyAndLayout { ty: self.tcx.types.u64, layout: self.tcx.layouts.u64 })
         } else if ty == self.tcx.types.i64 {
             Ok(TyAndLayout { ty: self.tcx.types.i64, layout: self.tcx.layouts.i64 })
+        } else if ty == self.tcx.types.f16 {
+            Ok(TyAndLayout { ty: self.tcx.types.f16, layout: self.tcx.layouts.f16 })
+        } else if ty == self.tcx.types.f32 {
+            Ok(TyAndLayout { ty: self.tcx.types.f32, layout: self.tcx.layouts.f32 })
+        } else if ty == self.tcx.types.f64 {
+            Ok(TyAndLayout { ty: self.tcx.types.f64, layout: self.tcx.layouts.f64 })
+        } else if ty == self.tcx.types.f128 {
+            Ok(TyAndLayout { ty: self.tcx.types.f128, layout: self.tcx.layouts.f128 })
         } else {
             LayoutOf::layout_of(self, ty)
         }

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use either::{Left, Right};
 use rustc_abi::{Align, HasDataLayout, Size, TargetDataLayout};
 use rustc_hir::def_id::DefId;
@@ -44,6 +46,8 @@ pub struct InterpCx<'tcx, M: Machine<'tcx>> {
 
     /// The recursion limit (cached from `tcx.recursion_limit(())`)
     pub recursion_limit: Limit,
+
+    pub(super) usize_layout: Cell<Option<TyAndLayout<'tcx>>>,
 }
 
 impl<'tcx, M: Machine<'tcx>> HasDataLayout for InterpCx<'tcx, M> {
@@ -135,6 +139,16 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     pub fn layout_of(&self, ty: Ty<'tcx>) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
         let _trace = enter_trace_span!(M, layouting::layout_of, ty = ?ty.kind());
         LayoutOf::layout_of(self, ty)
+    }
+
+    pub fn layout_of_usize(&self) -> Result<TyAndLayout<'tcx>, InterpErrorKind<'tcx>> {
+        if let Some(layout) = self.usize_layout.get() {
+            return Ok(layout);
+        };
+
+        let layout = self.layout_of(self.tcx.types.usize)?;
+        self.usize_layout.set(Some(layout));
+        Ok(layout)
     }
 
     /// This inherent method takes priority over the trait method with the same name in FnAbiOf,
@@ -260,6 +274,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             typing_env,
             memory: Memory::new(),
             recursion_limit: tcx.recursion_limit(),
+            usize_layout: Cell::new(None),
         }
     }
 

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -416,7 +416,7 @@ where
             Downcast(_, variant) => self.project_downcast(base, variant)?,
             Deref => self.deref_pointer(&base.to_op(self)?)?.into(),
             Index(local) => {
-                let layout = self.layout_of(self.tcx.types.usize)?;
+                let layout = self.layout_of_usize()?;
                 let n = self.local_to_op(local, Some(layout))?;
                 let n = self.read_target_usize(&n)?;
                 self.project_index(base, n)?

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -384,6 +384,12 @@ pub struct CommonConsts<'tcx> {
 
 pub struct CommonLayouts<'tcx> {
     pub usize: Layout<'tcx>,
+    pub u16: Layout<'tcx>,
+    pub i16: Layout<'tcx>,
+    pub u32: Layout<'tcx>,
+    pub i32: Layout<'tcx>,
+    pub u64: Layout<'tcx>,
+    pub i64: Layout<'tcx>,
 }
 
 impl<'tcx> CommonTypes<'tcx> {
@@ -478,7 +484,15 @@ impl<'tcx> CommonLayouts<'tcx> {
             ))
         };
 
-        CommonLayouts { usize: mk_scalar(mk_int(dl.ptr_sized_integer(), false)) }
+        CommonLayouts {
+            usize: mk_scalar(mk_int(dl.ptr_sized_integer(), false)),
+            u16: mk_scalar(mk_int(Integer::I16, false)),
+            i16: mk_scalar(mk_int(Integer::I16, true)),
+            u32: mk_scalar(mk_int(Integer::I32, false)),
+            i32: mk_scalar(mk_int(Integer::I32, true)),
+            u64: mk_scalar(mk_int(Integer::I64, false)),
+            i64: mk_scalar(mk_int(Integer::I64, true)),
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -395,6 +395,10 @@ pub struct CommonLayouts<'tcx> {
     pub i64: Layout<'tcx>,
     pub u128: Layout<'tcx>,
     pub i128: Layout<'tcx>,
+    pub f16: Layout<'tcx>,
+    pub f32: Layout<'tcx>,
+    pub f64: Layout<'tcx>,
+    pub f128: Layout<'tcx>,
 }
 
 impl<'tcx> CommonTypes<'tcx> {
@@ -470,11 +474,17 @@ impl<'tcx> CommonTypes<'tcx> {
 
 impl<'tcx> CommonLayouts<'tcx> {
     fn new(interners: &CtxtInterners<'tcx>, dl: &TargetDataLayout) -> CommonLayouts<'tcx> {
-        use rustc_abi::{Integer, Primitive, Scalar, WrappingRange};
+        use rustc_abi::{Float, Integer, Primitive, Scalar, WrappingRange};
 
         let mk_int = |int: Integer, signed: bool| {
             let primitive = Primitive::Int(int, signed);
             let size = int.size();
+            Scalar::Initialized { value: primitive, valid_range: WrappingRange::full(size) }
+        };
+
+        let mk_float = |float: Float| -> Scalar {
+            let primitive = Primitive::Float(float);
+            let size = float.size();
             Scalar::Initialized { value: primitive, valid_range: WrappingRange::full(size) }
         };
 
@@ -502,6 +512,10 @@ impl<'tcx> CommonLayouts<'tcx> {
             i64: mk_scalar(mk_int(Integer::I64, true)),
             u128: mk_scalar(mk_int(Integer::I128, false)),
             i128: mk_scalar(mk_int(Integer::I128, true)),
+            f16: mk_scalar(mk_float(Float::F16)),
+            f32: mk_scalar(mk_float(Float::F32)),
+            f64: mk_scalar(mk_float(Float::F64)),
+            f128: mk_scalar(mk_float(Float::F128)),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -382,6 +382,10 @@ pub struct CommonConsts<'tcx> {
     pub(crate) valtree_zst: ValTree<'tcx>,
 }
 
+pub struct CommonLayouts<'tcx> {
+    pub usize: Layout<'tcx>,
+}
+
 impl<'tcx> CommonTypes<'tcx> {
     fn new(interners: &CtxtInterners<'tcx>) -> CommonTypes<'tcx> {
         let mk = |ty| interners.intern_ty(ty);
@@ -450,6 +454,31 @@ impl<'tcx> CommonTypes<'tcx> {
             anon_bound_tys,
             anon_canonical_bound_tys,
         }
+    }
+}
+
+impl<'tcx> CommonLayouts<'tcx> {
+    fn new(interners: &CtxtInterners<'tcx>, dl: &TargetDataLayout) -> CommonLayouts<'tcx> {
+        use rustc_abi::{Integer, Primitive, Scalar, WrappingRange};
+
+        let mk_int = |int: Integer, signed: bool| {
+            let primitive = Primitive::Int(int, signed);
+            let size = int.size();
+            Scalar::Initialized { value: primitive, valid_range: WrappingRange::full(size) }
+        };
+
+        let mk_scalar = |scalar: Scalar| {
+            Layout(Interned::new_unchecked(
+                interners
+                    .layout
+                    .intern(LayoutData::scalar(dl, scalar), |v| {
+                        InternedInSet(interners.arena.alloc(v))
+                    })
+                    .0,
+            ))
+        };
+
+        CommonLayouts { usize: mk_scalar(mk_int(dl.ptr_sized_integer(), false)) }
     }
 }
 
@@ -697,6 +726,9 @@ pub struct GlobalCtxt<'tcx> {
     /// Common types, pre-interned for your convenience.
     pub types: CommonTypes<'tcx>,
 
+    /// Common layouts, pre-computed for MIR convenience.
+    pub layouts: CommonLayouts<'tcx>,
+
     /// Common lifetimes, pre-interned for your convenience.
     pub lifetimes: CommonLifetimes<'tcx>,
 
@@ -930,6 +962,7 @@ impl<'tcx> TyCtxt<'tcx> {
         });
         let interners = CtxtInterners::new(arena);
         let common_types = CommonTypes::new(&interners);
+        let common_layouts = CommonLayouts::new(&interners, &data_layout);
         let common_lifetimes = CommonLifetimes::new(&interners);
         let common_consts = CommonConsts::new(&interners, &common_types);
 
@@ -944,6 +977,7 @@ impl<'tcx> TyCtxt<'tcx> {
             hooks,
             prof: sess.prof.clone(),
             types: common_types,
+            layouts: common_layouts,
             lifetimes: common_lifetimes,
             consts: common_consts,
             untracked,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -384,12 +384,17 @@ pub struct CommonConsts<'tcx> {
 
 pub struct CommonLayouts<'tcx> {
     pub usize: Layout<'tcx>,
+    pub isize: Layout<'tcx>,
+    pub u8: Layout<'tcx>,
+    pub i8: Layout<'tcx>,
     pub u16: Layout<'tcx>,
     pub i16: Layout<'tcx>,
     pub u32: Layout<'tcx>,
     pub i32: Layout<'tcx>,
     pub u64: Layout<'tcx>,
     pub i64: Layout<'tcx>,
+    pub u128: Layout<'tcx>,
+    pub i128: Layout<'tcx>,
 }
 
 impl<'tcx> CommonTypes<'tcx> {
@@ -486,12 +491,17 @@ impl<'tcx> CommonLayouts<'tcx> {
 
         CommonLayouts {
             usize: mk_scalar(mk_int(dl.ptr_sized_integer(), false)),
+            isize: mk_scalar(mk_int(dl.ptr_sized_integer(), true)),
+            u8: mk_scalar(mk_int(Integer::I8, false)),
+            i8: mk_scalar(mk_int(Integer::I8, true)),
             u16: mk_scalar(mk_int(Integer::I16, false)),
             i16: mk_scalar(mk_int(Integer::I16, true)),
             u32: mk_scalar(mk_int(Integer::I32, false)),
             i32: mk_scalar(mk_int(Integer::I32, true)),
             u64: mk_scalar(mk_int(Integer::I64, false)),
             i64: mk_scalar(mk_int(Integer::I64, true)),
+            u128: mk_scalar(mk_int(Integer::I128, false)),
+            i128: mk_scalar(mk_int(Integer::I128, true)),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -23,7 +23,7 @@ use crate::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use crate::query::TyCtxtAt;
 use crate::traits::ObligationCause;
 use crate::ty::normalize_erasing_regions::NormalizationError;
-use crate::ty::{self, CoroutineArgsExt, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
+use crate::ty::{self, CoroutineArgsExt, Ty, TyCtxt, TyKind, TypeVisitableExt, Unnormalized};
 
 #[extension(pub trait IntegerExt)]
 impl abi::Integer {
@@ -708,7 +708,53 @@ pub trait LayoutOf<'tcx>: LayoutOfHelpers<'tcx> {
     /// executes in `TypingMode::PostAnalysis`, and will normalize the input type.
     #[inline]
     fn layout_of(&self, ty: Ty<'tcx>) -> Self::LayoutOfResult {
-        self.spanned_layout_of(ty, DUMMY_SP)
+        let simple_layout = match ty.kind() {
+            TyKind::Uint(inner) => {
+                let tcx = self.tcx();
+
+                match inner {
+                    ty::UintTy::U8 => TyAndLayout { ty: tcx.types.u8, layout: tcx.layouts.u8 },
+                    ty::UintTy::U16 => TyAndLayout { ty: tcx.types.u16, layout: tcx.layouts.u16 },
+                    ty::UintTy::U32 => TyAndLayout { ty: tcx.types.u32, layout: tcx.layouts.u32 },
+                    ty::UintTy::U64 => TyAndLayout { ty: tcx.types.u64, layout: tcx.layouts.u64 },
+                    ty::UintTy::U128 => {
+                        TyAndLayout { ty: tcx.types.u128, layout: tcx.layouts.u128 }
+                    }
+                    ty::UintTy::Usize => {
+                        TyAndLayout { ty: tcx.types.usize, layout: tcx.layouts.usize }
+                    }
+                }
+            }
+            TyKind::Int(inner) => {
+                let tcx = self.tcx();
+
+                match inner {
+                    ty::IntTy::I8 => TyAndLayout { ty: tcx.types.i8, layout: tcx.layouts.i8 },
+                    ty::IntTy::I16 => TyAndLayout { ty: tcx.types.i16, layout: tcx.layouts.i16 },
+                    ty::IntTy::I32 => TyAndLayout { ty: tcx.types.i32, layout: tcx.layouts.i32 },
+                    ty::IntTy::I64 => TyAndLayout { ty: tcx.types.i64, layout: tcx.layouts.i64 },
+                    ty::IntTy::I128 => TyAndLayout { ty: tcx.types.i128, layout: tcx.layouts.i128 },
+                    ty::IntTy::Isize => {
+                        TyAndLayout { ty: tcx.types.isize, layout: tcx.layouts.isize }
+                    }
+                }
+            }
+            TyKind::Float(inner) => {
+                let tcx = self.tcx();
+
+                match inner {
+                    ty::FloatTy::F16 => TyAndLayout { ty: tcx.types.f16, layout: tcx.layouts.f16 },
+                    ty::FloatTy::F32 => TyAndLayout { ty: tcx.types.f32, layout: tcx.layouts.f32 },
+                    ty::FloatTy::F64 => TyAndLayout { ty: tcx.types.f64, layout: tcx.layouts.f64 },
+                    ty::FloatTy::F128 => {
+                        TyAndLayout { ty: tcx.types.f128, layout: tcx.layouts.f128 }
+                    }
+                }
+            }
+            _ => return self.spanned_layout_of(ty, DUMMY_SP),
+        };
+
+        <Self::LayoutOfResult as MaybeResult<_>>::from(Ok(simple_layout))
     }
 
     /// Computes the layout of a type, at `span`. Note that this implicitly

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -395,8 +395,22 @@ fn layout_of_uncached<'tcx>(
                 valid_range: WrappingRange { start: 0, end: 0x10FFFF },
             },
         )),
-        ty::Int(ity) => scalar(Int(abi::Integer::from_int_ty(dl, ity), true)),
-        ty::Uint(ity) => scalar(Int(abi::Integer::from_uint_ty(dl, ity), false)),
+        ty::Int(ity) => match ity {
+            ty::IntTy::I8 => tcx.layouts.i8,
+            ty::IntTy::I16 => tcx.layouts.i16,
+            ty::IntTy::I32 => tcx.layouts.i32,
+            ty::IntTy::I64 => tcx.layouts.i64,
+            ty::IntTy::I128 => tcx.layouts.i128,
+            ty::IntTy::Isize => tcx.layouts.isize,
+        },
+        ty::Uint(ity) => match ity {
+            ty::UintTy::U8 => tcx.layouts.u8,
+            ty::UintTy::U16 => tcx.layouts.u16,
+            ty::UintTy::U32 => tcx.layouts.u32,
+            ty::UintTy::U64 => tcx.layouts.u64,
+            ty::UintTy::U128 => tcx.layouts.u128,
+            ty::UintTy::Usize => tcx.layouts.usize,
+        },
         ty::Float(fty) => scalar(Float(abi::Float::from_float_ty(fty))),
         ty::FnPtr(..) => {
             let mut ptr = scalar_unit(Pointer(dl.instruction_address_space));

--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -1,7 +1,7 @@
 use hir::def_id::DefId;
 use rustc_abi as abi;
 use rustc_abi::Integer::{I8, I32};
-use rustc_abi::Primitive::{self, Float, Int, Pointer};
+use rustc_abi::Primitive::{self, Int, Pointer};
 use rustc_abi::{
     AddressSpace, BackendRepr, FIRST_VARIANT, FieldIdx, FieldsShape, HasDataLayout, Layout,
     LayoutCalculatorError, LayoutData, Niche, ReprOptions, Scalar, Size, StructKind, TagEncoding,
@@ -15,7 +15,7 @@ use rustc_middle::bug;
 use rustc_middle::query::Providers;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::layout::{
-    FloatExt, HasTyCtxt, IntegerExt, LayoutCx, LayoutError, LayoutOf, SimdLayoutError, TyAndLayout,
+    HasTyCtxt, IntegerExt, LayoutCx, LayoutError, LayoutOf, SimdLayoutError, TyAndLayout,
 };
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
@@ -411,7 +411,12 @@ fn layout_of_uncached<'tcx>(
             ty::UintTy::U128 => tcx.layouts.u128,
             ty::UintTy::Usize => tcx.layouts.usize,
         },
-        ty::Float(fty) => scalar(Float(abi::Float::from_float_ty(fty))),
+        ty::Float(fty) => match fty {
+            ty::FloatTy::F16 => tcx.layouts.f16,
+            ty::FloatTy::F32 => tcx.layouts.f32,
+            ty::FloatTy::F64 => tcx.layouts.f64,
+            ty::FloatTy::F128 => tcx.layouts.f128,
+        },
         ty::FnPtr(..) => {
             let mut ptr = scalar_unit(Pointer(dl.instruction_address_space));
             ptr.valid_range_mut().start = 1;


### PR DESCRIPTION
While investigating build performance for `image`, we noted through `perf` samples that a surprising amount of time was spent in consteval and more specifically calls to `layout_of`. That was curious since we use a few const tables but definitely not of extreme size nor complicated computation and really only with primitive types. Through instrumenting (printf debugging the types being queried) a `debug` build, this pattern emerged the tail end of the summary:

```
RDTSC    count  type
-------
2968652 48376   u8
2975486 75647   usize
3372234 2024    std::num::NonZero<usize>
3494159 65639   FnDef(DefId(2:705 ~ core[93c5]::f64::{impl#0}::to_bits), [])
6016422 107343  ()
7589954 145971  FnDef(DefId(21:947 ~ pxfm[d8cc]::common::fmla), [])
10072816        175205  i64
15194244        290049  i32
22053787        392617  u32
22284234        322397  bool
40392452        615785  u64
58157921        2110    std::alloc::Layout
179631693       2996946 f64
```

Several question arise:
- Is it necessary to query `f64` and other primitive types so often? This fits to a query _per evaluation_ of the lines in MIR instead of a query per line itself. There is a cache of layouts for locals of a block; but it is only local and that cache is constructed within the query to a const evaluation of a block.
- What's happening while querying the layout of `std::alloc::Layout`?

In an attempt to mitigate the first and considering that `usize` is necessarily used for indexing into an array at the moment, maybe one of the large uses, I've attempted to pre-intern the layouts of common integer types and special case them out.

This is obviously fraught with peril; it must not disagree with the other layout computations and a second source of truth is risky in that regard. So the main  question is whether to continue down this path or find a way to reduce the count by doing more clever type assignment in expression evaluation maybe.

Performance results have been okay. I've had problems reliably producing numbers in debug builds in the first place, sometimes the instrumentation did not seem to trigger, so there was definitely something I don't understand about the eval. In a `--release` profile build I seem to observe a moderate effect of ~1-2% overall.

@RalfJung we chatted about related topics, hopefully this isn't taking too much of your time from other matters.