### PR TITLE
Remove stale RTN FIXME for assoc item constraint fallback

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1197,8 +1197,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         }
                     } else {
                         self.emit_bad_parenthesized_trait_in_assoc_ty(data);
-                        // FIXME(return_type_notation): we could issue a feature error
-                        // if the parens are empty and there's no return type.
                         self.lower_angle_bracketed_parameter_data(
                             &data.as_angle_bracketed_args(),
                             ParamMode::Explicit,


### PR DESCRIPTION
The old FIXME suggested that this diagnostic path should emit a `return_type_notation` feature-gate diagnostic.

That is no longer correct: RTN associated item constraints now use `(..)`, so a form like `Trait<method(): Bound>` is not made valid by enabling `return_type_notation`.

This PR removes the stale FIXME without changing the diagnostic behavior.

@rustbot label F-return_type_notation