### PR TITLE
Fix jump-to-def links broken by turbofish syntax

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -1001,8 +1001,8 @@ impl<'src> Classifier<'src> {
                 has_ident = true;
                 nb_items += 1;
             } else if nb > 0 && has_ident {
-                // Following `;` will be handled on its own.
-                break Some(nb_items - 1);
+                // Drop all the colons we just peeked (e.g. `Option::<T>` → keep `Option`).
+                break Some(nb_items - nb);
             } else if has_ident {
                 break Some(nb_items);
             } else {

--- a/tests/rustdoc-html/jump-to-def/turbofish.rs
+++ b/tests/rustdoc-html/jump-to-def/turbofish.rs
@@ -1,0 +1,17 @@
+// This test ensures that turbofish (`::<...>`) does not prevent jump-to-definition
+// links from being generated.
+
+//@ compile-flags: -Zunstable-options --generate-link-to-definition
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/turbofish.rs.html'
+use std::marker::PhantomData;
+
+pub fn foo() {
+    // `PhantomData::<usize>` — `PhantomData` must be linked despite the turbofish.
+    type TheOne = PhantomData<()>;
+
+    //@ has - '//a[@href="#13"]' 'TheOne'
+    let _: TheOne::<usize> = PhantomData;
+}

--- a/tests/rustdoc-html/jump-to-def/turbofish.rs
+++ b/tests/rustdoc-html/jump-to-def/turbofish.rs
@@ -6,12 +6,10 @@
 #![crate_name = "foo"]
 
 //@ has 'src/foo/turbofish.rs.html'
-use std::marker::PhantomData;
+use std::marker::PhantomData as TheOne;
+
 
 pub fn foo() {
-    // `PhantomData::<usize>` — `PhantomData` must be linked despite the turbofish.
-    type TheOne = PhantomData<()>;
-
-    //@ has - '//a[@href="#13"]' 'TheOne'
-    let _: TheOne::<usize> = PhantomData;
+    //@ has - '//a[@href="{{channel}}/core/marker/struct.PhantomData.html"]' 'TheOne'
+    let _: TheOne::<usize>;
 }


### PR DESCRIPTION
Fixes rust-lang/rust#156706