### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/effect_goals.rs
@@ -374,7 +374,7 @@ where
         _ecx: &mut EvalCtxt<'_, D>,
         _goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolutionOrRerunNonErased> {
-        todo!("Iterator is not yet const")
+        Err(NoSolutionOrRerunNonErased::NoSolution(NoSolution))
     }
 
     fn consider_builtin_fused_iterator_candidate(

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -10,7 +10,8 @@ use core::marker::PhantomData;
 #[cfg(not(no_global_oom_handling))]
 use core::marker::Unsize;
 #[cfg(not(no_global_oom_handling))]
-use core::mem::{self, SizedTypeProperties};
+use core::mem;
+use core::mem::SizedTypeProperties;
 use core::ops::{Deref, DerefMut};
 use core::ptr::{self, NonNull, Pointee};
 
@@ -112,7 +113,7 @@ impl<Dyn: ?Sized> ThinBox<Dyn> {
     where
         T: Unsize<Dyn>,
     {
-        if size_of::<T>() == 0 {
+        if T::IS_ZST {
             let ptr = WithOpaqueHeader::new_unsize_zst::<Dyn, T>(value);
             ThinBox { ptr, _marker: PhantomData }
         } else {
@@ -281,7 +282,7 @@ impl<H> WithHeader<H> {
             let ptr = if layout.size() == 0 {
                 // Some paranoia checking, mostly so that the ThinBox tests are
                 // more able to catch issues.
-                debug_assert!(value_offset == 0 && size_of::<T>() == 0 && size_of::<H>() == 0);
+                debug_assert!(value_offset == 0 && T::IS_ZST && H::IS_ZST);
                 layout.dangling_ptr()
             } else {
                 let ptr = alloc::alloc(layout);
@@ -311,7 +312,7 @@ impl<H> WithHeader<H> {
         Dyn: Pointee<Metadata = H> + ?Sized,
         T: Unsize<Dyn>,
     {
-        assert!(size_of::<T>() == 0);
+        assert!(T::IS_ZST);
 
         const fn max(a: usize, b: usize) -> usize {
             if a > b { a } else { b }

--- a/library/core/src/iter/adapters/map_windows.rs
+++ b/library/core/src/iter/adapters/map_windows.rs
@@ -1,5 +1,5 @@
 use crate::iter::FusedIterator;
-use crate::mem::MaybeUninit;
+use crate::mem::{MaybeUninit, SizedTypeProperties};
 use crate::{fmt, ptr};
 
 /// An iterator over the mapped windows of another iterator.
@@ -47,7 +47,7 @@ impl<I: Iterator, F, const N: usize> MapWindows<I, F, N> {
         assert!(N != 0, "array in `Iterator::map_windows` must contain more than 0 elements");
 
         // Only ZST arrays' length can be so large.
-        if size_of::<I::Item>() == 0 {
+        if I::Item::IS_ZST {
             assert!(
                 N.checked_mul(2).is_some(),
                 "array size of `Iterator::map_windows` is too large"

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1619,7 +1619,7 @@ pub macro offset_of($Container:ty, $($fields:expr)+ $(,)?) {
 #[rustc_const_unstable(feature = "mem_conjure_zst", issue = "95383")]
 pub const unsafe fn conjure_zst<T>() -> T {
     const_assert!(
-        size_of::<T>() == 0,
+        T::IS_ZST,
         "mem::conjure_zst invoked on a non-zero-sized type",
         "mem::conjure_zst invoked on type {name}, which is not zero-sized",
         name: &str = crate::any::type_name::<T>()

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -18,3 +18,8 @@ set -ex
 # This is intended to make sure that both `--pass=check` continues to
 # work.
 ../x.ps1 --stage 2 test tests/ui --pass=check --host='' --target=i686-unknown-linux-gnu
+
+# Rebuild the stdlib using the new trait solver, to ensure it doesn't regress
+# until stabilization.
+RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x --stage 1 build library \
+    --host='' --target=i686-unknown-linux-gnu

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -13,10 +13,7 @@ set -ex
 # despite having different output on 32-bit vs 64-bit targets.
 ../x --stage 2 test tests/mir-opt --host='' --target=i686-unknown-linux-gnu
 
-# Run the UI test suite again, but in `--pass=check` mode
-#
-# This is intended to make sure that both `--pass=check` continues to
-# work.
+# Run the UI test suite in `--pass=check` mode, to ensure it continues to work.
 ../x.ps1 --stage 2 test tests/ui --pass=check --host='' --target=i686-unknown-linux-gnu
 
 # Rebuild the stdlib using the new trait solver, to ensure it doesn't regress


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156146 (test new solver on CI until stabilization)
 - rust-lang/rust#155840 (prefer `T::IS_ZST` over manual check)
 - rust-lang/rust#156723 (Update books)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156146,155840,156723)
<!-- homu-ignore:end -->

