### PR TITLE
docs: remove duplicate "hermit" entry in OS constants list

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -1091,7 +1091,6 @@ pub mod consts {
     /// * `"uefi"`
     /// * `"fuchsia"`
     /// * `"haiku"`
-    /// * `"hermit"`
     /// * `"watchos"`
     /// * `"visionos"`
     /// * `"tvos"`


### PR DESCRIPTION
Removes a duplicate "hermit" entry in the documentation list for std::env::consts::OS.

Relevant source:
- https://doc.rust-lang.org/src/std/env.rs.html#1072
- https://doc.rust-lang.org/src/std/env.rs.html#1082


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
