### PR TITLE
Move NativeLib::filename to the rmeta-link archive member

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -26,7 +26,7 @@ use rustc_lint_defs::builtin::LINKER_INFO;
 use rustc_macros::Diagnostic;
 use rustc_metadata::fs::{METADATA_FILENAME, copy_to_stdout, emit_wrapper_file};
 use rustc_metadata::{
-    EncodedMetadata, NativeLibSearchFallback, find_native_static_library,
+    EncodedMetadata, NativeLibSearchFallback, find_bundled_library, find_native_static_library,
     walk_native_lib_search_dirs,
 };
 use rustc_middle::bug;
@@ -329,8 +329,25 @@ fn link_rlib<'a>(
         .map(|obj| obj.file_name().unwrap().to_str().unwrap().to_string())
         .collect();
 
+    let native_lib_filenames: Vec<Option<Symbol>> = crate_info
+        .used_libraries
+        .iter()
+        .map(|lib| {
+            find_bundled_library(
+                lib.name,
+                Some(lib.verbatim),
+                lib.kind,
+                lib.cfg.is_some(),
+                sess,
+                &crate_info.crate_types,
+            )
+        })
+        .collect();
+
     let metadata_link_file = if matches!(flavor, RlibFlavor::Normal) {
-        let metadata_link = rmeta_link::RmetaLink { rust_object_files };
+        let native_lib_filenames: Vec<Option<String>> =
+            native_lib_filenames.iter().map(|f| f.map(|s| s.to_string())).collect();
+        let metadata_link = rmeta_link::RmetaLink { rust_object_files, native_lib_filenames };
         let metadata_link_data = metadata_link.encode();
         let (wrapper, _) =
             create_wrapper_file(sess, rmeta_link::SECTION.to_string(), &metadata_link_data);
@@ -413,12 +430,12 @@ fn link_rlib<'a>(
     // feature then we'll need to figure out how to record what objects were
     // loaded from the libraries found here and then encode that into the
     // metadata of the rlib we're generating somehow.
-    for lib in crate_info.used_libraries.iter() {
+    for (i, lib) in crate_info.used_libraries.iter().enumerate() {
         let NativeLibKind::Static { bundle: None | Some(true), .. } = lib.kind else {
             continue;
         };
         if flavor == RlibFlavor::Normal
-            && let Some(filename) = lib.filename
+            && let Some(filename) = native_lib_filenames[i]
         {
             let path = find_native_static_library(filename.as_str(), true, sess);
             let src = read(path)
@@ -532,11 +549,21 @@ fn link_staticlib(
         let lto = are_upstream_rust_objects_already_included(sess)
             && !ignored_for_lto(sess, crate_info, cnum);
 
-        let native_libs = crate_info.native_libraries[&cnum].iter();
-        let relevant = native_libs.clone().filter(|lib| relevant_lib(sess, lib));
-        let relevant_libs: FxIndexSet<_> = relevant.filter_map(|lib| lib.filename).collect();
+        let native_libs = &crate_info.native_libraries[&cnum];
+        let bundled_filenames =
+            rmeta_link_cache.native_lib_filenames(&sess.target, path, native_libs);
+        let relevant_libs: FxIndexSet<_> = native_libs
+            .iter()
+            .enumerate()
+            .filter(|(_, lib)| relevant_lib(sess, lib))
+            .filter_map(|(i, _)| bundled_filenames.get(i).copied().flatten())
+            .collect();
 
-        let bundled_libs: FxIndexSet<_> = native_libs.filter_map(|lib| lib.filename).collect();
+        let bundled_libs: FxIndexSet<_> = native_libs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, _)| bundled_filenames.get(i).copied().flatten())
+            .collect();
         ab.add_archive(
             path,
             AddArchiveKind::Rlib(rmeta_link_cache, &|fname: &str, entry_kind| {
@@ -2739,6 +2766,7 @@ fn linker_with_args(
         cmd,
         sess,
         archive_builder_builder,
+        rmeta_link_cache,
         crate_info,
         tmpdir,
         link_output_kind,
@@ -2761,6 +2789,7 @@ fn linker_with_args(
         cmd,
         sess,
         archive_builder_builder,
+        rmeta_link_cache,
         crate_info,
         tmpdir,
         link_output_kind,
@@ -3060,6 +3089,7 @@ fn add_native_libs_from_crate(
     cmd: &mut dyn Linker,
     sess: &Session,
     archive_builder_builder: &dyn ArchiveBuilderBuilder,
+    rmeta_link_cache: &mut RmetaLinkCache,
     crate_info: &CrateInfo,
     tmpdir: &Path,
     bundled_libs: &FxIndexSet<Symbol>,
@@ -3083,13 +3113,38 @@ fn add_native_libs_from_crate(
             .unwrap_or_else(|e| sess.dcx().emit_fatal(e));
     }
 
-    let native_libs = match cnum {
-        LOCAL_CRATE => &crate_info.used_libraries,
-        _ => &crate_info.native_libraries[&cnum],
+    let (native_libs, bundled_filenames): (&Vec<NativeLib>, Vec<Option<Symbol>>) = match cnum {
+        LOCAL_CRATE => {
+            let libs = &crate_info.used_libraries;
+            let filenames = libs
+                .iter()
+                .map(|lib| {
+                    find_bundled_library(
+                        lib.name,
+                        Some(lib.verbatim),
+                        lib.kind,
+                        lib.cfg.is_some(),
+                        sess,
+                        &crate_info.crate_types,
+                    )
+                })
+                .collect();
+            (libs, filenames)
+        }
+        _ => {
+            let native_libs = &crate_info.native_libraries[&cnum];
+            let filenames =
+                if let Some(rlib_path) = crate_info.used_crate_source[&cnum].rlib.as_ref() {
+                    rmeta_link_cache.native_lib_filenames(&sess.target, rlib_path, native_libs)
+                } else {
+                    Vec::new()
+                };
+            (native_libs, filenames)
+        }
     };
 
     let mut last = (None, NativeLibKind::Unspecified, false);
-    for lib in native_libs {
+    for (i, lib) in native_libs.iter().enumerate() {
         if !relevant_lib(sess, lib) {
             continue;
         }
@@ -3109,7 +3164,7 @@ fn add_native_libs_from_crate(
                     let bundle = bundle.unwrap_or(true);
                     let whole_archive = whole_archive == Some(true);
                     if bundle && cnum != LOCAL_CRATE {
-                        if let Some(filename) = lib.filename {
+                        if let Some(filename) = bundled_filenames.get(i).copied().flatten() {
                             // If rlib contains native libs as archives, they are unpacked to tmpdir.
                             let path = tmpdir.join(filename.as_str());
                             cmd.link_staticlib_by_path(&path, whole_archive);
@@ -3161,6 +3216,7 @@ fn add_local_native_libraries(
     cmd: &mut dyn Linker,
     sess: &Session,
     archive_builder_builder: &dyn ArchiveBuilderBuilder,
+    rmeta_link_cache: &mut RmetaLinkCache,
     crate_info: &CrateInfo,
     tmpdir: &Path,
     link_output_kind: LinkOutputKind,
@@ -3172,6 +3228,7 @@ fn add_local_native_libraries(
         cmd,
         sess,
         archive_builder_builder,
+        rmeta_link_cache,
         crate_info,
         tmpdir,
         &Default::default(),
@@ -3231,10 +3288,17 @@ fn add_upstream_rust_crates(
         match linkage {
             Linkage::Static | Linkage::IncludedFromDylib | Linkage::NotLinked => {
                 if link_static_crate {
-                    bundled_libs = crate_info.native_libraries[&cnum]
-                        .iter()
-                        .filter_map(|lib| lib.filename)
-                        .collect();
+                    if let Some(rlib_path) = crate_info.used_crate_source[&cnum].rlib.as_ref() {
+                        bundled_libs = rmeta_link_cache
+                            .native_lib_filenames(
+                                &sess.target,
+                                rlib_path,
+                                &crate_info.native_libraries[&cnum],
+                            )
+                            .into_iter()
+                            .flatten()
+                            .collect();
+                    }
                     add_static_crate(
                         cmd,
                         sess,
@@ -3268,6 +3332,7 @@ fn add_upstream_rust_crates(
             cmd,
             sess,
             archive_builder_builder,
+            rmeta_link_cache,
             crate_info,
             tmpdir,
             &bundled_libs,
@@ -3283,6 +3348,7 @@ fn add_upstream_native_libraries(
     cmd: &mut dyn Linker,
     sess: &Session,
     archive_builder_builder: &dyn ArchiveBuilderBuilder,
+    rmeta_link_cache: &mut RmetaLinkCache,
     crate_info: &CrateInfo,
     tmpdir: &Path,
     link_output_kind: LinkOutputKind,
@@ -3306,6 +3372,7 @@ fn add_upstream_native_libraries(
             cmd,
             sess,
             archive_builder_builder,
+            rmeta_link_cache,
             crate_info,
             tmpdir,
             &Default::default(),

--- a/compiler/rustc_codegen_ssa/src/back/rmeta_link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/rmeta_link.rs
@@ -2,27 +2,38 @@
 //! and potentially other data collected and used when building or linking a rlib.
 //! See <https://github.com/rust-lang/rust/issues/138243>.
 
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use object::read::archive::ArchiveFile;
 use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::memmap::Mmap;
+use rustc_hir::attrs::NativeLibKind;
 use rustc_serialize::opaque::mem_encoder::MemEncoder;
 use rustc_serialize::opaque::{MAGIC_END_BYTES, MemDecoder};
 use rustc_serialize::{Decodable, Encodable};
+use rustc_span::Symbol;
+use rustc_target::spec::Target;
+use tracing::debug;
 
-use super::metadata::search_for_section;
+use super::metadata::{get_metadata_xcoff, search_for_section};
+use crate::NativeLib;
 
 pub(crate) const FILENAME: &str = "lib.rmeta-link";
 pub(crate) const SECTION: &str = ".rmeta-link";
 
 pub struct RmetaLink {
     pub rust_object_files: Vec<String>,
+    /// Positionally aligned with `native_libraries` in regular metadata: index `i` is the
+    /// bundled filename for native library `i`, or `None` if that library needs no bundling.
+    pub native_lib_filenames: Vec<Option<String>>,
 }
 
 impl RmetaLink {
     pub(crate) fn encode(&self) -> Vec<u8> {
         let mut encoder = MemEncoder::new();
         self.rust_object_files.encode(&mut encoder);
+        self.native_lib_filenames.encode(&mut encoder);
         let mut data = encoder.finish();
         data.extend_from_slice(MAGIC_END_BYTES);
         data
@@ -31,7 +42,8 @@ impl RmetaLink {
     pub(crate) fn decode(data: &[u8]) -> Option<RmetaLink> {
         let mut decoder = MemDecoder::new(data, 0).ok()?;
         let rust_object_files = Vec::<String>::decode(&mut decoder);
-        Some(RmetaLink { rust_object_files })
+        let native_lib_filenames = Vec::<Option<String>>::decode(&mut decoder);
+        Some(RmetaLink { rust_object_files, native_lib_filenames })
     }
 }
 
@@ -69,4 +81,52 @@ impl RmetaLinkCache {
     ) -> Option<&RmetaLink> {
         self.cache.entry(rlib_path.to_path_buf()).or_insert_with(load).as_ref()
     }
+
+    pub fn native_lib_filenames(
+        &mut self,
+        target: &Target,
+        rlib_path: &Path,
+        native_libs: &[NativeLib],
+    ) -> Vec<Option<Symbol>> {
+        if !crate_may_have_bundled_libs(native_libs) {
+            return Vec::new();
+        }
+        self.get_or_insert_with(rlib_path, || read_from_path(target, rlib_path))
+            .map(|rl| {
+                rl.native_lib_filenames.iter().map(|f| f.as_deref().map(Symbol::intern)).collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+fn crate_may_have_bundled_libs(libs: &[NativeLib]) -> bool {
+    libs.iter()
+        .any(|lib| matches!(lib.kind, NativeLibKind::Static { bundle: Some(true) | None, .. }))
+}
+
+// FIXME: this is mostly a copy-paste of `DefaultMetadataLoader::get_rlib_metadata`.
+fn read_from_path(target: &Target, path: &Path) -> Option<RmetaLink> {
+    let Ok(file) = File::open(path) else {
+        debug!("failed to open rlib for rmeta-link: {}", path.display());
+        return None;
+    };
+    let Ok(mmap) = (unsafe { Mmap::map(file) }) else {
+        debug!("failed to mmap rlib for rmeta-link: {}", path.display());
+        return None;
+    };
+
+    if target.is_like_aix {
+        let archive = ArchiveFile::parse(&*mmap).ok()?;
+        for entry in archive.members() {
+            let entry = entry.ok()?;
+            if entry.name() == FILENAME.as_bytes() {
+                let member_data = entry.data(&*mmap).ok()?;
+                let section_data = get_metadata_xcoff(path, member_data).ok()?;
+                return RmetaLink::decode(section_data);
+            }
+        }
+        return None;
+    }
+
+    read_from_data(&mmap, path)
 }

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -214,7 +214,6 @@ bitflags::bitflags! {
 pub struct NativeLib {
     pub kind: NativeLibKind,
     pub name: Symbol,
-    pub filename: Option<Symbol>,
     pub cfg: Option<CfgEntry>,
     pub verbatim: bool,
     pub dll_imports: Vec<cstore::DllImport>,
@@ -224,7 +223,6 @@ impl From<&cstore::NativeLib> for NativeLib {
     fn from(lib: &cstore::NativeLib) -> Self {
         NativeLib {
             kind: lib.kind,
-            filename: lib.filename,
             name: lib.name,
             cfg: lib.cfg.clone(),
             verbatim: lib.verbatim.unwrap_or(false),

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -29,7 +29,7 @@ pub mod locator;
 pub use fs::{METADATA_FILENAME, emit_wrapper_file};
 pub use host_dylib::{DylibError, load_symbol_from_dylib};
 pub use native_libs::{
-    NativeLibSearchFallback, find_native_static_library, try_find_native_dynamic_library,
-    try_find_native_static_library, walk_native_lib_search_dirs,
+    NativeLibSearchFallback, find_bundled_library, find_native_static_library,
+    try_find_native_dynamic_library, try_find_native_static_library, walk_native_lib_search_dirs,
 };
 pub use rmeta::{EncodedMetadata, METADATA_HEADER, ProcMacroKind, encode_metadata, rendered_const};

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -168,16 +168,16 @@ pub fn find_native_static_library(name: &str, verbatim: bool, sess: &Session) ->
     })
 }
 
-fn find_bundled_library(
+pub fn find_bundled_library(
     name: Symbol,
     verbatim: Option<bool>,
     kind: NativeLibKind,
     has_cfg: bool,
-    tcx: TyCtxt<'_>,
+    sess: &Session,
+    crate_types: &[CrateType],
 ) -> Option<Symbol> {
-    let sess = tcx.sess;
     if let NativeLibKind::Static { bundle: Some(true) | None, whole_archive, .. } = kind
-        && tcx.crate_types().iter().any(|t| matches!(t, &CrateType::Rlib | CrateType::StaticLib))
+        && crate_types.iter().any(|t| matches!(t, &CrateType::Rlib | CrateType::StaticLib))
         && (sess.opts.unstable_opts.packed_bundled_libs || has_cfg || whole_archive == Some(true))
     {
         let verbatim = verbatim.unwrap_or(false);
@@ -275,16 +275,8 @@ impl<'tcx> Collector<'tcx> {
                 }
             };
 
-            let filename = find_bundled_library(
-                attr.name,
-                attr.verbatim,
-                attr.kind,
-                attr.cfg.is_some(),
-                self.tcx,
-            );
             self.libs.push(NativeLib {
                 name: attr.name,
-                filename,
                 kind: attr.kind,
                 cfg: attr.cfg.clone(),
                 foreign_module: Some(def_id.to_def_id()),
@@ -366,16 +358,8 @@ impl<'tcx> Collector<'tcx> {
                 // Add if not found
                 let new_name: Option<&str> = passed_lib.new_name.as_deref();
                 let name = Symbol::intern(new_name.unwrap_or(&passed_lib.name));
-                let filename = find_bundled_library(
-                    name,
-                    passed_lib.verbatim,
-                    passed_lib.kind,
-                    false,
-                    self.tcx,
-                );
                 self.libs.push(NativeLib {
                     name,
-                    filename,
                     kind: passed_lib.kind,
                     cfg: None,
                     foreign_module: None,

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -68,8 +68,6 @@ pub enum LinkagePreference {
 pub struct NativeLib {
     pub kind: NativeLibKind,
     pub name: Symbol,
-    /// If packed_bundled_libs enabled, actual filename of library is stored.
-    pub filename: Option<Symbol>,
     pub cfg: Option<CfgEntry>,
     pub foreign_module: Option<DefId>,
     pub verbatim: Option<bool>,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156735)*
<!-- homu-ignore:end -->

Second PR in rust-lang/rust#138243  
Moves `NativeLib::filename` out of `rmeta` into `lib.rmeta-link` archive member that was introduced in the first PR. Filename is a link time only data so requiring a full metadata decode should be avoided.  It is stored as `(name, filename)` pairs keyed by name, the new `MetadataLoader::get_rlib_native_lib_filenames` patches it back on decode.  Also bumped `METADATA_VERSION` from version 10 to 11. Added also new round trip test and existing bundled-libs tests still pass. 

