### PR TITLE
fix E0371 description

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0371.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0371.md
@@ -7,10 +7,18 @@ trait Foo { fn foo(&self) { } }
 trait Bar: Foo { }
 trait Baz: Bar { }
 
-impl Bar for Baz { } // error, `Baz` implements `Bar` by definition
-impl Foo for Baz { } // error, `Baz` implements `Bar` which implements `Foo`
-impl Baz for Baz { } // error, `Baz` (trivially) implements `Baz`
-impl Baz for Bar { } // Note: This is OK
+impl Bar for dyn Baz { } // error, `Baz` implements `Bar` by definition
+impl Foo for dyn Baz { } // error, `Baz` implements `Bar` which implements `Foo`
+impl Baz for dyn Baz { } // error, `Baz` (trivially) implements `Baz`
+```
+
+This is okay, because `Bar` does not implement `Baz` by definition:
+
+```
+# trait Foo { fn foo(&self) { } }
+# trait Bar: Foo { }
+# trait Baz: Bar { }
+impl Baz for dyn Bar { } // Note: This is OK
 ```
 
 When `Trait2` is a subtrait of `Trait1` (for example, when `Trait2` has a


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This changes the `impl`s to be `impl {Trait} for dyn {Trait}` instead of just `impl {Trait} for {Trait}` in the description of E0371.

(While this was not part of "Crafting errors like rustc" workshop at RustWeek by @jdonszelmann and @estebank, I found this while going through all errors Rust emits to pick a favourite)