### PR TITLE
Fix LLVM IR expectations for the autodiff generic test

### DIFF
--- a/tests/codegen-llvm/autodiff/generic.rs
+++ b/tests/codegen-llvm/autodiff/generic.rs
@@ -34,7 +34,7 @@ fn square<T: std::ops::Mul<Output = T> + Copy>(x: &T) -> T {
 // F64-NEXT: ; Function Attrs: {{.*}}
 // F64-NEXT: define internal {{.*}} void
 // F64-NEXT: start:
-// F64-NEXT:   {{(tail )?}}call {{.*}} @diffe_{{.*}}
+// F64-NEXT:   {{(tail )?}}call {{.*}}{ double } @diffe_{{.*}}(ptr {{.*}}, ptr {{.*}}, double {{.*}})
 // F64: ret void
 
 // Ensure that `square::<f64>` is generated so that it can be differentiated

--- a/tests/codegen-llvm/autodiff/generic.rs
+++ b/tests/codegen-llvm/autodiff/generic.rs
@@ -34,8 +34,17 @@ fn square<T: std::ops::Mul<Output = T> + Copy>(x: &T) -> T {
 // F64-NEXT: ; Function Attrs: {{.*}}
 // F64-NEXT: define internal {{.*}} void
 // F64-NEXT: start:
-// F64-NEXT:   {{(tail )?}}call {{(fastcc )?}}void @diffe_{{.*}}(double {{.*}}, ptr {{.*}})
-// F64-NEXT: ret void
+// F64-NEXT:   {{(tail )?}}call {{.*}} @diffe_{{.*}}
+// F64: ret void
+
+// Ensure that `square::<f64>` is generated so that it can be differentiated
+
+// F64-LABEL: ; generic::square::<f64>
+// F64-NEXT: ; Function Attrs: {{.*}}
+// F64-NEXT: define internal {{.*}} double
+// F64-NEXT: start:
+// F64-NOT: ret
+// F64: fmul double
 
 // Main-LABEL: ; generic::main
 // Main: ; call generic::square::<f32>


### PR DESCRIPTION
Relax the LLVM IR checks for `d_square::<f64>` so they do not depend on the exact return type or argument ABI(which I don't think are necessary to check here) of the generated `@diffe_` call.

Also add checks that `square::<f64>` is generated, since `d_square::<f64>` needs the `f64` monomorphization even though `square::<f64>` is not called directly. I thought it seems natural to check it, but let me know if we do not need it.

I tested it works on my local(aarch64 mac) and dev-desktop(x86_64 linux)

| aarch64 apple | x86_64 linux |
| --- | --- |
| <img width="900" height="663" alt="スクリーンショット 2026-05-20 0 08 44" src="https://github.com/user-attachments/assets/89649d9e-3a46-440f-b5d1-e4dbdec0afb6" /> | <img width="843" height="708" alt="スクリーンショット 2026-05-20 0 09 19" src="https://github.com/user-attachments/assets/9ffa4a04-1adf-4679-bfbc-24dc15535acb" /> |

r? @ZuseZ4 