### PR TITLE
xfs support in `test_rename_directory_to_non_empty_directory`

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2153,7 +2153,13 @@ fn test_rename_directory_to_non_empty_directory() {
     fs::write(target_path.join("target_file.txt"), b"target hello world").unwrap();
 
     let err = fs::rename(source_path, target_path).unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::DirectoryNotEmpty);
+    assert_matches!(
+        err.kind(),
+        // On ext4, ntfs, apfs, tmpfs, and btrfs `DirectoryNotEmpty` is returned.
+        // On xfs `AlreadyExists` is returned.
+        ErrorKind::DirectoryNotEmpty | ErrorKind::AlreadyExists,
+        "Expected DirectoryNotEmpty or AlreadyExists error, got {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
While running Ferrocene's test suite we use a variety of filesystems, including XFS. Those systems caught a failing test in [a recent upstream pull](https://github.com/ferrocene/ferrocene/pull/2375).

The test failing:

https://github.com/rust-lang/rust/blob/1ea1171c1e537f295225be1c7b67dba46794e6ad/library/std/src/fs/tests.rs#L2141-L2157

It was recently removed from being Windows-only in: https://github.com/rust-lang/rust/commit/a0298aa7e5bccd8cb1a00073ad6ed6cb413eb3a8#diff-0ec4075fea7f5f4cc82c306e975ae7638b1fc500d30c11a83f337a69ef1dfd65L2177

Seemingly on XFS only, the `AlreadyExists` variant is returned instead.

This workaround allows both possible errors. I am unsure at this time if it is a signal of incorrectness in Rust somewhere, but on Python a similar failure can be noted:

```bash
ana@autonoma ~/git/ferrocene/scratch
❯ mkdir blap flap
ana@autonoma ~/git/ferrocene/scratch
❯ touch flap/zap
ana@autonoma ~/git/ferrocene/scratch
❯ python
Python 3.13.13 (main, May 15 2026, 12:38:54) [GCC 15.2.1 20260214] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.rename("blap", "flap")
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    os.rename("blap", "flap")
    ~~~~~~~~~^^^^^^^^^^^^^^^^
FileExistsError: [Errno 17] File exists: 'blap' -> 'flap'
ana@autonoma ~/git/ferrocene/scratch
❯ cd /tmp/
ana@autonoma /tmp
❯ mkdir blap flap
ana@autonoma /tmp
❯ touch flap/zap
ana@autonoma /tmp
❯ python
Python 3.13.13 (main, May 15 2026, 12:38:54) [GCC 15.2.1 20260214] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.rename("blap", "flap")
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    os.rename("blap", "flap")
    ~~~~~~~~~^^^^^^^^^^^^^^^^
OSError: [Errno 39] Directory not empty: 'blap' -> 'flap'
```

I tested on `ext4`, `tmpfs`, `overlayfs`, `btrfs`, and `xfs`. Only XFS seems to display this error.

## Reproduction

On Linux hosts:

```rust
use clap::Parser;

struct Args {
    /// Destination to try
    #[arg()]
    path: std::path::PathBuf,
}

fn main() {
    let args = Args::parse();

    // Renaming a directory over a non-empty existing directory should fail.
    let tmpdir = std::path::Path::new(&args.path);
    std::fs::create_dir_all(tmpdir).unwrap();

    let source_path = tmpdir.join("source_directory");
    let target_path = tmpdir.join("target_directory");

    std::fs::create_dir(&source_path).unwrap();
    std::fs::create_dir(&target_path).unwrap();

    let target_path_file = target_path.join("target_file.txt");
    std::fs::write(target_path.join("target_file.txt"), b"target hello world").unwrap();
    println!("wrote {target_path_file:?}");

    println!("{source_path:?} -> {target_path:?}");
    let err = std::fs::rename(source_path, target_path).unwrap_err();
    assert_eq!(err.kind(), std::io::ErrorKind::DirectoryNotEmpty);
}
```

```bash
XFS_BLOCK=image-xfs
truncate -s 512M image-xfs
mkfs.xfs -q image-xfs
mkdir mnt-xfs
sudo mount -o loop image-xfs mnt-xfs
sudo chmod 777 mnt-xfs
cargo run -- mnt-xfs/
```

Output:

```
wrote "mnt-xfs/target_directory/target_file.txt"
"mnt-xfs/source_directory" -> "mnt-xfs/target_directory"

thread 'main' (267220) panicked at src/main.rs:30:5:
assertion `left == right` failed
  left: AlreadyExists
 right: DirectoryNotEmpty
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

You can run this test directly:

```bash
./x.py --stage 2 test library/std --target x86_64-unknown-linux-gnu -- fs::tests::test_rename_directory_to_non_empty_directory --nocapture
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
