### PR TITLE
Account for proc macro spans in do_not_recommend diagnostics

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -827,6 +827,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     // Keep more precise spans that still point within the parent obligation,
                     // but do not let hidden impl details move the span outside of it.
                     if code == *root_obligation.cause.code()
+                        && root_obligation.cause.span.eq_ctxt(obligation.cause.span)
                         && !root_obligation.cause.span.contains(obligation.cause.span)
                     {
                         obligation.cause.span = root_obligation.cause.span;

--- a/tests/ui/diagnostic_namespace/do_not_recommend/auxiliary/proc_macro_repro.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/auxiliary/proc_macro_repro.rs
@@ -1,0 +1,37 @@
+#![feature(proc_macro_quote)]
+
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, TokenTree, quote};
+
+#[proc_macro_attribute]
+pub fn repro(_args: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse input that looks like `fn f(arg: &mut Arg);`
+    let mut input = input.into_iter();
+    assert_eq!(input.next().unwrap().to_string(), "fn");
+    assert_eq!(input.next().unwrap().to_string(), "f");
+    let TokenTree::Group(group) = input.next().unwrap() else { unreachable!() };
+    let mut input = group.stream().into_iter();
+    assert_eq!(input.next().unwrap().to_string(), "arg");
+    assert_eq!(input.next().unwrap().to_string(), ":");
+    let arg: TokenStream = input.collect();
+
+    // Emit output:
+    quote! {
+        const _: fn() = {
+            #[diagnostic::on_unimplemented(
+                message = "mutable reference to C++ type requires a pin -- use Pin<&mut Arg>",
+                label = "use `Pin<&mut Arg>`"
+            )]
+            trait ReferenceToUnpin_Arg {
+                fn check_unpin() {}
+            }
+            #[diagnostic::do_not_recommend]
+            impl<
+                'a,
+                T: ?::core::marker::Sized + ::core::marker::Unpin,
+            > ReferenceToUnpin_Arg for &'a mut T {}
+            <$arg as ReferenceToUnpin_Arg>::check_unpin
+        };
+    }
+}

--- a/tests/ui/diagnostic_namespace/do_not_recommend/proc-macro-span.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/proc-macro-span.current.stderr
@@ -1,0 +1,11 @@
+error[E0277]: mutable reference to C++ type requires a pin -- use Pin<&mut Arg>
+  --> $DIR/proc-macro-span.rs:15:11
+   |
+LL | fn f(arg: &mut Arg);
+   |           ^^^^^^^^ use `Pin<&mut Arg>`
+   |
+   = help: the trait `ReferenceToUnpin_Arg` is not implemented for `&mut Arg`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/proc-macro-span.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/proc-macro-span.next.stderr
@@ -1,0 +1,11 @@
+error[E0277]: mutable reference to C++ type requires a pin -- use Pin<&mut Arg>
+  --> $DIR/proc-macro-span.rs:15:11
+   |
+LL | fn f(arg: &mut Arg);
+   |           ^^^^^^^^ use `Pin<&mut Arg>`
+   |
+   = help: the trait `ReferenceToUnpin_Arg` is not implemented for `&mut Arg`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/diagnostic_namespace/do_not_recommend/proc-macro-span.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/proc-macro-span.rs
@@ -1,0 +1,16 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@ compile-flags: --crate-type=lib
+//@[next] compile-flags: -Znext-solver
+//@ edition: 2024
+//@ proc-macro: proc_macro_repro.rs
+
+// Regression test for https://github.com/rust-lang/rust/issues/156759.
+
+extern crate proc_macro_repro;
+
+struct Arg(std::marker::PhantomPinned);
+
+#[proc_macro_repro::repro]
+fn f(arg: &mut Arg);
+//~^ ERROR mutable reference to C++ type requires a pin


### PR DESCRIPTION
Follow up to rust-lang/rust#156676.

Fixes rust-lang/rust#156759

r? @chenyukang