### PR TITLE
tests: fix pub-priv-dep test expectation

### DIFF
--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
@@ -1,7 +1,6 @@
 //@ aux-crate:priv:shared=shared.rs
-//@ aux-crate:reexport=reexport.rs
+//@ aux-crate:priv:reexport=reexport.rs
 //@ compile-flags: -Zunstable-options
-//@ check-pass
 
 // A shared dependency, where a private dependency reexports a public dependency.
 //
@@ -21,12 +20,12 @@
 extern crate shared;
 extern crate reexport;
 
-// FIXME: This should trigger.
 pub fn leaks_priv() -> shared::Shared {
+    //~^ ERROR type `Shared` from private dependency 'shared' in public interface
     shared::Shared
 }
 
-// FIXME: This should trigger.
 pub fn leaks_priv_reexport() -> reexport::Shared {
+    //~^ ERROR type `Shared` from private dependency 'shared' in public interface
     reexport::Shared
 }

--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.stderr
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.stderr
@@ -1,0 +1,20 @@
+error: type `Shared` from private dependency 'shared' in public interface
+  --> $DIR/shared_both_private.rs:23:1
+   |
+LL | pub fn leaks_priv() -> shared::Shared {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/shared_both_private.rs:18:9
+   |
+LL | #![deny(exported_private_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `Shared` from private dependency 'shared' in public interface
+  --> $DIR/shared_both_private.rs:28:1
+   |
+LL | pub fn leaks_priv_reexport() -> reexport::Shared {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Related to private dependencies rust-lang/rust#44663

The test had wrongly configured dependency privacy. The ascii graph shows that both dependencies should be private. Furthermore, the way this test existed was effectively identical to `shared_direct_private.rs`.