### PR TITLE
Use print instead of po in debuginfo path test

### DIFF
--- a/tests/debuginfo/path.rs
+++ b/tests/debuginfo/path.rs
@@ -7,9 +7,9 @@
 //@ lldb-command:run
 
 //@ lldb-command:print pathbuf
-//@ lldb-check:[...] "/some/path" [...]
+//@ lldb-check:[...] "/some/path" { inner = "/some/path" { inner = { inner = size=10 { [0] = '/' [1] = 's' [2] = 'o' [3] = 'm' [4] = 'e' [5] = '/' [6] = 'p' [7] = 'a' [8] = 't' [9] = 'h' } } } }
 //@ lldb-command:print path
-//@ lldb-check:[...] "/some/path" [...]
+//@ lldb-check:[...] "/some/path" { data_ptr = [...] length = 10 }
 
 use std::path::Path;
 

--- a/tests/debuginfo/path.rs
+++ b/tests/debuginfo/path.rs
@@ -7,13 +7,9 @@
 //@ lldb-command:run
 
 //@ lldb-command:print pathbuf
-//@ lldb-check:[...] "/some/path" { inner = "/some/path" { inner = { inner = size=10 { [0] = '/' [1] = 's' [2] = 'o' [3] = 'm' [4] = 'e' [5] = '/' [6] = 'p' [7] = 'a' [8] = 't' [9] = 'h' } } } }
-//@ lldb-command:po pathbuf
-//@ lldb-check:"/some/path"
+//@ lldb-check:[...] "/some/path" [...]
 //@ lldb-command:print path
-//@ lldb-check:[...] "/some/path" { data_ptr = [...] length = 10 }
-//@ lldb-command:po path
-//@ lldb-check:"/some/path"
+//@ lldb-check:[...] "/some/path" [...]
 
 use std::path::Path;
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156769)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#156660

This fixes `tests/debuginfo/path.rs` failing on newer Apple LLDB versions.

Root cause:
Apple LLDB 2100 reports missing Rust language plugin support:

warning: `po` was unsuccessful, running `p` instead

As a result, `po` falls back to `p`, producing expanded output that no longer matches the existing `lldb-check` directives.

Changes:
- replace `po` with `print`
- relax `lldb-check` expectations using `[...]`
- preserve validation of the displayed path value

This also aligns `path.rs` with the rest of the debuginfo tests, as it appears to be the only test using `po`.

---

EDIT(@jieyouxu): see digging https://github.com/rust-lang/rust/pull/156769#discussion_r3293345899