### PR TITLE
Minor unsoundness fix with `FnDef` lifetimes

### DIFF
--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -75,6 +75,7 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
         if !self.visited.insert(ty) {
             return;
         }
+
         // Descend through the types, looking for the various "base"
         // components and collecting them into `out`. This is not written
         // with `collect()` because of the need to sometimes skip subtrees
@@ -82,25 +83,18 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
         // projection).
         match ty.kind() {
             ty::FnDef(_, args) => {
-                // HACK(eddyb) ignore lifetimes found shallowly in `args`.
-                // This is inconsistent with `ty::Adt` (including all args)
-                // and with `ty::Closure` (ignoring all args other than
-                // upvars, of which a `ty::FnDef` doesn't have any), but
-                // consistent with previous (accidental) behavior.
-                // See https://github.com/rust-lang/rust/issues/70917
-                // for further background and discussion.
                 for child in args.iter() {
-                    match child.kind() {
-                        ty::GenericArgKind::Lifetime(_) => {}
-                        ty::GenericArgKind::Type(_) | ty::GenericArgKind::Const(_) => {
-                            child.visit_with(self);
-                        }
-                    }
+                    child.visit_with(self);
                 }
             }
 
             ty::Closure(_, args) => {
+                // FIXME: this is still impacted by #84366
                 args.as_closure().tupled_upvars_ty().visit_with(self);
+                // i think this works? but crossbeam wouldn't compile with it enabled and it didn't fix The Bug.
+                // for child in args.as_closure().args.iter().filter(|a| a.as_type().is_none()) {
+                //     child.visit_with(self);
+                // }
             }
 
             ty::CoroutineClosure(_, args) => {

--- a/compiler/rustc_type_ir/src/outlives.rs
+++ b/compiler/rustc_type_ir/src/outlives.rs
@@ -83,26 +83,28 @@ impl<I: Interner> TypeVisitor<I> for OutlivesCollector<'_, I> {
         // projection).
         match ty.kind() {
             ty::FnDef(_, args) => {
-                for child in args.iter() {
-                    child.visit_with(self);
-                }
+                args.visit_with(self);
             }
 
             ty::Closure(_, args) => {
-                // FIXME: this is still impacted by #84366
                 args.as_closure().tupled_upvars_ty().visit_with(self);
-                // i think this works? but crossbeam wouldn't compile with it enabled and it didn't fix The Bug.
-                // for child in args.as_closure().args.iter().filter(|a| a.as_type().is_none()) {
-                //     child.visit_with(self);
-                // }
+                // FIXME: this branch is still impacted by #84366. needs investigation:
+                //
+                // when returning a closure, if that closure is bound by a lifetime (eg. `impl Fn() + 'a`),
+                // any generic args present in the closure's signature are NOT assumed to outlive 'a and
+                // require adding 'a as a bound. And then like 20% of core::iterator fails to compile.
+                // There's probably some inference logic somewhere that needs to be changed.
+                // args.as_closure().sig().visit_with(self);
             }
 
             ty::CoroutineClosure(_, args) => {
                 args.as_coroutine_closure().tupled_upvars_ty().visit_with(self);
+                args.as_coroutine_closure().coroutine_closure_sig().visit_with(self);
             }
 
             ty::Coroutine(_, args) => {
                 args.as_coroutine().tupled_upvars_ty().visit_with(self);
+                args.as_coroutine().sig().visit_with(self);
 
                 // Coroutines may not outlive a region unless the resume
                 // ty outlives a region. This is because the resume ty may

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2342,7 +2342,7 @@ pub const trait Iterator {
         // These closure "factory" functions exist to avoid genericity in `Self`.
 
         #[inline]
-        fn is_false<'a, T>(
+        fn is_false<'a, T: 'a>(
             predicate: &'a mut impl FnMut(&T) -> bool,
             true_count: &'a mut usize,
         ) -> impl FnMut(&&mut T) -> bool + 'a {
@@ -2354,7 +2354,9 @@ pub const trait Iterator {
         }
 
         #[inline]
-        fn is_true<T>(predicate: &mut impl FnMut(&T) -> bool) -> impl FnMut(&&mut T) -> bool + '_ {
+        fn is_true<'a, T: 'a>(
+            predicate: &'a mut impl FnMut(&T) -> bool,
+        ) -> impl FnMut(&&mut T) -> bool + 'a {
             move |x| predicate(&**x)
         }
 

--- a/tests/ui/coroutine/static-coroutine-with-nonstatic-yield.rs
+++ b/tests/ui/coroutine/static-coroutine-with-nonstatic-yield.rs
@@ -1,5 +1,4 @@
-//@ check-pass
-//@ known-bug: #144442
+// regression test for #144442
 
 // Same family as #84366 / #112905: a coroutine that yields a non-`'static`
 // reference is wrongly `: 'static`, allowing a `Box<dyn Any>` downcast to
@@ -19,7 +18,7 @@ type Payload = Box<i32>;
 fn make_coro<'a>()
 -> impl Coroutine<Yield = Rc<RefCell<Option<&'a Payload>>>, Return = ()> + 'static {
     #[coroutine]
-    || {
+    || { //~ERROR lifetime may not live long enough
         let storage: Rc<RefCell<Option<&'a Payload>>> = Rc::new(RefCell::new(None));
         yield storage.clone();
         yield storage;

--- a/tests/ui/coroutine/static-coroutine-with-nonstatic-yield.stderr
+++ b/tests/ui/coroutine/static-coroutine-with-nonstatic-yield.stderr
@@ -1,0 +1,20 @@
+error: lifetime may not live long enough
+  --> $DIR/static-coroutine-with-nonstatic-yield.rs:21:5
+   |
+LL |   fn make_coro<'a>()
+   |                -- lifetime `'a` defined here
+...
+LL | /     || {
+LL | |         let storage: Rc<RefCell<Option<&'a Payload>>> = Rc::new(RefCell::new(None));
+LL | |         yield storage.clone();
+LL | |         yield storage;
+LL | |     }
+   | |_____^ returning this value requires that `'a` must outlive `'static`
+   |
+help: consider adding 'move' keyword before the nested closure
+   |
+LL |     move || {
+   |     ++++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/function-pointer/the-pointerrrr-84366.rs
+++ b/tests/ui/function-pointer/the-pointerrrr-84366.rs
@@ -1,0 +1,48 @@
+use std::fmt;
+
+trait Trait: 'static {
+    type Associated;
+}
+
+impl<R, F: (Fn() -> R) + 'static> Trait for F {
+    type Associated = R;
+}
+
+// NOTE: this is early-bound, see https://rustc-dev-guide.rust-lang.org/early-late-parameters.html#must-be-constrained-by-argument-types
+fn early_bound_function<'evil_intimidating>() -> &'evil_intimidating str { "" }
+
+fn static_transfers_to_associated<T: Trait + 'static>(
+    _: &T,
+    // it is assumed that the associated value is also static
+    x: T::Associated,
+) -> Box<dyn fmt::Display + 'static>
+where
+    T::Associated: fmt::Display,
+{
+    Box::new(x)
+}
+
+fn require_static<F: 'static>(_: F) {}
+
+fn make_static_displayable<'temp>(not_static: &'temp str) -> Box<dyn fmt::Display> {
+    require_static(early_bound_function);
+    static_transfers_to_associated(&early_bound_function, not_static)
+    //~^ ERROR borrowed data escapes outside of function [E0521]
+}
+
+// FIXME: add a test for closures, those are currently broken
+// fn make_static_displayable_closure<'temp>(not_static: &'temp str) -> Box<dyn fmt::Display> {
+//     let closure = || -> &'temp str { "" };
+//     require_static(closure);
+//     static_transfers_to_associated(&closure, not_static)
+//     // ERROR borrowed data escapes outside of function [E0521]
+// }
+
+fn main() {
+    let d;
+    {
+        let x = "Hello World".to_string();
+        d = make_static_displayable(&x);
+    }
+    println!("{}", d);
+}

--- a/tests/ui/function-pointer/the-pointerrrr-84366.rs
+++ b/tests/ui/function-pointer/the-pointerrrr-84366.rs
@@ -30,7 +30,8 @@ fn make_static_displayable<'temp>(not_static: &'temp str) -> Box<dyn fmt::Displa
     //~^ ERROR borrowed data escapes outside of function [E0521]
 }
 
-// FIXME: add a test for closures, those are currently broken
+// FIXME: add a test for closures, those are currently broken.
+//        see the match on `ty::Closure` in compiler/rustc_type_ir/src/outlives.rs (line ~91)
 // fn make_static_displayable_closure<'temp>(not_static: &'temp str) -> Box<dyn fmt::Display> {
 //     let closure = || -> &'temp str { "" };
 //     require_static(closure);
@@ -43,6 +44,7 @@ fn main() {
     {
         let x = "Hello World".to_string();
         d = make_static_displayable(&x);
+        // d = make_static_displayable_closure(&x);
     }
     println!("{}", d);
 }

--- a/tests/ui/function-pointer/the-pointerrrr-84366.stderr
+++ b/tests/ui/function-pointer/the-pointerrrr-84366.stderr
@@ -1,0 +1,17 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/the-pointerrrr-84366.rs:29:5
+   |
+LL | fn make_static_displayable<'temp>(not_static: &'temp str) -> Box<dyn fmt::Display> {
+   |                            -----  ---------- `not_static` is a reference that is only valid in the function body
+   |                            |
+   |                            lifetime `'temp` defined here
+LL |     require_static(early_bound_function);
+LL |     static_transfers_to_associated(&early_bound_function, not_static)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `not_static` escapes the function body here
+   |     argument requires that `'temp` must outlive `'static`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/tests/ui/lifetimes/issue-70917-lifetimes-in-fn-def.rs
+++ b/tests/ui/lifetimes/issue-70917-lifetimes-in-fn-def.rs
@@ -1,4 +1,4 @@
-//@ check-pass
+//
 
 fn assert_static<T: 'static>(_: T) {}
 
@@ -8,6 +8,7 @@ fn capture_lifetime<'a: 'a>() {}
 
 fn test_lifetime<'a>() {
     assert_static(capture_lifetime::<'a>);
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/lifetimes/issue-70917-lifetimes-in-fn-def.stderr
+++ b/tests/ui/lifetimes/issue-70917-lifetimes-in-fn-def.stderr
@@ -1,0 +1,14 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-70917-lifetimes-in-fn-def.rs:10:5
+   |
+LL | fn test_lifetime<'a>() {
+   |                  -- lifetime `'a` defined here
+LL |     assert_static(capture_lifetime::<'a>);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'static`
+   |
+   = note: requirement occurs because of the function item type defined by `capture_lifetime`
+   = note: the function `capture_lifetime` is invariant over the parameter `'a`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This is a minor breaking(?) change that tries to fix some issues brought up in https://github.com/rust-lang/rust/issues/70917 and https://github.com/rust-lang/rust/issues/84366 . As far as I can tell, the behavior for closures is still unchanged, which I believe is another part of the unsoundness. I don't have enough experience working with the compiler yet to fix it though.

r? oli-obk