### PR TITLE
Add -Zautodiff_post_passes flag to limit which llvm passes to run after enzyme to make autodiff tests more robust

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -620,7 +620,9 @@ pub(crate) fn run_pass_manager(
     if cfg!(feature = "llvm_enzyme") && enable_ad && !thin {
         let opt_stage = llvm::OptStage::FatLTO;
         let stage = write::AutodiffStage::PostAD;
-        if !config.autodiff.contains(&config::AutoDiff::NoPostopt) {
+        if !config.autodiff.contains(&config::AutoDiff::NoPostopt)
+            && config.autodiff_post_passes.as_deref() != Some("")
+        {
             unsafe {
                 write::llvm_optimize(
                     cgcx, prof, dcx, module, None, None, config, opt_level, opt_stage, stage,

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -566,6 +566,14 @@ pub(crate) unsafe fn llvm_optimize(
     let print_before_enzyme = config.autodiff.contains(&config::AutoDiff::PrintModBefore);
     let print_after_enzyme = config.autodiff.contains(&config::AutoDiff::PrintModAfter);
     let print_passes = config.autodiff.contains(&config::AutoDiff::PrintPasses);
+    let passes_after_enzyme = if autodiff_stage == AutodiffStage::PostAD {
+        config.autodiff_post_passes.as_deref()
+    } else {
+        None
+    };
+    let passes_after_enzyme_ptr =
+        passes_after_enzyme.map_or(std::ptr::null(), |s| s.as_c_char_ptr());
+    let passes_after_enzyme_len = passes_after_enzyme.map_or(0, |s| s.len());
     let merge_functions;
     let unroll_loops;
     let vectorize_slp;
@@ -795,6 +803,8 @@ pub(crate) unsafe fn llvm_optimize(
             llvm_selfprofiler,
             selfprofile_before_pass_callback,
             selfprofile_after_pass_callback,
+            passes_after_enzyme_ptr,
+            passes_after_enzyme_len,
             extra_passes.as_c_char_ptr(),
             extra_passes.len(),
             llvm_plugins.as_c_char_ptr(),

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2492,6 +2492,8 @@ unsafe extern "C" {
         llvm_selfprofiler: *mut c_void,
         begin_callback: SelfProfileBeforePassCallback,
         end_callback: SelfProfileAfterPassCallback,
+        PostEnzymePasses: *const c_char,
+        PostEnzymePassesLen: size_t,
         ExtraPasses: *const c_char,
         ExtraPassesLen: size_t,
         LLVMPlugins: *const c_char,

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -108,6 +108,7 @@ pub struct ModuleConfig {
     pub emit_lifetime_markers: bool,
     pub llvm_plugins: Vec<String>,
     pub autodiff: Vec<config::AutoDiff>,
+    pub autodiff_post_passes: Option<String>,
     pub offload: Vec<config::Offload>,
 }
 
@@ -259,6 +260,10 @@ impl ModuleConfig {
             emit_lifetime_markers: sess.emit_lifetime_markers(),
             llvm_plugins: if_regular!(sess.opts.unstable_opts.llvm_plugins.clone(), vec![]),
             autodiff: if_regular!(sess.opts.unstable_opts.autodiff.clone(), vec![]),
+            autodiff_post_passes: if_regular!(
+                sess.opts.unstable_opts.autodiff_post_passes.clone(),
+                None
+            ),
             offload: if_regular!(sess.opts.unstable_opts.offload.clone(), vec![]),
         }
     }

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -788,6 +788,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(annotate_moves, AnnotateMoves::Enabled(Some(1234)));
     tracked!(assume_incomplete_release, true);
     tracked!(autodiff, vec![AutoDiff::Enable, AutoDiff::NoTT]);
+    tracked!(autodiff_post_passes, Some("function(mem2reg,instsimplify,simplifycfg)".to_string()));
     tracked!(binary_dep_depinfo, true);
     tracked!(box_noalias, false);
     tracked!(

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -606,6 +606,7 @@ extern "C" LLVMRustResult LLVMRustOptimize(
     bool DebugInfoForProfiling, void *LlvmSelfProfiler,
     LLVMRustSelfProfileBeforePassCallback BeforePassCallback,
     LLVMRustSelfProfileAfterPassCallback AfterPassCallback,
+    const char *PostEnzymePasses, size_t PostEnzymePassesLen,
     const char *ExtraPasses, size_t ExtraPassesLen, const char *LLVMPlugins,
     size_t LLVMPluginsLen) {
   Module *TheModule = unwrap(ModuleRef);
@@ -842,120 +843,130 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   raw_string_ostream ThinLinkDataOS(ThinLTOSummaryBuffer->data);
   bool IsLTO = OptStage == LLVMRustOptStage::ThinLTO ||
                OptStage == LLVMRustOptStage::FatLTO;
-  if (!NoPrepopulatePasses) {
-    for (const auto &C : PipelineStartEPCallbacks)
-      PB.registerPipelineStartEPCallback(C);
-    for (const auto &C : OptimizerLastEPCallbacks)
-      PB.registerOptimizerLastEPCallback(C);
-
-    // The pre-link pipelines don't support O0 and require using
-    // buildO0DefaultPipeline() instead. At the same time, the LTO pipelines do
-    // support O0 and using them is required.
-    if (OptLevel == OptimizationLevel::O0 && !IsLTO) {
-      // We manually schedule ThinLTOBufferPasses below, so don't pass the value
-      // to enable it here.
-      MPM = PB.buildO0DefaultPipeline(OptLevel);
-    } else {
-      switch (OptStage) {
-      case LLVMRustOptStage::PreLinkNoLTO:
-        if (ThinLTOBufferRef) {
-          // This is similar to LLVM's `buildFatLTODefaultPipeline`, where the
-          // bitcode for embedding is obtained after performing
-          // `ThinLTOPreLinkDefaultPipeline`.
-          MPM.addPass(PB.buildThinLTOPreLinkDefaultPipeline(OptLevel));
-          MPM.addPass(ThinLTOBitcodeWriterPass(
-              ThinLTODataOS,
-              ThinLTOSummaryBufferRef ? &ThinLinkDataOS : nullptr));
-          *ThinLTOBufferRef = ThinLTOBuffer.release();
-          if (ThinLTOSummaryBufferRef) {
-            *ThinLTOSummaryBufferRef = ThinLTOSummaryBuffer.release();
-          }
-          MPM.addPass(PB.buildModuleOptimizationPipeline(
-              OptLevel, ThinOrFullLTOPhase::None));
-          MPM.addPass(
-              createModuleToFunctionPassAdaptor(AnnotationRemarksPass()));
-        } else {
-          MPM = PB.buildPerModuleDefaultPipeline(OptLevel);
-        }
-        break;
-      case LLVMRustOptStage::PreLinkThinLTO:
-      case LLVMRustOptStage::PreLinkFatLTO:
-        MPM = PB.buildThinLTOPreLinkDefaultPipeline(OptLevel);
-        NeedThinLTOBufferPasses = false;
-        break;
-      case LLVMRustOptStage::ThinLTO:
-        // FIXME: Does it make sense to pass the ModuleSummaryIndex?
-        // It only seems to be needed for C++ specific optimizations.
-        MPM = PB.buildThinLTODefaultPipeline(OptLevel, nullptr);
-        break;
-      case LLVMRustOptStage::FatLTO:
-        MPM = PB.buildLTODefaultPipeline(OptLevel, nullptr);
-        NeedThinLTOBufferPasses = false;
-        break;
-      }
+  if (PostEnzymePassesLen) {
+    if (auto Err = PB.parsePassPipeline(
+            MPM, StringRef(PostEnzymePasses, PostEnzymePassesLen))) {
+      std::string ErrMsg = toString(std::move(Err));
+      LLVMRustSetLastError(ErrMsg.c_str());
+      return LLVMRustResult::Failure;
     }
   } else {
-    // We're not building any of the default pipelines but we still want to
-    // add the verifier, instrumentation, etc passes if they were requested
-    for (const auto &C : PipelineStartEPCallbacks)
-      C(MPM, OptLevel);
-    for (const auto &C : OptimizerLastEPCallbacks)
-      C(MPM, OptLevel, ThinOrFullLTOPhase::None);
-  }
+    if (!NoPrepopulatePasses) {
+      for (const auto &C : PipelineStartEPCallbacks)
+        PB.registerPipelineStartEPCallback(C);
+      for (const auto &C : OptimizerLastEPCallbacks)
+        PB.registerOptimizerLastEPCallback(C);
 
-  if (ExtraPassesLen) {
-    if (auto Err =
-            PB.parsePassPipeline(MPM, StringRef(ExtraPasses, ExtraPassesLen))) {
-      std::string ErrMsg = toString(std::move(Err));
-      LLVMRustSetLastError(ErrMsg.c_str());
-      return LLVMRustResult::Failure;
-    }
-  }
-
-  if (NeedThinLTOBufferPasses) {
-    MPM.addPass(CanonicalizeAliasesPass());
-    MPM.addPass(NameAnonGlobalPass());
-  }
-  // For `-Copt-level=0`, and the pre-link fat/thin LTO stages.
-  if (ThinLTOBufferRef && *ThinLTOBufferRef == nullptr) {
-    // thin lto summaries prevent fat lto, so do not emit them if fat
-    // lto is requested. See PR #136840 for background information.
-    if (OptStage != LLVMRustOptStage::PreLinkFatLTO) {
-      MPM.addPass(ThinLTOBitcodeWriterPass(
-          ThinLTODataOS, ThinLTOSummaryBufferRef ? &ThinLinkDataOS : nullptr));
+      // The pre-link pipelines don't support O0 and require using
+      // buildO0DefaultPipeline() instead. At the same time, the LTO pipelines
+      // do support O0 and using them is required.
+      if (OptLevel == OptimizationLevel::O0 && !IsLTO) {
+        // We manually schedule ThinLTOBufferPasses below, so don't pass the
+        // value to enable it here.
+        MPM = PB.buildO0DefaultPipeline(OptLevel);
+      } else {
+        switch (OptStage) {
+        case LLVMRustOptStage::PreLinkNoLTO:
+          if (ThinLTOBufferRef) {
+            // This is similar to LLVM's `buildFatLTODefaultPipeline`, where the
+            // bitcode for embedding is obtained after performing
+            // `ThinLTOPreLinkDefaultPipeline`.
+            MPM.addPass(PB.buildThinLTOPreLinkDefaultPipeline(OptLevel));
+            MPM.addPass(ThinLTOBitcodeWriterPass(
+                ThinLTODataOS,
+                ThinLTOSummaryBufferRef ? &ThinLinkDataOS : nullptr));
+            *ThinLTOBufferRef = ThinLTOBuffer.release();
+            if (ThinLTOSummaryBufferRef) {
+              *ThinLTOSummaryBufferRef = ThinLTOSummaryBuffer.release();
+            }
+            MPM.addPass(PB.buildModuleOptimizationPipeline(
+                OptLevel, ThinOrFullLTOPhase::None));
+            MPM.addPass(
+                createModuleToFunctionPassAdaptor(AnnotationRemarksPass()));
+          } else {
+            MPM = PB.buildPerModuleDefaultPipeline(OptLevel);
+          }
+          break;
+        case LLVMRustOptStage::PreLinkThinLTO:
+        case LLVMRustOptStage::PreLinkFatLTO:
+          MPM = PB.buildThinLTOPreLinkDefaultPipeline(OptLevel);
+          NeedThinLTOBufferPasses = false;
+          break;
+        case LLVMRustOptStage::ThinLTO:
+          // FIXME: Does it make sense to pass the ModuleSummaryIndex?
+          // It only seems to be needed for C++ specific optimizations.
+          MPM = PB.buildThinLTODefaultPipeline(OptLevel, nullptr);
+          break;
+        case LLVMRustOptStage::FatLTO:
+          MPM = PB.buildLTODefaultPipeline(OptLevel, nullptr);
+          NeedThinLTOBufferPasses = false;
+          break;
+        }
+      }
     } else {
-      MPM.addPass(BitcodeWriterPass(ThinLTODataOS));
-    }
-    *ThinLTOBufferRef = ThinLTOBuffer.release();
-    if (ThinLTOSummaryBufferRef) {
-      *ThinLTOSummaryBufferRef = ThinLTOSummaryBuffer.release();
-    }
-  }
-
-  // now load "-enzyme" pass:
-  // With dlopen, ENZYME macro may not be defined, so check EnzymePtr directly
-  // In the case of debug builds with multiple codegen units, we might not
-  // have all function definitions available during the early compiler
-  // invocations. We therefore wait for the final lto step to run Enzyme.
-  if (EnzymePtr && IsLTO) {
-
-    if (PrintBeforeEnzyme) {
-      // Handle the Rust flag `-Zautodiff=PrintModBefore`.
-      std::string Banner = "Module before EnzymeNewPM";
-      MPM.addPass(PrintModulePass(outs(), Banner, true, false));
+      // We're not building any of the default pipelines but we still want to
+      // add the verifier, instrumentation, etc passes if they were requested
+      for (const auto &C : PipelineStartEPCallbacks)
+        C(MPM, OptLevel);
+      for (const auto &C : OptimizerLastEPCallbacks)
+        C(MPM, OptLevel, ThinOrFullLTOPhase::None);
     }
 
-    EnzymePtr(PB, false);
-    if (auto Err = PB.parsePassPipeline(MPM, "enzyme")) {
-      std::string ErrMsg = toString(std::move(Err));
-      LLVMRustSetLastError(ErrMsg.c_str());
-      return LLVMRustResult::Failure;
+    if (ExtraPassesLen) {
+      if (auto Err = PB.parsePassPipeline(
+              MPM, StringRef(ExtraPasses, ExtraPassesLen))) {
+        std::string ErrMsg = toString(std::move(Err));
+        LLVMRustSetLastError(ErrMsg.c_str());
+        return LLVMRustResult::Failure;
+      }
     }
 
-    if (PrintAfterEnzyme) {
-      // Handle the Rust flag `-Zautodiff=PrintModAfter`.
-      std::string Banner = "Module after EnzymeNewPM";
-      MPM.addPass(PrintModulePass(outs(), Banner, true, false));
+    if (NeedThinLTOBufferPasses) {
+      MPM.addPass(CanonicalizeAliasesPass());
+      MPM.addPass(NameAnonGlobalPass());
+    }
+    // For `-Copt-level=0`, and the pre-link fat/thin LTO stages.
+    if (ThinLTOBufferRef && *ThinLTOBufferRef == nullptr) {
+      // thin lto summaries prevent fat lto, so do not emit them if fat
+      // lto is requested. See PR #136840 for background information.
+      if (OptStage != LLVMRustOptStage::PreLinkFatLTO) {
+        MPM.addPass(ThinLTOBitcodeWriterPass(
+            ThinLTODataOS,
+            ThinLTOSummaryBufferRef ? &ThinLinkDataOS : nullptr));
+      } else {
+        MPM.addPass(BitcodeWriterPass(ThinLTODataOS));
+      }
+      *ThinLTOBufferRef = ThinLTOBuffer.release();
+      if (ThinLTOSummaryBufferRef) {
+        *ThinLTOSummaryBufferRef = ThinLTOSummaryBuffer.release();
+      }
+    }
+
+    // now load "-enzyme" pass:
+    // With dlopen, ENZYME macro may not be defined, so check EnzymePtr directly
+    // In the case of debug builds with multiple codegen units, we might not
+    // have all function definitions available during the early compiler
+    // invocations. We therefore wait for the final lto step to run Enzyme.
+    if (EnzymePtr && IsLTO) {
+
+      if (PrintBeforeEnzyme) {
+        // Handle the Rust flag `-Zautodiff=PrintModBefore`.
+        std::string Banner = "Module before EnzymeNewPM";
+        MPM.addPass(PrintModulePass(outs(), Banner, true, false));
+      }
+
+      EnzymePtr(PB, false);
+      if (auto Err = PB.parsePassPipeline(MPM, "enzyme")) {
+        std::string ErrMsg = toString(std::move(Err));
+        LLVMRustSetLastError(ErrMsg.c_str());
+        return LLVMRustResult::Failure;
+      }
+
+      if (PrintAfterEnzyme) {
+        // Handle the Rust flag `-Zautodiff=PrintModAfter`.
+        std::string Banner = "Module after EnzymeNewPM";
+        MPM.addPass(PrintModulePass(outs(), Banner, true, false));
+      }
     }
   }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2294,6 +2294,8 @@ options! {
         `=LooseTypes`
         `=Inline`
         Multiple options can be combined with commas."),
+    autodiff_post_passes: Option<String> = (None, parse_opt_string, [TRACKED],
+        "set llvm passes to run after enzyme (no passes run when it is empty)"),
     #[rustc_lint_opt_deny_field_access("use `Session::binary_dep_depinfo` instead of this field")]
     binary_dep_depinfo: bool = (false, parse_bool, [TRACKED],
         "include artifacts (sysroot, crate dependencies) used during compilation in dep-info \

--- a/tests/codegen-llvm/autodiff/abi_handling.rs
+++ b/tests/codegen-llvm/autodiff/abi_handling.rs
@@ -1,7 +1,7 @@
 //@ revisions: debug release
 
 //@[debug] compile-flags: -Zautodiff=Enable,NoTT -C opt-level=0 -Clto=fat
-//@[release] compile-flags: -Zautodiff=Enable,NoTT -C opt-level=3 -Clto=fat
+//@[release] compile-flags: -Zautodiff=Enable,NoTT -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3 -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 
@@ -39,15 +39,15 @@ fn square(x: f32) -> f32 {
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal { float, float }
 // debug-SAME: (ptr {{.*}}%x, ptr {{.*}}%bx_0)
-// release-NEXT: define internal fastcc float
-// release-SAME: (float %x.0.val, float %x.4.val)
+// release-NEXT: define internal fastcc { float, float }
+// release-SAME: (ptr {{.*}}%x)
 
 // CHECK-LABEL: ; abi_handling::f1
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (ptr {{.*}}%x)
-// release-NEXT: define internal fastcc noundef float
-// release-SAME: (float %x.0.val, float %x.4.val)
+// release-NEXT: define internal noundef float
+// release-SAME: (ptr {{.*}}%x)
 #[autodiff_forward(df1, Dual, Dual)]
 #[inline(never)]
 fn f1(x: &[f32; 2]) -> f32 {
@@ -58,15 +58,15 @@ fn f1(x: &[f32; 2]) -> f32 {
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal { float, float }
 // debug-SAME: (ptr %f, float %x, float %dret)
-// release-NEXT: define internal fastcc noundef float
+// release-NEXT: define internal fastcc { float, float }
 // release-SAME: (float noundef %x)
 
 // CHECK-LABEL: ; abi_handling::f2
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (ptr %f, float %x)
-// release-NEXT: define internal fastcc noundef float
-// release-SAME: (float noundef %x)
+// release-NEXT: define internal noundef float
+// release-SAME: (ptr {{.*}}%f, float {{.*}}%x)
 #[autodiff_reverse(df2, Const, Active, Active)]
 #[inline(never)]
 fn f2(f: fn(f32) -> f32, x: f32) -> f32 {
@@ -77,15 +77,15 @@ fn f2(f: fn(f32) -> f32, x: f32) -> f32 {
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal { float, float }
 // debug-SAME: (ptr align 4 %x, ptr align 4 %bx_0, ptr align 4 %y, ptr align 4 %by_0)
-// release-NEXT: define internal fastcc float
-// release-SAME: (float %x.0.val)
+// release-NEXT: define internal fastcc { float, float }
+// release-SAME: (ptr {{.*}}%x)
 
 // CHECK-LABEL: ; abi_handling::f3
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (ptr {{.*}}%x, ptr {{.*}}%y)
-// release-NEXT: define internal fastcc noundef float
-// release-SAME: (float %x.0.val)
+// release-NEXT: define internal noundef float
+// release-SAME: (ptr {{.*}}%y)
 #[autodiff_forward(df3, Dual, Dual, Dual)]
 #[inline(never)]
 fn f3<'a>(x: &'a f32, y: &'a f32) -> f32 {
@@ -103,7 +103,7 @@ fn f3<'a>(x: &'a f32, y: &'a f32) -> f32 {
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (float %x.0, float %x.1)
-// release-NEXT: define internal fastcc noundef float
+// release-NEXT: define internal noundef float
 // release-SAME: (float noundef %x.0, float noundef %x.1)
 #[autodiff_forward(df4, Dual, Dual)]
 #[inline(never)]
@@ -122,7 +122,7 @@ fn f4(x: (f32, f32)) -> f32 {
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (float %i.0, float %i.1)
-// release-NEXT: define internal fastcc noundef float
+// release-NEXT: define internal noundef float
 // release-SAME: (float noundef %i.0, float noundef %i.1)
 #[autodiff_forward(df5, Dual, Dual)]
 #[inline(never)]
@@ -142,7 +142,7 @@ fn f5(i: Input) -> f32 {
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (float %i.0, float %i.1)
-// release-NEXT: define internal fastcc noundef float
+// release-NEXT: define internal noundef float
 // release-SAME: (float noundef %i.0, float noundef %i.1)
 #[autodiff_forward(df6, Dual, Dual)]
 #[inline(never)]
@@ -155,14 +155,14 @@ fn f6(i: NestedInput) -> f32 {
 // debug-NEXT: define internal { float, float }
 // debug-SAME: (ptr align 4 %x.0, ptr align 4 %x.1, ptr align 4 %bx_0.0, ptr align 4 %bx_0.1)
 // release-NEXT: define internal fastcc { float, float }
-// release-SAME: (float %x.0.0.val, float %x.1.0.val)
+// release-SAME: (ptr {{.*}}%x.0, ptr {{.*}}%x.1)
 
 // CHECK-LABEL: ; abi_handling::f7
 // CHECK-NEXT: Function Attrs
 // debug-NEXT: define internal float
 // debug-SAME: (ptr {{.*}}%x.0, ptr {{.*}}%x.1)
-// release-NEXT: define internal fastcc noundef float
-// release-SAME: (float %x.0.0.val, float %x.1.0.val)
+// release-NEXT: define internal noundef float
+// release-SAME: (ptr {{.*}}%x.0, ptr {{.*}}%x.1)
 #[autodiff_forward(df7, Dual, Dual)]
 #[inline(never)]
 fn f7(x: (&f32, &f32)) -> f32 {

--- a/tests/codegen-llvm/autodiff/autodiffv2.rs
+++ b/tests/codegen-llvm/autodiff/autodiffv2.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable -C opt-level=3  -Clto=fat
+//@ compile-flags: -Zautodiff=Enable,NoTT -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3  -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 //

--- a/tests/codegen-llvm/autodiff/batched.rs
+++ b/tests/codegen-llvm/autodiff/batched.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable,NoTT,NoPostopt -C opt-level=3  -Clto=fat
+//@ compile-flags: -Zautodiff=Enable,NoTT -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3  -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 
@@ -20,21 +20,27 @@ fn square(x: &f32) -> f32 {
     x * x
 }
 
+// CHECK: ; batched::d_square2
+// CHECK: define internal fastcc void
+// CHECK-SAME: (ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK:   ret void
+// CHECK-NEXT:   }
+
+// CHECK: ; batched::d_square1
+// CHECK: define internal fastcc void
+// CHECK-SAME: (ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}})
+// CHECK:   ret void
+// CHECK-NEXT:   }
+
 // The base ("scalar") case d_square3, without batching.
-// CHECK: define internal fastcc float @fwddiffesquare(float %x.0.val, float %"x'.0.val")
-// CHECK:   %0 = fadd fast float %"x'.0.val", %"x'.0.val"
-// CHECK-NEXT:   %1 = fmul fast float %0, %x.0.val
-// CHECK-NEXT:   ret float %1
+// CHECK: define internal float @fwddiffesquare(ptr {{.*}}, ptr {{.*}})
+// CHECK:  [[SHADOW_X:%"_[0-9]+'ipl"]] = load float, ptr %"x'"
+// CHECK-NEXT:  [[PRIMAL_X:%_[0-9]+]] = load float, ptr %x
+// CHECK-NEXT:  [[MUL1:%[0-9]+]] = fmul fast float [[SHADOW_X]], [[PRIMAL_X]]
+// CHECK-NEXT:  [[MUL2:%[0-9]+]] = fmul fast float [[SHADOW_X]], [[PRIMAL_X]]
+// CHECK-NEXT:  [[ADD1:%[0-9]+]] = fadd fast float [[MUL1]], [[MUL2]]
+// CHECK-NEXT:  ret float [[ADD1]]
 // CHECK-NEXT: }
-
-// d_square2
-// CHECK: define internal fastcc [4 x float] @fwddiffe4square(float %x.0.val, [4 x ptr] %"x'")
-// CHECK:   ret [4 x float]
-// CHECK-NEXT:   }
-
-// CHECK: define internal fastcc { float, [4 x float] } @fwddiffe4square.{{.*}}(float %x.0.val, [4 x ptr] %"x'")
-// CHECK:   ret { float, [4 x float] }
-// CHECK-NEXT:   }
 
 fn main() {
     let x = std::hint::black_box(3.0);

--- a/tests/codegen-llvm/autodiff/generic.rs
+++ b/tests/codegen-llvm/autodiff/generic.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable -Zautodiff=NoPostopt -C opt-level=3 -Clto=fat
+//@ compile-flags: -Zautodiff=Enable -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3 -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 //@ revisions: F32 F64 Main
@@ -34,7 +34,7 @@ fn square<T: std::ops::Mul<Output = T> + Copy>(x: &T) -> T {
 // F64-NEXT: ; Function Attrs: {{.*}}
 // F64-NEXT: define internal {{.*}} void
 // F64-NEXT: start:
-// F64-NEXT:   {{(tail )?}}call {{(fastcc )?}}void @diffe_{{.*}}(double {{.*}}, ptr {{.*}})
+// F64-NEXT:   {{(tail )?}}call fast { double } @diffe_{{.*}}(ptr {{.*}}, ptr {{.*}}, double {{.*}})
 // F64-NEXT: ret void
 
 // Main-LABEL: ; generic::main

--- a/tests/codegen-llvm/autodiff/identical_fnc.rs
+++ b/tests/codegen-llvm/autodiff/identical_fnc.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable -C opt-level=3  -Clto=fat
+//@ compile-flags: -Zautodiff=Enable -Zautodiff_post_passes=mergefunc,function(mem2reg,instsimplify,simplifycfg) -C opt-level=3  -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 //
@@ -32,9 +32,9 @@ fn square2(x: &f64) -> f64 {
 // CHECK-NOT:br
 // CHECK-NOT:ret
 // CHECK:; call identical_fnc::d_square
-// CHECK-NEXT:call fastcc void @[[HASH:.+]](double %x.val, ptr noalias noundef align 8 dereferenceable(8) %dx1)
+// CHECK-NEXT:call fastcc void @[[HASH:.+]](ptr {{.*}}, ptr {{.*}})
 // CHECK:; call identical_fnc::d_square
-// CHECK-NEXT:call fastcc void @[[HASH]](double %x.val, ptr noalias noundef align 8 dereferenceable(8) %dx2)
+// CHECK-NEXT:call fastcc void @[[HASH]](ptr {{.*}}, ptr {{.*}})
 
 fn main() {
     let x = std::hint::black_box(3.0);

--- a/tests/codegen-llvm/autodiff/impl.rs
+++ b/tests/codegen-llvm/autodiff/impl.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable -Zautodiff=NoPostopt -C opt-level=3 -Clto=fat
+//@ compile-flags: -Zautodiff=Enable -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3 -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 

--- a/tests/codegen-llvm/autodiff/scalar.rs
+++ b/tests/codegen-llvm/autodiff/scalar.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable,NoTT -C opt-level=3  -Clto=fat
+//@ compile-flags: -Zautodiff=Enable,NoTT -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3  -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 #![feature(autodiff)]
@@ -12,14 +12,18 @@ fn square(x: &f64) -> f64 {
     x * x
 }
 
-// CHECK:define internal fastcc double @diffesquare(double %x.0.val, ptr nonnull align 8 captures(none) %"x'")
-// CHECK-NEXT:invertstart:
-// CHECK-NEXT:  %_0 = fmul double %x.0.val, %x.0.val
-// CHECK-NEXT:  %0 = fadd fast double %x.0.val, %x.0.val
-// CHECK-NEXT:  %1 = load double, ptr %"x'", align 8
-// CHECK-NEXT:  %2 = fadd fast double %1, %0
-// CHECK-NEXT:  store double %2, ptr %"x'", align 8
-// CHECK-NEXT:  ret double %_0
+// CHECK:define internal { double } @diffesquare(ptr {{.*}}, ptr {{.*}}, double {{.*}})
+// CHECK-NEXT:start:
+// CHECK-NEXT:  [[X:%_[0-9]+]] = load double, ptr %x, align 8
+// CHECK-NEXT:  [[SQUARE:%_[0-9]+]] = fmul double [[X]], [[X]]
+// CHECK-NEXT:  [[DIFFR1:%[0-9]+]] = fmul fast double %differeturn, [[X]]
+// CHECK-NEXT:  [[DIFFR2:%[0-9]+]] = fmul fast double %differeturn, [[X]]
+// CHECK-NEXT:  [[ADD1:%[0-9]+]] = fadd fast double [[DIFFR1]], [[DIFFR2]]
+// CHECK-NEXT:  [[SHADOW_X:%[0-9]+]] = load double, ptr %"x'", align 8
+// CHECK-NEXT:  [[ADD2:%[0-9]+]] = fadd fast double [[SHADOW_X]], [[ADD1]]
+// CHECK-NEXT:  store double [[ADD2]], ptr %"x'", align 8
+// CHECK-NEXT:  [[RET:%[0-9]+]] = insertvalue { double } undef, double [[SQUARE]], 0
+// CHECK-NEXT:  ret { double } [[RET]]
 // CHECK-NEXT:}
 
 fn main() {

--- a/tests/codegen-llvm/autodiff/sret.rs
+++ b/tests/codegen-llvm/autodiff/sret.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable,NoTT -C opt-level=3  -Clto=fat
+//@ compile-flags: -Zautodiff=Enable,NoTT -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3  -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 
@@ -18,17 +18,21 @@ fn primal(x: f32, y: f32) -> f64 {
     (x * x * y) as f64
 }
 
-// CHECK: define internal fastcc { double, float, float } @diffeprimal(float noundef %x, float noundef %y)
-// CHECK-NEXT: invertstart:
+// CHECK: define internal { double, float, float } @diffeprimal(float noundef %x, float noundef %y, double %differeturn)
+// CHECK-NEXT: start:
 // CHECK-NEXT: %_4 = fmul float %x, %x
 // CHECK-NEXT: %_3 = fmul float %_4, %y
 // CHECK-NEXT: %_0 = fpext float %_3 to double
-// CHECK-NEXT: %0 = fadd fast float %y, %y
-// CHECK-NEXT: %1 = fmul fast float %0, %x
-// CHECK-NEXT: %2 = insertvalue { double, float, float } undef, double %_0, 0
-// CHECK-NEXT: %3 = insertvalue { double, float, float } %2, float %1, 1
-// CHECK-NEXT: %4 = insertvalue { double, float, float } %3, float %_4, 2
-// CHECK-NEXT: ret { double, float, float } %4
+// CHECK-NEXT: %0 = fptrunc fast double %differeturn to float
+// CHECK-NEXT: %1 = fmul fast float %0, %y
+// CHECK-NEXT: %2 = fmul fast float %0, %_4
+// CHECK-NEXT: %3 = fmul fast float %1, %x
+// CHECK-NEXT: %4 = fmul fast float %1, %x
+// CHECK-NEXT: %5 = fadd fast float %3, %4
+// CHECK-NEXT: %6 = insertvalue { double, float, float } undef, double %_0, 0
+// CHECK-NEXT: %7 = insertvalue { double, float, float } %6, float %5, 1
+// CHECK-NEXT: %8 = insertvalue { double, float, float } %7, float %2, 2
+// CHECK-NEXT: ret { double, float, float } %8
 // CHECK-NEXT: }
 
 fn main() {

--- a/tests/codegen-llvm/autodiff/trait.rs
+++ b/tests/codegen-llvm/autodiff/trait.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable -Zautodiff=NoPostopt -C opt-level=3 -Clto=fat
+//@ compile-flags: -Zautodiff=Enable -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3 -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 

--- a/tests/codegen-llvm/autodiff/typetree.rs
+++ b/tests/codegen-llvm/autodiff/typetree.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable -C opt-level=3 -Clto=fat
+//@ compile-flags: -Zautodiff=Enable -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C opt-level=3 -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 

--- a/tests/codegen-llvm/autodiff/void_ret.rs
+++ b/tests/codegen-llvm/autodiff/void_ret.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zautodiff=Enable,NoTT,NoPostopt -C no-prepopulate-passes -C opt-level=3  -Clto=fat
+//@ compile-flags: -Zautodiff=Enable,NoTT -Zautodiff_post_passes=function(mem2reg,instsimplify,simplifycfg) -C no-prepopulate-passes -C opt-level=3  -Clto=fat
 //@ no-prefer-dynamic
 //@ needs-enzyme
 


### PR DESCRIPTION
* Add -Zautodiff_post_passes flag to limit which llvm passes to run after enzyme to make autodiff tests more robust
* Change some llvm ir check in codegen_llvm/autodiff tests

r? @ZuseZ4 