### PR TITLE
Fix reborrow_info early return skipping field validation

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -563,8 +563,8 @@ pub(crate) fn reborrow_info<'tcx>(
         )
         .is_ok()
         {
-            // Field implements Reborrow.
-            return Ok(());
+            // Field implements Reborrow, check remaining fields.
+            continue;
         }
 
         // Field does not implement Reborrow: it must be Copy.

--- a/tests/ui/reborrow/reborrow_multi_field_validation.rs
+++ b/tests/ui/reborrow/reborrow_multi_field_validation.rs
@@ -1,0 +1,15 @@
+#![feature(reborrow)]
+
+use std::marker::Reborrow;
+
+// Regression test: `reborrow_info` must validate ALL data fields,
+// not just stop at the first Reborrow field.
+
+struct Bad<'a> {
+    first: &'a mut i32,
+    second: String, //~ ERROR the trait bound `String: Copy` is not satisfied
+}
+
+impl<'a> Reborrow for Bad<'a> {}
+
+fn main() {}

--- a/tests/ui/reborrow/reborrow_multi_field_validation.stderr
+++ b/tests/ui/reborrow/reborrow_multi_field_validation.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/reborrow_multi_field_validation.rs:10:5
+   |
+LL |     second: String,
+   |     ^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
`reborrow_info` validates that all data fields of a struct implementing `Reborrow` are either `Copy` or themselves `Reborrow`. When iterating the fields, finding a `Reborrow` field returned `Ok(())` immediately, so any remaining fields were never validated. This let a struct with a non-`Copy`, non-`Reborrow` second field implement `Reborrow`.

Changing the early `return Ok(())` to `continue` makes the loop validate every field.

Tracking issue: rust-lang/rust#145612