### PR TITLE
Filter PhantomData fields in CoerceShared borrowck field matching

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2516,8 +2516,19 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             // Field-by-field relate_types is expected to work based on the wf-checks that the
             // CoerceShared trait performs.
             let ty::Adt(borrowed_adt, borrowed_args) = borrowed_ty.kind() else { unreachable!() };
-            let borrowed_fields = borrowed_adt.all_fields().collect::<Vec<_>>();
-            for dest_field in dest_adt.all_fields() {
+            // Filter out PhantomData fields to match the coherence check in
+            // `coerce_shared_info`, which uses `collect_struct_data_fields`.
+            // Without this filter, PhantomData fields with different names
+            // between source and dest would be silently skipped, potentially
+            // dropping lifetime constraints.
+            let borrowed_fields: Vec<_> = borrowed_adt
+                .all_fields()
+                .filter(|f| !f.ty(tcx, borrowed_args).skip_norm_wip().is_phantom_data())
+                .collect();
+            let dest_data_fields = dest_adt
+                .all_fields()
+                .filter(|f| !f.ty(tcx, dest_args).skip_norm_wip().is_phantom_data());
+            for dest_field in dest_data_fields {
                 let Some(borrowed_field) =
                     borrowed_fields.iter().find(|f| f.name == dest_field.name)
                 else {

--- a/tests/ui/reborrow/coerce_shared_phantom_field_names.rs
+++ b/tests/ui/reborrow/coerce_shared_phantom_field_names.rs
@@ -6,6 +6,7 @@
 // PhantomData fields would cause lifetime constraints to be silently dropped.
 
 #![feature(reborrow)]
+#![allow(dead_code)]
 use std::marker::{CoerceShared, PhantomData, Reborrow};
 
 struct Source<'a> {

--- a/tests/ui/reborrow/coerce_shared_phantom_field_names.rs
+++ b/tests/ui/reborrow/coerce_shared_phantom_field_names.rs
@@ -1,0 +1,33 @@
+//@ run-pass
+
+// Regression test: CoerceShared borrowck must filter PhantomData fields
+// before matching by name, consistent with coherence's
+// `collect_struct_data_fields`. Without the filter, differently-named
+// PhantomData fields would cause lifetime constraints to be silently dropped.
+
+#![feature(reborrow)]
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct Source<'a> {
+    data: &'a mut i32,
+    _marker: PhantomData<&'a ()>,
+}
+impl<'a> Reborrow for Source<'a> {}
+
+#[derive(Clone, Copy)]
+struct Dest<'a> {
+    data: &'a i32,
+    _lifetime: PhantomData<&'a ()>, // Different name from Source's PhantomData field
+}
+impl<'a> CoerceShared<Dest<'a>> for Source<'a> {}
+
+fn use_ref<'a>(s: Dest<'a>) -> &'a i32 {
+    s.data
+}
+
+fn main() {
+    let mut val = 42;
+    let s = Source { data: &mut val, _marker: PhantomData };
+    let r = use_ref(s);
+    assert_eq!(*r, 42);
+}


### PR DESCRIPTION
## Summary

The `add_generic_reborrow_constraint` function in `compiler/rustc_borrowck/src/type_check/mod.rs` matches source and dest struct fields by name when establishing borrow constraints for `CoerceShared`. However, it uses `all_fields()` which includes `PhantomData` fields, while the coherence check (`coerce_shared_info`) filters them out via `collect_struct_data_fields`.

This mismatch means `PhantomData` fields with different names between source and dest structs are silently skipped via `continue` (line 2524), potentially dropping lifetime constraints that should be established.

## Fix

Filter out `PhantomData` fields before matching, consistent with the coherence check's use of `collect_struct_data_fields`.

## Test plan

- Added `tests/ui/reborrow/coerce_shared_phantom_field_names.rs` — a run-pass test with `CoerceShared` source/dest structs that have differently-named `PhantomData` fields (`_marker` vs `_lifetime`)
- This test verifies the borrow constraints are correctly established even with mismatched PhantomData field names

Tracking issue: rust-lang/rust#145612 (reborrow feature)