### PR TITLE
alloc: clarify comment on ArcInner::weak lock sentinel

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -389,8 +389,12 @@ struct ArcInner<T: ?Sized> {
     strong: Atomic<usize>,
 
     // the value usize::MAX acts as a sentinel for temporarily "locking" the
-    // ability to upgrade weak pointers or downgrade strong ones; this is used
-    // to avoid races in `make_mut` and `get_mut`.
+    // weak count, preventing `Arc::downgrade` from racing to create new
+    // `Weak` references. `Arc::is_unique` (which backs `Arc::get_mut`)
+    // needs to observe both the strong and weak counts as indicating
+    // uniqueness in one logical atomic step; since they live in separate
+    // atomic words, it locks the weak count while reading the strong
+    // count to keep the two reads consistent.
     weak: Atomic<usize>,
 
     data: T,


### PR DESCRIPTION
The comment on the `weak` field of `ArcInner` currently states that the `usize::MAX` sentinel locks "the ability to upgrade weak pointers or downgrade strong ones", and that this is used to avoid races in `make_mut` and `get_mut`. Both halves of that description are inaccurate.

`Weak::upgrade` never inspects the weak count, so the lock has no effect on it. The operation only CASes on the strong count and is happy to succeed while the weak count is locked. `Arc::make_mut` also does not participate in the locking protocol, and the function body already contains a comment noting that observing `usize::MAX` for the weak count there is impossible because only a thread holding a strong reference can take the lock.

The lock is actually only taken in `Arc::is_unique` (which backs `Arc::get_mut`), and the only operation that observes and waits on it is `Arc::downgrade`, which spins while `weak == usize::MAX` before attempting its CAS to create a new `Weak`.

This PR rewrites the comment to describe what the lock is and what it actually prevents.

Closes rust-lang/rust#144296