### PR TITLE
Document that destructors in running threads are not run on program exit

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -26,9 +26,10 @@
 //! non-zero exit code.
 //!
 //! When the main thread of a Rust program terminates, the entire program shuts
-//! down, even if other threads are still running. However, this module provides
-//! convenient facilities for automatically waiting for the termination of a
-//! thread (i.e., join).
+//! down, even if other threads are still running, and any destructors on the
+//! remaining threads' stacks may not be executed.  However, this module
+//! provides convenient facilities for automatically waiting for the
+//! termination of a thread (i.e., join).
 //!
 //! ## Spawning a thread
 //!


### PR DESCRIPTION
It's my understanding that, when a Rust program's main thread terminates and thereby causes any still-running threads to be shut down, destructors are not run for the shut-down threads; however, the documentation doesn't seem to come out and say that explicitly anywhere.  This PR therefore adds an explicit statement about this to the `std::thread` docs.

If I am mistaken and destructors *are* run, that's worth documenting explicitly, too.