### PR TITLE
Unsafe kept in help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,6 +4010,7 @@ dependencies = [
 name = "rustc_feature"
 version = "0.0.0"
 dependencies = [
+ "rustc_ast",
  "rustc_data_structures",
  "rustc_hir",
  "rustc_span",

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -327,8 +327,11 @@ pub fn parse_cfg_attr(
             }) {
                 Ok(r) => return Some(r),
                 Err(e) => {
-                    let suggestions = CFG_ATTR_TEMPLATE
-                        .suggestions(AttrSuggestionStyle::Attribute(cfg_attr.style), sym::cfg_attr);
+                    let suggestions = CFG_ATTR_TEMPLATE.suggestions(
+                        AttrSuggestionStyle::Attribute(cfg_attr.style),
+                        matches!(cfg_attr.get_normal_item().unsafety, rustc_ast::Safety::Unsafe(_)),
+                        sym::cfg_attr,
+                    );
                     e.with_span_suggestions(
                         cfg_attr.span,
                         "must be of the form",
@@ -360,8 +363,11 @@ pub fn parse_cfg_attr(
                 description: ParsedDescription::Attribute,
                 reason,
                 suggestions: session_diagnostics::AttributeParseErrorSuggestions::CreatedByTemplate(
-                    CFG_ATTR_TEMPLATE
-                        .suggestions(AttrSuggestionStyle::Attribute(cfg_attr.style), sym::cfg_attr),
+                    CFG_ATTR_TEMPLATE.suggestions(
+                        AttrSuggestionStyle::Attribute(cfg_attr.style),
+                        matches!(cfg_attr.get_normal_item().unsafety, rustc_ast::Safety::Unsafe(_)),
+                        sym::cfg_attr,
+                    ),
                 ),
             });
         }

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -329,7 +329,7 @@ pub fn parse_cfg_attr(
                 Err(e) => {
                     let suggestions = CFG_ATTR_TEMPLATE.suggestions(
                         AttrSuggestionStyle::Attribute(cfg_attr.style),
-                        matches!(cfg_attr.get_normal_item().unsafety, rustc_ast::Safety::Unsafe(_)),
+                        cfg_attr.get_normal_item().unsafety,
                         sym::cfg_attr,
                     );
                     e.with_span_suggestions(
@@ -365,7 +365,7 @@ pub fn parse_cfg_attr(
                 suggestions: session_diagnostics::AttributeParseErrorSuggestions::CreatedByTemplate(
                     CFG_ATTR_TEMPLATE.suggestions(
                         AttrSuggestionStyle::Attribute(cfg_attr.style),
-                        matches!(cfg_attr.get_normal_item().unsafety, rustc_ast::Safety::Unsafe(_)),
+                        cfg_attr.get_normal_item().unsafety,
                         sym::cfg_attr,
                     ),
                 ),

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -358,7 +358,7 @@ pub struct AcceptContext<'f, 'sess> {
     pub(crate) template: &'f AttributeTemplate,
 
     /// The safety attribute (if any) applied to the attribute.
-    pub(crate) attr_safety: rustc_ast::Safety,
+    pub(crate) attr_safety: Safety,
 
     /// The name of the attribute we're currently accepting.
     pub(crate) attr_path: AttrPath,
@@ -876,11 +876,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
             ParsedDescription::Macro => AttrSuggestionStyle::Macro,
         };
 
-        self.template.suggestions(
-            style,
-            matches!(self.attr_safety, rustc_ast::Safety::Unsafe(_)),
-            &self.attr_path,
-        )
+        self.template.suggestions(style, self.attr_safety, &self.attr_path)
     }
 }
 
@@ -1071,11 +1067,7 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
             ParsedDescription::Macro => AttrSuggestionStyle::Macro,
         };
 
-        self.template.suggestions(
-            style,
-            matches!(self.attr_safety, Safety::Unsafe(_)),
-            &self.attr_path,
-        )
+        self.template.suggestions(style, self.attr_safety, &self.attr_path)
     }
     /// Error that a string literal was expected.
     /// You can optionally give the literal you did find (which you found not to be a string literal)

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -5,7 +5,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::LazyLock;
 
-use rustc_ast::{AttrStyle, MetaItemLit};
+use rustc_ast::{AttrStyle, MetaItemLit, Safety};
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
 use rustc_feature::{AttrSuggestionStyle, AttributeTemplate};
@@ -356,6 +356,9 @@ pub struct AcceptContext<'f, 'sess> {
     ///
     /// Used in reporting errors to give a hint to users what the attribute *should* look like.
     pub(crate) template: &'f AttributeTemplate,
+
+    /// The safety attribute (if any) applied to the attribute.
+    pub(crate) attr_safety: rustc_ast::Safety,
 
     /// The name of the attribute we're currently accepting.
     pub(crate) attr_path: AttrPath,
@@ -873,7 +876,11 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
             ParsedDescription::Macro => AttrSuggestionStyle::Macro,
         };
 
-        self.template.suggestions(style, &self.attr_path)
+        self.template.suggestions(
+            style,
+            matches!(self.attr_safety, rustc_ast::Safety::Unsafe(_)),
+            &self.attr_path,
+        )
     }
 }
 
@@ -1064,7 +1071,11 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
             ParsedDescription::Macro => AttrSuggestionStyle::Macro,
         };
 
-        self.template.suggestions(style, &self.attr_path)
+        self.template.suggestions(
+            style,
+            matches!(self.attr_safety, Safety::Unsafe(_)),
+            &self.attr_path,
+        )
     }
     /// Error that a string literal was expected.
     /// You can optionally give the literal you did find (which you found not to be a string literal)

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -234,6 +234,7 @@ impl<'sess> AttributeParser<'sess> {
             attr_style,
             parsed_description,
             template,
+            attr_safety: attr_safety.unwrap_or(Safety::Default),
             attr_path,
         };
         parse_fn(&mut cx, args)
@@ -404,6 +405,7 @@ impl<'sess> AttributeParser<'sess> {
                             attr_style: attr.style,
                             parsed_description: ParsedDescription::Attribute,
                             template: &accept.template,
+                            attr_safety: n.item.unsafety,
                             attr_path: attr_path.clone(),
                         };
 

--- a/compiler/rustc_feature/Cargo.toml
+++ b/compiler/rustc_feature/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
+rustc_ast = { path = "../rustc_ast" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -3,6 +3,7 @@
 use std::sync::LazyLock;
 
 use AttributeGate::*;
+use rustc_ast::ast::Safety;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::AttrStyle;
 use rustc_span::{Symbol, sym};
@@ -118,7 +119,7 @@ impl AttributeTemplate {
     pub fn suggestions(
         &self,
         style: AttrSuggestionStyle,
-        wrap_with_unsafe: bool,
+        safety: Safety,
         name: impl std::fmt::Display,
     ) -> Vec<String> {
         let (start, macro_call, end) = match style {
@@ -130,29 +131,32 @@ impl AttributeTemplate {
 
         let mut suggestions = vec![];
 
-        let (maybe_unsafe_start, maybe_unsafe_end) =
-            if wrap_with_unsafe { ("unsafe(", ")") } else { ("", "") };
+        let (safety_start, safety_end) = match safety {
+            Safety::Unsafe(_) => ("unsafe(", ")"),
+            _ => ("", ""),
+        };
 
         if self.word {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
-            suggestions.push(format!("{start}{maybe_unsafe_start}{name}{maybe_unsafe_end}{end}"));
+            suggestions.push(format!("{start}{safety_start}{name}{safety_end}{end}"));
         }
         if let Some(descr) = self.list {
             for descr in descr {
                 suggestions.push(format!(
-                    "{start}{maybe_unsafe_start}{name}{macro_call}({descr}){maybe_unsafe_end}{end}"
+                    "{start}{safety_start}{name}{macro_call}({descr}){safety_end}{end}"
                 ));
             }
         }
-        suggestions.extend(self.one_of.iter().map(|&word| {
-            format!("{start}{maybe_unsafe_start}{name}({word}){maybe_unsafe_end}{end}")
-        }));
+        suggestions.extend(
+            self.one_of
+                .iter()
+                .map(|&word| format!("{start}{safety_start}{name}({word}){safety_end}{end}")),
+        );
         if let Some(descr) = self.name_value_str {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
             for descr in descr {
-                suggestions.push(format!(
-                    "{start}{maybe_unsafe_start}{name} = \"{descr}\"{maybe_unsafe_end}{end}"
-                ));
+                suggestions
+                    .push(format!("{start}{safety_start}{name} = \"{descr}\"{safety_end}{end}"));
             }
         }
         suggestions.sort();

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -118,6 +118,7 @@ impl AttributeTemplate {
     pub fn suggestions(
         &self,
         style: AttrSuggestionStyle,
+        wrap_with_unsafe: bool,
         name: impl std::fmt::Display,
     ) -> Vec<String> {
         let (start, macro_call, end) = match style {
@@ -129,20 +130,29 @@ impl AttributeTemplate {
 
         let mut suggestions = vec![];
 
+        let (maybe_unsafe_start, maybe_unsafe_end) =
+            if wrap_with_unsafe { ("unsafe(", ")") } else { ("", "") };
+
         if self.word {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
-            suggestions.push(format!("{start}{name}{end}"));
+            suggestions.push(format!("{maybe_unsafe_start}{start}{name}{end}{maybe_unsafe_end}"));
         }
         if let Some(descr) = self.list {
             for descr in descr {
-                suggestions.push(format!("{start}{name}{macro_call}({descr}){end}"));
+                suggestions.push(format!(
+                    "{maybe_unsafe_start}{start}{name}{macro_call}({descr}){end}{maybe_unsafe_end}"
+                ));
             }
         }
-        suggestions.extend(self.one_of.iter().map(|&word| format!("{start}{name}({word}){end}")));
+        suggestions.extend(self.one_of.iter().map(|&word| {
+            format!("{maybe_unsafe_start}{start}{name}({word}){end}{maybe_unsafe_end}")
+        }));
         if let Some(descr) = self.name_value_str {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
             for descr in descr {
-                suggestions.push(format!("{start}{name} = \"{descr}\"{end}"));
+                suggestions.push(format!(
+                    "{maybe_unsafe_start}{start}{name} = \"{descr}\"{end}{maybe_unsafe_end}"
+                ));
             }
         }
         suggestions.sort();

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -135,23 +135,23 @@ impl AttributeTemplate {
 
         if self.word {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
-            suggestions.push(format!("{maybe_unsafe_start}{start}{name}{end}{maybe_unsafe_end}"));
+            suggestions.push(format!("{start}{maybe_unsafe_start}{name}{maybe_unsafe_end}{end}"));
         }
         if let Some(descr) = self.list {
             for descr in descr {
                 suggestions.push(format!(
-                    "{maybe_unsafe_start}{start}{name}{macro_call}({descr}){end}{maybe_unsafe_end}"
+                    "{start}{maybe_unsafe_start}{name}{macro_call}({descr}){maybe_unsafe_end}{end}"
                 ));
             }
         }
         suggestions.extend(self.one_of.iter().map(|&word| {
-            format!("{maybe_unsafe_start}{start}{name}({word}){end}{maybe_unsafe_end}")
+            format!("{start}{maybe_unsafe_start}{name}({word}){maybe_unsafe_end}{end}")
         }));
         if let Some(descr) = self.name_value_str {
             debug_assert!(macro_call.is_empty(), "Macro suggestions use list style");
             for descr in descr {
                 suggestions.push(format!(
-                    "{maybe_unsafe_start}{start}{name} = \"{descr}\"{end}{maybe_unsafe_end}"
+                    "{start}{maybe_unsafe_start}{name} = \"{descr}\"{maybe_unsafe_end}{end}"
                 ));
             }
         }

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -159,9 +159,8 @@ LL | #[unsafe(export_name)]
    |
 help: must be of the form
    |
-LL - #[unsafe(export_name)]
-LL + #[export_name = "name"]
-   |
+LL | #[unsafe(export_name = "name")]
+   |                      ++++++++
 
 error: `rustc_allow_const_fn_unstable` expects a list of feature names
   --> $DIR/malformed-attrs.rs:31:1
@@ -330,7 +329,7 @@ LL | #[unsafe(naked())]
 help: must be of the form
    |
 LL - #[unsafe(naked())]
-LL + #[naked]
+LL + #[unsafe(naked)]
    |
 
 error[E0565]: malformed `track_caller` attribute input
@@ -651,7 +650,7 @@ LL |     #[unsafe(ffi_pure = 1)]
 help: must be of the form
    |
 LL -     #[unsafe(ffi_pure = 1)]
-LL +     #[ffi_pure]
+LL +     #[unsafe(ffi_pure)]
    |
 
 error[E0539]: malformed `link_ordinal` attribute input
@@ -677,7 +676,7 @@ LL |     #[unsafe(ffi_const = 1)]
 help: must be of the form
    |
 LL -     #[unsafe(ffi_const = 1)]
-LL +     #[ffi_const]
+LL +     #[unsafe(ffi_const)]
    |
 
 error[E0539]: malformed `linkage` attribute input


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Currently when encountering a malformed attribute, the compiler will suggest removing unsafe in the well-formed template even when unsafe is required. This PR preserves whatever unsafe (or lack) exists in the user's code.

r? @jdonszelmann 