### PR TITLE
Handle generic reborrow in expression-use adjustment walking

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -727,7 +727,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         let typeck_results = self.cx.typeck_results();
         let adjustments = typeck_results.expr_adjustments(expr);
         let mut place_with_id = self.cat_expr_unadjusted(expr)?;
-        for adjustment in adjustments {
+        for (adjustment_index, adjustment) in adjustments.iter().enumerate() {
+            let is_last_adjustment = adjustment_index + 1 == adjustments.len();
             debug!("walk_adjustment expr={:?} adj={:?}", expr, adjustment);
             match adjustment.kind {
                 adjustment::Adjust::NeverToAny | adjustment::Adjust::Pointer(_) => {
@@ -752,13 +753,13 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     self.walk_autoref(expr, &place_with_id, autoref);
                 }
 
-                adjustment::Adjust::GenericReborrow(_reborrow) => {
-                    // To build an expression as a place expression, it needs to be a field
-                    // projection or deref at the outmost layer. So it is field projection or deref
-                    // on an adjusted value. But this means that adjustment is applied on a
-                    // subexpression that is not the final operand/rvalue for function call or
-                    // assignment. This is a contradiction.
-                    unreachable!("Reborrow trait usage during adjustment walk");
+                adjustment::Adjust::GenericReborrow(mutability) if is_last_adjustment => {
+                    let bk = ty::BorrowKind::from_mutbl(mutability);
+                    self.delegate.borrow_mut().borrow(&place_with_id, place_with_id.hir_id, bk);
+                }
+
+                adjustment::Adjust::GenericReborrow(_) => {
+                    span_bug!(expr.span, "generic reborrow adjustment must be terminal");
                 }
             }
             place_with_id = self.cat_expr_adjusted(expr, place_with_id, adjustment)?;

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor-closure.rs
@@ -1,0 +1,34 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    let mut f = || {
+        takes_mut(a);
+        takes_shared(a);
+    };
+
+    f();
+    f();
+}

--- a/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
+++ b/tests/ui/reborrow/generic-reborrow-expr-use-visitor.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn takes_mut(_: CustomMut<'_, ()>) {}
+fn takes_shared(_: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    takes_mut(a);
+    takes_mut(a);
+
+    takes_shared(a);
+    takes_shared(a);
+}


### PR DESCRIPTION
Fixes an ICE in expression-use adjustment walking where `Adjust::GenericReborrow` could reach a match arm that assumed generic reborrow was unreachable.

`GenericReborrow` is already emitted by typeck and classified as rvalue-producing elsewhere in `expr_use_visitor.rs`, so the adjustment walker must handle it explicitly instead of panicking.

This PR models `GenericReborrow` as a borrow-like use of the source expression:
- `Mutability::Mut` is treated like an exclusive/mutable reborrow use.
- `Mutability::Not` is treated like a shared/coerce-shared borrow-like use.
- The source is not moved or treated as a mere copy.

cc @aapoalas 
@rustbot label F-reborrow
Fixes https://github.com/rust-lang/rust/issues/156339
Tracking: https://github.com/rust-lang/rust/issues/145612