### PR TITLE
Fix missing suggestion when matching `String` with `&str`

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -1007,7 +1007,22 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         //
         // then that's equivalent to there existing a LUB.
         let cause = self.pattern_cause(ti, span);
-        if let Err(err) = self.demand_suptype_with_origin(&cause, expected, pat_ty) {
+        if let Err(mut err) = self.demand_suptype_with_origin(&cause, expected, pat_ty) {
+            // If scrutinee is String and pattern is &str, suggest .as_str()
+            let expected = self.resolve_vars_with_obligations(expected);
+            if let ty::Adt(adt, _) = expected.kind()
+                && self.tcx.is_lang_item(adt.did(), LangItem::String)
+                && pat_ty.is_ref()
+                && pat_ty.peel_refs().is_str()
+                && let Some(origin_expr) = ti.origin_expr
+            {
+                err.span_suggestion_verbose(
+                    origin_expr.span.shrink_to_hi(),
+                    "consider converting the `String` to a `&str` using `.as_str()`",
+                    ".as_str()",
+                    Applicability::MachineApplicable,
+                );
+            }
             err.emit();
         }
 

--- a/tests/ui/pattern/deref-patterns/needs-gate.stderr
+++ b/tests/ui/pattern/deref-patterns/needs-gate.stderr
@@ -76,6 +76,11 @@ LL |     match "str".to_owned() {
    |           ---------------- this expression has type `String`
 LL |         "str" => {}
    |         ^^^^^ expected `String`, found `&str`
+   |
+help: consider converting the `String` to a `&str` using `.as_str()`
+   |
+LL |     match "str".to_owned().as_str() {
+   |                           +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/needs-gate.rs:52:12

--- a/tests/ui/pattern/string-match-as-str-suggestion.fixed
+++ b/tests/ui/pattern/string-match-as-str-suggestion.fixed
@@ -1,0 +1,18 @@
+//@ run-rustfix
+
+fn main() {
+    let s = "yes".to_owned();
+
+    let _ = match s.as_str() {
+        "yes" => Some(true),
+        //~^ ERROR mismatched types
+        "no" => Some(false),
+        //~^ ERROR mismatched types
+        _ => None,
+    };
+
+    let s2 = String::from("hello");
+    if let "hello" = s2.as_str() {
+        //~^ ERROR mismatched types
+    }
+}

--- a/tests/ui/pattern/string-match-as-str-suggestion.rs
+++ b/tests/ui/pattern/string-match-as-str-suggestion.rs
@@ -1,0 +1,18 @@
+//@ run-rustfix
+
+fn main() {
+    let s = "yes".to_owned();
+
+    let _ = match s {
+        "yes" => Some(true),
+        //~^ ERROR mismatched types
+        "no" => Some(false),
+        //~^ ERROR mismatched types
+        _ => None,
+    };
+
+    let s2 = String::from("hello");
+    if let "hello" = s2 {
+        //~^ ERROR mismatched types
+    }
+}

--- a/tests/ui/pattern/string-match-as-str-suggestion.stderr
+++ b/tests/ui/pattern/string-match-as-str-suggestion.stderr
@@ -1,0 +1,43 @@
+error[E0308]: mismatched types
+  --> $DIR/string-match-as-str-suggestion.rs:7:9
+   |
+LL |     let _ = match s {
+   |                   - this expression has type `String`
+LL |         "yes" => Some(true),
+   |         ^^^^^ expected `String`, found `&str`
+   |
+help: consider converting the `String` to a `&str` using `.as_str()`
+   |
+LL |     let _ = match s.as_str() {
+   |                    +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/string-match-as-str-suggestion.rs:9:9
+   |
+LL |     let _ = match s {
+   |                   - this expression has type `String`
+...
+LL |         "no" => Some(false),
+   |         ^^^^ expected `String`, found `&str`
+   |
+help: consider converting the `String` to a `&str` using `.as_str()`
+   |
+LL |     let _ = match s.as_str() {
+   |                    +++++++++
+
+error[E0308]: mismatched types
+  --> $DIR/string-match-as-str-suggestion.rs:15:12
+   |
+LL |     if let "hello" = s2 {
+   |            ^^^^^^^   -- this expression has type `String`
+   |            |
+   |            expected `String`, found `&str`
+   |
+help: consider converting the `String` to a `&str` using `.as_str()`
+   |
+LL |     if let "hello" = s2.as_str() {
+   |                        +++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes rust-lang/rust#156404 

Add suggestion when matching `String` with `&str`
