### PR TITLE
Suggest adding quotation marks to identifiers in attributes

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -12,7 +12,7 @@ use rustc_ast::{
     AttrArgs, Expr, ExprKind, LitKind, MetaItemLit, Path, PathSegment, StmtKind, UnOp,
 };
 use rustc_ast_pretty::pprust;
-use rustc_errors::{Diag, PResult};
+use rustc_errors::{Applicability, Diag, PResult};
 use rustc_hir::{self as hir, AttrPath};
 use rustc_parse::exp;
 use rustc_parse::parser::{ForceCollect, Parser, PathStyle, Recovery, token_descr};
@@ -410,7 +410,20 @@ fn expr_to_lit<'sess>(
         // - `#[foo = include_str!("nonexistent-file.rs")]`:
         //   results in `ast::ExprKind::Err`.
         let msg = "attribute value must be a literal";
-        let err = psess.dcx().struct_span_err(span, msg);
+        let mut err = psess.dcx().struct_span_err(span, msg);
+
+        // Suggest adding quotation marks to turn an identifier into a string literal
+        if let ExprKind::Path(None, ref path) = expr.kind
+            && let [segment] = path.segments.as_slice()
+        {
+            err.span_suggestion(
+                expr.span,
+                "try adding quotation marks",
+                &format!("\"{}\"", segment.ident),
+                Applicability::MaybeIncorrect,
+            );
+        }
+
         Err(err)
     }
 }

--- a/tests/ui/attributes/crate-type-non-crate.stderr
+++ b/tests/ui/attributes/crate-type-non-crate.stderr
@@ -40,7 +40,7 @@ error: attribute value must be a literal
   --> $DIR/crate-type-non-crate.rs:9:16
    |
 LL | #[crate_type = lib]
-   |                ^^^
+   |                ^^^ help: try adding quotation marks: `"lib"`
 
 error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:12:1
@@ -72,7 +72,7 @@ error: attribute value must be a literal
   --> $DIR/crate-type-non-crate.rs:14:16
    |
 LL | #[crate_type = foo]
-   |                ^^^
+   |                ^^^ help: try adding quotation marks: `"foo"`
 
 error[E0539]: malformed `crate_type` attribute input
   --> $DIR/crate-type-non-crate.rs:17:1

--- a/tests/ui/attributes/validation-on-associated-items-issue-121537.stderr
+++ b/tests/ui/attributes/validation-on-associated-items-issue-121537.stderr
@@ -2,7 +2,7 @@ error: attribute value must be a literal
   --> $DIR/validation-on-associated-items-issue-121537.rs:2:13
    |
 LL |     #[doc = MyTrait]
-   |             ^^^^^^^
+   |             ^^^^^^^ help: try adding quotation marks: `"MyTrait"`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/darwin-objc/darwin-objc-bad-arg.stderr
+++ b/tests/ui/darwin-objc/darwin-objc-bad-arg.stderr
@@ -2,13 +2,13 @@ error: attribute value must be a literal
   --> $DIR/darwin-objc-bad-arg.rs:12:18
    |
 LL |     objc::class!(s);
-   |                  ^
+   |                  ^ help: try adding quotation marks: `"s"`
 
 error: attribute value must be a literal
   --> $DIR/darwin-objc-bad-arg.rs:15:18
    |
 LL |     objc::class!(NSObject);
-   |                  ^^^^^^^^
+   |                  ^^^^^^^^ help: try adding quotation marks: `"NSObject"`
 
 error: `objc::class!` expected a string literal
   --> $DIR/darwin-objc-bad-arg.rs:18:18
@@ -26,13 +26,13 @@ error: attribute value must be a literal
   --> $DIR/darwin-objc-bad-arg.rs:25:21
    |
 LL |     objc::selector!(s);
-   |                     ^
+   |                     ^ help: try adding quotation marks: `"s"`
 
 error: attribute value must be a literal
   --> $DIR/darwin-objc-bad-arg.rs:28:21
    |
 LL |     objc::selector!(alloc);
-   |                     ^^^^^
+   |                     ^^^^^ help: try adding quotation marks: `"alloc"`
 
 error: `objc::selector!` expected a string literal
   --> $DIR/darwin-objc-bad-arg.rs:31:21


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

When the user provides an identifier when a literal was expected in an attribute value, suggest adding quotation marks to the identifier to make it a string literal.

For instance:
```
error: attribute value must be a literal
  --> $DIR/crate-type-non-crate.rs:9:16
   |
LL | #[crate_type = lib]
   |                ^^^ help: try adding quotation marks: `"lib"`
```