### PR TITLE
Fix bootstrap coverage skip handling

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1713,6 +1713,12 @@ impl Coverage {
     const SUITE: &'static str = "coverage";
     const ALL_MODES: &[CompiletestMode] =
         &[CompiletestMode::CoverageMap, CompiletestMode::CoverageRun];
+
+    fn is_mode_skipped(mode: CompiletestMode, skip: &Path) -> bool {
+        let mode = Path::new(mode.as_str());
+        let suite = Path::new(Self::PATH);
+        mode == skip || suite.starts_with(skip) || suite.ends_with(skip)
+    }
 }
 
 impl Step for Coverage {
@@ -1765,18 +1771,12 @@ impl Step for Coverage {
             }
         }
 
-        // Skip any modes that were explicitly skipped/excluded on the command-line.
+        // Skip any modes that were skipped/excluded on the command-line, either
+        // directly or through the coverage suite path.
         // FIXME(Zalathar): Integrate this into central skip handling somehow?
-        modes.retain(|mode| {
-            !run.builder.config.skip.iter().any(|skip| skip == Path::new(mode.as_str()))
+        modes.retain(|&mode| {
+            !run.builder.config.skip.iter().any(|skip| Self::is_mode_skipped(mode, skip))
         });
-
-        // FIXME(Zalathar): Make these commands skip all coverage tests, as expected:
-        // - `./x test --skip=tests`
-        // - `./x test --skip=tests/coverage`
-        // - `./x test --skip=coverage`
-        // Skip handling currently doesn't have a way to know that skipping the coverage
-        // suite should also skip the `coverage-map` and `coverage-run` aliases.
 
         for mode in modes {
             run.builder.ensure(Coverage { compiler, target, mode });

--- a/src/bootstrap/src/core/builder/cli_paths/tests.rs
+++ b/src/bootstrap/src/core/builder/cli_paths/tests.rs
@@ -163,7 +163,7 @@ declare_tests!(
     (x_test_coverage, "test coverage"),
     (x_test_coverage_map, "test coverage-map"),
     (x_test_coverage_run, "test coverage-run"),
-    // FIXME(Zalathar): Currently this doesn't actually skip the coverage-run tests!
+    // Snapshot logging happens before `Coverage::make_run` filters the skipped modes.
     (x_test_coverage_skip_coverage_run, "test coverage --skip=coverage-run"),
     (x_test_debuginfo, "test debuginfo"),
     (x_test_library, "test library"),
@@ -173,7 +173,7 @@ declare_tests!(
     (x_test_rustdoc, "test rustdoc"),
     (x_test_rustdoc_html, "test rustdoc-html"),
     (x_test_skip_coverage, "test --skip=coverage"),
-    // FIXME(Zalathar): This doesn't skip the coverage-map or coverage-run tests.
+    // Snapshot logging happens before `Coverage::make_run` filters the skipped modes.
     (x_test_skip_tests, "test --skip=tests"),
     // From `src/ci/docker/scripts/stage_2_test_set2.sh`.
     (

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -331,11 +331,16 @@ fn test_test_coverage() {
         Case { cmd: &["test", "coverage"], expected: &["coverage-map", "coverage-run"] },
         Case { cmd: &["test", "coverage-map"], expected: &["coverage-map"] },
         Case { cmd: &["test", "coverage-run"], expected: &["coverage-run"] },
+        Case { cmd: &["test", "--skip=coverage"], expected: &[] },
         Case { cmd: &["test", "coverage", "--skip=coverage"], expected: &[] },
+        Case { cmd: &["test", "--skip=tests/coverage"], expected: &[] },
         Case { cmd: &["test", "coverage", "--skip=tests/coverage"], expected: &[] },
+        Case { cmd: &["test", "--skip=coverage-map"], expected: &["coverage-run"] },
         Case { cmd: &["test", "coverage", "--skip=coverage-map"], expected: &["coverage-run"] },
+        Case { cmd: &["test", "--skip=coverage-run"], expected: &["coverage-map"] },
         Case { cmd: &["test", "coverage", "--skip=coverage-run"], expected: &["coverage-map"] },
         Case { cmd: &["test", "--skip=coverage-map", "--skip=coverage-run"], expected: &[] },
+        Case { cmd: &["test", "--skip=tests"], expected: &[] },
         Case { cmd: &["test", "coverage", "--skip=tests"], expected: &[] },
     ];
 


### PR DESCRIPTION
Fixes rust-lang/rust#156799

### What changed

This updates bootstrap coverage test selection so suite-level skips for `tests/coverage` also suppress the `coverage-map` and `coverage-run` mode aliases.

The direct mode skips still behave independently:

- `--skip=coverage-map` skips only `coverage-map`
- `--skip=coverage-run` skips only `coverage-run`

### Why

`tests/coverage` is represented as two compiletest modes, exposed through the `coverage-map` and `coverage-run` aliases. When default test paths select those aliases, central skip handling does not know that suite-level skips such as `--skip=coverage`, `--skip=tests/coverage`, or `--skip=tests` should apply to both modes.

This keeps the special handling local to `Coverage::make_run`, where the coverage aliases are already expanded and filtered.

### Tests

- `git diff --check`
- `cargo test --manifest-path src/bootstrap/Cargo.toml core::builder::tests::test_test_coverage`
- `cargo test --manifest-path src/bootstrap/Cargo.toml core::builder::cli_paths::tests::x_test_coverage_skip_coverage_run`
- `cargo test --manifest-path src/bootstrap/Cargo.toml core::builder::cli_paths::tests::x_test_skip_tests`

The local bootstrap tests were run with a temporary `ninja` shim for dry-run command detection because this machine does not have `ninja` installed.
