### PR TITLE
Fix reborrow ICE in MIR place lowering

### DIFF
--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -583,18 +583,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::ThreadLocalRef(_)
             | ExprKind::Call { .. }
             | ExprKind::ByUse { .. }
+            // A reborrow is an rvalue. If a place is needed for it, materialize
+            // the rvalue in a temporary instead of treating the reborrow
+            // expression itself as an assignable place.
+            | ExprKind::Reborrow { .. }
             | ExprKind::WrapUnsafeBinder { .. } => {
                 // these are not places, so we need to make a temporary.
                 debug_assert!(!matches!(Category::of(&expr.kind), Some(Category::Place)));
                 let temp_lifetime = this.region_scope_tree.temporary_scope(expr.temp_scope_id);
                 let temp = unpack!(block = this.as_temp(block, temp_lifetime, expr_id, mutability));
                 block.and(PlaceBuilder::from(temp))
-            }
-            ExprKind::Reborrow { .. } => {
-                // FIXME(reborrow): it should currently be impossible to end up evaluating a
-                // Reborrow expression as a place. That might not in the future, but what this then
-                // evaluates to requires further thought.
-                unreachable!();
             }
         }
     }

--- a/compiler/rustc_mir_build/src/builder/expr/category.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/category.rs
@@ -43,8 +43,7 @@ impl Category {
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. }
             | ExprKind::PlaceUnwrapUnsafeBinder { .. }
-            | ExprKind::ValueUnwrapUnsafeBinder { .. }
-            | ExprKind::Reborrow { .. } => Some(Category::Place),
+            | ExprKind::ValueUnwrapUnsafeBinder { .. } => Some(Category::Place),
 
             ExprKind::LogicalOp { .. }
             | ExprKind::Match { .. }
@@ -70,6 +69,10 @@ impl Category {
             | ExprKind::Repeat { .. }
             | ExprKind::Assign { .. }
             | ExprKind::AssignOp { .. }
+            // A reborrow expression produces a value represented in MIR as
+            // `Rvalue::Reborrow`. Its source may be a place, but the reborrow
+            // expression itself does not denote an assignable place.
+            | ExprKind::Reborrow { .. }
             | ExprKind::ThreadLocalRef(_)
             | ExprKind::WrapUnsafeBinder { .. } => Some(Category::Rvalue(RvalueFunc::AsRvalue)),
 

--- a/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
+++ b/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
@@ -1,0 +1,40 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+// Regression test for rust-lang/rust#156482.
+// This used to ICE in MIR building when a THIR `ExprKind::Reborrow`
+// was categorized as a place but `expr_as_place` treated it as unreachable.
+struct Thing<'a>(&'a ());
+
+impl<'a> Reborrow for Thing<'a> {}
+
+fn foo(x: Thing<'_>) {
+    let _: Thing<'_> = x;
+}
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    let _: CustomMut<'_, ()> = a;
+    let _: CustomMut<'_, ()> = a;
+
+    let _: CustomRef<'_, ()> = a;
+    let _: CustomRef<'_, ()> = a;
+}

--- a/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
+++ b/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
@@ -1,12 +1,12 @@
 //@ check-pass
+// Regression test for rust-lang/rust#156482.
+// This used to ICE in MIR building when a THIR `ExprKind::Reborrow`
+// was categorized as a place but `expr_as_place` treated it as unreachable.
 
 #![feature(reborrow)]
 
 use std::marker::{CoerceShared, Reborrow};
 
-// Regression test for rust-lang/rust#156482.
-// This used to ICE in MIR building when a THIR `ExprKind::Reborrow`
-// was categorized as a place but `expr_as_place` treated it as unreachable.
 struct Thing<'a>(&'a ());
 
 impl<'a> Reborrow for Thing<'a> {}


### PR DESCRIPTION
## Summary

Fixes rust-lang/rust#156482.

This fixes an internal THIR/MIR contract inconsistency for generic reborrow expressions.

`ExprKind::Reborrow` is lowered into MIR as `Rvalue::Reborrow`, but MIR expression categorization treated it as place-like while `expr_as_place` treated evaluating it as a place as unreachable. That caused the rust-lang/rust#156482 ICE, where the compiler panicked with `entered unreachable code` in `expr_as_place` while building MIR for a generic reborrow expression.

The fix makes the MIR builder contract explicit: a reborrow expression is rvalue-producing. Its source may be a place, but the reborrow expression itself is not an assignable place.

## What changed

- Updated MIR expression categorization so `ExprKind::Reborrow` is categorized as rvalue-producing rather than place-like.
- Updated place lowering so reborrow follows the normal rvalue temporary-materialization path if a place is needed.
- Added a targeted UI regression test covering the exact rust-lang/rust#156482 repro.

cc @aapoalas 

@rustbot label F-reborrow
Tracking: https://github.com/rust-lang/rust/issues/145612