### PR TITLE
Add `#[unsafe_eii]` to unsafe EII UI tests

### DIFF
--- a/tests/ui/eii/unsafe_impl_err.rs
+++ b/tests/ui/eii/unsafe_impl_err.rs
@@ -5,6 +5,7 @@
 #![feature(rustc_attrs)]
 #![feature(eii_internals)]
 
+// Uses manual desugaring of EII internals.
 #[eii_declaration(bar, "unsafe")]
 #[rustc_builtin_macro(eii_shared_macro)]
 macro foo() {}
@@ -18,6 +19,16 @@ fn other(x: u64) -> u64 {
     x
 }
 
+// Uses the user-facing unsafe_eii wrapper.
+#[unsafe_eii(baz)]
+fn qux(x: u64) -> u64;
+
+#[baz] //~ ERROR `#[baz]` is unsafe to implement
+fn another(x: u64) -> u64 {
+    x
+}
+
 fn main() {
     bar(0);
+    qux(0);
 }

--- a/tests/ui/eii/unsafe_impl_err.stderr
+++ b/tests/ui/eii/unsafe_impl_err.stderr
@@ -1,5 +1,5 @@
 error: `#[foo]` is unsafe to implement
-  --> $DIR/unsafe_impl_err.rs:16:1
+  --> $DIR/unsafe_impl_err.rs:17:1
    |
 LL | #[foo]
    | ^^^^^^
@@ -9,5 +9,16 @@ help: wrap the attribute in `unsafe(...)`
 LL | #[unsafe(foo)]
    |   +++++++   +
 
-error: aborting due to 1 previous error
+error: `#[baz]` is unsafe to implement
+  --> $DIR/unsafe_impl_err.rs:26:1
+   |
+LL | #[baz]
+   | ^^^^^^
+   |
+help: wrap the attribute in `unsafe(...)`
+   |
+LL | #[unsafe(baz)]
+   |   +++++++   +
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/eii/unsafe_impl_ok.rs
+++ b/tests/ui/eii/unsafe_impl_ok.rs
@@ -1,12 +1,12 @@
 //@ compile-flags: --crate-type rlib
 //@ check-pass
-// Uses manual desugaring of EII internals:
 // Tests whether it's okay to implement an unsafe EII with an unsafe implementation.
 #![feature(extern_item_impls)]
 #![feature(decl_macro)]
 #![feature(rustc_attrs)]
 #![feature(eii_internals)]
 
+// Uses manual desugaring of EII internals.
 #[eii_declaration(bar, "unsafe")]
 #[rustc_builtin_macro(eii_shared_macro)]
 macro foo() {}
@@ -20,6 +20,16 @@ fn other(x: u64) -> u64 {
     x
 }
 
+// Uses the user-facing unsafe_eii wrapper.
+#[unsafe_eii(baz)]
+fn qux(x: u64) -> u64;
+
+#[unsafe(baz)]
+fn another(x: u64) -> u64 {
+    x
+}
+
 fn main() {
     bar(0);
+    qux(0);
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#125418

Add UI test coverage for unsafe implementations of declarations created with `#[unsafe_eii]`.