### PR TITLE
compiletest: sort unexpected and unimportant errors

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -745,6 +745,11 @@ impl<'test> TestCx<'test> {
             }
         }
 
+        unexpected.sort_by_key(|e| (e.line_num, e.column_num));
+        unimportant.sort_by_key(|e| (e.line_num, e.column_num));
+
+        // `not_found` are sorted because `expected_errors` are sorted as they are read from file
+        // line by line.
         let mut not_found = Vec::new();
         // anything not yet found is a problem
         for (index, expected_error) in expected_errors.iter().enumerate() {


### PR DESCRIPTION
Sort unexpected errors before printing in tests, this helps inserting annotations manually from bottom to top and searching for errors is a bit simpler.

Output before:
```rust
tests/ui/delegation/explicit-paths.rs:47:9: ERROR: method `foo3` is not a member of trait `Trait` [E0407]
tests/ui/delegation/explicit-paths.rs:48:9: ERROR: method `foo4` is not a member of trait `Trait` [E0407]
tests/ui/delegation/explicit-paths.rs:27:14: ERROR: cannot find function `foo4` in `S` [E0425]
tests/ui/delegation/explicit-paths.rs:37:18: ERROR: cannot find function `foo4` in `F` [E0425]
tests/ui/delegation/explicit-paths.rs:48:18: ERROR: cannot find function `foo4` in `F` [E0425]
tests/ui/delegation/explicit-paths.rs:59:18: ERROR: cannot find function `foo4` in `F` [E0425]
tests/ui/delegation/explicit-paths.rs:67:5: ERROR: conflicting implementations of trait `Trait` for type `S` [E0119]
tests/ui/delegation/explicit-paths.rs:56:36: ERROR: mismatched types [E0308]
tests/ui/delegation/explicit-paths.rs:68:16: ERROR: the trait bound `S2: Trait` is not satisfied [E0277]
tests/ui/delegation/explicit-paths.rs:68:30: ERROR: mismatched types [E0308]
```

Output after:
```rust
tests/ui/delegation/explicit-paths.rs:27:14: ERROR: cannot find function `foo4` in `S` [E0425]
tests/ui/delegation/explicit-paths.rs:37:18: ERROR: cannot find function `foo4` in `F` [E0425]
tests/ui/delegation/explicit-paths.rs:47:9: ERROR: method `foo3` is not a member of trait `Trait` [E0407]
tests/ui/delegation/explicit-paths.rs:48:9: ERROR: method `foo4` is not a member of trait `Trait` [E0407]
tests/ui/delegation/explicit-paths.rs:48:18: ERROR: cannot find function `foo4` in `F` [E0425]
tests/ui/delegation/explicit-paths.rs:56:36: ERROR: mismatched types [E0308]
tests/ui/delegation/explicit-paths.rs:59:18: ERROR: cannot find function `foo4` in `F` [E0425]
tests/ui/delegation/explicit-paths.rs:67:5: ERROR: conflicting implementations of trait `Trait` for type `S` [E0119]
tests/ui/delegation/explicit-paths.rs:68:16: ERROR: the trait bound `S2: Trait` is not satisfied [E0277]
tests/ui/delegation/explicit-paths.rs:68:30: ERROR: mismatched types [E0308]
```

r? @petrochenkov 