### PR TITLE
style: Clarify nullary call and `()` no-break rule applies past max width

### DIFF
--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -185,7 +185,9 @@ let f = Foo {
 
 ## Unit literals
 
-Never break between the opening and closing parentheses of the `()` unit literal.
+Never break between the opening and closing parentheses of the `()` unit
+literal. This applies even when the closing parenthesis would fall past the
+maximum line width.
 
 ## Tuple literals
 
@@ -384,7 +386,8 @@ Prefer not to break a line in the callee expression.
 For a function call with no arguments (a nullary function call like `func()`),
 never break within the parentheses, and never put a space between the
 parentheses. Always write a nullary function call as a single-line call, never
-a multi-line call.
+a multi-line call. This applies even when the closing parenthesis would fall
+past the maximum line width.
 
 ### Single-line calls
 


### PR DESCRIPTION
…idth

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
