### PR TITLE
float_literal_f32_fallback: Don't suggest invalid code

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -171,7 +171,13 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             .inspect(|vid| {
                 let origin = self.float_var_origin(*vid);
                 // Show the entire literal in the suggestion to make it clearer.
-                let literal = self.tcx.sess.source_map().span_to_snippet(origin.span).ok();
+                let mut literal = self.tcx.sess.source_map().span_to_snippet(origin.span).ok();
+                // A `.` at the end of the literal is no longer necessary if `f32` is explicitly specified
+                if let Some(ref mut literal) = literal
+                    && literal.ends_with('.')
+                {
+                    literal.pop();
+                }
                 self.tcx.emit_node_span_lint(
                     FLOAT_LITERAL_F32_FALLBACK,
                     origin.lint_id.unwrap_or(CRATE_HIR_ID),

--- a/tests/ui/float/f32-into-f32.next-solver.fixed
+++ b/tests/ui/float/f32-into-f32.next-solver.fixed
@@ -15,6 +15,9 @@ fn main() {
     foo(1e5_f32);
     //~^ WARN falling back to `f32`
     //~| WARN this was previously accepted
+    foo(0_f32);
+    //~^ WARN falling back to `f32`
+    //~| WARN this was previously accepted
     foo(4f32); // no warning
     let x = -4.0_f32;
     //~^ WARN falling back to `f32`

--- a/tests/ui/float/f32-into-f32.next-solver.stderr
+++ b/tests/ui/float/f32-into-f32.next-solver.stderr
@@ -27,7 +27,16 @@ LL |     foo(1e5);
    = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
 
 warning: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
-  --> $DIR/f32-into-f32.rs:19:14
+  --> $DIR/f32-into-f32.rs:18:9
+   |
+LL |     foo(0.);
+   |         ^^ help: explicitly specify the type as `f32`: `0_f32`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
+
+warning: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
+  --> $DIR/f32-into-f32.rs:22:14
    |
 LL |     let x = -4.0;
    |              ^^^ help: explicitly specify the type as `f32`: `4.0_f32`
@@ -35,5 +44,5 @@ LL |     let x = -4.0;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
 
-warning: 4 warnings emitted
+warning: 5 warnings emitted
 

--- a/tests/ui/float/f32-into-f32.old-solver.fixed
+++ b/tests/ui/float/f32-into-f32.old-solver.fixed
@@ -15,6 +15,9 @@ fn main() {
     foo(1e5_f32);
     //~^ WARN falling back to `f32`
     //~| WARN this was previously accepted
+    foo(0_f32);
+    //~^ WARN falling back to `f32`
+    //~| WARN this was previously accepted
     foo(4f32); // no warning
     let x = -4.0_f32;
     //~^ WARN falling back to `f32`

--- a/tests/ui/float/f32-into-f32.old-solver.stderr
+++ b/tests/ui/float/f32-into-f32.old-solver.stderr
@@ -27,7 +27,16 @@ LL |     foo(1e5);
    = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
 
 warning: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
-  --> $DIR/f32-into-f32.rs:19:14
+  --> $DIR/f32-into-f32.rs:18:9
+   |
+LL |     foo(0.);
+   |         ^^ help: explicitly specify the type as `f32`: `0_f32`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
+
+warning: falling back to `f32` as the trait bound `f32: From<f64>` is not satisfied
+  --> $DIR/f32-into-f32.rs:22:14
    |
 LL |     let x = -4.0;
    |              ^^^ help: explicitly specify the type as `f32`: `4.0_f32`
@@ -35,5 +44,5 @@ LL |     let x = -4.0;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #154024 <https://github.com/rust-lang/rust/issues/154024>
 
-warning: 4 warnings emitted
+warning: 5 warnings emitted
 

--- a/tests/ui/float/f32-into-f32.rs
+++ b/tests/ui/float/f32-into-f32.rs
@@ -15,6 +15,9 @@ fn main() {
     foo(1e5);
     //~^ WARN falling back to `f32`
     //~| WARN this was previously accepted
+    foo(0.);
+    //~^ WARN falling back to `f32`
+    //~| WARN this was previously accepted
     foo(4f32); // no warning
     let x = -4.0;
     //~^ WARN falling back to `f32`


### PR DESCRIPTION
When a float literal ended with a dot, `float_literal_f32_fallback` should not include it in its suggestion, as that would result in invalid syntax ([playgound](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=de47274bf2b07070b79a97ce6744ffcbO)):

```
2 |     let _: f32 = From::from(0.);
  |                             ^^ help: explicitly specify the type as `f32`: `0._f32`
```

Relevant tracking issue: rust-lang/rust#154024

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
