### PR TITLE
Turn `lint_index` from `Option<u16>` to `u16` for LintExpectationId

### DIFF
--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -38,7 +38,7 @@ fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
                 (tcx.hir_attrs(id.hir_id)[id.attr_index as usize].id(), id.lint_index)
             }
         };
-        (attr_id, lint_index.expect("fulfilled expectations must have a lint index"))
+        (attr_id, lint_index)
     };
 
     let fulfilled_expectations: FxHashSet<_> =

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -233,7 +233,7 @@ pub trait LintLevelsProvider {
         &self,
         attr_id: AttrId,
         attr_index: usize,
-        lint_index: Option<u16>,
+        lint_index: u16,
     ) -> Self::LintExpectationId;
 }
 
@@ -258,7 +258,7 @@ impl LintLevelsProvider for TopDown {
         &self,
         attr_id: AttrId,
         _attr_index: usize,
-        lint_index: Option<u16>,
+        lint_index: u16,
     ) -> Self::LintExpectationId {
         UnstableLintExpectationId { attr_id, lint_index }
     }
@@ -296,7 +296,7 @@ impl LintLevelsProvider for LintLevelQueryMap<'_> {
         &self,
         _attr_id: AttrId,
         attr_index: usize,
-        lint_index: Option<u16>,
+        lint_index: u16,
     ) -> Self::LintExpectationId {
         let attr_index = attr_index.try_into().unwrap();
         StableLintExpectationId { hir_id: self.cur, attr_index, lint_index }
@@ -740,11 +740,7 @@ where
                 // `Expect` is the only lint level with a `LintExpectationId` that can be created
                 // from an attribute.
                 let lint_id = (level == Level::Expect).then(|| {
-                    self.provider.mk_lint_expectation_id(
-                        attr.id(),
-                        attr_index,
-                        Some(lint_index as u16),
-                    )
+                    self.provider.mk_lint_expectation_id(attr.id(), attr_index, lint_index as u16)
                 });
 
                 let sp = li.span();

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -109,7 +109,7 @@ pub enum LintExpectationId {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Encodable, Decodable)]
 pub struct UnstableLintExpectationId {
     pub attr_id: AttrId,
-    pub lint_index: Option<u16>,
+    pub lint_index: u16,
 }
 
 impl From<UnstableLintExpectationId> for LintExpectationId {
@@ -125,7 +125,7 @@ impl From<UnstableLintExpectationId> for LintExpectationId {
 pub struct StableLintExpectationId {
     pub hir_id: HirId,
     pub attr_index: u16,
-    pub lint_index: Option<u16>,
+    pub lint_index: u16,
 }
 
 impl StableHash for StableLintExpectationId {
@@ -135,7 +135,7 @@ impl StableHash for StableLintExpectationId {
 
         hir_id.stable_hash(hcx, hasher);
         attr_index.stable_hash(hcx, hasher);
-        lint_index.expect("must be filled to call `stable_hash`").stable_hash(hcx, hasher);
+        lint_index.stable_hash(hcx, hasher);
     }
 }
 


### PR DESCRIPTION
While doing lint attributes PR, I realised that the field `lint_index` didn't need to be Optional

(this PR is part of a series of PRs that will make the lint attrs PR more easily reviewable)

r? @nnethercote because you did rust-lang/rust#156596 recently