### PR TITLE
Add `#[doc(alias = "phi")]` for float `GOLDEN_RATIO` constants

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -33,6 +33,7 @@ pub mod consts {
     pub const TAU: f128 = 6.28318530717958647692528676655900576839433879875021164194989_f128;
 
     /// The golden ratio (φ)
+    #[doc(alias = "phi")]
     #[unstable(feature = "f128", issue = "116909")]
     pub const GOLDEN_RATIO: f128 =
         1.61803398874989484820458683436563811772030917980576286213545_f128;

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -35,6 +35,7 @@ pub mod consts {
     pub const TAU: f16 = 6.28318530717958647692528676655900577_f16;
 
     /// The golden ratio (φ)
+    #[doc(alias = "phi")]
     #[unstable(feature = "f16", issue = "116909")]
     pub const GOLDEN_RATIO: f16 = 1.618033988749894848204586834365638118_f16;
 

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -292,6 +292,7 @@ pub mod consts {
     pub const TAU: f32 = 6.28318530717958647692528676655900577_f32;
 
     /// The golden ratio (φ)
+    #[doc(alias = "phi")]
     #[stable(feature = "euler_gamma_golden_ratio", since = "1.94.0")]
     pub const GOLDEN_RATIO: f32 = 1.618033988749894848204586834365638118_f32;
 

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -292,6 +292,7 @@ pub mod consts {
     pub const TAU: f64 = 6.28318530717958647692528676655900577_f64;
 
     /// The golden ratio (φ)
+    #[doc(alias = "phi")]
     #[stable(feature = "euler_gamma_golden_ratio", since = "1.94.0")]
     pub const GOLDEN_RATIO: f64 = 1.618033988749894848204586834365638118_f64;
 


### PR DESCRIPTION
- Adds "phi" doc alias for `f16`, `f32`, `f64`, and `f128`

I knew this constant was stabilized but I couldn't remember what it was called.
Searching "phi" in the docs only surfaces the π constant, `is_ascii_graphic`, and `spin_loop_hint` methods. This alias would make it much easier to find.  
https://doc.rust-lang.org/nightly/std/?search=phi