### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1197,8 +1197,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         }
                     } else {
                         self.emit_bad_parenthesized_trait_in_assoc_ty(data);
-                        // FIXME(return_type_notation): we could issue a feature error
-                        // if the parens are empty and there's no return type.
                         self.lower_angle_bracketed_parameter_data(
                             &data.as_angle_bracketed_args(),
                             ParamMode::Explicit,

--- a/compiler/rustc_borrowck/src/diagnostics/var_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/var_name.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use crate::region_infer::RegionInferenceContext;
 
 impl<'tcx> RegionInferenceContext<'tcx> {
-    /// Find the the name and span of the variable corresponding to the given region.
+    /// Find the name and span of the variable corresponding to the given region.
     /// The returned var will also be ensured to actually be used in `body`.
     pub(crate) fn get_var_name_and_span_for_region(
         &self,

--- a/compiler/rustc_mir_build/src/builder/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_place.rs
@@ -583,18 +583,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::ThreadLocalRef(_)
             | ExprKind::Call { .. }
             | ExprKind::ByUse { .. }
+            // A reborrow is an rvalue. If a place is needed for it, materialize
+            // the rvalue in a temporary instead of treating the reborrow
+            // expression itself as an assignable place.
+            | ExprKind::Reborrow { .. }
             | ExprKind::WrapUnsafeBinder { .. } => {
                 // these are not places, so we need to make a temporary.
                 debug_assert!(!matches!(Category::of(&expr.kind), Some(Category::Place)));
                 let temp_lifetime = this.region_scope_tree.temporary_scope(expr.temp_scope_id);
                 let temp = unpack!(block = this.as_temp(block, temp_lifetime, expr_id, mutability));
                 block.and(PlaceBuilder::from(temp))
-            }
-            ExprKind::Reborrow { .. } => {
-                // FIXME(reborrow): it should currently be impossible to end up evaluating a
-                // Reborrow expression as a place. That might not in the future, but what this then
-                // evaluates to requires further thought.
-                unreachable!();
             }
         }
     }

--- a/compiler/rustc_mir_build/src/builder/expr/category.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/category.rs
@@ -43,8 +43,7 @@ impl Category {
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. }
             | ExprKind::PlaceUnwrapUnsafeBinder { .. }
-            | ExprKind::ValueUnwrapUnsafeBinder { .. }
-            | ExprKind::Reborrow { .. } => Some(Category::Place),
+            | ExprKind::ValueUnwrapUnsafeBinder { .. } => Some(Category::Place),
 
             ExprKind::LogicalOp { .. }
             | ExprKind::Match { .. }
@@ -70,6 +69,10 @@ impl Category {
             | ExprKind::Repeat { .. }
             | ExprKind::Assign { .. }
             | ExprKind::AssignOp { .. }
+            // A reborrow expression produces a value represented in MIR as
+            // `Rvalue::Reborrow`. Its source may be a place, but the reborrow
+            // expression itself does not denote an assignable place.
+            | ExprKind::Reborrow { .. }
             | ExprKind::ThreadLocalRef(_)
             | ExprKind::WrapUnsafeBinder { .. } => Some(Category::Rvalue(RvalueFunc::AsRvalue)),
 

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -783,7 +783,7 @@ impl ReachEverythingInTheInterfaceVisitor<'_, '_> {
                 }
             }
 
-            DefKind::TraitAlias | DefKind::Fn => {
+            DefKind::TraitAlias | DefKind::Fn | DefKind::TyAlias => {
                 self.ev.queue.insert(def_id);
             }
 
@@ -808,7 +808,6 @@ impl ReachEverythingInTheInterfaceVisitor<'_, '_> {
 
             // Can't be reached
             DefKind::Impl { .. }
-            | DefKind::TyAlias
             | DefKind::Field
             | DefKind::Variant
             | DefKind::Static { .. }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3937,7 +3937,9 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
             //As we lower target_expr_template body to a body of a function we need a label rib (#148889)
             this.with_label_rib(RibKind::FnOrCoroutine, |this| {
-                this.visit_block(body);
+                this.with_lifetime_rib(LifetimeRibKind::Elided(LifetimeRes::Infer), |this| {
+                    this.visit_block(body);
+                });
             });
         });
     }

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -145,7 +145,7 @@ impl<T: Copy + Debug + Hash + Eq> AsRef<[T]> for SmallCopyList<T> {
 /// | never                   | no    | no                                                                                                                   |
 /// | always                  | yes   | yes                                                                                                                  |
 /// | [defid in storage]      | no    | only if any of the defids in the list is in the opaque type storage OR if TypingMode::PostAnalysis                   |
-/// | opaque with hidden type | no    | only if any of the the opaques in the opaque type storage has a hidden type in this list AND if TypingMode::Analysis |
+/// | opaque with hidden type | no    | only if any of the opaques in the opaque type storage has a hidden type in this list AND if TypingMode::Analysis |
 ///
 /// - "bail" is implemented with [`should_bail`](Self::should_bail).
 ///   If true, we're abandoning our attempt to canonicalize in [`TypingMode::ErasedNotCoherence`],

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -305,16 +305,33 @@ def StdStringSummaryProvider(valobj: SBValue, dict: LLDBOpaque):
     )
 
     length = inner_vec.GetChildMemberWithName("len").GetValueAsUnsigned()
+    capacity = (
+        inner_vec.GetChildMemberWithName("buf")
+        .GetChildMemberWithName("cap")
+        .GetValueAsUnsigned()
+    )
 
     if length <= 0:
         return '""'
+
+    no_hi_bit_max: int = 1 << ((pointer.GetByteSize() * 8) - 1)
+    # technically length isn't a NoHighBit<usize>, but length should always be <= capacity
+    if length >= no_hi_bit_max or capacity >= no_hi_bit_max:
+        return "<error: invalid len/capacity>"
+    if pointer.GetValueAsUnsigned() == 0:
+        return "<error: String pointer is null>"
+
     error = SBError()
     process = pointer.GetProcess()
-    data = process.ReadMemory(pointer.GetValueAsUnsigned(), length, error)
-    if error.Success():
-        return '"' + data.decode("utf8", "replace") + '"'
-    else:
-        raise Exception("ReadMemory error: %s", error.GetCString())
+    try:
+        data = process.ReadMemory(pointer.GetValueAsUnsigned(), length, error)
+        if error.Success():
+            return '"' + data.decode("utf8", "replace") + '"'
+        else:
+            return f"<error: {error.GetCString()}>"
+    except Exception as e:
+        print(f"Unable to generate String summary: {e.__cause__}")
+        return "<error: Unable to read memory>"
 
 
 def StdOsStringSummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
@@ -443,6 +460,9 @@ class StructSyntheticProvider:
 class StdStringSyntheticProvider:
     def __init__(self, valobj: SBValue, _dict: LLDBOpaque):
         self.valobj = valobj
+        ptr_size = valobj.GetTarget().GetAddressByteSize() * 8
+        self.no_hi_bit_max = 1 << (ptr_size - 1)
+
         self.update()
 
     def update(self):
@@ -454,7 +474,25 @@ class StdStringSyntheticProvider:
             .GetChildMemberWithName("pointer")
             .GetChildMemberWithName("pointer")
         )
-        self.length = inner_vec.GetChildMemberWithName("len").GetValueAsUnsigned()
+
+        self.capacity = (
+            inner_vec.GetChildMemberWithName("buf")
+            .GetChildMemberWithName("cap")
+            .GetValueAsUnsigned()
+        )
+
+        # As of 4/18/2026, LLDB cannot accurately determine the difference between Some("") and None
+        # this just makes sure we're not trying to access data when the string is clearly in an
+        # invalid state.
+        if (
+            self.capacity >= self.no_hi_bit_max
+            or self.data_ptr.GetValueAsUnsigned() == 0
+        ):
+            self.capacity = 0
+            self.length = 0
+        else:
+            self.length = inner_vec.GetChildMemberWithName("len").GetValueAsUnsigned()
+
         self.element_type = self.data_ptr.GetType().GetPointeeType()
 
     def has_children(self) -> bool:
@@ -928,6 +966,8 @@ class StdVecSyntheticProvider:
         # logger >> "[StdVecSyntheticProvider] for " + str(valobj.GetName())
         self.valobj = valobj
         self.element_type = None
+        ptr_size = valobj.GetTarget().GetAddressByteSize() * 8
+        self.no_hi_bit_max = 1 << (ptr_size - 1)
         self.update()
 
     def num_children(self) -> int:
@@ -949,14 +989,18 @@ class StdVecSyntheticProvider:
         return element
 
     def update(self):
-        self.length = self.valobj.GetChildMemberWithName("len").GetValueAsUnsigned()
-        self.buf = self.valobj.GetChildMemberWithName("buf").GetChildMemberWithName(
-            "inner"
+        buf: SBValue = self.valobj.GetChildMemberWithName("buf")
+        self.data_ptr = unwrap_unique_or_non_null(
+            buf.GetChildMemberWithName("inner").GetChildMemberWithName("ptr")
         )
 
-        self.data_ptr = unwrap_unique_or_non_null(
-            self.buf.GetChildMemberWithName("ptr")
-        )
+        capacity: int = buf.GetChildMemberWithName("cap").GetValueAsUnsigned()
+
+        if capacity >= self.no_hi_bit_max or self.data_ptr.GetValueAsUnsigned() == 0:
+            self.capacity = 0
+            self.length = 0
+        else:
+            self.length = self.valobj.GetChildMemberWithName("len").GetValueAsUnsigned()
 
         self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
 

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -15,7 +15,7 @@ from lldb import (
 from rust_types import is_tuple_fields
 
 if TYPE_CHECKING:
-    from lldb import SBValue, SBType, SBTypeStaticField, SBTarget
+    from lldb import SBValue, SBType, SBTypeStaticField, SBTarget, SBProcess
 
 # from lldb.formatters import Logger
 
@@ -289,6 +289,28 @@ def vec_to_string(vec: SBValue) -> str:
     )
 
 
+def read_string(
+    process: SBProcess, address: int, length: int, error: Optional[SBError] = None
+) -> str:
+    """Reads a string from running process's memory. If `error` is passed in, it will be passed
+    to the `SBProcess.ReadMemory` call, and will reflect any errors after the function is called.
+
+    If any error or exception occurs, a placeholder byte array of the form "<error: [reason]>" will
+    be returned instead."""
+
+    if error is None:
+        error = SBError()
+    try:
+        data = process.ReadMemory(address, length, error)
+        if error.Success():
+            return '"' + data.decode("utf-8", "replace") + '"'
+        else:
+            return f"<error: {error.GetCString()}>"
+    except Exception as e:
+        print(f"Unable to generate String summary: {e.__cause__}")
+        return "<error: Unable to read memory>"
+
+
 def StdStringSummaryProvider(valobj: SBValue, dict: LLDBOpaque):
     inner_vec = (
         valobj.GetNonSyntheticValue()
@@ -321,17 +343,9 @@ def StdStringSummaryProvider(valobj: SBValue, dict: LLDBOpaque):
     if pointer.GetValueAsUnsigned() == 0:
         return "<error: String pointer is null>"
 
-    error = SBError()
     process = pointer.GetProcess()
-    try:
-        data = process.ReadMemory(pointer.GetValueAsUnsigned(), length, error)
-        if error.Success():
-            return '"' + data.decode("utf8", "replace") + '"'
-        else:
-            return f"<error: {error.GetCString()}>"
-    except Exception as e:
-        print(f"Unable to generate String summary: {e.__cause__}")
-        return "<error: Unable to read memory>"
+
+    return read_string(process, pointer.GetValueAsAddress(), length)
 
 
 def StdOsStringSummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
@@ -380,15 +394,9 @@ def StdPathSummaryProvider(valobj: SBValue, _dict: LLDBOpaque) -> str:
     data_ptr = valobj.GetChildMemberWithName("data_ptr")
 
     start = data_ptr.GetValueAsUnsigned()
-    error = SBError()
     process = data_ptr.GetProcess()
-    data = process.ReadMemory(start, length, error)
-    if PY3:
-        try:
-            data = data.decode(encoding="UTF-8")
-        except UnicodeDecodeError:
-            return "%r" % data
-    return '"%s"' % data
+
+    return read_string(process, start, length)
 
 
 def sequence_formatter(output: str, valobj: SBValue, _dict: LLDBOpaque):

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.rs
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.rs
@@ -2,7 +2,7 @@ reuse a as b {
     //~^ ERROR cannot find function `a` in this scope
     //~| ERROR functions delegation is not yet fully implemented
     dbg!(b);
-    //~^ ERROR missing lifetime specifier
+    //~^ ERROR: `fn() {b}` doesn't implement `Debug`
 }
 
 fn main() {}

--- a/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
+++ b/tests/ui/delegation/ice-line-bounds-issue-148732.stderr
@@ -1,9 +1,3 @@
-error[E0106]: missing lifetime specifier
-  --> $DIR/ice-line-bounds-issue-148732.rs:4:5
-   |
-LL |     dbg!(b);
-   |     ^^^^^^^ expected named lifetime parameter
-
 error[E0425]: cannot find function `a` in this scope
   --> $DIR/ice-line-bounds-issue-148732.rs:1:7
    |
@@ -25,7 +19,18 @@ LL | | }
    = help: add `#![feature(fn_delegation)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0277]: `fn() {b}` doesn't implement `Debug`
+  --> $DIR/ice-line-bounds-issue-148732.rs:4:5
+   |
+LL | reuse a as b {
+   |            - consider calling this function
+...
+LL |     dbg!(b);
+   |     ^^^^^^^ the trait `Debug` is not implemented for fn item `fn() {b}`
+   |
+   = help: use parentheses to call this function: `b()`
+
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0106, E0425, E0658.
-For more information about an error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0277, E0425, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/delegation/wrong-lifetime-rib.rs
+++ b/tests/ui/delegation/wrong-lifetime-rib.rs
@@ -29,4 +29,14 @@ mod ice_156758 {
     }
 }
 
+mod ice_156806 {
+    trait X {}
+
+    impl X { //~ ERROR: expected a type, found a trait
+        reuse Iterator::fold { //~ ERROR: `()` is not an iterator
+            let _: &X; //~ ERROR: expected a type, found a trait
+        }
+    }
+}
+
 fn main() {}

--- a/tests/ui/delegation/wrong-lifetime-rib.stderr
+++ b/tests/ui/delegation/wrong-lifetime-rib.stderr
@@ -19,6 +19,21 @@ help: you might have intended to implement this trait for a given type
 LL |     impl X for /* Type */ {
    |            ++++++++++++++
 
+error[E0782]: expected a type, found a trait
+  --> $DIR/wrong-lifetime-rib.rs:35:10
+   |
+LL |     impl X {
+   |          ^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |     impl dyn X {
+   |          +++
+help: you might have intended to implement this trait for a given type
+   |
+LL |     impl X for /* Type */ {
+   |            ++++++++++++++
+
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
   --> $DIR/wrong-lifetime-rib.rs:9:5
    |
@@ -40,7 +55,28 @@ LL -         reuse<<<&Project> :: Ty> :: Ty as Iterator>::next;
 LL +         reuse<<<&() as Example>::Ty> :: Ty as Iterator>::next;
    |
 
-error: aborting due to 4 previous errors
+error[E0782]: expected a type, found a trait
+  --> $DIR/wrong-lifetime-rib.rs:37:21
+   |
+LL |             let _: &X;
+   |                     ^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |             let _: &dyn X;
+   |                     +++
 
-Some errors have detailed explanations: E0116, E0223, E0423, E0782.
+error[E0599]: `()` is not an iterator
+  --> $DIR/wrong-lifetime-rib.rs:36:25
+   |
+LL |         reuse Iterator::fold {
+   |                         ^^^^ `()` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `(): Iterator`
+           which is required by `&mut (): Iterator`
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0116, E0223, E0423, E0599, E0782.
 For more information about an error, try `rustc --explain E0116`.

--- a/tests/ui/privacy/reach-type-alias-issue-156778.rs
+++ b/tests/ui/privacy/reach-type-alias-issue-156778.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+#![feature(lazy_type_alias)]
+
+use src::hidden_core;
+mod src {
+    mod aliases {
+        use hidden_core::InternalStruct;
+        pub type ExposedType = InternalStruct<f32>;
+    }
+    pub mod hidden_core {
+        use super::aliases::ExposedType;
+        pub struct InternalStruct<T> {
+            _x: T,
+        }
+        pub fn new() -> ExposedType {
+            InternalStruct { _x: 1.0 }
+        }
+    }
+}
+fn main() {}

--- a/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
+++ b/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
@@ -1,0 +1,40 @@
+//@ check-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+// Regression test for rust-lang/rust#156482.
+// This used to ICE in MIR building when a THIR `ExprKind::Reborrow`
+// was categorized as a place but `expr_as_place` treated it as unreachable.
+struct Thing<'a>(&'a ());
+
+impl<'a> Reborrow for Thing<'a> {}
+
+fn foo(x: Thing<'_>) {
+    let _: Thing<'_> = x;
+}
+
+#[allow(unused)]
+struct CustomMut<'a, T>(&'a mut T);
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+#[allow(unused)]
+struct CustomRef<'a, T>(&'a T);
+impl<'a, T> Clone for CustomRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+impl<'a, T> Copy for CustomRef<'a, T> {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+
+    let _: CustomMut<'_, ()> = a;
+    let _: CustomMut<'_, ()> = a;
+
+    let _: CustomRef<'_, ()> = a;
+    let _: CustomRef<'_, ()> = a;
+}

--- a/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
+++ b/tests/ui/reborrow/generic-reborrow-rvalue-contract.rs
@@ -1,12 +1,12 @@
 //@ check-pass
+// Regression test for rust-lang/rust#156482.
+// This used to ICE in MIR building when a THIR `ExprKind::Reborrow`
+// was categorized as a place but `expr_as_place` treated it as unreachable.
 
 #![feature(reborrow)]
 
 use std::marker::{CoerceShared, Reborrow};
 
-// Regression test for rust-lang/rust#156482.
-// This used to ICE in MIR building when a THIR `ExprKind::Reborrow`
-// was categorized as a place but `expr_as_place` treated it as unreachable.
 struct Thing<'a>(&'a ());
 
 impl<'a> Reborrow for Thing<'a> {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155509 ([Debug Info] Gracefully handle invalid `String`/`Vec`)
 - rust-lang/rust#156560 (compiler: fix duplicated "the" in two doc-comments)
 - rust-lang/rust#156725 (Remove stale RTN FIXME for assoc item constraint fallback)
 - rust-lang/rust#156803 (Fix reborrow ICE in MIR place lowering)
 - rust-lang/rust#156818 (Privacy: enqueue type alias)
 - rust-lang/rust#156820 (delegation: visit body under elided-infer lifetime rib)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155509,156560,156725,156803,156818,156820)
<!-- homu-ignore:end -->

