### PR TITLE
Add regression test for const parameter default ICE

### DIFF
--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param_default.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param_default.rs
@@ -1,0 +1,18 @@
+// Regression test for https://github.com/rust-lang/rust/issues/142913.
+
+// A const parameter introduced by `generic_const_parameter_types`,
+// whose type mentions an earlier lifetime
+// parameter and which carries a default value, used to ICE in `rustc_type_ir`
+// with "region parameter out of range when instantiating args". It is now
+// rejected with ordinary errors instead of crashing.
+
+#![feature(generic_const_parameter_types)]
+
+struct Variant;
+
+fn foo<'a, const N: &'a Variant = {}>() {}
+//~^ ERROR: defaults for generic parameters are not allowed here
+//~| ERROR: anonymous constants with lifetimes in their type are not yet supported
+//~| ERROR: `&'a Variant` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param_default.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param_default.stderr
@@ -1,0 +1,30 @@
+error: defaults for generic parameters are not allowed here
+  --> $DIR/lifetime_dependent_const_param_default.rs:13:12
+   |
+LL | fn foo<'a, const N: &'a Variant = {}>() {}
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param_default.rs:13:35
+   |
+LL | fn foo<'a, const N: &'a Variant = {}>() {}
+   |                                   ^^
+
+error: `&'a Variant` is forbidden as the type of a const generic parameter
+  --> $DIR/lifetime_dependent_const_param_default.rs:13:21
+   |
+LL | fn foo<'a, const N: &'a Variant = {}>() {}
+   |                     ^^^^^^^^^^^
+   |
+   = note: the only supported types are integers, `bool`, and `char`
+help: add `#![feature(min_adt_const_params)]` to the crate attributes to enable more complex and user defined types
+   |
+LL + #![feature(min_adt_const_params)]
+   |
+help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
+   |
+LL + #![feature(unsized_const_params)]
+   |
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Closes rust-lang/rust#142913

This adds a UI regression test for a fixed ICE where a const generic parameter
type mentioned an earlier lifetime and also had a default value.

The reproducer is the minimized version posted in the issue.

Tested:
- ./x test tests/ui/const-generics/generic_const_parameter_types/region-parameter-out-of-range-ice-142913.rs --force-rerun
- ./x test tidy --bless
