### PR TITLE
Also emit "Dyn Compatibility" section for traits that *are* dyn compatible

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -946,24 +946,22 @@ fn item_trait(cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) -> impl fmt:
 
         let mut extern_crates = FxIndexSet::default();
 
-        if !t.is_dyn_compatible(cx.tcx()) {
-            write!(
-                w,
-                "{}",
-                write_section_heading(
-                    "Dyn Compatibility",
-                    "dyn-compatibility",
-                    None,
-                    format!(
-                        "<div class=\"dyn-compatibility-info\"><p>This trait is <b>not</b> \
-                        <a href=\"{base}/reference/items/traits.html#dyn-compatibility\">dyn compatible</a>.</p>\
-                        <p><i>In older versions of Rust, dyn compatibility was called \"object safety\", \
-                        so this trait is not object safe.</i></p></div>",
-                        base = crate::clean::utils::DOC_RUST_LANG_ORG_VERSION
-                    ),
+        write!(
+            w,
+            "{}",
+            write_section_heading(
+                "Dyn Compatibility",
+                "dyn-compatibility",
+                None,
+                format!(
+                    "<div class=\"dyn-compatibility-info\"><p>This trait {} \
+                    <a href=\"{base}/reference/items/traits.html#dyn-compatibility\">dyn compatible</a>.</p>\
+                    <p><i>In older versions of Rust, dyn compatibility was called \"object safety\".</i></p></div>",
+                    if t.is_dyn_compatible(cx.tcx()) { "<b>is</b>" } else { "is <b>not</b>" },
+                    base = crate::clean::utils::DOC_RUST_LANG_ORG_VERSION
                 ),
-            )?;
-        }
+            ),
+        )?;
 
         if let Some(implementors) = cx.shared.cache.implementors.get(&it.item_id.expect_def_id()) {
             // The DefId is for the first Type found with that name. The bool is

--- a/tests/rustdoc-html/dyn-compatibility.rs
+++ b/tests/rustdoc-html/dyn-compatibility.rs
@@ -15,8 +15,8 @@ pub trait DynIncompatible2<T> {
 }
 
 //@ has 'foo/trait.DynCompatible.html'
-//@ !has - '//*[@class="dyn-compatibility-info"]' ''
-//@ !has - '//*[@id="dyn-compatibility"]' ''
+//@ has - '//*[@class="dyn-compatibility-info"]' 'This trait is dyn compatible.'
+//@ has - '//*[@id="dyn-compatibility"]' 'Dyn Compatibility'
 pub trait DynCompatible {
     fn foo(&self);
 }


### PR DESCRIPTION
I was using the std docs to check if a trait was dyn compatible, and was very confused that it had no info about dyn compatibility. I had to go look at a trait that I knew for certain was *not* dyn compatible (`Clone`) to verify that we still had the dyn compatibility section, and that its omission meant a trait *was* compatible.

(also removed the "..., so this trait is not object safe" text because it seemed pretty redundant)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @fmease 