### PR TITLE
Centralize generic reborrow MIR lowering

### DIFF
--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -312,7 +312,10 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'tcx> {
                 borrowed_place,
             );
             let region = reborrow.target_region.as_var();
-            let kind = reborrow.kind.borrow_kind();
+            let kind = match mutability {
+                mir::Mutability::Mut => mir::BorrowKind::Mut { kind: mir::MutBorrowKind::Default },
+                mir::Mutability::Not => mir::BorrowKind::Shared,
+            };
             let borrow = BorrowData {
                 kind,
                 region,

--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -2,16 +2,16 @@ use std::fmt;
 use std::ops::Index;
 
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
-use rustc_hir::Mutability;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_middle::mir::visit::{MutatingUseContext, NonUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, Body, Local, Location, traversal};
+use rustc_middle::span_bug;
 use rustc_middle::ty::{RegionVid, TyCtxt};
-use rustc_middle::{bug, span_bug, ty};
 use rustc_mir_dataflow::move_paths::MoveData;
 use tracing::debug;
 
 use crate::BorrowIndex;
+use crate::generic_reborrow::generic_reborrow_info;
 use crate::place_ext::PlaceExt;
 
 pub struct BorrowSet<'tcx> {
@@ -303,37 +303,16 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'tcx> {
 
             self.local_map.entry(borrowed_place.local).or_default().insert(idx);
         } else if let &mir::Rvalue::Reborrow(target, mutability, borrowed_place) = rvalue {
-            let borrowed_place_ty = borrowed_place.ty(self.body, self.tcx).ty;
-            let &ty::Adt(reborrowed_adt, _reborrowed_args) = borrowed_place_ty.kind() else {
-                unreachable!()
-            };
-            let &ty::Adt(target_adt, assigned_args) = target.kind() else { unreachable!() };
-            let Some(ty::GenericArgKind::Lifetime(region)) = assigned_args.get(0).map(|r| r.kind())
-            else {
-                bug!(
-                    "hir-typeck passed but {} does not have a lifetime argument",
-                    if mutability == Mutability::Mut { "Reborrow" } else { "CoerceShared" }
-                );
-            };
-            let region = region.as_var();
-            let kind = if mutability == Mutability::Mut {
-                // Reborrow
-                if target_adt.did() != reborrowed_adt.did() {
-                    bug!(
-                        "hir-typeck passed but Reborrow involves mismatching types at {location:?}"
-                    )
-                }
-
-                mir::BorrowKind::Mut { kind: mir::MutBorrowKind::Default }
-            } else {
-                // CoerceShared
-                if target_adt.did() == reborrowed_adt.did() {
-                    bug!(
-                        "hir-typeck passed but CoerceShared involves matching types at {location:?}"
-                    )
-                }
-                mir::BorrowKind::Shared
-            };
+            let reborrow = generic_reborrow_info(
+                self.tcx,
+                self.body,
+                location,
+                target,
+                mutability,
+                borrowed_place,
+            );
+            let region = reborrow.target_region.as_var();
+            let kind = reborrow.kind.borrow_kind();
             let borrow = BorrowData {
                 kind,
                 region,

--- a/compiler/rustc_borrowck/src/generic_reborrow.rs
+++ b/compiler/rustc_borrowck/src/generic_reborrow.rs
@@ -1,39 +1,16 @@
 use rustc_hir::Mutability;
-use rustc_middle::mir::{Body, BorrowKind, Location, MutBorrowKind, Place};
+use rustc_middle::mir::{Body, Location, Place};
 use rustc_middle::span_bug;
 use rustc_middle::ty::{self, AdtDef, GenericArgsRef, Ty, TyCtxt};
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) enum GenericReborrowKind {
-    Reborrow,
-    CoerceShared,
-}
-
-impl GenericReborrowKind {
-    pub(crate) fn from_mutability(mutability: Mutability) -> Self {
-        match mutability {
-            Mutability::Mut => GenericReborrowKind::Reborrow,
-            Mutability::Not => GenericReborrowKind::CoerceShared,
-        }
-    }
-
-    pub(crate) fn name(self) -> &'static str {
-        match self {
-            GenericReborrowKind::Reborrow => "Reborrow",
-            GenericReborrowKind::CoerceShared => "CoerceShared",
-        }
-    }
-
-    pub(crate) fn borrow_kind(self) -> BorrowKind {
-        match self {
-            GenericReborrowKind::Reborrow => BorrowKind::Mut { kind: MutBorrowKind::Default },
-            GenericReborrowKind::CoerceShared => BorrowKind::Shared,
-        }
+fn generic_reborrow_name(mutability: Mutability) -> &'static str {
+    match mutability {
+        Mutability::Mut => "Reborrow",
+        Mutability::Not => "CoerceShared",
     }
 }
 
 pub(crate) struct GenericReborrowInfo<'tcx> {
-    pub(crate) kind: GenericReborrowKind,
     pub(crate) source_ty: Ty<'tcx>,
     pub(crate) source_adt: AdtDef<'tcx>,
     pub(crate) source_args: GenericArgsRef<'tcx>,
@@ -51,13 +28,13 @@ pub(crate) fn generic_reborrow_info<'tcx>(
     source_place: Place<'tcx>,
 ) -> GenericReborrowInfo<'tcx> {
     let span = body.source_info(location).span;
-    let kind = GenericReborrowKind::from_mutability(mutability);
+    let name = generic_reborrow_name(mutability);
     let source_ty = source_place.ty(body, tcx).ty;
     let &ty::Adt(source_adt, source_args) = source_ty.kind() else {
-        span_bug!(span, "{} source must be an ADT, found `{source_ty}`", kind.name());
+        span_bug!(span, "{name} source must be an ADT, found `{source_ty}`");
     };
     let &ty::Adt(target_adt, target_args) = target_ty.kind() else {
-        span_bug!(span, "{} target must be an ADT, found `{target_ty}`", kind.name());
+        span_bug!(span, "{name} target must be an ADT, found `{target_ty}`");
     };
 
     // The current model supports a single relevant lifetime, carried in the first target
@@ -65,27 +42,26 @@ pub(crate) fn generic_reborrow_info<'tcx>(
     let Some(ty::GenericArgKind::Lifetime(target_region)) =
         target_args.get(0).map(|arg| arg.kind())
     else {
-        span_bug!(span, "{} target `{target_ty}` does not start with a lifetime", kind.name());
+        span_bug!(span, "{name} target `{target_ty}` does not start with a lifetime");
     };
 
-    match kind {
-        GenericReborrowKind::Reborrow if source_adt.did() != target_adt.did() => {
+    match mutability {
+        Mutability::Mut if source_adt.did() != target_adt.did() => {
             span_bug!(
                 span,
                 "Reborrow source `{source_ty}` and target `{target_ty}` have different ADTs",
             );
         }
-        GenericReborrowKind::CoerceShared if source_adt.did() == target_adt.did() => {
+        Mutability::Not if source_adt.did() == target_adt.did() => {
             span_bug!(
                 span,
                 "CoerceShared source `{source_ty}` and target `{target_ty}` have the same ADT",
             );
         }
-        GenericReborrowKind::Reborrow | GenericReborrowKind::CoerceShared => {}
+        Mutability::Mut | Mutability::Not => {}
     }
 
     GenericReborrowInfo {
-        kind,
         source_ty,
         source_adt,
         source_args,

--- a/compiler/rustc_borrowck/src/generic_reborrow.rs
+++ b/compiler/rustc_borrowck/src/generic_reborrow.rs
@@ -1,0 +1,96 @@
+use rustc_hir::Mutability;
+use rustc_middle::mir::{Body, BorrowKind, Location, MutBorrowKind, Place};
+use rustc_middle::span_bug;
+use rustc_middle::ty::{self, AdtDef, GenericArgsRef, Ty, TyCtxt};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum GenericReborrowKind {
+    Reborrow,
+    CoerceShared,
+}
+
+impl GenericReborrowKind {
+    pub(crate) fn from_mutability(mutability: Mutability) -> Self {
+        match mutability {
+            Mutability::Mut => GenericReborrowKind::Reborrow,
+            Mutability::Not => GenericReborrowKind::CoerceShared,
+        }
+    }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            GenericReborrowKind::Reborrow => "Reborrow",
+            GenericReborrowKind::CoerceShared => "CoerceShared",
+        }
+    }
+
+    pub(crate) fn borrow_kind(self) -> BorrowKind {
+        match self {
+            GenericReborrowKind::Reborrow => BorrowKind::Mut { kind: MutBorrowKind::Default },
+            GenericReborrowKind::CoerceShared => BorrowKind::Shared,
+        }
+    }
+}
+
+pub(crate) struct GenericReborrowInfo<'tcx> {
+    pub(crate) kind: GenericReborrowKind,
+    pub(crate) source_ty: Ty<'tcx>,
+    pub(crate) source_adt: AdtDef<'tcx>,
+    pub(crate) source_args: GenericArgsRef<'tcx>,
+    pub(crate) target_adt: AdtDef<'tcx>,
+    pub(crate) target_args: GenericArgsRef<'tcx>,
+    pub(crate) target_region: ty::Region<'tcx>,
+}
+
+pub(crate) fn generic_reborrow_info<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    body: &Body<'tcx>,
+    location: Location,
+    target_ty: Ty<'tcx>,
+    mutability: Mutability,
+    source_place: Place<'tcx>,
+) -> GenericReborrowInfo<'tcx> {
+    let span = body.source_info(location).span;
+    let kind = GenericReborrowKind::from_mutability(mutability);
+    let source_ty = source_place.ty(body, tcx).ty;
+    let &ty::Adt(source_adt, source_args) = source_ty.kind() else {
+        span_bug!(span, "{} source must be an ADT, found `{source_ty}`", kind.name());
+    };
+    let &ty::Adt(target_adt, target_args) = target_ty.kind() else {
+        span_bug!(span, "{} target must be an ADT, found `{target_ty}`", kind.name());
+    };
+
+    // The current model supports a single relevant lifetime, carried in the first target
+    // argument. Keep that assumption checked here until richer metadata is available.
+    let Some(ty::GenericArgKind::Lifetime(target_region)) =
+        target_args.get(0).map(|arg| arg.kind())
+    else {
+        span_bug!(span, "{} target `{target_ty}` does not start with a lifetime", kind.name());
+    };
+
+    match kind {
+        GenericReborrowKind::Reborrow if source_adt.did() != target_adt.did() => {
+            span_bug!(
+                span,
+                "Reborrow source `{source_ty}` and target `{target_ty}` have different ADTs",
+            );
+        }
+        GenericReborrowKind::CoerceShared if source_adt.did() == target_adt.did() => {
+            span_bug!(
+                span,
+                "CoerceShared source `{source_ty}` and target `{target_ty}` have the same ADT",
+            );
+        }
+        GenericReborrowKind::Reborrow | GenericReborrowKind::CoerceShared => {}
+    }
+
+    GenericReborrowInfo {
+        kind,
+        source_ty,
+        source_adt,
+        source_args,
+        target_adt,
+        target_args,
+        target_region,
+    }
+}

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -57,6 +57,7 @@ use crate::dataflow::{BorrowIndex, Borrowck, BorrowckDomain, Borrows};
 use crate::diagnostics::{
     AccessKind, BorrowckDiagnosticsBuffer, IllegalMoveOriginKind, MoveError, RegionName,
 };
+use crate::generic_reborrow::GenericReborrowKind;
 use crate::path_utils::*;
 use crate::place_ext::PlaceExt;
 use crate::places_conflict::{PlaceConflictBias, places_conflict};
@@ -78,6 +79,7 @@ mod constraints;
 mod dataflow;
 mod def_use;
 mod diagnostics;
+mod generic_reborrow;
 mod handle_placeholders;
 mod nll;
 mod path_utils;
@@ -1515,14 +1517,16 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
             }
 
             &Rvalue::Reborrow(_target, mutability, place) => {
+                let reborrow_kind = GenericReborrowKind::from_mutability(mutability);
                 let access_kind = (
                     Deep,
-                    if mutability == Mutability::Mut {
-                        Write(WriteKind::MutableBorrow(BorrowKind::Mut {
-                            kind: MutBorrowKind::Default,
-                        }))
-                    } else {
-                        Read(ReadKind::Borrow(BorrowKind::Shared))
+                    match reborrow_kind {
+                        GenericReborrowKind::Reborrow => {
+                            Write(WriteKind::MutableBorrow(reborrow_kind.borrow_kind()))
+                        }
+                        GenericReborrowKind::CoerceShared => {
+                            Read(ReadKind::Borrow(reborrow_kind.borrow_kind()))
+                        }
                     },
                 );
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -57,7 +57,6 @@ use crate::dataflow::{BorrowIndex, Borrowck, BorrowckDomain, Borrows};
 use crate::diagnostics::{
     AccessKind, BorrowckDiagnosticsBuffer, IllegalMoveOriginKind, MoveError, RegionName,
 };
-use crate::generic_reborrow::GenericReborrowKind;
 use crate::path_utils::*;
 use crate::place_ext::PlaceExt;
 use crate::places_conflict::{PlaceConflictBias, places_conflict};
@@ -1517,16 +1516,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
             }
 
             &Rvalue::Reborrow(_target, mutability, place) => {
-                let reborrow_kind = GenericReborrowKind::from_mutability(mutability);
                 let access_kind = (
                     Deep,
-                    match reborrow_kind {
-                        GenericReborrowKind::Reborrow => {
-                            Write(WriteKind::MutableBorrow(reborrow_kind.borrow_kind()))
-                        }
-                        GenericReborrowKind::CoerceShared => {
-                            Read(ReadKind::Borrow(reborrow_kind.borrow_kind()))
-                        }
+                    match mutability {
+                        Mutability::Mut => Write(WriteKind::MutableBorrow(BorrowKind::Mut {
+                            kind: MutBorrowKind::Default,
+                        })),
+                        Mutability::Not => Read(ReadKind::Borrow(BorrowKind::Shared)),
                     },
                 );
 

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -9,7 +9,6 @@ use tracing::debug;
 
 use super::{PoloniusFacts, PoloniusLocationTable};
 use crate::borrow_set::BorrowSet;
-use crate::generic_reborrow::GenericReborrowKind;
 use crate::path_utils::*;
 use crate::{
     AccessDepth, Activation, ArtificialField, BorrowIndex, Deep, LocalMutationIsAllowed, Read,
@@ -274,18 +273,13 @@ impl<'a, 'tcx> LoanInvalidationsGenerator<'a, 'tcx> {
             }
 
             &Rvalue::Reborrow(_target, mutability, place) => {
-                let reborrow_kind = GenericReborrowKind::from_mutability(mutability);
                 let access_kind = (
                     Deep,
-                    match reborrow_kind {
-                        GenericReborrowKind::Reborrow => {
-                            Reservation(WriteKind::MutableBorrow(BorrowKind::Mut {
-                                kind: MutBorrowKind::TwoPhaseBorrow,
-                            }))
-                        }
-                        GenericReborrowKind::CoerceShared => {
-                            Read(ReadKind::Borrow(reborrow_kind.borrow_kind()))
-                        }
+                    match mutability {
+                        Mutability::Mut => Reservation(WriteKind::MutableBorrow(BorrowKind::Mut {
+                            kind: MutBorrowKind::TwoPhaseBorrow,
+                        })),
+                        Mutability::Not => Read(ReadKind::Borrow(BorrowKind::Shared)),
                     },
                 );
 

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -9,6 +9,7 @@ use tracing::debug;
 
 use super::{PoloniusFacts, PoloniusLocationTable};
 use crate::borrow_set::BorrowSet;
+use crate::generic_reborrow::GenericReborrowKind;
 use crate::path_utils::*;
 use crate::{
     AccessDepth, Activation, ArtificialField, BorrowIndex, Deep, LocalMutationIsAllowed, Read,
@@ -273,14 +274,18 @@ impl<'a, 'tcx> LoanInvalidationsGenerator<'a, 'tcx> {
             }
 
             &Rvalue::Reborrow(_target, mutability, place) => {
+                let reborrow_kind = GenericReborrowKind::from_mutability(mutability);
                 let access_kind = (
                     Deep,
-                    if mutability == Mutability::Mut {
-                        Reservation(WriteKind::MutableBorrow(BorrowKind::Mut {
-                            kind: MutBorrowKind::TwoPhaseBorrow,
-                        }))
-                    } else {
-                        Read(ReadKind::Borrow(BorrowKind::Shared))
+                    match reborrow_kind {
+                        GenericReborrowKind::Reborrow => {
+                            Reservation(WriteKind::MutableBorrow(BorrowKind::Mut {
+                                kind: MutBorrowKind::TwoPhaseBorrow,
+                            }))
+                        }
+                        GenericReborrowKind::CoerceShared => {
+                            Read(ReadKind::Borrow(reborrow_kind.borrow_kind()))
+                        }
                     },
                 );
 

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -41,7 +41,7 @@ use tracing::{debug, instrument, trace};
 use crate::borrow_set::BorrowSet;
 use crate::constraints::{OutlivesConstraint, OutlivesConstraintSet};
 use crate::diagnostics::UniverseInfo;
-use crate::generic_reborrow::{GenericReborrowKind, generic_reborrow_info};
+use crate::generic_reborrow::generic_reborrow_info;
 use crate::polonius::PoloniusContext;
 use crate::polonius::legacy::{PoloniusFacts, PoloniusLocationTable};
 use crate::region_infer::TypeTest;
@@ -2510,7 +2510,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             }
         }
 
-        if reborrow.kind == GenericReborrowKind::CoerceShared {
+        if mutability == Mutability::Not {
             // FIXME(reborrow): for CoerceShared we need to relate the types manually, field by
             // field. We cannot just attempt to relate `T` and `<T as CoerceShared>::Target` by
             // calling relate_types as they are (generally) two unrelated user-defined ADTs, such as

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -41,6 +41,7 @@ use tracing::{debug, instrument, trace};
 use crate::borrow_set::BorrowSet;
 use crate::constraints::{OutlivesConstraint, OutlivesConstraintSet};
 use crate::diagnostics::UniverseInfo;
+use crate::generic_reborrow::{GenericReborrowKind, generic_reborrow_info};
 use crate::polonius::PoloniusContext;
 use crate::polonius::legacy::{PoloniusFacts, PoloniusLocationTable};
 use crate::region_infer::TypeTest;
@@ -2487,11 +2488,12 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             ConstraintCategory::Boring
         };
 
-        let borrowed_ty = borrowed_place.ty(self.body, tcx).ty;
-
-        let ty::Adt(dest_adt, dest_args) = dest_ty.kind() else { bug!() };
-        let [dest_arg, ..] = ***dest_args else { bug!() };
-        let ty::GenericArgKind::Lifetime(dest_region) = dest_arg.kind() else { bug!() };
+        let reborrow =
+            generic_reborrow_info(tcx, body, location, dest_ty, mutability, *borrowed_place);
+        let borrowed_ty = reborrow.source_ty;
+        let dest_adt = reborrow.target_adt;
+        let dest_args = reborrow.target_args;
+        let dest_region = reborrow.target_region;
         constraints.liveness_constraints.add_location(dest_region.as_var(), location);
 
         // In Polonius mode, we also push a `loan_issued_at` fact
@@ -2508,15 +2510,14 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             }
         }
 
-        if mutability.is_not() {
+        if reborrow.kind == GenericReborrowKind::CoerceShared {
             // FIXME(reborrow): for CoerceShared we need to relate the types manually, field by
             // field. We cannot just attempt to relate `T` and `<T as CoerceShared>::Target` by
             // calling relate_types as they are (generally) two unrelated user-defined ADTs, such as
             // `CustomMut<'a>` and `CustomRef<'a>`, or `CustomMut<'a, T>` and `CustomRef<'a, T>`.
             // Field-by-field relate_types is expected to work based on the wf-checks that the
             // CoerceShared trait performs.
-            let ty::Adt(borrowed_adt, borrowed_args) = borrowed_ty.kind() else { unreachable!() };
-            let borrowed_fields = borrowed_adt.all_fields().collect::<Vec<_>>();
+            let borrowed_fields = reborrow.source_adt.all_fields().collect::<Vec<_>>();
             for dest_field in dest_adt.all_fields() {
                 let Some(borrowed_field) =
                     borrowed_fields.iter().find(|f| f.name == dest_field.name)
@@ -2524,7 +2525,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     continue;
                 };
                 let dest_ty = dest_field.ty(tcx, dest_args).skip_norm_wip();
-                let borrowed_ty = borrowed_field.ty(tcx, borrowed_args).skip_norm_wip();
+                let borrowed_ty = borrowed_field.ty(tcx, reborrow.source_args).skip_norm_wip();
                 if let (
                     ty::Ref(borrow_region, _, Mutability::Mut),
                     ty::Ref(ref_region, _, Mutability::Not),

--- a/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_rvalue.rs
@@ -434,10 +434,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 );
                 block.and(Rvalue::Use(operand, WithRetag::Yes))
             }
-            ExprKind::Reborrow { source, mutability, target } => {
-                let temp = unpack!(block = this.as_temp(block, scope, source, mutability));
-                block.and(Rvalue::Reborrow(target, mutability, temp.into()))
-            }
+            ExprKind::Reborrow { source, mutability, target } => this
+                .lower_reborrow_as_result_temp(block, source, mutability, target, scope, expr_span),
         }
     }
 

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -909,13 +909,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.unit()
             }
             ExprKind::Reborrow { source, mutability, target } => {
-                let place = unpack!(block = this.as_place(block, source));
-                this.cfg.push_assign(
-                    block,
-                    source_info,
-                    destination,
-                    Rvalue::Reborrow(target, mutability, place.into()),
+                let rvalue = unpack!(
+                    block =
+                        this.reborrow_rvalue_from_source_place(block, source, mutability, target)
                 );
+                this.cfg.push_assign(block, source_info, destination, rvalue);
                 block.unit()
             }
         };

--- a/compiler/rustc_mir_build/src/builder/expr/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/mod.rs
@@ -67,4 +67,5 @@ mod as_rvalue;
 mod as_temp;
 pub(crate) mod category;
 mod into;
+mod reborrow;
 mod stmt;

--- a/compiler/rustc_mir_build/src/builder/expr/reborrow.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/reborrow.rs
@@ -1,0 +1,58 @@
+//! Helpers for lowering generic reborrow expressions.
+
+use rustc_middle::middle::region::TempLifetime;
+use rustc_middle::mir::*;
+use rustc_middle::thir::ExprId;
+use rustc_middle::ty::Ty;
+use rustc_span::Span;
+
+use crate::builder::scope::DropKind;
+use crate::builder::{BlockAnd, BlockAndExtension, Builder};
+
+impl<'a, 'tcx> Builder<'a, 'tcx> {
+    /// Build a reborrow from the source expression as a place.
+    pub(in crate::builder::expr) fn reborrow_rvalue_from_source_place(
+        &mut self,
+        mut block: BasicBlock,
+        source: ExprId,
+        mutability: Mutability,
+        target: Ty<'tcx>,
+    ) -> BlockAnd<Rvalue<'tcx>> {
+        let source = unpack!(block = self.as_place(block, source));
+
+        block.and(Rvalue::Reborrow(target, mutability, source))
+    }
+
+    /// Materialize the reborrow result before later user code, such as an assignment LHS, runs.
+    pub(in crate::builder::expr) fn lower_reborrow_as_result_temp(
+        &mut self,
+        mut block: BasicBlock,
+        source: ExprId,
+        mutability: Mutability,
+        target: Ty<'tcx>,
+        temp_lifetime: TempLifetime,
+        span: Span,
+    ) -> BlockAnd<Rvalue<'tcx>> {
+        let reborrow = unpack!(
+            block = self.reborrow_rvalue_from_source_place(block, source, mutability, target)
+        );
+        let result = self.temp(target, span);
+        let source_info = self.source_info(span);
+
+        self.cfg.push(block, Statement::new(source_info, StatementKind::StorageLive(result.local)));
+        if let Some(temp_lifetime) = temp_lifetime.temp_lifetime {
+            self.schedule_drop(span, temp_lifetime, result.local, DropKind::Storage);
+        }
+
+        self.cfg.push_assign(block, source_info, result, reborrow);
+
+        if let Some(temp_lifetime) = temp_lifetime.temp_lifetime {
+            self.schedule_drop(span, temp_lifetime, result.local, DropKind::Value);
+        }
+        if let Some(backwards_incompatible) = temp_lifetime.backwards_incompatible {
+            self.schedule_backwards_incompatible_drop(span, backwards_incompatible, result.local);
+        }
+
+        block.and(Rvalue::Use(Operand::Move(result), WithRetag::Yes))
+    }
+}

--- a/tests/ui/reborrow/generic-reborrow-lowering.rs
+++ b/tests/ui/reborrow/generic-reborrow-lowering.rs
@@ -1,0 +1,37 @@
+//@ run-pass
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct CustomMarker<'a>(PhantomData<&'a ()>);
+impl<'a> Reborrow for CustomMarker<'a> {}
+
+#[derive(Clone, Copy)]
+struct CustomMarkerRef<'a>(PhantomData<&'a ()>);
+impl<'a> CoerceShared<CustomMarkerRef<'a>> for CustomMarker<'a> {}
+
+fn take_mut<'a>(_value: CustomMarker<'a>) {}
+fn take_ref<'a>(_value: CustomMarkerRef<'a>) {}
+
+fn assignment_style_reborrow(value: CustomMarker<'_>) {
+    let reborrowed = value;
+    take_mut(reborrowed);
+}
+
+fn assignment_style_coerce_shared(value: CustomMarker<'_>) {
+    let shared: CustomMarkerRef<'_> = value;
+    take_ref(shared);
+}
+
+fn rvalue_style_coerce_shared(value: CustomMarker<'_>) {
+    let mut slots = [CustomMarkerRef(PhantomData)];
+    slots[0] = value;
+    take_ref(slots[0]);
+}
+
+fn main() {
+    assignment_style_reborrow(CustomMarker(PhantomData));
+    assignment_style_coerce_shared(CustomMarker(PhantomData));
+    rvalue_style_coerce_shared(CustomMarker(PhantomData));
+}

--- a/tests/ui/reborrow/generic-reborrow-rvalue-before-lhs.rs
+++ b/tests/ui/reborrow/generic-reborrow-rvalue-before-lhs.rs
@@ -1,0 +1,24 @@
+#![feature(reborrow)]
+
+use std::marker::{PhantomData, Reborrow};
+
+struct CustomMut<'a>(PhantomData<&'a mut ()>);
+impl<'a> Reborrow for CustomMut<'a> {}
+
+fn index<'a>(_value: CustomMut<'a>) -> usize {
+    0
+}
+
+fn rvalue_reborrow_is_live_while_lhs_is_evaluated<'a>(
+    value: CustomMut<'a>,
+    mut slots: [CustomMut<'a>; 1],
+) {
+    // Assignment evaluates the RHS before the assignee place. Rvalue lowering must materialize
+    // the reborrow result before `index(value)` is evaluated, without reborrowing from an
+    // artificial source temporary.
+    slots[index(value)] = value;
+    //~^ ERROR cannot borrow `value` as mutable more than once at a time
+    //~| ERROR `value` does not live long enough
+}
+
+fn main() {}

--- a/tests/ui/reborrow/generic-reborrow-rvalue-before-lhs.stderr
+++ b/tests/ui/reborrow/generic-reborrow-rvalue-before-lhs.stderr
@@ -1,0 +1,34 @@
+error[E0499]: cannot borrow `value` as mutable more than once at a time
+  --> $DIR/generic-reborrow-rvalue-before-lhs.rs:19:17
+   |
+LL | fn rvalue_reborrow_is_live_while_lhs_is_evaluated<'a>(
+   |                                                   -- lifetime `'a` defined here
+...
+LL |     slots[index(value)] = value;
+   |     ------------^^^^^----------
+   |     |           |         |
+   |     |           |         first mutable borrow occurs here
+   |     |           second mutable borrow occurs here
+   |     assignment requires that `value` is borrowed for `'a`
+
+error[E0597]: `value` does not live long enough
+  --> $DIR/generic-reborrow-rvalue-before-lhs.rs:19:27
+   |
+LL | fn rvalue_reborrow_is_live_while_lhs_is_evaluated<'a>(
+   |                                                   -- lifetime `'a` defined here
+LL |     value: CustomMut<'a>,
+   |     ----- binding `value` declared here
+...
+LL |     slots[index(value)] = value;
+   |     ----------------------^^^^^
+   |     |                     |
+   |     |                     borrowed value does not live long enough
+   |     assignment requires that `value` is borrowed for `'a`
+...
+LL | }
+   |  - `value` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0499, E0597.
+For more information about an error, try `rustc --explain E0499`.


### PR DESCRIPTION
## Summary

This PR centralizes MIR lowering for generic reborrow expressions so direct-destination and rvalue contexts share an explicit lowering contract instead of constructing `Rvalue::Reborrow` through separate ad-hoc paths.

It also moves the current `Rvalue::Reborrow` source/target assumptions behind checked helper logic, preserving the existing single-lifetime model while making the current invariants explicit.

## What changed

- Centralized construction/lowering of `Rvalue::Reborrow`.
- Made direct-destination versus rvalue result-temporary lowering explicit.
- Ensured rvalue lowering materializes the reborrow result without unnecessarily materializing place-like sources into artificial source temporaries.
- Replaced duplicated or implicit borrowck assumptions around generic reborrow source/target handling with checked helper logic.
- Added regression coverage for direct-destination and rvalue generic reborrow lowering, including both mutable `Reborrow` and shared `CoerceShared` paths.
- Kept richer metadata, multi-lifetime reborrow support, and decomposed/layout-changing lowering out of scope.

## Why

The previous implementation had different lowering strategies depending on context:

- direct-destination lowering used the source directly as a place;
- rvalue lowering materialized the source into a temporary first.

That made the reborrow lowering contract implicit and could make source-temporary behavior observable. This PR keeps the current feature scope but makes the lowering strategy explicit and uses a result-temporary rvalue path where the reborrow result must be materialized before later assignee/consumer evaluation.

## Please note

This PR is deliberately scoped as enabling cleanup for the remaining `Reborrow` work.

It does not change move-vs-reborrow classification in typeck, does not add richer per-operation metadata, and does not implement multi-lifetime generic reborrow support. Instead, it removes one piece of implicit compiler behavior by centralizing generic reborrow MIR lowering and putting the current `Rvalue::Reborrow` source/target assumptions behind checked helper logic.

This is useful before continuing with the larger feature work because multi-lifetime reborrow support will need a clearer phase boundary between MIR construction and borrowck. If that work is attempted while lowering still depends on separate context-specific paths, and while borrowck reconstructs the same assumptions in multiple places, follow-up patches become harder to reason about and more likely to introduce ICEs around unexpected `Rvalue::Reborrow` shapes.

The intended sequencing is therefore:

1. make the current single-lifetime MIR/borrowck contract explicit here;
2. fix remaining issues;
3. only then extend the model with richer metadata or multi-lifetime support.

Tracking: https://github.com/rust-lang/rust/issues/145612
cc @aapoalas
@rustbot label F-Reborrow