### PR TITLE
Wrap multi-bound impl/dyn after prefix type constructors in the type printer

### DIFF
--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -203,6 +203,12 @@ impl<'tcx> PrettyPrinter<'tcx> for TypeNamePrinter<'tcx> {
         // `std::any::type_name` should never print verbose type names
         false
     }
+
+    // `type_name` output is user-observable; keep it byte-stable here even
+    // though the docs permit drift.
+    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+        false
+    }
 }
 
 impl Write for TypeNamePrinter<'_> {

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -203,12 +203,6 @@ impl<'tcx> PrettyPrinter<'tcx> for TypeNamePrinter<'tcx> {
         // `std::any::type_name` should never print verbose type names
         false
     }
-
-    // `type_name` output is user-observable; keep it byte-stable here even
-    // though the docs permit drift.
-    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
-        false
-    }
 }
 
 impl Write for TypeNamePrinter<'_> {

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -204,6 +204,12 @@ impl<'tcx> PrettyPrinter<'tcx> for TypeNamePrinter<'tcx> {
         // `std::any::type_name` should never print verbose type names
         false
     }
+
+    // `type_name` output is user-observable; keep it byte-stable here even
+    // though the docs permit drift.
+    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+        false
+    }
 }
 
 impl Write for TypeNamePrinter<'_> {

--- a/compiler/rustc_const_eval/src/util/type_name.rs
+++ b/compiler/rustc_const_eval/src/util/type_name.rs
@@ -204,12 +204,6 @@ impl<'tcx> PrettyPrinter<'tcx> for TypeNamePrinter<'tcx> {
         // `std::any::type_name` should never print verbose type names
         false
     }
-
-    // `type_name` output is user-observable; keep it byte-stable here even
-    // though the docs permit drift.
-    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
-        false
-    }
 }
 
 impl Write for TypeNamePrinter<'_> {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -353,11 +353,13 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     fn should_print_optional_region(&self, region: ty::Region<'tcx>) -> bool;
 
     /// Whether `pretty_print_type` should wrap a multi-bound `impl` / `dyn`
-    /// inner in parens after a prefix type constructor (`&`, `&mut`, `*const`,
-    /// `*mut`), so the output is `&(impl A + B)` rather than the parser-
-    /// ambiguous `&impl A + B`. Byte-stable printers (mangling, `type_name`)
-    /// override this to `false`.
-    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+    /// inner in parens at positions where the bare form would be parser-
+    /// ambiguous: after a prefix type constructor (`&`, `&mut`, `*const`,
+    /// `*mut`) where `&T + B` parses as `(&T) + B`, and in the function-
+    /// pointer / `Fn(..) -> T` return position where `-> T + B` parses as
+    /// the outer signature picking up an extra bound. Byte-stable printers
+    /// (mangling, etc.) override this to `false`.
+    fn add_disambiguating_parens(&self) -> bool {
         true
     }
 
@@ -817,16 +819,11 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             ty::Adt(def, args) => self.print_def_path(def.did(), args)?,
             ty::Dynamic(data, r) => {
-                let print_r = self.should_print_optional_region(r);
-                if print_r {
-                    write!(self, "(")?;
-                }
                 write!(self, "dyn ")?;
                 data.print(self)?;
-                if print_r {
+                if self.should_print_optional_region(r) {
                     write!(self, " + ")?;
                     r.print(self)?;
-                    write!(self, ")")?;
                 }
             }
             ty::Foreign(def_id) => self.print_def_path(def_id, &[])?,
@@ -1100,7 +1097,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// print with a top-level `+`. Without the wrap, `&impl A + B` parses as
     /// the ambiguous `(&impl A) + B`.
     fn inner_needs_disambiguating_parens(&self, ty: Ty<'tcx>) -> bool {
-        if !self.add_disambiguating_parens_in_prefix_position() || self.should_print_verbose() {
+        if !self.add_disambiguating_parens() || self.should_print_verbose() {
             return false;
         }
         match ty.kind() {
@@ -1114,24 +1111,21 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 self.opaque_has_multiple_bounds(*def_id)
             }
             ty::Dynamic(predicates, region) => {
-                if self.should_print_optional_region(*region) {
-                    // `ty::Dynamic` self-wraps when it has an explicit region.
-                    false
-                } else {
-                    // Projections inline into the principal as `<Item = X>`;
-                    // only principal/auto traits produce a top-level `+`.
-                    predicates
-                        .iter()
-                        .filter(|pred| {
-                            matches!(
-                                pred.skip_binder(),
-                                ty::ExistentialPredicate::Trait(_)
-                                    | ty::ExistentialPredicate::AutoTrait(_)
-                            )
-                        })
-                        .count()
-                        > 1
-                }
+                // Projections inline into the principal as `<Item = X>`;
+                // only principal/auto traits produce a top-level `+`. An
+                // explicit (printable) region adds one more `+`-joined part.
+                let trait_count = predicates
+                    .iter()
+                    .filter(|pred| {
+                        matches!(
+                            pred.skip_binder(),
+                            ty::ExistentialPredicate::Trait(_)
+                                | ty::ExistentialPredicate::AutoTrait(_)
+                        )
+                    })
+                    .count();
+                let region_count = usize::from(self.should_print_optional_region(*region));
+                trait_count + region_count > 1
             }
             _ => false,
         }
@@ -1150,7 +1144,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
         // positive `Sized` and `MetaSized` are absorbed into the synthetic
         // suffix below; negative `Sized` (`?Sized`) falls through and is
-        // printed inline. Only clause *kinds* are inspected here, so the
+        // printed inline. We only ever look at clause *kinds* here, so the
         // identity-instantiated bounds carry all the information we need.
         let mut trait_emits = 0usize;
         let mut lifetimes_count = 0usize;
@@ -1669,7 +1663,10 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         write!(self, ")")?;
         if !output.is_unit() {
             write!(self, " -> ")?;
-            output.print(self)?;
+            // `Fn(..) -> X + B` parses as if `+ B` extended the outer signature,
+            // so wrap if `X` would print with `+`-joined bounds. Same machinery
+            // as the `&T`, `*const T`, `*mut T` prefix arms.
+            self.print_inner_with_disambiguating_parens(output)?;
         }
 
         Ok(())

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1105,13 +1105,13 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         }
         match ty.kind() {
             // RPITIT trait-side appears as `Projection`, not `Opaque`.
-            ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => {
-                self.opaque_has_multiple_bounds(*def_id, args)
+            ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, .. }) => {
+                self.opaque_has_multiple_bounds(*def_id)
             }
-            ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
+            ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, .. })
                 if self.tcx().is_impl_trait_in_trait(*def_id) =>
             {
-                self.opaque_has_multiple_bounds(*def_id, args)
+                self.opaque_has_multiple_bounds(*def_id)
             }
             ty::Dynamic(predicates, region) => {
                 if self.should_print_optional_region(*region) {
@@ -1143,23 +1143,22 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// the synthetic `Sized` / `?Sized` / `MetaSized` / `PointeeSized` suffix
     /// each contribute one top-level joinable component. Regressions land in
     /// `tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs`.
-    fn opaque_has_multiple_bounds(&self, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> bool {
+    fn opaque_has_multiple_bounds(&self, def_id: DefId) -> bool {
         let tcx = self.tcx();
         let bounds = tcx.explicit_item_bounds(def_id);
 
         // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
         // positive `Sized` and `MetaSized` are absorbed into the synthetic
         // suffix below; negative `Sized` (`?Sized`) falls through and is
-        // printed inline.
+        // printed inline. Only clause *kinds* are inspected here, so the
+        // identity-instantiated bounds carry all the information we need.
         let mut trait_emits = 0usize;
         let mut lifetimes_count = 0usize;
         let mut has_sized_bound = false;
         let mut has_negative_sized_bound = false;
         let mut has_meta_sized_bound = false;
 
-        for (predicate, _) in
-            bounds.iter_instantiated_copied(tcx, args).map(Unnormalized::skip_norm_wip)
-        {
+        for (predicate, _) in bounds.iter_identity_copied().map(Unnormalized::skip_norm_wip) {
             match predicate.kind().skip_binder() {
                 ty::ClauseKind::Trait(pred) => match tcx.as_lang_item(pred.def_id()) {
                     Some(LangItem::Sized) => match pred.polarity {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -352,6 +352,15 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// will always be printed.)
     fn should_print_optional_region(&self, region: ty::Region<'tcx>) -> bool;
 
+    /// Whether `pretty_print_type` should wrap a multi-bound `impl` / `dyn`
+    /// inner in parens after a prefix type constructor (`&`, `&mut`, `*const`,
+    /// `*mut`), so the output is `&(impl A + B)` rather than the parser-
+    /// ambiguous `&impl A + B`. Byte-stable printers (mangling, `type_name`)
+    /// override this to `false`.
+    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+        true
+    }
+
     fn reset_type_limit(&mut self) {}
 
     // Defaults (should not be overridden):
@@ -723,7 +732,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             ty::RawPtr(ty, mutbl) => {
                 write!(self, "*{} ", mutbl.ptr_str())?;
-                ty.print(self)?;
+                self.print_inner_with_disambiguating_parens(ty)?;
             }
             ty::Ref(r, ty, mutbl) => {
                 write!(self, "&")?;
@@ -731,7 +740,9 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     r.print(self)?;
                     write!(self, " ")?;
                 }
-                ty::TypeAndMut { ty, mutbl }.print(self)?;
+                // `&mut (impl A + B)`, not `&(mut impl A + B)`: emit `mut ` before the parens.
+                write!(self, "{}", mutbl.prefix_str())?;
+                self.print_inner_with_disambiguating_parens(ty)?;
             }
             ty::Never => write!(self, "!")?,
             ty::Tuple(tys) => {
@@ -1069,6 +1080,121 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         }
 
         Ok(())
+    }
+
+    /// Prints `ty` after a prefix type constructor, wrapping in parens iff
+    /// [`Self::inner_needs_disambiguating_parens`] returns `true`.
+    fn print_inner_with_disambiguating_parens(&mut self, ty: Ty<'tcx>) -> Result<(), PrintError> {
+        let need_paren = self.inner_needs_disambiguating_parens(ty);
+        if need_paren {
+            write!(self, "(")?;
+        }
+        ty.print(self)?;
+        if need_paren {
+            write!(self, ")")?;
+        }
+        Ok(())
+    }
+
+    /// Whether `ty`, sitting right after a prefix type constructor, would
+    /// print with a top-level `+`. Without the wrap, `&impl A + B` parses as
+    /// the ambiguous `(&impl A) + B`.
+    fn inner_needs_disambiguating_parens(&self, ty: Ty<'tcx>) -> bool {
+        if !self.add_disambiguating_parens_in_prefix_position() || self.should_print_verbose() {
+            return false;
+        }
+        match ty.kind() {
+            // RPITIT trait-side appears as `Projection`, not `Opaque`.
+            ty::Alias(ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => {
+                self.opaque_has_multiple_bounds(*def_id, args)
+            }
+            ty::Alias(ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
+                if self.tcx().is_impl_trait_in_trait(*def_id) =>
+            {
+                self.opaque_has_multiple_bounds(*def_id, args)
+            }
+            ty::Dynamic(predicates, region) => {
+                if self.should_print_optional_region(*region) {
+                    // `ty::Dynamic` self-wraps when it has an explicit region.
+                    false
+                } else {
+                    // Projections inline into the principal as `<Item = X>`;
+                    // only principal/auto traits produce a top-level `+`.
+                    predicates
+                        .iter()
+                        .filter(|pred| {
+                            matches!(
+                                pred.skip_binder(),
+                                ty::ExistentialPredicate::Trait(_)
+                                    | ty::ExistentialPredicate::AutoTrait(_)
+                            )
+                        })
+                        .count()
+                        > 1
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether `Alias(Opaque)` would print with more than one top-level
+    /// `+`-joined component. Must stay in sync with
+    /// `pretty_print_opaque_impl_type`'s sized-bound handling. `?Sized` and
+    /// the synthetic `Sized` / `?Sized` / `MetaSized` / `PointeeSized` suffix
+    /// each contribute one top-level joinable component. Regressions land in
+    /// `tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs`.
+    fn opaque_has_multiple_bounds(&self, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> bool {
+        let tcx = self.tcx();
+        let bounds = tcx.explicit_item_bounds(def_id);
+
+        // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
+        // positive `Sized` and `MetaSized` are absorbed into the synthetic
+        // suffix below; negative `Sized` (`?Sized`) falls through and is
+        // printed inline.
+        let mut trait_emits = 0usize;
+        let mut lifetimes_count = 0usize;
+        let mut has_sized_bound = false;
+        let mut has_negative_sized_bound = false;
+        let mut has_meta_sized_bound = false;
+
+        for (predicate, _) in
+            bounds.iter_instantiated_copied(tcx, args).map(Unnormalized::skip_norm_wip)
+        {
+            match predicate.kind().skip_binder() {
+                ty::ClauseKind::Trait(pred) => match tcx.as_lang_item(pred.def_id()) {
+                    Some(LangItem::Sized) => match pred.polarity {
+                        ty::PredicatePolarity::Positive => {
+                            has_sized_bound = true;
+                        }
+                        ty::PredicatePolarity::Negative => {
+                            has_negative_sized_bound = true;
+                            trait_emits += 1;
+                        }
+                    },
+                    Some(LangItem::MetaSized) => {
+                        has_meta_sized_bound = true;
+                    }
+                    Some(LangItem::PointeeSized) => {}
+                    _ => trait_emits += 1,
+                },
+                ty::ClauseKind::TypeOutlives(_) => lifetimes_count += 1,
+                _ => {}
+            }
+        }
+
+        // The synthetic suffix in `pretty_print_opaque_impl_type` emits at most
+        // one extra bound (`Sized` / `?Sized` / `MetaSized` / `PointeeSized`).
+        let using_sized_hierarchy = tcx.features().sized_hierarchy();
+        let add_sized = has_sized_bound && (trait_emits == 0 || has_negative_sized_bound);
+        let add_maybe_sized =
+            has_meta_sized_bound && !has_negative_sized_bound && !using_sized_hierarchy;
+        let has_pointee_sized =
+            !has_sized_bound && !has_meta_sized_bound && !has_negative_sized_bound;
+        let synthetic = add_sized
+            || add_maybe_sized
+            || (using_sized_hierarchy && (has_meta_sized_bound || has_pointee_sized));
+
+        trait_emits + lifetimes_count + usize::from(synthetic) > 1
     }
 
     fn pretty_print_opaque_impl_type(

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1100,53 +1100,91 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         let tcx = self.tcx();
         let bounds = tcx.explicit_item_bounds(def_id);
 
-        // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
-        // positive `Sized` and `MetaSized` are absorbed into the synthetic
-        // suffix below; negative `Sized` (`?Sized`) falls through and is
-        // printed inline. We only ever look at clause *kinds* here, so the
-        // identity-instantiated bounds carry all the information we need.
-        let mut trait_emits = 0usize;
-        let mut lifetimes_count = 0usize;
-        let mut has_sized_bound = false;
-        let mut has_negative_sized_bound = false;
-        let mut has_meta_sized_bound = false;
+        // Only the *number* of printed components matters here, and that is
+        // invariant under instantiation, so identity args are enough.
+        let collected = self.collect_opaque_bounds(
+            bounds
+                .iter_identity_copied()
+                .map(Unnormalized::skip_norm_wip)
+                .map(|(clause, _)| clause),
+        );
 
-        for (predicate, _) in bounds.iter_identity_copied().map(Unnormalized::skip_norm_wip) {
-            match predicate.kind().skip_binder() {
-                ty::ClauseKind::Trait(pred) => match tcx.as_lang_item(pred.def_id()) {
-                    Some(LangItem::Sized) => match pred.polarity {
-                        ty::ClausePolarity::Positive => {
-                            has_sized_bound = true;
+        collected.printed_component_count(tcx.features().sized_hierarchy()) > 1
+    }
+
+    /// Gather the `+`-joined components of an opaque type's item bounds, in the
+    /// order `pretty_print_opaque_impl_type` prints them.
+    fn collect_opaque_bounds(
+        &self,
+        clauses: impl Iterator<Item = ty::Clause<'tcx>>,
+    ) -> OpaqueBounds<'tcx> {
+        let tcx = self.tcx();
+
+        let mut collected = OpaqueBounds {
+            traits: FxIndexMap::default(),
+            fn_traits: FxIndexMap::default(),
+            lifetimes: SmallVec::new(),
+            has_sized_bound: false,
+            has_negative_sized_bound: false,
+            has_meta_sized_bound: false,
+        };
+
+        for predicate in clauses {
+            let bound_predicate = predicate.kind();
+
+            match bound_predicate.skip_binder() {
+                ty::ClauseKind::Trait(pred) => {
+                    // With `feature(sized_hierarchy)`, don't print `?Sized` as an alias for
+                    // `MetaSized`, and skip sizedness bounds to be added at the end.
+                    match tcx.as_lang_item(pred.def_id()) {
+                        Some(LangItem::Sized) => match pred.polarity {
+                            ty::ClausePolarity::Positive => {
+                                collected.has_sized_bound = true;
+                                continue;
+                            }
+                            ty::ClausePolarity::Negative => {
+                                collected.has_negative_sized_bound = true
+                            }
+                        },
+                        Some(LangItem::MetaSized) => {
+                            collected.has_meta_sized_bound = true;
+                            continue;
                         }
-                        ty::ClausePolarity::Negative => {
-                            has_negative_sized_bound = true;
-                            trait_emits += 1;
+                        Some(LangItem::PointeeSized) => {
+                            bug!("`PointeeSized` is removed during lowering");
                         }
-                    },
-                    Some(LangItem::MetaSized) => {
-                        has_meta_sized_bound = true;
+                        _ => (),
                     }
-                    Some(LangItem::PointeeSized) => {}
-                    _ => trait_emits += 1,
-                },
-                ty::ClauseKind::TypeOutlives(_) => lifetimes_count += 1,
+
+                    self.insert_trait_and_projection(
+                        bound_predicate.rebind(pred),
+                        None,
+                        &mut collected.traits,
+                        &mut collected.fn_traits,
+                    );
+                }
+                ty::ClauseKind::Projection(pred) => {
+                    let proj = bound_predicate.rebind(pred);
+                    let trait_ref = proj.map_bound(|proj| TraitClause {
+                        trait_ref: proj.projection_term.trait_ref(tcx),
+                        polarity: ty::ClausePolarity::Positive,
+                    });
+
+                    self.insert_trait_and_projection(
+                        trait_ref,
+                        Some((proj.item_def_id(), proj.term())),
+                        &mut collected.traits,
+                        &mut collected.fn_traits,
+                    );
+                }
+                ty::ClauseKind::TypeOutlives(outlives) => {
+                    collected.lifetimes.push(outlives.1);
+                }
                 _ => {}
             }
         }
 
-        // The synthetic suffix in `pretty_print_opaque_impl_type` emits at most
-        // one extra bound (`Sized` / `?Sized` / `MetaSized` / `PointeeSized`).
-        let using_sized_hierarchy = tcx.features().sized_hierarchy();
-        let add_sized = has_sized_bound && (trait_emits == 0 || has_negative_sized_bound);
-        let add_maybe_sized =
-            has_meta_sized_bound && !has_negative_sized_bound && !using_sized_hierarchy;
-        let has_pointee_sized =
-            !has_sized_bound && !has_meta_sized_bound && !has_negative_sized_bound;
-        let synthetic = add_sized
-            || add_maybe_sized
-            || (using_sized_hierarchy && (has_meta_sized_bound || has_pointee_sized));
-
-        trait_emits + lifetimes_count + usize::from(synthetic) > 1
+        collected
     }
 
     fn pretty_print_opaque_impl_type(
@@ -1160,68 +1198,19 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         // by looking up the projections associated with the def_id.
         let bounds = tcx.explicit_item_bounds(def_id);
 
-        let mut traits = FxIndexMap::default();
-        let mut fn_traits = FxIndexMap::default();
-        let mut lifetimes = SmallVec::<[ty::Region<'tcx>; 1]>::new();
-
-        let mut has_sized_bound = false;
-        let mut has_negative_sized_bound = false;
-        let mut has_meta_sized_bound = false;
-
-        for (predicate, _) in
-            bounds.iter_instantiated_copied(tcx, args).map(Unnormalized::skip_norm_wip)
-        {
-            let bound_predicate = predicate.kind();
-
-            match bound_predicate.skip_binder() {
-                ty::ClauseKind::Trait(pred) => {
-                    // With `feature(sized_hierarchy)`, don't print `?Sized` as an alias for
-                    // `MetaSized`, and skip sizedness bounds to be added at the end.
-                    match tcx.as_lang_item(pred.def_id()) {
-                        Some(LangItem::Sized) => match pred.polarity {
-                            ty::ClausePolarity::Positive => {
-                                has_sized_bound = true;
-                                continue;
-                            }
-                            ty::ClausePolarity::Negative => has_negative_sized_bound = true,
-                        },
-                        Some(LangItem::MetaSized) => {
-                            has_meta_sized_bound = true;
-                            continue;
-                        }
-                        Some(LangItem::PointeeSized) => {
-                            bug!("`PointeeSized` is removed during lowering");
-                        }
-                        _ => (),
-                    }
-
-                    self.insert_trait_and_projection(
-                        bound_predicate.rebind(pred),
-                        None,
-                        &mut traits,
-                        &mut fn_traits,
-                    );
-                }
-                ty::ClauseKind::Projection(pred) => {
-                    let proj = bound_predicate.rebind(pred);
-                    let trait_ref = proj.map_bound(|proj| TraitClause {
-                        trait_ref: proj.projection_term.trait_ref(tcx),
-                        polarity: ty::ClausePolarity::Positive,
-                    });
-
-                    self.insert_trait_and_projection(
-                        trait_ref,
-                        Some((proj.item_def_id(), proj.term())),
-                        &mut traits,
-                        &mut fn_traits,
-                    );
-                }
-                ty::ClauseKind::TypeOutlives(outlives) => {
-                    lifetimes.push(outlives.1);
-                }
-                _ => {}
-            }
-        }
+        let OpaqueBounds {
+            mut traits,
+            fn_traits,
+            lifetimes,
+            has_sized_bound,
+            has_negative_sized_bound,
+            has_meta_sized_bound,
+        } = self.collect_opaque_bounds(
+            bounds
+                .iter_instantiated_copied(tcx, args)
+                .map(Unnormalized::skip_norm_wip)
+                .map(|(clause, _)| clause),
+        );
 
         write!(self, "impl ")?;
 
@@ -1375,7 +1364,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// Insert the trait ref and optionally a projection type associated with it into either the
     /// traits map or fn_traits map, depending on if the trait is in the Fn* family of traits.
     fn insert_trait_and_projection(
-        &mut self,
+        &self,
         trait_pred: ty::PolyTraitClause<'tcx>,
         proj_ty: Option<(DefId, ty::Binder<'tcx, Term<'tcx>>)>,
         traits: &mut FxIndexMap<
@@ -3742,4 +3731,52 @@ pub fn provide(providers: &mut Providers) {
 pub struct OpaqueFnEntry<'tcx> {
     kind: ty::ClosureKind,
     return_ty: Option<ty::Binder<'tcx, Term<'tcx>>>,
+}
+
+/// The `+`-joined components of an `impl Trait`, gathered from its item bounds.
+///
+/// [`PrettyPrinter::pretty_print_opaque_impl_type`] renders these, and
+/// [`PrettyPrinter::opaque_has_multiple_bounds`] counts them to decide whether
+/// the opaque needs disambiguating parens. Both go through
+/// [`PrettyPrinter::collect_opaque_bounds`] so that the two never disagree.
+pub struct OpaqueBounds<'tcx> {
+    traits: FxIndexMap<ty::PolyTraitClause<'tcx>, FxIndexMap<DefId, ty::Binder<'tcx, Term<'tcx>>>>,
+    fn_traits: FxIndexMap<
+        (ty::Binder<'tcx, (&'tcx ty::List<Ty<'tcx>>, Ty<'tcx>)>, bool),
+        OpaqueFnEntry<'tcx>,
+    >,
+    lifetimes: SmallVec<[ty::Region<'tcx>; 1]>,
+    has_sized_bound: bool,
+    has_negative_sized_bound: bool,
+    has_meta_sized_bound: bool,
+}
+
+impl<'tcx> OpaqueBounds<'tcx> {
+    /// Whether the sizedness suffix adds a component of its own, mirroring the
+    /// tail of `pretty_print_opaque_impl_type`.
+    fn prints_sized_suffix(&self, using_sized_hierarchy: bool) -> bool {
+        let nothing_printed_yet = self.fn_traits.is_empty() && self.traits.is_empty();
+        let add_sized =
+            self.has_sized_bound && (nothing_printed_yet || self.has_negative_sized_bound);
+        let add_maybe_sized =
+            self.has_meta_sized_bound && !self.has_negative_sized_bound && !using_sized_hierarchy;
+        let has_pointee_sized_bound =
+            !self.has_sized_bound && !self.has_meta_sized_bound && !self.has_negative_sized_bound;
+
+        add_sized
+            || add_maybe_sized
+            || (using_sized_hierarchy && (self.has_meta_sized_bound || has_pointee_sized_bound))
+    }
+
+    /// How many `+`-joined components the opaque actually prints as. Lifetimes
+    /// are only rendered outside of forced-trimmed mode, so they only count
+    /// when they will be printed.
+    fn printed_component_count(&self, using_sized_hierarchy: bool) -> usize {
+        let lifetimes = if with_forced_trimmed_paths() { 0 } else { self.lifetimes.len() };
+
+        self.fn_traits.len()
+            + self.traits.len()
+            + lifetimes
+            + usize::from(self.prints_sized_suffix(using_sized_hierarchy))
+    }
 }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -359,6 +359,15 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// will always be printed.)
     fn should_print_optional_region(&self, region: ty::Region<'tcx>) -> bool;
 
+    /// Whether `pretty_print_type` should wrap a multi-bound `impl` / `dyn`
+    /// inner in parens after a prefix type constructor (`&`, `&mut`, `*const`,
+    /// `*mut`), so the output is `&(impl A + B)` rather than the parser-
+    /// ambiguous `&impl A + B`. Byte-stable printers (mangling, `type_name`)
+    /// override this to `false`.
+    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+        true
+    }
+
     fn reset_type_limit(&mut self) {}
 
     // Defaults (should not be overridden):
@@ -762,7 +771,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             ty::RawPtr(ty, mutbl) => {
                 write!(self, "*{} ", mutbl.ptr_str())?;
-                ty.print(self)?;
+                self.print_inner_with_disambiguating_parens(ty)?;
             }
             ty::Ref(r, ty, mutbl) => {
                 write!(self, "&")?;
@@ -770,7 +779,9 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     r.print(self)?;
                     write!(self, " ")?;
                 }
-                ty::TypeAndMut { ty, mutbl }.print(self)?;
+                // `&mut (impl A + B)`, not `&(mut impl A + B)`: emit `mut ` before the parens.
+                write!(self, "{}", mutbl.prefix_str())?;
+                self.print_inner_with_disambiguating_parens(ty)?;
             }
             ty::Never => write!(self, "!")?,
             ty::Tuple(tys) => {
@@ -1028,6 +1039,121 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         }
 
         Ok(())
+    }
+
+    /// Prints `ty` after a prefix type constructor, wrapping in parens iff
+    /// [`Self::inner_needs_disambiguating_parens`] returns `true`.
+    fn print_inner_with_disambiguating_parens(&mut self, ty: Ty<'tcx>) -> Result<(), PrintError> {
+        let need_paren = self.inner_needs_disambiguating_parens(ty);
+        if need_paren {
+            write!(self, "(")?;
+        }
+        ty.print(self)?;
+        if need_paren {
+            write!(self, ")")?;
+        }
+        Ok(())
+    }
+
+    /// Whether `ty`, sitting right after a prefix type constructor, would
+    /// print with a top-level `+`. Without the wrap, `&impl A + B` parses as
+    /// the ambiguous `(&impl A) + B`.
+    fn inner_needs_disambiguating_parens(&self, ty: Ty<'tcx>) -> bool {
+        if !self.add_disambiguating_parens_in_prefix_position() || self.should_print_verbose() {
+            return false;
+        }
+        match ty.kind() {
+            // RPITIT trait-side appears as `Projection`, not `Opaque`.
+            ty::Alias(_, ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => {
+                self.opaque_has_multiple_bounds(*def_id, args)
+            }
+            ty::Alias(_, ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
+                if self.tcx().is_impl_trait_in_trait(*def_id) =>
+            {
+                self.opaque_has_multiple_bounds(*def_id, args)
+            }
+            ty::Dynamic(predicates, region) => {
+                if self.should_print_optional_region(*region) {
+                    // `ty::Dynamic` self-wraps when it has an explicit region.
+                    false
+                } else {
+                    // Projections inline into the principal as `<Item = X>`;
+                    // only principal/auto traits produce a top-level `+`.
+                    predicates
+                        .iter()
+                        .filter(|pred| {
+                            matches!(
+                                pred.skip_binder(),
+                                ty::ExistentialPredicate::Trait(_)
+                                    | ty::ExistentialPredicate::AutoTrait(_)
+                            )
+                        })
+                        .count()
+                        > 1
+                }
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether `Alias(Opaque)` would print with more than one top-level
+    /// `+`-joined component. Must stay in sync with
+    /// `pretty_print_opaque_impl_type`'s sized-bound handling. `?Sized` and
+    /// the synthetic `Sized` / `?Sized` / `MetaSized` / `PointeeSized` suffix
+    /// each contribute one top-level joinable component. Regressions land in
+    /// `tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs`.
+    fn opaque_has_multiple_bounds(&self, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> bool {
+        let tcx = self.tcx();
+        let bounds = tcx.explicit_item_bounds(def_id);
+
+        // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
+        // positive `Sized` and `MetaSized` are absorbed into the synthetic
+        // suffix below; negative `Sized` (`?Sized`) falls through and is
+        // printed inline.
+        let mut trait_emits = 0usize;
+        let mut lifetimes_count = 0usize;
+        let mut has_sized_bound = false;
+        let mut has_negative_sized_bound = false;
+        let mut has_meta_sized_bound = false;
+
+        for (predicate, _) in
+            bounds.iter_instantiated_copied(tcx, args).map(Unnormalized::skip_norm_wip)
+        {
+            match predicate.kind().skip_binder() {
+                ty::ClauseKind::Trait(pred) => match tcx.as_lang_item(pred.def_id()) {
+                    Some(LangItem::Sized) => match pred.polarity {
+                        ty::ClausePolarity::Positive => {
+                            has_sized_bound = true;
+                        }
+                        ty::ClausePolarity::Negative => {
+                            has_negative_sized_bound = true;
+                            trait_emits += 1;
+                        }
+                    },
+                    Some(LangItem::MetaSized) => {
+                        has_meta_sized_bound = true;
+                    }
+                    Some(LangItem::PointeeSized) => {}
+                    _ => trait_emits += 1,
+                },
+                ty::ClauseKind::TypeOutlives(_) => lifetimes_count += 1,
+                _ => {}
+            }
+        }
+
+        // The synthetic suffix in `pretty_print_opaque_impl_type` emits at most
+        // one extra bound (`Sized` / `?Sized` / `MetaSized` / `PointeeSized`).
+        let using_sized_hierarchy = tcx.features().sized_hierarchy();
+        let add_sized = has_sized_bound && (trait_emits == 0 || has_negative_sized_bound);
+        let add_maybe_sized =
+            has_meta_sized_bound && !has_negative_sized_bound && !using_sized_hierarchy;
+        let has_pointee_sized =
+            !has_sized_bound && !has_meta_sized_bound && !has_negative_sized_bound;
+        let synthetic = add_sized
+            || add_maybe_sized
+            || (using_sized_hierarchy && (has_meta_sized_bound || has_pointee_sized));
+
+        trait_emits + lifetimes_count + usize::from(synthetic) > 1
     }
 
     fn pretty_print_opaque_impl_type(

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1064,13 +1064,13 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         }
         match ty.kind() {
             // RPITIT trait-side appears as `Projection`, not `Opaque`.
-            ty::Alias(_, ty::AliasTy { kind: ty::Opaque { def_id }, args, .. }) => {
-                self.opaque_has_multiple_bounds(*def_id, args)
+            ty::Alias(_, ty::AliasTy { kind: ty::Opaque { def_id }, .. }) => {
+                self.opaque_has_multiple_bounds(*def_id)
             }
-            ty::Alias(_, ty::AliasTy { kind: ty::Projection { def_id }, args, .. })
+            ty::Alias(_, ty::AliasTy { kind: ty::Projection { def_id }, .. })
                 if self.tcx().is_impl_trait_in_trait(*def_id) =>
             {
-                self.opaque_has_multiple_bounds(*def_id, args)
+                self.opaque_has_multiple_bounds(*def_id)
             }
             ty::Dynamic(predicates, region) => {
                 if self.should_print_optional_region(*region) {
@@ -1102,23 +1102,22 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// the synthetic `Sized` / `?Sized` / `MetaSized` / `PointeeSized` suffix
     /// each contribute one top-level joinable component. Regressions land in
     /// `tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs`.
-    fn opaque_has_multiple_bounds(&self, def_id: DefId, args: ty::GenericArgsRef<'tcx>) -> bool {
+    fn opaque_has_multiple_bounds(&self, def_id: DefId) -> bool {
         let tcx = self.tcx();
         let bounds = tcx.explicit_item_bounds(def_id);
 
         // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
         // positive `Sized` and `MetaSized` are absorbed into the synthetic
         // suffix below; negative `Sized` (`?Sized`) falls through and is
-        // printed inline.
+        // printed inline. Only clause *kinds* are inspected here, so the
+        // identity-instantiated bounds carry all the information we need.
         let mut trait_emits = 0usize;
         let mut lifetimes_count = 0usize;
         let mut has_sized_bound = false;
         let mut has_negative_sized_bound = false;
         let mut has_meta_sized_bound = false;
 
-        for (predicate, _) in
-            bounds.iter_instantiated_copied(tcx, args).map(Unnormalized::skip_norm_wip)
-        {
+        for (predicate, _) in bounds.iter_identity_copied().map(Unnormalized::skip_norm_wip) {
             match predicate.kind().skip_binder() {
                 ty::ClauseKind::Trait(pred) => match tcx.as_lang_item(pred.def_id()) {
                     Some(LangItem::Sized) => match pred.polarity {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -360,11 +360,13 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     fn should_print_optional_region(&self, region: ty::Region<'tcx>) -> bool;
 
     /// Whether `pretty_print_type` should wrap a multi-bound `impl` / `dyn`
-    /// inner in parens after a prefix type constructor (`&`, `&mut`, `*const`,
-    /// `*mut`), so the output is `&(impl A + B)` rather than the parser-
-    /// ambiguous `&impl A + B`. Byte-stable printers (mangling, `type_name`)
-    /// override this to `false`.
-    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+    /// inner in parens at positions where the bare form would be parser-
+    /// ambiguous: after a prefix type constructor (`&`, `&mut`, `*const`,
+    /// `*mut`) where `&T + B` parses as `(&T) + B`, and in the function-
+    /// pointer / `Fn(..) -> T` return position where `-> T + B` parses as
+    /// the outer signature picking up an extra bound. Byte-stable printers
+    /// (mangling, etc.) override this to `false`.
+    fn add_disambiguating_parens(&self) -> bool {
         true
     }
 
@@ -857,16 +859,11 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             ty::Adt(def, args) => self.print_def_path(def.did(), args)?,
             ty::Dynamic(data, r) => {
-                let print_r = self.should_print_optional_region(r);
-                if print_r {
-                    write!(self, "(")?;
-                }
                 write!(self, "dyn ")?;
                 data.print(self)?;
-                if print_r {
+                if self.should_print_optional_region(r) {
                     write!(self, " + ")?;
                     r.print(self)?;
-                    write!(self, ")")?;
                 }
             }
             ty::Foreign(def_id) => self.print_def_path(def_id, &[])?,
@@ -1059,7 +1056,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
     /// print with a top-level `+`. Without the wrap, `&impl A + B` parses as
     /// the ambiguous `(&impl A) + B`.
     fn inner_needs_disambiguating_parens(&self, ty: Ty<'tcx>) -> bool {
-        if !self.add_disambiguating_parens_in_prefix_position() || self.should_print_verbose() {
+        if !self.add_disambiguating_parens() || self.should_print_verbose() {
             return false;
         }
         match ty.kind() {
@@ -1073,24 +1070,21 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 self.opaque_has_multiple_bounds(*def_id)
             }
             ty::Dynamic(predicates, region) => {
-                if self.should_print_optional_region(*region) {
-                    // `ty::Dynamic` self-wraps when it has an explicit region.
-                    false
-                } else {
-                    // Projections inline into the principal as `<Item = X>`;
-                    // only principal/auto traits produce a top-level `+`.
-                    predicates
-                        .iter()
-                        .filter(|pred| {
-                            matches!(
-                                pred.skip_binder(),
-                                ty::ExistentialPredicate::Trait(_)
-                                    | ty::ExistentialPredicate::AutoTrait(_)
-                            )
-                        })
-                        .count()
-                        > 1
-                }
+                // Projections inline into the principal as `<Item = X>`;
+                // only principal/auto traits produce a top-level `+`. An
+                // explicit (printable) region adds one more `+`-joined part.
+                let trait_count = predicates
+                    .iter()
+                    .filter(|pred| {
+                        matches!(
+                            pred.skip_binder(),
+                            ty::ExistentialPredicate::Trait(_)
+                                | ty::ExistentialPredicate::AutoTrait(_)
+                        )
+                    })
+                    .count();
+                let region_count = usize::from(self.should_print_optional_region(*region));
+                trait_count + region_count > 1
             }
             _ => false,
         }
@@ -1109,7 +1103,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         // Mirror `pretty_print_opaque_impl_type`'s sized-bound handling:
         // positive `Sized` and `MetaSized` are absorbed into the synthetic
         // suffix below; negative `Sized` (`?Sized`) falls through and is
-        // printed inline. Only clause *kinds* are inspected here, so the
+        // printed inline. We only ever look at clause *kinds* here, so the
         // identity-instantiated bounds carry all the information we need.
         let mut trait_emits = 0usize;
         let mut lifetimes_count = 0usize;
@@ -1644,7 +1638,10 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
         write!(self, ")")?;
         if !output.is_unit() {
             write!(self, " -> ")?;
-            output.print(self)?;
+            // `Fn(..) -> X + B` parses as if `+ B` extended the outer signature,
+            // so wrap if `X` would print with `+`-joined bounds. Same machinery
+            // as the `&T`, `*const T`, `*mut T` prefix arms.
+            self.print_inner_with_disambiguating_parens(output)?;
         }
 
         Ok(())

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -479,7 +479,7 @@ impl<'tcx> PrettyPrinter<'tcx> for LegacySymbolMangler<'tcx> {
 
     // Mangled symbols are ABI-stable; don't pick up the default printer's
     // parser-disambiguating parens.
-    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+    fn add_disambiguating_parens(&self) -> bool {
         false
     }
 

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -477,6 +477,12 @@ impl<'tcx> PrettyPrinter<'tcx> for LegacySymbolMangler<'tcx> {
         false
     }
 
+    // Mangled symbols are ABI-stable; don't pick up the default printer's
+    // parser-disambiguating parens.
+    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+        false
+    }
+
     // Identical to `PrettyPrinter::comma_sep` except there is no space after each comma.
     fn comma_sep<T>(&mut self, mut elems: impl Iterator<Item = T>) -> Result<(), PrintError>
     where

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -489,7 +489,7 @@ impl<'tcx> PrettyPrinter<'tcx> for LegacySymbolMangler<'tcx> {
 
     // Mangled symbols are ABI-stable; don't pick up the default printer's
     // parser-disambiguating parens.
-    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+    fn add_disambiguating_parens(&self) -> bool {
         false
     }
 

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -487,6 +487,12 @@ impl<'tcx> PrettyPrinter<'tcx> for LegacySymbolMangler<'tcx> {
         false
     }
 
+    // Mangled symbols are ABI-stable; don't pick up the default printer's
+    // parser-disambiguating parens.
+    fn add_disambiguating_parens_in_prefix_position(&self) -> bool {
+        false
+    }
+
     // Identical to `PrettyPrinter::comma_sep` except there is no space after each comma.
     fn comma_sep<T>(&mut self, mut elems: impl Iterator<Item = T>) -> Result<(), PrintError>
     where

--- a/src/tools/clippy/tests/ui/crashes/ice-3969.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-3969.stderr
@@ -7,7 +7,7 @@ LL |     str: Sized;
    = note: `-D trivial-bounds` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(trivial_bounds)]`
 
-error: trait bound for<'a> Dst<(dyn A + 'a)>: std::marker::Sized does not depend on any type or lifetime parameters
+error: trait bound for<'a> Dst<dyn A + 'a>: std::marker::Sized does not depend on any type or lifetime parameters
   --> tests/ui/crashes/ice-3969.rs:25:30
    |
 LL |     for<'a> Dst<dyn A + 'a>: Sized,

--- a/src/tools/clippy/tests/ui/crashes/ice-3969.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-3969.stderr
@@ -7,7 +7,7 @@ LL |     str: Sized;
    = note: `-D trivial-bounds` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(trivial_bounds)]`
 
-error: trait bound for<'a> Dst<(dyn A + 'a)>: std::marker::Sized does not depend on any type or lifetime parameters
+error: trait bound for<'a> Dst<dyn A + 'a>: std::marker::Sized does not depend on any type or lifetime parameters
   --> tests/ui/crashes/ice-3969.rs:24:30
    |
 LL |     for<'a> Dst<dyn A + 'a>: Sized,

--- a/src/tools/miri/tests/fail/dyn-upcast-nop-wrong-trait.stderr
+++ b/src/tools/miri/tests/fail/dyn-upcast-nop-wrong-trait.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value of type *const dyn std::fmt::Debug + std::marker::Send + std::marker::Sync: wrong trait in wide pointer vtable: expected `std::fmt::Debug + std::marker::Send + std::marker::Sync`, but encountered `std::fmt::Display`
+error: Undefined Behavior: constructing invalid value of type *const (dyn std::fmt::Debug + std::marker::Send + std::marker::Sync): wrong trait in wide pointer vtable: expected `std::fmt::Debug + std::marker::Send + std::marker::Sync`, but encountered `std::fmt::Display`
   --> tests/fail/dyn-upcast-nop-wrong-trait.rs:LL:CC
    |
 LL |     let ptr: *const (dyn fmt::Debug + Send + Sync) = unsafe { std::mem::transmute(ptr) };

--- a/src/tools/miri/tests/fail/tail_calls/cc-mismatch.stderr
+++ b/src/tools/miri/tests/fail/tail_calls/cc-mismatch.stderr
@@ -13,13 +13,13 @@ LL |     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
            2: std::rt::lang_start::<()>::{closure#0}
                at RUSTLIB/std/src/rt.rs:LL:CC
-           3: std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
+           3: std::ops::function::impls::<impl std::ops::FnOnce<()> for &(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe)>::call_once
                at RUSTLIB/core/src/ops/function.rs:LL:CC
-           4: std::panicking::catch_unwind::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
+           4: std::panicking::catch_unwind::do_call::<&(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe), i32>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           5: std::panicking::catch_unwind::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
+           5: std::panicking::catch_unwind::<i32, &(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe)>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           6: std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
+           6: std::panic::catch_unwind::<&(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe), i32>
                at RUSTLIB/std/src/panic.rs:LL:CC
            7: std::rt::lang_start_internal::{closure#0}
                at RUSTLIB/std/src/rt.rs:LL:CC

--- a/src/tools/miri/tests/pass/backtrace/backtrace-global-alloc.stderr
+++ b/src/tools/miri/tests/pass/backtrace/backtrace-global-alloc.stderr
@@ -6,13 +6,13 @@
              at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
    3: std::rt::lang_start::<()>::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC
-   4: std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
+   4: std::ops::function::impls::<impl std::ops::FnOnce<()> for &(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe)>::call_once
              at RUSTLIB/core/src/ops/function.rs:LL:CC
-   5: std::panicking::catch_unwind::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
+   5: std::panicking::catch_unwind::do_call::<&(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe), i32>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-   6: std::panicking::catch_unwind::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
+   6: std::panicking::catch_unwind::<i32, &(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe)>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-   7: std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
+   7: std::panic::catch_unwind::<&(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe), i32>
              at RUSTLIB/std/src/panic.rs:LL:CC
    8: std::rt::lang_start_internal::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC

--- a/src/tools/miri/tests/pass/backtrace/backtrace-std.stderr
+++ b/src/tools/miri/tests/pass/backtrace/backtrace-std.stderr
@@ -14,13 +14,13 @@
              at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
    7: std::rt::lang_start::<()>::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC
-   8: std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
+   8: std::ops::function::impls::<impl std::ops::FnOnce<()> for &(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe)>::call_once
              at RUSTLIB/core/src/ops/function.rs:LL:CC
-   9: std::panicking::catch_unwind::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
+   9: std::panicking::catch_unwind::do_call::<&(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe), i32>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  10: std::panicking::catch_unwind::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
+  10: std::panicking::catch_unwind::<i32, &(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe)>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  11: std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
+  11: std::panic::catch_unwind::<&(dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe), i32>
              at RUSTLIB/std/src/panic.rs:LL:CC
   12: std::rt::lang_start_internal::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/ui/abi/invalid-self-parameter-type-56806.stderr
+++ b/tests/ui/abi/invalid-self-parameter-type-56806.stderr
@@ -1,4 +1,4 @@
-error[E0307]: invalid `self` parameter type: `Box<(dyn Trait + 'static)>`
+error[E0307]: invalid `self` parameter type: `Box<dyn Trait + 'static>`
   --> $DIR/invalid-self-parameter-type-56806.rs:3:34
    |
 LL |     fn dyn_instead_of_self(self: Box<dyn Trait>);

--- a/tests/ui/allocator/159445-unsize-pin-box.stderr
+++ b/tests/ui/allocator/159445-unsize-pin-box.stderr
@@ -23,7 +23,7 @@ help: the following other types implement trait `StaticAllocator`
    |
    = note: `std::alloc::Global`
    = note: required for `Box<i32, BadAlloc>` to implement `PinSafePointer`
-   = note: required for the cast from `Pin<Box<i32, BadAlloc>>` to `Pin<Box<(dyn Any + 'static), BadAlloc>>`
+   = note: required for the cast from `Pin<Box<i32, BadAlloc>>` to `Pin<Box<dyn Any + 'static, BadAlloc>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/display-is-suggestable.stderr
+++ b/tests/ui/argument-suggestions/display-is-suggestable.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/display-is-suggestable.rs:6:5
    |
 LL |     foo();
-   |     ^^^-- argument #1 of type `&dyn std::fmt::Display + Send` is missing
+   |     ^^^-- argument #1 of type `&(dyn std::fmt::Display + Send)` is missing
    |
 note: function defined here
   --> $DIR/display-is-suggestable.rs:3:4
@@ -11,8 +11,8 @@ LL | fn foo(x: &(dyn Display + Send)) {}
    |    ^^^ ------------------------
 help: provide the argument
    |
-LL |     foo(/* &dyn std::fmt::Display + Send */);
-   |         +++++++++++++++++++++++++++++++++++
+LL |     foo(/* &(dyn std::fmt::Display + Send) */);
+   |         +++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/display-is-suggestable.stderr
+++ b/tests/ui/argument-suggestions/display-is-suggestable.stderr
@@ -2,7 +2,7 @@ error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/display-is-suggestable.rs:6:5
    |
 LL |     foo();
-   |     ^^^-- argument #1 of type `&dyn std::fmt::Display + Send` is missing
+   |     ^^^-- argument #1 of type `&(dyn std::fmt::Display + Send)` is missing
    |
 note: function defined here
   --> $DIR/display-is-suggestable.rs:3:4
@@ -11,8 +11,8 @@ LL | fn foo(x: &(dyn Display + Send)) {}
    |    ^^^ ------------------------
 help: provide the argument
    |
-LL |     foo(/* &dyn Display + Send */);
-   |         +++++++++++++++++++++++++
+LL |     foo(/* &(dyn Display + Send) */);
+   |         +++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/dyn-impl-missing-assoc-type-ice-152668.rs
+++ b/tests/ui/associated-types/dyn-impl-missing-assoc-type-ice-152668.rs
@@ -6,12 +6,12 @@ use std::ops::Sub;
 trait Vector2 {}
 impl Sub for dyn Vector2 {
   //~^ ERROR not all trait items implemented, missing: `Output` [E0046]
-  //~| ERROR the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time [E0277]
+  //~| ERROR the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time [E0277]
     fn sub(self, rhs: Self) -> Self::Output {}
-    //~^ ERROR: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time [E0277]
-    //~| ERROR: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time [E0277]
-    //~| ERROR: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time [E0277]
-    //~| ERROR: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time [E0277]
+    //~^ ERROR: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time [E0277]
+    //~| ERROR: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time [E0277]
+    //~| ERROR: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time [E0277]
+    //~| ERROR: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time [E0277]
     //~| ERROR: mismatched types [E0308]
 }
 

--- a/tests/ui/associated-types/dyn-impl-missing-assoc-type-ice-152668.stderr
+++ b/tests/ui/associated-types/dyn-impl-missing-assoc-type-ice-152668.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time
   --> $DIR/dyn-impl-missing-assoc-type-ice-152668.rs:10:5
    |
 LL |     fn sub(self, rhs: Self) -> Self::Output {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Vector2 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Vector2 + 'static`
 note: required by an implicit `Sized` bound in `Sub`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -16,23 +16,23 @@ LL | impl Sub for dyn Vector2 {
    |
    = help: implement the missing item: `type Output = /* Type */;`
 
-error[E0277]: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time
   --> $DIR/dyn-impl-missing-assoc-type-ice-152668.rs:7:14
    |
 LL | impl Sub for dyn Vector2 {
    |              ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Vector2 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Vector2 + 'static`
 note: required by an implicit `Sized` bound in `Sub`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
-error[E0277]: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time
   --> $DIR/dyn-impl-missing-assoc-type-ice-152668.rs:10:32
    |
 LL |     fn sub(self, rhs: Self) -> Self::Output {}
    |                                ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Vector2 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Vector2 + 'static`
 note: required by an implicit `Sized` bound in `Sub`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 
@@ -44,31 +44,31 @@ LL |     fn sub(self, rhs: Self) -> Self::Output {}
    |        |
    |        implicitly returns `()` as its body has no tail or `return` expression
    |
-   = note: expected associated type `<(dyn Vector2 + 'static) as Sub>::Output`
+   = note: expected associated type `<dyn Vector2 + 'static as Sub>::Output`
                     found unit type `()`
-   = help: consider constraining the associated type `<(dyn Vector2 + 'static) as Sub>::Output` to `()` or calling a method that returns `<(dyn Vector2 + 'static) as Sub>::Output`
+   = help: consider constraining the associated type `<dyn Vector2 + 'static as Sub>::Output` to `()` or calling a method that returns `<dyn Vector2 + 'static as Sub>::Output`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
-error[E0277]: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time
   --> $DIR/dyn-impl-missing-assoc-type-ice-152668.rs:10:12
    |
 LL |     fn sub(self, rhs: Self) -> Self::Output {}
    |            ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Vector2 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Vector2 + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL |     fn sub(&self, rhs: Self) -> Self::Output {}
    |            +
 
-error[E0277]: the size for values of type `(dyn Vector2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Vector2 + 'static` cannot be known at compilation time
   --> $DIR/dyn-impl-missing-assoc-type-ice-152668.rs:10:23
    |
 LL |     fn sub(self, rhs: Self) -> Self::Output {}
    |                       ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Vector2 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Vector2 + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/associated-types/issue-43924.stderr
+++ b/tests/ui/associated-types/issue-43924.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `(dyn ToString + 'static): Default` is not satisfied
+error[E0277]: the trait bound `dyn ToString + 'static: Default` is not satisfied
   --> $DIR/issue-43924.rs:8:45
    |
 LL |     type Out: Default + ToString + ?Sized = dyn ToString;
-   |                                             ^^^^^^^^^^^^ the trait `Default` is not implemented for `(dyn ToString + 'static)`
+   |                                             ^^^^^^^^^^^^ the trait `Default` is not implemented for `dyn ToString + 'static`
    |
 note: required by a bound in `Foo::Out`
   --> $DIR/issue-43924.rs:8:15
@@ -10,11 +10,11 @@ note: required by a bound in `Foo::Out`
 LL |     type Out: Default + ToString + ?Sized = dyn ToString;
    |               ^^^^^^^ required by this bound in `Foo::Out`
 
-error[E0599]: no associated function or constant named `default` found for trait object `(dyn ToString + 'static)` in the current scope
+error[E0599]: no associated function or constant named `default` found for trait object `dyn ToString + 'static` in the current scope
   --> $DIR/issue-43924.rs:15:39
    |
 LL |     assert_eq!(<() as Foo<u32>>::Out::default().to_string(), "false");
-   |                                       ^^^^^^^ associated function or constant not found in `(dyn ToString + 'static)`
+   |                                       ^^^^^^^ associated function or constant not found in `dyn ToString + 'static`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -83,13 +83,13 @@ LL | pub trait Foo: NotFoo {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn ThriftService<(), AssocType = _> + 'static` cannot be known at compilation time
   --> $DIR/issue-59324.rs:24:29
    |
 LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn ThriftService<(), AssocType = _> + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn ThriftService<(), AssocType = _> + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -61,13 +61,13 @@ LL | pub trait Foo: NotFoo {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn ThriftService<(), AssocType = _> + 'static` cannot be known at compilation time
   --> $DIR/issue-59324.rs:22:29
    |
 LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
    |                             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn ThriftService<(), AssocType = _> + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn ThriftService<(), AssocType = _> + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/associated-types/projection-dyn-associated-type.rs
+++ b/tests/ui/associated-types/projection-dyn-associated-type.rs
@@ -21,8 +21,8 @@ impl<T: ?Sized> Mirror for A {
 pub fn foo<'a>(
     x: &'a <dyn A + 'static as Mirror>::Assoc
 ) -> &'a <dyn B + 'static as Mirror>::Assoc {
-    //~^ ERROR the trait bound `(dyn B + 'static): Mirror` is not satisfied [E0277]
-    //~| ERROR the trait bound `(dyn B + 'static): Mirror` is not satisfied [E0277]
+    //~^ ERROR the trait bound `dyn B + 'static: Mirror` is not satisfied [E0277]
+    //~| ERROR the trait bound `dyn B + 'static: Mirror` is not satisfied [E0277]
     static
 } //~ ERROR expected identifier, found `}`
 

--- a/tests/ui/associated-types/projection-dyn-associated-type.stderr
+++ b/tests/ui/associated-types/projection-dyn-associated-type.stderr
@@ -29,11 +29,11 @@ error[E0207]: the type parameter `T` is not constrained by the impl trait, self 
 LL | impl<T: ?Sized> Mirror for A {
    |      ^ unconstrained type parameter
 
-error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
+error[E0277]: the trait bound `dyn B + 'static: Mirror` is not satisfied
   --> $DIR/projection-dyn-associated-type.rs:23:6
    |
 LL | ) -> &'a <dyn B + 'static as Mirror>::Assoc {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `(dyn B + 'static)`
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `dyn B + 'static`
    |
 help: the trait `Mirror` is implemented for `dyn A`
   --> $DIR/projection-dyn-associated-type.rs:14:1
@@ -41,11 +41,11 @@ help: the trait `Mirror` is implemented for `dyn A`
 LL | impl<T: ?Sized> Mirror for A {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `(dyn B + 'static): Mirror` is not satisfied
+error[E0277]: the trait bound `dyn B + 'static: Mirror` is not satisfied
   --> $DIR/projection-dyn-associated-type.rs:23:6
    |
 LL | ) -> &'a <dyn B + 'static as Mirror>::Assoc {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `(dyn B + 'static)`
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Mirror` is not implemented for `dyn B + 'static`
    |
 help: the trait `Mirror` is implemented for `dyn A`
   --> $DIR/projection-dyn-associated-type.rs:14:1

--- a/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `#[target_features] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn()` is not satisfied
+error[E0277]: the trait bound `#[target_features] fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {target_feature}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception-target-features.rs:15:10
    |
 LL |     test(target_feature);
@@ -6,7 +6,7 @@ LL |     test(target_feature);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_features] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
+   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_features] fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {target_feature}`
 note: required by a bound in `test`
   --> $DIR/fn-exception-target-features.rs:12:17
    |

--- a/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `#[target_feature(..)] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn()` is not satisfied
+error[E0277]: the trait bound `#[target_feature(..)] fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {target_feature}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception-target-features.rs:15:10
    |
 LL |     test(target_feature);
@@ -6,7 +6,7 @@ LL |     test(target_feature);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_feature(..)] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
+   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_feature(..)] fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {target_feature}`
 note: required by a bound in `test`
   --> $DIR/fn-exception-target-features.rs:12:17
    |

--- a/tests/ui/async-await/async-closures/fn-exception.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `unsafe fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {unsafety}: AsyncFn()` is not satisfied
+error[E0277]: the trait bound `unsafe fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {unsafety}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception.rs:17:10
    |
 LL |     test(unsafety);
-   |     ---- ^^^^^^^^ the trait `AsyncFn()` is not implemented for fn item `unsafe fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {unsafety}`
+   |     ---- ^^^^^^^^ the trait `AsyncFn()` is not implemented for fn item `unsafe fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {unsafety}`
    |     |
    |     required by a bound introduced by this call
    |
@@ -12,11 +12,11 @@ note: required by a bound in `test`
 LL | fn test(f: impl AsyncFn()) {}
    |                 ^^^^^^^^^ required by this bound in `test`
 
-error[E0277]: the trait bound `extern "C" fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {abi}: AsyncFn()` is not satisfied
+error[E0277]: the trait bound `extern "C" fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {abi}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception.rs:18:10
    |
 LL |     test(abi);
-   |     ---- ^^^ the trait `AsyncFn()` is not implemented for fn item `extern "C" fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {abi}`
+   |     ---- ^^^ the trait `AsyncFn()` is not implemented for fn item `extern "C" fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> {abi}`
    |     |
    |     required by a bound introduced by this call
    |

--- a/tests/ui/async-await/higher-ranked-auto-trait-12.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-12.no_assumptions.stderr
@@ -11,8 +11,8 @@ LL | |         yield_now().await;
 LL | |     });
    | |______^ implementation of `Robot` is not general enough
    |
-   = note: `Box<(dyn Robot<Id = u32> + Send + '0)>` must implement `Robot`, for any lifetime `'0`...
-   = note: ...but `Robot` is actually implemented for the type `Box<(dyn Robot<Id = u32> + Send + 'static)>`
+   = note: `Box<dyn Robot<Id = u32> + Send + '0>` must implement `Robot`, for any lifetime `'0`...
+   = note: ...but `Robot` is actually implemented for the type `Box<dyn Robot<Id = u32> + Send + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/higher-ranked-auto-trait-9.no_assumptions.stderr
+++ b/tests/ui/async-await/higher-ranked-auto-trait-9.no_assumptions.stderr
@@ -4,8 +4,8 @@ error: implementation of `Debug` is not general enough
 LL |     let fut: &(dyn Future<Output = ()> + Send) = &fut as _;
    |                                                  ^^^^^^^^^ implementation of `Debug` is not general enough
    |
-   = note: `(dyn Any + '0)` must implement `Debug`, for any lifetime `'0`...
-   = note: ...but `Debug` is actually implemented for the type `(dyn Any + 'static)`
+   = note: `dyn Any + '0` must implement `Debug`, for any lifetime `'0`...
+   = note: ...but `Debug` is actually implemented for the type `dyn Any + 'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/unconstrained-closure-lifetime-generic.stderr
+++ b/tests/ui/borrowck/unconstrained-closure-lifetime-generic.stderr
@@ -111,7 +111,7 @@ LL |         self.bar = Box::new(|baz| Box::new(f(baz)));
 LL |     }
    |     - `f` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn for<'a> Fn(&'a usize) -> Box<(dyn Any + 'a)>>` actually means `Box<(dyn for<'a> Fn(&'a usize) -> Box<(dyn Any + 'a)> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn for<'a> Fn(&'a usize) -> Box<dyn Any + 'a>>` actually means `Box<dyn for<'a> Fn(&'a usize) -> Box<dyn Any + 'a> + 'static>`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/cast/casts-differing-anon.stderr
+++ b/tests/ui/cast/casts-differing-anon.stderr
@@ -1,4 +1,4 @@
-error[E0606]: casting `*mut impl Debug + ?Sized` as `*mut impl Debug + ?Sized` is invalid
+error[E0606]: casting `*mut (impl Debug + ?Sized)` as `*mut (impl Debug + ?Sized)` is invalid
   --> $DIR/casts-differing-anon.rs:21:13
    |
 LL |     b_raw = f_raw as *mut _;

--- a/tests/ui/cast/ptr-to-ptr-indirect-different-regions.stderr
+++ b/tests/ui/cast/ptr-to-ptr-indirect-different-regions.stderr
@@ -24,7 +24,7 @@ LL + fn bar<'a>(a: *mut MyWrap<(dyn Trait + 'a)>) -> *mut MyWrap<(dyn Trait + 'a
 help: alternatively, add an explicit `'static` bound to this reference
    |
 LL - fn bar<'a>(a: *mut MyWrap<(dyn Trait + 'a)>) -> *mut MyWrap<(dyn Trait + 'static)> {
-LL + fn bar<'a>(a: *mut MyWrap<(dyn Trait + 'static)>) -> *mut MyWrap<(dyn Trait + 'static)> {
+LL + fn bar<'a>(a: *mut MyWrap<dyn Trait + 'static>) -> *mut MyWrap<(dyn Trait + 'static)> {
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/cast/ptr-to-ptr-principalless.rs
+++ b/tests/ui/cast/ptr-to-ptr-principalless.rs
@@ -61,14 +61,14 @@ fn unprincipled3_static<'a>(x: *mut (dyn Trait + Send + 'a)) -> *mut (dyn Send +
 
 fn unprincipled_wrap3<'a, 'b>(x: *mut (dyn Trait + Send + 'a)) -> *mut Wrapper<dyn Send + 'b> {
     x as _
-    //~^ ERROR: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<(dyn Send + 'b)>` is invalid
+    //~^ ERROR: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<dyn Send + 'b>` is invalid
 }
 
 fn unprincipled_wrap3_static<'a>(
     x: *mut (dyn Trait + Send + 'a)
 ) -> *mut Wrapper<dyn Send + 'static> {
     x as _
-    //~^ ERROR: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<(dyn Send + 'static)>` is invalid
+    //~^ ERROR: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<dyn Send + 'static>` is invalid
 }
 
 fn main() {}

--- a/tests/ui/cast/ptr-to-ptr-principalless.stderr
+++ b/tests/ui/cast/ptr-to-ptr-principalless.stderr
@@ -1,4 +1,4 @@
-error[E0606]: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<(dyn Send + 'b)>` is invalid
+error[E0606]: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<dyn Send + 'b>` is invalid
   --> $DIR/ptr-to-ptr-principalless.rs:63:5
    |
 LL |     x as _
@@ -6,7 +6,7 @@ LL |     x as _
    |
    = note: the trait objects may have different vtables
 
-error[E0606]: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<(dyn Send + 'static)>` is invalid
+error[E0606]: casting `*mut (dyn Trait + Send + 'a)` as `*mut Wrapper<dyn Send + 'static>` is invalid
   --> $DIR/ptr-to-ptr-principalless.rs:70:5
    |
 LL |     x as _

--- a/tests/ui/checked-type-alias/auto-trait-impls.rs
+++ b/tests/ui/checked-type-alias/auto-trait-impls.rs
@@ -48,6 +48,6 @@ unsafe impl Send for ToRef {}
 // An alias expanding to a trait object is still rejected for the local auto trait.
 type ToDyn = dyn Send;
 impl Marker for ToDyn {}
-//~^ ERROR traits with a default impl, like `Marker`, cannot be implemented for trait object `(dyn Send + 'static)`
+//~^ ERROR traits with a default impl, like `Marker`, cannot be implemented for trait object `dyn Send + 'static`
 
 fn main() {}

--- a/tests/ui/checked-type-alias/auto-trait-impls.stderr
+++ b/tests/ui/checked-type-alias/auto-trait-impls.stderr
@@ -1,4 +1,4 @@
-error[E0321]: traits with a default impl, like `Marker`, cannot be implemented for trait object `(dyn Send + 'static)`
+error[E0321]: traits with a default impl, like `Marker`, cannot be implemented for trait object `dyn Send + 'static`
   --> $DIR/auto-trait-impls.rs:50:1
    |
 LL | impl Marker for ToDyn {}

--- a/tests/ui/closure_context/issue-26046-fn-mut.stderr
+++ b/tests/ui/closure_context/issue-26046-fn-mut.stderr
@@ -9,7 +9,7 @@ LL |         num += 1;
 LL |     Box::new(closure)
    |     ----------------- the requirement to implement `Fn` derives from here
    |
-   = note: required for the cast from `Box<{closure@$DIR/issue-26046-fn-mut.rs:4:19: 4:21}>` to `Box<(dyn Fn() + 'static)>`
+   = note: required for the cast from `Box<{closure@$DIR/issue-26046-fn-mut.rs:4:19: 4:21}>` to `Box<dyn Fn() + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closure_context/issue-26046-fn-once.stderr
+++ b/tests/ui/closure_context/issue-26046-fn-once.stderr
@@ -9,7 +9,7 @@ LL |         vec
 LL |     Box::new(closure)
    |     ----------------- the requirement to implement `Fn` derives from here
    |
-   = note: required for the cast from `Box<{closure@$DIR/issue-26046-fn-once.rs:4:19: 4:26}>` to `Box<(dyn Fn() -> Vec<u8> + 'static)>`
+   = note: required for the cast from `Box<{closure@$DIR/issue-26046-fn-once.rs:4:19: 4:26}>` to `Box<dyn Fn() -> Vec<u8> + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/capture-unsized-by-move.rs
+++ b/tests/ui/closures/capture-unsized-by-move.rs
@@ -5,6 +5,6 @@
 pub fn f(k: dyn std::fmt::Display) {
     let k2 = move || {
         k.to_string();
-        //~^ ERROR the size for values of type `(dyn std::fmt::Display + 'static)` cannot be known at compilation time
+        //~^ ERROR the size for values of type `dyn std::fmt::Display + 'static` cannot be known at compilation time
     };
 }

--- a/tests/ui/closures/capture-unsized-by-move.stderr
+++ b/tests/ui/closures/capture-unsized-by-move.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the size for values of type `(dyn std::fmt::Display + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn std::fmt::Display + 'static` cannot be known at compilation time
   --> $DIR/capture-unsized-by-move.rs:7:9
    |
 LL |     let k2 = move || {
@@ -6,7 +6,7 @@ LL |     let k2 = move || {
 LL |         k.to_string();
    |         ^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn std::fmt::Display + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn std::fmt::Display + 'static`
    = note: all values captured by value by a closure must have a statically known size
 
 error: aborting due to 1 previous error

--- a/tests/ui/closures/closure-arg-borrow-ice-issue-152331.stderr
+++ b/tests/ui/closures/closure-arg-borrow-ice-issue-152331.stderr
@@ -7,7 +7,7 @@ LL |     h2(|_: (), _: (), _: (), x: &_| {});
    |     |  found signature defined here
    |     expected due to this
    |
-   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
+   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<dyn for<'a> Fn(&'a ()) + 'static>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
               found closure signature `fn((), (), (), &_) -> _`
 note: required by a bound in `h2`
   --> $DIR/closure-arg-borrow-ice-issue-152331.rs:8:8

--- a/tests/ui/closures/issue-111932.stderr
+++ b/tests/ui/closures/issue-111932.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/issue-111932.rs:4:20
    |
 LL |     foos.for_each(|foo| {
    |                    ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = note: all function arguments must have a statically known size
    = help: unsized fn params are gated as an unstable feature
 

--- a/tests/ui/coercion/coerce-issue-49593-box-never.e2021.stderr
+++ b/tests/ui/coercion/coerce-issue-49593-box-never.e2021.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `(): std::error::Error` is not satisfied
 LL |     Box::new(x)
    |     ^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `()`
    |
-   = note: required for the cast from `Box<()>` to `Box<(dyn std::error::Error + 'static)>`
+   = note: required for the cast from `Box<()>` to `Box<dyn std::error::Error + 'static>`
 
 error[E0277]: the trait bound `(): std::error::Error` is not satisfied
   --> $DIR/coerce-issue-49593-box-never.rs:33:5

--- a/tests/ui/coercion/pin-dyn-dispatch-sound.stderr
+++ b/tests/ui/coercion/pin-dyn-dispatch-sound.stderr
@@ -1,4 +1,4 @@
-error[E0321]: cross-crate traits with a default impl, like `Unpin`, can only be implemented for a struct/enum type, not `(dyn MyUnpinTrait + 'static)`
+error[E0321]: cross-crate traits with a default impl, like `Unpin`, can only be implemented for a struct/enum type, not `dyn MyUnpinTrait + 'static`
   --> $DIR/pin-dyn-dispatch-sound.rs:12:1
    |
 LL | impl Unpin for dyn MyUnpinTrait {}

--- a/tests/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
@@ -1,4 +1,4 @@
-error[E0321]: traits with a default impl, like `Marker1`, cannot be implemented for trait object `(dyn Object + Marker2 + 'static)`
+error[E0321]: traits with a default impl, like `Marker1`, cannot be implemented for trait object `dyn Object + Marker2 + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:15:1
    |
 LL | impl !Marker1 for dyn Object + Marker2 {}
@@ -6,13 +6,13 @@ LL | impl !Marker1 for dyn Object + Marker2 {}
    |
    = note: a trait object implements `Marker1` if and only if `Marker1` is one of the trait object's trait bounds
 
-error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker1`
+error[E0371]: the object type `dyn Object + Marker2 + 'static` automatically implements the trait `Marker1`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:15:1
    |
 LL | impl !Marker1 for dyn Object + Marker2 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker1`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Object + Marker2 + 'static` automatically implements trait `Marker1`
 
-error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `(dyn Object + Marker2 + 'static)`
+error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `dyn Object + Marker2 + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:18:1
    |
 LL | impl !Marker2 for dyn Object + Marker2 {}
@@ -20,13 +20,13 @@ LL | impl !Marker2 for dyn Object + Marker2 {}
    |
    = note: a trait object implements `Marker2` if and only if `Marker2` is one of the trait object's trait bounds
 
-error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker2`
+error[E0371]: the object type `dyn Object + Marker2 + 'static` automatically implements the trait `Marker2`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:18:1
    |
 LL | impl !Marker2 for dyn Object + Marker2 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker2`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Object + Marker2 + 'static` automatically implements trait `Marker2`
 
-error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `(dyn Object + 'static)`
+error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `dyn Object + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:26:1
    |
 LL | impl !Marker2 for dyn Object {}
@@ -46,13 +46,13 @@ LL | impl !Send for dyn Marker2 {}
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
    = note: define and implement a trait or new type instead
 
-error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`
+error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `dyn Object + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:27:1
    |
 LL | impl !Send for dyn Object {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
 
-error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `(dyn Object + Marker2 + 'static)`
+error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `dyn Object + Marker2 + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:28:1
    |
 LL | impl !Send for dyn Object + Marker2 {}

--- a/tests/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
@@ -1,10 +1,10 @@
-error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker1`
+error[E0371]: the object type `dyn Object + Marker2 + 'static` automatically implements the trait `Marker1`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:15:1
    |
 LL | impl Marker1 for dyn Object + Marker2 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker1`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Object + Marker2 + 'static` automatically implements trait `Marker1`
 
-error[E0321]: traits with a default impl, like `Marker1`, cannot be implemented for trait object `(dyn Object + Marker2 + 'static)`
+error[E0321]: traits with a default impl, like `Marker1`, cannot be implemented for trait object `dyn Object + Marker2 + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:15:1
    |
 LL | impl Marker1 for dyn Object + Marker2 {}
@@ -12,13 +12,13 @@ LL | impl Marker1 for dyn Object + Marker2 {}
    |
    = note: a trait object implements `Marker1` if and only if `Marker1` is one of the trait object's trait bounds
 
-error[E0371]: the object type `(dyn Object + Marker2 + 'static)` automatically implements the trait `Marker2`
+error[E0371]: the object type `dyn Object + Marker2 + 'static` automatically implements the trait `Marker2`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:18:1
    |
 LL | impl Marker2 for dyn Object + Marker2 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Object + Marker2 + 'static)` automatically implements trait `Marker2`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Object + Marker2 + 'static` automatically implements trait `Marker2`
 
-error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `(dyn Object + Marker2 + 'static)`
+error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `dyn Object + Marker2 + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:18:1
    |
 LL | impl Marker2 for dyn Object + Marker2 {}
@@ -26,7 +26,7 @@ LL | impl Marker2 for dyn Object + Marker2 {}
    |
    = note: a trait object implements `Marker2` if and only if `Marker2` is one of the trait object's trait bounds
 
-error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `(dyn Object + 'static)`
+error[E0321]: traits with a default impl, like `Marker2`, cannot be implemented for trait object `dyn Object + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:26:1
    |
 LL | impl Marker2 for dyn Object {}
@@ -46,13 +46,13 @@ LL | unsafe impl Send for dyn Marker2 {}
    = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
    = note: define and implement a trait or new type instead
 
-error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`
+error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `dyn Object + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:27:1
    |
 LL | unsafe impl Send for dyn Object {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't implement cross-crate trait with a default impl for non-struct/enum type
 
-error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `(dyn Object + Marker2 + 'static)`
+error[E0321]: cross-crate traits with a default impl, like `Send`, can only be implemented for a struct/enum type, not `dyn Object + Marker2 + 'static`
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:28:1
    |
 LL | unsafe impl Send for dyn Object + Marker2 {}

--- a/tests/ui/coherence/coherence-impl-trait-for-trait.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-trait.stderr
@@ -1,20 +1,20 @@
-error[E0371]: the object type `(dyn Baz + 'static)` automatically implements the trait `Foo`
+error[E0371]: the object type `dyn Baz + 'static` automatically implements the trait `Foo`
   --> $DIR/coherence-impl-trait-for-trait.rs:9:1
    |
 LL | impl Foo for dyn Baz { }
-   | ^^^^^^^^^^^^^^^^^^^^ `(dyn Baz + 'static)` automatically implements trait `Foo`
+   | ^^^^^^^^^^^^^^^^^^^^ `dyn Baz + 'static` automatically implements trait `Foo`
 
-error[E0371]: the object type `(dyn Baz + 'static)` automatically implements the trait `Bar`
+error[E0371]: the object type `dyn Baz + 'static` automatically implements the trait `Bar`
   --> $DIR/coherence-impl-trait-for-trait.rs:11:1
    |
 LL | impl Bar for dyn Baz { }
-   | ^^^^^^^^^^^^^^^^^^^^ `(dyn Baz + 'static)` automatically implements trait `Bar`
+   | ^^^^^^^^^^^^^^^^^^^^ `dyn Baz + 'static` automatically implements trait `Bar`
 
-error[E0371]: the object type `(dyn Baz + 'static)` automatically implements the trait `Baz`
+error[E0371]: the object type `dyn Baz + 'static` automatically implements the trait `Baz`
   --> $DIR/coherence-impl-trait-for-trait.rs:13:1
    |
 LL | impl Baz for dyn Baz { }
-   | ^^^^^^^^^^^^^^^^^^^^ `(dyn Baz + 'static)` automatically implements trait `Baz`
+   | ^^^^^^^^^^^^^^^^^^^^ `dyn Baz + 'static` automatically implements trait `Baz`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:20:12
    |
@@ -29,23 +29,23 @@ LL |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ----------------------------------------- this field does not implement `ConstParamTy_`
    |
-note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` requires that `(dyn Debug + 'static): ConstParamTy_`
+note: the `ConstParamTy_` impl for `&'static Bar<dyn Debug + 'static>` requires that `dyn Debug + 'static: ConstParamTy_`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` requires that `(dyn Debug + 'static): Eq`
+note: the `ConstParamTy_` impl for `&'static Bar<dyn Debug + 'static>` requires that `dyn Debug + 'static: Eq`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` requires that `(dyn Debug + 'static): Sized`
+note: the `ConstParamTy_` impl for `&'static Bar<dyn Debug + 'static>` requires that `dyn Debug + 'static: Sized`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:5
    |
 LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
@@ -54,13 +54,13 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 help: the trait `Debug` is implemented for `Bar<T>`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:19:10
    |
 LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
    |          ^^^^^
-note: required for `Bar<(dyn Debug + 'static)>` to implement `Debug`
+note: required for `Bar<dyn Debug + 'static>` to implement `Debug`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:20:8
    |
 LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
@@ -69,8 +69,8 @@ LL | struct Bar<T>(T);
    |        ^^^ - unsatisfied trait bound
    = help: consider manually implementing `Debug` to avoid undesired bounds
    = note: 2 redundant requirements hidden
-   = note: required for `&&'static Bar<(dyn Debug + 'static)>` to implement `Debug`
-   = note: required for the cast from `&&&'static Bar<(dyn Debug + 'static)>` to `&dyn Debug`
+   = note: required for `&&'static Bar<dyn Debug + 'static>` to implement `Debug`
+   = note: required for the cast from `&&&'static Bar<dyn Debug + 'static>` to `&dyn Debug`
 
 error[E0369]: binary operation `==` cannot be applied to type `&Bar<dyn Debug>`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:5
@@ -131,13 +131,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:25:33
    |
 LL |     let x: Test<{ Foo { nested: &Bar(4) } }> = Test;
    |                                 ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:20:12
    |

--- a/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:20:12
    |
@@ -29,23 +29,23 @@ LL |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ----------------------------------------- this field does not implement `ConstParamTy_`
    |
-note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` requires that `(dyn Debug + 'static): ConstParamTy_`
+note: the `ConstParamTy_` impl for `&'static Bar<dyn Debug + 'static>` requires that `dyn Debug + 'static: ConstParamTy_`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` requires that `(dyn Debug + 'static): Eq`
+note: the `ConstParamTy_` impl for `&'static Bar<dyn Debug + 'static>` requires that `dyn Debug + 'static: Eq`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` requires that `(dyn Debug + 'static): Sized`
+note: the `ConstParamTy_` impl for `&'static Bar<dyn Debug + 'static>` requires that `dyn Debug + 'static: Sized`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:5
    |
 LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
@@ -54,13 +54,13 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 help: the trait `Debug` is implemented for `Bar<T>`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:19:10
    |
 LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
    |          ^^^^^
-note: required for `Bar<(dyn Debug + 'static)>` to implement `Debug`
+note: required for `Bar<dyn Debug + 'static>` to implement `Debug`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:20:8
    |
 LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
@@ -70,8 +70,8 @@ LL | struct Bar<T>(T);
    = help: consider manually implementing `Debug` to avoid undesired bounds caused by "imperfect derives"
    = note: to learn more, visit <https://github.com/rust-lang/rust/issues/26925>
    = note: 2 redundant requirements hidden
-   = note: required for `&&'static Bar<(dyn Debug + 'static)>` to implement `Debug`
-   = note: required for the cast from `&&&'static Bar<(dyn Debug + 'static)>` to `&dyn Debug`
+   = note: required for `&&'static Bar<dyn Debug + 'static>` to implement `Debug`
+   = note: required for the cast from `&&&'static Bar<dyn Debug + 'static>` to `&dyn Debug`
 
 error[E0369]: binary operation `==` cannot be applied to type `&Bar<dyn Debug>`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:11:5
@@ -133,13 +133,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:25:33
    |
 LL |     let x: Test<{ Foo { nested: &Bar(4) } }> = Test;
    |                                 ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:20:12
    |

--- a/tests/ui/const-generics/generic_const_exprs/size_of-dyn-trait-2.rs
+++ b/tests/ui/const-generics/generic_const_exprs/size_of-dyn-trait-2.rs
@@ -13,6 +13,6 @@ struct A<T: Size<8> + ?Sized> {
 
 fn foo(x: A<dyn Send>) {}
 //~^ ERROR mismatched types
-//~| ERROR the size for values of type `(dyn Send + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `dyn Send + 'static` cannot be known at compilation time
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/size_of-dyn-trait-2.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/size_of-dyn-trait-2.stderr
@@ -12,14 +12,14 @@ note: required by a bound in `A`
 LL | struct A<T: Size<8> + ?Sized> {
    |             ^^^^^^^ required by this bound in `A`
 
-error[E0277]: the size for values of type `(dyn Send + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Send + 'static` cannot be known at compilation time
   --> $DIR/size_of-dyn-trait-2.rs:14:11
    |
 LL | fn foo(x: A<dyn Send>) {}
    |           ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Send + 'static)`
-note: required for `(dyn Send + 'static)` to implement `Size<8>`
+   = help: the trait `Sized` is not implemented for `dyn Send + 'static`
+note: required for `dyn Send + 'static` to implement `Size<8>`
   --> $DIR/size_of-dyn-trait-2.rs:8:16
    |
 LL | impl<T: Sized> Size<{ std::mem::size_of::<T>() }> for T {}

--- a/tests/ui/const-generics/issues/issue-63322-forbid-dyn.full.stderr
+++ b/tests/ui/const-generics/issues/issue-63322-forbid-dyn.full.stderr
@@ -4,7 +4,7 @@ error[E0741]: `&'static (dyn A + 'static)` can't be used as a const parameter ty
 LL | fn test<const T: &'static dyn A>() {
    |                  ^^^^^^^^^^^^^^
    |
-   = note: `(dyn A + 'static)` must implement `ConstParamTy_`, but it does not
+   = note: `dyn A + 'static` must implement `ConstParamTy_`, but it does not
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + Sync + 'static` cannot be known at compilation time
   --> $DIR/const-unsized.rs:3:16
    |
 LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
    |                ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + Sync + 'static`
    = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
@@ -16,13 +16,13 @@ LL | const CONST_FOO: str = *"foo";
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size
 
-error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + Sync + 'static` cannot be known at compilation time
   --> $DIR/const-unsized.rs:11:1
    |
 LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + Sync + 'static`
    = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -9,10 +9,10 @@ const REF_INTERIOR_MUT: &usize = {
     static FOO: Sync = AtomicUsize::new(0);
     //~^ ERROR cannot find
     //~| WARN trait objects without an explicit `dyn` are deprecated
-    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `dyn Sync + 'static` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| HELP if this is a dyn-compatible trait, use `dyn`
-    //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+    //~| HELP the trait `Sized` is not implemented for `dyn Sync + 'static`
     unsafe { &*(&FOO as *const _ as *const usize) }
 };
 pub fn main() {}

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -10,10 +10,10 @@ const REF_INTERIOR_MUT: &usize = {
     static FOO: Sync = AtomicUsize::new(0);
     //~^ ERROR cannot find
     //~| WARN trait objects without an explicit `dyn` are deprecated
-    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `dyn Sync + 'static` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| HELP if this is a dyn-compatible trait, use `dyn`
-    //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+    //~| HELP the trait `Sized` is not implemented for `dyn Sync + 'static`
     unsafe { &*(&FOO as *const _ as *const usize) }
 };
 pub fn main() {}

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -23,13 +23,13 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL |     static FOO: dyn Sync = AtomicUsize::new(0);
    |                 +++
 
-error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Sync + 'static` cannot be known at compilation time
   --> $DIR/const_refs_to_static-ice-121413.rs:9:5
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
    |     ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Sync + 'static`
    = note: statics and constants must have a statically known size
 
 error: aborting due to 2 previous errors; 1 warning emitted

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -23,13 +23,13 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL |     static FOO: dyn Sync = AtomicUsize::new(0);
    |                 +++
 
-error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Sync + 'static` cannot be known at compilation time
   --> $DIR/const_refs_to_static-ice-121413.rs:10:5
    |
 LL |     static FOO: Sync = AtomicUsize::new(0);
    |     ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Sync + 'static`
    = note: statics and constants must have a statically known size
 
 error: aborting due to 2 previous errors; 1 warning emitted

--- a/tests/ui/deref/box-pattern-trait-object-cannot-deref.stderr
+++ b/tests/ui/deref/box-pattern-trait-object-cannot-deref.stderr
@@ -1,8 +1,8 @@
-error[E0033]: type `Box<(dyn MyTrait + 'static)>` cannot be dereferenced
+error[E0033]: type `Box<dyn MyTrait + 'static>` cannot be dereferenced
   --> $DIR/box-pattern-trait-object-cannot-deref.rs:15:25
    |
 LL |         TraitWrapper::A(box ref map) => map,
-   |                         ^^^^^^^^^^^ type `Box<(dyn MyTrait + 'static)>` cannot be dereferenced
+   |                         ^^^^^^^^^^^ type `Box<dyn MyTrait + 'static>` cannot be dereferenced
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -173,10 +173,10 @@ error[E0223]: ambiguous associated type
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: if there were a trait named `Example` with associated type `AssocTy` implemented for `(dyn Send + 'static)`, you could use the fully-qualified path
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `dyn Send + 'static`, you could use the fully-qualified path
    |
 LL - type G = dyn 'static + (Send)::AssocTy;
-LL + type G = <(dyn Send + 'static) as Example>::AssocTy;
+LL + type G = <dyn Send + 'static as Example>::AssocTy;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated
@@ -202,10 +202,10 @@ LL | type H = Fn(u8) -> (u8)::Output;
 help: use fully-qualified syntax
    |
 LL - type H = Fn(u8) -> (u8)::Output;
-LL + type H = <(dyn Fn(u8) -> u8 + 'static) as BitOr>::Output;
+LL + type H = <dyn Fn(u8) -> u8 + 'static as BitOr>::Output;
    |
 LL - type H = Fn(u8) -> (u8)::Output;
-LL + type H = <(dyn Fn(u8) -> u8 + 'static) as IntoFuture>::Output;
+LL + type H = <dyn Fn(u8) -> u8 + 'static as IntoFuture>::Output;
    |
 
 error[E0223]: ambiguous associated type

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2015.stderr
@@ -173,10 +173,10 @@ error[E0223]: ambiguous associated type
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: if there were a trait named `Example` with associated type `AssocTy` implemented for `(dyn Send + 'static)`, you could use the fully-qualified path
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `dyn Send + 'static`, you could use the fully-qualified path
    |
 LL - type G = dyn 'static + (Send)::AssocTy;
-LL + type G = <(dyn Send + 'static) as Example>::AssocTy;
+LL + type G = <dyn Send + 'static as Example>::AssocTy;
    |
 
 warning: trait objects without an explicit `dyn` are deprecated

--- a/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.edition2021.stderr
@@ -173,10 +173,10 @@ error[E0223]: ambiguous associated type
 LL | type G = dyn 'static + (Send)::AssocTy;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: if there were a trait named `Example` with associated type `AssocTy` implemented for `(dyn Send + 'static)`, you could use the fully-qualified path
+help: if there were a trait named `Example` with associated type `AssocTy` implemented for `dyn Send + 'static`, you could use the fully-qualified path
    |
 LL - type G = dyn 'static + (Send)::AssocTy;
-LL + type G = <(dyn Send + 'static) as Example>::AssocTy;
+LL + type G = <dyn Send + 'static as Example>::AssocTy;
    |
 
 error[E0782]: expected a type, found a trait

--- a/tests/ui/dropck/dropck_trait_cycle_checked.stderr
+++ b/tests/ui/dropck/dropck_trait_cycle_checked.stderr
@@ -9,7 +9,7 @@ LL |     o1.set0(&o2);
 LL | }
    | - `o2` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<dyn Obj<'_> + 'static>`
 
 error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:112:13
@@ -23,7 +23,7 @@ LL |     o1.set1(&o3);
 LL | }
    | - `o3` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<dyn Obj<'_> + 'static>`
 
 error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:113:13
@@ -37,7 +37,7 @@ LL |     o2.set0(&o2);
 LL | }
    | - `o2` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<dyn Obj<'_> + 'static>`
 
 error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:114:13
@@ -51,7 +51,7 @@ LL |     o2.set1(&o3);
 LL | }
    | - `o3` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<dyn Obj<'_> + 'static>`
 
 error[E0597]: `o1` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:115:13
@@ -65,7 +65,7 @@ LL |     o3.set1(&o2);
 LL | }
    | - `o1` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<dyn Obj<'_> + 'static>`
 
 error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:116:13
@@ -78,7 +78,7 @@ LL |     o3.set1(&o2);
 LL | }
    | - `o2` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<dyn Obj<'_> + 'static>`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/dyn-compatibility/assoc_type_bounds_implicit_sized.stderr
+++ b/tests/ui/dyn-compatibility/assoc_type_bounds_implicit_sized.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/assoc_type_bounds_implicit_sized.rs:9:17
    |
 LL |     type Item = dyn Trait;
    |                 ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Trait + 'static`
 note: required by a bound in `TraitWithAType::Item`
   --> $DIR/assoc_type_bounds_implicit_sized.rs:4:5
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
@@ -36,24 +36,24 @@ LL | fn id<F>(f: Copy) -> usize {
    = note: for a trait to be dyn compatible it needs to allow building a vtable
            for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
-error[E0618]: expected function, found `(dyn Copy + 'static)`
+error[E0618]: expected function, found `dyn Copy + 'static`
   --> $DIR/avoid-ice-on-warning-2.rs:12:5
    |
 LL | fn id<F>(f: Copy) -> usize {
-   |          - `f` has type `(dyn Copy + 'static)`
+   |          - `f` has type `dyn Copy + 'static`
 ...
 LL |     f()
    |     ^--
    |     |
    |     call expression requires function
 
-error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Copy + 'static` cannot be known at compilation time
   --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Copy + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.rs
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.rs
@@ -4,12 +4,12 @@
 fn id<F>(f: Copy) -> usize {
 //[new]~^ ERROR expected a type, found a trait
 //[old]~^^ ERROR the trait `Copy` is not dyn compatible
-//[old]~| ERROR the size for values of type `(dyn Copy + 'static)`
+//[old]~| ERROR the size for values of type `dyn Copy + 'static`
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     f()
-    //[old]~^ ERROR: expected function, found `(dyn Copy + 'static)`
+    //[old]~^ ERROR: expected function, found `dyn Copy + 'static`
 }
 fn main() {}

--- a/tests/ui/dyn-compatibility/dyn-compatible-trait-implementation-20939.rs
+++ b/tests/ui/dyn-compatibility/dyn-compatible-trait-implementation-20939.rs
@@ -2,6 +2,6 @@
 trait Foo {}
 
 impl<'a> Foo for dyn Foo + 'a {}
-//~^ ERROR the object type `(dyn Foo + 'a)` automatically implements the trait `Foo`
+//~^ ERROR the object type `dyn Foo + 'a` automatically implements the trait `Foo`
 
 fn main() {}

--- a/tests/ui/dyn-compatibility/dyn-compatible-trait-implementation-20939.stderr
+++ b/tests/ui/dyn-compatibility/dyn-compatible-trait-implementation-20939.stderr
@@ -1,8 +1,8 @@
-error[E0371]: the object type `(dyn Foo + 'a)` automatically implements the trait `Foo`
+error[E0371]: the object type `dyn Foo + 'a` automatically implements the trait `Foo`
   --> $DIR/dyn-compatible-trait-implementation-20939.rs:4:1
    |
 LL | impl<'a> Foo for dyn Foo + 'a {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Foo + 'a)` automatically implements trait `Foo`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Foo + 'a` automatically implements trait `Foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/ergonomic-clones/closure/fn-once.stderr
+++ b/tests/ui/ergonomic-clones/closure/fn-once.stderr
@@ -9,7 +9,7 @@ LL |         vec
 LL |     Box::new(closure)
    |     ----------------- the requirement to implement `Fn` derives from here
    |
-   = note: required for the cast from `Box<{closure@$DIR/fn-once.rs:7:19: 7:25}>` to `Box<(dyn Fn() -> Vec<u8> + 'static)>`
+   = note: required for the cast from `Box<{closure@$DIR/fn-once.rs:7:19: 7:25}>` to `Box<dyn Fn() -> Vec<u8> + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-emitter/highlighting.svg
+++ b/tests/ui/error-emitter/highlighting.svg
@@ -1,4 +1,4 @@
-<svg width="785px" height="434px" xmlns="http://www.w3.org/2000/svg">
+<svg width="768px" height="434px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -37,9 +37,9 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-bright-blue bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: expected fn pointer `</tspan><tspan class="fg-magenta bold">for&lt;'a&gt; </tspan><tspan>fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'a)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;`</tspan>
+    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-bright-blue bold">= </tspan><tspan class="bold">note</tspan><tspan>: expected fn pointer `</tspan><tspan class="fg-magenta bold">for&lt;'a&gt; </tspan><tspan>fn(Box&lt;</tspan><tspan class="fg-magenta bold">dyn Any + Send + 'a</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'static)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;</tspan><tspan class="fg-magenta bold"> {wrapped_fn}</tspan><tspan>`</tspan>
+    <tspan x="10px" y="190px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">dyn Any + Send + 'static</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;</tspan><tspan class="fg-magenta bold"> {wrapped_fn}</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">note</tspan><tspan>: function defined here</tspan>
 </tspan>

--- a/tests/ui/error-emitter/unicode-output.svg
+++ b/tests/ui/error-emitter/unicode-output.svg
@@ -1,4 +1,4 @@
-<svg width="785px" height="434px" xmlns="http://www.w3.org/2000/svg">
+<svg width="768px" height="434px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -37,9 +37,9 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-bright-blue bold">│</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╰ </tspan><tspan class="bold">note</tspan><tspan>: expected fn pointer `</tspan><tspan class="fg-magenta bold">for&lt;'a&gt; </tspan><tspan>fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'a)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;`</tspan>
+    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-bright-blue bold">╰ </tspan><tspan class="bold">note</tspan><tspan>: expected fn pointer `</tspan><tspan class="fg-magenta bold">for&lt;'a&gt; </tspan><tspan>fn(Box&lt;</tspan><tspan class="fg-magenta bold">dyn Any + Send + 'a</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">(dyn Any + Send + 'static)</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;</tspan><tspan class="fg-magenta bold"> {wrapped_fn}</tspan><tspan>`</tspan>
+    <tspan x="10px" y="190px"><tspan>                 found fn item `fn(Box&lt;</tspan><tspan class="fg-magenta bold">dyn Any + Send + 'static</tspan><tspan>&gt;) -&gt; Pin&lt;_&gt;</tspan><tspan class="fg-magenta bold"> {wrapped_fn}</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">note</tspan><tspan>: function defined here</tspan>
 </tspan>

--- a/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -129,14 +129,14 @@ help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 LL + #![feature(trivial_bounds)]
    |
 
-error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn A + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-trivial_bounds.rs:55:26
    |
 LL | fn unsized_local() where Dst<dyn A>: Sized {
    |                          ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Dst<(dyn A + 'static)>`, the trait `Sized` is not implemented for `(dyn A + 'static)`
-note: required because it appears within the type `Dst<(dyn A + 'static)>`
+   = help: within `Dst<dyn A + 'static>`, the trait `Sized` is not implemented for `dyn A + 'static`
+note: required because it appears within the type `Dst<dyn A + 'static>`
   --> $DIR/feature-gate-trivial_bounds.rs:48:8
    |
 LL | struct Dst<X: ?Sized> {

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2015.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2015.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_fn_params.rs:20:11
    |
 LL | fn foo(x: dyn Foo) {
    |           ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |
@@ -16,13 +16,13 @@ help: function arguments must have a statically known size, borrowed types alway
 LL | fn foo(x: &dyn Foo) {
    |           +
 
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_fn_params.rs:24:11
    |
 LL | fn bar(x: Foo) {
    |           ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |
@@ -46,13 +46,13 @@ help: function arguments must have a statically known size, borrowed slices alwa
 LL | fn qux(_: &[()]) {}
    |           +
 
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_fn_params.rs:34:9
    |
 LL |     foo(*x);
    |         ^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = note: all function arguments must have a statically known size
    = help: unsized fn params are gated as an unstable feature
 

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2021.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.edition2021.stderr
@@ -18,13 +18,13 @@ help: alternatively, use a trait object to accept any type that implements `Foo`
 LL | fn bar(x: &dyn Foo) {
    |           ++++
 
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_fn_params.rs:20:11
    |
 LL | fn foo(x: dyn Foo) {
    |           ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |
@@ -49,13 +49,13 @@ help: function arguments must have a statically known size, borrowed slices alwa
 LL | fn qux(_: &[()]) {}
    |           +
 
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_fn_params.rs:34:9
    |
 LL |     foo(*x);
    |         ^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = note: all function arguments must have a statically known size
    = help: unsized fn params are gated as an unstable feature
 

--- a/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn FnOnce() + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn FnOnce() + 'static` cannot be known at compilation time
   --> $DIR/feature-gate-unsized_locals.rs:1:9
    |
 LL | fn f(f: dyn FnOnce()) {}
    |         ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn FnOnce() + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn FnOnce() + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/fn/coerce-suggestion-infer-region.stderr
+++ b/tests/ui/fn/coerce-suggestion-infer-region.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     Desugared { callback }
    |                 ^^^^^^^^ expected `Box<dyn MyFn<&Container<&u8>>>`, found `Box<dyn MyFn<Container<&u8>>>`
    |
-   = note: expected struct `Box<(dyn for<'a> MyFn<&'a Container<&'a u8>> + 'static)>`
-              found struct `Box<(dyn for<'a> MyFn<Container<&'a u8>> + 'static)>`
+   = note: expected struct `Box<dyn for<'a> MyFn<&'a Container<&'a u8>> + 'static>`
+              found struct `Box<dyn for<'a> MyFn<Container<&'a u8>> + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/function-pointer/unsized-ret.rs
+++ b/tests/ui/function-pointer/unsized-ret.rs
@@ -11,5 +11,5 @@ fn main() {
     //~^ ERROR the size for values of type `str` cannot be known at compilation time
 
     foo::<for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a), _>(None, (&(),));
-    //~^ ERROR the size for values of type `(dyn std::fmt::Display + 'a)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn std::fmt::Display + 'a` cannot be known at compilation time
 }

--- a/tests/ui/function-pointer/unsized-ret.stderr
+++ b/tests/ui/function-pointer/unsized-ret.stderr
@@ -12,13 +12,13 @@ note: required by a bound in `foo`
 LL | fn foo<F: Fn<T>, T:std::marker::Tuple>(f: Option<F>, t: T) {
    |           ^^^^^ required by this bound in `foo`
 
-error[E0277]: the size for values of type `(dyn std::fmt::Display + 'a)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn std::fmt::Display + 'a` cannot be known at compilation time
   --> $DIR/unsized-ret.rs:13:11
    |
 LL |     foo::<for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a), _>(None, (&(),));
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`, the trait `for<'a> Sized` is not implemented for `(dyn std::fmt::Display + 'a)`
+   = help: within `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`, the trait `for<'a> Sized` is not implemented for `dyn std::fmt::Display + 'a`
    = note: required because it appears within the type `for<'a> fn(&'a ()) -> (dyn std::fmt::Display + 'a)`
 note: required by a bound in `foo`
   --> $DIR/unsized-ret.rs:5:11

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs
@@ -8,7 +8,7 @@ struct RcFamily;
 
 impl PointerFamily for RcFamily {
     type Pointer<T> = dyn Deref<Target = T>;
-    //~^ ERROR the size for values of type `(dyn Deref<Target = T> + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Deref<Target = T> + 'static` cannot be known at compilation time
 }
 
 enum Node<T, P: PointerFamily> {

--- a/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Deref<Target = T> + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Deref<Target = T> + 'static` cannot be known at compilation time
   --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:10:23
    |
 LL |     type Pointer<T> = dyn Deref<Target = T>;
    |                       ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Deref<Target = T> + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Deref<Target = T> + 'static`
 note: required by a bound in `PointerFamily::Pointer`
   --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:4:5
    |
@@ -24,7 +24,7 @@ LL | enum Node<T, P: PointerFamily> {
 LL |     let mut list = RcNode::<i32>::new();
    |                                   ^^^ variant, associated function, or constant cannot be called on `Node<i32, RcFamily>` due to unsatisfied trait bounds
    |
-note: trait bound `(dyn Deref<Target = Node<i32, RcFamily>> + 'static): Sized` was not satisfied
+note: trait bound `dyn Deref<Target = Node<i32, RcFamily>> + 'static: Sized` was not satisfied
   --> $DIR/issue-119942-unsatisified-gat-bound-during-assoc-ty-selection.rs:23:29
    |
 LL | impl<T, P: PointerFamily> Node<T, P>

--- a/tests/ui/higher-ranked/anonymous-higher-ranked-lifetime.stderr
+++ b/tests/ui/higher-ranked/anonymous-higher-ranked-lifetime.stderr
@@ -112,7 +112,7 @@ LL |     g1(|_: (), _: ()| {});
    |     |  found signature defined here
    |     expected due to this
    |
-   = note: expected closure signature `for<'a> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>) -> _`
+   = note: expected closure signature `for<'a> fn(&'a (), Box<dyn for<'a> Fn(&'a ()) + 'static>) -> _`
               found closure signature `fn((), ()) -> _`
 note: required by a bound in `g1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:29:25
@@ -154,7 +154,7 @@ LL |     g3(|_: (), _: ()| {});
    |     |  found signature defined here
    |     expected due to this
    |
-   = note: expected closure signature `for<'s> fn(&'s (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>) -> _`
+   = note: expected closure signature `for<'s> fn(&'s (), Box<dyn for<'a> Fn(&'a ()) + 'static>) -> _`
               found closure signature `fn((), ()) -> _`
 note: required by a bound in `g3`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:31:25
@@ -196,7 +196,7 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     |  found signature defined here
    |     expected due to this
    |
-   = note: expected closure signature `for<'a, 'b> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'b (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
+   = note: expected closure signature `for<'a, 'b> fn(&'a (), Box<dyn for<'a> Fn(&'a ()) + 'static>, &'b (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
               found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h1`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:35:25
@@ -217,7 +217,7 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     |  found signature defined here
    |     expected due to this
    |
-   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<(dyn for<'a> Fn(&'a ()) + 'static)>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
+   = note: expected closure signature `for<'a, 't0> fn(&'a (), Box<dyn for<'a> Fn(&'a ()) + 'static>, &'t0 (), for<'a, 'b> fn(&'a (), &'b ())) -> _`
               found closure signature `fn((), (), (), ()) -> _`
 note: required by a bound in `h2`
   --> $DIR/anonymous-higher-ranked-lifetime.rs:36:25

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2015.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2015.stderr
@@ -1,21 +1,21 @@
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:13
    |
 LL | fn fuz() -> (usize, Trait) { (42, Struct) }
    |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = help: within `(usize, dyn Trait + 'static)`, the trait `Sized` is not implemented for `dyn Trait + 'static`
+   = note: required because it appears within the type `(usize, dyn Trait + 'static)`
    = note: the return type of a function must have a statically known size
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = help: within `(usize, dyn Trait + 'static)`, the trait `Sized` is not implemented for `dyn Trait + 'static`
+   = note: required because it appears within the type `(usize, dyn Trait + 'static)`
    = note: the return type of a function must have a statically known size
 
 error[E0746]: return type cannot be a trait object without pointer indirection
@@ -151,18 +151,18 @@ error[E0308]: mismatched types
 LL | fn fuz() -> (usize, Trait) { (42, Struct) }
    |                                   ^^^^^^ expected `dyn Trait`, found `Struct`
    |
-   = note: expected trait object `(dyn Trait + 'static)`
+   = note: expected trait object `dyn Trait + 'static`
                     found struct `Struct`
    = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:30
    |
 LL | fn fuz() -> (usize, Trait) { (42, Struct) }
    |                              ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = help: within `(usize, dyn Trait + 'static)`, the trait `Sized` is not implemented for `dyn Trait + 'static`
+   = note: required because it appears within the type `(usize, dyn Trait + 'static)`
    = note: tuples must have a statically known size to be initialized
 
 error[E0308]: mismatched types
@@ -171,30 +171,30 @@ error[E0308]: mismatched types
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
    |
-   = note: expected trait object `(dyn Trait + 'static)`
+   = note: expected trait object `dyn Trait + 'static`
                     found struct `Struct`
    = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:34
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                  ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = help: within `(usize, dyn Trait + 'static)`, the trait `Sized` is not implemented for `dyn Trait + 'static`
+   = note: required because it appears within the type `(usize, dyn Trait + 'static)`
    = note: tuples must have a statically known size to be initialized
 
 error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:41:16
    |
 LL | fn bam() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         return Struct;
    |                ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
               found struct `Struct`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -206,12 +206,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:43:5
    |
 LL | fn bam() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |     42
    |     ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -223,12 +223,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:47:16
    |
 LL | fn baq() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         return 0;
    |                ^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -240,12 +240,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:49:5
    |
 LL | fn baq() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |     42
    |     ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -257,12 +257,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:53:9
    |
 LL | fn baz() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         Struct
    |         ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
               found struct `Struct`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -274,12 +274,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
    |
 LL | fn baz() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |         42
    |         ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -291,12 +291,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:60:9
    |
 LL | fn baw() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         0
    |         ^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -308,12 +308,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:9
    |
 LL | fn baw() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |         42
    |         ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2021.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.edition2021.stderr
@@ -9,14 +9,14 @@ help: you can add the `dyn` keyword if you want a trait object
 LL | fn fuz() -> (usize, dyn Trait) { (42, Struct) }
    |                     +++
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = help: within `(usize, dyn Trait + 'static)`, the trait `Sized` is not implemented for `dyn Trait + 'static`
+   = note: required because it appears within the type `(usize, dyn Trait + 'static)`
    = note: the return type of a function must have a statically known size
 
 error[E0782]: expected a type, found a trait
@@ -152,30 +152,30 @@ error[E0308]: mismatched types
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
    |
-   = note: expected trait object `(dyn Trait + 'static)`
+   = note: expected trait object `dyn Trait + 'static`
                     found struct `Struct`
    = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:34
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                  ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
-   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = help: within `(usize, dyn Trait + 'static)`, the trait `Sized` is not implemented for `dyn Trait + 'static`
+   = note: required because it appears within the type `(usize, dyn Trait + 'static)`
    = note: tuples must have a statically known size to be initialized
 
 error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:41:16
    |
 LL | fn bam() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         return Struct;
    |                ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
               found struct `Struct`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -187,12 +187,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:43:5
    |
 LL | fn bam() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |     42
    |     ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -204,12 +204,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:47:16
    |
 LL | fn baq() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         return 0;
    |                ^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -221,12 +221,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:49:5
    |
 LL | fn baq() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |     42
    |     ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -238,12 +238,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:53:9
    |
 LL | fn baz() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         Struct
    |         ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
               found struct `Struct`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -255,12 +255,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
    |
 LL | fn baz() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |         42
    |         ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -272,12 +272,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:60:9
    |
 LL | fn baw() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 LL |     if true {
 LL |         0
    |         ^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`
@@ -289,12 +289,12 @@ error[E0308]: mismatched types
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:9
    |
 LL | fn baw() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+   |             -------------- expected `Box<dyn Trait + 'static>` because of return type
 ...
 LL |         42
    |         ^^ expected `Box<dyn Trait>`, found integer
    |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
+   = note: expected struct `Box<dyn Trait + 'static>`
                 found type `{integer}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 help: store this in the heap by calling `Box::new`

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.pre2021.stderr
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.pre2021.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied
+error[E0277]: the trait bound `(): AsRef<dyn for<'a> Fn(&'a ()) + 'static>` is not satisfied
   --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:7:13
    |
 LL | fn ice() -> impl AsRef<Fn(&())> {
-   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not implemented for `()`
+   |             ^^^^^^^^^^^^^^^^^^^ the trait `AsRef<dyn for<'a> Fn(&'a ()) + 'static>` is not implemented for `()`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
@@ -5,7 +5,7 @@
 #![allow(warnings)]
 
 fn ice() -> impl AsRef<Fn(&())> {
-    //[pre2021]~^ ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
+    //[pre2021]~^ ERROR: the trait bound `(): AsRef<dyn for<'a> Fn(&'a ()) + 'static>` is not satisfied [E0277]
     //[edition2021]~^^ ERROR: expected a type, found a trait [E0782]
     //[edition2021]~| ERROR: expected a type, found a trait [E0782]
     todo!()

--- a/tests/ui/impl-trait/in-trait/refine-rustfix-parens.fixed
+++ b/tests/ui/impl-trait/in-trait/refine-rustfix-parens.fixed
@@ -1,0 +1,139 @@
+//@ run-rustfix
+
+// The `refining_impl_trait` suggestion must wrap a `+`-joined `impl Trait` in
+// parens when it sits after a prefix type constructor (`&`, `&mut`, `*const`,
+// `*mut`), so the suggestion is parser-correct. Covers multi-trait, `?Sized`,
+// lifetime, projection-inlined and projection-only opaques, nested `&&`, and
+// raw-pointer prefixes. Bare-position `impl A + B` must stay unwrapped.
+//
+// https://github.com/rust-lang/rust/issues/144401
+
+#![allow(unused)]
+#![deny(refining_impl_trait)]
+
+pub trait BarA {}
+impl<T: ?Sized> BarA for T {}
+
+pub trait BarB {}
+impl<T> BarB for T {}
+
+pub trait Iter {
+    type Item;
+}
+impl<T: ?Sized> Iter for T {
+    type Item = u8;
+}
+
+pub struct Fool;
+
+// (1)
+pub trait BehindRef {
+    fn bar(&self) -> &(impl BarA + BarB);
+}
+impl BehindRef for Fool {
+    fn bar(&self) -> &(impl BarA + BarB) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (2)
+pub trait BehindRefUnsized {
+    fn bar_unsized(&self) -> &(impl BarA + ?Sized);
+}
+impl BehindRefUnsized for Fool {
+    fn bar_unsized(&self) -> &(impl BarA + ?Sized) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (3)
+pub trait BehindRefMut {
+    fn bar_mut(&mut self) -> &mut (impl BarA + BarB);
+}
+impl BehindRefMut for Fool {
+    fn bar_mut(&mut self) -> &mut (impl BarA + BarB) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        self
+    }
+}
+
+// (4)
+pub trait BehindRefLifetime<'a> {
+    fn bar_lt(&'a self) -> &'a (impl BarA + 'a);
+}
+impl<'a> BehindRefLifetime<'a> for Fool {
+    fn bar_lt(&'a self) -> &'a (impl BarA + 'a) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (5)
+pub trait BehindRefProjAndTrait {
+    fn bar_proj_trait(&self) -> &(impl Iter<Item = u8> + BarB);
+}
+impl BehindRefProjAndTrait for Fool {
+    fn bar_proj_trait(&self) -> &(impl Iter<Item = u8> + BarB) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (6) - no-wrap control: projection inlined, single joinable.
+pub trait BehindRefProjOnly {
+    fn bar_proj_only(&self) -> &impl Iter<Item = u8>;
+}
+impl BehindRefProjOnly for Fool {
+    fn bar_proj_only(&self) -> &impl Iter<Item = u8> {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (7) - nested ref: only the inner `&` wraps.
+pub trait BehindRefNested {
+    fn bar_nested(&self) -> &&(impl BarA + BarB);
+}
+impl BehindRefNested for Fool {
+    fn bar_nested(&self) -> &&(impl BarA + BarB) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &&Fool
+    }
+}
+
+// (8) - raw-pointer prefix generalization (`*const`).
+pub trait BehindRawPtr {
+    fn baz_raw() -> *const (impl BarA + BarB);
+}
+impl BehindRawPtr for Fool {
+    fn baz_raw() -> *const (impl BarA + BarB) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        core::ptr::null::<Fool>()
+    }
+}
+
+// (8b) - same generalization, `*mut` variant.
+pub trait BehindRawPtrMut {
+    fn baz_raw_mut() -> *mut (impl BarA + BarB);
+}
+impl BehindRawPtrMut for Fool {
+    fn baz_raw_mut() -> *mut (impl BarA + BarB) {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        core::ptr::null_mut::<Fool>()
+    }
+}
+
+// Bare position must NOT pick up parens.
+pub trait BarePosition {
+    fn baz() -> impl BarA + BarB;
+}
+impl BarePosition for Fool {
+    fn baz() -> impl BarA + BarB {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        Fool
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs
+++ b/tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs
@@ -1,0 +1,139 @@
+//@ run-rustfix
+
+// The `refining_impl_trait` suggestion must wrap a `+`-joined `impl Trait` in
+// parens when it sits after a prefix type constructor (`&`, `&mut`, `*const`,
+// `*mut`), so the suggestion is parser-correct. Covers multi-trait, `?Sized`,
+// lifetime, projection-inlined and projection-only opaques, nested `&&`, and
+// raw-pointer prefixes. Bare-position `impl A + B` must stay unwrapped.
+//
+// https://github.com/rust-lang/rust/issues/144401
+
+#![allow(unused)]
+#![deny(refining_impl_trait)]
+
+pub trait BarA {}
+impl<T: ?Sized> BarA for T {}
+
+pub trait BarB {}
+impl<T> BarB for T {}
+
+pub trait Iter {
+    type Item;
+}
+impl<T: ?Sized> Iter for T {
+    type Item = u8;
+}
+
+pub struct Fool;
+
+// (1)
+pub trait BehindRef {
+    fn bar(&self) -> &(impl BarA + BarB);
+}
+impl BehindRef for Fool {
+    fn bar(&self) -> &Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (2)
+pub trait BehindRefUnsized {
+    fn bar_unsized(&self) -> &(impl BarA + ?Sized);
+}
+impl BehindRefUnsized for Fool {
+    fn bar_unsized(&self) -> &Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (3)
+pub trait BehindRefMut {
+    fn bar_mut(&mut self) -> &mut (impl BarA + BarB);
+}
+impl BehindRefMut for Fool {
+    fn bar_mut(&mut self) -> &mut Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        self
+    }
+}
+
+// (4)
+pub trait BehindRefLifetime<'a> {
+    fn bar_lt(&'a self) -> &'a (impl BarA + 'a);
+}
+impl<'a> BehindRefLifetime<'a> for Fool {
+    fn bar_lt(&'a self) -> &'a Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (5)
+pub trait BehindRefProjAndTrait {
+    fn bar_proj_trait(&self) -> &(impl Iter<Item = u8> + BarB);
+}
+impl BehindRefProjAndTrait for Fool {
+    fn bar_proj_trait(&self) -> &Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (6) - no-wrap control: projection inlined, single joinable.
+pub trait BehindRefProjOnly {
+    fn bar_proj_only(&self) -> &impl Iter<Item = u8>;
+}
+impl BehindRefProjOnly for Fool {
+    fn bar_proj_only(&self) -> &Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &Fool
+    }
+}
+
+// (7) - nested ref: only the inner `&` wraps.
+pub trait BehindRefNested {
+    fn bar_nested(&self) -> &&(impl BarA + BarB);
+}
+impl BehindRefNested for Fool {
+    fn bar_nested(&self) -> &&Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        &&Fool
+    }
+}
+
+// (8) - raw-pointer prefix generalization (`*const`).
+pub trait BehindRawPtr {
+    fn baz_raw() -> *const (impl BarA + BarB);
+}
+impl BehindRawPtr for Fool {
+    fn baz_raw() -> *const Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        core::ptr::null::<Fool>()
+    }
+}
+
+// (8b) - same generalization, `*mut` variant.
+pub trait BehindRawPtrMut {
+    fn baz_raw_mut() -> *mut (impl BarA + BarB);
+}
+impl BehindRawPtrMut for Fool {
+    fn baz_raw_mut() -> *mut Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        core::ptr::null_mut::<Fool>()
+    }
+}
+
+// Bare position must NOT pick up parens.
+pub trait BarePosition {
+    fn baz() -> impl BarA + BarB;
+}
+impl BarePosition for Fool {
+    fn baz() -> Fool {
+        //~^ ERROR impl trait in impl method signature does not match trait method signature
+        Fool
+    }
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine-rustfix-parens.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-rustfix-parens.stderr
@@ -1,0 +1,178 @@
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:34:22
+   |
+LL |     fn bar(&self) -> &(impl BarA + BarB);
+   |                      ------------------- return type from trait method defined here
+...
+LL |     fn bar(&self) -> &Fool {
+   |                      ^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+note: the lint level is defined here
+  --> $DIR/refine-rustfix-parens.rs:12:9
+   |
+LL | #![deny(refining_impl_trait)]
+   |         ^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(refining_impl_trait_reachable)]` implied by `#[deny(refining_impl_trait)]`
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar(&self) -> &Fool {
+LL +     fn bar(&self) -> &(impl BarA + BarB) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:45:30
+   |
+LL |     fn bar_unsized(&self) -> &(impl BarA + ?Sized);
+   |                              --------------------- return type from trait method defined here
+...
+LL |     fn bar_unsized(&self) -> &Fool {
+   |                              ^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar_unsized(&self) -> &Fool {
+LL +     fn bar_unsized(&self) -> &(impl BarA + ?Sized) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:56:30
+   |
+LL |     fn bar_mut(&mut self) -> &mut (impl BarA + BarB);
+   |                              ----------------------- return type from trait method defined here
+...
+LL |     fn bar_mut(&mut self) -> &mut Fool {
+   |                              ^^^^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar_mut(&mut self) -> &mut Fool {
+LL +     fn bar_mut(&mut self) -> &mut (impl BarA + BarB) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:67:28
+   |
+LL |     fn bar_lt(&'a self) -> &'a (impl BarA + 'a);
+   |                            -------------------- return type from trait method defined here
+...
+LL |     fn bar_lt(&'a self) -> &'a Fool {
+   |                            ^^^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar_lt(&'a self) -> &'a Fool {
+LL +     fn bar_lt(&'a self) -> &'a (impl BarA + 'a) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:78:33
+   |
+LL |     fn bar_proj_trait(&self) -> &(impl Iter<Item = u8> + BarB);
+   |                                 ------------------------------ return type from trait method defined here
+...
+LL |     fn bar_proj_trait(&self) -> &Fool {
+   |                                 ^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar_proj_trait(&self) -> &Fool {
+LL +     fn bar_proj_trait(&self) -> &(impl Iter<Item = u8> + BarB) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:89:32
+   |
+LL |     fn bar_proj_only(&self) -> &impl Iter<Item = u8>;
+   |                                --------------------- return type from trait method defined here
+...
+LL |     fn bar_proj_only(&self) -> &Fool {
+   |                                ^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar_proj_only(&self) -> &Fool {
+LL +     fn bar_proj_only(&self) -> &impl Iter<Item = u8> {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:100:29
+   |
+LL |     fn bar_nested(&self) -> &&(impl BarA + BarB);
+   |                             -------------------- return type from trait method defined here
+...
+LL |     fn bar_nested(&self) -> &&Fool {
+   |                             ^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn bar_nested(&self) -> &&Fool {
+LL +     fn bar_nested(&self) -> &&(impl BarA + BarB) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:111:21
+   |
+LL |     fn baz_raw() -> *const (impl BarA + BarB);
+   |                     ------------------------- return type from trait method defined here
+...
+LL |     fn baz_raw() -> *const Fool {
+   |                     ^^^^^^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn baz_raw() -> *const Fool {
+LL +     fn baz_raw() -> *const (impl BarA + BarB) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:122:25
+   |
+LL |     fn baz_raw_mut() -> *mut (impl BarA + BarB);
+   |                         ----------------------- return type from trait method defined here
+...
+LL |     fn baz_raw_mut() -> *mut Fool {
+   |                         ^^^^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn baz_raw_mut() -> *mut Fool {
+LL +     fn baz_raw_mut() -> *mut (impl BarA + BarB) {
+   |
+
+error: impl trait in impl method signature does not match trait method signature
+  --> $DIR/refine-rustfix-parens.rs:133:17
+   |
+LL |     fn baz() -> impl BarA + BarB;
+   |                 ---------------- return type from trait method defined here
+...
+LL |     fn baz() -> Fool {
+   |                 ^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: replace the return type so that it matches the trait
+   |
+LL -     fn baz() -> Fool {
+LL +     fn baz() -> impl BarA + BarB {
+   |
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/impl-trait/opaque-prefix-position-parens.rs
+++ b/tests/ui/impl-trait/opaque-prefix-position-parens.rs
@@ -1,0 +1,32 @@
+//! The type printer wraps a multi-bound `impl Trait` in parens after a prefix
+//! type constructor, because `&impl A + B` parses as the ambiguous `(&impl A) + B`.
+//! A single-bound opaque needs no parens, and neither does one whose only extra
+//! bound is a lifetime that the printer does not render.
+
+pub trait Ta {}
+pub trait Tb {}
+impl Ta for u8 {}
+impl Tb for u8 {}
+
+pub fn one() -> impl Ta { 0u8 }
+pub fn two() -> impl Ta + Tb { 0u8 }
+pub fn lifetime<'a>(_x: &'a u8) -> impl Ta + 'a { 0u8 }
+
+pub fn takes_unit(_: ()) {}
+
+pub fn a() {
+    takes_unit(&one());
+    //~^ ERROR mismatched types
+}
+
+pub fn b() {
+    takes_unit(&two());
+    //~^ ERROR mismatched types
+}
+
+pub fn c(x: &u8) {
+    takes_unit(&lifetime(x));
+    //~^ ERROR mismatched types
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/opaque-prefix-position-parens.stderr
+++ b/tests/ui/impl-trait/opaque-prefix-position-parens.stderr
@@ -1,0 +1,60 @@
+error[E0308]: mismatched types
+  --> $DIR/opaque-prefix-position-parens.rs:18:16
+   |
+LL | pub fn one() -> impl Ta { 0u8 }
+   |                 ------- the found opaque type
+...
+LL |     takes_unit(&one());
+   |     ---------- ^^^^^^ expected `()`, found `&impl Ta`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected unit type `()`
+              found reference `&impl Ta`
+note: function defined here
+  --> $DIR/opaque-prefix-position-parens.rs:15:8
+   |
+LL | pub fn takes_unit(_: ()) {}
+   |        ^^^^^^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/opaque-prefix-position-parens.rs:23:16
+   |
+LL | pub fn two() -> impl Ta + Tb { 0u8 }
+   |                 ------------ the found opaque type
+...
+LL |     takes_unit(&two());
+   |     ---------- ^^^^^^ expected `()`, found `&(impl Ta + Tb)`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected unit type `()`
+              found reference `&impl Ta + Tb`
+note: function defined here
+  --> $DIR/opaque-prefix-position-parens.rs:15:8
+   |
+LL | pub fn takes_unit(_: ()) {}
+   |        ^^^^^^^^^^ -----
+
+error[E0308]: mismatched types
+  --> $DIR/opaque-prefix-position-parens.rs:28:16
+   |
+LL | pub fn lifetime<'a>(_x: &'a u8) -> impl Ta + 'a { 0u8 }
+   |                                    ------------ the found opaque type
+...
+LL |     takes_unit(&lifetime(x));
+   |     ---------- ^^^^^^^^^^^^ expected `()`, found `&impl Ta`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: expected unit type `()`
+              found reference `&impl Ta + '_`
+note: function defined here
+  --> $DIR/opaque-prefix-position-parens.rs:15:8
+   |
+LL | pub fn takes_unit(_: ()) {}
+   |        ^^^^^^^^^^ -----
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr
+++ b/tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr
@@ -75,7 +75,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/opaque-used-in-extraneous-argument.rs:20:5
    |
 LL |     open_parent(&old_path)
-   |     ^^^^^^^^^^^ --------- unexpected argument of type `&impl Fn<{type error}> + FnOnce<{type error}, Output = {type error}> + '_`
+   |     ^^^^^^^^^^^ --------- unexpected argument of type `&(impl Fn<{type error}> + FnOnce<{type error}, Output = {type error}> + '_)`
    |
 note: function defined here
   --> $DIR/opaque-used-in-extraneous-argument.rs:12:4

--- a/tests/ui/issues/issue-18446.stderr
+++ b/tests/ui/issues/issue-18446.stderr
@@ -9,7 +9,7 @@ note: candidate #1 is defined in the trait `T`
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
-note: candidate #2 is defined in an impl for the type `(dyn T + 'a)`
+note: candidate #2 is defined in an impl for the type `dyn T + 'a`
   --> $DIR/issue-18446.rs:9:5
    |
 LL |     fn foo(&self) {}

--- a/tests/ui/issues/issue-42312.stderr
+++ b/tests/ui/issues/issue-42312.stderr
@@ -15,13 +15,13 @@ help: function arguments must have a statically known size, borrowed types alway
 LL |     fn baz(_: &Self::Target) where Self: Deref {}
    |               +
 
-error[E0277]: the size for values of type `(dyn ToString + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn ToString + 'static` cannot be known at compilation time
   --> $DIR/issue-42312.rs:8:13
    |
 LL | pub fn f(_: dyn ToString) {}
    |             ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn ToString + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn ToString + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/layout/invalid-unsized-const-eval.stderr
+++ b/tests/ui/layout/invalid-unsized-const-eval.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Sync + 'static` cannot be known at compilation time
   --> $DIR/invalid-unsized-const-eval.rs:9:11
    |
 LL |     data: (dyn Sync, ()),
    |           ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Sync + 'static`
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0080]: the type `(dyn Sync, ())` has an unknown layout

--- a/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
+++ b/tests/ui/lifetimes/issue-90600-expected-return-static-indirect.stderr
@@ -26,7 +26,7 @@ LL |     read_thing(read);
    |     `foo` escapes the function body here
    |     argument requires that `'1` must outlive `'static`
    |
-   = note: requirement occurs because of the type `RefCell<(dyn std::io::Read + 'static)>`, which makes the generic argument `(dyn std::io::Read + 'static)` invariant
+   = note: requirement occurs because of the type `RefCell<dyn std::io::Read + 'static>`, which makes the generic argument `dyn std::io::Read + 'static` invariant
    = note: the struct `RefCell<T>` is invariant over the parameter `T`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/tests/ui/lint/lint-incoherent-auto-trait-objects.stderr
+++ b/tests/ui/lint/lint-incoherent-auto-trait-objects.stderr
@@ -1,29 +1,29 @@
-error[E0119]: conflicting implementations of trait `Foo` for type `(dyn Send + 'static)`
+error[E0119]: conflicting implementations of trait `Foo` for type `dyn Send + 'static`
   --> $DIR/lint-incoherent-auto-trait-objects.rs:5:1
    |
 LL | impl Foo for dyn Send {}
    | --------------------- first implementation here
 LL |
 LL | impl Foo for dyn Send + Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + 'static`
 
-error[E0119]: conflicting implementations of trait `Foo` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Foo` for type `dyn Send + Sync + 'static`
   --> $DIR/lint-incoherent-auto-trait-objects.rs:10:1
    |
 LL | impl Foo for dyn Send + Sync {}
    | ---------------------------- first implementation here
 LL |
 LL | impl Foo for dyn Sync + Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
-error[E0119]: conflicting implementations of trait `Foo` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Foo` for type `dyn Send + Sync + 'static`
   --> $DIR/lint-incoherent-auto-trait-objects.rs:13:1
    |
 LL | impl Foo for dyn Send + Sync {}
    | ---------------------------- first implementation here
 ...
 LL | impl Foo for dyn Send + Sync + Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/methods/call-ambig-trait-object-method.stderr
+++ b/tests/ui/methods/call-ambig-trait-object-method.stderr
@@ -9,7 +9,7 @@ note: candidate #1 is defined in the trait `T`
    |
 LL |     fn foo(&self);
    |     ^^^^^^^^^^^^^^
-note: candidate #2 is defined in an impl for the type `(dyn T + 'a)`
+note: candidate #2 is defined in an impl for the type `dyn T + 'a`
   --> $DIR/call-ambig-trait-object-method.rs:10:5
    |
 LL |     fn foo(&self) {}

--- a/tests/ui/mir/static-by-value-dyn.rs
+++ b/tests/ui/mir/static-by-value-dyn.rs
@@ -6,7 +6,7 @@
 use std::fmt::Debug;
 
 static STATIC_1: dyn Debug + Sync = *();
-//~^ ERROR the size for values of type `(dyn Debug + Sync + 'static)` cannot be known
+//~^ ERROR the size for values of type `dyn Debug + Sync + 'static` cannot be known
 //~| ERROR type `()` cannot be dereferenced
 
 fn main() {

--- a/tests/ui/mir/static-by-value-dyn.stderr
+++ b/tests/ui/mir/static-by-value-dyn.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + Sync + 'static` cannot be known at compilation time
   --> $DIR/static-by-value-dyn.rs:8:1
    |
 LL | static STATIC_1: dyn Debug + Sync = *();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + Sync + 'static`
    = note: statics and constants must have a statically known size
 
 error[E0614]: type `()` cannot be dereferenced

--- a/tests/ui/mismatched_types/issue-75361-mismatched-impl.stderr
+++ b/tests/ui/mismatched_types/issue-75361-mismatched-impl.stderr
@@ -2,13 +2,13 @@ error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/issue-75361-mismatched-impl.rs:18:3
    |
 LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
-   |   --------------------------------------------------------------------- expected `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + 'static)>`
+   |   --------------------------------------------------------------------- expected `fn(&'1 T) -> Box<dyn MyTrait<Item = &'1 T> + 'static>`
 ...
 LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType> + '_> {
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + '1)>`
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 T) -> Box<dyn MyTrait<Item = &'1 T> + '1>`
    |
-   = note: expected signature `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + 'static)>`
-              found signature `fn(&'1 T) -> Box<(dyn MyTrait<Item = &'1 T> + '1)>`
+   = note: expected signature `fn(&'1 T) -> Box<dyn MyTrait<Item = &'1 T> + 'static>`
+              found signature `fn(&'1 T) -> Box<dyn MyTrait<Item = &'1 T> + '1>`
 help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
   --> $DIR/issue-75361-mismatched-impl.rs:12:55
    |

--- a/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
+++ b/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
@@ -57,7 +57,7 @@ LL |     let a = async { 42 };
 LL |     let s = Demo { a };
    |                    ^ expected `Pin<Box<...>>`, found `async` block
    |
-   = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note:     expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
            found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:18}`
 help: you need to pin and box this expression
    |

--- a/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
+++ b/tests/ui/mismatched_types/mismatch-sugg-for-shorthand-field.stderr
@@ -57,7 +57,7 @@ LL |     let a = async { 42 };
 LL |     let s = Demo { a };
    |                    ^ expected `Pin<Box<_>>`, found `async` block
    |
-   = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note:     expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
            found `async` block `{async block@$DIR/mismatch-sugg-for-shorthand-field.rs:53:13: 53:18}`
 help: you need to pin and box this expression
    |

--- a/tests/ui/mismatched_types/trait-bounds-cant-coerce.stderr
+++ b/tests/ui/mismatched_types/trait-bounds-cant-coerce.stderr
@@ -6,8 +6,8 @@ LL |     a(x);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected struct `Box<(dyn Foo + Send + 'static)>`
-              found struct `Box<(dyn Foo + 'static)>`
+   = note: expected struct `Box<dyn Foo + Send + 'static>`
+              found struct `Box<dyn Foo + 'static>`
 note: function defined here
   --> $DIR/trait-bounds-cant-coerce.rs:5:4
    |

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -6,7 +6,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
    = note: defining type: no_region::<'?1, T>::{closure#0} with closure args [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<dyn Anything + '?2>,
                (),
            ]
    = note: number of external vids: 3
@@ -44,7 +44,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
    = note: defining type: correct_region::<'?1, T>::{closure#0} with closure args [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?2)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<dyn Anything + '?2>,
                (),
            ]
    = note: number of external vids: 3
@@ -68,7 +68,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
    = note: defining type: wrong_region::<'?1, '?2, T>::{closure#0} with closure args [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<dyn Anything + '?3>,
                (),
            ]
    = note: number of external vids: 4
@@ -106,7 +106,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
    = note: defining type: outlives_region::<'?1, '?2, T>::{closure#0} with closure args [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn Anything + '?3)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<dyn Anything + '?3>,
                (),
            ]
    = note: number of external vids: 4

--- a/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
+++ b/tests/ui/nll/ty-outlives/ty-param-closure-outlives-from-return-type.stderr
@@ -6,7 +6,7 @@ LL |     with_signature(x, |y| y)
    |
    = note: defining type: no_region::<'?1, T>::{closure#0} with closure args [
                i32,
-               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<(dyn std::fmt::Debug + '?2)>,
+               extern "rust-call" fn((std::boxed::Box<T>,)) -> std::boxed::Box<dyn std::fmt::Debug + '?2>,
                (),
            ]
    = note: number of external vids: 3

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -7,13 +7,13 @@ LL |     offset_of!(Alpha, z);
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:38:5
    |
 LL |     offset_of!(Beta, z);
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Trait + 'static`
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `Extern` cannot be known at compilation time

--- a/tests/ui/offset-of/offset-of-dst-field.stderr
+++ b/tests/ui/offset-of/offset-of-dst-field.stderr
@@ -6,13 +6,13 @@ LL |     offset_of!(Alpha, z);
    |
    = help: the trait `Sized` is not implemented for `[u8]`
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:38:5
    |
 LL |     offset_of!(Beta, z);
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Trait + 'static`
 
 error[E0277]: the size for values of type `Extern` cannot be known at compilation time
   --> $DIR/offset-of-dst-field.rs:39:5

--- a/tests/ui/parallel-rustc/dyn-trait-ice-153366.rs
+++ b/tests/ui/parallel-rustc/dyn-trait-ice-153366.rs
@@ -16,10 +16,10 @@ where
 fn iso_un_option<B>() -> Box<_> {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
     iso(())
-    //~^ ERROR the size for values of type `(dyn Fn(_) + 'static)` cannot be known at compilation
+    //~^ ERROR the size for values of type `dyn Fn(_) + 'static` cannot be known at compilation
 }
 
 fn main() {
     iso(())
-    //~^ ERROR the size for values of type `(dyn Fn(_) + 'static)` cannot be known at compilation
+    //~^ ERROR the size for values of type `dyn Fn(_) + 'static` cannot be known at compilation
 }

--- a/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
+++ b/tests/ui/parallel-rustc/dyn-trait-ice-153366.stderr
@@ -23,13 +23,13 @@ help: add missing generic argument
 LL | fn iso<A>(a: Fn<Args>) -> Option<_>
    |                ++++++
 
-error[E0277]: the size for values of type `(dyn Fn(_) + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn(_) + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-ice-153366.rs:18:5
    |
 LL |     iso(())
    |     ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn(_) + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn(_) + 'static`
 note: required by a bound in `iso`
   --> $DIR/dyn-trait-ice-153366.rs:11:22
    |
@@ -71,13 +71,13 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL | fn iso<A>(a: Fn) -> Option<_>
    |                            ^ not allowed in type signatures
 
-error[E0277]: the size for values of type `(dyn Fn(_) + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn(_) + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-ice-153366.rs:23:5
    |
 LL |     iso(())
    |     ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn(_) + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn(_) + 'static`
 note: required by a bound in `iso`
   --> $DIR/dyn-trait-ice-153366.rs:11:22
    |

--- a/tests/ui/regions/regions-close-object-into-object-2.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-2.stderr
@@ -14,7 +14,7 @@ LL + fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'a> {
 help: alternatively, add an explicit `'static` bound to this reference
    |
 LL - fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {
-LL + fn g<'a, T: 'static>(v: Box<(dyn A<T> + 'static)>) -> Box<dyn X + 'static> {
+LL + fn g<'a, T: 'static>(v: Box<dyn A<T> + 'static>) -> Box<dyn X + 'static> {
    |
 
 error[E0515]: cannot return value referencing local data `*v`

--- a/tests/ui/regions/regions-close-object-into-object-4.stderr
+++ b/tests/ui/regions/regions-close-object-into-object-4.stderr
@@ -56,7 +56,7 @@ LL + fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'a> {
 help: alternatively, add an explicit `'static` bound to this reference
    |
 LL - fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {
-LL + fn i<'a, T, U>(v: Box<(dyn A<U> + 'static)>) -> Box<dyn X + 'static> {
+LL + fn i<'a, T, U>(v: Box<dyn A<U> + 'static>) -> Box<dyn X + 'static> {
    |
 
 error[E0515]: cannot return value referencing local data `*v`

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -11,13 +11,13 @@ note: for a trait to be dyn compatible it needs to allow building a vtable
 LL |     fn bar();
    |        ^^^ the trait is not dyn compatible because associated function `bar` has no `self` parameter
 
-error[E0277]: the size for values of type `(dyn issue_3907::Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn issue_3907::Foo + 'static` cannot be known at compilation time
   --> $DIR/issue-3907-2.rs:11:12
    |
 LL | fn bar(_x: Foo) {}
    |            ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn issue_3907::Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn issue_3907::Foo + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/resolve/issue-5035-2.stderr
+++ b/tests/ui/resolve/issue-5035-2.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn I + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn I + 'static` cannot be known at compilation time
   --> $DIR/issue-5035-2.rs:4:12
    |
 LL | fn foo(_x: K) {}
    |            ^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn I + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn I + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/sized/reject-unsized-fn-params.stderr
+++ b/tests/ui/sized/reject-unsized-fn-params.stderr
@@ -15,13 +15,13 @@ help: function arguments must have a statically known size, borrowed types alway
 LL |     fn baz(_: &Self::Target) where Self: Deref {}
    |               +
 
-error[E0277]: the size for values of type `(dyn ToString + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn ToString + 'static` cannot be known at compilation time
   --> $DIR/reject-unsized-fn-params.rs:12:13
    |
 LL | pub fn f(_: dyn ToString) {}
    |             ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn ToString + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn ToString + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.rs
@@ -10,7 +10,7 @@ impl<T> dyn FnOnce(T) -> () {
     extern "rust-call" fn call_once(#[rustc_splat] self) {}
     //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
     //~| ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
-    //~| ERROR the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known
+    //~| ERROR the size for values of type `dyn FnOnce(T) + 'static` cannot be known
 }
 
 fn main() {}

--- a/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-fn-trait-self-issue-158800.stderr
@@ -21,13 +21,13 @@ LL | impl<T> dyn FnOnce(T) -> () {
    = help: consider defining a trait and implementing it for the type or using a newtype wrapper like `struct MyType(ExternalType);` and implement it
    = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
 
-error[E0277]: the size for values of type `(dyn FnOnce(T) + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn FnOnce(T) + 'static` cannot be known at compilation time
   --> $DIR/splat-rust-call-fn-trait-self-issue-158800.rs:10:52
    |
 LL |     extern "rust-call" fn call_once(#[rustc_splat] self) {}
    |                                                    ^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn FnOnce(T) + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn FnOnce(T) + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/splat/splat-rust-call-trait-issue-158800.rs
+++ b/tests/ui/splat/splat-rust-call-trait-issue-158800.rs
@@ -13,7 +13,7 @@ trait Trait {
 impl dyn Trait {
     extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized {}
     //~^ ERROR `#[rustc_splat]` is not allowed in the arguments of functions with the `rust-call` ABI
-    //~| ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `dyn Trait + 'static` cannot be known at compilation time
 }
 
 fn main() {}

--- a/tests/ui/splat/splat-rust-call-trait-issue-158800.stderr
+++ b/tests/ui/splat/splat-rust-call-trait-issue-158800.stderr
@@ -14,13 +14,13 @@ LL |     extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized {}
    |
    = help: remove `#[rustc_splat]` or change the ABI
 
-error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Trait + 'static` cannot be known at compilation time
   --> $DIR/splat-rust-call-trait-issue-158800.rs:14:57
    |
 LL |     extern "rust-call" fn f(#[rustc_splat] _: ()) where Self: Sized {}
    |                                                         ^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Trait + 'static`
 help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
    |
 LL + #![feature(trivial_bounds)]

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Fn() -> u32 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn() -> u32 + 'static` cannot be known at compilation time
   --> $DIR/issue-24446.rs:2:5
    |
 LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn() -> u32 + 'static`
    = note: statics and constants must have a statically known size
 
 error: aborting due to 1 previous error

--- a/tests/ui/static/issue-5216.stderr
+++ b/tests/ui/static/issue-5216.stderr
@@ -6,7 +6,7 @@ LL | pub static C: S = S(f);
    |                   |
    |                   arguments to this struct are incorrect
    |
-   = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
+   = note: expected struct `Box<dyn FnMut() + Sync + 'static>`
              found fn item `fn() {f}`
 note: tuple struct defined here
   --> $DIR/issue-5216.rs:2:8
@@ -22,7 +22,7 @@ LL | pub static D: T = g;
    |               |
    |               expected because of the type of the static
    |
-   = note: expected struct `Box<(dyn FnMut() + Sync + 'static)>`
+   = note: expected struct `Box<dyn FnMut() + Sync + 'static>`
              found fn item `fn() {g}`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -21,13 +21,13 @@ help: alternatively, consider constraining `bar` so it does not apply to trait o
 LL |     fn bar() -> i32 where Self: Sized;
    |                     +++++++++++++++++
 
-error[E0277]: `(dyn Qux + 'static)` cannot be shared between threads safely
+error[E0277]: `dyn Qux + 'static` cannot be shared between threads safely
   --> $DIR/unsizing-wfcheck-issue-127299.rs:12:13
    |
 LL | static FOO: &Lint = &Lint { desc: "desc" };
-   |             ^^^^^ `(dyn Qux + 'static)` cannot be shared between threads safely
+   |             ^^^^^ `dyn Qux + 'static` cannot be shared between threads safely
    |
-   = help: within `&'static Lint`, the trait `Sync` is not implemented for `(dyn Qux + 'static)`
+   = help: within `&'static Lint`, the trait `Sync` is not implemented for `dyn Qux + 'static`
    = note: required because it appears within the type `&'static (dyn Qux + 'static)`
 note: required because it appears within the type `Lint`
   --> $DIR/unsizing-wfcheck-issue-127299.rs:7:12

--- a/tests/ui/structs/field-implied-unsizing-wfcheck.rs
+++ b/tests/ui/structs/field-implied-unsizing-wfcheck.rs
@@ -1,19 +1,19 @@
 struct FooStruct {
     nested: &'static Bar<dyn std::fmt::Debug>,
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
 }
 
 struct FooTuple(&'static Bar<dyn std::fmt::Debug>);
-//~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+//~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
 
 enum FooEnum1 {
     Struct { nested: &'static Bar<dyn std::fmt::Debug> },
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
 }
 
 enum FooEnum2 {
     Tuple(&'static Bar<dyn std::fmt::Debug>),
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
 }
 
 struct Bar<T>(T);
@@ -22,11 +22,11 @@ fn main() {
     // Ensure there's an error at the construction site, for error tainting purposes.
 
     FooStruct { nested: &Bar(4) };
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
     FooTuple(&Bar(4));
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
     FooEnum1::Struct { nested: &Bar(4) };
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
     FooEnum2::Tuple(&Bar(4));
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
 }

--- a/tests/ui/structs/field-implied-unsizing-wfcheck.stderr
+++ b/tests/ui/structs/field-implied-unsizing-wfcheck.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:2:13
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -18,13 +18,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:6:17
    |
 LL | struct FooTuple(&'static Bar<dyn std::fmt::Debug>);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -38,13 +38,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:10:22
    |
 LL |     Struct { nested: &'static Bar<dyn std::fmt::Debug> },
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -58,13 +58,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:15:11
    |
 LL |     Tuple(&'static Bar<dyn std::fmt::Debug>),
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -78,13 +78,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:24:25
    |
 LL |     FooStruct { nested: &Bar(4) };
    |                         ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -98,13 +98,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:26:14
    |
 LL |     FooTuple(&Bar(4));
    |              ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -118,13 +118,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:28:32
    |
 LL |     FooEnum1::Struct { nested: &Bar(4) };
    |                                ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |
@@ -138,13 +138,13 @@ LL | struct Bar<T>(T);
    |            |
    |            this could be changed to `T: ?Sized`...
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/field-implied-unsizing-wfcheck.rs:30:21
    |
 LL |     FooEnum2::Tuple(&Bar(4));
    |                     ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/field-implied-unsizing-wfcheck.rs:19:12
    |

--- a/tests/ui/suggestions/ambiguous-assoc-type-path-suggest-similar-item.stderr
+++ b/tests/ui/suggestions/ambiguous-assoc-type-path-suggest-similar-item.stderr
@@ -136,10 +136,10 @@ error[E0223]: ambiguous associated type
 LL |     <dyn std::any::Any>::downcast::mut_unchecked;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: if there were a trait named `Example` with associated type `downcast` implemented for `(dyn Any + 'static)`, you could use the fully-qualified path
+help: if there were a trait named `Example` with associated type `downcast` implemented for `dyn Any + 'static`, you could use the fully-qualified path
    |
 LL -     <dyn std::any::Any>::downcast::mut_unchecked;
-LL +     <(dyn Any + 'static) as Example>::downcast::mut_unchecked;
+LL +     <dyn Any + 'static as Example>::downcast::mut_unchecked;
    |
 
 error: aborting due to 12 previous errors

--- a/tests/ui/suggestions/box-future-wrong-output.stderr
+++ b/tests/ui/suggestions/box-future-wrong-output.stderr
@@ -6,7 +6,7 @@ LL |     let _: BoxFuture<'static, bool> = async {}.boxed();
    |            |
    |            expected due to this
    |
-   = note: expected struct `Pin<Box<(dyn Future<Output = bool> + Send + 'static)>>`
+   = note: expected struct `Pin<Box<dyn Future<Output = bool> + Send + 'static>>`
               found struct `Pin<Box<dyn Future<Output = ()> + Send>>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.stderr
+++ b/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.stderr
@@ -22,7 +22,7 @@ LL |     bar(async move || {});
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected struct `Box<(dyn FnOnce() -> _ + 'static)>`
+   = note: expected struct `Box<dyn FnOnce() -> _ + 'static>`
              found closure `{async closure@$DIR/dont-suggest-boxing-async-closure-body.rs:11:9: 11:22}`
    = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
 note: function defined here

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:11:5
    |
 LL | fn foo<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
-   |        - found this type parameter                      ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
+   |        - found this type parameter                      ----------------------- expected `Pin<Box<dyn Future<Output = i32> + Send + 'static>>` because of return type
 LL |     // We could instead use an `async` block, but this way we have no std spans.
 LL |     x
    |     ^ expected `Pin<Box<...>>`, found type parameter `F`
    |
-   = note:      expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note:      expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
            found type parameter `F`
 help: you need to pin and box this expression
    |
@@ -18,11 +18,11 @@ error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:15:5
    |
 LL | fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
-   |                                                         ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
+   |                                                         ----------------------- expected `Pin<Box<dyn Future<Output = i32> + Send + 'static>>` because of return type
 LL |     Box::new(x)
    |     ^^^^^^^^^^^ expected `Pin<Box<...>>`, found `Box<F>`
    |
-   = note: expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note: expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
               found struct `Box<F>`
    = help: use `Box::pin`
 
@@ -72,13 +72,13 @@ error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:28:5
    |
 LL |   fn zap() -> BoxFuture<'static, i32> {
-   |               ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
+   |               ----------------------- expected `Pin<Box<dyn Future<Output = i32> + Send + 'static>>` because of return type
 LL | /     async {
 LL | |         42
 LL | |     }
    | |_____^ expected `Pin<Box<...>>`, found `async` block
    |
-   = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note:     expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
            found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 28:10}`
 help: you need to pin and box this expression
    |

--- a/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
+++ b/tests/ui/suggestions/expected-boxed-future-isnt-pinned.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:11:5
    |
 LL | fn foo<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
-   |        - found this type parameter                      ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
+   |        - found this type parameter                      ----------------------- expected `Pin<Box<dyn Future<Output = i32> + Send + 'static>>` because of return type
 LL |     // We could instead use an `async` block, but this way we have no std spans.
 LL |     x
    |     ^ expected `Pin<Box<_>>`, found type parameter `F`
    |
-   = note:      expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note:      expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
            found type parameter `F`
 help: you need to pin and box this expression
    |
@@ -18,11 +18,11 @@ error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:15:5
    |
 LL | fn bar<F: Future<Output=i32> + Send + 'static>(x: F) -> BoxFuture<'static, i32> {
-   |                                                         ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
+   |                                                         ----------------------- expected `Pin<Box<dyn Future<Output = i32> + Send + 'static>>` because of return type
 LL |     Box::new(x)
    |     ^^^^^^^^^^^ expected `Pin<Box<_>>`, found `Box<F>`
    |
-   = note: expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note: expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
               found struct `Box<F>`
    = help: use `Box::pin`
 
@@ -72,13 +72,13 @@ error[E0308]: mismatched types
   --> $DIR/expected-boxed-future-isnt-pinned.rs:28:5
    |
 LL |   fn zap() -> BoxFuture<'static, i32> {
-   |               ----------------------- expected `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>` because of return type
+   |               ----------------------- expected `Pin<Box<dyn Future<Output = i32> + Send + 'static>>` because of return type
 LL | /     async {
 LL | |         42
 LL | |     }
    | |_____^ expected `Pin<Box<_>>`, found `async` block
    |
-   = note:     expected struct `Pin<Box<(dyn Future<Output = i32> + Send + 'static)>>`
+   = note:     expected struct `Pin<Box<dyn Future<Output = i32> + Send + 'static>>`
            found `async` block `{async block@$DIR/expected-boxed-future-isnt-pinned.rs:28:5: 28:10}`
 help: you need to pin and box this expression
    |

--- a/tests/ui/suggestions/issue-104327.stderr
+++ b/tests/ui/suggestions/issue-104327.stderr
@@ -9,8 +9,8 @@ LL |     Foo::f();
    |
 help: use the fully-qualified path to the only available implementation
    |
-LL |     <(dyn Bar + 'static) as Foo>::f();
-   |     +++++++++++++++++++++++    +
+LL |     <dyn Bar + 'static as Foo>::f();
+   |     +++++++++++++++++++++    +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.stderr
+++ b/tests/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.stderr
@@ -10,7 +10,7 @@ LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'1` must outlive `'static`
    |
-help: to declare that `impl Iterator<Item = Box<(dyn Foo + 'static)>>` captures data from argument `self`, you can add an explicit `'_` lifetime bound
+help: to declare that `impl Iterator<Item = Box<dyn Foo + 'static>>` captures data from argument `self`, you can add an explicit `'_` lifetime bound
    |
 LL |     fn iter(&self) -> impl Iterator<Item = Box<dyn Foo>> + '_ {
    |                                                          ++++
@@ -65,7 +65,7 @@ LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'a` must outlive `'static`
    |
-help: to declare that `impl Iterator<Item = Box<(dyn Foo + 'static)>>` captures data from argument `self`, you can add an explicit `'a` lifetime bound
+help: to declare that `impl Iterator<Item = Box<dyn Foo + 'static>>` captures data from argument `self`, you can add an explicit `'a` lifetime bound
    |
 LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> + 'a {
    |                                                                 ++++

--- a/tests/ui/suggestions/match-with-different-arm-types-as-stmt-instead-of-expr.stderr
+++ b/tests/ui/suggestions/match-with-different-arm-types-as-stmt-instead-of-expr.stderr
@@ -43,7 +43,7 @@ LL | fn wrong(c: &str) -> Box<dyn Foo> {
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
    |
-   = note: expected struct `Box<(dyn Foo + 'static)>`
+   = note: expected struct `Box<dyn Foo + 'static>`
            found unit type `()`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/symbol-names/impl1.legacy.stderr
+++ b/tests/ui/symbol-names/impl1.legacy.stderr
@@ -64,7 +64,7 @@ error: demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::A
 LL |             #[rustc_dump_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: def-path(<[&dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait; 3] as main::{closure#1}::Bar>::method)
+error: def-path(<[&(dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait); 3] as main::{closure#1}::Bar>::method)
   --> $DIR/impl1.rs:69:13
    |
 LL |             #[rustc_dump_def_path]

--- a/tests/ui/symbol-names/impl1.rs
+++ b/tests/ui/symbol-names/impl1.rs
@@ -67,8 +67,8 @@ fn main() {
                 //[v0]~| ERROR demangling(<[&dyn
                 //[v0]~| ERROR demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)
             #[rustc_dump_def_path]
-            //[legacy]~^ ERROR def-path(<[&dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait; 3] as main::{closure#1}::Bar>::method)
-               //[v0]~^^ ERROR def-path(<[&dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait; 3] as main::{closure#1}::Bar>::method)
+            //[legacy]~^ ERROR def-path(<[&(dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait); 3] as main::{closure#1}::Bar>::method)
+               //[v0]~^^ ERROR def-path(<[&(dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait); 3] as main::{closure#1}::Bar>::method)
             fn method(&self) {}
         }
     };

--- a/tests/ui/symbol-names/impl1.v0.stderr
+++ b/tests/ui/symbol-names/impl1.v0.stderr
@@ -64,7 +64,7 @@ error: demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ..
 LL |             #[rustc_dump_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: def-path(<[&dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait; 3] as main::{closure#1}::Bar>::method)
+error: def-path(<[&(dyn Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + AutoTrait); 3] as main::{closure#1}::Bar>::method)
   --> $DIR/impl1.rs:69:13
    |
 LL |             #[rustc_dump_def_path]

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
@@ -7,9 +7,9 @@ type Fn = dyn FnOnce() -> u8;
 
 const TEST: Fn = some_fn;
 //~^ ERROR cannot find value `some_fn` in this scope
-//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `dyn FnOnce() -> u8 + 'static` cannot be known at compilation time
 const TEST2: (Fn, u8) = (TEST, 0);
-//~^ ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+//~^ ERROR the size for values of type `dyn FnOnce() -> u8 + 'static` cannot be known at compilation time
+//~| ERROR the size for values of type `dyn FnOnce() -> u8 + 'static` cannot be known at compilation time
 
 fn main() {}

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
@@ -4,31 +4,31 @@ error[E0425]: cannot find value `some_fn` in this scope
 LL | const TEST: Fn = some_fn;
    |                  ^^^^^^^ not found in this scope
 
-error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn FnOnce() -> u8 + 'static` cannot be known at compilation time
   --> $DIR/ice-unsized-tuple-const-issue-121443.rs:8:13
    |
 LL | const TEST: Fn = some_fn;
    |             ^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn FnOnce() -> u8 + 'static`
    = note: statics and constants must have a statically known size
 
-error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn FnOnce() -> u8 + 'static` cannot be known at compilation time
   --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:14
    |
 LL | const TEST2: (Fn, u8) = (TEST, 0);
    |              ^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn FnOnce() -> u8 + 'static`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn FnOnce() -> u8 + 'static` cannot be known at compilation time
   --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:25
    |
 LL | const TEST2: (Fn, u8) = (TEST, 0);
    |                         ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn FnOnce() -> u8 + 'static`
    = note: only the last element of a tuple may have a dynamically sized type
 
 error: aborting due to 4 previous errors

--- a/tests/ui/traits/alias/dont-elaborate-non-self.rs
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.rs
@@ -5,6 +5,6 @@ use std::future::Future;
 trait F<Fut: Future<Output = usize>> = Fn() -> Fut;
 
 fn f<Fut>(a: dyn F<Fut>) {}
-//~^ ERROR the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
+//~^ ERROR the size for values of type `dyn Fn() -> Fut + 'static` cannot be known at compilation time
 
 fn main() {}

--- a/tests/ui/traits/alias/dont-elaborate-non-self.stderr
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn() -> Fut + 'static` cannot be known at compilation time
   --> $DIR/dont-elaborate-non-self.rs:7:14
    |
 LL | fn f<Fut>(a: dyn F<Fut>) {}
    |              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn() -> Fut + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn() -> Fut + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -12,13 +12,13 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | fn foo(_x: dyn Foo + Send) {
    |            +++
 
-error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + Send + 'static` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:8:12
    |
 LL | fn foo(_x: Foo + Send) {
    |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + Send + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |
@@ -29,13 +29,13 @@ help: function arguments must have a statically known size, borrowed types alway
 LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
-error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + Send + 'static` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:13:12
    |
 LL | fn bar(_x: (dyn Foo + Send)) {
    |            ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + Send + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/traits/bound/sugar.stderr
+++ b/tests/ui/traits/bound/sugar.stderr
@@ -6,8 +6,8 @@ LL |     a(x);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected struct `Box<(dyn Foo + Send + 'static)>`
-              found struct `Box<(dyn Foo + Sync + 'static)>`
+   = note: expected struct `Box<dyn Foo + Send + 'static>`
+              found struct `Box<dyn Foo + Sync + 'static>`
 note: function defined here
   --> $DIR/sugar.rs:5:4
    |

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
@@ -6,14 +6,14 @@ LL | impl const dyn T {
 LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |         ^^^^^^ help: remove the `const`
 
-error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn T + 'static` cannot be known at compilation time
   --> $DIR/span-bug-issue-121418.rs:7:27
    |
 LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `std::sync::Mutex<(dyn T + 'static)>`, the trait `Sized` is not implemented for `(dyn T + 'static)`
-note: required because it appears within the type `std::sync::Mutex<(dyn T + 'static)>`
+   = help: within `std::sync::Mutex<dyn T + 'static>`, the trait `Sized` is not implemented for `dyn T + 'static`
+note: required because it appears within the type `std::sync::Mutex<dyn T + 'static>`
   --> $SRC_DIR/std/src/sync/poison/mutex.rs:LL:COL
    = note: the return type of a function must have a statically known size
 
@@ -25,7 +25,7 @@ LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |                  |
    |                  implicitly returns `()` as its body has no tail or `return` expression
    |
-   = note: expected struct `std::sync::Mutex<(dyn T + 'static)>`
+   = note: expected struct `std::sync::Mutex<dyn T + 'static>`
            found unit type `()`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
@@ -6,14 +6,14 @@ LL | const impl dyn T {
 LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |         ^^^^^^ help: remove the `const`
 
-error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn T + 'static` cannot be known at compilation time
   --> $DIR/span-bug-issue-121418.rs:7:27
    |
 LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `std::sync::Mutex<(dyn T + 'static)>`, the trait `Sized` is not implemented for `(dyn T + 'static)`
-note: required because it appears within the type `std::sync::Mutex<(dyn T + 'static)>`
+   = help: within `std::sync::Mutex<dyn T + 'static>`, the trait `Sized` is not implemented for `dyn T + 'static`
+note: required because it appears within the type `std::sync::Mutex<dyn T + 'static>`
   --> $SRC_DIR/std/src/sync/poison/mutex.rs:LL:COL
    = note: the return type of a function must have a statically known size
 
@@ -25,7 +25,7 @@ LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    |                  |
    |                  implicitly returns `()` as its body has no tail or `return` expression
    |
-   = note: expected struct `std::sync::Mutex<(dyn T + 'static)>`
+   = note: expected struct `std::sync::Mutex<dyn T + 'static>`
            found unit type `()`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr
+++ b/tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr
@@ -14,7 +14,7 @@ help: the trait `bounds_check::LeakTr` is implemented for `LeakS`
    |
 LL |     impl LeakTr for LeakS {}
    |     ^^^^^^^^^^^^^^^^^^^^^
-   = note: required for the cast from `&NonLeakS` to `&dyn bounds_check::LeakTr + Leak`
+   = note: required for the cast from `&NonLeakS` to `&(dyn bounds_check::LeakTr + Leak)`
 
 error[E0038]: the trait `DynCompatCheck2` is not dyn compatible
   --> $DIR/maybe-bounds-in-dyn-traits.rs:90:17

--- a/tests/ui/traits/dont-suggest-impl-as-closure-arg.rs
+++ b/tests/ui/traits/dont-suggest-impl-as-closure-arg.rs
@@ -1,5 +1,5 @@
 // Suggestion to use impl trait in closure parameter is invalid, see issue 138932
 fn main() {
     let c = |f: dyn Fn()| f();
-    //~^ ERROR: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+    //~^ ERROR: the size for values of type `dyn Fn() + 'static` cannot be known at compilation time
 }

--- a/tests/ui/traits/dont-suggest-impl-as-closure-arg.stderr
+++ b/tests/ui/traits/dont-suggest-impl-as-closure-arg.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn() + 'static` cannot be known at compilation time
   --> $DIR/dont-suggest-impl-as-closure-arg.rs:3:17
    |
 LL |     let c = |f: dyn Fn()| f();
    |                 ^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn() + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |

--- a/tests/ui/traits/dyn-coerce-unsized-ice.rs
+++ b/tests/ui/traits/dyn-coerce-unsized-ice.rs
@@ -10,7 +10,7 @@ pub trait Trait {}
 pub fn foo(x: dyn CoerceUnsized<*const dyn Trait>) -> *const dyn Trait {
 //~^ ERROR: the trait `CoerceUnsized` is not dyn compatible [E0038]
     x
-//~^ ERROR: the size for values of type `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)` cannot be known at compilation time [E0277]
+//~^ ERROR: the size for values of type `dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static` cannot be known at compilation time [E0277]
 }
 
 fn main() {}

--- a/tests/ui/traits/dyn-coerce-unsized-ice.stderr
+++ b/tests/ui/traits/dyn-coerce-unsized-ice.stderr
@@ -8,14 +8,14 @@ LL | pub fn foo(x: dyn CoerceUnsized<*const dyn Trait>) -> *const dyn Trait {
    = note: for a trait to be dyn compatible it needs to allow building a vtable
            for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
-error[E0277]: the size for values of type `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static` cannot be known at compilation time
   --> $DIR/dyn-coerce-unsized-ice.rs:12:5
    |
 LL |     x
    |     ^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)`
-   = note: required for the cast from `(dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static)` to `*const (dyn Trait + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static`
+   = note: required for the cast from `dyn CoerceUnsized<*const (dyn Trait + 'static)> + 'static` to `*const (dyn Trait + 'static)`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/dyn-trait-size-error-23281.stderr
+++ b/tests/ui/traits/dyn-trait-size-error-23281.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn() + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-size-error-23281.rs:4:27
    |
 LL |     pub fn function(funs: Vec<dyn Fn() -> ()>) {}
    |                           ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn() + 'static`
 note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/dyn-trait-size-error-23281.rs:8:12
    |

--- a/tests/ui/traits/ice-trait-with-default-method-but-no-impl-broken-mir-109869-1.stderr
+++ b/tests/ui/traits/ice-trait-with-default-method-but-no-impl-broken-mir-109869-1.stderr
@@ -2,14 +2,14 @@ error[E0308]: mismatched types
   --> $DIR/ice-trait-with-default-method-but-no-impl-broken-mir-109869-1.rs:16:9
    |
 LL |     fn from((from, ()): Spanned<F>) -> Self {
-   |                                        ---- expected `(dyn Span<T> + 'static)` because of return type
+   |                                        ---- expected `dyn Span<T> + 'static` because of return type
 LL |         (T::from(from), ())
    |         ^^^^^^^^^^^^^^^^^^^ expected `dyn Span`, found `(T, ())`
    |
-   = note: expected trait object `(dyn Span<T> + 'static)`
+   = note: expected trait object `dyn Span<T> + 'static`
                      found tuple `(T, ())`
    = help: `(T, ())` implements `Span` so you could box the found value and coerce it to the trait object `Box<dyn Span>`, you will have to change the expected type as well
-help: call `Into::into` on this expression to convert `(T, ())` into `(dyn Span<T> + 'static)`
+help: call `Into::into` on this expression to convert `(T, ())` into `dyn Span<T> + 'static`
    |
 LL |         (T::from(from), ()).into()
    |                            +++++++

--- a/tests/ui/traits/ice-trait-with-default-method-but-no-impl-broken-mir-109869-2.stderr
+++ b/tests/ui/traits/ice-trait-with-default-method-but-no-impl-broken-mir-109869-2.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/ice-trait-with-default-method-but-no-impl-broken-mir-109869-2.rs:12:9
    |
 LL |     fn default() -> Self {
-   |                     ---- expected `(dyn Empty<T> + 'static)` because of return type
+   |                     ---- expected `dyn Empty<T> + 'static` because of return type
 LL |         ()
    |         ^^ expected `dyn Empty`, found `()`
    |
-   = note: expected trait object `(dyn Empty<T> + 'static)`
+   = note: expected trait object `dyn Empty<T> + 'static`
                  found unit type `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/ice-trait-with-default-method-but-no-impl-broken-mir-109869-trivial-bounds.stderr
+++ b/tests/ui/traits/ice-trait-with-default-method-but-no-impl-broken-mir-109869-trivial-bounds.stderr
@@ -2,11 +2,11 @@ error[E0308]: mismatched types
   --> $DIR/ice-trait-with-default-method-but-no-impl-broken-mir-109869-trivial-bounds.rs:13:9
    |
 LL |     fn default() -> Self {
-   |                     ---- expected `(dyn Empty + 'static)` because of return type
+   |                     ---- expected `dyn Empty + 'static` because of return type
 LL |         ()
    |         ^^ expected `dyn Empty`, found `()`
    |
-   = note: expected trait object `(dyn Empty + 'static)`
+   = note: expected trait object `dyn Empty + 'static`
                  found unit type `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/traits/issue-33140-hack-boundaries.stderr
+++ b/tests/ui/traits/issue-33140-hack-boundaries.stderr
@@ -1,20 +1,20 @@
-error[E0119]: conflicting implementations of trait `Trait0` for type `(dyn Send + 'static)`
+error[E0119]: conflicting implementations of trait `Trait0` for type `dyn Send + 'static`
   --> $DIR/issue-33140-hack-boundaries.rs:9:1
    |
 LL | impl Trait0 for dyn Send {}
    | ------------------------ first implementation here
 LL | impl Trait0 for dyn Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + 'static`
 
-error[E0119]: conflicting implementations of trait `Trait1` for type `(dyn Send + 'static)`
+error[E0119]: conflicting implementations of trait `Trait1` for type `dyn Send + 'static`
   --> $DIR/issue-33140-hack-boundaries.rs:18:1
    |
 LL | impl Trait1 for dyn Send {}
    | ------------------------ first implementation here
 LL | impl Trait1 for dyn Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + 'static`
 
-error[E0751]: found both positive and negative implementation of trait `Trait2` for type `(dyn Send + 'static)`:
+error[E0751]: found both positive and negative implementation of trait `Trait2` for type `dyn Send + 'static`:
   --> $DIR/issue-33140-hack-boundaries.rs:25:1
    |
 LL | impl Trait2 for dyn Send {}
@@ -22,21 +22,21 @@ LL | impl Trait2 for dyn Send {}
 LL | impl !Trait2 for dyn Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ negative implementation here
 
-error[E0119]: conflicting implementations of trait `Trait3<(dyn Sync + 'static)>` for type `(dyn Send + 'static)`
+error[E0119]: conflicting implementations of trait `Trait3<dyn Sync + 'static>` for type `dyn Send + 'static`
   --> $DIR/issue-33140-hack-boundaries.rs:32:1
    |
 LL | impl Trait3<dyn Sync> for dyn Send {}
    | ---------------------------------- first implementation here
 LL | impl Trait3<dyn Sync> for dyn Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + 'static`
 
-error[E0119]: conflicting implementations of trait `Trait4a` for type `(dyn Send + 'static)`
+error[E0119]: conflicting implementations of trait `Trait4a` for type `dyn Send + 'static`
   --> $DIR/issue-33140-hack-boundaries.rs:39:1
    |
 LL | impl<T: ?Sized> Trait4a for T {}
    | ----------------------------- first implementation here
 LL | impl Trait4a for dyn Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + 'static`
 
 error[E0119]: conflicting implementations of trait `Trait4b` for type `()`
   --> $DIR/issue-33140-hack-boundaries.rs:46:1
@@ -46,13 +46,13 @@ LL | impl Trait4b for () {}
 LL | impl Trait4b for () {}
    | ^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
 
-error[E0119]: conflicting implementations of trait `Trait4c` for type `(dyn Trait1 + Send + 'static)`
+error[E0119]: conflicting implementations of trait `Trait4c` for type `dyn Trait1 + Send + 'static`
   --> $DIR/issue-33140-hack-boundaries.rs:53:1
    |
 LL | impl Trait4c for dyn Trait1 + Send {}
    | ---------------------------------- first implementation here
 LL | impl Trait4c for dyn Trait1 + Send {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Trait1 + Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Trait1 + Send + 'static`
 
 error[E0119]: conflicting implementations of trait `Trait4d` for type `dyn Send`
   --> $DIR/issue-33140-hack-boundaries.rs:60:1
@@ -62,13 +62,13 @@ LL | impl<'a> Trait4d for dyn Send + 'a {}
 LL | impl<'a> Trait4d for dyn Send + 'a {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send`
 
-error[E0119]: conflicting implementations of trait `Trait5` for type `(dyn Send + 'static)`
+error[E0119]: conflicting implementations of trait `Trait5` for type `dyn Send + 'static`
   --> $DIR/issue-33140-hack-boundaries.rs:67:1
    |
 LL | impl Trait5 for dyn Send {}
    | ------------------------ first implementation here
 LL | impl Trait5 for dyn Send where u32: Copy {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + 'static`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/traits/issue-33140.stderr
+++ b/tests/ui/traits/issue-33140.stderr
@@ -1,20 +1,20 @@
-error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Trait` for type `dyn Send + Sync + 'static`
   --> $DIR/issue-33140.rs:9:1
    |
 LL | impl Trait for dyn Send + Sync {
    | ------------------------------ first implementation here
 ...
 LL | impl Trait for dyn Sync + Send {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
-error[E0119]: conflicting implementations of trait `Trait2` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Trait2` for type `dyn Send + Sync + 'static`
   --> $DIR/issue-33140.rs:22:1
    |
 LL | impl Trait2 for dyn Send + Sync {
    | ------------------------------- first implementation here
 ...
 LL | impl Trait2 for dyn Sync + Send + Sync {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
 error[E0592]: duplicate definitions with name `abc`
   --> $DIR/issue-33140.rs:29:5
@@ -31,12 +31,12 @@ error[E0034]: multiple applicable items in scope
 LL |     assert_eq!(<Foo<dyn Send + Sync>>::abc(), false);
    |                                        ^^^ multiple `abc` found
    |
-note: candidate #1 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+note: candidate #1 is defined in an impl for the type `Foo<dyn Send + Sync + 'static>`
   --> $DIR/issue-33140.rs:29:5
    |
 LL |     fn abc() -> bool {
    |     ^^^^^^^^^^^^^^^^
-note: candidate #2 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+note: candidate #2 is defined in an impl for the type `Foo<dyn Send + Sync + 'static>`
   --> $DIR/issue-33140.rs:35:5
    |
 LL |     fn abc() -> bool {
@@ -48,12 +48,12 @@ error[E0034]: multiple applicable items in scope
 LL |     assert_eq!(<Foo<dyn Sync + Send>>::abc(), true);
    |                                        ^^^ multiple `abc` found
    |
-note: candidate #1 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+note: candidate #1 is defined in an impl for the type `Foo<dyn Send + Sync + 'static>`
   --> $DIR/issue-33140.rs:29:5
    |
 LL |     fn abc() -> bool {
    |     ^^^^^^^^^^^^^^^^
-note: candidate #2 is defined in an impl for the type `Foo<(dyn Send + Sync + 'static)>`
+note: candidate #2 is defined in an impl for the type `Foo<dyn Send + Sync + 'static>`
   --> $DIR/issue-33140.rs:35:5
    |
 LL |     fn abc() -> bool {

--- a/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.rs
+++ b/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     let f = |f: dyn Fn()| f;
-    //~^ ERROR the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+    //~^ ERROR the size for values of type `dyn Fn() + 'static` cannot be known at compilation time
     //~| ERROR return type cannot be a trait object without pointer indirection
     f();
     //~^ ERROR this function takes 1 argument but 0 arguments were supplied

--- a/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.stderr
+++ b/tests/ui/traits/next-solver/deferred-closure-call-recovery-issue-157951.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn() + 'static` cannot be known at compilation time
   --> $DIR/deferred-closure-call-recovery-issue-157951.rs:5:17
    |
 LL |     let f = |f: dyn Fn()| f;
    |                 ^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Fn() + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
@@ -21,7 +21,7 @@ error[E0057]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/deferred-closure-call-recovery-issue-157951.rs:8:5
    |
 LL |     f();
-   |     ^-- argument #1 of type `(dyn Fn() + 'static)` is missing
+   |     ^-- argument #1 of type `dyn Fn() + 'static` is missing
    |
 note: closure defined here
   --> $DIR/deferred-closure-call-recovery-issue-157951.rs:5:13

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.current.stderr
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.current.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `(dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>` is not satisfied
+error[E0277]: the trait bound `dyn Trait<i32, Assoc = i64> + 'static: Trait<<U as Foo>::FooAssoc>` is not satisfied
   --> $DIR/object-projection-with-unsatisfied-bound-1.rs:18:25
    |
 LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc);
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<<U as Foo>::FooAssoc>` is not implemented for `(dyn Trait<i32, Assoc = i64> + 'static)`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<<U as Foo>::FooAssoc>` is not implemented for `dyn Trait<i32, Assoc = i64> + 'static`
    |
 help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc) where (dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>;
-   |                                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc) where dyn Trait<i32, Assoc = i64> + 'static: Trait<<U as Foo>::FooAssoc>;
+   |                                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.next.stderr
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.next.stderr
@@ -1,13 +1,13 @@
-error[E0277]: the trait bound `(dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>` is not satisfied
+error[E0277]: the trait bound `dyn Trait<i32, Assoc = i64> + 'static: Trait<<U as Foo>::FooAssoc>` is not satisfied
   --> $DIR/object-projection-with-unsatisfied-bound-1.rs:18:25
    |
 LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc);
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<<U as Foo>::FooAssoc>` is not implemented for `(dyn Trait<i32, Assoc = i64> + 'static)`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<<U as Foo>::FooAssoc>` is not implemented for `dyn Trait<i32, Assoc = i64> + 'static`
    |
 help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc) where (dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>;
-   |                                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc) where dyn Trait<i32, Assoc = i64> + 'static: Trait<<U as Foo>::FooAssoc>;
+   |                                                                                     ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.rs
+++ b/tests/ui/traits/next-solver/object-projection-with-unsatisfied-bound-1.rs
@@ -16,6 +16,6 @@ pub trait Foo {
 }
 
 pub struct Wrap<U: Foo>(<dyn Trait<i32, Assoc = i64> as Trait<U::FooAssoc>>::Assoc);
-//~^ ERROR: the trait bound `(dyn Trait<i32, Assoc = i64> + 'static): Trait<<U as Foo>::FooAssoc>` is not satisfied
+//~^ ERROR: the trait bound `dyn Trait<i32, Assoc = i64> + 'static: Trait<<U as Foo>::FooAssoc>` is not satisfied
 
 fn main() {}

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch-2.next.stderr
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch-2.next.stderr
@@ -6,7 +6,7 @@ LL |     x
    |
    = note: cannot satisfy `dyn Trait<&()>: Unsize<dyn Super<&()>>`
    = note: required for `Box<dyn Trait<&()>>` to implement `CoerceUnsized<Box<dyn Super<&()>>>`
-   = note: required for the cast from `Box<(dyn Trait<&'a ()> + 'static)>` to `Box<(dyn Super<&'a ()> + 'static)>`
+   = note: required for the cast from `Box<dyn Trait<&'a ()> + 'static>` to `Box<dyn Super<&'a ()> + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/unsize-goal-mismatch.next.stderr
+++ b/tests/ui/traits/next-solver/unsize-goal-mismatch.next.stderr
@@ -6,7 +6,7 @@ LL |     x
    |
    = note: cannot satisfy `dyn Trait<'_>: Unsize<dyn Super<'_>>`
    = note: required for `Box<dyn Trait<'_>>` to implement `CoerceUnsized<Box<dyn Super<'_>>>`
-   = note: required for the cast from `Box<(dyn Trait<'a> + 'static)>` to `Box<(dyn Super<'a> + 'static)>`
+   = note: required for the cast from `Box<dyn Trait<'a> + 'static>` to `Box<dyn Super<'a> + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/object/incomplete-multiple-super-projection.rs
+++ b/tests/ui/traits/object/incomplete-multiple-super-projection.rs
@@ -18,7 +18,7 @@ impl Trait for dyn Dyn<(), ()> {
     type Assoc = &'static str;
 }
 impl<A, B> Trait for dyn Dyn<A, B> {
-//~^ ERROR conflicting implementations of trait `Trait` for type `(dyn Dyn<(), ()> + 'static)`
+//~^ ERROR conflicting implementations of trait `Trait` for type `dyn Dyn<(), ()> + 'static`
     type Assoc = usize;
 }
 

--- a/tests/ui/traits/object/incomplete-multiple-super-projection.stderr
+++ b/tests/ui/traits/object/incomplete-multiple-super-projection.stderr
@@ -1,11 +1,11 @@
-error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Dyn<(), ()> + 'static)`
+error[E0119]: conflicting implementations of trait `Trait` for type `dyn Dyn<(), ()> + 'static`
   --> $DIR/incomplete-multiple-super-projection.rs:20:1
    |
 LL | impl Trait for dyn Dyn<(), ()> {
    | ------------------------------ first implementation here
 ...
 LL | impl<A, B> Trait for dyn Dyn<A, B> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Dyn<(), ()> + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Dyn<(), ()> + 'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/object/issue-33140-traitobject-crate.stderr
+++ b/tests/ui/traits/object/issue-33140-traitobject-crate.stderr
@@ -1,28 +1,28 @@
-error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Trait` for type `dyn Send + Sync + 'static`
   --> $DIR/issue-33140-traitobject-crate.rs:83:1
    |
 LL | unsafe impl Trait for dyn (::std::marker::Send) + Sync { }
    | ------------------------------------------------------ first implementation here
 LL | unsafe impl Trait for dyn (::std::marker::Send) + Send + Sync { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
-error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Trait` for type `dyn Send + Sync + 'static`
   --> $DIR/issue-33140-traitobject-crate.rs:85:1
    |
 LL | unsafe impl Trait for dyn (::std::marker::Send) + Sync { }
    | ------------------------------------------------------ first implementation here
 ...
 LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
-error[E0119]: conflicting implementations of trait `Trait` for type `(dyn Send + Sync + 'static)`
+error[E0119]: conflicting implementations of trait `Trait` for type `dyn Send + Sync + 'static`
   --> $DIR/issue-33140-traitobject-crate.rs:88:1
    |
 LL | unsafe impl Trait for dyn (::std::marker::Send) + Sync { }
    | ------------------------------------------------------ first implementation here
 ...
 LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send + Sync { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn Send + Sync + 'static)`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `dyn Send + Sync + 'static`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/opaque-trait-size-error-5883.stderr
+++ b/tests/ui/traits/opaque-trait-size-error-5883.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn A + 'static` cannot be known at compilation time
   --> $DIR/opaque-trait-size-error-5883.rs:10:6
    |
 LL | ) -> Struct {
    |      ^^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Struct`, the trait `Sized` is not implemented for `(dyn A + 'static)`
+   = help: within `Struct`, the trait `Sized` is not implemented for `dyn A + 'static`
 note: required because it appears within the type `Struct`
   --> $DIR/opaque-trait-size-error-5883.rs:4:8
    |
@@ -12,13 +12,13 @@ LL | struct Struct {
    |        ^^^^^^
    = note: the return type of a function must have a statically known size
 
-error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn A + 'static` cannot be known at compilation time
   --> $DIR/opaque-trait-size-error-5883.rs:9:8
    |
 LL |     r: dyn A + 'static
    |        ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn A + 'static`
    = help: unsized fn params are gated as an unstable feature
 help: you can use `impl Trait` as the argument type
    |

--- a/tests/ui/traits/send-trait-objects-basic.rs
+++ b/tests/ui/traits/send-trait-objects-basic.rs
@@ -17,7 +17,7 @@ fn test2<'a>() {
 
 fn test3<'a>() {
     assert_send_static::<Box<dyn Dummy + 'a>>();
-    //~^ ERROR `(dyn Dummy + 'a)` cannot be sent between threads safely
+    //~^ ERROR `dyn Dummy + 'a` cannot be sent between threads safely
 }
 
 fn test4<'a>() {

--- a/tests/ui/traits/send-trait-objects-basic.stderr
+++ b/tests/ui/traits/send-trait-objects-basic.stderr
@@ -4,7 +4,7 @@ error[E0277]: `&'a (dyn Dummy + 'a)` cannot be sent between threads safely
 LL |     assert_send_static::<&'a dyn Dummy>();
    |                          ^^^^^^^^^^^^^ `&'a (dyn Dummy + 'a)` cannot be sent between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'a)`
+   = help: the trait `Sync` is not implemented for `dyn Dummy + 'a`
    = note: required for `&'a (dyn Dummy + 'a)` to implement `Send`
 note: required by a bound in `assert_send_static`
   --> $DIR/send-trait-objects-basic.rs:3:26
@@ -12,15 +12,15 @@ note: required by a bound in `assert_send_static`
 LL | fn assert_send_static<T: Send + 'static>() {}
    |                          ^^^^ required by this bound in `assert_send_static`
 
-error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
+error[E0277]: `dyn Dummy + 'a` cannot be sent between threads safely
   --> $DIR/send-trait-objects-basic.rs:19:26
    |
 LL |     assert_send_static::<Box<dyn Dummy + 'a>>();
-   |                          ^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
+   |                          ^^^^^^^^^^^^^^^^^^^ `dyn Dummy + 'a` cannot be sent between threads safely
    |
-   = help: the trait `Send` is not implemented for `(dyn Dummy + 'a)`
-   = note: required for `std::ptr::Unique<(dyn Dummy + 'a)>` to implement `Send`
-note: required because it appears within the type `Box<(dyn Dummy + 'a)>`
+   = help: the trait `Send` is not implemented for `dyn Dummy + 'a`
+   = note: required for `std::ptr::Unique<dyn Dummy + 'a>` to implement `Send`
+note: required because it appears within the type `Box<dyn Dummy + 'a>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
 note: required by a bound in `assert_send_static`
   --> $DIR/send-trait-objects-basic.rs:3:26
@@ -47,7 +47,7 @@ error[E0277]: `&'static (dyn Dummy + 'static)` cannot be sent between threads sa
 LL |     assert_send::<&'static dyn Dummy>();
    |                   ^^^^^^^^^^^^^^^^^^ `&'static (dyn Dummy + 'static)` cannot be sent between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
+   = help: the trait `Sync` is not implemented for `dyn Dummy + 'static`
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/send-trait-objects-basic.rs:4:19
@@ -106,7 +106,7 @@ error[E0277]: `&'static (dyn Dummy + 'static)` cannot be sent between threads sa
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'static (dyn Dummy + 'static)` cannot be sent between threads safely
    |
-   = help: the trait `Sync` is not implemented for `(dyn Dummy + 'static)`
+   = help: the trait `Sync` is not implemented for `dyn Dummy + 'static`
    = note: required for `&'static (dyn Dummy + 'static)` to implement `Send`
 note: required by a bound in `assert_send`
   --> $DIR/send-trait-objects-basic.rs:4:19

--- a/tests/ui/traits/trait-object-lifetime-default-note.rs
+++ b/tests/ui/traits/trait-object-lifetime-default-note.rs
@@ -6,7 +6,7 @@ fn main() {
     let local = 0; //~ NOTE binding `local` declared here
     let r = &local; //~ ERROR `local` does not live long enough
     //~| NOTE borrowed value does not live long enough
-    //~| NOTE due to object lifetime defaults, `Box<dyn A>` actually means `Box<(dyn A + 'static)>`
+    //~| NOTE due to object lifetime defaults, `Box<dyn A>` actually means `Box<dyn A + 'static>`
     require_box(Box::new(r));
     //~^ NOTE coercion requires that `local` is borrowed for `'static`
 

--- a/tests/ui/traits/trait-object-lifetime-default-note.stderr
+++ b/tests/ui/traits/trait-object-lifetime-default-note.stderr
@@ -12,7 +12,7 @@ LL |     require_box(Box::new(r));
 LL | }
    | - `local` dropped here while still borrowed
    |
-   = note: due to object lifetime defaults, `Box<dyn A>` actually means `Box<(dyn A + 'static)>`
+   = note: due to object lifetime defaults, `Box<dyn A>` actually means `Box<dyn A + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/trait-object-method-receiver-rules.stderr
+++ b/tests/ui/traits/trait-object-method-receiver-rules.stderr
@@ -21,11 +21,11 @@ LL |     fn owned(self: Box<Self>);
 LL |     x.owned();
    |       ^^^^^ method not found in `&mut dyn Foo`
 
-error[E0599]: no method named `managed` found for struct `Box<(dyn Foo + 'static)>` in the current scope
+error[E0599]: no method named `managed` found for struct `Box<dyn Foo + 'static>` in the current scope
   --> $DIR/trait-object-method-receiver-rules.rs:24:7
    |
 LL |     x.managed();
-   |       ^^^^^^^ method not found in `Box<(dyn Foo + 'static)>`
+   |       ^^^^^^^ method not found in `Box<dyn Foo + 'static>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/unsize-goal-escaping-bounds.current.stderr
+++ b/tests/ui/traits/unsize-goal-escaping-bounds.current.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `for<'a> (): Unsize<(dyn Trait + 'a)>` is not satisfied
+error[E0277]: the trait bound `for<'a> (): Unsize<dyn Trait + 'a>` is not satisfied
   --> $DIR/unsize-goal-escaping-bounds.rs:20:5
    |
 LL |     foo();
-   |     ^^^^^ the nightly-only, unstable trait `for<'a> Unsize<(dyn Trait + 'a)>` is not implemented for `()`
+   |     ^^^^^ the nightly-only, unstable trait `for<'a> Unsize<dyn Trait + 'a>` is not implemented for `()`
    |
    = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
 note: required by a bound in `foo`

--- a/tests/ui/traits/unsize-goal-escaping-bounds.rs
+++ b/tests/ui/traits/unsize-goal-escaping-bounds.rs
@@ -18,5 +18,5 @@ where
 
 fn main() {
     foo();
-    //[current]~^ ERROR the trait bound `for<'a> (): Unsize<(dyn Trait + 'a)>` is not satisfied
+    //[current]~^ ERROR the trait bound `for<'a> (): Unsize<dyn Trait + 'a>` is not satisfied
 }

--- a/tests/ui/traits/well-formed-recursion-limit.stderr
+++ b/tests/ui/traits/well-formed-recursion-limit.stderr
@@ -1,4 +1,4 @@
-error[E0609]: no field `ab` on type `(Box<(dyn Fn(Option<A>) -> Option<B> + 'static)>, Box<(dyn Fn(Option<B>) -> Option<A> + 'static)>)`
+error[E0609]: no field `ab` on type `(Box<dyn Fn(Option<A>) -> Option<B> + 'static>, Box<dyn Fn(Option<B>) -> Option<A> + 'static>)`
   --> $DIR/well-formed-recursion-limit.rs:12:23
    |
 LL |     let (ab, ba) = (i.ab, i.ba);
@@ -6,7 +6,7 @@ LL |     let (ab, ba) = (i.ab, i.ba);
    |
    = note: available fields are: `0`, `1`
 
-error[E0609]: no field `ba` on type `(Box<(dyn Fn(Option<A>) -> Option<B> + 'static)>, Box<(dyn Fn(Option<B>) -> Option<A> + 'static)>)`
+error[E0609]: no field `ba` on type `(Box<dyn Fn(Option<A>) -> Option<B> + 'static>, Box<dyn Fn(Option<B>) -> Option<A> + 'static>)`
   --> $DIR/well-formed-recursion-limit.rs:12:29
    |
 LL |     let (ab, ba) = (i.ab, i.ba);

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
@@ -6,7 +6,7 @@ LL | struct S(str, str) where str: Sized;
    |
    = note: `#[warn(trivial_bounds)]` on by default
 
-warning: trait bound for<'a> T<(dyn A + 'a)>: Sized does not depend on any type or lifetime parameters
+warning: trait bound for<'a> T<dyn A + 'a>: Sized does not depend on any type or lifetime parameters
   --> $DIR/trivial-bounds-inconsistent-sized.rs:17:49
    |
 LL | fn unsized_local() where for<'a> T<dyn A + 'a>: Sized {

--- a/tests/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -70,7 +70,7 @@ warning: trait bound str: Sized does not depend on any type or lifetime paramete
 LL | struct TwoStrs(str, str) where str: Sized;
    |                                     ^^^^^
 
-warning: trait bound for<'a> Dst<(dyn A + 'a)>: Sized does not depend on any type or lifetime parameters
+warning: trait bound for<'a> Dst<dyn A + 'a>: Sized does not depend on any type or lifetime parameters
   --> $DIR/trivial-bounds-inconsistent.rs:57:51
    |
 LL | fn unsized_local() where for<'a> Dst<dyn A + 'a>: Sized {

--- a/tests/ui/type-alias-impl-trait/issue-98604.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-98604.stderr
@@ -4,7 +4,7 @@ error[E0271]: expected `test` to return `Pin<Box<dyn Future<Output = ()>>>`, but
 LL |     Box::new(test) as AsyncFnPtr;
    |     ^^^^^^^^^^^^^^ expected `Pin<Box<dyn Future<Output = ()>>>`, found future
    |
-   = note: required for the cast from `Box<fn() -> impl Future<Output = ()> {test}>` to `Box<(dyn Fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> + 'static)>`
+   = note: required for the cast from `Box<fn() -> impl Future<Output = ()> {test}>` to `Box<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + 'static>> + 'static>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias/dyn-trait-type-alias-return-type.fixed
+++ b/tests/ui/type-alias/dyn-trait-type-alias-return-type.fixed
@@ -5,16 +5,16 @@ type T = dyn core::fmt::Debug;
 //~| NOTE this type alias is unsized
 
 fn f() -> Box<T> { loop {} }
-//~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-//~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+//~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+//~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
 //~| NOTE doesn't have a size known at compile-time
 //~| NOTE the return type of a function must have a statically known size
 //~| HELP consider boxing the return type
 
 trait X {
     fn f(&self) -> Box<T> { loop {} }
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-    //~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+    //~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
     //~| NOTE doesn't have a size known at compile-time
     //~| NOTE the return type of a function must have a statically known size
     //~| HELP consider boxing the return type
@@ -22,8 +22,8 @@ trait X {
 
 impl X for () {
     fn f(&self) -> Box<T> { loop {} }
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-    //~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+    //~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
     //~| NOTE doesn't have a size known at compile-time
     //~| NOTE the return type of a function must have a statically known size
     //~| HELP consider boxing the return type
@@ -31,8 +31,8 @@ impl X for () {
 
 fn main() {
     f();
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-    //~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+    //~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
     //~| NOTE doesn't have a size known at compile-time
     //~| NOTE the return type of a function must have a statically known size
     ().f();

--- a/tests/ui/type-alias/dyn-trait-type-alias-return-type.rs
+++ b/tests/ui/type-alias/dyn-trait-type-alias-return-type.rs
@@ -5,16 +5,16 @@ type T = dyn core::fmt::Debug;
 //~| NOTE this type alias is unsized
 
 fn f() -> T { loop {} }
-//~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-//~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+//~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+//~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
 //~| NOTE doesn't have a size known at compile-time
 //~| NOTE the return type of a function must have a statically known size
 //~| HELP consider boxing the return type
 
 trait X {
     fn f(&self) -> T { loop {} }
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-    //~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+    //~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
     //~| NOTE doesn't have a size known at compile-time
     //~| NOTE the return type of a function must have a statically known size
     //~| HELP consider boxing the return type
@@ -22,8 +22,8 @@ trait X {
 
 impl X for () {
     fn f(&self) -> T { loop {} }
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-    //~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+    //~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
     //~| NOTE doesn't have a size known at compile-time
     //~| NOTE the return type of a function must have a statically known size
     //~| HELP consider boxing the return type
@@ -31,8 +31,8 @@ impl X for () {
 
 fn main() {
     f();
-    //~^ ERROR the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
-    //~| HELP the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+    //~^ ERROR the size for values of type `dyn Debug + 'static` cannot be known at compilation time
+    //~| HELP the trait `Sized` is not implemented for `dyn Debug + 'static`
     //~| NOTE doesn't have a size known at compile-time
     //~| NOTE the return type of a function must have a statically known size
     ().f();

--- a/tests/ui/type-alias/dyn-trait-type-alias-return-type.stderr
+++ b/tests/ui/type-alias/dyn-trait-type-alias-return-type.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-type-alias-return-type.rs:7:11
    |
 LL | fn f() -> T { loop {} }
    |           ^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: this type alias is unsized
   --> $DIR/dyn-trait-type-alias-return-type.rs:2:1
    |
@@ -16,13 +16,13 @@ help: consider boxing the return type, and wrapping all of the returned values i
 LL | fn f() -> Box<T> { loop {} }
    |           ++++ +
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-type-alias-return-type.rs:24:20
    |
 LL |     fn f(&self) -> T { loop {} }
    |                    ^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: this type alias is unsized
   --> $DIR/dyn-trait-type-alias-return-type.rs:2:1
    |
@@ -34,13 +34,13 @@ help: consider boxing the return type, and wrapping all of the returned values i
 LL |     fn f(&self) -> Box<T> { loop {} }
    |                    ++++ +
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-type-alias-return-type.rs:15:20
    |
 LL |     fn f(&self) -> T { loop {} }
    |                    ^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
 note: this type alias is unsized
   --> $DIR/dyn-trait-type-alias-return-type.rs:2:1
    |
@@ -52,13 +52,13 @@ help: consider boxing the return type, and wrapping all of the returned values i
 LL |     fn f(&self) -> Box<T> { loop {} }
    |                    ++++ +
 
-error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Debug + 'static` cannot be known at compilation time
   --> $DIR/dyn-trait-type-alias-return-type.rs:33:5
    |
 LL |     f();
    |     ^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Debug + 'static`
    = note: the return type of a function must have a statically known size
 
 error: aborting due to 4 previous errors

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -8,10 +8,10 @@ LL |         map.insert(1, Struct::do_something);
 LL |         Self { map }
    |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<...>>>`, found `HashMap<{integer}, ...>`
    |
-   = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>>`
+   = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>>`
               found struct `HashMap<{integer}, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
    = note: fn items are distinct from fn pointers
-   = help: consider casting the fn item to a fn pointer: `<Struct as Trait>::do_something::<'_> as fn(u8) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>`
+   = help: consider casting the fn item to a fn pointer: `<Struct as Trait>::do_something::<'_> as fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-107775.stderr
+++ b/tests/ui/typeck/issue-107775.stderr
@@ -8,10 +8,10 @@ LL |         map.insert(1, Struct::do_something);
 LL |         Self { map }
    |                ^^^ expected `HashMap<u16, fn(u8) -> Pin<Box<_>>>`, found `HashMap<{integer}, _>`
    |
-   = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>>`
+   = note: expected struct `HashMap<u16, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>>`
               found struct `HashMap<{integer}, fn(_) -> Pin<Box<dyn Future<Output = ()> + Send>> {<Struct as Trait>::do_something::<'_>}>`
    = note: fn items are distinct from fn pointers
-   = help: consider casting the fn item to a fn pointer: `<Struct as Trait>::do_something::<'_> as fn(u8) -> Pin<Box<(dyn Future<Output = ()> + Send + 'static)>>`
+   = help: consider casting the fn item to a fn pointer: `<Struct as Trait>::do_something::<'_> as fn(u8) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-13853-2.stderr
+++ b/tests/ui/typeck/issue-13853-2.stderr
@@ -1,4 +1,4 @@
-error[E0615]: attempted to take value of method `get` on type `Box<(dyn ResponseHook + 'static)>`
+error[E0615]: attempted to take value of method `get` on type `Box<dyn ResponseHook + 'static>`
   --> $DIR/issue-13853-2.rs:5:43
    |
 LL | fn foo(res : Box<dyn ResponseHook>) { res.get }

--- a/tests/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
+++ b/tests/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-57673-ice-on-deref-of-boxed-trait.rs:5:5
    |
 LL | fn ice(x: Box<dyn Iterator<Item=()>>) {
-   |                                      - help: try adding a return type: `-> (dyn Iterator<Item = ()> + 'static)`
+   |                                      - help: try adding a return type: `-> dyn Iterator<Item = ()> + 'static`
 LL |     *x
    |     ^^ expected `()`, found `dyn Iterator`
    |
    = note: expected unit type `()`
-           found trait object `(dyn Iterator<Item = ()> + 'static)`
+           found trait object `dyn Iterator<Item = ()> + 'static`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/return-dyn-type-mismatch-2.stderr
+++ b/tests/ui/typeck/return-dyn-type-mismatch-2.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/return-dyn-type-mismatch-2.rs:7:5
    |
 LL | fn foo<T>() -> dyn Trait<T>
-   |                ------------ expected `(dyn Trait<T> + 'static)` because of return type
+   |                ------------ expected `dyn Trait<T> + 'static` because of return type
 ...
 LL |     42
    |     ^^ expected `dyn Trait`, found integer
    |
-   = note: expected trait object `(dyn Trait<T> + 'static)`
+   = note: expected trait object `dyn Trait<T> + 'static`
                       found type `{integer}`
 
 error: aborting due to 1 previous error

--- a/tests/ui/typeck/return-dyn-type-mismatch.stderr
+++ b/tests/ui/typeck/return-dyn-type-mismatch.stderr
@@ -2,12 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/return-dyn-type-mismatch.rs:15:21
    |
 LL |     fn other_func() -> dyn TestTrait<MyType = T> {
-   |                        ------------------------- expected `(dyn TestTrait<MyType = T> + 'static)` because of return type
+   |                        ------------------------- expected `dyn TestTrait<MyType = T> + 'static` because of return type
 LL |         match Self::func() {
 LL |             None => None,
    |                     ^^^^ expected `dyn TestTrait`, found `Option<_>`
    |
-   = note: expected trait object `(dyn TestTrait<MyType = T> + 'static)`
+   = note: expected trait object `dyn TestTrait<MyType = T> + 'static`
                       found enum `Option<_>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/typeck/unsized-rvalue-issue-41139.stderr
+++ b/tests/ui/typeck/unsized-rvalue-issue-41139.stderr
@@ -5,7 +5,7 @@ LL | fn get_function<'a>() -> &'a dyn Fn() -> dyn Trait {
    | -------------------------------------------------- `get_function` defined here returns `&dyn Fn() -> (dyn Trait + 'static)`
 ...
 LL |     let t: &dyn Trait = &get_function()();
-   |                          ^^^^^^^^^^^^^^ this trait object returns an unsized value `(dyn Trait + 'static)`, so it cannot be called
+   |                          ^^^^^^^^^^^^^^ this trait object returns an unsized value `dyn Trait + 'static`, so it cannot be called
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unsafe-binders/discriminant-for-variant.rs
+++ b/tests/ui/unsafe-binders/discriminant-for-variant.rs
@@ -1,8 +1,8 @@
 #![feature(unsafe_binders)]
 
 const None: Option<unsafe<> Option<Box<dyn Send>>> = None;
-//~^ ERROR the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
-//~| ERROR the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+//~^ ERROR the trait bound `Box<dyn Send + 'static>: Copy` is not satisfied
+//~| ERROR the trait bound `Box<dyn Send + 'static>: Copy` is not satisfied
 
 fn main() {
     match None {

--- a/tests/ui/unsafe-binders/discriminant-for-variant.stderr
+++ b/tests/ui/unsafe-binders/discriminant-for-variant.stderr
@@ -1,18 +1,18 @@
-error[E0277]: the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+error[E0277]: the trait bound `Box<dyn Send + 'static>: Copy` is not satisfied
   --> $DIR/discriminant-for-variant.rs:3:13
    |
 LL | const None: Option<unsafe<> Option<Box<dyn Send>>> = None;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<(dyn Send + 'static)>`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<dyn Send + 'static>`
    |
-   = note: required for `Option<Box<(dyn Send + 'static)>>` to implement `Copy`
+   = note: required for `Option<Box<dyn Send + 'static>>` to implement `Copy`
 
-error[E0277]: the trait bound `Box<(dyn Send + 'static)>: Copy` is not satisfied
+error[E0277]: the trait bound `Box<dyn Send + 'static>: Copy` is not satisfied
   --> $DIR/discriminant-for-variant.rs:3:54
    |
 LL | const None: Option<unsafe<> Option<Box<dyn Send>>> = None;
-   |                                                      ^^^^ the trait `Copy` is not implemented for `Box<(dyn Send + 'static)>`
+   |                                                      ^^^^ the trait `Copy` is not implemented for `Box<dyn Send + 'static>`
    |
-   = note: required for `Option<Box<(dyn Send + 'static)>>` to implement `Copy`
+   = note: required for `Option<Box<dyn Send + 'static>>` to implement `Copy`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/unsized/issue-91801.stderr
+++ b/tests/ui/unsized/issue-91801.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the size for values of type `(dyn Fn(&'a Something) -> Result<(), ()> + Send + Sync + 'a)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Fn(&'a Something) -> Result<(), ()> + Send + Sync + 'a` cannot be known at compilation time
   --> $DIR/issue-91801.rs:8:77
    |
 LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
    |                                                                             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Fn(&'a Something) -> Result<(), ()> + Send + Sync + 'a)`
+   = help: the trait `Sized` is not implemented for `dyn Fn(&'a Something) -> Result<(), ()> + Send + Sync + 'a`
 note: this type alias is unsized
   --> $DIR/issue-91801.rs:3:1
    |

--- a/tests/ui/unsized/unsized-enum2.stderr
+++ b/tests/ui/unsized/unsized-enum2.stderr
@@ -170,13 +170,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VH{u: isize, x: Box<[u32]>},
    |                     ++++     +
 
-error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Foo + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:53:8
    |
 LL |     VM(dyn Foo),
    |        ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Foo + 'static`
    = note: no field of an enum variant may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: borrowed types always have a statically known size
@@ -188,13 +188,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VM(Box<dyn Foo>),
    |        ++++       +
 
-error[E0277]: the size for values of type `(dyn Bar + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Bar + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:55:11
    |
 LL |     VN{x: dyn Bar},
    |           ^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Bar + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Bar + 'static`
    = note: no field of an enum variant may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: borrowed types always have a statically known size
@@ -206,13 +206,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VN{x: Box<dyn Bar>},
    |           ++++       +
 
-error[E0277]: the size for values of type `(dyn FooBar + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn FooBar + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:57:15
    |
 LL |     VO(isize, dyn FooBar),
    |               ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn FooBar + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn FooBar + 'static`
    = note: no field of an enum variant may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: borrowed types always have a statically known size
@@ -224,13 +224,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VO(isize, Box<dyn FooBar>),
    |               ++++          +
 
-error[E0277]: the size for values of type `(dyn BarFoo + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn BarFoo + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:59:21
    |
 LL |     VP{u: isize, x: dyn BarFoo},
    |                     ^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn BarFoo + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn BarFoo + 'static`
    = note: no field of an enum variant may have a dynamically sized type
    = help: change the field's type to have a statically known size
 help: borrowed types always have a statically known size
@@ -314,13 +314,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VT{u: isize, x: Box<<&'static [i32] as Deref>::Target>},
    |                     ++++                                 +
 
-error[E0277]: the size for values of type `(dyn PathHelper1 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn PathHelper1 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:43:8
    |
 LL |     VI(Path1),
    |        ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path1`, the trait `Sized` is not implemented for `(dyn PathHelper1 + 'static)`
+   = help: within `Path1`, the trait `Sized` is not implemented for `dyn PathHelper1 + 'static`
 note: required because it appears within the type `Path1`
   --> $DIR/unsized-enum2.rs:16:8
    |
@@ -337,13 +337,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VI(Box<Path1>),
    |        ++++     +
 
-error[E0277]: the size for values of type `(dyn PathHelper2 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn PathHelper2 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:45:11
    |
 LL |     VJ{x: Path2},
    |           ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path2`, the trait `Sized` is not implemented for `(dyn PathHelper2 + 'static)`
+   = help: within `Path2`, the trait `Sized` is not implemented for `dyn PathHelper2 + 'static`
 note: required because it appears within the type `Path2`
   --> $DIR/unsized-enum2.rs:17:8
    |
@@ -360,13 +360,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VJ{x: Box<Path2>},
    |           ++++     +
 
-error[E0277]: the size for values of type `(dyn PathHelper3 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn PathHelper3 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:47:15
    |
 LL |     VK(isize, Path3),
    |               ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path3`, the trait `Sized` is not implemented for `(dyn PathHelper3 + 'static)`
+   = help: within `Path3`, the trait `Sized` is not implemented for `dyn PathHelper3 + 'static`
 note: required because it appears within the type `Path3`
   --> $DIR/unsized-enum2.rs:18:8
    |
@@ -383,13 +383,13 @@ help: the `Box` type always has a statically known size and allocates its conten
 LL |     VK(isize, Box<Path3>),
    |               ++++     +
 
-error[E0277]: the size for values of type `(dyn PathHelper4 + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn PathHelper4 + 'static` cannot be known at compilation time
   --> $DIR/unsized-enum2.rs:49:21
    |
 LL |     VL{u: isize, x: Path4},
    |                     ^^^^^ doesn't have a size known at compile-time
    |
-   = help: within `Path4`, the trait `Sized` is not implemented for `(dyn PathHelper4 + 'static)`
+   = help: within `Path4`, the trait `Sized` is not implemented for `dyn PathHelper4 + 'static`
 note: required because it appears within the type `Path4`
   --> $DIR/unsized-enum2.rs:19:8
    |

--- a/tests/ui/wf/hir-wf-canonicalized.rs
+++ b/tests/ui/wf/hir-wf-canonicalized.rs
@@ -9,8 +9,8 @@ trait Callback<T: Foo>: Fn(&Bar<'_, T>, &T::V) {}
 struct Bar<'a, T> {
     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
     //~^ ERROR the trait bound `Bar<'a, T>: Foo` is not satisfied
-    //~| ERROR the trait bound `(dyn Callback<Bar<'a, T>, Output = ()> + 'static): Foo` is not satisfied
-    //~| ERROR the size for values of type `(dyn Callback<Bar<'a, T>, Output = ()> + 'static)` cannot be known at compilation time
+    //~| ERROR the trait bound `dyn Callback<Bar<'a, T>, Output = ()> + 'static: Foo` is not satisfied
+    //~| ERROR the size for values of type `dyn Callback<Bar<'a, T>, Output = ()> + 'static` cannot be known at compilation time
 }
 
 impl<T: Foo> Bar<'_, Bar<'_, T>> {}

--- a/tests/ui/wf/hir-wf-canonicalized.stderr
+++ b/tests/ui/wf/hir-wf-canonicalized.stderr
@@ -15,11 +15,11 @@ help: this trait has no implementations, consider adding one
 LL | trait Foo {
    | ^^^^^^^^^
 
-error[E0277]: the trait bound `(dyn Callback<Bar<'a, T>, Output = ()> + 'static): Foo` is not satisfied
+error[E0277]: the trait bound `dyn Callback<Bar<'a, T>, Output = ()> + 'static: Foo` is not satisfied
   --> $DIR/hir-wf-canonicalized.rs:10:15
    |
 LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `(dyn Callback<Bar<'a, T>, Output = ()> + 'static)`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `dyn Callback<Bar<'a, T>, Output = ()> + 'static`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/hir-wf-canonicalized.rs:3:1
@@ -27,13 +27,13 @@ help: this trait has no implementations, consider adding one
 LL | trait Foo {
    | ^^^^^^^^^
 
-error[E0277]: the size for values of type `(dyn Callback<Bar<'a, T>, Output = ()> + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Callback<Bar<'a, T>, Output = ()> + 'static` cannot be known at compilation time
   --> $DIR/hir-wf-canonicalized.rs:10:15
    |
 LL |     callback: Box<dyn Callback<dyn Callback<Bar<'a, T>>>>,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Callback<Bar<'a, T>, Output = ()> + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Callback<Bar<'a, T>, Output = ()> + 'static`
 note: required by an implicit `Sized` bound in `Bar`
   --> $DIR/hir-wf-canonicalized.rs:9:16
    |

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -24,13 +24,13 @@ LL | fn bar() where Vec<dyn Copy>:, {}
    = note: for a trait to be dyn compatible it needs to allow building a vtable
            for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
 
-error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
+error[E0277]: the size for values of type `dyn Copy + 'static` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:16
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
+   = help: the trait `Sized` is not implemented for `dyn Copy + 'static`
 note: required by an implicit `Sized` bound in `Vec`
   --> $DIR/wf-fn-where-clause.rs:16:12
    |


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156844)*
<!-- homu-ignore:end -->

Closes rust-lang/rust#144401

When the `Ty` pretty printer emits a prefix type constructor whose inner type prints with `+`-joined bounds - `&impl A + B`, `&mut impl A + B`, `*const impl A + B`, `&dyn A + B`, `&(impl A + ?Sized)`, ... - the resulting text is parser-ambiguous and rejected as `(&impl A) + B`. Diagnostics that surface such types - `refining_impl_trait` machine-applicable suggestions, argument-of-type hints, etc. - therefore emit non-compilable Rust.

Per review feedback that the fix belongs in the default printer, this PR handles the ambiguity in the `ty::Ref` and `ty::RawPtr` arms of `pretty_print_type`.

## What changed

* `ty::Ref` and `ty::RawPtr` in `compiler/rustc_middle/src/ty/print/pretty.rs` now wrap the inner type in parens when it would print with `+`-joined bounds. For `&mut`, the mutability prefix is printed *before* the parens so the output is `&mut (impl A + B)`, not the ill-formed `&(mut impl A + B)`. `ty::Dynamic` already wraps itself when carrying an explicit region; that case is skipped to avoid double-wrapping. `should_print_verbose()` is also skipped because the `-Zverbose-internals` form (`Opaque(DefId, ..)`) does not contain a `+`.
* A new `opaque_has_multiple_bounds` helper keeps its count aligned with `pretty_print_opaque_impl_type`'s trait/lifetime emission plus the synthetic sizedness suffix block (`add_sized` / `add_maybe_sized` / `has_pointee_sized_bound`), so:
  * single-bound `&impl Trait` / `&dyn Trait` keeps printing unchanged,
  * bare-position `impl A + B` keeps printing without parens,
  * `&(impl A + B)`, `&mut (impl A + B)`, `&'a (impl A + 'a)`, `&&(impl A + B)` are all wrapped,
  * `&(impl A + ?Sized)` is wrapped (`?Sized` routes through `MetaSized` + the synthetic suffix on stable, which the helper accounts for),
  * `&(impl Iter<Item = u8> + B)` is wrapped (projection inlined into the principal trait, second trait counts),
  * `&(dyn A + B)` is wrapped (subsumes the symmetric `dyn`-side ambiguity),
  * `*const (impl A + B)` and `*mut (impl A + B)` are wrapped (prefix-type generalization).
* A new `PrettyPrinter::add_disambiguating_parens_in_prefix_position` method makes this opt-out. `LegacySymbolMangler` overrides it to `false` so legacy mangled bytes stay byte-identical (any change would be an ABI break); `TypeNamePrinter` overrides it to `false` so `std::any::type_name` runtime output stays byte-identical. The v0 mangler is unaffected because it carries its own `ty::Ref` encoding.

## Tests

`tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs` (`run-rustfix`) covers:

* `&(impl A + B)` - multi positive trait,
* `&(impl A + ?Sized)` - positive trait + relaxed sizedness (exercises the synthetic `?Sized` suffix path),
* `&mut (impl A + B)` - `mut ` prefix must come before the disambiguating parens,
* `&'a (impl A + 'a)` - lifetime as a joinable part,
* `&(impl Iter<Item = u8> + B)` - associated-type projection inlined, second trait counts,
* `&impl Iter<Item = u8>` - no-wrap control: projection only, single joinable,
* `&&(impl A + B)` - nested ref: only the inner `&` wraps,
* `*const (impl A + B)` and `*mut (impl A + B)` - raw-pointer prefix generalization,
* bare-position `impl A + B` - must not pick up parens.

Re-blessed baselines that intentionally pick up the new `&(...)` form:

* `tests/ui/argument-suggestions/display-is-suggestable.stderr`
* `tests/ui/cast/casts-differing-anon.stderr`
* `tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr`
* `tests/ui/symbol-names/impl1.{legacy,v0}.stderr` and `impl1.rs` (only the `def-path(...)` line and its matching `//~ ERROR def-path(...)` annotations; the legacy mangled symbol bytes and the `demangling-alt` line are unchanged because `LegacySymbolMangler` opts out)
* `tests/ui/traits/default_auto_traits/maybe-bounds-in-dyn-traits.stderr`

Local verification:

```
./x test tests/ui/impl-trait/in-trait/refine-rustfix-parens.rs --force-rerun
./x test tidy --bless
```
