### PR TITLE
Clarify "infinite size" in cyclic-type diagnostic refers to the type name

### DIFF
--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -35,7 +35,7 @@ impl<'tcx> TypeError<'tcx> {
         }
 
         match self {
-            TypeError::CyclicTy(_) => "cyclic type of infinite size".into(),
+            TypeError::CyclicTy(_) => "recursive type with infinite-size name".into(),
             TypeError::CyclicConst(_) => "encountered a self-referencing constant".into(),
             TypeError::Mismatch => "types differ".into(),
             TypeError::PolarityMismatch(values) => {

--- a/tests/ui/closures/closure-referencing-itself-issue-25954.stderr
+++ b/tests/ui/closures/closure-referencing-itself-issue-25954.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/closure-referencing-itself-issue-25954.rs:16:13
    |
 LL |     let q = || p.b.set(5i32);
-   |             ^^^^^^^^^^^^^^^^ cyclic type of infinite size
+   |             ^^^^^^^^^^^^^^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/generic-typed-nested-closures-59494.stderr
+++ b/tests/ui/closures/generic-typed-nested-closures-59494.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/generic-typed-nested-closures-59494.rs:21:40
    |
 LL |     let t7 = |env| |a| |b| t7p(f, g)(((env, a), b));
-   |                                        ^^^ cyclic type of infinite size
+   |                                        ^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/issue-25439.stderr
+++ b/tests/ui/closures/issue-25439.stderr
@@ -2,7 +2,7 @@ error[E0644]: closure/coroutine type that references itself
   --> $DIR/issue-25439.rs:8:9
    |
 LL |     fix(|_, x| x);
-   |         ^^^^^^ cyclic type of infinite size
+   |         ^^^^^^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/tests/ui/const-generics/occurs-check/unused-substs-2.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-2.rs
@@ -21,7 +21,7 @@ impl<T> Bind<T> for Foo<{ 6 + 1 }> {
 fn main() {
     let (mut t, foo) = Foo::bind();
     //~^ ERROR mismatched types
-    //~| NOTE cyclic type
+    //~| NOTE recursive type
 
     // `t` is `ty::Infer(TyVar(?1t))`
     // `foo` contains `ty::Infer(TyVar(?1t))` in its substs

--- a/tests/ui/const-generics/occurs-check/unused-substs-2.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-2.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/unused-substs-2.rs:22:24
    |
 LL |     let (mut t, foo) = Foo::bind();
-   |                        ^^^^^^^^^^^ cyclic type of infinite size
+   |                        ^^^^^^^^^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/occurs-check/unused-substs-3.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.rs
@@ -12,7 +12,7 @@ fn bind<T>() -> (T, [u8; 6 + 1]) {
 fn main() {
     let (mut t, foo) = bind();
     //~^ ERROR mismatched types
-    //~| NOTE cyclic type
+    //~| NOTE recursive type
 
     // `t` is `ty::Infer(TyVar(?1t))`
     // `foo` contains `ty::Infer(TyVar(?1t))` in its substs

--- a/tests/ui/const-generics/occurs-check/unused-substs-3.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/unused-substs-3.rs:13:24
    |
 LL |     let (mut t, foo) = bind();
-   |                        ^^^^^^ cyclic type of infinite size
+   |                        ^^^^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/occurs-check/unused-substs-5.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-5.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/unused-substs-5.rs:15:19
    |
 LL |     x = q::<_, N>(x);
-   |                   ^ cyclic type of infinite size
+   |                   ^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/coroutine-yielding-or-returning-itself.stderr
+++ b/tests/ui/coroutine/coroutine-yielding-or-returning-itself.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |         if false { yield None.unwrap(); }
 LL | |         None.unwrap()
 LL | |     })
-   | |_____^ cyclic type of infinite size
+   | |_____^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,
@@ -34,7 +34,7 @@ LL | |
 LL | |         if false { yield None.unwrap(); }
 LL | |         None.unwrap()
 LL | |     })
-   | |_____^ cyclic type of infinite size
+   | |_____^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/tests/ui/typeck/cyclic_type_ice.stderr
+++ b/tests/ui/typeck/cyclic_type_ice.stderr
@@ -2,7 +2,7 @@ error[E0644]: closure/coroutine type that references itself
   --> $DIR/cyclic_type_ice.rs:3:7
    |
 LL |     f(f);
-   |       ^ cyclic type of infinite size
+   |       ^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/tests/ui/unboxed-closures/unboxed-closure-no-cyclic-sig.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-no-cyclic-sig.stderr
@@ -2,7 +2,7 @@ error[E0644]: closure/coroutine type that references itself
   --> $DIR/unboxed-closure-no-cyclic-sig.rs:8:7
    |
 LL |     g(|_| {  });
-   |       ^^^ cyclic type of infinite size
+   |       ^^^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,


### PR DESCRIPTION
Closes rust-lang/rust#149842

The `TypeError::CyclicTy` diagnostic currently emits
"cyclic type of infinite size". As discussed in the issue, "infinite
size" reads as the in-memory `size_of::<T>()` of values, when it
actually refers to the textual representation of the type name (an
iso-recursive occurs-check failure).

This rewords the message so the qualifier "infinite-size" clearly
modifies the *name*, matching the direction `@fmease`, `@BoxyUwU`,
and the issue author converged on:

```
- cyclic type of infinite size
+ recursive type with infinite-size name
```

Nine existing UI `.stderr` baselines and two `//~ NOTE` annotations
are updated to track the new wording. No semantics change.

Tested:
- ./x test tests/ui/const-generics/occurs-check/ tests/ui/closures/ tests/ui/unboxed-closures/ tests/ui/typeck/ tests/ui/coroutine/ --force-rerun
- ./x test tidy
