### PR TITLE
Fix suggestion of unused variables with raw identifier in struct pattern

### DIFF
--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -290,7 +290,7 @@ pub(crate) enum UnusedVariableSugg {
         shorthands: Vec<Span>,
         #[suggestion_part(code = "_")]
         non_shorthands: Vec<Span>,
-        name: Symbol,
+        name: String,
     },
 
     #[multipart_suggestion(

--- a/compiler/rustc_mir_transform/src/liveness.rs
+++ b/compiler/rustc_mir_transform/src/liveness.rs
@@ -1068,7 +1068,7 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
 
             let sugg = if any_shorthand {
                 errors::UnusedVariableSugg::TryIgnore {
-                    name,
+                    name: name.to_ident_string(),
                     shorthands: introductions
                         .iter()
                         .filter_map(

--- a/tests/ui/lint/unused/unused-variable-with-raw-identifier-in-struct-pattern.fixed
+++ b/tests/ui/lint/unused/unused-variable-with-raw-identifier-in-struct-pattern.fixed
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ run-rustfix
+
+#![warn(unused)]
+#![allow(dead_code)]
+
+struct Foo {
+    r#move: u32
+}
+
+fn main() {
+    let y = Foo { r#move: 3 };
+
+    let _ = match y {
+         Foo { r#move: _ } => 0 //~ WARNING unused variable: `r#move`
+                             //~| HELP try ignoring the field
+                             //~| SUGGESTION r#move: _
+    };
+}

--- a/tests/ui/lint/unused/unused-variable-with-raw-identifier-in-struct-pattern.rs
+++ b/tests/ui/lint/unused/unused-variable-with-raw-identifier-in-struct-pattern.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ run-rustfix
+
+#![warn(unused)]
+#![allow(dead_code)]
+
+struct Foo {
+    r#move: u32
+}
+
+fn main() {
+    let y = Foo { r#move: 3 };
+
+    let _ = match y {
+         Foo { r#move } => 0 //~ WARNING unused variable: `r#move`
+                             //~| HELP try ignoring the field
+                             //~| SUGGESTION r#move: _
+    };
+}

--- a/tests/ui/lint/unused/unused-variable-with-raw-identifier-in-struct-pattern.stderr
+++ b/tests/ui/lint/unused/unused-variable-with-raw-identifier-in-struct-pattern.stderr
@@ -1,0 +1,15 @@
+warning: unused variable: `r#move`
+  --> $DIR/unused-variable-with-raw-identifier-in-struct-pattern.rs:15:16
+   |
+LL |          Foo { r#move } => 0
+   |                ^^^^^^ help: try ignoring the field: `r#move: _`
+   |
+note: the lint level is defined here
+  --> $DIR/unused-variable-with-raw-identifier-in-struct-pattern.rs:4:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This MR fixes a broken lint suggestion that occurs when a struct pattern contains an unused variable written with a raw identifier.

In the following fragment, `r#move` is an unused variable. The compiler suggested to change it to `move: _` which doesn’t compile since move is a keyword. This change makes it so that the suggestion becomes `r#move: _`

```rust
struct Foo {
    r#move: u32
}

fn bar(foo: Foo) -> u32 {
    match foo {
         Foo { r#move } => 0 
    }
}
```

r? JonathanBrouwer
