### PR TITLE
rustdoc: avoid ICE when rendering body-less type consts

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -351,8 +351,10 @@ pub(crate) fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
 pub(crate) fn print_const(tcx: TyCtxt<'_>, n: ty::Const<'_>) -> String {
     match n.kind() {
         ty::ConstKind::Unevaluated(ty::UnevaluatedConst { def, args: _ }) => {
-            if let Some(def) = def.as_local() {
-                rendered_const(tcx, tcx.hir_body_owned_by(def), def)
+            if let Some(def) = def.as_local()
+                && let Some(body_id) = tcx.hir_maybe_body_owned_by(def)
+            {
+                rendered_const(tcx, body_id, def)
             } else {
                 inline::print_inlined_const(tcx, def)
             }

--- a/tests/rustdoc-ui/type-const-associated-const-no-body.rs
+++ b/tests/rustdoc-ui/type-const-associated-const-no-body.rs
@@ -1,0 +1,16 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/149287>
+//! Ensure that rustdoc does not ICE when a body-less type const is used
+//! as an associated const.
+//@ check-pass
+
+#![feature(min_generic_const_args)]
+
+pub trait Tr {
+    type const SIZE: usize;
+}
+
+fn mk_array<T: Tr>() -> [(); <T as Tr>::SIZE] {
+    [(); T::SIZE]
+}
+
+fn main() {}


### PR DESCRIPTION
close: https://github.com/rust-lang/rust/issues/149287