### PR TITLE
Suppress garbled suggestions from strict provenance lints in macros

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -1134,28 +1134,30 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     }
 
     fn lossy_provenance_ptr2int_lint(&self, fcx: &FnCtxt<'a, 'tcx>, t_c: ty::cast::IntTy) {
-        let expr_prec = fcx.precedence(self.expr);
-        let needs_parens = expr_prec < ExprPrecedence::Unambiguous;
-
-        let needs_cast = !matches!(t_c, ty::cast::IntTy::U(ty::UintTy::Usize));
-        let cast_span = self.expr_span.shrink_to_hi().to(self.cast_span);
         let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
         let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
-        let expr_span = self.expr_span.shrink_to_lo();
-        let sugg = match (needs_parens, needs_cast) {
-            (true, true) => errors::LossyProvenancePtr2IntSuggestion::NeedsParensCast {
-                expr_span,
-                cast_span,
-                cast_ty,
-            },
-            (true, false) => {
-                errors::LossyProvenancePtr2IntSuggestion::NeedsParens { expr_span, cast_span }
+
+        let sugg = self.span.can_be_used_for_suggestions().then(|| {
+            let expr_prec = fcx.precedence(self.expr);
+            let needs_parens = expr_prec < ExprPrecedence::Unambiguous;
+            let needs_cast = !matches!(t_c, ty::cast::IntTy::U(ty::UintTy::Usize));
+            let cast_span = self.expr_span.shrink_to_hi().to(self.cast_span);
+            let expr_span = self.expr_span.shrink_to_lo();
+            match (needs_parens, needs_cast) {
+                (true, true) => errors::LossyProvenancePtr2IntSuggestion::NeedsParensCast {
+                    expr_span,
+                    cast_span,
+                    cast_ty,
+                },
+                (true, false) => {
+                    errors::LossyProvenancePtr2IntSuggestion::NeedsParens { expr_span, cast_span }
+                }
+                (false, true) => {
+                    errors::LossyProvenancePtr2IntSuggestion::NeedsCast { cast_span, cast_ty }
+                }
+                (false, false) => errors::LossyProvenancePtr2IntSuggestion::Other { cast_span },
             }
-            (false, true) => {
-                errors::LossyProvenancePtr2IntSuggestion::NeedsCast { cast_span, cast_ty }
-            }
-            (false, false) => errors::LossyProvenancePtr2IntSuggestion::Other { cast_span },
-        };
+        });
 
         let lint = errors::LossyProvenancePtr2Int { expr_ty, cast_ty, sugg };
         fcx.tcx.emit_node_span_lint(
@@ -1167,10 +1169,12 @@ impl<'a, 'tcx> CastCheck<'tcx> {
     }
 
     fn fuzzy_provenance_int2ptr_lint(&self, fcx: &FnCtxt<'a, 'tcx>) {
-        let sugg = errors::LossyProvenanceInt2PtrSuggestion {
-            lo: self.expr_span.shrink_to_lo(),
-            hi: self.expr_span.shrink_to_hi().to(self.cast_span),
-        };
+        let sugg = self.span.can_be_used_for_suggestions().then(|| {
+            errors::LossyProvenanceInt2PtrSuggestion {
+                lo: self.expr_span.shrink_to_lo(),
+                hi: self.expr_span.shrink_to_hi().to(self.cast_span),
+            }
+        });
         let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
         let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
         let lint = errors::LossyProvenanceInt2Ptr { expr_ty, cast_ty, sugg };

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -386,7 +386,7 @@ pub(crate) struct LossyProvenanceInt2Ptr<'tcx> {
     pub expr_ty: Ty<'tcx>,
     pub cast_ty: Ty<'tcx>,
     #[subdiagnostic]
-    pub sugg: LossyProvenanceInt2PtrSuggestion,
+    pub sugg: Option<LossyProvenanceInt2PtrSuggestion>,
 }
 
 #[derive(Diagnostic)]
@@ -427,7 +427,7 @@ pub(crate) struct LossyProvenancePtr2Int<'tcx> {
     pub expr_ty: Ty<'tcx>,
     pub cast_ty: Ty<'tcx>,
     #[subdiagnostic]
-    pub sugg: LossyProvenancePtr2IntSuggestion<'tcx>,
+    pub sugg: Option<LossyProvenancePtr2IntSuggestion<'tcx>>,
 }
 
 #[derive(Subdiagnostic)]

--- a/tests/ui/lint/lint-strict-provenance-macro-casts.rs
+++ b/tests/ui/lint/lint-strict-provenance-macro-casts.rs
@@ -1,0 +1,33 @@
+#![feature(strict_provenance_lints)]
+#![deny(lossy_provenance_casts)]
+#![deny(fuzzy_provenance_casts)]
+
+macro_rules! cast {
+    ($e:expr, $t:ty) => {
+        $e as $t
+        //~^ ERROR under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
+        //~| ERROR strict provenance disallows casting integer `usize` to pointer `*const u8`
+    };
+}
+
+macro_rules! p2i {
+    ($e:expr) => { $e as usize };
+    //~^ ERROR under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
+}
+
+macro_rules! i2p {
+    ($e:expr) => { $e as *const () };
+    //~^ ERROR strict provenance disallows casting integer `usize` to pointer `*const ()`
+}
+
+fn main() {
+    let ptr = &0u8 as *const u8;
+    let _addr = cast!(ptr, usize);
+
+    let _ptr = cast!(0usize, *const u8);
+
+    let x = 1u8;
+    p2i!(&raw const x);
+
+    i2p!(0x42);
+}

--- a/tests/ui/lint/lint-strict-provenance-macro-casts.stderr
+++ b/tests/ui/lint/lint-strict-provenance-macro-casts.stderr
@@ -1,0 +1,60 @@
+error: under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
+  --> $DIR/lint-strict-provenance-macro-casts.rs:7:9
+   |
+LL |         $e as $t
+   |         ^^^^^^^^
+...
+LL |     let _addr = cast!(ptr, usize);
+   |                 ----------------- in this macro invocation
+   |
+   = help: if you can't comply with strict provenance and need to expose the pointer provenance you can use `.expose_provenance()` instead
+note: the lint level is defined here
+  --> $DIR/lint-strict-provenance-macro-casts.rs:2:9
+   |
+LL | #![deny(lossy_provenance_casts)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `cast` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: strict provenance disallows casting integer `usize` to pointer `*const u8`
+  --> $DIR/lint-strict-provenance-macro-casts.rs:7:9
+   |
+LL |         $e as $t
+   |         ^^^^^^^^
+...
+LL |     let _ptr = cast!(0usize, *const u8);
+   |                ------------------------ in this macro invocation
+   |
+   = help: if you can't comply with strict provenance and don't have a pointer with the correct provenance you can use `std::ptr::with_exposed_provenance()` instead
+note: the lint level is defined here
+  --> $DIR/lint-strict-provenance-macro-casts.rs:3:9
+   |
+LL | #![deny(fuzzy_provenance_casts)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the macro `cast` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
+  --> $DIR/lint-strict-provenance-macro-casts.rs:14:20
+   |
+LL |     ($e:expr) => { $e as usize };
+   |                    ^^^^^^^^^^^
+...
+LL |     p2i!(&raw const x);
+   |     ------------------ in this macro invocation
+   |
+   = help: if you can't comply with strict provenance and need to expose the pointer provenance you can use `.expose_provenance()` instead
+   = note: this error originates in the macro `p2i` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: strict provenance disallows casting integer `usize` to pointer `*const ()`
+  --> $DIR/lint-strict-provenance-macro-casts.rs:19:20
+   |
+LL |     ($e:expr) => { $e as *const () };
+   |                    ^^^^^^^^^^^^^^^
+...
+LL |     i2p!(0x42);
+   |     ---------- in this macro invocation
+   |
+   = help: if you can't comply with strict provenance and don't have a pointer with the correct provenance you can use `std::ptr::with_exposed_provenance()` instead
+   = note: this error originates in the macro `i2p` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
The strict provenance lints (`lossy_provenance_casts`, `fuzzy_provenance_casts`) build suggestions using span arithmetic (`shrink_to_lo()`, `shrink_to_hi()`, `.to()`). When the cast sits inside a macro, those span operations produce broken output like `$e as ).addr()` because the spans don't map cleanly back to source text.

The fix wraps suggestion fields in `Option` and checks `can_be_used_for_suggestions()` before constructing them. The lint itself still fires, you just don't get the garbled suggestion. Same approach already used in `op.rs` and `static_mut_refs.rs` in this crate.

### What changed

- `errors.rs`: `sugg` fields in `LossyProvenanceInt2Ptr` and `LossyProvenancePtr2Int` are now `Option<...>`
- `cast.rs`: suggestion construction in both `lossy_provenance_ptr2int_lint` and `fuzzy_provenance_int2ptr_lint` is guarded behind `can_be_used_for_suggestions()`
- New regression test confirms both lints fire on casts inside macros, with no suggestion block in output

Fixes rust-lang/rust#156850