### PR TITLE
Make hint::cold_path #[cold] so that it works even if the MIR inliner can't inline it

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -778,6 +778,9 @@ pub const fn unlikely(b: bool) -> bool {
 #[stable(feature = "cold_path", since = "1.95.0")]
 #[rustc_const_stable(feature = "cold_path", since = "1.95.0")]
 #[inline(always)]
+// Even if for some reason the cold_path intrinsic is not visible to codegen, the coldness will
+// ensure that branches this is in are still known to be cold.
+#[cold]
 pub const fn cold_path() {
     crate::intrinsics::cold_path()
 }

--- a/tests/codegen-llvm/hint/cold_path-target_feature.rs
+++ b/tests/codegen-llvm/hint/cold_path-target_feature.rs
@@ -1,0 +1,56 @@
+//@ compile-flags: -Copt-level=3
+//@ only-x86_64
+#![crate_type = "lib"]
+
+// This test checks that hint::cold_path still works in #[target_feature] functions.
+
+use std::hint::cold_path;
+
+#[inline(never)]
+#[no_mangle]
+pub fn path_a() {
+    println!("path a");
+}
+
+#[inline(never)]
+#[no_mangle]
+pub fn path_b() {
+    println!("path b");
+}
+
+#[no_mangle]
+pub fn test1(x: bool) {
+    if x {
+        path_a();
+    } else {
+        cold_path();
+        path_b();
+    }
+
+    // CHECK-LABEL: @test1(
+    // CHECK: br i1 %x, label %bb1, label %bb2, !prof ![[NUM:[0-9]+]]
+    // CHECK: bb2:
+    // CHECK: path_b
+    // CHECK: bb1:
+    // CHECK: path_a
+}
+
+#[no_mangle]
+#[target_feature(enable = "sse2")]
+pub fn with_target_feature(x: bool) {
+    if x {
+        path_a();
+    } else {
+        cold_path();
+        path_b();
+    }
+
+    // CHECK-LABEL: @with_target_feature(
+    // CHECK: br i1 %x, label %bb1, label %bb2, !prof ![[NUM]]
+    // CHECK: bb2:
+    // CHECK: path_b
+    // CHECK: bb1:
+    // CHECK: path_a
+}
+
+// CHECK: ![[NUM]] = !{!"branch_weights", {{(!"expected", )?}}i32 2000, i32 1}


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/156859 because the branch weight metadata is actually keyed off seeing a `#[cold]` function call in an arm. We don't need the intrinsic, any `#[cold]` function will do. So if the hint wrapper itself is made `#[cold]`, we will still get the desired effect, and LLVM will clean up the call to an empty function when optimizations are enabled.