### PR TITLE
LLVM: Use pair types for equal-size pairs

### DIFF
--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -20,6 +20,11 @@ fn uncached_llvm_type<'a, 'tcx>(
 ) -> &'a Type {
     match layout.backend_repr {
         BackendRepr::Scalar(_) => bug!("handled elsewhere"),
+        BackendRepr::ScalarPair(a, b) if a.size(cx) == b.size(cx) => {
+            let a_llty = layout.scalar_llvm_type_at(cx, a);
+            let b_llty = layout.scalar_llvm_type_at(cx, b);
+            return cx.type_struct(&[a_llty, b_llty], false);
+        }
         BackendRepr::SimdVector { element, count } => {
             let element = layout.scalar_llvm_type_at(cx, element);
             return cx.type_vector(element, count);

--- a/tests/codegen-llvm/gep-index.rs
+++ b/tests/codegen-llvm/gep-index.rs
@@ -6,7 +6,9 @@
 
 #![crate_type = "lib"]
 
-struct Foo(i32, i32);
+struct Foo(i32, i16, i8, u8);
+
+struct Pair(i32, i32);
 
 // CHECK-LABEL: @index_on_struct(
 #[no_mangle]
@@ -19,6 +21,20 @@ fn index_on_struct(a: &[Foo], index: usize) -> &Foo {
 #[no_mangle]
 fn offset_on_struct(a: *const Foo, index: usize) -> *const Foo {
     // CHECK: getelementptr inbounds{{( nuw)?}} {{%Foo|\[8 x i8\]}}, ptr %a, {{i64|i32}} %index
+    unsafe { a.add(index) }
+}
+
+// CHECK-LABEL: @index_on_pair(
+#[no_mangle]
+fn index_on_pair(a: &[Pair], index: usize) -> &Pair {
+    // CHECK: getelementptr inbounds{{( nuw)?}} {{%Pair|{ i32, i32 }}}, ptr %a.0, {{i64|i32}} %index
+    &a[index]
+}
+
+// CHECK-LABEL: @offset_on_pair(
+#[no_mangle]
+fn offset_on_pair(a: *const Pair, index: usize) -> *const Pair {
+    // CHECK: getelementptr inbounds{{( nuw)?}} {{%Pair|{ i32, i32 }}}, ptr %a, {{i64|i32}} %index
     unsafe { a.add(index) }
 }
 

--- a/tests/codegen-llvm/intrinsics/volatile.rs
+++ b/tests/codegen-llvm/intrinsics/volatile.rs
@@ -33,6 +33,14 @@ pub unsafe fn volatile_load(a: *const u8) -> u8 {
     intrinsics::volatile_load(a)
 }
 
+// CHECK-LABEL: @volatile_load_pair
+#[no_mangle]
+pub unsafe fn volatile_load_pair(a: *const (u16, u16)) -> (u16, u16) {
+    // CHECK: load volatile { i16, i16 }
+    // CHECK-SAME: align 2{{,|$}}
+    intrinsics::volatile_load(a)
+}
+
 // CHECK-LABEL: @volatile_store
 #[no_mangle]
 pub unsafe fn volatile_store(a: *mut u8, b: u8) {
@@ -44,6 +52,14 @@ pub unsafe fn volatile_store(a: *mut u8, b: u8) {
 #[no_mangle]
 pub unsafe fn unaligned_volatile_load(a: *const u8) -> u8 {
     // CHECK: load volatile
+    intrinsics::unaligned_volatile_load(a)
+}
+
+// CHECK-LABEL: @unaligned_volatile_load_pair
+#[no_mangle]
+pub unsafe fn unaligned_volatile_load_pair(a: *const (u16, u16)) -> (u16, u16) {
+    // CHECK: load volatile { i16, i16 }
+    // CHECK-SAME: align 1{{,|$}}
     intrinsics::unaligned_volatile_load(a)
 }
 


### PR DESCRIPTION
Not sure if this is a good idea or not, but posting as draft to accompany the thread: [#t-compiler/llvm > &#96;llvm_type&#96; definition](https://rust-lang.zulipchat.com/#narrow/channel/187780-t-compiler.2Fllvm/topic/.60llvm_type.60.20definition/with/597359110)

Without this, this line is either wrong or basically meaningless:

https://github.com/rust-lang/rust/blob/23a3312d92a1c4ba0373f1e25277be20ba8bb28c/compiler/rustc_codegen_llvm/src/type_of.rs#L246

