### PR TITLE
Stop needing an alloca for `catch_unwind`

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -1365,8 +1365,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
             {
                 fx.bcx.ins().call_indirect(f_sig, f, &[data]);
 
-                let layout = fx.layout_of(fx.tcx.types.i32);
-                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I32, 0), layout);
+                let layout = fx.layout_of(fx.tcx.types.bool);
+                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I8, 0), layout);
                 ret.write_cvalue(fx, ret_val);
 
                 fx.bcx.ins().jump(ret_block, &[]);
@@ -1399,8 +1399,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
 
                 fx.bcx.seal_block(fallthrough_block);
                 fx.bcx.switch_to_block(fallthrough_block);
-                let layout = fx.layout_of(fx.tcx.types.i32);
-                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I32, 0), layout);
+                let layout = fx.layout_of(fx.tcx.types.bool);
+                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I8, 0), layout);
                 ret.write_cvalue(fx, ret_val);
                 fx.bcx.ins().jump(ret_block, &[]);
 
@@ -1409,8 +1409,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
                 fx.bcx.set_cold_block(catch_block);
                 let exception = fx.bcx.append_block_param(catch_block, pointer_ty(fx.tcx));
                 fx.bcx.ins().call_indirect(catch_fn_sig, catch_fn, &[data, exception]);
-                let layout = fx.layout_of(fx.tcx.types.i32);
-                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I32, 1), layout);
+                let layout = fx.layout_of(fx.tcx.types.bool);
+                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I8, 1), layout);
                 ret.write_cvalue(fx, ret_val);
                 fx.bcx.ins().jump(ret_block, &[]);
             }

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -1361,7 +1361,7 @@ fn try_intrinsic<'a, 'b, 'gcc, 'tcx>(
         bx.call(bx.type_void(), None, None, try_func, &[data], None, None);
         // Return 0 unconditionally from the intrinsic call;
         // we can never unwind.
-        OperandValue::Immediate(bx.const_i32(0)).store(bx, dest);
+        OperandValue::Immediate(bx.const_bool(false)).store(bx, dest);
     } else {
         if wants_msvc_seh(bx.sess()) {
             unimplemented!();
@@ -1418,7 +1418,7 @@ fn codegen_gnu_try<'gcc, 'tcx>(
         let current_block = bx.block;
 
         bx.switch_to_block(then);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         // Type indicator for the exception being thrown.
         //
@@ -1432,7 +1432,7 @@ fn codegen_gnu_try<'gcc, 'tcx>(
         let ptr = bx.cx.context.new_call(None, eh_pointer_builtin, &[zero]);
         let catch_ty = bx.type_func(&[bx.type_i8p(), bx.type_i8p()], bx.type_void());
         bx.call(catch_ty, None, None, catch_func, &[data, ptr], None, None);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
 
         // NOTE: the blocks must be filled before adding the try/catch, otherwise gcc will not
         // generate a try/catch.
@@ -1465,7 +1465,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
     // Define the type up front for the signature of the rust_try function.
     let tcx = cx.tcx;
     let i8p = Ty::new_mut_ptr(tcx, tcx.types.i8);
-    // `unsafe fn(*mut i8) -> ()`
+    // `unsafe fn(*mut Data) -> ()`
     let try_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi(
@@ -1474,7 +1474,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
             rustc_hir::Safety::Unsafe,
         )),
     );
-    // `unsafe fn(*mut i8, *mut i8) -> ()`
+    // `unsafe fn(*mut Data, *mut i8) -> ()`
     let catch_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi(
@@ -1483,10 +1483,10 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
             rustc_hir::Safety::Unsafe,
         )),
     );
-    // `unsafe fn(unsafe fn(*mut i8) -> (), *mut i8, unsafe fn(*mut i8, *mut i8) -> ()) -> i32`
+    // `unsafe fn(unsafe fn(*mut Data) -> (), *mut Data, unsafe fn(*mut Data, *mut i8) -> ()) -> bool`
     let rust_fn_sig = ty::Binder::dummy(cx.tcx.mk_fn_sig_rust_abi(
         [try_fn_ty, i8p, catch_fn_ty],
-        tcx.types.i32,
+        tcx.types.bool,
         rustc_hir::Safety::Unsafe,
     ));
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -941,11 +941,7 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn intrinsic_call_expects_place_always(&self, name: Symbol) -> bool {
         matches!(
             name,
-            sym::autodiff
-                | sym::catch_unwind
-                | sym::volatile_load
-                | sym::unaligned_volatile_load
-                | sym::black_box
+            sym::autodiff | sym::volatile_load | sym::unaligned_volatile_load | sym::black_box
         )
     }
 }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -288,18 +288,12 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 }
             }
             sym::catch_unwind => {
-                let result = PlaceRef {
-                    val: result_place.unwrap(),
-                    layout: result_layout,
-                };
                 catch_unwind_intrinsic(
                     self,
                     args[0].immediate(),
                     args[1].immediate(),
                     args[2].immediate(),
-                    result,
-                );
-                return IntrinsicResult::WroteIntoPlace;
+                )
             }
             sym::breakpoint => self.call_intrinsic("llvm.debugtrap", &[], &[]),
             sym::va_arg => {
@@ -1351,22 +1345,21 @@ fn catch_unwind_intrinsic<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     if !bx.sess().panic_strategy().unwinds() {
         let try_func_ty = bx.type_func(&[bx.type_ptr()], bx.type_void());
         bx.call(try_func_ty, None, None, try_func, &[data], None, None);
         // Return 0 unconditionally from the intrinsic call;
         // we can never unwind.
-        OperandValue::Immediate(bx.const_i32(0)).store(bx, dest);
+        bx.const_bool(false)
     } else if wants_msvc_seh(bx.sess()) {
-        codegen_msvc_try(bx, try_func, data, catch_func, dest);
+        codegen_msvc_try(bx, try_func, data, catch_func)
     } else if wants_wasm_eh(bx.sess()) {
-        codegen_wasm_try(bx, try_func, data, catch_func, dest);
+        codegen_wasm_try(bx, try_func, data, catch_func)
     } else if bx.sess().target.os == Os::Emscripten {
-        codegen_emcc_try(bx, try_func, data, catch_func, dest);
+        codegen_emcc_try(bx, try_func, data, catch_func)
     } else {
-        codegen_gnu_try(bx, try_func, data, catch_func, dest);
+        codegen_gnu_try(bx, try_func, data, catch_func)
     }
 }
 
@@ -1382,8 +1375,7 @@ fn codegen_msvc_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         bx.set_personality_fn(bx.eh_personality());
 
@@ -1399,12 +1391,12 @@ fn codegen_msvc_try<'ll, 'tcx>(
 
         // We're generating an IR snippet that looks like:
         //
-        //   declare i32 @rust_try(%try_func, %data, %catch_func) {
+        //   declare bool @rust_try(%try_func, %data, %catch_func) {
         //      %slot = alloca i8*
         //      invoke %try_func(%data) to label %normal unwind label %catchswitch
         //
         //   normal:
-        //      ret i32 0
+        //      ret i1 false
         //
         //   catchswitch:
         //      %cs = catchswitch within none [%catchpad_rust, %catchpad_foreign] unwind to caller
@@ -1421,7 +1413,7 @@ fn codegen_msvc_try<'ll, 'tcx>(
         //      catchret from %tok to label %caught
         //
         //   caught:
-        //      ret i32 1
+        //      ret i1 true
         //   }
         //
         // This structure follows the basic usage of throw/try/catch in LLVM.
@@ -1459,7 +1451,7 @@ fn codegen_msvc_try<'ll, 'tcx>(
         bx.invoke(try_func_ty, None, None, try_func, &[data], normal, catchswitch, None, None);
 
         bx.switch_to_block(normal);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         bx.switch_to_block(catchswitch);
         let cs = bx.catch_switch(None, None, &[catchpad_rust, catchpad_foreign]);
@@ -1516,13 +1508,13 @@ fn codegen_msvc_try<'ll, 'tcx>(
         bx.catch_ret(&funclet, caught);
 
         bx.switch_to_block(caught);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // WASM's definition of the `rust_try` function.
@@ -1531,8 +1523,7 @@ fn codegen_wasm_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         bx.set_personality_fn(bx.eh_personality());
 
@@ -1547,12 +1538,12 @@ fn codegen_wasm_try<'ll, 'tcx>(
 
         // We're generating an IR snippet that looks like:
         //
-        //   declare i32 @rust_try(%try_func, %data, %catch_func) {
+        //   declare i1 @rust_try(%try_func, %data, %catch_func) {
         //      %slot = alloca i8*
         //      invoke %try_func(%data) to label %normal unwind label %catchswitch
         //
         //   normal:
-        //      ret i32 0
+        //      ret i1 false
         //
         //   catchswitch:
         //      %cs = catchswitch within none [%catchpad] unwind to caller
@@ -1565,14 +1556,14 @@ fn codegen_wasm_try<'ll, 'tcx>(
         //      catchret from %tok to label %caught
         //
         //   caught:
-        //      ret i32 1
+        //      ret i1 true
         //   }
         //
         let try_func_ty = bx.type_func(&[bx.type_ptr()], bx.type_void());
         bx.invoke(try_func_ty, None, None, try_func, &[data], normal, catchswitch, None, None);
 
         bx.switch_to_block(normal);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         bx.switch_to_block(catchswitch);
         let cs = bx.catch_switch(None, None, &[catchpad]);
@@ -1589,13 +1580,13 @@ fn codegen_wasm_try<'ll, 'tcx>(
         bx.catch_ret(&funclet, caught);
 
         bx.switch_to_block(caught);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // Definition of the standard `try` function for Rust using the GNU-like model
@@ -1614,8 +1605,7 @@ fn codegen_gnu_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         // Codegens the shims described above:
         //
@@ -1639,7 +1629,7 @@ fn codegen_gnu_try<'ll, 'tcx>(
         bx.invoke(try_func_ty, None, None, try_func, &[data], then, catch, None, None);
 
         bx.switch_to_block(then);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         // Type indicator for the exception being thrown.
         //
@@ -1655,13 +1645,13 @@ fn codegen_gnu_try<'ll, 'tcx>(
         let ptr = bx.extract_value(vals, 0);
         let catch_ty = bx.type_func(&[bx.type_ptr(), bx.type_ptr()], bx.type_void());
         bx.call(catch_ty, None, None, catch_func, &[data, ptr], None, None);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // Variant of codegen_gnu_try used for emscripten where Rust panics are
@@ -1672,8 +1662,7 @@ fn codegen_emcc_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         // Codegens the shims described above:
         //
@@ -1702,7 +1691,7 @@ fn codegen_emcc_try<'ll, 'tcx>(
         bx.invoke(try_func_ty, None, None, try_func, &[data], then, catch, None, None);
 
         bx.switch_to_block(then);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         // Type indicator for the exception being thrown.
         //
@@ -1737,13 +1726,13 @@ fn codegen_emcc_try<'ll, 'tcx>(
 
         let catch_ty = bx.type_func(&[bx.type_ptr(), bx.type_ptr()], bx.type_void());
         bx.call(catch_ty, None, None, catch_func, &[data, catch_data], None, None);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // Helper function to give a Block to a closure to codegen a shim function.
@@ -1782,20 +1771,20 @@ fn get_rust_try_fn<'a, 'll, 'tcx>(
     // Define the type up front for the signature of the rust_try function.
     let tcx = cx.tcx;
     let i8p = Ty::new_mut_ptr(tcx, tcx.types.i8);
-    // `unsafe fn(*mut i8) -> ()`
+    // `unsafe fn(*mut Data) -> ()`
     let try_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi([i8p], tcx.types.unit, hir::Safety::Unsafe)),
     );
-    // `unsafe fn(*mut i8, *mut i8) -> ()`
+    // `unsafe fn(*mut Data, *mut i8) -> ()`
     let catch_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi([i8p, i8p], tcx.types.unit, hir::Safety::Unsafe)),
     );
-    // `unsafe fn(unsafe fn(*mut i8) -> (), *mut i8, unsafe fn(*mut i8, *mut i8) -> ()) -> i32`
+    // `unsafe fn(unsafe fn(*mut Data) -> (), *mut Data, unsafe fn(*mut Data, *mut i8) -> ()) -> bool`
     let rust_fn_sig = ty::Binder::dummy(cx.tcx.mk_fn_sig_rust_abi(
         [try_fn_ty, i8p, catch_fn_ty],
-        tcx.types.i32,
+        tcx.types.bool,
         hir::Safety::Unsafe,
     ));
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -627,16 +627,18 @@ pub(crate) fn check_intrinsic_type(
         }
 
         sym::catch_unwind => {
+            let mut_data = Ty::new_mut_ptr(tcx, param(0));
             let mut_u8 = Ty::new_mut_ptr(tcx, tcx.types.u8);
             let try_fn_ty =
-                ty::Binder::dummy(tcx.mk_fn_sig_safe_rust_abi([mut_u8], tcx.types.unit));
-            let catch_fn_ty =
-                ty::Binder::dummy(tcx.mk_fn_sig_safe_rust_abi([mut_u8, mut_u8], tcx.types.unit));
+                ty::Binder::dummy(tcx.mk_fn_sig_unsafe_rust_abi([mut_data], tcx.types.unit));
+            let catch_fn_ty = ty::Binder::dummy(
+                tcx.mk_fn_sig_unsafe_rust_abi([mut_data, mut_u8], tcx.types.unit),
+            );
             (
+                1,
                 0,
-                0,
-                vec![Ty::new_fn_ptr(tcx, try_fn_ty), mut_u8, Ty::new_fn_ptr(tcx, catch_fn_ty)],
-                tcx.types.i32,
+                vec![Ty::new_fn_ptr(tcx, try_fn_ty), mut_data, Ty::new_fn_ptr(tcx, catch_fn_ty)],
+                tcx.types.bool,
             )
         }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2355,6 +2355,15 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk_fn_sig(inputs, output, FnSigKind::default().set_safety(hir::Safety::Safe))
     }
 
+    /// `mk_fn_sig`, but with an **un**safe Rust ABI, and no C-variadic argument.
+    pub fn mk_fn_sig_unsafe_rust_abi<I, T>(self, inputs: I, output: I::Item) -> T::Output
+    where
+        I: IntoIterator<Item = T>,
+        T: CollectAndApply<Ty<'tcx>, ty::FnSig<'tcx>>,
+    {
+        self.mk_fn_sig(inputs, output, FnSigKind::default().set_safety(hir::Safety::Unsafe))
+    }
+
     pub fn mk_poly_existential_predicates_from_iter<I, T>(self, iter: I) -> T::Output
     where
         I: Iterator<Item = T>,

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2232,7 +2232,7 @@ pub const fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discrimina
 
 /// Rust's "try catch" construct for unwinding. Invokes the function pointer `try_fn` with the
 /// data pointer `data`, and calls `catch_fn` if unwinding occurs while `try_fn` runs.
-/// Returns `1` if unwinding occurred and `catch_fn` was called; returns `0` otherwise.
+/// Returns `true` if unwinding occurred and `catch_fn` was called; returns `false` otherwise.
 ///
 /// `catch_fn` must not unwind.
 ///
@@ -2249,11 +2249,11 @@ pub const fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discrimina
 /// version of this intrinsic, `std::panic::catch_unwind`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn catch_unwind(
-    _try_fn: fn(*mut u8),
-    _data: *mut u8,
-    _catch_fn: fn(*mut u8, *mut u8),
-) -> i32;
+pub unsafe fn catch_unwind<Data: ptr::Thin>(
+    _try_fn: unsafe fn(*mut Data),
+    _data: *mut Data,
+    _catch_fn: unsafe fn(*mut Data, *mut u8),
+) -> bool;
 
 /// Emits a `nontemporal` store, which gives a hint to the CPU that the data should not be held
 /// in cache. Except for performance, this is fully equivalent to `ptr.write(val)`.

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -530,7 +530,6 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // method of calling a catch panic whilst juggling ownership.
     let mut data = Data { f: ManuallyDrop::new(f) };
 
-    let data_ptr = (&raw mut data) as *mut u8;
     // SAFETY:
     //
     // Access to the union's fields: this is `std` and we know that the `catch_unwind`
@@ -541,10 +540,10 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // - `do_catch`, the second argument, can be called with the `data_ptr` as well.
     // See their safety preconditions for more information
     unsafe {
-        return if intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
-            Ok(ManuallyDrop::into_inner(data.r))
-        } else {
+        return if intrinsics::catch_unwind(do_call, &raw mut data, do_catch) {
             Err(ManuallyDrop::into_inner(data.p))
+        } else {
+            Ok(ManuallyDrop::into_inner(data.r))
         };
     }
 
@@ -568,17 +567,12 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // data must be non-NUL, correctly aligned, and a pointer to a `Data<F, R>`
     // Its must contains a valid `f` (type: F) value that can be use to fill
     // `data.r`.
-    //
-    // This function cannot be marked as `unsafe` because `intrinsics::catch_unwind`
-    // expects normal function pointers.
     #[inline]
-    fn do_call<F: FnOnce() -> R, R>(data: *mut u8) {
+    unsafe fn do_call<F: FnOnce() -> R, R>(data: *mut Data<F, R>) {
         // SAFETY: this is the responsibility of the caller, see above.
         unsafe {
-            let data = data as *mut Data<F, R>;
-            let data = &mut (*data);
-            let f = ManuallyDrop::take(&mut data.f);
-            data.r = ManuallyDrop::new(f());
+            let f = ManuallyDrop::take(&mut (*data).f);
+            (*data).r = ManuallyDrop::new(f());
         }
     }
 
@@ -590,22 +584,17 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // data must be non-NUL, correctly aligned, and a pointer to a `Data<F, R>`
     // Since this uses `cleanup` it also hinges on a correct implementation of
     // `__rustc_panic_cleanup`.
-    //
-    // This function cannot be marked as `unsafe` because `intrinsics::catch_unwind`
-    // expects normal function pointers.
     #[inline]
     #[rustc_nounwind] // `intrinsic::catch_unwind` requires catch fn to be nounwind
-    fn do_catch<F: FnOnce() -> R, R>(data: *mut u8, payload: *mut u8) {
+    unsafe fn do_catch<F: FnOnce() -> R, R>(data: *mut Data<F, R>, payload: *mut u8) {
         // SAFETY: this is the responsibility of the caller, see above.
         //
         // When `__rustc_panic_cleaner` is correctly implemented we can rely
         // on `obj` being the correct thing to pass to `data.p` (after wrapping
         // in `ManuallyDrop`).
         unsafe {
-            let data = data as *mut Data<F, R>;
-            let data = &mut (*data);
             let obj = cleanup(payload);
-            data.p = ManuallyDrop::new(obj);
+            (*data).p = ManuallyDrop::new(obj);
         }
     }
 }

--- a/src/tools/miri/src/shims/unwind.rs
+++ b/src/tools/miri/src/shims/unwind.rs
@@ -68,7 +68,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let this = self.eval_context_mut();
 
         // Signature:
-        //   fn catch_unwind(try_fn: fn(*mut u8), data: *mut u8, catch_fn: fn(*mut u8, *mut u8)) -> i32
+        //   fn catch_unwind(try_fn: unsafe fn(*mut Data), data: *mut Data, catch_fn: unsafe fn(*mut Data, *mut u8)) -> bool
         // Calls `try_fn` with `data` as argument. If that executes normally, returns 0.
         // If that unwinds, calls `catch_fn` with the first argument being `data` and
         // then second argument being a target-dependent `payload` (i.e. it is up to us to define
@@ -129,7 +129,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
 
             // We set the return value of `catch_unwind` to 1, since there was a panic.
-            this.write_scalar(Scalar::from_i32(1), &catch_unwind.dest)?;
+            this.write_scalar(Scalar::from_bool(true), &catch_unwind.dest)?;
 
             // The Thread's `panic_payload` holds what was passed to `miri_start_unwind`.
             // This is exactly the second argument we need to pass to `catch_fn`.

--- a/src/tools/miri/tests/fail/function_calls/check_callback_abi.rs
+++ b/src/tools/miri/tests/fail/function_calls/check_callback_abi.rs
@@ -11,7 +11,7 @@ fn main() {
         std::intrinsics::catch_unwind(
             //~^ ERROR: calling a function with calling convention "C" using calling convention "Rust"
             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<u8>(),
             |_, _| unreachable!(),
         );
     }

--- a/src/tools/miri/tests/fail/function_calls/check_callback_abi.stderr
+++ b/src/tools/miri/tests/fail/function_calls/check_callback_abi.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: calling a function with calling convention "C" using 
 LL | /         std::intrinsics::catch_unwind(
 LL | |
 LL | |             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
-LL | |             std::ptr::null_mut(),
+LL | |             std::ptr::null_mut::<u8>(),
 LL | |             |_, _| unreachable!(),
 LL | |         );
    | |_________^ Undefined Behavior occurred here

--- a/src/tools/miri/tests/pass/panic/unwind_dwarf.rs
+++ b/src/tools/miri/tests/pass/panic/unwind_dwarf.rs
@@ -64,10 +64,10 @@ fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
 
     let data_ptr = ptr::addr_of_mut!(data) as *mut u8;
     unsafe {
-        return if std::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
-            Ok(data.r.take().unwrap())
-        } else {
+        return if std::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) {
             Err(data.p.take().unwrap())
+        } else {
+            Ok(data.r.take().unwrap())
         };
     }
 

--- a/tests/assembly-llvm/wasm_exceptions.rs
+++ b/tests/assembly-llvm/wasm_exceptions.rs
@@ -48,7 +48,7 @@ pub fn test_rtry() {
             |_| {
                 may_panic();
             },
-            core::ptr::null_mut(),
+            core::ptr::null_mut::<u8>(),
             |data, exception| {
                 log_number(data as usize);
                 log_number(exception as usize);

--- a/tests/assembly-llvm/wasm_legacy_eh.rs
+++ b/tests/assembly-llvm/wasm_legacy_eh.rs
@@ -58,7 +58,7 @@ pub fn test_rtry() {
             |_| {
                 may_panic();
             },
-            core::ptr::null_mut(),
+            core::ptr::null_mut::<u8>(),
             |data, exception| {
                 log_number(data as usize);
                 log_number(exception as usize);

--- a/tests/codegen-llvm/emscripten-catch-unwind-js-eh.rs
+++ b/tests/codegen-llvm/emscripten-catch-unwind-js-eh.rs
@@ -30,11 +30,11 @@ const fn size_of<T>() -> usize {
 }
 
 #[rustc_intrinsic]
-unsafe fn catch_unwind(
-    try_fn: fn(_: *mut u8),
-    data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32;
+unsafe fn catch_unwind<Data>(
+    try_fn: unsafe fn(_: *mut Data),
+    data: *mut Data,
+    catch_fn: unsafe fn(_: *mut Data, _: *mut u8),
+) -> bool;
 
 // CHECK-LABEL: @ptr_size
 #[no_mangle]
@@ -46,10 +46,10 @@ pub fn ptr_size() -> usize {
 // CHECK-LABEL: @test_catch_unwind
 #[no_mangle]
 pub unsafe fn test_catch_unwind(
-    try_fn: fn(_: *mut u8),
+    try_fn: unsafe fn(_: *mut u8),
     data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32 {
+    catch_fn: unsafe fn(_: *mut u8, _: *mut u8),
+) -> bool {
     // CHECK: start:
     // CHECK: [[ALLOCA:%.*]] = alloca
 

--- a/tests/codegen-llvm/emscripten-catch-unwind-wasm-eh.rs
+++ b/tests/codegen-llvm/emscripten-catch-unwind-wasm-eh.rs
@@ -28,11 +28,11 @@ const fn size_of<T>() -> usize {
     loop {}
 }
 #[rustc_intrinsic]
-unsafe fn catch_unwind(
-    try_fn: fn(_: *mut u8),
-    data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32;
+unsafe fn catch_unwind<Data>(
+    try_fn: unsafe fn(_: *mut Data),
+    data: *mut Data,
+    catch_fn: unsafe fn(_: *mut Data, _: *mut u8),
+) -> bool;
 
 // CHECK-LABEL: @ptr_size
 #[no_mangle]
@@ -44,10 +44,10 @@ pub fn ptr_size() -> usize {
 // CHECK-LABEL: @test_catch_unwind
 #[no_mangle]
 pub unsafe fn test_catch_unwind(
-    try_fn: fn(_: *mut u8),
+    try_fn: unsafe fn(_: *mut u8),
     data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32 {
+    catch_fn: unsafe fn(_: *mut u8, _: *mut u8),
+) -> bool {
     // CHECK: start:
     // CHECK: invoke void %try_fn(ptr %data)
     // CHECK:         to label %__rust_try.exit unwind label %catchswitch.i
@@ -62,8 +62,8 @@ pub unsafe fn test_catch_unwind(
     // CHECK:   catchret from %catchpad2.i to label %__rust_try.exit
 
     // CHECK: __rust_try.exit:                                  ; preds = %start, %catchpad.i
-    // CHECK:   %common.ret.op.i = phi i32 [ 0, %start ], [ 1, %catchpad.i ]
-    // CHECK:   ret i32 %common.ret.op.i
+    // CHECK:   %common.ret.op.i = phi i1 [ false, %start ], [ true, %catchpad.i ]
+    // CHECK:   ret i1 %common.ret.op.i
 
     catch_unwind(try_fn, data, catch_fn)
 }

--- a/tests/codegen-llvm/wasm_exceptions.rs
+++ b/tests/codegen-llvm/wasm_exceptions.rs
@@ -49,7 +49,7 @@ pub fn test_rtry() {
             |_| {
                 may_panic();
             },
-            core::ptr::null_mut(),
+            core::ptr::null_mut::<u8>(),
             |data, exception| {
                 log_number(data as usize);
                 log_number(exception as usize);


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156867)*
<!-- homu-ignore:end -->

Turns out these were all making `OperandValue::Immediate`s already -- the intrinsic always returns a primitive scalar -- so pretty easy to handle.

cc https://github.com/rust-lang/rust/issues/153250 https://github.com/rust-lang/compiler-team/issues/970

While I was looking at it, I also "rustified" the intrinsic signature a bit: returning a `bool` and taking a generic pointee and `unsafe fn`s cleans up the call in `std` a bit without making the implementation in the backend any harder.

r? dianqk 