### PR TITLE
Reject `#[no_mangle]`/`#[link_name]`/`#[export_name]` on EII

### DIFF
--- a/compiler/rustc_builtin_macros/src/eii.rs
+++ b/compiler/rustc_builtin_macros/src/eii.rs
@@ -11,9 +11,9 @@ use thin_vec::{ThinVec, thin_vec};
 
 use crate::errors::{
     EiiExternTargetExpectedList, EiiExternTargetExpectedMacro, EiiExternTargetExpectedUnsafe,
-    EiiMacroExpectedMaxOneArgument, EiiOnlyOnce, EiiSharedMacroInStatementPosition,
-    EiiSharedMacroTarget, EiiStaticArgumentRequired, EiiStaticDefault,
-    EiiStaticMultipleImplementations, EiiStaticMutable,
+    EiiForbiddenAttr, EiiMacroExpectedMaxOneArgument, EiiOnlyOnce,
+    EiiSharedMacroInStatementPosition, EiiSharedMacroTarget, EiiStaticArgumentRequired,
+    EiiStaticDefault, EiiStaticMultipleImplementations, EiiStaticMutable,
 };
 
 /// ```rust
@@ -126,8 +126,7 @@ fn eii_(
     let attrs = attrs.clone();
     let vis = vis.clone();
 
-    let attrs_from_decl =
-        filter_attrs_for_multiple_eii_attr(ecx, attrs, eii_attr_span, &meta_item.path);
+    let attrs_from_decl = filter_attrs_for_eii_decl(ecx, attrs, eii_attr_span, &meta_item.path);
 
     let Ok(macro_name) = name_for_impl_macro(ecx, foreign_item_name, &meta_item) else {
         // we don't need to wrap in Annotatable::Stmt conditionally since
@@ -196,8 +195,9 @@ fn name_for_impl_macro(
     }
 }
 
-/// Ensure that in the list of attrs, there's only a single `eii` attribute.
-fn filter_attrs_for_multiple_eii_attr(
+/// Reject attributes that cannot be used with externally implementable items,
+/// and ensure that in the list of attrs, there's only a single `eii` attribute.
+fn filter_attrs_for_eii_decl(
     ecx: &mut ExtCtxt<'_>,
     attrs: ThinVec<Attribute>,
     eii_attr_span: Span,
@@ -212,6 +212,11 @@ fn filter_attrs_for_multiple_eii_attr(
                     first_span: eii_attr_span,
                     name: path_to_string(eii_attr_path),
                 });
+                false
+            } else if let Some(name @ (sym::export_name | sym::link_name | sym::no_mangle)) =
+                i.name()
+            {
+                ecx.dcx().emit_err(EiiForbiddenAttr { span: i.span, name });
                 false
             } else {
                 true
@@ -510,6 +515,15 @@ pub(crate) fn eii_shared_macro(
         ecx.dcx().emit_err(EiiSharedMacroTarget { span, name: path_to_string(&meta_item.path) });
         return vec![item];
     };
+
+    i.attrs.retain(|attr| {
+        if let Some(name @ (sym::export_name | sym::link_name | sym::no_mangle)) = attr.name() {
+            ecx.dcx().emit_err(EiiForbiddenAttr { span: attr.span, name });
+            false
+        } else {
+            true
+        }
+    });
 
     let eii_impls = match &mut i.kind {
         ItemKind::Fn(func) => &mut func.eii_impls,

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -1179,6 +1179,14 @@ pub(crate) struct EiiOnlyOnce {
 }
 
 #[derive(Diagnostic)]
+#[diag("`#[{$name}]` cannot be used on externally implementable items")]
+pub(crate) struct EiiForbiddenAttr {
+    #[primary_span]
+    pub span: Span,
+    pub name: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag("`#[{$name}]` expected no arguments or a single argument: `#[{$name}(default)]`")]
 pub(crate) struct EiiMacroExpectedMaxOneArgument {
     #[primary_span]

--- a/tests/ui/eii/forbidden_attrs.rs
+++ b/tests/ui/eii/forbidden_attrs.rs
@@ -1,0 +1,43 @@
+// Tests attributes that are forbidden on EII.
+#![feature(extern_item_impls)]
+
+#[unsafe(no_mangle)]
+//~^ ERROR `#[no_mangle]` cannot be used on externally implementable items
+#[eii]
+fn foo() {}
+
+#[unsafe(export_name = "bar")]
+//~^ ERROR `#[export_name]` cannot be used on externally implementable items
+#[eii]
+fn bar() {}
+
+#[link_name = "baz"]
+//~^ ERROR `#[link_name]` cannot be used on externally implementable items
+#[eii]
+fn baz() {}
+
+#[eii]
+fn qux();
+
+#[unsafe(no_mangle)]
+//~^ ERROR `#[no_mangle]` cannot be used on externally implementable items
+#[qux]
+fn qux_impl() {}
+
+#[eii]
+fn corge();
+
+#[unsafe(export_name = "corge_impl")]
+//~^ ERROR `#[export_name]` cannot be used on externally implementable items
+#[corge]
+fn corge_impl() {}
+
+#[eii]
+fn garply();
+
+#[link_name = "garply_impl"]
+//~^ ERROR `#[link_name]` cannot be used on externally implementable items
+#[garply]
+fn garply_impl() {}
+
+fn main() {}

--- a/tests/ui/eii/forbidden_attrs.stderr
+++ b/tests/ui/eii/forbidden_attrs.stderr
@@ -1,0 +1,38 @@
+error: `#[no_mangle]` cannot be used on externally implementable items
+  --> $DIR/forbidden_attrs.rs:4:1
+   |
+LL | #[unsafe(no_mangle)]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: `#[export_name]` cannot be used on externally implementable items
+  --> $DIR/forbidden_attrs.rs:9:1
+   |
+LL | #[unsafe(export_name = "bar")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[link_name]` cannot be used on externally implementable items
+  --> $DIR/forbidden_attrs.rs:14:1
+   |
+LL | #[link_name = "baz"]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: `#[no_mangle]` cannot be used on externally implementable items
+  --> $DIR/forbidden_attrs.rs:22:1
+   |
+LL | #[unsafe(no_mangle)]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: `#[export_name]` cannot be used on externally implementable items
+  --> $DIR/forbidden_attrs.rs:30:1
+   |
+LL | #[unsafe(export_name = "corge_impl")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[link_name]` cannot be used on externally implementable items
+  --> $DIR/forbidden_attrs.rs:38:1
+   |
+LL | #[link_name = "garply_impl"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#125418

The issue said "Check no_mangle on EIIs is rejected properly". I believe `link_name` should also be rejected.