### PR TITLE
Drop skip_move_check_fns query.

### DIFF
--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2710,12 +2710,6 @@ rustc_queries! {
         desc { "monomorphization-time checking" }
     }
 
-    /// Builds the set of functions that should be skipped for the move-size check.
-    query skip_move_check_fns(_: ()) -> &'tcx FxIndexSet<DefId> {
-        arena_cache
-        desc { "functions to skip for move-size check" }
-    }
-
     query items_of_instance(key: (ty::Instance<'tcx>, CollectionMode)) -> Result<(&'tcx [Spanned<MonoItem<'tcx>>], &'tcx [Spanned<MonoItem<'tcx>>]), NormalizationErrorInMono> {
         desc { "collecting items used by `{}`", key.0 }
         cache_on_disk

--- a/compiler/rustc_monomorphize/src/mono_checks/mod.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/mod.rs
@@ -15,9 +15,5 @@ fn check_mono_item<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) {
 }
 
 pub(super) fn provide(providers: &mut Providers) {
-    *providers = Providers {
-        check_mono_item,
-        skip_move_check_fns: move_check::skip_move_check_fns,
-        ..*providers
-    }
+    *providers = Providers { check_mono_item, ..*providers }
 }

--- a/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
@@ -1,12 +1,12 @@
 use rustc_abi::Size;
-use rustc_data_structures::fx::FxIndexSet;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_hir::limit::Limit;
 use rustc_middle::mir::visit::Visitor as MirVisitor;
 use rustc_middle::mir::{self, Location, traversal};
-use rustc_middle::ty::{self, AssocTag, Instance, Ty, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, Instance, Ty, TyCtxt, TypeFoldable};
 use rustc_session::lint::builtin::LARGE_ASSIGNMENTS;
-use rustc_span::{Ident, Span, Spanned, sym};
+use rustc_span::{Span, Spanned, sym};
 use tracing::{debug, trace};
 
 use crate::errors::LargeAssignmentsLint;
@@ -98,7 +98,7 @@ impl<'tcx> MoveCheckVisitor<'tcx> {
         let ty::FnDef(def_id, _) = *callee_ty.kind() else {
             return;
         };
-        if self.tcx.skip_move_check_fns(()).contains(&def_id) {
+        if should_skip_fn(self.tcx, def_id) {
             return;
         }
 
@@ -188,29 +188,18 @@ impl<'tcx> MoveCheckVisitor<'tcx> {
     }
 }
 
-fn assoc_fn_of_type<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, fn_ident: Ident) -> Option<DefId> {
-    for &impl_def_id in tcx.inherent_impls(def_id) {
-        if let Some(new) = tcx.associated_items(impl_def_id).find_by_ident_and_kind(
-            tcx,
-            fn_ident,
-            AssocTag::Fn,
-            def_id,
-        ) {
-            return Some(new.def_id);
-        }
+/// Return `true` if `def_id` is `Box::new`, `Rc::new` or `Arc::new`.
+fn should_skip_fn(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    if let DefKind::AssocFn = tcx.def_kind(def_id)
+        && tcx.item_name(def_id) == sym::new
+        && let parent = tcx.parent(def_id)
+        && let DefKind::Impl { of_trait: false } = tcx.def_kind(parent)
+        && let ty::Adt(adt_def, ..) =
+            tcx.type_of(parent).instantiate_identity().skip_normalization().kind()
+    {
+        return Some(adt_def.did()) == tcx.lang_items().owned_box()
+            || Some(adt_def.did()) == tcx.get_diagnostic_item(sym::Rc)
+            || Some(adt_def.did()) == tcx.get_diagnostic_item(sym::Arc);
     }
-    None
-}
-
-pub(crate) fn skip_move_check_fns(tcx: TyCtxt<'_>, _: ()) -> FxIndexSet<DefId> {
-    let fns = [
-        (tcx.lang_items().owned_box(), "new"),
-        (tcx.get_diagnostic_item(sym::Rc), "new"),
-        (tcx.get_diagnostic_item(sym::Arc), "new"),
-    ];
-    fns.into_iter()
-        .filter_map(|(def_id, fn_name)| {
-            def_id.and_then(|def_id| assoc_fn_of_type(tcx, def_id, Ident::from_str(fn_name)))
-        })
-        .collect()
+    false
 }


### PR DESCRIPTION
Looking at the header of the impl block for each method can be just as fast.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
