### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3583,6 +3583,13 @@ pub struct ImplRestriction {
 }
 
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
+pub struct MutRestriction {
+    pub kind: RestrictionKind,
+    pub span: Span,
+    pub tokens: Option<LazyAttrTokenStream>,
+}
+
+#[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub enum RestrictionKind {
     Unrestricted,
     Restricted { path: Box<Path>, id: NodeId, shorthand: bool },
@@ -3597,6 +3604,7 @@ pub struct FieldDef {
     pub id: NodeId,
     pub span: Span,
     pub vis: Visibility,
+    pub mut_restriction: MutRestriction,
     pub safety: Safety,
     pub ident: Option<Ident>,
 

--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -8,8 +8,8 @@ use std::marker::PhantomData;
 use crate::tokenstream::LazyAttrTokenStream;
 use crate::{
     Arm, AssocItem, AttrItem, AttrKind, AttrVec, Attribute, Block, Crate, Expr, ExprField,
-    FieldDef, ForeignItem, GenericParam, ImplRestriction, Item, NodeId, Param, Pat, PatField, Path,
-    Stmt, StmtKind, Ty, Variant, Visibility, WherePredicate,
+    FieldDef, ForeignItem, GenericParam, ImplRestriction, Item, MutRestriction, NodeId, Param, Pat,
+    PatField, Path, Stmt, StmtKind, Ty, Variant, Visibility, WherePredicate,
 };
 
 /// A trait for AST nodes having an ID.
@@ -108,7 +108,8 @@ impl_has_tokens!(
     Path,
     Ty,
     Visibility,
-    ImplRestriction
+    ImplRestriction,
+    MutRestriction,
 );
 impl_has_tokens_none!(
     Arm,
@@ -254,7 +255,17 @@ impl_has_attrs!(
     Variant,
     WherePredicate,
 );
-impl_has_attrs_none!(Attribute, AttrItem, Block, Pat, Path, Ty, Visibility, ImplRestriction);
+impl_has_attrs_none!(
+    Attribute,
+    AttrItem,
+    Block,
+    Pat,
+    Path,
+    Ty,
+    Visibility,
+    ImplRestriction,
+    MutRestriction
+);
 
 impl<T: HasAttrs> HasAttrs for Box<T> {
     const SUPPORTS_CUSTOM_INNER_ATTRS: bool = T::SUPPORTS_CUSTOM_INNER_ATTRS;

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -582,12 +582,14 @@ macro_rules! common_visitor_and_walkers {
                 fn visit_generics(Generics);
                 fn visit_inline_asm(InlineAsm);
                 fn visit_inline_asm_sym(InlineAsmSym);
+                fn visit_impl_restriction(ImplRestriction);
                 //fn visit_item(Item);
                 fn visit_label(Label);
                 fn visit_lifetime(Lifetime, _ctxt: LifetimeCtxt);
                 fn visit_local(Local);
                 fn visit_mac_call(MacCall);
                 fn visit_macro_def(MacroDef);
+                fn visit_mut_restriction(MutRestriction);
                 fn visit_param_bound(GenericBound, _ctxt: BoundKind);
                 fn visit_param(Param);
                 fn visit_pat_field(PatField);
@@ -597,7 +599,6 @@ macro_rules! common_visitor_and_walkers {
                 fn visit_poly_trait_ref(PolyTraitRef);
                 fn visit_precise_capturing_arg(PreciseCapturingArg);
                 fn visit_qself(QSelf);
-                fn visit_impl_restriction(ImplRestriction);
                 fn visit_trait_ref(TraitRef);
                 fn visit_ty_pat(TyPat);
                 fn visit_ty(Ty);
@@ -1106,12 +1107,14 @@ macro_rules! common_visitor_and_walkers {
             pub fn walk_generics(Generics);
             pub fn walk_inline_asm(InlineAsm);
             pub fn walk_inline_asm_sym(InlineAsmSym);
+            pub fn walk_impl_restriction(ImplRestriction);
             //pub fn walk_item(Item);
             pub fn walk_label(Label);
             pub fn walk_lifetime(Lifetime);
             pub fn walk_local(Local);
             pub fn walk_mac(MacCall);
             pub fn walk_macro_def(MacroDef);
+            pub fn walk_mut_restriction(MutRestriction);
             pub fn walk_param_bound(GenericBound);
             pub fn walk_param(Param);
             pub fn walk_pat_field(PatField);
@@ -1121,7 +1124,6 @@ macro_rules! common_visitor_and_walkers {
             pub fn walk_poly_trait_ref(PolyTraitRef);
             pub fn walk_precise_capturing_arg(PreciseCapturingArg);
             pub fn walk_qself(QSelf);
-            pub fn walk_impl_restriction(ImplRestriction);
             pub fn walk_trait_ref(TraitRef);
             pub fn walk_ty_pat(TyPat);
             pub fn walk_ty(Ty);

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -505,6 +505,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(more_qualified_paths, "usage of qualified paths in this context is experimental");
     gate_all!(move_expr, "`move(expr)` syntax is experimental");
     gate_all!(mut_ref, "mutable by-reference bindings are experimental");
+    gate_all!(mut_restriction, "`mut` restrictions are experimental");
     gate_all!(pin_ergonomics, "pinned reference syntax is experimental");
     gate_all!(postfix_match, "postfix match is experimental");
     gate_all!(return_type_notation, "return type notation is experimental");

--- a/compiler/rustc_ast_pretty/src/pprust/mod.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/mod.rs
@@ -84,6 +84,10 @@ pub fn impl_restriction_to_string(r: &ast::ImplRestriction) -> String {
     State::new().impl_restriction_to_string(r)
 }
 
+pub fn mut_restriction_to_string(r: &ast::MutRestriction) -> String {
+    State::new().mut_restriction_to_string(r)
+}
+
 pub fn meta_list_item_to_string(li: &ast::MetaItemInner) -> String {
     State::new().meta_list_item_to_string(li)
 }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1153,6 +1153,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         Self::to_string(|s| s.print_impl_restriction(r))
     }
 
+    fn mut_restriction_to_string(&self, r: &ast::MutRestriction) -> String {
+        Self::to_string(|s| s.print_mut_restriction(r))
+    }
+
     fn block_to_string(&self, blk: &ast::Block) -> String {
         Self::to_string(|s| {
             let (cb, ib) = s.head("");

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -511,6 +511,20 @@ impl<'a> State<'a> {
         }
     }
 
+    pub(crate) fn print_mut_restriction(&mut self, mut_restriction: &ast::MutRestriction) {
+        match &mut_restriction.kind {
+            ast::RestrictionKind::Restricted { path, shorthand, .. } => {
+                let path = Self::to_string(|s| s.print_path(path, false, 0));
+                if *shorthand {
+                    self.word_nbsp(format!("mut({path})"))
+                } else {
+                    self.word_nbsp(format!("mut(in {path})"))
+                }
+            }
+            ast::RestrictionKind::Unrestricted => {}
+        }
+    }
+
     fn print_defaultness(&mut self, defaultness: ast::Defaultness) {
         if let ast::Defaultness::Default(_) = defaultness {
             self.word_nbsp("default");
@@ -537,6 +551,7 @@ impl<'a> State<'a> {
                         s.maybe_print_comment(field.span.lo());
                         s.print_outer_attributes(&field.attrs);
                         s.print_visibility(&field.vis);
+                        s.print_mut_restriction(&field.mut_restriction);
                         s.print_type(&field.ty)
                     });
                     self.pclose();
@@ -562,6 +577,7 @@ impl<'a> State<'a> {
                         self.maybe_print_comment(field.span.lo());
                         self.print_outer_attributes(&field.attrs);
                         self.print_visibility(&field.vis);
+                        self.print_mut_restriction(&field.mut_restriction);
                         self.print_ident(field.ident.unwrap());
                         self.word_nbsp(":");
                         self.print_type(&field.ty);

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -186,6 +186,11 @@ pub(crate) fn placeholder(
             ty: ty(),
             vis,
             is_placeholder: true,
+            mut_restriction: ast::MutRestriction {
+                kind: ast::RestrictionKind::Unrestricted,
+                span: DUMMY_SP,
+                tokens: None,
+            },
             safety: Safety::Default,
             default: None,
         }]),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -648,6 +648,8 @@ declare_features! (
     (unstable, must_not_suspend, "1.57.0", Some(83310)),
     /// Allows `mut ref` and `mut ref mut` identifier patterns.
     (incomplete, mut_ref, "1.79.0", Some(123076)),
+    /// Allows `mut(crate) field: Type` restrictions.
+    (incomplete, mut_restriction, "CURRENT_RUSTC_VERSION", Some(105077)),
     /// Allows using `#[naked]` on `extern "Rust"` functions.
     (unstable, naked_functions_rustic_abi, "1.88.0", Some(138997)),
     /// Allows using `#[target_feature(enable = "...")]` on `#[naked]` on functions.

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -361,9 +361,9 @@ where
             // have no uncaptured args, then we should warn to the user that
             // it's redundant to capture all args explicitly.
             if new_capture_rules
-                && let Some((captured_args, capturing_span)) =
-                    opaque.bounds.iter().find_map(|bound| match *bound {
-                        hir::GenericBound::Use(a, s) => Some((a, s)),
+                && let Some((use_idx, captured_args, capturing_span)) =
+                    opaque.bounds.iter().enumerate().find_map(|(i, bound)| match *bound {
+                        hir::GenericBound::Use(a, s) => Some((i, a, s)),
                         _ => None,
                     })
             {
@@ -400,11 +400,25 @@ where
                     .iter()
                     .all(|(def_id, _)| explicitly_captured.contains(def_id))
                 {
+                    // Extend the removal span to include the `+` joiner adjacent
+                    // to `use<...>`, so applying the suggestion does not leave
+                    // behind a stray `+` that fails to parse.
+                    let suggestion_span = if let Some(next) = opaque.bounds.get(use_idx + 1) {
+                        capturing_span.with_hi(next.span().lo())
+                    } else if let Some(prev_idx) = use_idx.checked_sub(1) {
+                        let prev = opaque.bounds[prev_idx];
+                        capturing_span.with_lo(prev.span().hi())
+                    } else {
+                        // `impl use<...>` with no other bound is not valid
+                        // syntax, so this branch is unreachable in practice.
+                        capturing_span
+                    };
+
                     self.tcx.emit_node_span_lint(
                         IMPL_TRAIT_REDUNDANT_CAPTURES,
                         self.tcx.local_def_id_to_hir_id(opaque_def_id),
                         opaque_span,
-                        ImplTraitRedundantCapturesLint { capturing_span },
+                        ImplTraitRedundantCapturesLint { capturing_span: suggestion_span },
                     );
                 }
             }

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1288,6 +1288,26 @@ pub(crate) struct IncorrectImplRestriction {
 }
 
 #[derive(Diagnostic)]
+#[diag("incorrect `mut` restriction")]
+#[help(
+    "some possible `mut` restrictions are:
+    `mut(crate)`: can only be mutated in the current crate
+    `mut(super)`: can only be mutated in the parent module
+    `mut(self)`: can only be mutated in current module
+    `mut(in path::to::module)`: can only be mutated in the specified path"
+)]
+pub(crate) struct IncorrectMutRestriction {
+    #[primary_span]
+    #[suggestion(
+        "help: use `in` to restrict mutations to the path `{$inner_str}`",
+        code = "in {inner_str}",
+        applicability = "machine-applicable"
+    )]
+    pub span: Span,
+    pub inner_str: String,
+}
+
+#[derive(Diagnostic)]
 #[diag("<assignment> ... else {\"{\"} ... {\"}\"} is not allowed")]
 pub(crate) struct AssignmentElseNotAllowed {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2108,6 +2108,7 @@ impl<'a> Parser<'a> {
                         return Err(err);
                     }
                 };
+                let mut_restriction = p.parse_mut_restriction()?;
                 // Unsafe fields are not supported in tuple structs, as doing so would result in a
                 // parsing ambiguity for `struct X(unsafe fn())`.
                 let ty = match p.parse_ty() {
@@ -2140,6 +2141,7 @@ impl<'a> Parser<'a> {
                     FieldDef {
                         span: lo.to(ty.span),
                         vis,
+                        mut_restriction,
                         safety: Safety::Default,
                         ident: None,
                         id: DUMMY_NODE_ID,
@@ -2164,9 +2166,18 @@ impl<'a> Parser<'a> {
         self.collect_tokens(None, attrs, ForceCollect::No, |this, attrs| {
             let lo = this.token.span;
             let vis = this.parse_visibility(FollowedByType::No)?;
+            let mut_restriction = this.parse_mut_restriction()?;
             let safety = this.parse_unsafe_field();
-            this.parse_single_struct_field(adt_ty, lo, vis, safety, attrs, ident_span)
-                .map(|field| (field, Trailing::No, UsePreAttrPos::No))
+            this.parse_single_struct_field(
+                adt_ty,
+                lo,
+                vis,
+                mut_restriction,
+                safety,
+                attrs,
+                ident_span,
+            )
+            .map(|field| (field, Trailing::No, UsePreAttrPos::No))
         })
     }
 
@@ -2176,11 +2187,12 @@ impl<'a> Parser<'a> {
         adt_ty: &str,
         lo: Span,
         vis: Visibility,
+        mut_restriction: MutRestriction,
         safety: Safety,
         attrs: AttrVec,
         ident_span: Span,
     ) -> PResult<'a, FieldDef> {
-        let a_var = self.parse_name_and_ty(adt_ty, lo, vis, safety, attrs)?;
+        let a_var = self.parse_name_and_ty(adt_ty, lo, vis, mut_restriction, safety, attrs)?;
         match self.token.kind {
             token::Comma => {
                 self.bump();
@@ -2299,6 +2311,7 @@ impl<'a> Parser<'a> {
         adt_ty: &str,
         lo: Span,
         vis: Visibility,
+        mut_restriction: MutRestriction,
         safety: Safety,
         attrs: AttrVec,
     ) -> PResult<'a, FieldDef> {
@@ -2337,6 +2350,7 @@ impl<'a> Parser<'a> {
             ident: Some(name),
             vis,
             safety,
+            mut_restriction,
             id: DUMMY_NODE_ID,
             ty,
             default,

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -36,8 +36,8 @@ use rustc_ast::util::classify;
 use rustc_ast::{
     self as ast, AnonConst, AttrArgs, AttrId, BinOpKind, ByRef, Const, CoroutineKind,
     DUMMY_NODE_ID, DelimArgs, Expr, ExprKind, Extern, HasAttrs, HasTokens, ImplRestriction,
-    MgcaDisambiguation, Mutability, Recovered, RestrictionKind, Safety, StrLit, Visibility,
-    VisibilityKind,
+    MgcaDisambiguation, MutRestriction, Mutability, Recovered, RestrictionKind, Safety, StrLit,
+    Visibility, VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
@@ -51,8 +51,8 @@ pub use token_type::{ExpKeywordPair, ExpTokenPair, TokenType};
 use tracing::debug;
 
 use crate::errors::{
-    self, IncorrectImplRestriction, IncorrectVisibilityRestriction, NonStringAbiLiteral,
-    TokenDescription,
+    self, IncorrectImplRestriction, IncorrectMutRestriction, IncorrectVisibilityRestriction,
+    NonStringAbiLiteral, TokenDescription,
 };
 use crate::exp;
 
@@ -295,6 +295,13 @@ impl SeqSep {
     fn none() -> SeqSep {
         SeqSep { sep: None, trailing_sep_allowed: false }
     }
+}
+
+/// Whether parsing `impl` or `mut` restrictions.
+#[derive(Clone, Copy, Debug)]
+enum ParsingRestrictionKind {
+    Impl,
+    Mut,
 }
 
 #[derive(Debug)]
@@ -1550,37 +1557,9 @@ impl<'a> Parser<'a> {
     /// Enforces the `impl_restriction` feature gate whenever an explicit restriction is encountered.
     fn parse_impl_restriction(&mut self) -> PResult<'a, ImplRestriction> {
         if self.eat_keyword(exp!(Impl)) {
-            let lo = self.prev_token.span;
-            // No units or tuples are allowed to follow `impl` here, so we can safely bump `(`.
-            self.expect(exp!(OpenParen))?;
-            if self.eat_keyword(exp!(In)) {
-                let path = self.parse_path(PathStyle::Mod)?; // `in path`
-                self.expect(exp!(CloseParen))?; // `)`
-                let restriction = RestrictionKind::Restricted {
-                    path: Box::new(path),
-                    id: ast::DUMMY_NODE_ID,
-                    shorthand: false,
-                };
-                let span = lo.to(self.prev_token.span);
-                self.psess.gated_spans.gate(sym::impl_restriction, span);
-                return Ok(ImplRestriction { kind: restriction, span, tokens: None });
-            } else if self.look_ahead(1, |t| t == &token::CloseParen)
-                && self.is_keyword_ahead(0, &[kw::Crate, kw::Super, kw::SelfLower])
-            {
-                let path = self.parse_path(PathStyle::Mod)?; // `crate`/`super`/`self`
-                self.expect(exp!(CloseParen))?; // `)`
-                let restriction = RestrictionKind::Restricted {
-                    path: Box::new(path),
-                    id: ast::DUMMY_NODE_ID,
-                    shorthand: true,
-                };
-                let span = lo.to(self.prev_token.span);
-                self.psess.gated_spans.gate(sym::impl_restriction, span);
-                return Ok(ImplRestriction { kind: restriction, span, tokens: None });
-            } else {
-                self.recover_incorrect_impl_restriction(lo)?;
-                // Emit diagnostic, but continue with no impl restriction.
-            }
+            let (kind, span, gated_span) = self.parse_restriction(ParsingRestrictionKind::Impl)?;
+            self.psess.gated_spans.gate(sym::impl_restriction, gated_span);
+            return Ok(ImplRestriction { kind, span, tokens: None });
         }
         Ok(ImplRestriction {
             kind: RestrictionKind::Unrestricted,
@@ -1589,15 +1568,73 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Recovery for e.g. `impl(something) trait`
-    fn recover_incorrect_impl_restriction(&mut self, lo: Span) -> PResult<'a, ()> {
-        let path = self.parse_path(PathStyle::Mod)?;
-        self.expect(exp!(CloseParen))?; // `)`
-        let path_str = pprust::path_to_string(&path);
-        self.dcx().emit_err(IncorrectImplRestriction { span: path.span, inner_str: path_str });
-        let end = self.prev_token.span;
-        self.psess.gated_spans.gate(sym::impl_restriction, lo.to(end));
-        Ok(())
+    /// Parses an optional `mut` restriction.
+    /// Enforces the `mut_restriction` feature gate whenever an explicit restriction is encountered.
+    fn parse_mut_restriction(&mut self) -> PResult<'a, MutRestriction> {
+        if self.eat_keyword(exp!(Mut)) {
+            let (kind, span, gated_span) = self.parse_restriction(ParsingRestrictionKind::Mut)?;
+            self.psess.gated_spans.gate(sym::mut_restriction, gated_span);
+            return Ok(MutRestriction { kind, span, tokens: None });
+        }
+        Ok(MutRestriction {
+            kind: RestrictionKind::Unrestricted,
+            span: self.token.span.shrink_to_lo(),
+            tokens: None,
+        })
+    }
+
+    /// Parses `impl` or `mut` restrictions.
+    /// Returns the parsed restriction and its span, as well as the gated span.
+    fn parse_restriction(
+        &mut self,
+        restriction_kind: ParsingRestrictionKind,
+    ) -> PResult<'a, (RestrictionKind, Span, Span)> {
+        let lo = self.prev_token.span;
+        // No units or tuples are allowed to follow `impl` or `mut` here, so we can safely bump `(`.
+        self.expect(exp!(OpenParen))?;
+        if self.eat_keyword(exp!(In)) {
+            let path = self.parse_path(PathStyle::Mod)?; // `in path`
+            self.expect(exp!(CloseParen))?; // `)`
+            let restriction = RestrictionKind::Restricted {
+                path: Box::new(path),
+                id: ast::DUMMY_NODE_ID,
+                shorthand: false,
+            };
+            let span = lo.to(self.prev_token.span);
+            Ok((restriction, span, span))
+        } else if self.look_ahead(1, |t| t == &token::CloseParen)
+            && self.is_keyword_ahead(0, &[kw::Crate, kw::Super, kw::SelfLower])
+        {
+            let path = self.parse_path(PathStyle::Mod)?; // `crate`/`super`/`self`
+            self.expect(exp!(CloseParen))?; // `)`
+            let restriction = RestrictionKind::Restricted {
+                path: Box::new(path),
+                id: ast::DUMMY_NODE_ID,
+                shorthand: true,
+            };
+            let span = lo.to(self.prev_token.span);
+            Ok((restriction, span, span))
+        } else {
+            // Emit diagnostic, but continue with no restrictions.
+            // Recovery for `impl(something) trait` or `mut (something) field`.
+            let path = self.parse_path(PathStyle::Mod)?;
+            self.expect(exp!(CloseParen))?; // `)`
+            let path_str = pprust::path_to_string(&path);
+            let end = self.prev_token.span;
+            match restriction_kind {
+                ParsingRestrictionKind::Impl => {
+                    self.dcx().emit_err(IncorrectImplRestriction {
+                        span: path.span,
+                        inner_str: path_str,
+                    });
+                }
+                ParsingRestrictionKind::Mut => {
+                    self.dcx()
+                        .emit_err(IncorrectMutRestriction { span: path.span, inner_str: path_str });
+                }
+            }
+            Ok((RestrictionKind::Unrestricted, self.token.span.shrink_to_lo(), lo.to(end)))
+        }
     }
 
     /// Parses `extern string_literal?`.

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1479,6 +1479,7 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
             ty,
             is_placeholder: _,
             default,
+            mut_restriction: _,
             safety: _,
         } = f;
         walk_list!(self, visit_attribute, attrs);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1338,6 +1338,7 @@ symbols! {
         must_use,
         mut_preserve_binding_mode_2024,
         mut_ref,
+        mut_restriction,
         mutable,
         naked,
         naked_asm,

--- a/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/mod.rs
@@ -726,6 +726,7 @@ pub fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
     l.is_placeholder == r.is_placeholder
         && over(&l.attrs, &r.attrs, eq_attr)
         && eq_vis(&l.vis, &r.vis)
+        && eq_mut_restriction(&l.mut_restriction, &r.mut_restriction)
         && both(l.ident.as_ref(), r.ident.as_ref(), |l, r| eq_id(*l, *r))
         && eq_ty(&l.ty, &r.ty)
 }
@@ -843,6 +844,10 @@ pub fn eq_vis(l: &Visibility, r: &Visibility) -> bool {
 }
 
 pub fn eq_impl_restriction(l: &ImplRestriction, r: &ImplRestriction) -> bool {
+    eq_restriction_kind(&l.kind, &r.kind)
+}
+
+pub fn eq_mut_restriction(l: &MutRestriction, r: &MutRestriction) -> bool {
     eq_restriction_kind(&l.kind, &r.kind)
 }
 

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -1889,15 +1889,16 @@ pub(crate) fn rewrite_struct_field_prefix(
     field: &ast::FieldDef,
 ) -> RewriteResult {
     let vis = format_visibility(context, &field.vis);
+    let mut_restriction = format_mut_restriction(context, &field.mut_restriction);
     let safety = format_safety(field.safety);
     let type_annotation_spacing = type_annotation_spacing(context.config);
     Ok(match field.ident {
         Some(name) => format!(
-            "{vis}{safety}{}{}:",
+            "{vis}{mut_restriction}{safety}{}{}:",
             rewrite_ident(context, name),
             type_annotation_spacing.0
         ),
-        None => format!("{vis}{safety}"),
+        None => format!("{vis}{mut_restriction}{safety}"),
     })
 }
 

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 
 use rustc_ast::YieldKind;
 use rustc_ast::ast::{
-    self, Attribute, ImplRestriction, MetaItem, MetaItemInner, MetaItemKind, NodeId, Path,
-    RestrictionKind, Visibility, VisibilityKind,
+    self, Attribute, ImplRestriction, MetaItem, MetaItemInner, MetaItemKind, MutRestriction,
+    NodeId, Path, RestrictionKind, Visibility, VisibilityKind,
 };
 use rustc_ast_pretty::pprust;
 use rustc_span::{BytePos, LocalExpnId, Span, Symbol, SyntaxContext, sym, symbol};
@@ -79,6 +79,13 @@ pub(crate) fn format_impl_restriction(
     impl_restriction: &ImplRestriction,
 ) -> String {
     format_restriction("impl", context, &impl_restriction.kind)
+}
+
+pub(crate) fn format_mut_restriction(
+    context: &RewriteContext<'_>,
+    mut_restriction: &MutRestriction,
+) -> String {
+    format_restriction("mut", context, &mut_restriction.kind)
 }
 
 fn format_restriction(

--- a/src/tools/rustfmt/tests/source/mut-restriction.rs
+++ b/src/tools/rustfmt/tests/source/mut-restriction.rs
@@ -1,0 +1,108 @@
+#![feature(mut_restrictions, unsafe_fields)]
+
+struct FooS {
+    pub
+    mut(crate)
+    field1: (),
+    pub
+    mut(crate        
+    )
+    unsafe
+    field2: (),
+}
+
+struct BazS {
+    pub
+    mut ( in foo
+    ::
+    bar )
+    field1: (),
+    pub
+    mut(
+        in foo
+        ::
+        bar
+    ) unsafe
+    field2: (),
+}
+
+struct FooS2(
+    pub
+    mut(crate)
+    (),
+);
+
+struct BazS2(
+    pub
+    mut ( in foo
+    ::
+    bar )
+    (),
+);
+
+enum Enum {
+    Foo {
+        pub(crate) mut(self)
+        field1: (),
+        pub
+        mut(self        
+        )
+        unsafe
+        field2: (),
+    },
+    Baz {
+        pub
+        mut ( in foo
+        ::
+        bar )
+        field1: (),
+        pub(
+            crate
+        )
+        mut(
+            in foo
+            ::
+            bar
+        ) unsafe field2: (),
+    },
+    FooT(
+        pub(crate) 
+        mut(self)
+        (),
+    ),
+    BazT(
+        pub(crate
+        )
+        mut ( in foo
+        ::
+        bar )
+        (),
+    ),
+
+}
+
+union Union {
+    pub
+    mut(crate)
+    field1: (),
+    pub(crate
+    )
+    mut ( in foo
+    ::
+    bar )
+    field2: (),
+    pub
+    mut(crate        
+    )
+    unsafe
+    field3: (),
+    pub(
+        crate
+    )
+    mut(
+        in foo
+        ::
+        bar
+    ) unsafe
+    field4: (),
+}

--- a/src/tools/rustfmt/tests/target/mut-restriction.rs
+++ b/src/tools/rustfmt/tests/target/mut-restriction.rs
@@ -1,0 +1,35 @@
+#![feature(mut_restrictions, unsafe_fields)]
+
+struct FooS {
+    pub mut(crate) field1: (),
+    pub mut(crate) unsafe field2: (),
+}
+
+struct BazS {
+    pub mut(in foo::bar) field1: (),
+    pub mut(in foo::bar) unsafe field2: (),
+}
+
+struct FooS2(pub mut(crate) ());
+
+struct BazS2(pub mut(in foo::bar) ());
+
+enum Enum {
+    Foo {
+        pub(crate) mut(self) field1: (),
+        pub mut(self) unsafe field2: (),
+    },
+    Baz {
+        pub mut(in foo::bar) field1: (),
+        pub(crate) mut(in foo::bar) unsafe field2: (),
+    },
+    FooT(pub(crate) mut(self) ()),
+    BazT(pub(crate) mut(in foo::bar) ()),
+}
+
+union Union {
+    pub mut(crate) field1: (),
+    pub(crate) mut(in foo::bar) field2: (),
+    pub mut(crate) unsafe field3: (),
+    pub(crate) mut(in foo::bar) unsafe field4: (),
+}

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -943,6 +943,9 @@ Tests on moves (destructive moves).
 
 Broad category of tests on mutability, such as the `mut` keyword, borrowing a value as both immutable and mutable (and the associated error), or adding mutable references to `const` declarations.
 
+## `tests/ui/mut-restriction/`
+Tests for `#![feature(mut_restriction)]`. See [Tracking issue for restrictions #105077](https://github.com/rust-lang/rust/issues/105077).
+
 ## `tests/ui/namespace/`
 
 Contains a single test. It imports a massive amount of very similar types from a crate, then attempts various permutations of their namespace paths, checking for errors or the lackthereof.

--- a/tests/ui/impl-trait/precise-capturing/redundant-machine-applicable.fixed
+++ b/tests/ui/impl-trait/precise-capturing/redundant-machine-applicable.fixed
@@ -1,0 +1,28 @@
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+//@ edition: 2024
+
+// Verify that the suggestion produced by `impl_trait_redundant_captures`
+// removes the adjacent `+` joiner along with `use<...>`, instead of leaving
+// behind a stray `+` that fails to compile. Regression test for
+// https://github.com/rust-lang/rust/issues/143216.
+
+#![allow(unused)]
+#![deny(impl_trait_redundant_captures)]
+
+// `use<>` at the end of the bound list: the suggestion must remove the
+// preceding `+`.
+fn end_position() -> impl Sized {}
+//~^ ERROR all possible in-scope parameters are already captured
+
+// `use<>` at the start of the bound list: the suggestion must remove the
+// following `+`.
+fn start_position() -> impl Sized {}
+//~^ ERROR all possible in-scope parameters are already captured
+
+// `use<>` in the middle of the bound list: the suggestion must remove
+// exactly one `+`, keeping the other to join the remaining bounds.
+fn middle_position() -> impl Sized + Send {}
+//~^ ERROR all possible in-scope parameters are already captured
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/redundant-machine-applicable.rs
+++ b/tests/ui/impl-trait/precise-capturing/redundant-machine-applicable.rs
@@ -1,0 +1,28 @@
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+//@ edition: 2024
+
+// Verify that the suggestion produced by `impl_trait_redundant_captures`
+// removes the adjacent `+` joiner along with `use<...>`, instead of leaving
+// behind a stray `+` that fails to compile. Regression test for
+// https://github.com/rust-lang/rust/issues/143216.
+
+#![allow(unused)]
+#![deny(impl_trait_redundant_captures)]
+
+// `use<>` at the end of the bound list: the suggestion must remove the
+// preceding `+`.
+fn end_position() -> impl Sized + use<> {}
+//~^ ERROR all possible in-scope parameters are already captured
+
+// `use<>` at the start of the bound list: the suggestion must remove the
+// following `+`.
+fn start_position() -> impl use<> + Sized {}
+//~^ ERROR all possible in-scope parameters are already captured
+
+// `use<>` in the middle of the bound list: the suggestion must remove
+// exactly one `+`, keeping the other to join the remaining bounds.
+fn middle_position() -> impl Sized + use<> + Send {}
+//~^ ERROR all possible in-scope parameters are already captured
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/redundant-machine-applicable.stderr
+++ b/tests/ui/impl-trait/precise-capturing/redundant-machine-applicable.stderr
@@ -1,0 +1,32 @@
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+  --> $DIR/redundant-machine-applicable.rs:15:22
+   |
+LL | fn end_position() -> impl Sized + use<> {}
+   |                      ^^^^^^^^^^--------
+   |                                |
+   |                                help: remove the `use<...>` syntax
+   |
+note: the lint level is defined here
+  --> $DIR/redundant-machine-applicable.rs:11:9
+   |
+LL | #![deny(impl_trait_redundant_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+  --> $DIR/redundant-machine-applicable.rs:20:24
+   |
+LL | fn start_position() -> impl use<> + Sized {}
+   |                        ^^^^^--------^^^^^
+   |                             |
+   |                             help: remove the `use<...>` syntax
+
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+  --> $DIR/redundant-machine-applicable.rs:25:25
+   |
+LL | fn middle_position() -> impl Sized + use<> + Send {}
+   |                         ^^^^^^^^^^^^^--------^^^^
+   |                                      |
+   |                                      help: remove the `use<...>` syntax
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/impl-trait/precise-capturing/redundant.stderr
+++ b/tests/ui/impl-trait/precise-capturing/redundant.stderr
@@ -2,9 +2,9 @@ error: all possible in-scope parameters are already captured, so `use<...>` synt
   --> $DIR/redundant.rs:5:19
    |
 LL | fn hello<'a>() -> impl Sized + use<'a> {}
-   |                   ^^^^^^^^^^^^^-------
-   |                                |
-   |                                help: remove the `use<...>` syntax
+   |                   ^^^^^^^^^^----------
+   |                             |
+   |                             help: remove the `use<...>` syntax
    |
 note: the lint level is defined here
   --> $DIR/redundant.rs:3:9
@@ -16,25 +16,25 @@ error: all possible in-scope parameters are already captured, so `use<...>` synt
   --> $DIR/redundant.rs:10:27
    |
 LL |     fn inherent(&self) -> impl Sized + use<'_> {}
-   |                           ^^^^^^^^^^^^^-------
-   |                                        |
-   |                                        help: remove the `use<...>` syntax
+   |                           ^^^^^^^^^^----------
+   |                                     |
+   |                                     help: remove the `use<...>` syntax
 
 error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
   --> $DIR/redundant.rs:15:22
    |
 LL |     fn in_trait() -> impl Sized + use<'a, Self>;
-   |                      ^^^^^^^^^^^^^-------------
-   |                                   |
-   |                                   help: remove the `use<...>` syntax
+   |                      ^^^^^^^^^^----------------
+   |                                |
+   |                                help: remove the `use<...>` syntax
 
 error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
   --> $DIR/redundant.rs:19:22
    |
 LL |     fn in_trait() -> impl Sized + use<'a> {}
-   |                      ^^^^^^^^^^^^^-------
-   |                                   |
-   |                                   help: remove the `use<...>` syntax
+   |                      ^^^^^^^^^^----------
+   |                                |
+   |                                help: remove the `use<...>` syntax
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/stringify.rs
+++ b/tests/ui/macros/stringify.rs
@@ -10,14 +10,17 @@
 #![feature(const_trait_impl)]
 #![feature(coroutines)]
 #![feature(decl_macro)]
+#![feature(impl_restriction)]
 #![feature(macro_guard_matcher)]
 #![feature(more_qualified_paths)]
 #![feature(move_expr)]
+#![feature(mut_restriction)]
 #![feature(never_patterns)]
 #![feature(specialization)]
 #![feature(trait_alias)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]
+#![feature(unsafe_fields)]
 #![deny(unused_macros)]
 
 // These macros force the use of AST pretty-printing by converting the input to
@@ -921,6 +924,65 @@ fn test_impl_restriction() {
     assert_eq!(
         stringify!(pub const unsafe auto impl(in crate::path::to) trait Foo {}),
         "pub const unsafe auto impl(in crate::path::to) trait Foo {}"
+    );
+}
+
+#[test]
+fn test_mut_restriction() {
+    assert_eq!(
+        stringify!(pub struct Foo { pub mut(crate) x: u8, pub mut(self) unsafe y: u8 }),
+        "pub struct Foo { pub mut(crate) x: u8, pub mut(self) unsafe y: u8 }"
+    );
+    assert_eq!(
+        stringify!(pub struct Foo { pub mut(super) x: u8, pub mut(in path::to) unsafe y: u8 }),
+        "pub struct Foo { pub mut(super) x: u8, pub mut(in path::to) unsafe y: u8 }"
+    );
+    assert_eq!(
+        stringify!(pub struct Foo { pub mut(in crate::path::to) x: u8 }),
+        "pub struct Foo { pub mut(in crate::path::to) x: u8 }"
+    );
+
+    assert_eq!(
+        stringify!(pub struct Foo(pub mut(crate) u8, pub mut(self) u8, pub mut(super) u8)),
+        "pub struct Foo(pub mut(crate) u8, pub mut(self) u8, pub mut(super) u8)"
+    );
+    assert_eq!(
+        stringify!(pub struct Foo(pub mut(in path::to) u8, pub mut(in crate::path::to) u8)),
+        "pub struct Foo(pub mut(in path::to) u8, pub mut(in crate::path::to) u8)"
+    );
+
+    assert_eq!(
+        stringify!(pub enum Foo { Var{ pub mut(crate) x: u8, pub mut(self) unsafe y: u8 } }),
+        "pub enum Foo { Var{ pub mut(crate) x: u8, pub mut(self) unsafe y: u8 } }"
+    );
+    assert_eq!(
+        stringify!(pub enum Foo { Var{ pub mut(super) x: u8, pub mut(in path::to) y: u8 } }),
+        "pub enum Foo { Var{ pub mut(super) x: u8, pub mut(in path::to) y: u8 } }"
+    );
+    assert_eq!(
+        stringify!(pub enum Foo { Var{ pub mut(in crate::path::to) x: u8 } }),
+        "pub enum Foo { Var{ pub mut(in crate::path::to) x: u8 } }"
+    );
+    assert_eq!(
+        stringify!(pub enum Foo { Tup(pub mut(crate) u8, pub mut(self) u8, pub mut(super) u8) }),
+        "pub enum Foo { Tup(pub mut(crate) u8, pub mut(self) u8, pub mut(super) u8) }"
+    );
+    assert_eq!(
+        stringify!(pub enum Foo { Tup(pub mut(in path::to) u8, pub mut(in crate::path::to) u8) }),
+        "pub enum Foo { Tup(pub mut(in path::to) u8, pub mut(in crate::path::to) u8) }"
+    );
+
+    assert_eq!(
+        stringify!(pub union Foo { x: pub mut(crate) u8, y: pub mut(self) unsafe u8 }),
+        "pub union Foo { x: pub mut(crate) u8, y: pub mut(self) unsafe u8 }"
+    );
+    assert_eq!(
+        stringify!(pub union Foo { x: pub mut(super) u8, y: pub mut(in path::to) unsafe u8 }),
+        "pub union Foo { x: pub mut(super) u8, y: pub mut(in path::to) unsafe u8 }"
+    );
+    assert_eq!(
+        stringify!(pub union Foo { x: pub mut(in crate::path::to) u8 }),
+        "pub union Foo { x: pub mut(in crate::path::to) u8 }"
     );
 }
 

--- a/tests/ui/mut-restriction/feature-gate-mut-restriction.rs
+++ b/tests/ui/mut-restriction/feature-gate-mut-restriction.rs
@@ -1,0 +1,104 @@
+//@ revisions: with_gate without_gate
+//@[with_gate] check-pass
+
+#![cfg_attr(with_gate, feature(mut_restriction))]
+#![feature(unsafe_fields)]
+
+pub struct Foo {
+    pub mut(crate) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    pub mut(self) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+}
+
+pub struct TupFoo(pub mut(crate) i32, pub mut(self) i32); //[without_gate]~ ERROR `mut` restrictions are experimental
+//[without_gate]~^ ERROR `mut` restrictions are experimental
+
+pub enum EnumFoo {
+    Var {
+        mut(self) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        mut(crate) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    },
+    Tup(mut(self) i32, mut(crate) i32), //[without_gate]~ ERROR `mut` restrictions are experimental
+    //[without_gate]~^ ERROR `mut` restrictions are experimental
+}
+
+pub union UnionFoo {
+    pub mut(self) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    pub mut(crate) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+}
+
+pub mod foo {
+    pub struct Bar {
+        pub mut(super) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        pub mut(in crate::foo) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    }
+
+    pub struct TupBar(pub mut(super) i32, pub mut(in crate::foo) i32); //[without_gate]~ ERROR `mut` restrictions are experimental
+    //[without_gate]~^ ERROR `mut` restrictions are experimental
+
+    pub enum EnumBar {
+        Var {
+            mut(in crate::foo) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+            mut(super) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        },
+        Tup(mut(in crate::foo) i32, mut(super) i32), //[without_gate]~ ERROR `mut` restrictions are experimental
+        //[without_gate]~^ ERROR `mut` restrictions are experimental
+    }
+
+    pub union UnionBar {
+        pub mut(in crate::foo) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        pub mut(super) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    }
+}
+
+#[cfg(false)]
+pub struct Baz {
+    pub mut(crate) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    pub mut(self) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+}
+
+#[cfg(false)]
+pub struct TupBaz(pub mut(crate) i32, pub mut(self) i32); //[without_gate]~ ERROR `mut` restrictions are experimental
+//[without_gate]~^ ERROR `mut` restrictions are experimental
+
+#[cfg(false)]
+pub enum EnumBaz {
+    Var {
+        mut(self) x: i32, //[without_gate]~ ERROR `mut` restrictions
+        mut(crate) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    },
+    Tup(mut(self) i32, mut(crate) i32), //[without_gate]~ ERROR `mut` restrictions are experimental
+    //[without_gate]~^ ERROR `mut` restrictions are experimental
+}
+
+#[cfg(false)]
+pub union UnionBaz {
+    pub mut(self) x: i32, //[without_gate]~ ERROR `mut`
+    pub mut(crate) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+}
+
+#[cfg(false)]
+pub mod bar {
+    pub struct Bar {
+        pub mut(super) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        pub mut(in crate::foo) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    }
+
+    pub struct TupBar(pub mut(super) i32, pub mut(in crate::foo) i32); //[without_gate]~ ERROR `mut` restrictions are experimental
+    //[without_gate]~^ ERROR `mut` restrictions are experimental
+
+    pub enum EnumBar {
+        Var {
+            mut(in crate::foo) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+            mut(super) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        },
+        Tup(mut(in crate::foo) i32, mut(super) i32), //[without_gate]~ ERROR `mut` restrictions are experimental
+        //[without_gate]~^ ERROR `mut` restrictions are experimental
+    }
+
+    pub union UnionBar {
+        pub mut(in crate::foo) x: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+        pub mut(super) unsafe y: i32, //[without_gate]~ ERROR `mut` restrictions are experimental
+    }
+}
+
+fn main() {}

--- a/tests/ui/mut-restriction/feature-gate-mut-restriction.without_gate.stderr
+++ b/tests/ui/mut-restriction/feature-gate-mut-restriction.without_gate.stderr
@@ -1,0 +1,403 @@
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:8:9
+   |
+LL |     pub mut(crate) x: i32,
+   |         ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:9:9
+   |
+LL |     pub mut(self) unsafe y: i32,
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:12:23
+   |
+LL | pub struct TupFoo(pub mut(crate) i32, pub mut(self) i32);
+   |                       ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:12:43
+   |
+LL | pub struct TupFoo(pub mut(crate) i32, pub mut(self) i32);
+   |                                           ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:17:9
+   |
+LL |         mut(self) x: i32,
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:18:9
+   |
+LL |         mut(crate) unsafe y: i32,
+   |         ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:20:9
+   |
+LL |     Tup(mut(self) i32, mut(crate) i32),
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:20:24
+   |
+LL |     Tup(mut(self) i32, mut(crate) i32),
+   |                        ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:25:9
+   |
+LL |     pub mut(self) x: i32,
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:26:9
+   |
+LL |     pub mut(crate) unsafe y: i32,
+   |         ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:31:13
+   |
+LL |         pub mut(super) x: i32,
+   |             ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:32:13
+   |
+LL |         pub mut(in crate::foo) unsafe y: i32,
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:35:27
+   |
+LL |     pub struct TupBar(pub mut(super) i32, pub mut(in crate::foo) i32);
+   |                           ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:35:47
+   |
+LL |     pub struct TupBar(pub mut(super) i32, pub mut(in crate::foo) i32);
+   |                                               ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:40:13
+   |
+LL |             mut(in crate::foo) x: i32,
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:41:13
+   |
+LL |             mut(super) unsafe y: i32,
+   |             ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:43:13
+   |
+LL |         Tup(mut(in crate::foo) i32, mut(super) i32),
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:43:37
+   |
+LL |         Tup(mut(in crate::foo) i32, mut(super) i32),
+   |                                     ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:48:13
+   |
+LL |         pub mut(in crate::foo) x: i32,
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:49:13
+   |
+LL |         pub mut(super) unsafe y: i32,
+   |             ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:55:9
+   |
+LL |     pub mut(crate) x: i32,
+   |         ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:56:9
+   |
+LL |     pub mut(self) unsafe y: i32,
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:60:23
+   |
+LL | pub struct TupBaz(pub mut(crate) i32, pub mut(self) i32);
+   |                       ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:60:43
+   |
+LL | pub struct TupBaz(pub mut(crate) i32, pub mut(self) i32);
+   |                                           ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:66:9
+   |
+LL |         mut(self) x: i32,
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:67:9
+   |
+LL |         mut(crate) unsafe y: i32,
+   |         ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:69:9
+   |
+LL |     Tup(mut(self) i32, mut(crate) i32),
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:69:24
+   |
+LL |     Tup(mut(self) i32, mut(crate) i32),
+   |                        ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:75:9
+   |
+LL |     pub mut(self) x: i32,
+   |         ^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:76:9
+   |
+LL |     pub mut(crate) unsafe y: i32,
+   |         ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:82:13
+   |
+LL |         pub mut(super) x: i32,
+   |             ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:83:13
+   |
+LL |         pub mut(in crate::foo) unsafe y: i32,
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:86:27
+   |
+LL |     pub struct TupBar(pub mut(super) i32, pub mut(in crate::foo) i32);
+   |                           ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:86:47
+   |
+LL |     pub struct TupBar(pub mut(super) i32, pub mut(in crate::foo) i32);
+   |                                               ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:91:13
+   |
+LL |             mut(in crate::foo) x: i32,
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:92:13
+   |
+LL |             mut(super) unsafe y: i32,
+   |             ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:94:13
+   |
+LL |         Tup(mut(in crate::foo) i32, mut(super) i32),
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:94:37
+   |
+LL |         Tup(mut(in crate::foo) i32, mut(super) i32),
+   |                                     ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:99:13
+   |
+LL |         pub mut(in crate::foo) x: i32,
+   |             ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `mut` restrictions are experimental
+  --> $DIR/feature-gate-mut-restriction.rs:100:13
+   |
+LL |         pub mut(super) unsafe y: i32,
+   |             ^^^^^^^^^^
+   |
+   = note: see issue #105077 <https://github.com/rust-lang/rust/issues/105077> for more information
+   = help: add `#![feature(mut_restriction)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 40 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/mut-restriction/recover-incorrect-mut-restriction.rs
+++ b/tests/ui/mut-restriction/recover-incorrect-mut-restriction.rs
@@ -1,0 +1,25 @@
+#![feature(mut_restriction, unsafe_fields)]
+
+pub mod foo {
+    pub struct Foo {
+        pub mut(crate::foo) x: i32, //~ ERROR incorrect `mut` restriction
+        pub mut(crate::foo) unsafe y: i32, //~ ERROR incorrect `mut` restriction
+    }
+
+    pub struct TupFoo(pub mut(crate::foo) i32); //~ ERROR incorrect `mut` restriction
+
+    pub enum EnumFoo {
+        Var {
+            mut(crate::foo) x: i32, //~ ERROR incorrect `mut` restriction
+            mut(crate::foo) unsafe y: i32 //~ ERROR incorrect `mut` restriction
+        },
+        Tup(mut(crate::foo) i32), //~ ERROR incorrect `mut` restriction
+    }
+
+    pub union UnionFoo {
+        pub mut(crate::foo) x: i32, //~ ERROR incorrect `mut` restriction
+        pub mut(crate::foo) unsafe y: i32, //~ ERROR incorrect `mut` restriction
+    }
+}
+
+fn main() {}

--- a/tests/ui/mut-restriction/recover-incorrect-mut-restriction.stderr
+++ b/tests/ui/mut-restriction/recover-incorrect-mut-restriction.stderr
@@ -1,0 +1,130 @@
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:5:17
+   |
+LL |         pub mut(crate::foo) x: i32,
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |         pub mut(in crate::foo) x: i32,
+   |                 ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:6:17
+   |
+LL |         pub mut(crate::foo) unsafe y: i32,
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |         pub mut(in crate::foo) unsafe y: i32,
+   |                 ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:9:31
+   |
+LL |     pub struct TupFoo(pub mut(crate::foo) i32);
+   |                               ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |     pub struct TupFoo(pub mut(in crate::foo) i32);
+   |                               ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:13:17
+   |
+LL |             mut(crate::foo) x: i32,
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |             mut(in crate::foo) x: i32,
+   |                 ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:14:17
+   |
+LL |             mut(crate::foo) unsafe y: i32
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |             mut(in crate::foo) unsafe y: i32
+   |                 ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:16:17
+   |
+LL |         Tup(mut(crate::foo) i32),
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |         Tup(mut(in crate::foo) i32),
+   |                 ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:20:17
+   |
+LL |         pub mut(crate::foo) x: i32,
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |         pub mut(in crate::foo) x: i32,
+   |                 ++
+
+error: incorrect `mut` restriction
+  --> $DIR/recover-incorrect-mut-restriction.rs:21:17
+   |
+LL |         pub mut(crate::foo) unsafe y: i32,
+   |                 ^^^^^^^^^^
+   |
+   = help: some possible `mut` restrictions are:
+           `mut(crate)`: can only be mutated in the current crate
+           `mut(super)`: can only be mutated in the parent module
+           `mut(self)`: can only be mutated in current module
+           `mut(in path::to::module)`: can only be mutated in the specified path
+help: help: use `in` to restrict mutations to the path `crate::foo`
+   |
+LL |         pub mut(in crate::foo) unsafe y: i32,
+   |                 ++
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -33,8 +33,8 @@ ast-stats - Trait                    352 (NN.N%)             4
 ast-stats AssocItem                320 (NN.N%)             4            80
 ast-stats - Fn                       160 (NN.N%)             2
 ast-stats - Type                     160 (NN.N%)             2
+ast-stats FieldDef                 272 (NN.N%)             2           136
 ast-stats Variant                  208 (NN.N%)             2           104
-ast-stats FieldDef                 208 (NN.N%)             2           104
 ast-stats Block                    192 (NN.N%)             6            32
 ast-stats Stmt                     160 (NN.N%)             5            32
 ast-stats - Let                       32 (NN.N%)             1
@@ -57,7 +57,7 @@ ast-stats GenericArgs               40 (NN.N%)             1            40
 ast-stats - AngleBracketed            40 (NN.N%)             1
 ast-stats Crate                     40 (NN.N%)             1            40
 ast-stats ----------------------------------------------------------------
-ast-stats Total                  7_560                   127
+ast-stats Total                  7_624                   127
 ast-stats ================================================================
 hir-stats ================================================================
 hir-stats HIR STATS: input_stats


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156824 (Parse `mut` restrictions)
 - rust-lang/rust#156843 (Make impl_trait_redundant_captures suggestion remove adjacent +)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156824,156843)
<!-- homu-ignore:end -->

