### PR TITLE
Enable distcheck for aarch64-apple-darwin

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/154485
+Last change is for: https://github.com/rust-lang/rust/pull/156880

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2513,22 +2513,6 @@ fn maybe_install_llvm(
         let llvm_dylib_path = src_libdir.join("libLLVM.dylib");
         if llvm_dylib_path.exists() {
             builder.install(&llvm_dylib_path, dst_libdir, FileType::NativeLibrary);
-
-            if install_symlink && let Some(llvm_config_path) = &builder.llvm_config(target) {
-                let major = llvm::get_llvm_version_major(builder, llvm_config_path);
-                let versioned_name = match &builder.config.llvm_version_suffix {
-                    Some(version_suffix) => format!("libLLVM-{major}{version_suffix}.dylib"),
-                    None => {
-                        // same logic as ./llvm.rs
-                        if builder.config.channel == "dev" {
-                            format!("libLLVM-{major}-rust-dev.dylib")
-                        } else {
-                            format!("libLLVM-rust-{}-{}", builder.version, builder.config.channel)
-                        }
-                    }
-                };
-                t!(builder.symlink_file("libLLVM.dylib", dst_libdir.join(versioned_name)));
-            }
         }
         !builder.config.dry_run()
     } else if let llvm::LlvmBuildStatus::AlreadyBuilt(llvm::LlvmResult {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2513,6 +2513,22 @@ fn maybe_install_llvm(
         let llvm_dylib_path = src_libdir.join("libLLVM.dylib");
         if llvm_dylib_path.exists() {
             builder.install(&llvm_dylib_path, dst_libdir, FileType::NativeLibrary);
+
+            if install_symlink && let Some(llvm_config_path) = &builder.llvm_config(target) {
+                let major = llvm::get_llvm_version_major(builder, llvm_config_path);
+                let versioned_name = match &builder.config.llvm_version_suffix {
+                    Some(version_suffix) => format!("libLLVM-{major}{version_suffix}.dylib"),
+                    None => {
+                        // same logic as ./llvm.rs
+                        if builder.config.channel == "dev" {
+                            format!("libLLVM-{major}-rust-dev.dylib")
+                        } else {
+                            format!("libLLVM-rust-{}-{}", builder.version, builder.config.channel)
+                        }
+                    }
+                };
+                t!(builder.symlink_file("libLLVM.dylib", dst_libdir.join(versioned_name)));
+            }
         }
         !builder.config.dry_run()
     } else if let llvm::LlvmBuildStatus::AlreadyBuilt(llvm::LlvmResult {

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2856,7 +2856,8 @@ impl Step for RustDev {
         if src_bindir.exists() {
             for entry in walkdir::WalkDir::new(&src_bindir) {
                 let entry = t!(entry);
-                if entry.file_type().is_file() && !entry.path_is_symlink() {
+                //if entry.file_type().is_file() && !entry.path_is_symlink() {
+                if entry.path().is_file() {
                     let name = entry.file_name().to_str().unwrap();
                     tarball.add_file(src_bindir.join(name), "bin", FileType::Executable);
                 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3520,7 +3520,14 @@ fn distcheck_rust_dev_ci_llvm(builder: &Builder<'_>, dir: &Path) {
         .current_dir(&plain_source_dir)
         .run(builder);
 
-    command("./x.py").arg("build").arg("library").current_dir(&plain_source_dir).run(builder);
+    let llvm_lib_dir = ci_llvm_dir.join("rust-dev").join("lib");
+
+    command("./x.py")
+        .arg("build")
+        .arg("library")
+        .env("DYLD_LIBRARY_PATH", &llvm_lib_dir)
+        .current_dir(&plain_source_dir)
+        .run(builder);
 
     builder.remove_dir(dir);
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3521,11 +3521,12 @@ fn distcheck_rust_dev_ci_llvm(builder: &Builder<'_>, dir: &Path) {
         .run(builder);
 
     let llvm_lib_dir = ci_llvm_dir.join("rust-dev").join("lib");
+    let llvm_rpath = format!("-Clink-arg=-Wl,-rpath,{}", llvm_lib_dir.display());
 
     command("./x.py")
         .arg("build")
         .arg("library")
-        .env("DYLD_LIBRARY_PATH", &llvm_lib_dir)
+        .env("RUSTFLAGS_BOOTSTRAP", llvm_rpath)
         .current_dir(&plain_source_dir)
         .run(builder);
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -3467,100 +3467,152 @@ impl Step for Distcheck {
         // local source code, built artifacts or configuration by accident
         let root_dir = std::env::temp_dir().join("distcheck");
 
-        distcheck_plain_source_tarball(builder, &root_dir.join("distcheck-rustc-src"));
-        distcheck_rust_src(builder, &root_dir.join("distcheck-rust-src"));
-        distcheck_rustc_dev(builder, &root_dir.join("distcheck-rustc-dev"));
+        distcheck_rust_dev_ci_llvm(builder, &root_dir.join("distcheck_rust_dev"));
+        // distcheck_plain_source_tarball(builder, &root_dir.join("distcheck-rustc-src"));
+        // distcheck_rust_src(builder, &root_dir.join("distcheck-rust-src"));
+        // distcheck_rustc_dev(builder, &root_dir.join("distcheck-rustc-dev"));
     }
 }
 
-/// Check that we can build some basic things from the plain source tarball
-fn distcheck_plain_source_tarball(builder: &Builder<'_>, plain_src_dir: &Path) {
-    builder.info("Distcheck plain source tarball");
-    let plain_src_tarball = builder.ensure(dist::PlainSourceTarball);
-    builder.clear_dir(plain_src_dir);
+fn distcheck_rust_dev_ci_llvm(builder: &Builder<'_>, dir: &Path) {
+    builder.info("Distcheck rust dev");
+    let Some(rust_dev) = builder.ensure(dist::RustDev { target: builder.host_target }) else {
+        return;
+    };
+    builder.clear_dir(dir);
 
-    let configure_args: Vec<String> = std::env::var("DISTCHECK_CONFIGURE_ARGS")
-        .map(|args| args.split(" ").map(|s| s.to_string()).collect::<Vec<String>>())
-        .unwrap_or_default();
+    let ci_llvm_dir = dir.join("ci-llvm");
+    builder.clear_dir(&ci_llvm_dir);
+
+    command("tar")
+        .arg("-xf")
+        .arg(rust_dev.tarball())
+        .arg("--strip-components=1")
+        .current_dir(&ci_llvm_dir)
+        .run(builder);
+
+    let llvm_config = ci_llvm_dir
+        .join("rust-dev")
+        .join("bin")
+        .join(helpers::exe("llvm-config", builder.host_target));
+
+    let plain_source_dir = dir.join("plain_source_dir");
+    let plain_src_tarball = builder.ensure(dist::PlainSourceTarball);
+    builder.clear_dir(&plain_source_dir);
 
     command("tar")
         .arg("-xf")
         .arg(plain_src_tarball.tarball())
         .arg("--strip-components=1")
-        .current_dir(plain_src_dir)
+        .current_dir(&plain_source_dir)
         .run(builder);
+
     command("./configure")
         .arg("--set")
         .arg("rust.omit-git-hash=false")
         .arg("--set")
         .arg("rust.remap-debuginfo=false")
-        .args(&configure_args)
+        .arg("--set")
+        .arg(format!("target.{}.llvm-config={}", builder.host_target.triple, llvm_config.display()))
+        .arg("--set")
+        .arg("llvm.link-shared=true")
         .arg("--enable-vendor")
-        .current_dir(plain_src_dir)
-        .run(builder);
-    command(helpers::make(&builder.config.host_target.triple))
-        .arg("check")
-        // Do not run the build as if we were in CI, otherwise git would be assumed to be
-        // present, but we build from a tarball here
-        .env("GITHUB_ACTIONS", "0")
-        .current_dir(plain_src_dir)
-        .run(builder);
-    // Mitigate pressure on small-capacity disks.
-    builder.remove_dir(plain_src_dir);
-}
-
-/// Check that rust-src has all of libstd's dependencies
-fn distcheck_rust_src(builder: &Builder<'_>, src_dir: &Path) {
-    builder.info("Distcheck rust-src");
-    let src_tarball = builder.ensure(dist::Src);
-    builder.clear_dir(src_dir);
-
-    command("tar")
-        .arg("-xf")
-        .arg(src_tarball.tarball())
-        .arg("--strip-components=1")
-        .current_dir(src_dir)
+        .current_dir(&plain_source_dir)
         .run(builder);
 
-    let toml = src_dir.join("rust-src/lib/rustlib/src/rust/library/std/Cargo.toml");
-    command(&builder.initial_cargo)
-        // Will read the libstd Cargo.toml
-        // which uses the unstable `public-dependency` feature.
-        .env("RUSTC_BOOTSTRAP", "1")
-        .arg("generate-lockfile")
-        .arg("--manifest-path")
-        .arg(&toml)
-        .current_dir(src_dir)
-        .run(builder);
-    // Mitigate pressure on small-capacity disks.
-    builder.remove_dir(src_dir);
-}
+    command("./x.py").arg("build").arg("library").current_dir(&plain_source_dir).run(builder);
 
-/// Check that rustc-dev's compiler crate source code can be loaded with `cargo metadata`
-fn distcheck_rustc_dev(builder: &Builder<'_>, dir: &Path) {
-    builder.info("Distcheck rustc-dev");
-    let tarball = builder.ensure(dist::RustcDev::new(builder, builder.host_target)).unwrap();
-    builder.clear_dir(dir);
-
-    command("tar")
-        .arg("-xf")
-        .arg(tarball.tarball())
-        .arg("--strip-components=1")
-        .current_dir(dir)
-        .run(builder);
-
-    command(&builder.initial_cargo)
-        .arg("metadata")
-        .arg("--manifest-path")
-        .arg("rustc-dev/lib/rustlib/rustc-src/rust/compiler/rustc/Cargo.toml")
-        .env("RUSTC_BOOTSTRAP", "1")
-        // We might not have a globally available `rustc` binary on CI
-        .env("RUSTC", &builder.initial_rustc)
-        .current_dir(dir)
-        .run(builder);
-    // Mitigate pressure on small-capacity disks.
     builder.remove_dir(dir);
 }
+
+// /// Check that we can build some basic things from the plain source tarball
+// fn distcheck_plain_source_tarball(builder: &Builder<'_>, plain_src_dir: &Path) {
+//     builder.info("Distcheck plain source tarball");
+//     let plain_src_tarball = builder.ensure(dist::PlainSourceTarball);
+//     builder.clear_dir(plain_src_dir);
+
+//     let configure_args: Vec<String> = std::env::var("DISTCHECK_CONFIGURE_ARGS")
+//         .map(|args| args.split(" ").map(|s| s.to_string()).collect::<Vec<String>>())
+//         .unwrap_or_default();
+
+//     command("tar")
+//         .arg("-xf")
+//         .arg(plain_src_tarball.tarball())
+//         .arg("--strip-components=1")
+//         .current_dir(plain_src_dir)
+//         .run(builder);
+//     command("./configure")
+//         .arg("--set")
+//         .arg("rust.omit-git-hash=false")
+//         .arg("--set")
+//         .arg("rust.remap-debuginfo=false")
+//         .args(&configure_args)
+//         .arg("--enable-vendor")
+//         .current_dir(plain_src_dir)
+//         .run(builder);
+//     command(helpers::make(&builder.config.host_target.triple))
+//         .arg("check")
+//         // Do not run the build as if we were in CI, otherwise git would be assumed to be
+//         // present, but we build from a tarball here
+//         .env("GITHUB_ACTIONS", "0")
+//         .current_dir(plain_src_dir)
+//         .run(builder);
+//     // Mitigate pressure on small-capacity disks.
+//     builder.remove_dir(plain_src_dir);
+// }
+
+// /// Check that rust-src has all of libstd's dependencies
+// fn distcheck_rust_src(builder: &Builder<'_>, src_dir: &Path) {
+//     builder.info("Distcheck rust-src");
+//     let src_tarball = builder.ensure(dist::Src);
+//     builder.clear_dir(src_dir);
+
+//     command("tar")
+//         .arg("-xf")
+//         .arg(src_tarball.tarball())
+//         .arg("--strip-components=1")
+//         .current_dir(src_dir)
+//         .run(builder);
+
+//     let toml = src_dir.join("rust-src/lib/rustlib/src/rust/library/std/Cargo.toml");
+//     command(&builder.initial_cargo)
+//         // Will read the libstd Cargo.toml
+//         // which uses the unstable `public-dependency` feature.
+//         .env("RUSTC_BOOTSTRAP", "1")
+//         .arg("generate-lockfile")
+//         .arg("--manifest-path")
+//         .arg(&toml)
+//         .current_dir(src_dir)
+//         .run(builder);
+//     // Mitigate pressure on small-capacity disks.
+//     builder.remove_dir(src_dir);
+// }
+
+// /// Check that rustc-dev's compiler crate source code can be loaded with `cargo metadata`
+// fn distcheck_rustc_dev(builder: &Builder<'_>, dir: &Path) {
+//     builder.info("Distcheck rustc-dev");
+//     let tarball = builder.ensure(dist::RustcDev::new(builder, builder.host_target)).unwrap();
+//     builder.clear_dir(dir);
+
+//     command("tar")
+//         .arg("-xf")
+//         .arg(tarball.tarball())
+//         .arg("--strip-components=1")
+//         .current_dir(dir)
+//         .run(builder);
+
+//     command(&builder.initial_cargo)
+//         .arg("metadata")
+//         .arg("--manifest-path")
+//         .arg("rustc-dev/lib/rustlib/rustc-src/rust/compiler/rustc/Cargo.toml")
+//         .env("RUSTC_BOOTSTRAP", "1")
+//         // We might not have a globally available `rustc` binary on CI
+//         .env("RUSTC", &builder.initial_rustc)
+//         .current_dir(dir)
+//         .run(builder);
+//     // Mitigate pressure on small-capacity disks.
+//     builder.remove_dir(dir);
+// }
 
 /// Runs unit tests in `bootstrap_test.py`, which test the Python parts of bootstrap.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -285,17 +285,18 @@ pub fn is_valid_test_suite_arg<'a, P: AsRef<Path>>(
     }
 }
 
-// pub fn make(host: &str) -> PathBuf {
-//     if host.contains("dragonfly")
-//         || host.contains("freebsd")
-//         || host.contains("netbsd")
-//         || host.contains("openbsd")
-//     {
-//         PathBuf::from("gmake")
-//     } else {
-//         PathBuf::from("make")
-//     }
-// }
+#[allow(dead_code)]
+pub fn make(host: &str) -> PathBuf {
+    if host.contains("dragonfly")
+        || host.contains("freebsd")
+        || host.contains("netbsd")
+        || host.contains("openbsd")
+    {
+        PathBuf::from("gmake")
+    } else {
+        PathBuf::from("make")
+    }
+}
 
 /// Returns the last-modified time for `path`, or zero if it doesn't exist.
 pub fn mtime(path: &Path) -> SystemTime {

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -285,17 +285,17 @@ pub fn is_valid_test_suite_arg<'a, P: AsRef<Path>>(
     }
 }
 
-pub fn make(host: &str) -> PathBuf {
-    if host.contains("dragonfly")
-        || host.contains("freebsd")
-        || host.contains("netbsd")
-        || host.contains("openbsd")
-    {
-        PathBuf::from("gmake")
-    } else {
-        PathBuf::from("make")
-    }
-}
+// pub fn make(host: &str) -> PathBuf {
+//     if host.contains("dragonfly")
+//         || host.contains("freebsd")
+//         || host.contains("netbsd")
+//         || host.contains("openbsd")
+//     {
+//         PathBuf::from("gmake")
+//     } else {
+//         PathBuf::from("make")
+//     }
+// }
 
 /// Returns the last-modified time for `path`, or zero if it doesn't exist.
 pub fn mtime(path: &Path) -> SystemTime {

--- a/src/bootstrap/src/utils/helpers/tests.rs
+++ b/src/bootstrap/src/utils/helpers/tests.rs
@@ -3,7 +3,8 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use crate::utils::helpers::{
-    check_cfg_arg, extract_beta_rev, hex_encode, set_file_times, submodule_path_of, symlink_dir,
+    check_cfg_arg, extract_beta_rev, hex_encode, make, set_file_times, submodule_path_of,
+    symlink_dir,
 };
 use crate::utils::tests::TestCtx;
 use crate::{Config, Flags};

--- a/src/bootstrap/src/utils/helpers/tests.rs
+++ b/src/bootstrap/src/utils/helpers/tests.rs
@@ -3,8 +3,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use crate::utils::helpers::{
-    check_cfg_arg, extract_beta_rev, hex_encode, make, set_file_times, submodule_path_of,
-    symlink_dir,
+    check_cfg_arg, extract_beta_rev, hex_encode, set_file_times, submodule_path_of, symlink_dir,
 };
 use crate::utils::tests::TestCtx;
 use crate::{Config, Flags};

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -534,6 +534,19 @@ auto:
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-macos
 
+  - name: aarch64-apple-distcheck
+    env:
+      SCRIPT: >-
+        ./x.py test distcheck
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+      # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
+      # supports the hardware.
+      MACOSX_DEPLOYMENT_TARGET: 11.0
+      MACOSX_STD_DEPLOYMENT_TARGET: 11.0
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+    <<: *job-macos
+
   - name: aarch64-apple
     env:
       SCRIPT: >

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -540,6 +540,8 @@ auto:
         ./x.py test distcheck
         --host=aarch64-apple-darwin
         --target=aarch64-apple-darwin
+      DISTCHECK_CONFIGURE_ARGS: >-
+        --set llvm.link-shared=true
       # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
       # supports the hardware.
       MACOSX_DEPLOYMENT_TARGET: 11.0

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -549,6 +549,22 @@ auto:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     <<: *job-macos
 
+  - name: aarch64-apple-distcheck-ci-llvm
+    env:
+      SCRIPT: >-
+        ./x.py test distcheck
+        --host=aarch64-apple-darwin
+        --target=aarch64-apple-darwin
+      DISTCHECK_CONFIGURE_ARGS: >-
+        --set llvm.download-ci-llvm=true
+        --set llvm.link-shared=true
+      # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
+      # supports the hardware.
+      MACOSX_DEPLOYMENT_TARGET: 11.0
+      MACOSX_STD_DEPLOYMENT_TARGET: 11.0
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+    <<: *job-macos
+
   - name: aarch64-apple
     env:
       SCRIPT: >

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -555,8 +555,7 @@ auto:
         ./x.py test distcheck
         --host=aarch64-apple-darwin
         --target=aarch64-apple-darwin
-      DISTCHECK_CONFIGURE_ARGS: >-
-        --set llvm.download-ci-llvm=true
+      RUST_CONFIGURE_ARGS: >-
         --set llvm.link-shared=true
       # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else
       # supports the hardware.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156880)*
<!-- homu-ignore:end -->

Add a minimal macOS distcheck CI job.

Linux already has an x86_64-gnu-distcheck, which runs `x.py test distcheck`.
This PR adds the same distcheck for aarch64-apple-darwin.

Background: [#gsoc > Project: Bringing autodiff and offload into Rust CI @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Project.3A.20Bringing.20autodiff.20and.20offload.20into.20Rust.20CI/near/597296474)