### PR TITLE
Disable `tests/debuginfo/numeric-types.rs` `v nz_{i,u}size` checks

### DIFF
--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -213,8 +213,9 @@
 //@ lldb-command:v nz_i128
 //@ lldb-check:[...] 55 { 0 = { 0 = 55 } }
 
-//@ lldb-command:v nz_isize
-//@ lldb-check:[...] 66 { 0 = { 0 = 66 } }
+// FIXME(#156886): "error: Invalid type: Cannot determine size"
+//(DISABLED) @ lldb-command:v nz_isize
+//(DISABLED) @ lldb-check:[...] 66 { 0 = { 0 = 66 } }
 
 //@ lldb-command:v/d nz_u8
 //@ lldb-check:[...] 77 { 0 = { 0 = 77 } }
@@ -231,8 +232,9 @@
 //@ lldb-command:v nz_u128
 //@ lldb-check:[...] 111 { 0 = { 0 = 111 } }
 
-//@ lldb-command:v nz_usize
-//@ lldb-check:[...] 122 { 0 = { 0 = 122 } }
+// FIXME(#156886): "error: Invalid type: Cannot determine size"
+//(DISABLED) @ lldb-command:v nz_usize
+//(DISABLED) @ lldb-check:[...] 122 { 0 = { 0 = 122 } }
 
 use std::num::*;
 use std::sync::atomic::*;


### PR DESCRIPTION
On lldb 22 (locally lldb 22.1.6) I see

```
v nz_isize
error: Invalid type: Cannot determine size
[...]
v nz_usize
error: Invalid type: Cannot determine size
```

AFAICT this might be an upstream issue, as reported in <https://github.com/llvm/llvm-project/issues/196812>. Let's disable for now to not have `./x test` fail for contributors using lldb 22. Tracked in rust-lang/rust#156886.