### PR TITLE
Suppress run-make subprocess output (incl. fences) when `--verbose-run-make-subprocess-output=false`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2003,7 +2003,8 @@ impl<'test> TestCx<'test> {
         self.dump_output_file(out, &format!("{}out", revision));
         self.dump_output_file(err, &format!("{}err", revision));
 
-        if !print_output {
+        // Suppress verbose run-make subprocess output, including fences.
+        if !print_output || !self.config.verbose_run_make_subprocess_output {
             return;
         }
 


### PR DESCRIPTION
Fixes rust-lang/rust#156276.