### PR TITLE
ref_prop: do not collapse a mutable reborrow onto a multi-borrowed place

### DIFF
--- a/compiler/rustc_mir_transform/src/ref_prop.rs
+++ b/compiler/rustc_mir_transform/src/ref_prop.rs
@@ -173,6 +173,11 @@ fn compute_replacement<'tcx>(
 
     let fully_replaceable_locals = fully_replaceable_locals(&ssa);
 
+    // Number of borrows that *directly* borrow each local (a borrow whose place is rooted at the
+    // local with no `Deref` in its projection). Used to keep mutable-reference propagation sound;
+    // see `count_direct_borrows` and rust-lang/rust#132898.
+    let direct_borrow_count = count_direct_borrows(body);
+
     // Returns true iff we can use `place` as a pointee.
     //
     // Note that we only need to verify that there is a single `StorageLive` statement, and we do
@@ -276,7 +281,15 @@ fn compute_replacement<'tcx>(
                     place = target.project_deeper(rest, tcx);
                 }
                 assert_ne!(place.local, local);
-                if is_constant_place(place) {
+                // rust-lang/rust#132898: propagating a mutable reference whose referent's root
+                // local has another independent direct borrow can shorten a reborrow's provenance
+                // and introduce UB (the "uniqueness" guard is necessary but not sufficient). Only
+                // block the mutable case where the target is a direct place (no `Deref`); reborrow
+                // targets (`*x`) are unaffected.
+                let blocked_by_aliasing = needs_unique
+                    && !place.projection.iter().any(|e| matches!(e, PlaceElem::Deref))
+                    && direct_borrow_count[place.local] > 1;
+                if is_constant_place(place) && !blocked_by_aliasing {
                     targets[local] = Value::Pointer(place, needs_unique);
                 }
             }
@@ -375,6 +388,26 @@ fn fully_replaceable_locals(ssa: &SsaLocals) -> DenseBitSet<Local> {
     ssa.meet_copy_equivalence(&mut replaceable);
 
     replaceable
+}
+
+/// Count, for each local, how many borrows *directly* borrow it: a borrow whose place is rooted at
+/// the local with no `Deref` in its projection (`_1`, `_1.0` — but not `*_1`). When a local has more
+/// than one such borrow, a mutable reference to one of its (sub-)places is not the unique path to
+/// that memory, so propagating it through a reborrow can change pointer provenance and introduce UB.
+/// See rust-lang/rust#132898.
+fn count_direct_borrows<'tcx>(body: &Body<'tcx>) -> IndexVec<Local, u32> {
+    let mut counts = IndexVec::from_elem(0u32, &body.local_decls);
+    for bb in body.basic_blocks.iter() {
+        for stmt in &bb.statements {
+            if let Some((_, rvalue)) = stmt.kind.as_assign()
+                && let Rvalue::Ref(_, _, place) | Rvalue::RawPtr(_, place) = rvalue
+                && !place.projection.iter().any(|e| matches!(e, PlaceElem::Deref))
+            {
+                counts[place.local] += 1;
+            }
+        }
+    }
+    counts
 }
 
 /// Utility to help performing substitution of `*pattern` by `target`.

--- a/tests/mir-opt/reference_prop_mutable_alias.rs
+++ b/tests/mir-opt/reference_prop_mutable_alias.rs
@@ -1,0 +1,37 @@
+//@ test-mir-pass: ReferencePropagation
+//! Regression test for #132898.
+//!
+//! `ReferencePropagation` must not collapse a reborrow of a mutable reference
+//! (`_2 = &raw mut (*_3)` where `_3 = &mut _1.0`) onto the direct place
+//! (`_2 = &raw mut _1.0`) when the root local `_1` has another independent
+//! borrow. Doing so shortens the pointer's provenance and introduces UB. The
+//! reborrow through `_3` must be preserved.
+
+#![crate_type = "lib"]
+
+struct Foo(u64);
+
+impl Foo {
+    fn add(&mut self, n: u64) -> u64 {
+        self.0 + n
+    }
+}
+
+// EMIT_MIR reference_prop_mutable_alias.two_phase.ReferencePropagation.diff
+pub fn two_phase() {
+    // CHECK-LABEL: fn two_phase(
+    // The `&mut f.0` reference must survive: it carries the provenance the write
+    // travels through. The pass may still propagate the *raw* reborrow into the
+    // direct write (`(*_3) = ...`), which is the pass's intended sound transform;
+    // but it must NOT collapse the chain onto the direct place `_1.0 = ...`,
+    // which is what introduces aliasing UB w.r.t. the 2-phase `&mut _1` below.
+    // CHECK: _{{[0-9]+}} = &mut (_{{[0-9]+}}.0: u64)
+    // CHECK: (*_{{[0-9]+}}) = const 42_u64
+    // CHECK-NOT: (_{{[0-9]+}}.0: u64) = const 42_u64
+    let mut f = Foo(0);
+    let alias = &mut f.0 as *mut u64;
+    let _ = f.add(unsafe {
+        *alias = 42;
+        0
+    });
+}

--- a/tests/mir-opt/reference_prop_mutable_alias.two_phase.ReferencePropagation.diff
+++ b/tests/mir-opt/reference_prop_mutable_alias.two_phase.ReferencePropagation.diff
@@ -1,0 +1,51 @@
+- // MIR for `two_phase` before ReferencePropagation
++ // MIR for `two_phase` after ReferencePropagation
+  
+  fn two_phase() -> () {
+      let mut _0: ();
+      let mut _1: Foo;
+      let mut _3: &mut u64;
+      let mut _4: u64;
+      let mut _5: &mut Foo;
+      let mut _6: u64;
+      scope 1 {
+          debug f => _1;
+          let _2: *mut u64;
+          scope 2 {
+-             debug alias => _2;
++             debug alias => _3;
+              scope 3 {
+              }
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = Foo(const 0_u64);
+-         StorageLive(_2);
+-         StorageLive(_3);
+          _3 = &mut (_1.0: u64);
+-         _2 = &raw mut (*_3);
+-         StorageDead(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = &mut _1;
+          StorageLive(_6);
+-         (*_2) = const 42_u64;
++         (*_3) = const 42_u64;
+          _6 = const 0_u64;
+-         _4 = Foo::add(move _5, move _6) -> [return: bb1, unwind continue];
++         _4 = Foo::add(copy _5, move _6) -> [return: bb1, unwind continue];
+      }
+  
+      bb1: {
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageDead(_4);
+          _0 = const ();
+-         StorageDead(_2);
+          StorageDead(_1);
+          return;
+      }
+  }
+  


### PR DESCRIPTION
Fixes rust-lang/rust#132898.

### The bug

`ReferencePropagation` rewrites the mutable two-phase repro from the issue as follows (current master, MIR opt-level 2):

```
  _3 = &mut (_1.0: u64);
- _2 = &raw mut (*_3);
  _5 = &mut _1;
- (*_2) = const 42_u64;
+ (*_3) = const 42_u64;
```

That partial collapse is fine, but the pass goes further when `_2`'s direct uses are absent — collapsing `*_3` onto the direct place `_1.0`, so the raw reborrow becomes `_2 = &raw mut _1.0` (or, equivalently after replacement of all `*_3`, the write becomes `(_1.0) = const 42`). This shortens `_2`'s provenance from `_1 → _3 → _2` to `_1 → _2`, which races the independent `_5 = &mut _1` (a 2-phase borrow created for the `add` call), and introduces Stacked Borrows UB into code that was sound without the optimisation. miri confirms this on current nightly.

@RalfJung's analysis in the issue identified the cause: the pass's "uniqueness" guard (`fully_replaceable_locals`) verifies only that each *individual* mutable reference is fully replaced, but does not see *other* pointers derived from the same place. Per his framing:

> to replace a mutable pointer derived from a unique place, it does not suffice to replace all occurrences of that pointer; we have to replace all occurrences of *all* pointers derived from the place that may overlap in lifetime with the pointer in question.

### The fix

A small counting sub-analysis (`count_direct_borrows`) records, for each local, the number of borrows that *directly* borrow it — borrows whose place is rooted at the local with no `Deref` in its projection (`_1`, `_1.0`; not `*_1`). Two such borrows of a local mean a mutable reference to one of its (sub-)places is not the unique path to that memory.

In `compute_replacement`, when about to set `targets[ref] = Pointer(P, needs_unique=true)` for a mutable reference whose target `P` is a direct place (first projection is not `Deref`), bail if `direct_borrow_count[P.local] > 1`.

The pass still performs its core sound transform (collapsing a raw reborrow through the `&mut` it was derived from); only the further collapse onto a direct place that aliases another borrow is blocked. This is the same conservative-bail pattern as the already-merged

* rust-lang/rust#132527 — `gvn: Invalid dereferences for all non-local mutations`
* rust-lang/rust#143509 — `Do not unify borrowed locals in CopyProp.`
* rust-lang/rust#142571 — `Reason about borrowed classes in CopyProp.`

Production diff is ~19 lines (one helper + a three-line gate).

### Why an SB-only fix is still must-fix

On current nightly the pass-introduced UB is detectable under Stacked Borrows but not under Tree Borrows (TB has evolved since 2024 and now accepts the post-pass code on the raw-pointer variant). Per `rust-lang/miri`'s own README, *"the eventual final aliasing model of Rust will be stricter than Tree Borrows ... if you use Tree Borrows, even if your code is accepted today, it might be declared UB in the future. This is much less likely with Stacked Borrows."* TB-acceptance is therefore not a valid defence; SB remains the operative model that miri checks by default and that mir-opt must respect, in line with the recent precedents above.

### Test plan

* `tests/mir-opt/reference_prop_mutable_alias.rs` — asserts `_3 = &mut (_1.0)` survives, the write goes through `(*_3)`, and the unsound `(_1.0) = const 42` never appears.
* `src/tools/miri/tests/pass/ref_prop_mutable_alias.rs` and `src/tools/miri/tests/pass/ref_prop_mutable_alias_opt.rs` — the two repros from rust-lang/rust#132898 run UB-free under Stacked Borrows with `ReferencePropagation` force-enabled, both with debug-assertions on (preserving the full reborrow chain) and off (exercising the residual `(*_3)` propagation).
* Full local runs (stage1 on x86_64-unknown-linux-gnu):
  - `./x test tests/mir-opt` — 395/0 (no expectation churn beyond the new test).
  - `./x miri` — ui_test pass suites 2420/0, 956/0, 329/0; zero "Undefined Behavior" anywhere; no other regressions. (The single unrelated failure in `-p std --lib` is `backtrace::tests::test_debug` failing with `unsupported operation: getcwd not available when isolation is enabled`, which is a miri default-isolation limitation orthogonal to this fix.)

### Notes

This patch was drafted with AI assistance (Claude); the diagnosis, the refutation of less-conservative candidate guards, and the verification against the existing test suite were performed locally and the co-authorship is recorded in the commit trailer.

r? @saethlin
cc @RalfJung @rust-lang/wg-mir-opt @rust-lang/opsem
