### PR TITLE
Add missing PartialEq impls for Vec and array

### DIFF
--- a/library/alloc/src/vec/partial_eq.rs
+++ b/library/alloc/src/vec/partial_eq.rs
@@ -34,13 +34,13 @@ __impl_slice_eq1! { [] Cow<'_, [T]>, &[U] where T: Clone, #[stable(feature = "ru
 __impl_slice_eq1! { [] Cow<'_, [T]>, &mut [U] where T: Clone, #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, [U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
 __impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, &[U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "rust1", since = "1.0.0")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] Vec<T, A>, &mut [U; N], #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_array_for_vec", since = "CURRENT_RUSTC_VERSION")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] [T; N], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_array_for_vec", since = "CURRENT_RUSTC_VERSION")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] &[T; N], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_array_for_vec", since = "CURRENT_RUSTC_VERSION")] }
+__impl_slice_eq1! { const, [A: Allocator, const N: usize] &mut [T; N], Vec<U, A>, #[rustc_const_unstable(feature = "const_cmp", issue = "143800")] #[stable(feature = "partialeq_array_for_vec", since = "CURRENT_RUSTC_VERSION")] }
 
 // NOTE: some less important impls are omitted to reduce code bloat
 // FIXME(Centril): Reconsider this?
-//__impl_slice_eq1! { [const N: usize] Vec<A>, &mut [B; N], }
-//__impl_slice_eq1! { [const N: usize] [A; N], Vec<B>, }
-//__impl_slice_eq1! { [const N: usize] &[A; N], Vec<B>, }
-//__impl_slice_eq1! { [const N: usize] &mut [A; N], Vec<B>, }
 //__impl_slice_eq1! { [const N: usize] Cow<'a, [A]>, [B; N], }
 //__impl_slice_eq1! { [const N: usize] Cow<'a, [A]>, &[B; N], }
 //__impl_slice_eq1! { [const N: usize] Cow<'a, [A]>, &mut [B; N], }

--- a/library/alloctests/tests/vec.rs
+++ b/library/alloctests/tests/vec.rs
@@ -2790,3 +2790,15 @@ fn const_make_global_empty_or_zst_regression() {
 
     assert_eq!(ZST_SLICE, &[(), (), ()]);
 }
+
+#[test]
+fn test_vec_partial_eq_array() {
+    let x = vec![1, 2, 3];
+    let mut y = [1, 2, 3];
+    assert_eq!(x, y);
+    assert_eq!(y, x);
+    assert_eq!(x, &y);
+    assert_eq!(&y, x);
+    assert_eq!(x, &mut y);
+    assert_eq!(&mut y, x);
+}

--- a/tests/ui/consts/too_generic_eval_ice.current.stderr
+++ b/tests/ui/consts/too_generic_eval_ice.current.stderr
@@ -30,15 +30,15 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
    |
    = help: the trait `PartialEq<[{integer}; 0]>` is not implemented for `[{integer}; Self::HOST_SIZE]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+             `&mut [T; N]` implements `PartialEq<Vec<U, A>>`
+           and 14 others
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
+++ b/tests/ui/macros/assert-ne-no-invalid-help-issue-146204.stderr
@@ -6,15 +6,15 @@ LL |     assert_ne!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+             `&mut [T; N]` implements `PartialEq<Vec<U, A>>`
+           and 14 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:19:5
@@ -24,15 +24,15 @@ LL |     assert_eq!(buf, b"----");
    |
    = help: the trait `PartialEq<&[u8; 4]>` is not implemented for `[u8; 4]`
    = help: the following other types implement trait `PartialEq<Rhs>`:
+             `&[T; N]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<Vec<U, A>>`
              `&[T]` implements `PartialEq<[U; N]>`
              `&[u8; N]` implements `PartialEq<ByteStr>`
              `&[u8; N]` implements `PartialEq<ByteString>`
              `&[u8]` implements `PartialEq<ByteStr>`
              `&[u8]` implements `PartialEq<ByteString>`
-             `&mut [T]` implements `PartialEq<Vec<U, A>>`
-             `&mut [T]` implements `PartialEq<[U; N]>`
-           and 11 others
+             `&mut [T; N]` implements `PartialEq<Vec<U, A>>`
+           and 14 others
 
 error[E0277]: can't compare `[u8; 4]` with `&[u8; 4]`
   --> $DIR/assert-ne-no-invalid-help-issue-146204.rs:5:30


### PR DESCRIPTION
Fixes rust-lang/rust#149017.

This PR adds the missing `PartialEq` implementations between `Vec<T>` and `[U; N]`, specifically:
- `[T; N] == Vec<U>`
- `&[T; N] == Vec<U>`
- `&mut [T; N] == Vec<U>`
- `Vec<T> == &mut [U; N]`

Tested locally by adding equality assertions in `library/alloctests/tests/vec.rs`.

Please let me know if any other adjustments are needed.