### PR TITLE
fix breakpoint callback registration in `lldb_batchmode`

### DIFF
--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -97,10 +97,9 @@ def execute_command(command_interpreter, command):
                 print_debug(
                     "registering breakpoint callback, id = " + str(breakpoint_id)
                 )
-                callback_command = (
-                    "breakpoint command add -F breakpoint_callback "
-                    + str(breakpoint_id)
-                )
+                callback_command = f"breakpoint command add -s python {str(breakpoint_id)} -o \
+                    'import lldb_batchmode; lldb_batchmode.breakpoint_callback'"
+
                 command_interpreter.HandleCommand(callback_command, res)
                 if res.Succeeded():
                     print_debug(


### PR DESCRIPTION
We'd been failing to register the callback for a while now, because it couldn't find the specified function. This change imports `lldb_batchmode` and uses the namespaced name of the function.

As an aside, I'm relatively sure this breakpoint callback isn't necessary anymore. Whenever lldb stops at a breakpoint, it updates the selected thread/frame automatically. I don't want to remove it quite yet because I *might* need it for some bookkeeping with the `lldb-repr` directive (and `--bless` behavior)