### PR TITLE
compiletest: Simplify `//@ needs-asm-mnemonic: ret` to just `//@ needs-asm-ret`

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/compiletest.md
+++ b/src/doc/rustc-dev-guide/src/tests/compiletest.md
@@ -346,17 +346,6 @@ See also the [codegen tests](#codegen-tests) for a similar set of tests.
 If you need to work with `#![no_std]` cross-compiling tests, consult the
 [`minicore` test auxiliary](./minicore.md) chapter.
 
-#### Conditional assembly tests based on instruction support
-
-Tests that depend on specific assembly instructions being available can use the
-`//@ needs-asm-mnemonic: <MNEMONIC>` directive.
-This will skip the test if the target backend does not support the specified instruction mnemonic.
-
-For example, a test that requires the `RET` instruction:
-```rust,ignore
-//@ needs-asm-mnemonic: RET
-```
-
 [`tests/assembly-llvm`]: https://github.com/rust-lang/rust/tree/HEAD/tests/assembly-llvm
 
 

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -164,9 +164,10 @@ The following directives will check rustc build settings and target settings:
   For tests that cross-compile to explicit targets
   via `--target`, use `needs-llvm-components` instead to ensure the appropriate
   backend is available.
-- `needs-asm-mnemonic: <MNEMONIC>` — ignores if the target backend does not
-  support the specified assembly mnemonic (e.g., `RET`, `NOP`).
-  Only supported with the LLVM backend.
+- `needs-asm-ret` - ignores if the target does not have a `ret` instruction
+  in its assembly syntax. Most target architectures have this instruction,
+  making it handy for portable inline-assembly tests, but some architectures
+  (e.g. 32-bit ARM) do not have it.
 - `needs-profiler-runtime` — ignores the test if the profiler runtime was not
   enabled for the target (`build.profiler = true` in `bootstrap.toml`)
 - `needs-sanitizer-support` — ignores if the sanitizer support was not enabled

--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -159,7 +159,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "min-llvm-version",
     "min-system-llvm-version",
     "minicore-compile-flags",
-    "needs-asm-mnemonic",
+    "needs-asm-ret",
     "needs-asm-support",
     "needs-backends",
     "needs-crate-type",

--- a/src/tools/compiletest/src/directives/needs.rs
+++ b/src/tools/compiletest/src/directives/needs.rs
@@ -101,37 +101,6 @@ pub(super) fn handle_needs(
         }
     }
 
-    if name == "needs-asm-mnemonic" {
-        let Some(rest) = ln.value_after_colon() else {
-            return IgnoreDecision::Error {
-                message: "expected `needs-asm-mnemonic` to have a mnemonic name after colon"
-                    .to_string(),
-            };
-        };
-
-        if !config.default_codegen_backend.is_llvm() {
-            return IgnoreDecision::Ignore {
-                reason: "skipping test as non-LLVM backend does not support mnemonic queries"
-                    .to_string(),
-            };
-        }
-
-        let mnemonic = rest.trim();
-        let has_mnemonic = match mnemonic {
-            "ret" => conditions.has_ret_mnemonic,
-            "nop" => conditions.has_nop_mnemonic,
-            _ => has_mnemonic(config, mnemonic),
-        };
-
-        if has_mnemonic {
-            return IgnoreDecision::Continue;
-        } else {
-            return IgnoreDecision::Ignore {
-                reason: format!("skipping test as target does not have `{mnemonic}` mnemonic"),
-            };
-        }
-    }
-
     // Handled elsewhere.
     if name == "needs-llvm-components" || name == "needs-backends" {
         return IgnoreDecision::Continue;
@@ -163,11 +132,6 @@ struct Need {
 pub(crate) struct PreparedNeedsConditions {
     /// The `//@ needs-*` conditions that can be treated as a simple name->boolean mapping.
     simple_needs: HashMap<&'static str, Need>,
-
-    /// Might add particular other mnemonics heavily needed by tests here.
-    /// Otherwise call into llvm for every check
-    has_ret_mnemonic: bool,
-    has_nop_mnemonic: bool,
 }
 
 pub(crate) fn prepare_needs_conditions(config: &Config) -> PreparedNeedsConditions {
@@ -177,6 +141,14 @@ pub(crate) fn prepare_needs_conditions(config: &Config) -> PreparedNeedsConditio
     // Note that we intentionally still put the needs- prefix here to make the file show up when
     // grepping for a directive name, even though we could technically strip that.
     let simple_needs = vec![
+        // This used to be a more general `//@ needs-asm-mnemonic: ret` directive,
+        // but was simplified to just `//@ needs-asm-ret` because there are very
+        // few other mnemonics (`nop`?) that it could ever be useful with.
+        Need {
+            name: "needs-asm-ret",
+            condition: has_mnemonic(config, "ret"),
+            ignore_reason: "ignored on targets without a `ret` assembly instruction",
+        },
         Need {
             name: "needs-asm-support",
             condition: config.has_asm_support(),
@@ -398,11 +370,7 @@ pub(crate) fn prepare_needs_conditions(config: &Config) -> PreparedNeedsConditio
         })
         .collect::<HashMap<_, _>>();
 
-    PreparedNeedsConditions {
-        simple_needs,
-        has_ret_mnemonic: has_mnemonic(config, "ret"),
-        has_nop_mnemonic: has_mnemonic(config, "nop"),
-    }
+    PreparedNeedsConditions { simple_needs }
 }
 
 fn find_dlltool(config: &Config) -> bool {

--- a/src/tools/compiletest/src/directives/tests.rs
+++ b/src/tools/compiletest/src/directives/tests.rs
@@ -1270,23 +1270,15 @@ fn test_edition_range_edition_to_test() {
 }
 
 #[test]
-fn needs_asm_mnemonic() {
+fn needs_asm_ret() {
     let config_x86_64 = cfg().target("x86_64-unknown-linux-gnu").build();
     let config_aarch64 = cfg().target("aarch64-unknown-linux-gnu").build();
+    // 32-bit ARM does not have a "ret" mnemonic.
+    let config_arm32 = cfg().target("armv7a-none-eabi").build();
+    let config_wasm = cfg().target("wasm32v1-none").build();
 
-    // invalid mnemonic
-    assert!(check_ignore(&config_x86_64, "//@ needs-asm-mnemonic:GRUGGY"));
-    assert!(check_ignore(&config_aarch64, "//@ needs-asm-mnemonic:gruggy"));
-
-    // valid x86 and aarch64
-    assert!(!check_ignore(&config_x86_64, "//@ needs-asm-mnemonic:RET"));
-    assert!(!check_ignore(&config_aarch64, "//@ needs-asm-mnemonic:ret"));
-
-    // this is aarch64 specific
-    assert!(check_ignore(&config_x86_64, "//@ needs-asm-mnemonic:ldrsbwui"));
-    assert!(!check_ignore(&config_aarch64, "//@ needs-asm-mnemonic:LDRSBWui"));
-
-    // this is x86 specific
-    assert!(check_ignore(&config_aarch64, "//@ needs-asm-mnemonic:CMPxCHG16B"));
-    assert!(!check_ignore(&config_x86_64, "//@ needs-asm-mnemonic:CMPXchg16B"));
+    assert!(!check_ignore(&config_x86_64, "//@ needs-asm-ret"));
+    assert!(!check_ignore(&config_aarch64, "//@ needs-asm-ret"));
+    assert!(check_ignore(&config_arm32, "//@ needs-asm-ret"));
+    assert!(check_ignore(&config_wasm, "//@ needs-asm-ret"));
 }

--- a/tests/codegen-llvm/cffi/c-variadic-naked.rs
+++ b/tests/codegen-llvm/cffi/c-variadic-naked.rs
@@ -1,5 +1,5 @@
 //@ needs-asm-support
-//@ needs-asm-mnemonic: ret
+//@ needs-asm-ret
 
 // tests that `va_start` is not injected into naked functions
 

--- a/tests/codegen-llvm/naked-fn/aligned.rs
+++ b/tests/codegen-llvm/naked-fn/aligned.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0
 //@ needs-asm-support
-//@ needs-asm-mnemonic: ret
+//@ needs-asm-ret
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 #![crate_type = "lib"]

--- a/tests/codegen-llvm/naked-fn/min-function-alignment.rs
+++ b/tests/codegen-llvm/naked-fn/min-function-alignment.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0 -Zmin-function-alignment=16
 //@ needs-asm-support
-//@ needs-asm-mnemonic: ret
+//@ needs-asm-ret
 //@ ignore-wasm32 aligning functions is not currently supported on wasm (#143368)
 
 // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity

--- a/tests/run-make/naked-dead-code-elimination/rmake.rs
+++ b/tests/run-make/naked-dead-code-elimination/rmake.rs
@@ -1,6 +1,6 @@
 //@ ignore-cross-compile
 //@ needs-asm-support
-//@ needs-asm-mnemonic: RET
+//@ needs-asm-ret
 
 use run_make_support::symbols::object_contains_any_symbol;
 use run_make_support::{bin_name, rustc};


### PR DESCRIPTION
- Simplification of https://github.com/rust-lang/rust/pull/155692.
---

The `needs-asm-mnemonic` directive was very general, but in practice was only being used for `ret`. There are very few other mnemonics that it could plausibly be useful for (e.g. `nop`), because any instruction that requires arguments is probably going to be non-portable.

This PR replaces `needs-asm-mnemonic` with a simpler `needs-asm-ret` directive that uses the same machinery as other simple needs directives.

If we happend to need more mnemonics in the future, we can just add more simple directives as appropriate (e.g. `needs-asm-nop`).
