### PR TITLE
Allow `global_asm!` in statement positions (take 2)

### DIFF
--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -1,9 +1,11 @@
+use rustc_ast as ast;
 use rustc_ast::{Block, BlockCheckMode, Local, LocalKind, Stmt, StmtKind};
 use rustc_hir as hir;
 use rustc_hir::Target;
 use rustc_span::sym;
 use smallvec::SmallVec;
 
+use crate::errors::GlobalAsmStatementPositionUnstable;
 use crate::{ImplTraitContext, ImplTraitPosition, LoweringContext};
 
 impl<'hir> LoweringContext<'_, 'hir> {
@@ -44,6 +46,19 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     stmts.push(hir::Stmt { hir_id, kind, span });
                 }
                 StmtKind::Item(it) => {
+                    if let ast::ItemKind::GlobalAsm(_) = &it.kind {
+                        if !self.tcx.features().global_asm_statement_position() {
+                            let span = self.lower_span(s.span);
+                            self.tcx
+                                .sess
+                                .create_feature_err(
+                                    GlobalAsmStatementPositionUnstable { span },
+                                    sym::global_asm_statement_position,
+                                )
+                                .emit();
+                        }
+                    }
+
                     stmts.extend(self.lower_item_ref(it).into_iter().enumerate().map(
                         |(i, item_id)| {
                             let hir_id = match i {

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -535,3 +535,10 @@ pub(crate) struct CycleInDelegationSignatureResolution {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("using `global_asm!` in statement positions is experimental")]
+pub(crate) struct GlobalAsmStatementPositionUnstable {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -10,7 +10,7 @@ use rustc_parse_format as parse;
 use rustc_session::lint;
 use rustc_span::{ErrorGuaranteed, InnerSpan, Span, Symbol, sym};
 use rustc_target::asm::InlineAsmArch;
-use smallvec::smallvec;
+use smallvec::{SmallVec, smallvec};
 
 use crate::errors;
 use crate::util::{ExprToSpannedString, expr_to_spanned_string};
@@ -24,6 +24,24 @@ struct ValidatedAsmArgs {
     pub clobber_abis: Vec<(Symbol, Span)>,
     options: ast::InlineAsmOptions,
     pub options_spans: Vec<Span>,
+}
+
+struct MacGlobalAsm {
+    item: ast::Item,
+}
+
+impl MacResult for MacGlobalAsm {
+    fn make_items(self: Box<Self>) -> Option<SmallVec<[Box<ast::Item>; 1]>> {
+        Some(smallvec![Box::new(self.item)])
+    }
+
+    fn make_stmts(self: Box<Self>) -> Option<SmallVec<[ast::Stmt; 1]>> {
+        Some(smallvec![ast::Stmt {
+            id: ast::DUMMY_NODE_ID,
+            span: self.item.span,
+            kind: ast::StmtKind::Item(Box::new(self.item)),
+        }])
+    }
 }
 
 fn parse_args<'a>(
@@ -650,18 +668,20 @@ pub(super) fn expand_global_asm<'cx>(
                 return ExpandResult::Retry(());
             };
             match mac {
-                Ok(inline_asm) => MacEager::items(smallvec![Box::new(ast::Item {
-                    attrs: ast::AttrVec::new(),
-                    id: ast::DUMMY_NODE_ID,
-                    kind: ast::ItemKind::GlobalAsm(Box::new(inline_asm)),
-                    vis: ast::Visibility {
-                        span: sp.shrink_to_lo(),
-                        kind: ast::VisibilityKind::Inherited,
+                Ok(inline_asm) => Box::new(MacGlobalAsm {
+                    item: ast::Item {
+                        attrs: ast::AttrVec::new(),
+                        id: ast::DUMMY_NODE_ID,
+                        kind: ast::ItemKind::GlobalAsm(Box::new(inline_asm)),
+                        vis: ast::Visibility {
+                            span: sp.shrink_to_lo(),
+                            kind: ast::VisibilityKind::Inherited,
+                            tokens: None,
+                        },
+                        span: sp,
                         tokens: None,
                     },
-                    span: sp,
-                    tokens: None,
-                })]),
+                }),
                 Err(guar) => DummyResult::any(sp, guar),
             }
         }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -573,6 +573,8 @@ declare_features! (
     (incomplete, generic_const_parameter_types, "1.87.0", Some(137626)),
     /// Allows any generic constants being used as pattern type range ends
     (incomplete, generic_pattern_types, "1.86.0", Some(136574)),
+    /// Allows `global_asm!` in statement positions.
+    (unstable, global_asm_statement_position, "CURRENT_RUSTC_VERSION", Some(156965)),
     /// Allows registering static items globally, possibly across crates, to iterate over at runtime.
     (unstable, global_registration, "1.80.0", Some(125119)),
     /// Allows using guards in patterns.

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1438,22 +1438,38 @@ impl<'ast, 'ra, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'ra, 'tc
                     // generic parameters like an inline const.
                     self.resolve_anon_const(anon_const, AnonConstKind::InlineConst);
                 }
-                InlineAsmOperand::Sym { sym } => self.visit_inline_asm_sym(sym),
+                InlineAsmOperand::Sym { sym } => {
+                    // global_asm! can be defined as an inner item, but should not be able to use
+                    // generic parameters from outer items.
+                    let rib_kind = match asm.asm_macro {
+                        AsmMacro::Asm | AsmMacro::NakedAsm => RibKind::InlineAsmSym,
+                        AsmMacro::GlobalAsm => {
+                            RibKind::Item(HasGenericParams::No, DefKind::GlobalAsm)
+                        }
+                    };
+
+                    // This is similar to the code for AnonConst.
+                    self.with_rib(ValueNS, rib_kind, |this| {
+                        this.with_rib(TypeNS, rib_kind, |this| {
+                            this.with_label_rib(rib_kind, |this| {
+                                this.smart_resolve_path(
+                                    sym.id,
+                                    &sym.qself,
+                                    &sym.path,
+                                    PathSource::Expr(None),
+                                );
+                                visit::walk_inline_asm_sym(this, sym);
+                            });
+                        })
+                    });
+                }
                 InlineAsmOperand::Label { block } => self.visit_block(block),
             }
         }
     }
 
-    fn visit_inline_asm_sym(&mut self, sym: &'ast InlineAsmSym) {
-        // This is similar to the code for AnonConst.
-        self.with_rib(ValueNS, RibKind::InlineAsmSym, |this| {
-            this.with_rib(TypeNS, RibKind::InlineAsmSym, |this| {
-                this.with_label_rib(RibKind::InlineAsmSym, |this| {
-                    this.smart_resolve_path(sym.id, &sym.qself, &sym.path, PathSource::Expr(None));
-                    visit::walk_inline_asm_sym(this, sym);
-                });
-            })
-        });
+    fn visit_inline_asm_sym(&mut self, _sym: &'ast InlineAsmSym) {
+        unreachable!("handled in `visit_inline_asm`");
     }
 
     fn visit_variant(&mut self, v: &'ast Variant) {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1036,6 +1036,7 @@ symbols! {
         global_alloc_ty,
         global_allocator,
         global_asm,
+        global_asm_statement_position,
         global_registration,
         globs,
         gpu_launch_sized_workgroup_mem,

--- a/tests/ui/asm/global-asm-sym-generic-param.rs
+++ b/tests/ui/asm/global-asm-sym-generic-param.rs
@@ -1,0 +1,52 @@
+// Ensure that we don't ICE when using a type/const parameter in a `sym` operand
+// of `global_asm!`. See #156760.
+
+//@ needs-asm-support
+
+#![feature(global_asm_statement_position, sized_hierarchy)]
+
+use std::arch::global_asm;
+use std::marker::{PhantomData, PointeeSized};
+
+trait Trait {
+    fn pure();
+}
+
+fn fun_ty<T: Trait>() {
+    global_asm!("{}", sym<T>::pure);
+    //~^ ERROR can't use generic parameters from outer item
+}
+
+trait TraitWithConstParam<const N: usize> {
+    fn pure();
+}
+
+impl<const N: usize> TraitWithConstParam<N> for () {
+    fn pure() {}
+}
+
+fn fun_const<const N: usize>() {
+    global_asm!("{}", sym <() as TraitWithConstParam<N>>::pure);
+    //~^ ERROR can't use generic parameters from outer item
+    //~| ERROR unresolved item provided when a constant was expected
+}
+
+struct S<T>(PhantomData<T>);
+
+impl<T> S<T> {
+    fn meow(&self) {
+        global_asm!("/* {} */", sym Self::meow);
+        //~^ ERROR can't use `Self` from outer item [E0401]
+    }
+}
+
+struct U<T: PointeeSized>(PhantomData<T>);
+
+impl<T: PointeeSized> U<T> {
+    fn meow(&self) {
+        global_asm!("/* {} */", sym Self::meow);
+        //~^ ERROR can't use `Self` from outer item [E0401]
+    }
+}
+
+fn main() {}

--- a/tests/ui/asm/global-asm-sym-generic-param.stderr
+++ b/tests/ui/asm/global-asm-sym-generic-param.stderr
@@ -1,0 +1,79 @@
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/global-asm-sym-generic-param.rs:16:27
+   |
+LL | fn fun_ty<T: Trait>() {
+   |           - type parameter from outer item
+LL |     global_asm!("{}", sym<T>::pure);
+   |     ----------------------^--------
+   |     |                     |
+   |     |                     use of generic parameter from outer item
+   |     generic parameter used in this inner global asm item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+
+error[E0401]: can't use generic parameters from outer item
+  --> $DIR/global-asm-sym-generic-param.rs:29:54
+   |
+LL | fn fun_const<const N: usize>() {
+   |                    - const parameter from outer item
+LL |     global_asm!("{}", sym <() as TraitWithConstParam<N>>::pure);
+   |     -------------------------------------------------^---------
+   |     |                                                |
+   |     |                                                use of generic parameter from outer item
+   |     generic parameter used in this inner global asm item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+
+error[E0401]: can't use `Self` from outer item
+  --> $DIR/global-asm-sym-generic-param.rs:38:37
+   |
+LL | impl<T> S<T> {
+   | ---- `Self` type implicitly declared here, by this `impl`
+LL |     fn meow(&self) {
+LL |         global_asm!("/* {} */", sym Self::meow);
+   |         ----------------------------^^^^-------
+   |         |                           |
+   |         |                           use of `Self` from outer item
+   |         `Self` used in this inner global asm item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+help: refer to the type directly here instead
+   |
+LL -         global_asm!("/* {} */", sym Self::meow);
+LL +         global_asm!("/* {} */", sym S<T>::meow);
+   |
+
+error[E0401]: can't use `Self` from outer item
+  --> $DIR/global-asm-sym-generic-param.rs:47:37
+   |
+LL | impl<T: PointeeSized> U<T> {
+   | ---- `Self` type implicitly declared here, by this `impl`
+LL |     fn meow(&self) {
+LL |         global_asm!("/* {} */", sym Self::meow);
+   |         ----------------------------^^^^-------
+   |         |                           |
+   |         |                           use of `Self` from outer item
+   |         `Self` used in this inner global asm item
+   |
+   = note: nested items are independent from their parent item for everything except for privacy and name resolution
+help: refer to the type directly here instead
+   |
+LL -         global_asm!("/* {} */", sym Self::meow);
+LL +         global_asm!("/* {} */", sym U<T>::meow);
+   |
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/global-asm-sym-generic-param.rs:29:54
+   |
+LL |     global_asm!("{}", sym <() as TraitWithConstParam<N>>::pure);
+   |                                                      ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |     global_asm!("{}", sym <() as TraitWithConstParam<{ N }>>::pure);
+   |                                                      +   +
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0401, E0747.
+For more information about an error, try `rustc --explain E0401`.

--- a/tests/ui/asm/naked-functions.rs
+++ b/tests/ui/asm/naked-functions.rs
@@ -3,15 +3,27 @@
 //@ ignore-spirv
 //@ reference: attributes.codegen.naked.body
 
-#![feature(asm_unwind, linkage, rustc_attrs, cfg_target_object_format)]
+#![feature(
+    asm_unwind,
+    global_asm_statement_position,
+    linkage,
+    rustc_attrs,
+    cfg_target_object_format
+)]
 #![crate_type = "lib"]
 
-use std::arch::{asm, naked_asm};
+use std::arch::{asm, global_asm, naked_asm};
 
 #[unsafe(naked)]
 pub extern "C" fn inline_asm_macro() {
     unsafe { asm!("", options(raw)) };
     //~^ERROR the `asm!` macro is not allowed in naked functions
+}
+
+#[unsafe(naked)]
+pub extern "C" fn global_asm_macro() {
+    //~^ERROR naked functions must contain a single `naked_asm!` invocation
+    global_asm!("");
 }
 
 #[repr(C)]

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -1,107 +1,113 @@
 error: the `in` operand cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:47:29
+  --> $DIR/naked-functions.rs:59:29
    |
 LL |     naked_asm!("/* {0} */", in(reg) a)
    |                             ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
 
 error: the `in` operand cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:68:10
+  --> $DIR/naked-functions.rs:80:10
    |
 LL |          in(reg) a,
    |          ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
 
 error: the `noreturn` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:88:28
+  --> $DIR/naked-functions.rs:100:28
    |
 LL |     naked_asm!("", options(noreturn));
    |                            ^^^^^^^^ the `noreturn` option is not meaningful for global-scoped inline assembly
 
 error: the `nomem` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:105:28
+  --> $DIR/naked-functions.rs:117:28
    |
 LL |     naked_asm!("", options(nomem, preserves_flags));
    |                            ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
 
 error: the `preserves_flags` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:105:35
+  --> $DIR/naked-functions.rs:117:35
    |
 LL |     naked_asm!("", options(nomem, preserves_flags));
    |                                   ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
 
 error: the `readonly` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:112:28
+  --> $DIR/naked-functions.rs:124:28
    |
 LL |     naked_asm!("", options(readonly, nostack), options(pure));
    |                            ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
 
 error: the `nostack` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:112:38
+  --> $DIR/naked-functions.rs:124:38
    |
 LL |     naked_asm!("", options(readonly, nostack), options(pure));
    |                                      ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
 
 error: the `pure` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:112:56
+  --> $DIR/naked-functions.rs:124:56
    |
 LL |     naked_asm!("", options(readonly, nostack), options(pure));
    |                                                        ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
 
 error: the `may_unwind` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:120:28
+  --> $DIR/naked-functions.rs:132:28
    |
 LL |     naked_asm!("", options(may_unwind));
    |                            ^^^^^^^^^^ the `may_unwind` option is not meaningful for global-scoped inline assembly
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:151:5
+  --> $DIR/naked-functions.rs:163:5
    |
 LL |     compile_error!("this is a user specified error")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:157:5
+  --> $DIR/naked-functions.rs:169:5
    |
 LL |     compile_error!("this is a user specified error");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/naked-functions.rs:164:16
+  --> $DIR/naked-functions.rs:176:16
    |
 LL |     naked_asm!(invalid_syntax)
    |                ^^^^^^^^^^^^^^
 
 error[E0787]: the `asm!` macro is not allowed in naked functions
-  --> $DIR/naked-functions.rs:13:14
+  --> $DIR/naked-functions.rs:19:14
    |
 LL |     unsafe { asm!("", options(raw)) };
    |              ^^^^^^^^^^^^^^^^^^^^^^ consider using the `naked_asm!` macro instead
 
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:24:1
+   |
+LL | pub extern "C" fn global_asm_macro() {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:25:5
+  --> $DIR/naked-functions.rs:37:5
    |
 LL |     mut a: u32,
    |     ^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:27:5
+  --> $DIR/naked-functions.rs:39:5
    |
 LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:29:6
+  --> $DIR/naked-functions.rs:41:6
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
    |      ^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:31:5
+  --> $DIR/naked-functions.rs:43:5
    |
 LL |     P { x, y }: P,
    |     ^^^^^^^^^^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:40:5
+  --> $DIR/naked-functions.rs:52:5
    |
 LL |     a + 1
    |     ^
@@ -109,7 +115,7 @@ LL |     a + 1
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single `naked_asm!` invocation
-  --> $DIR/naked-functions.rs:38:1
+  --> $DIR/naked-functions.rs:50:1
    |
 LL | pub extern "C" fn inc(a: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +124,7 @@ LL |     a + 1
    |     ----- not allowed in naked functions
 
 error[E0787]: naked functions must contain a single `naked_asm!` invocation
-  --> $DIR/naked-functions.rs:52:1
+  --> $DIR/naked-functions.rs:64:1
    |
 LL | pub extern "C" fn inc_closure(a: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,7 +133,7 @@ LL |     (|| a + 1)()
    |     ------------ not allowed in naked functions
 
 error[E0787]: naked functions must contain a single `naked_asm!` invocation
-  --> $DIR/naked-functions.rs:58:1
+  --> $DIR/naked-functions.rs:70:1
    |
 LL | pub extern "C" fn unsupported_operands() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -144,13 +150,13 @@ LL |     let mut e = 0usize;
    |     ------------------- not allowed in naked functions
 
 error[E0787]: naked functions must contain a single `naked_asm!` invocation
-  --> $DIR/naked-functions.rs:80:1
+  --> $DIR/naked-functions.rs:92:1
    |
 LL | pub extern "C" fn missing_assembly() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: naked functions must contain a single `naked_asm!` invocation
-  --> $DIR/naked-functions.rs:85:1
+  --> $DIR/naked-functions.rs:97:1
    |
 LL | pub extern "C" fn too_many_asm_blocks() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +165,7 @@ LL |     naked_asm!("");
    |     -------------- multiple `naked_asm!` invocations are not allowed in naked functions
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:97:11
+  --> $DIR/naked-functions.rs:109:11
    |
 LL |         *&y
    |           ^
@@ -167,7 +173,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single `naked_asm!` invocation
-  --> $DIR/naked-functions.rs:95:5
+  --> $DIR/naked-functions.rs:107:5
    |
 LL |     pub extern "C" fn inner(y: usize) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,6 +181,6 @@ LL |
 LL |         *&y
    |         --- not allowed in naked functions
 
-error: aborting due to 25 previous errors
+error: aborting due to 26 previous errors
 
 For more information about this error, try `rustc --explain E0787`.

--- a/tests/ui/asm/statement-global-asm-error.rs
+++ b/tests/ui/asm/statement-global-asm-error.rs
@@ -1,0 +1,15 @@
+//@ needs-asm-support
+
+#![feature(global_asm_statement_position)]
+
+use std::arch::global_asm;
+
+fn main() {
+    let x = 42;
+    global_asm!("{}", in(x));
+    //~^ ERROR the `in` operand cannot be used with `global_asm!`
+    //~^^ NOTE the `in` operand is not meaningful for global-scoped inline assembly, remove it
+
+    let y = global_asm!("");
+    //~^ ERROR non-expression macro in expression position: global_asm
+}

--- a/tests/ui/asm/statement-global-asm-error.stderr
+++ b/tests/ui/asm/statement-global-asm-error.stderr
@@ -1,0 +1,14 @@
+error: the `in` operand cannot be used with `global_asm!`
+  --> $DIR/statement-global-asm-error.rs:9:23
+   |
+LL |     global_asm!("{}", in(x));
+   |                       ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
+
+error: non-expression macro in expression position: global_asm
+  --> $DIR/statement-global-asm-error.rs:13:13
+   |
+LL |     let y = global_asm!("");
+   |             ^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/asm/statement-global-asm.rs
+++ b/tests/ui/asm/statement-global-asm.rs
@@ -1,0 +1,10 @@
+//@ needs-asm-support
+//@ run-pass
+
+#![feature(global_asm_statement_position)]
+
+use std::arch::global_asm;
+
+fn main() {
+    global_asm!("");
+}

--- a/tests/ui/asm/x86_64/statement-global-asm.rs
+++ b/tests/ui/asm/x86_64/statement-global-asm.rs
@@ -1,0 +1,23 @@
+//@ only-x86_64
+//@ needs-asm-support
+//@ run-pass
+
+// This makes sure that even though `foo()` is instantiated multiple times, `bar()` is not.
+
+#![feature(global_asm_statement_position)]
+
+fn foo<T: std::fmt::Display>(value: T) {
+    std::arch::global_asm!(".global bar", "bar:", "ret");
+
+    println!("{value}");
+}
+
+unsafe extern "C" {
+    safe fn bar();
+}
+
+fn main() {
+    foo("test");
+    foo(42);
+    bar();
+}

--- a/tests/ui/feature-gates/feature-gate-global_asm_statement_position.rs
+++ b/tests/ui/feature-gates/feature-gate-global_asm_statement_position.rs
@@ -1,0 +1,6 @@
+//@ needs-asm-support
+
+fn main() {
+    std::arch::global_asm!("");
+    //~^ ERROR using `global_asm!` in statement positions is experimental [E0658]
+}

--- a/tests/ui/feature-gates/feature-gate-global_asm_statement_position.stderr
+++ b/tests/ui/feature-gates/feature-gate-global_asm_statement_position.stderr
@@ -1,0 +1,13 @@
+error[E0658]: using `global_asm!` in statement positions is experimental
+  --> $DIR/feature-gate-global_asm_statement_position.rs:4:5
+   |
+LL |     std::arch::global_asm!("");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #156965 <https://github.com/rust-lang/rust/issues/156965> for more information
+   = help: add `#![feature(global_asm_statement_position)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/156965.
Fixes rust-lang/rust#156760 .
Fixes rust-lang/rust#156894.

### Description

Currently `global_asm!` is only allowed in a module root. This feature, `feature(global_asm_statement_position)`, allows it to appear in any position an item can appear.

```rust
mod foo {
    // This was previously the only allowed position.
    global_asm!("");

    fn bar() {
        // Like any item, `Baz` can be added inside a function,
        // but has no relation to the parent function `bar()`.
        struct Baz;

        // This is not allowed today, its what this feature enables.
        global_asm!("");
    }
}
```

This is particularly useful for macros, where you otherwise have to wrap `global_asm!` in `mod foo { global_asm!(...); }`.

### History

Previously discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/216763-project-inline-asm/topic/Item.20position.20global_asm/with/581784943).

This has been merged in rust-lang/rust#156582 and then reverted in rust-lang/rust#156884 because it was insta-stable. In that time two bugs surfaced: rust-lang/rust#156760 and rust-lang/rust#156894. Both were fixed with rust-lang/rust#156855, which was incorporated here. Thank you @Kokoro2336 and @folkertdev.