### PR TITLE
Use #[panic_handler] rather than #[lang = "panic_impl"]

### DIFF
--- a/tests/ui/error-codes/E0152-duplicate-lang-items.rs
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.rs
@@ -12,9 +12,9 @@ extern crate core;
 
 use core::panic::PanicInfo;
 
-#[lang = "panic_impl"]
-fn panic_impl(info: &PanicInfo) -> ! {
-    //~^ ERROR: found duplicate lang item `panic_impl`
+#[lang = "eh_personality"]
+fn personality() {
+    //~^ ERROR: found duplicate lang item `eh_personality`
     //~| NOTE first defined in crate `std`
     loop {}
 }

--- a/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
+++ b/tests/ui/error-codes/E0152-duplicate-lang-items.stderr
@@ -1,7 +1,7 @@
-error[E0152]: found duplicate lang item `panic_impl`
+error[E0152]: found duplicate lang item `eh_personality`
   --> $DIR/E0152-duplicate-lang-items.rs:16:1
    |
-LL | / fn panic_impl(info: &PanicInfo) -> ! {
+LL | / fn personality() {
 LL | |
 LL | |
 LL | |     loop {}

--- a/tests/ui/macros/macro-comma-behavior.rs
+++ b/tests/ui/macros/macro-comma-behavior.rs
@@ -10,7 +10,7 @@
 #[cfg(core)] use core::fmt;
 #[cfg(core)] #[lang = "eh_personality"] fn eh_personality() {}
 #[cfg(core)] #[lang = "eh_catch_typeinfo"] static EH_CATCH_TYPEINFO: u8 = 0;
-#[cfg(core)] #[lang = "panic_impl"] fn panic_impl(panic: &core::panic::PanicInfo) -> ! { loop {} }
+#[cfg(core)] #[panic_handler] fn panic_impl(panic: &core::panic::PanicInfo) -> ! { loop {} }
 
 // (see documentation of the similarly-named test in run-pass)
 fn to_format_or_not_to_format() {

--- a/tests/ui/panic-handler/panic-handler-duplicate.rs
+++ b/tests/ui/panic-handler/panic-handler-duplicate.rs
@@ -11,7 +11,7 @@ fn panic(info: &PanicInfo) -> ! {
     loop {}
 }
 
-#[lang = "panic_impl"]
+#[panic_handler]
 fn panic2(info: &PanicInfo) -> ! { //~ ERROR found duplicate lang item `panic_impl`
     loop {}
 }

--- a/tests/ui/panic-runtime/auxiliary/panic-runtime-lang-items.rs
+++ b/tests/ui/panic-runtime/auxiliary/panic-runtime-lang-items.rs
@@ -7,7 +7,7 @@
 
 use core::panic::PanicInfo;
 
-#[lang = "panic_impl"]
+#[panic_handler]
 fn panic_impl(info: &PanicInfo) -> ! { loop {} }
 #[lang = "eh_personality"]
 fn eh_personality() {}


### PR DESCRIPTION
As preparation for turning #[panic_handler] from a weak lang item into an EII.

r? @jdonszelmann