### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -78,15 +78,11 @@ impl bool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bool_to_result)]
-    ///
     /// assert_eq!(false.ok_or(0), Err(0));
     /// assert_eq!(true.ok_or(0), Ok(()));
     /// ```
     ///
     /// ```
-    /// #![feature(bool_to_result)]
-    ///
     /// let mut a = 0;
     /// let mut function_with_side_effects = || { a += 1; };
     ///
@@ -97,7 +93,7 @@ impl bool {
     /// // evaluated eagerly.
     /// assert_eq!(a, 2);
     /// ```
-    #[unstable(feature = "bool_to_result", issue = "142748")]
+    #[stable(feature = "bool_to_result", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_bool", issue = "151531")]
     #[inline]
     pub const fn ok_or<E: [const] Destruct>(self, err: E) -> Result<(), E> {
@@ -110,15 +106,11 @@ impl bool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bool_to_result)]
-    ///
     /// assert_eq!(false.ok_or_else(|| 0), Err(0));
     /// assert_eq!(true.ok_or_else(|| 0), Ok(()));
     /// ```
     ///
     /// ```
-    /// #![feature(bool_to_result)]
-    ///
     /// let mut a = 0;
     ///
     /// assert!(true.ok_or_else(|| { a += 1; }).is_ok());
@@ -128,7 +120,7 @@ impl bool {
     /// // `ok_or_else`.
     /// assert_eq!(a, 1);
     /// ```
-    #[unstable(feature = "bool_to_result", issue = "142748")]
+    #[stable(feature = "bool_to_result", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_const_unstable(feature = "const_bool", issue = "151531")]
     #[inline]
     pub const fn ok_or_else<E, F: [const] FnOnce() -> E + [const] Destruct>(

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -5,11 +5,10 @@
 //!
 //! - Implement the [`AsRef`] trait for cheap reference-to-reference conversions
 //! - Implement the [`AsMut`] trait for cheap mutable-to-mutable conversions
-//! - Implement the [`From`] trait for consuming value-to-value conversions
-//! - Implement the [`Into`] trait for consuming value-to-value conversions to types
-//!   outside the current crate
-//! - The [`TryFrom`] and [`TryInto`] traits behave like [`From`] and [`Into`],
-//!   but should be implemented when the conversion can fail.
+//! - Implement the [`From`] trait for consuming value-to-value conversions that cannot fail. This
+//!   automatically provides an implementation of [`Into`]
+//! - Implement the [`TryFrom`] trait for consuming value-to-value conversions that can fail. This
+//!   automatically provides an implementation of [`TryInto`]
 //!
 //! The traits in this module are often used as trait bounds for generic functions such that
 //! arguments of multiple types are supported. See the documentation of each trait for examples.
@@ -18,9 +17,9 @@
 //! [`TryFrom<T>`][`TryFrom`] rather than [`Into<U>`][`Into`] or [`TryInto<U>`][`TryInto`],
 //! as [`From`] and [`TryFrom`] provide greater flexibility and offer
 //! equivalent [`Into`] or [`TryInto`] implementations for free, thanks to a
-//! blanket implementation in the standard library. When targeting a version prior to Rust 1.41, it
-//! may be necessary to implement [`Into`] or [`TryInto`] directly when converting to a type
-//! outside the current crate.
+//! blanket implementation in the standard library. In versions of Rust prior to Rust 1.41,
+//! it was sometimes necessary to implement [`Into`] or [`TryInto`] directly when converting to a
+//! type outside the current crate.
 //!
 //! # Generic Implementations
 //!

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -8,7 +8,6 @@
 #![feature(ascii_char_variants)]
 #![feature(async_iter_from_iter)]
 #![feature(async_iterator)]
-#![feature(bool_to_result)]
 #![feature(borrowed_buf_init)]
 #![feature(bstr)]
 #![feature(cfg_target_has_reliable_f16_f128)]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -745,6 +745,11 @@ impl<'test> TestCx<'test> {
             }
         }
 
+        unexpected.sort_by_key(|e| (e.line_num, e.column_num));
+        unimportant.sort_by_key(|e| (e.line_num, e.column_num));
+
+        // `not_found` are sorted because `expected_errors` are sorted as they are read from file
+        // line by line.
         let mut not_found = Vec::new();
         // anything not yet found is a problem
         for (index, expected_error) in expected_errors.iter().enumerate() {

--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
@@ -1,7 +1,6 @@
 //@ aux-crate:priv:shared=shared.rs
-//@ aux-crate:reexport=reexport.rs
+//@ aux-crate:priv:reexport=reexport.rs
 //@ compile-flags: -Zunstable-options
-//@ check-pass
 
 // A shared dependency, where a private dependency reexports a public dependency.
 //
@@ -21,12 +20,12 @@
 extern crate shared;
 extern crate reexport;
 
-// FIXME: This should trigger.
 pub fn leaks_priv() -> shared::Shared {
+    //~^ ERROR type `Shared` from private dependency 'shared' in public interface
     shared::Shared
 }
 
-// FIXME: This should trigger.
 pub fn leaks_priv_reexport() -> reexport::Shared {
+    //~^ ERROR type `Shared` from private dependency 'shared' in public interface
     reexport::Shared
 }

--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.stderr
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.stderr
@@ -1,0 +1,20 @@
+error: type `Shared` from private dependency 'shared' in public interface
+  --> $DIR/shared_both_private.rs:23:1
+   |
+LL | pub fn leaks_priv() -> shared::Shared {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/shared_both_private.rs:18:9
+   |
+LL | #![deny(exported_private_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `Shared` from private dependency 'shared' in public interface
+  --> $DIR/shared_both_private.rs:28:1
+   |
+LL | pub fn leaks_priv_reexport() -> reexport::Shared {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156594 (Stabilize bool_to_result)
 - rust-lang/rust#156764 (tests: fix pub-priv-dep test expectation)
 - rust-lang/rust#156825 (compiletest: sort unexpected and unimportant errors)
 - rust-lang/rust#156909 (Rewrite documentation that said to implement `Into`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156594,156764,156825,156909)
<!-- homu-ignore:end -->

