### PR TITLE
Allow rustdoc JSON rustup component to be installed on stable.

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -34,7 +34,6 @@ static PKG_INSTALLERS: &[&str] = &["x86_64-apple-darwin", "aarch64-apple-darwin"
 fn is_nightly_only(pkg: &PkgType) -> bool {
     match pkg {
         PkgType::Miri
-        | PkgType::JsonDocs
         | PkgType::RustcCodegenCranelift
         | PkgType::RustcCodegenGcc
         | PkgType::Gcc { .. }
@@ -49,6 +48,7 @@ fn is_nightly_only(pkg: &PkgType) -> bool {
         | PkgType::RustStd
         | PkgType::Cargo
         | PkgType::HtmlDocs
+        | PkgType::JsonDocs
         | PkgType::RustAnalysis
         | PkgType::RustAnalyzer
         | PkgType::Clippy


### PR DESCRIPTION
Currently, the `rust-docs-json` component is only available [on nightly Rust](https://doc.rust-lang.org/rustdoc/unstable-features.html#json).

It would be very useful to `cargo-semver-checks` to have rustdoc JSON available in stable as well, to allow performing cross-crate linting that involves types from `std/core/alloc` etc. This will also simplify the process of linting the standard library itself for possible breaking changes, which is something T-libs is interested in as well.

Even though rustdoc JSON is an unstable component, each JSON file carries a version number meaning that the installed files remain parseable and usable with the matching version of [`rustdoc-types`](https://crates.io/crates/rustdoc-types). So even though future stable Rust releases may change the format, it still makes sense to provide this machine-readable artifact that says "this is what the standard lib contained in this stable release."

For avoidance of confusion: different stable releases may ship mutually-incompatible rustdoc format versions in the `rust-docs-json` component. The component's contents and shape are valid with respect only to the toolchain in which it is found, analogously to how the rustdoc HTML docs component works.

[Zulip Discussion](https://rust-lang.zulipchat.com/#narrow/channel/490103-t-rustup/topic/rust-docs-json.20component.20for.20stable.20Rust/with/597559250)

r? @Mark-Simulacrum @GuillaumeGomez 