### PR TITLE
Co-opt the x86_64-linux-musl for CFI

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/dist.sh
@@ -5,7 +5,7 @@ set -eux
 python3 ../x.py build --set rust.debug=true opt-dist
 
 ./build/$HOSTS/stage1-tools-bin/opt-dist linux-ci -- python3 ../x.py dist \
-    --host $HOSTS --target $HOSTS \
+    --host $HOSTS --target $HOSTS,x86_64-unknown-linux-musl \
     --include-default-paths \
     build-manifest \
     bootstrap \

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -246,7 +246,8 @@ SCCACHE_IDLE_TIMEOUT=10800 sccache --start-server || true
 rm -f bootstrap.toml
 
 $SRC/configure $RUST_CONFIGURE_ARGS
-
+echo '[target.x86_64-unknown-linux-musl]' >> bootstrap.toml
+echo 'rustflags = ["-Ctarget-feature=-crt-static", "-Ccodegen-units=1", "-Clto=thin", "-Clinker-plugin-lto", "-Zsanitizer=cfi"]' >> bootstrap.toml
 retry make prepare
 
 # Display the CPU and memory information. This helps us know why the CI timing


### PR DESCRIPTION
I'm trying to create a pre-built libstd with CFI so that we can do a crater run with it. Everything in here is a hack.