### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -5,11 +5,10 @@
 //!
 //! - Implement the [`AsRef`] trait for cheap reference-to-reference conversions
 //! - Implement the [`AsMut`] trait for cheap mutable-to-mutable conversions
-//! - Implement the [`From`] trait for consuming value-to-value conversions
-//! - Implement the [`Into`] trait for consuming value-to-value conversions to types
-//!   outside the current crate
-//! - The [`TryFrom`] and [`TryInto`] traits behave like [`From`] and [`Into`],
-//!   but should be implemented when the conversion can fail.
+//! - Implement the [`From`] trait for consuming value-to-value conversions that cannot fail. This
+//!   automatically provides an implementation of [`Into`]
+//! - Implement the [`TryFrom`] trait for consuming value-to-value conversions that can fail. This
+//!   automatically provides an implementation of [`TryInto`]
 //!
 //! The traits in this module are often used as trait bounds for generic functions such that
 //! arguments of multiple types are supported. See the documentation of each trait for examples.
@@ -18,9 +17,9 @@
 //! [`TryFrom<T>`][`TryFrom`] rather than [`Into<U>`][`Into`] or [`TryInto<U>`][`TryInto`],
 //! as [`From`] and [`TryFrom`] provide greater flexibility and offer
 //! equivalent [`Into`] or [`TryInto`] implementations for free, thanks to a
-//! blanket implementation in the standard library. When targeting a version prior to Rust 1.41, it
-//! may be necessary to implement [`Into`] or [`TryInto`] directly when converting to a type
-//! outside the current crate.
+//! blanket implementation in the standard library. In versions of Rust prior to Rust 1.41,
+//! it was sometimes necessary to implement [`Into`] or [`TryInto`] directly when converting to a
+//! type outside the current crate.
 //!
 //! # Generic Implementations
 //!

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -745,6 +745,11 @@ impl<'test> TestCx<'test> {
             }
         }
 
+        unexpected.sort_by_key(|e| (e.line_num, e.column_num));
+        unimportant.sort_by_key(|e| (e.line_num, e.column_num));
+
+        // `not_found` are sorted because `expected_errors` are sorted as they are read from file
+        // line by line.
         let mut not_found = Vec::new();
         // anything not yet found is a problem
         for (index, expected_error) in expected_errors.iter().enumerate() {

--- a/tests/codegen-llvm/scalable-vectors/tuple-intrinsics.rs
+++ b/tests/codegen-llvm/scalable-vectors/tuple-intrinsics.rs
@@ -1,5 +1,3 @@
-// FIXME: The FileCheck directives in this test are unchecked and probably broken.
-//@ skip-filecheck
 //@ only-aarch64
 #![crate_type = "lib"]
 #![allow(incomplete_features, internal_features)]
@@ -38,27 +36,29 @@ pub fn svdup_n_f32(op: f32) -> svfloat32_t {
     unsafe { _svdup_n_f32(op) }
 }
 
-// CHECK: define { <vscale x 4 x float>, <vscale x 4 x float> } @svcreate2_f32(<vscale x 4 x float> %x0, <vscale x 4 x float> %x1)
+// CHECK-LABEL: define { <vscale x 4 x float>, <vscale x 4 x float> } @svcreate2_f32(
+// CHECK-SAME: <vscale x 4 x float> %x0, <vscale x 4 x float> %x1)
 #[no_mangle]
 #[target_feature(enable = "sve")]
 pub fn svcreate2_f32(x0: svfloat32_t, x1: svfloat32_t) -> svfloat32x2_t {
-    // CHECK: %1 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float> } poison, <vscale x 4 x float> %x0, 0
-    // CHECK-NEXT: %2 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float> } %1, <vscale x 4 x float> %x1, 1
+    // CHECK: [[TUP0:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float> } poison, <vscale x 4 x float> %x0, 0
+    // CHECK-NEXT: [[TUP1:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float> } [[TUP0]], <vscale x 4 x float> %x1, 1
     unsafe { std::intrinsics::simd::scalable::sve_tuple_create2(x0, x1) }
 }
 
-// CHECK: define { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @svcreate3_f32(<vscale x 4 x float> %x0, <vscale x 4 x float> %x1, <vscale x 4 x float> %x2)
+// CHECK-LABEL: define { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @svcreate3_f32(
+// CHECK-SAME: <vscale x 4 x float> %x0, <vscale x 4 x float> %x1, <vscale x 4 x float> %x2)
 #[no_mangle]
 #[target_feature(enable = "sve")]
 pub fn svcreate3_f32(x0: svfloat32_t, x1: svfloat32_t, x2: svfloat32_t) -> svfloat32x3_t {
-    // CHECK-LABEL: @_RNvCsk3YxfLN8zWY_6tuples13svcreate3_f32
-    // CHECK: %1 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } poison, <vscale x 4 x float> %x0, 0
-    // CHECK-NEXT: %2 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %1, <vscale x 4 x float> %x1, 1
-    // CHECK-NEXT: %3 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %2, <vscale x 4 x float> %x2, 2
+    // CHECK: [[TUP0:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } poison, <vscale x 4 x float> %x0, 0
+    // CHECK-NEXT: [[TUP1:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } [[TUP0]], <vscale x 4 x float> %x1, 1
+    // CHECK-NEXT: [[TUP2:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } [[TUP1]], <vscale x 4 x float> %x2, 2
     unsafe { std::intrinsics::simd::scalable::sve_tuple_create3(x0, x1, x2) }
 }
 
-// CHECK: define { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @svcreate4_f32(<vscale x 4 x float> %x0, <vscale x 4 x float> %x1, <vscale x 4 x float> %x2, <vscale x 4 x float> %x3)
+// CHECK-LABEL: define { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } @svcreate4_f32(
+// CHECK-SAME: <vscale x 4 x float> %x0, <vscale x 4 x float> %x1, <vscale x 4 x float> %x2, <vscale x 4 x float> %x3)
 #[no_mangle]
 #[target_feature(enable = "sve")]
 pub fn svcreate4_f32(
@@ -67,35 +67,36 @@ pub fn svcreate4_f32(
     x2: svfloat32_t,
     x3: svfloat32_t,
 ) -> svfloat32x4_t {
-    // CHECK-LABEL: @_RNvCsk3YxfLN8zWY_6tuples13svcreate4_f32
-    // CHECK: %1 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } poison, <vscale x 4 x float> %x0, 0
-    // CHECK-NEXT: %2 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %1, <vscale x 4 x float> %x1, 1
-    // CHECK-NEXT: %3 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %2, <vscale x 4 x float> %x2, 2
-    // CHECK-NEXT: %4 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } %3, <vscale x 4 x float> %x3, 3
+    // CHECK: [[TUP0:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } poison, <vscale x 4 x float> %x0, 0
+    // CHECK-NEXT: [[TUP1:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } [[TUP0]], <vscale x 4 x float> %x1, 1
+    // CHECK-NEXT: [[TUP2:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } [[TUP1]], <vscale x 4 x float> %x2, 2
+    // CHECK-NEXT: [[TUP3:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float>, <vscale x 4 x float> } [[TUP2]], <vscale x 4 x float> %x3, 3
     unsafe { std::intrinsics::simd::scalable::sve_tuple_create4(x0, x1, x2, x3) }
 }
 
-// CHECK: define <vscale x 4 x float> @svget2_f32({ <vscale x 4 x float>, <vscale x 4 x float> } %tup)
+// CHECK-LABEL: define <vscale x 4 x float> @svget2_f32(
+// CHECK-SAME: { <vscale x 4 x float>, <vscale x 4 x float> } %tup)
 #[no_mangle]
 #[target_feature(enable = "sve")]
-pub fn svget2_f32<const IDX: i32>(tup: svfloat32x2_t) -> svfloat32_t {
-    // CHECK: %1 = extractvalue { <vscale x 4 x float>, <vscale x 4 x float> } %tup, 0
-    unsafe { std::intrinsics::simd::scalable::sve_tuple_get::<_, _, { IDX }>(tup) }
+pub fn svget2_f32(tup: svfloat32x2_t) -> svfloat32_t {
+    // CHECK: [[X:%.*]] = extractvalue { <vscale x 4 x float>, <vscale x 4 x float> } %tup, 0
+    unsafe { std::intrinsics::simd::scalable::sve_tuple_get::<_, _, 0>(tup) }
 }
 
-// CHECK: define { <vscale x 4 x float>, <vscale x 4 x float> } @svset2_f32({ <vscale x 4 x float>, <vscale x 4 x float> } %tup, <vscale x 4 x float> %x)
+// CHECK-LABEL: define { <vscale x 4 x float>, <vscale x 4 x float> } @svset2_f32(
+// CHECK-SAME: { <vscale x 4 x float>, <vscale x 4 x float> } %tup, <vscale x 4 x float> %x)
 #[no_mangle]
 #[target_feature(enable = "sve")]
-pub fn svset2_f32<const IDX: i32>(tup: svfloat32x2_t, x: svfloat32_t) -> svfloat32x2_t {
-    // CHECK: %1 = insertvalue { <vscale x 4 x float>, <vscale x 4 x float> } %tup, <vscale x 4 x float> %x, 0
-    unsafe { std::intrinsics::simd::scalable::sve_tuple_set::<_, _, { IDX }>(tup, x) }
+pub fn svset2_f32(tup: svfloat32x2_t, x: svfloat32_t) -> svfloat32x2_t {
+    // CHECK: [[TUP:%.*]] = insertvalue { <vscale x 4 x float>, <vscale x 4 x float> } %tup, <vscale x 4 x float> %x, 0
+    unsafe { std::intrinsics::simd::scalable::sve_tuple_set::<_, _, 0>(tup, x) }
 }
 
-// This function exists only so there are calls to the generic functions
+// This function exists only so there are calls to the intrinsics
 #[target_feature(enable = "sve")]
 pub fn test() {
     let x = svdup_n_f32(2f32);
     let tup = svcreate2_f32(x, x);
-    let x = svget2_f32::<0>(tup);
-    let tup = svset2_f32::<0>(tup, x);
+    let x = svget2_f32(tup);
+    let _tup = svset2_f32(tup, x);
 }

--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.rs
@@ -1,7 +1,6 @@
 //@ aux-crate:priv:shared=shared.rs
-//@ aux-crate:reexport=reexport.rs
+//@ aux-crate:priv:reexport=reexport.rs
 //@ compile-flags: -Zunstable-options
-//@ check-pass
 
 // A shared dependency, where a private dependency reexports a public dependency.
 //
@@ -21,12 +20,12 @@
 extern crate shared;
 extern crate reexport;
 
-// FIXME: This should trigger.
 pub fn leaks_priv() -> shared::Shared {
+    //~^ ERROR type `Shared` from private dependency 'shared' in public interface
     shared::Shared
 }
 
-// FIXME: This should trigger.
 pub fn leaks_priv_reexport() -> reexport::Shared {
+    //~^ ERROR type `Shared` from private dependency 'shared' in public interface
     reexport::Shared
 }

--- a/tests/ui/privacy/pub-priv-dep/shared_both_private.stderr
+++ b/tests/ui/privacy/pub-priv-dep/shared_both_private.stderr
@@ -1,0 +1,20 @@
+error: type `Shared` from private dependency 'shared' in public interface
+  --> $DIR/shared_both_private.rs:23:1
+   |
+LL | pub fn leaks_priv() -> shared::Shared {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/shared_both_private.rs:18:9
+   |
+LL | #![deny(exported_private_dependencies)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `Shared` from private dependency 'shared' in public interface
+  --> $DIR/shared_both_private.rs:28:1
+   |
+LL | pub fn leaks_priv_reexport() -> reexport::Shared {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156764 (tests: fix pub-priv-dep test expectation)
 - rust-lang/rust#156825 (compiletest: sort unexpected and unimportant errors)
 - rust-lang/rust#156878 (codegen: re-enable FileCheck for scalable-vector tuple intrinsics)
 - rust-lang/rust#156909 (Rewrite documentation that said to implement `Into`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156764,156825,156878,156909)
<!-- homu-ignore:end -->

