### PR TITLE
rustc_parse_format: improve the error diagnostic for `+` sign flag

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -491,6 +491,7 @@ impl<'input> Parser<'input> {
                 ('<' | '^' | '>', _) => self.suggest_format_align(c),
                 (',', _) => self.suggest_unsupported_python_numeric_grouping(),
                 ('=', '}') => self.suggest_rust_debug_printing_macro(),
+                ('+', _) => self.suggest_format_missing_colon_for_sign(),
                 _ => self.suggest_positional_arg_instead_of_captured_arg(arg),
             }
         }
@@ -934,6 +935,24 @@ impl<'input> Parser<'input> {
                     span: range,
                     secondary_label: None,
                     suggestion: Suggestion::None,
+                },
+            );
+        }
+    }
+
+    fn suggest_format_missing_colon_for_sign(&mut self) {
+        if let Some((range, _)) = self.consume_pos('+') {
+            let span = range.clone();
+            self.errors.insert(
+                0,
+                ParseError {
+                    description: "the `+` sign flag must appear after `:` in a format string"
+                        .to_owned(),
+                    note: Some("`+` comes after `:`, try `{:+}` instead of `{+}`".to_owned()),
+                    label: "expected `:` before `+` sign flag".to_owned(),
+                    span: range,
+                    secondary_label: None,
+                    suggestion: Suggestion::AddMissingColon(span),
                 },
             );
         }

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -942,7 +942,6 @@ impl<'input> Parser<'input> {
 
     fn suggest_format_missing_colon_for_sign(&mut self) {
         if let Some((range, _)) = self.consume_pos('+') {
-            let span = range.clone();
             self.errors.insert(
                 0,
                 ParseError {
@@ -952,7 +951,7 @@ impl<'input> Parser<'input> {
                     label: "expected `:` before `+` sign flag".to_owned(),
                     span: range,
                     secondary_label: None,
-                    suggestion: Suggestion::AddMissingColon(span),
+                    suggestion: Suggestion::None,
                 },
             );
         }

--- a/compiler/rustc_parse_format/src/tests.rs
+++ b/compiler/rustc_parse_format/src/tests.rs
@@ -553,7 +553,6 @@ fn asm_concat() {
     assert_eq!(parser.by_ref().collect::<Vec<Piece<'static>>>(), &[Lit(asm)]);
     assert_eq!(parser.line_spans, &[]);
 }
-
 #[test]
 fn diagnostic_format_flags() {
     let lit = "{thing:blah}";
@@ -594,4 +593,14 @@ fn diagnostic_format_mod() {
 
     assert_eq!(parser.line_spans, &[]);
     assert!(parser.errors.is_empty());
+}
+#[test]
+fn format_plus_sign_missing_colon_error() {
+    // `{+}` should produce an error suggesting `:` before `+`
+    let mut p = Parser::new("{+}", None, None, false, ParseMode::Format);
+    let _ = p.by_ref().collect::<Vec<Piece<'static>>>();
+    assert!(!p.errors.is_empty());
+    assert!(p.errors[0].description.contains("`+` sign flag must appear after `:`"));
+    assert!(p.errors[0].label.contains("expected `:` before `+` sign flag"));
+    assert_eq!(p.errors[0].span, 2..3);
 }

--- a/compiler/rustc_parse_format/src/tests.rs
+++ b/compiler/rustc_parse_format/src/tests.rs
@@ -553,6 +553,7 @@ fn asm_concat() {
     assert_eq!(parser.by_ref().collect::<Vec<Piece<'static>>>(), &[Lit(asm)]);
     assert_eq!(parser.line_spans, &[]);
 }
+
 #[test]
 fn diagnostic_format_flags() {
     let lit = "{thing:blah}";

--- a/tests/ui/fmt/format-string-wrong-order.rs
+++ b/tests/ui/fmt/format-string-wrong-order.rs
@@ -20,4 +20,8 @@ fn main() {
     //~^ ERROR invalid format string: expected alignment specifier after `:` in format string; example: `{:>?}`
     println!("{0:#X>18}", 12345);
     //~^ ERROR invalid format string: expected alignment specifier after `:` in format string; example: `{:>?}`
+    format!("{+:}");
+    //~^ ERROR invalid format string: the `+` sign flag must appear after `:` in a format string
+    format!("{bar+:}");
+    //~^ ERROR invalid format string: the `+` sign flag must appear after `:` in a format string
 }

--- a/tests/ui/fmt/format-string-wrong-order.stderr
+++ b/tests/ui/fmt/format-string-wrong-order.stderr
@@ -78,10 +78,7 @@ error: invalid format string: the `+` sign flag must appear after `:` in a forma
   --> $DIR/format-string-wrong-order.rs:23:15
    |
 LL |     format!("{+:}");
-   |               ^
-   |               |
-   |               expected `:` before `+` sign flag in format string
-   |               help: add a colon before the format specifier: `:?`
+   |               ^ expected `:` before `+` sign flag in format string
    |
    = note: `+` comes after `:`, try `{:+}` instead of `{+}`
 
@@ -89,10 +86,7 @@ error: invalid format string: the `+` sign flag must appear after `:` in a forma
   --> $DIR/format-string-wrong-order.rs:25:18
    |
 LL |     format!("{bar+:}");
-   |                  ^
-   |                  |
-   |                  expected `:` before `+` sign flag in format string
-   |                  help: add a colon before the format specifier: `:?`
+   |                  ^ expected `:` before `+` sign flag in format string
    |
    = note: `+` comes after `:`, try `{:+}` instead of `{+}`
 

--- a/tests/ui/fmt/format-string-wrong-order.stderr
+++ b/tests/ui/fmt/format-string-wrong-order.stderr
@@ -74,5 +74,27 @@ error: invalid format string: expected alignment specifier after `:` in format s
 LL |     println!("{0:#X>18}", 12345);
    |                    ^ expected `>` to occur after `:` in format string
 
-error: aborting due to 10 previous errors
+error: invalid format string: the `+` sign flag must appear after `:` in a format string
+  --> $DIR/format-string-wrong-order.rs:23:15
+   |
+LL |     format!("{+:}");
+   |               ^
+   |               |
+   |               expected `:` before `+` sign flag in format string
+   |               help: add a colon before the format specifier: `:?`
+   |
+   = note: `+` comes after `:`, try `{:+}` instead of `{+}`
+
+error: invalid format string: the `+` sign flag must appear after `:` in a format string
+  --> $DIR/format-string-wrong-order.rs:25:18
+   |
+LL |     format!("{bar+:}");
+   |                  ^
+   |                  |
+   |                  expected `:` before `+` sign flag in format string
+   |                  help: add a colon before the format specifier: `:?`
+   |
+   = note: `+` comes after `:`, try `{:+}` instead of `{+}`
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Added a new parser diagnostic in rustc_parse_format that detects when the `+` sign flag is used without a preceding colon in a format string (e.g., `{+}`) and provides a helpful error message and suggestion to use `{:+}` instead.

r? estebank