### PR TITLE
Add a check for impossible predicates to trivial_const

### DIFF
--- a/compiler/rustc_mir_transform/src/impossible_predicates.rs
+++ b/compiler/rustc_mir_transform/src/impossible_predicates.rs
@@ -36,7 +36,7 @@ use crate::pass_manager::MirPass;
 
 pub(crate) struct ImpossiblePredicates;
 
-fn has_impossible_predicates(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+pub(crate) fn has_impossible_predicates(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     let predicates = tcx.predicates_of(def_id).instantiate_identity(tcx);
     tracing::trace!(?predicates);
     let predicates =

--- a/compiler/rustc_mir_transform/src/trivial_const.rs
+++ b/compiler/rustc_mir_transform/src/trivial_const.rs
@@ -59,6 +59,14 @@ where
         return None;
     }
 
+    // If there are impossible predicates then MIR passes will replace the body with
+    // `unreachable` causing const eval errors when trying to evaluate the body. For
+    // now we avoid using trivial consts for such bodies so that the behaviour doesn't
+    // change.
+    if crate::impossible_predicates::has_impossible_predicates(tcx, def.into()) {
+        return None;
+    }
+
     if !tcx.opaque_types_defined_by(def).is_empty() {
         return None;
     }

--- a/tests/ui/traits/trivial-const-with-impossible-bounds.rs
+++ b/tests/ui/traits/trivial-const-with-impossible-bounds.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+
+struct Dummy;
+impl Dummy where for<'a> &'a mut i32: Copy {
+    const C: usize = 1; //~ ERROR entering unreachable code
+}
+
+fn foo() where for<'a> &'a mut i32: Copy {
+    if let Dummy::C = 1 {}
+}

--- a/tests/ui/traits/trivial-const-with-impossible-bounds.stderr
+++ b/tests/ui/traits/trivial-const-with-impossible-bounds.stderr
@@ -1,0 +1,9 @@
+error[E0080]: entering unreachable code
+  --> $DIR/trivial-const-with-impossible-bounds.rs:5:5
+   |
+LL |     const C: usize = 1;
+   |     ^^^^^^^^^^^^^^^^^^^ evaluation of `Dummy::C` failed here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156934)*
<!-- homu-ignore:end -->

The problem here is that trivial consts bypass the MIR pass which replaces bodies with `unreachable` when there are false global bounds.  see https://github.com/rust-lang/rust/issues/147721#issuecomment-4524510696.

This fixes the problem, but it is a bit hacky. But maybe all the handling of false global bounds is hacky?