### PR TITLE
Remove FIXME about impl PinCoerceUnsized for UnsafePinned<T>

### DIFF
--- a/library/core/src/pin/unsafe_pinned.rs
+++ b/library/core/src/pin/unsafe_pinned.rs
@@ -178,5 +178,3 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafePinned<U>> for UnsafePinned<T> 
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 // #[unstable(feature = "unsafe_pinned", issue = "125735")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<UnsafePinned<U>> for UnsafePinned<T> {}
-
-// FIXME(unsafe_pinned): impl PinCoerceUnsized for UnsafePinned<T>?


### PR DESCRIPTION
The `PinCoerceUnsized` trait may only be implemented for smart pointer types, but `UnsafePinned` has no indirection. Thus, it will not be correct to add this impl.

Follow-up to rust-lang/rust#137043

cc @Sky9x 
