### PR TITLE
Remove unneeded `#[skip_arg]` attributes

### DIFF
--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -274,11 +274,7 @@ pub(crate) enum IncorrectReprFormatGenericCause {
     Int {
         #[primary_span]
         span: Span,
-
-        #[skip_arg]
         name: Symbol,
-
-        #[skip_arg]
         value: u128,
     },
 
@@ -290,11 +286,7 @@ pub(crate) enum IncorrectReprFormatGenericCause {
     Symbol {
         #[primary_span]
         span: Span,
-
-        #[skip_arg]
         name: Symbol,
-
-        #[skip_arg]
         value: Symbol,
     },
 }

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -869,7 +869,6 @@ pub(crate) enum ExplicitLifetimeRequired<'a> {
             style = "verbose"
         )]
         new_ty_span: Span,
-        #[skip_arg]
         new_ty: Ty<'a>,
     },
     #[diag("explicit lifetime required in parameter type", code = E0621)]
@@ -885,7 +884,6 @@ pub(crate) enum ExplicitLifetimeRequired<'a> {
             style = "verbose"
         )]
         new_ty_span: Span,
-        #[skip_arg]
         new_ty: Ty<'a>,
     },
 }
@@ -1519,7 +1517,6 @@ pub(crate) enum FunctionPointerSuggestion<'a> {
     RemoveRef {
         #[primary_span]
         span: Span,
-        #[skip_arg]
         fn_name: String,
     },
     #[suggestion(
@@ -1531,9 +1528,7 @@ pub(crate) enum FunctionPointerSuggestion<'a> {
     CastRef {
         #[primary_span]
         span: Span,
-        #[skip_arg]
         fn_name: String,
-        #[skip_arg]
         sig: Binder<'a, FnSig<'a>>,
     },
     #[suggestion(
@@ -1545,7 +1540,6 @@ pub(crate) enum FunctionPointerSuggestion<'a> {
     Cast {
         #[primary_span]
         span: Span,
-        #[skip_arg]
         sig: Binder<'a, FnSig<'a>>,
     },
     #[suggestion(
@@ -1557,7 +1551,6 @@ pub(crate) enum FunctionPointerSuggestion<'a> {
     CastBoth {
         #[primary_span]
         span: Span,
-        #[skip_arg]
         found_sig: Binder<'a, FnSig<'a>>,
         expected_sig: Binder<'a, FnSig<'a>>,
     },
@@ -1570,9 +1563,7 @@ pub(crate) enum FunctionPointerSuggestion<'a> {
     CastBothRef {
         #[primary_span]
         span: Span,
-        #[skip_arg]
         fn_name: String,
-        #[skip_arg]
         found_sig: Binder<'a, FnSig<'a>>,
         expected_sig: Binder<'a, FnSig<'a>>,
     },


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156942)*
<!-- homu-ignore:end -->

@mejrs talked with me about the `Diagnostic` rework that happened recently and suggested that the `skip_arg` might be unneeded. This PR removes all of them, except one. I'll run a perf check to see if it's actually worth keeping around or if we can just remove this attribute altogether (or eventually do the same thing in the proc-macro directly).

cc @JonathanBrouwer 

r? ghost