### PR TITLE
add help when constructing ADTs with private fields

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2638,6 +2638,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         field_name,
                         Applicability::MaybeIncorrect,
                     );
+                } else if self.has_inaccessible_fields(variant, expr) {
+                    err.span_help(
+                        expr.span,
+                        format!(
+                            "initializer expressions cannot construct structs with private fields"
+                        ),
+                    );
                 } else {
                     match ty.kind() {
                         ty::Adt(adt, ..) => {
@@ -2667,6 +2674,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
         err.emit()
+    }
+
+    fn has_inaccessible_fields(&self, variant: &'tcx ty::VariantDef, expr: &hir::Expr<'_>) -> bool {
+        variant.fields.iter().any(|field| {
+            !field.vis.is_accessible_from(self.tcx.parent_module(expr.hir_id), self.tcx)
+        })
     }
 
     fn available_field_names(

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -22,6 +22,8 @@ pub(crate) struct FieldIsPrivate {
     #[subdiagnostic]
     pub labels: Vec<FieldIsPrivateLabel>,
     pub len: usize,
+    #[help("initializer expressions cannot construct {$variant_descr}s with private fields")]
+    pub expr_span: Option<Span>,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -955,6 +955,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
         def: ty::AdtDef<'tcx>, // definition of the struct or enum
         update_syntax: Option<Span>,
         struct_span: Span,
+        expr: Option<&'tcx hir::Expr<'_>>,
     ) {
         if def.is_enum() || fields.is_empty() {
             return;
@@ -1009,6 +1010,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
             def_path_str: self.tcx.def_path_str(def.did()),
             labels,
             len: fields.len(),
+            expr_span: expr.map(|e| e.span),
         });
     }
 
@@ -1018,6 +1020,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
         variant: &'tcx ty::VariantDef,
         fields: &[hir::ExprField<'tcx>],
         hir_id: hir::HirId,
+        expr: &'tcx hir::Expr<'_>,
         span: Span,
         struct_span: Span,
     ) {
@@ -1037,7 +1040,7 @@ impl<'tcx> NamePrivacyVisitor<'tcx> {
                 failed_fields.push((name, span, field.is_some()));
             }
         }
-        self.emit_unreachable_field_error(failed_fields, adt, Some(span), struct_span);
+        self.emit_unreachable_field_error(failed_fields, adt, Some(span), struct_span, Some(expr));
     }
 }
 
@@ -1068,6 +1071,7 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
                         variant,
                         fields,
                         base.hir_id,
+                        expr,
                         base.span,
                         qpath.span(),
                     );
@@ -1078,6 +1082,7 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
                         variant,
                         fields,
                         expr.hir_id,
+                        expr,
                         span,
                         qpath.span(),
                     );
@@ -1091,7 +1096,13 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
                             failed_fields.push((field.ident.name, field.ident.span, true));
                         }
                     }
-                    self.emit_unreachable_field_error(failed_fields, adt, None, qpath.span());
+                    self.emit_unreachable_field_error(
+                        failed_fields,
+                        adt,
+                        None,
+                        qpath.span(),
+                        Some(expr),
+                    );
                 }
             }
         }
@@ -1112,7 +1123,7 @@ impl<'tcx> Visitor<'tcx> for NamePrivacyVisitor<'tcx> {
                     failed_fields.push((field.ident.name, field.ident.span, true));
                 }
             }
-            self.emit_unreachable_field_error(failed_fields, adt, None, qpath.span());
+            self.emit_unreachable_field_error(failed_fields, adt, None, qpath.span(), None);
         }
 
         intravisit::walk_pat(self, pat);

--- a/tests/ui/deprecation/deprecation-lint.stderr
+++ b/tests/ui/deprecation/deprecation-lint.stderr
@@ -744,6 +744,17 @@ LL |         let _ = nested::DeprecatedStruct {
 LL |
 LL |             i: 0
    |             ^ private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/deprecation-lint.rs:278:17
+   |
+LL |           let _ = nested::DeprecatedStruct {
+   |  _________________^
+LL | |
+LL | |             i: 0
+LL | |
+LL | |         };
+   | |_________^
 
 error: aborting due to 123 previous errors
 

--- a/tests/ui/error-codes/E0451.stderr
+++ b/tests/ui/error-codes/E0451.stderr
@@ -9,6 +9,12 @@ error[E0451]: field `b` of struct `Foo` is private
    |
 LL |     let f = bar::Foo{ a: 0, b: 0 };
    |                             ^ private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/E0451.rs:18:13
+   |
+LL |     let f = bar::Foo{ a: 0, b: 0 };
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/functional-struct-update/functional-struct-update-respects-privacy.stderr
+++ b/tests/ui/functional-struct-update/functional-struct-update-respects-privacy.stderr
@@ -3,6 +3,12 @@ error[E0451]: field `secret_uid` of struct `S` is private
    |
 LL |     let s_2 = foo::S { b: format!("ess two"), ..s_1 }; // FRU ...
    |                                                 ^^^ field `secret_uid` is private
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/functional-struct-update-respects-privacy.rs:32:15
+   |
+LL |     let s_2 = foo::S { b: format!("ess two"), ..s_1 }; // FRU ...
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/private-struct-field-ctor.stderr
+++ b/tests/ui/privacy/private-struct-field-ctor.stderr
@@ -3,6 +3,12 @@ error[E0451]: field `x` of struct `Foo` is private
    |
 LL |     let s = a::Foo { x: 1 };
    |                      ^ private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/private-struct-field-ctor.rs:8:13
+   |
+LL |     let s = a::Foo { x: 1 };
+   |             ^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/restricted/struct-literal-field.stderr
+++ b/tests/ui/privacy/restricted/struct-literal-field.stderr
@@ -3,6 +3,12 @@ error[E0451]: field `x` of struct `S` is private
    |
 LL |     S { x: 0 };
    |         ^ private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/struct-literal-field.rs:19:5
+   |
+LL |     S { x: 0 };
+   |     ^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/union-field-privacy-1.stderr
+++ b/tests/ui/privacy/union-field-privacy-1.stderr
@@ -3,6 +3,12 @@ error[E0451]: field `c` of union `U` is private
    |
 LL |     let u = m::U { c: 0 };
    |                    ^ private field
+   |
+help: initializer expressions cannot construct unions with private fields
+  --> $DIR/union-field-privacy-1.rs:12:13
+   |
+LL |     let u = m::U { c: 0 };
+   |             ^^^^^^^^^^^^^
 
 error[E0451]: field `c` of union `U` is private
   --> $DIR/union-field-privacy-1.rs:16:16

--- a/tests/ui/structs/default-field-values/visibility.stderr
+++ b/tests/ui/structs/default-field-values/visibility.stderr
@@ -5,6 +5,15 @@ LL |     let _a = baz::S {
    |              ------ in this type
 LL |         ..
    |         ^^ field `x` is private
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:36:14
+   |
+LL |       let _a = baz::S {
+   |  ______________^
+LL | |         ..
+LL | |     };
+   | |_____^
 
 error[E0451]: field `x` of struct `S` is private
   --> $DIR/visibility.rs:40:9
@@ -13,12 +22,27 @@ LL |     let _b = baz::S {
    |              ------ in this type
 LL |         x: 0,
    |         ^ private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:39:14
+   |
+LL |       let _b = baz::S {
+   |  ______________^
+LL | |         x: 0,
+LL | |     };
+   | |_____^
 
 error[E0451]: fields `beta` and `gamma` of struct `Alpha` are private
   --> $DIR/visibility.rs:13:26
    |
 LL |         let _x = Alpha { .. };
    |                          ^^ fields `beta` and `gamma` are private
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:13:18
+   |
+LL |         let _x = Alpha { .. };
+   |                  ^^^^^^^^^^^^
 
 error[E0451]: fields `beta` and `gamma` of struct `Alpha` are private
   --> $DIR/visibility.rs:16:13
@@ -29,6 +53,16 @@ LL |             beta: 0,
    |             ^^^^ private field
 LL |             gamma: false,
    |             ^^^^^ private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:15:18
+   |
+LL |           let _x = Alpha {
+   |  __________________^
+LL | |             beta: 0,
+LL | |             gamma: false,
+LL | |         };
+   | |_________^
 
 error[E0451]: fields `beta` and `gamma` of struct `Alpha` are private
   --> $DIR/visibility.rs:20:13
@@ -39,6 +73,16 @@ LL |             beta: 0,
    |             ^^^^^^^ private field
 LL |             ..
    |             ^^ field `gamma` is private
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:19:18
+   |
+LL |           let _x = Alpha {
+   |  __________________^
+LL | |             beta: 0,
+LL | |             ..
+LL | |         };
+   | |_________^
 
 error[E0451]: fields `beta` and `gamma` of struct `Alpha` are private
   --> $DIR/visibility.rs:23:26
@@ -47,6 +91,12 @@ LL |         let _x = Alpha { beta: 0, .. };
    |                          ^^^^^^^  ^^ field `gamma` is private
    |                          |
    |                          private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:23:18
+   |
+LL |         let _x = Alpha { beta: 0, .. };
+   |                  ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0451]: fields `beta` and `gamma` of struct `Alpha` are private
   --> $DIR/visibility.rs:25:26
@@ -55,6 +105,12 @@ LL |         let _x = Alpha { beta: 0, ..Default::default() };
    |                          ^^^^^^^    ^^^^^^^^^^^^^^^^^^ field `gamma` is private
    |                          |
    |                          private field
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/visibility.rs:25:18
+   |
+LL |         let _x = Alpha { beta: 0, ..Default::default() };
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/structs/suggest-private-fields.stderr
+++ b/tests/ui/structs/suggest-private-fields.stderr
@@ -14,9 +14,19 @@ error[E0560]: struct `B` has no field named `bb`
   --> $DIR/suggest-private-fields.rs:17:9
    |
 LL |         bb: 20,
-   |         ^^ `B` does not have this field
+   |         ^^
    |
-   = note: available fields are: `a`
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/suggest-private-fields.rs:14:13
+   |
+LL |       let k = B {
+   |  _____________^
+LL | |         aa: 20,
+LL | |
+LL | |         bb: 20,
+LL | |
+LL | |     };
+   | |_____^
 
 error[E0560]: struct `A` has no field named `aa`
   --> $DIR/suggest-private-fields.rs:22:9

--- a/tests/ui/suggestions/struct-initializer-private.rs
+++ b/tests/ui/suggestions/struct-initializer-private.rs
@@ -1,0 +1,12 @@
+mod foo {
+    pub struct Foo {
+        bar: i32,
+        baz: i32,
+    }
+}
+
+use foo::*;
+
+fn main() {
+    let _f = Foo { bar: 0, quux: 0 }; //~ ERROR no field named `quux`
+}

--- a/tests/ui/suggestions/struct-initializer-private.stderr
+++ b/tests/ui/suggestions/struct-initializer-private.stderr
@@ -1,0 +1,15 @@
+error[E0560]: struct `foo::Foo` has no field named `quux`
+  --> $DIR/struct-initializer-private.rs:11:28
+   |
+LL |     let _f = Foo { bar: 0, quux: 0 };
+   |                            ^^^^
+   |
+help: initializer expressions cannot construct structs with private fields
+  --> $DIR/struct-initializer-private.rs:11:14
+   |
+LL |     let _f = Foo { bar: 0, quux: 0 };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0560`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#153259.

I'm a little unsure about the wording. I don't want to imply that private fields can *never* be used in initializer expressions, since private fields are fine if the fields are in the same module. The existing error message uses the term "private", though, so I went for consistency.

I also wonder if it would be useful to include a note about `fn new` being a common idiom to construct private structs, or even suggesting it if it exists.