### PR TITLE
delegation: emit error when there is an infer lifetime in user-specified args

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -46,7 +46,7 @@ use rustc_trait_selection::traits::{
 };
 use tracing::{debug, instrument};
 
-use crate::errors;
+use crate::errors::{self, ElidedLifetimesAreNotAllowedInDelegations};
 use crate::hir_ty_lowering::{HirTyLowerer, InherentAssocCandidate, RegionInferReason};
 
 pub(crate) mod dump;
@@ -131,6 +131,7 @@ pub(crate) struct ItemCtxt<'tcx> {
     tcx: TyCtxt<'tcx>,
     item_def_id: LocalDefId,
     tainted_by_errors: Cell<Option<ErrorGuaranteed>>,
+    lowering_delegation_segment: bool,
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -241,7 +242,24 @@ fn bad_placeholder<'cx, 'tcx>(
 
 impl<'tcx> ItemCtxt<'tcx> {
     pub(crate) fn new(tcx: TyCtxt<'tcx>, item_def_id: LocalDefId) -> ItemCtxt<'tcx> {
-        ItemCtxt { tcx, item_def_id, tainted_by_errors: Cell::new(None) }
+        ItemCtxt::new_internal(tcx, item_def_id, false)
+    }
+
+    fn new_internal(
+        tcx: TyCtxt<'tcx>,
+        item_def_id: LocalDefId,
+        delegation: bool,
+    ) -> ItemCtxt<'tcx> {
+        ItemCtxt {
+            tcx,
+            item_def_id,
+            tainted_by_errors: Cell::new(None),
+            lowering_delegation_segment: delegation,
+        }
+    }
+
+    pub(crate) fn new_for_delegation(tcx: TyCtxt<'tcx>, item_def_id: LocalDefId) -> ItemCtxt<'tcx> {
+        ItemCtxt::new_internal(tcx, item_def_id, true)
     }
 
     pub(crate) fn lower_ty(&self, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
@@ -335,8 +353,15 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                 .emit();
             ty::Region::new_error(self.tcx(), guar)
         } else {
+            // If we found elided lifetime during lowering of delegation parent or child
+            // segment then emit an error, as we need a named lifetime for proper signature
+            // inheritance (#156848).
+            if self.lowering_delegation_segment {
+                self.tcx.dcx().emit_err(ElidedLifetimesAreNotAllowedInDelegations { span });
+            }
+
             // This indicates an illegal lifetime in a non-assoc-trait position
-            ty::Region::new_error_with_message(self.tcx(), span, "unelided lifetime in signature")
+            ty::Region::new_error_with_message(self.tcx(), span, "inferred lifetime in signature")
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -7,7 +7,7 @@ use std::debug_assert_matches;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::{DelegationInfo, HirId, PathSegment};
+use rustc_hir::{DelegationInfo, PathSegment};
 use rustc_middle::ty::{
     self, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
@@ -551,7 +551,7 @@ pub(crate) fn inherit_predicates_for_delegation_item<'tcx>(
         }
     }
 
-    let (parent_args, child_args) = get_delegation_user_specified_args(tcx, def_id);
+    let (parent_args, child_args) = tcx.delegation_user_specified_args(def_id);
     let (folder, args) = create_folder_and_args(tcx, def_id, sig_id, parent_args, child_args);
     let self_pos_kind = create_self_position_kind(tcx, def_id, sig_id);
     let filter_self_preds = matches!(self_pos_kind, SelfPositionKind::AfterLifetimes(true));
@@ -627,7 +627,7 @@ pub(crate) fn inherit_sig_for_delegation_item<'tcx>(
         return tcx.arena.alloc_from_iter((0..sig_len).map(|_| err_type));
     }
 
-    let (parent_args, child_args) = get_delegation_user_specified_args(tcx, def_id);
+    let (parent_args, child_args) = tcx.delegation_user_specified_args(def_id);
     let (mut folder, args) = create_folder_and_args(tcx, def_id, sig_id, parent_args, child_args);
     let caller_sig = EarlyBinder::bind(caller_sig.skip_binder().fold_with(&mut folder));
 
@@ -640,18 +640,18 @@ pub(crate) fn inherit_sig_for_delegation_item<'tcx>(
 // they will be used during delegation signature and predicates inheritance.
 // Example: reuse Trait::<'static, i32, 1>::foo::<A, B>
 // we want to extract [Self, 'static, i32, 1] for parent and [A, B] for child.
-fn get_delegation_user_specified_args<'tcx>(
+pub(crate) fn delegation_user_specified_args<'tcx>(
     tcx: TyCtxt<'tcx>,
     delegation_id: LocalDefId,
 ) -> (&'tcx [ty::GenericArg<'tcx>], &'tcx [ty::GenericArg<'tcx>]) {
     let info = get_delegation_info(tcx, delegation_id);
 
-    let get_segment = |hir_id: HirId| -> Option<(&'tcx PathSegment<'tcx>, DefId)> {
+    let get_segment = |hir_id| -> Option<(&'tcx PathSegment<'tcx>, DefId)> {
         let segment = tcx.hir_node(hir_id).expect_path_segment();
         segment.res.opt_def_id().map(|def_id| (segment, def_id))
     };
 
-    let ctx = ItemCtxt::new(tcx, delegation_id);
+    let ctx = ItemCtxt::new_for_delegation(tcx, delegation_id);
     let lowerer = ctx.lowerer();
 
     let parent_args = info.parent_args_segment_id.and_then(get_segment).map(|(segment, def_id)| {

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1681,6 +1681,13 @@ pub(crate) struct DelegationSelfTypeNotSpecified {
 }
 
 #[derive(Diagnostic)]
+#[diag("inferred lifetimes are not allowed in delegations as we need to inherit signature")]
+pub(crate) struct ElidedLifetimesAreNotAllowedInDelegations {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("method should be `async` or return a future, but it is synchronous")]
 pub(crate) struct MethodShouldReturnFuture {
     #[primary_span]

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -137,6 +137,7 @@ pub fn provide(providers: &mut Providers) {
         inferred_outlives_crate: outlives::inferred_outlives_crate,
         inferred_outlives_of: outlives::inferred_outlives_of,
         inherit_sig_for_delegation_item: delegation::inherit_sig_for_delegation_item,
+        delegation_user_specified_args: delegation::delegation_user_specified_args,
         enforce_impl_non_lifetime_params_are_constrained:
             impl_wf_check::enforce_impl_non_lifetime_params_are_constrained,
         crate_variances: variance::crate_variances,

--- a/compiler/rustc_middle/src/queries.rs
+++ b/compiler/rustc_middle/src/queries.rs
@@ -2065,6 +2065,10 @@ rustc_queries! {
         desc { "inheriting delegation signature" }
     }
 
+    query delegation_user_specified_args(def_id: LocalDefId) -> (&'tcx [GenericArg<'tcx>], &'tcx [GenericArg<'tcx>]) {
+        desc { "getting delegation user-specified args" }
+    }
+
     /// Does lifetime resolution on items. Importantly, we can't resolve
     /// lifetimes directly on things like trait methods, because of trait params.
     /// See `rustc_resolve::late::lifetimes` for details.

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -147,6 +147,10 @@ impl<T0, T1> Erasable for (&'_ T0, &'_ T1) {
     type Storage = [u8; size_of::<(&'_ (), &'_ ())>()];
 }
 
+impl<T0, T1> Erasable for (&'_ [T0], &'_ [T1]) {
+    type Storage = [u8; size_of::<(&'_ [()], &'_ [()])>()];
+}
+
 macro_rules! impl_erasable_for_types_with_no_type_params {
     ($($ty:ty),+ $(,)?) => {
         $(

--- a/tests/ui/delegation/generics/generics-gen-args-errors.rs
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.rs
@@ -36,6 +36,7 @@ mod test_1 {
         //~| ERROR can't use generic parameters from outer item
         //~| ERROR: unresolved item provided when a constant was expected
         //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+        //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
     }
 }
 
@@ -44,36 +45,45 @@ mod test_2 {
 
     reuse foo::<> as bar1;
     //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse foo::<String, String> as bar2;
     //~^ ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
     //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
     //~^ ERROR: use of undeclared lifetime name `'asdasd`
     //~| ERROR: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
     //~| ERROR: function takes 3 generic arguments but 2 generic arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+
     reuse foo::<String, 'static, 123, asdasd> as bar4;
     //~^ ERROR: cannot find type `asdasd` in this scope
     //~| ERROR: function takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse foo::<1, 2, _, 4, 5, _> as bar5;
     //~^ ERROR: function takes 3 generic arguments but 6 generic arguments were supplied
     //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
     //~^ ERROR: cannot find type `asd` in this scope
     //~| ERROR: function takes 3 generic arguments but 5 generic arguments were supplied
     //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
     //~^ ERROR: use of undeclared lifetime name `'a`
     //~| ERROR: cannot find type `asd` in this scope
     //~| ERROR: constant provided when a type was expected
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse foo::<{}, {}, {}> as bar8;
     //~^ ERROR: constant provided when a type was expected
     //~| ERROR: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 }
 
 mod test_3 {
@@ -90,21 +100,26 @@ mod test_3 {
     //~| ERROR: cannot find type `asdasa` in this scope
     //~| ERROR: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
     //~| ERROR: trait takes 2 generic arguments but 6 generic arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse Trait::<'static, 'static>::foo as bar2;
     //~^ ERROR: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
     //~| ERROR: the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
     //~^ ERROR: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
     //~| ERROR: trait takes 2 generic arguments but 5 generic arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse Trait::<1, 2, true>::foo as bar4;
     //~^ ERROR: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
     //~| ERROR: trait takes 2 generic arguments but 3 generic arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse Trait::<'static>::foo as bar5;
     //~^ ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR: the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
     //~^ ERROR: cannot find type `DDDD` in this scope [E0425]
@@ -112,12 +127,16 @@ mod test_3 {
     //~| ERROR: trait takes 2 generic arguments but 3 generic arguments were supplied
     //~| ERROR: method takes 2 generic arguments but 6 generic arguments were supplied
     //~| ERROR: method takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 
     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
     //~^ ERROR: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR: trait takes 2 generic arguments but 5 generic arguments were supplied
     //~| ERROR: method takes 2 generic arguments but 5 generic arguments were supplied
     //~| ERROR: method takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 }
 
 fn main() {}

--- a/tests/ui/delegation/generics/generics-gen-args-errors.stderr
+++ b/tests/ui/delegation/generics/generics-gen-args-errors.stderr
@@ -38,7 +38,7 @@ LL |         reuse foo::<A, B, C> as xd;
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0261]: use of undeclared lifetime name `'asdasd`
-  --> $DIR/generics-gen-args-errors.rs:52:29
+  --> $DIR/generics-gen-args-errors.rs:55:29
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |                             ^^^^^^^ undeclared lifetime
@@ -49,7 +49,7 @@ LL |     reuse foo'asdasd, ::<'static, _, 'asdasd, 'static, 'static, 'static, _>
    |              ++++++++
 
 error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/generics-gen-args-errors.rs:69:50
+  --> $DIR/generics-gen-args-errors.rs:77:50
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                                                  ^^ undeclared lifetime
@@ -103,61 +103,61 @@ LL |     fn check<A, B, C, asd>() {
    |                     +++++
 
 error[E0425]: cannot find type `asdasd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:56:39
+  --> $DIR/generics-gen-args-errors.rs:61:39
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |                                       ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:64:22
+  --> $DIR/generics-gen-args-errors.rs:71:22
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |                      ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:69:27
+  --> $DIR/generics-gen-args-errors.rs:77:27
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                           ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:84:19
+  --> $DIR/generics-gen-args-errors.rs:94:19
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                   ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:84:24
+  --> $DIR/generics-gen-args-errors.rs:94:24
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                        ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:84:29
+  --> $DIR/generics-gen-args-errors.rs:94:29
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                             ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:84:34
+  --> $DIR/generics-gen-args-errors.rs:94:34
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                  ^^^ not found in this scope
 
 error[E0425]: cannot find type `asd` in this scope
-  --> $DIR/generics-gen-args-errors.rs:84:39
+  --> $DIR/generics-gen-args-errors.rs:94:39
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                       ^^^ not found in this scope
 
 error[E0425]: cannot find type `asdasa` in this scope
-  --> $DIR/generics-gen-args-errors.rs:84:44
+  --> $DIR/generics-gen-args-errors.rs:94:44
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |                                            ^^^^^^ not found in this scope
 
 error[E0425]: cannot find type `DDDD` in this scope
-  --> $DIR/generics-gen-args-errors.rs:109:34
+  --> $DIR/generics-gen-args-errors.rs:124:34
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                  ^^^^ not found in this scope
@@ -178,20 +178,32 @@ help: add missing lifetime arguments
 LL |         reuse foo::<'a, 'b, A, B, C> as xd;
    |                     +++++++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:33:15
+   |
+LL |         reuse foo::<A, B, C> as xd;
+   |               ^^^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:46:11
+   |
+LL |     reuse foo::<> as bar1;
+   |           ^^^
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:45:11
+  --> $DIR/generics-gen-args-errors.rs:46:11
    |
 LL |     reuse foo::<> as bar1;
    |           ^^^ not allowed in type signatures
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:48:11
+  --> $DIR/generics-gen-args-errors.rs:50:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -201,7 +213,7 @@ LL |     reuse foo::<'a, 'b, String, String> as bar2;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:48:11
+  --> $DIR/generics-gen-args-errors.rs:50:11
    |
 LL |     reuse foo::<String, String> as bar2;
    |           ^^^   ------  ------ supplied 2 generic arguments
@@ -209,7 +221,7 @@ LL |     reuse foo::<String, String> as bar2;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
@@ -218,8 +230,14 @@ help: add missing generic argument
 LL |     reuse foo::<String, String, N> as bar2;
    |                               +++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:50:11
+   |
+LL |     reuse foo::<String, String> as bar2;
+   |           ^^^
+
 error[E0107]: function takes 2 lifetime arguments but 5 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:52:11
+  --> $DIR/generics-gen-args-errors.rs:55:11
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           ^^^                      --------------------------- help: remove the lifetime arguments
@@ -227,19 +245,19 @@ LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
 
 error[E0107]: function takes 3 generic arguments but 2 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:52:11
+  --> $DIR/generics-gen-args-errors.rs:55:11
    |
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
    |           ^^^ expected 3 generic arguments             -------  - supplied 2 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
@@ -248,8 +266,14 @@ help: add missing generic argument
 LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _, N> as bar3;
    |                                                                  +++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:55:11
+   |
+LL |     reuse foo::<'static, _, 'asdasd, 'static, 'static, 'static, _> as bar3;
+   |           ^^^
+
 error[E0107]: function takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:56:11
+  --> $DIR/generics-gen-args-errors.rs:61:11
    |
 LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           ^^^   ------ supplied 1 lifetime argument
@@ -257,7 +281,7 @@ LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
    |           expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -266,14 +290,20 @@ help: add missing lifetime argument
 LL |     reuse foo::<String, 'static, 'static, 123, asdasd> as bar4;
    |                       +++++++++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:61:11
+   |
+LL |     reuse foo::<String, 'static, 123, asdasd> as bar4;
+   |           ^^^
+
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:60:11
+  --> $DIR/generics-gen-args-errors.rs:66:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -283,7 +313,7 @@ LL |     reuse foo::<'a, 'b, 1, 2, _, 4, 5, _> as bar5;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:60:11
+  --> $DIR/generics-gen-args-errors.rs:66:11
    |
 LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           ^^^          --------- help: remove the unnecessary generic arguments
@@ -291,19 +321,25 @@ LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:66:11
+   |
+LL |     reuse foo::<1, 2, _, 4, 5, _> as bar5;
+   |           ^^^
+
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:64:11
+  --> $DIR/generics-gen-args-errors.rs:71:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -313,7 +349,7 @@ LL |     reuse foo::<'a, 'b, 1, 2,asd,String, { let x = 0; }> as bar6;
    |                 +++++++
 
 error[E0107]: function takes 3 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:64:11
+  --> $DIR/generics-gen-args-errors.rs:71:11
    |
 LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           ^^^           ----------------------- help: remove the unnecessary generic arguments
@@ -321,25 +357,37 @@ LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
    |           expected 3 generic arguments
    |
 note: function defined here, with 3 generic parameters: `T`, `U`, `N`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^                 -         -         --------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:71:11
+   |
+LL |     reuse foo::<1, 2,asd,String, { let x = 0; }> as bar6;
+   |           ^^^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:77:11
+   |
+LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
+   |           ^^^
+
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:69:17
+  --> $DIR/generics-gen-args-errors.rs:77:17
    |
 LL |     reuse foo::<"asdasd", asd, "askdn", 'static, 'a> as bar7;
    |                 ^^^^^^^^
 
 error[E0107]: function takes 2 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:74:11
+  --> $DIR/generics-gen-args-errors.rs:83:11
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |           ^^^ expected 2 lifetime arguments
    |
 note: function defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/generics-gen-args-errors.rs:43:8
+  --> $DIR/generics-gen-args-errors.rs:44:8
    |
 LL |     fn foo<'a: 'a, 'b: 'b, T: Clone, U: Clone, const N: usize>() {}
    |        ^^^ --      --
@@ -348,14 +396,20 @@ help: add missing lifetime arguments
 LL |     reuse foo::<'a, 'b, {}, {}, {}> as bar8;
    |                 +++++++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:83:11
+   |
+LL |     reuse foo::<{}, {}, {}> as bar8;
+   |           ^^^
+
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:84:11
+  --> $DIR/generics-gen-args-errors.rs:94:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -365,7 +419,7 @@ LL |     reuse Trait::<'b, 'c, 'a, asd, asd, asd, asd, asd, asdasa>::foo as bar1
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:84:11
+  --> $DIR/generics-gen-args-errors.rs:94:11
    |
 LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           ^^^^^           ----------------------- help: remove the unnecessary generic arguments
@@ -373,13 +427,19 @@ LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
-error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
   --> $DIR/generics-gen-args-errors.rs:94:11
+   |
+LL |     reuse Trait::<asd, asd, asd, asd, asd, asdasa>::foo as bar1;
+   |           ^^^^^
+
+error[E0107]: trait takes 3 lifetime arguments but 2 lifetime arguments were supplied
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^   -------  ------- supplied 2 lifetime arguments
@@ -387,7 +447,7 @@ LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -396,20 +456,26 @@ help: add missing lifetime argument
 LL |     reuse Trait::<'static, 'static, 'static>::foo as bar2;
    |                                   +++++++++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:105:11
+   |
+LL |     reuse Trait::<'static, 'static>::foo as bar2;
+   |           ^^^^^
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:94:11
+  --> $DIR/generics-gen-args-errors.rs:105:11
    |
 LL |     reuse Trait::<'static, 'static>::foo as bar2;
    |           ^^^^^ not allowed in type signatures
 
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:97:11
+  --> $DIR/generics-gen-args-errors.rs:109:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -419,7 +485,7 @@ LL |     reuse Trait::<'b, 'c, 'a, 1, 2, 3, 4, 5>::foo as bar3;
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:97:11
+  --> $DIR/generics-gen-args-errors.rs:109:11
    |
 LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           ^^^^^       --------- help: remove the unnecessary generic arguments
@@ -427,19 +493,25 @@ LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:109:11
+   |
+LL |     reuse Trait::<1, 2, 3, 4, 5>::foo as bar3;
+   |           ^^^^^
+
 error[E0107]: trait takes 3 lifetime arguments but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:101:11
+  --> $DIR/generics-gen-args-errors.rs:114:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^ expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -449,7 +521,7 @@ LL |     reuse Trait::<'b, 'c, 'a, 1, 2, true>::foo as bar4;
    |                   +++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:101:11
+  --> $DIR/generics-gen-args-errors.rs:114:11
    |
 LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           ^^^^^       ------ help: remove the unnecessary generic argument
@@ -457,13 +529,19 @@ LL |     reuse Trait::<1, 2, true>::foo as bar4;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:114:11
+   |
+LL |     reuse Trait::<1, 2, true>::foo as bar4;
+   |           ^^^^^
+
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:105:11
+  --> $DIR/generics-gen-args-errors.rs:119:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^   ------- supplied 1 lifetime argument
@@ -471,7 +549,7 @@ LL |     reuse Trait::<'static>::foo as bar5;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -480,14 +558,20 @@ help: add missing lifetime arguments
 LL |     reuse Trait::<'static, 'static, 'static>::foo as bar5;
    |                          ++++++++++++++++++
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:119:11
+   |
+LL |     reuse Trait::<'static>::foo as bar5;
+   |           ^^^^^
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
-  --> $DIR/generics-gen-args-errors.rs:105:11
+  --> $DIR/generics-gen-args-errors.rs:119:11
    |
 LL |     reuse Trait::<'static>::foo as bar5;
    |           ^^^^^ not allowed in type signatures
 
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:109:11
+  --> $DIR/generics-gen-args-errors.rs:124:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^   - supplied 1 lifetime argument
@@ -495,7 +579,7 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -505,7 +589,7 @@ LL |     reuse Trait::<1, 'static, 'static, 2, 'static, DDDD>::foo::<1, 2, 3, 4,
    |                    ++++++++++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:109:11
+  --> $DIR/generics-gen-args-errors.rs:124:11
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           ^^^^^       --------------- help: remove the unnecessary generic argument
@@ -513,19 +597,25 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:124:11
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |           ^^^^^
+
 error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:109:41
+  --> $DIR/generics-gen-args-errors.rs:124:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^ expected 1 lifetime argument
    |
 note: method defined here, with 1 lifetime parameter: `'d`
-  --> $DIR/generics-gen-args-errors.rs:81:12
+  --> $DIR/generics-gen-args-errors.rs:91:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^ --
@@ -535,7 +625,7 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<'d, 1, 2, 3, 4, 5, 6> as bar6
    |                                               +++
 
 error[E0107]: method takes 2 generic arguments but 6 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:109:41
+  --> $DIR/generics-gen-args-errors.rs:124:41
    |
 LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         ^^^       ------------ help: remove the unnecessary generic arguments
@@ -543,13 +633,19 @@ LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
    |                                         expected 2 generic arguments
    |
 note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:81:12
+  --> $DIR/generics-gen-args-errors.rs:91:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^         -  -------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:124:41
+   |
+LL |     reuse Trait::<1, 2, 'static, DDDD>::foo::<1, 2, 3, 4, 5, 6> as bar6;
+   |                                         ^^^
+
 error[E0107]: trait takes 3 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/generics-gen-args-errors.rs:116:11
+  --> $DIR/generics-gen-args-errors.rs:133:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^   ----- supplied 1 lifetime argument
@@ -557,7 +653,7 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |           expected 3 lifetime arguments
    |
 note: trait defined here, with 3 lifetime parameters: `'b`, `'c`, `'a`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^ --  --  --
@@ -567,7 +663,7 @@ LL |     reuse Trait::<Trait, 'static, 'static, Clone, _, 'static, dyn Send, _>:
    |                        ++++++++++++++++++
 
 error[E0107]: trait takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:116:11
+  --> $DIR/generics-gen-args-errors.rs:133:11
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |           ^^^^^               --- help: remove the unnecessary generic argument
@@ -575,19 +671,25 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |           expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `T`, `N`
-  --> $DIR/generics-gen-args-errors.rs:80:11
+  --> $DIR/generics-gen-args-errors.rs:90:11
    |
 LL |     trait Trait<'b, 'c, 'a, T, const N: usize>: Sized {
    |           ^^^^^             -  --------------
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:133:11
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |           ^^^^^
+
 error[E0107]: method takes 1 lifetime argument but 0 lifetime arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:116:59
+  --> $DIR/generics-gen-args-errors.rs:133:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^ expected 1 lifetime argument
    |
 note: method defined here, with 1 lifetime parameter: `'d`
-  --> $DIR/generics-gen-args-errors.rs:81:12
+  --> $DIR/generics-gen-args-errors.rs:91:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^ --
@@ -597,7 +699,7 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<'d, 1, 2, 3
    |                                                                 +++
 
 error[E0107]: method takes 2 generic arguments but 5 generic arguments were supplied
-  --> $DIR/generics-gen-args-errors.rs:116:59
+  --> $DIR/generics-gen-args-errors.rs:133:59
    |
 LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
    |                                                           ^^^       --------- help: remove the unnecessary generic arguments
@@ -605,10 +707,16 @@ LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _,
    |                                                           expected 2 generic arguments
    |
 note: method defined here, with 2 generic parameters: `U`, `M`
-  --> $DIR/generics-gen-args-errors.rs:81:12
+  --> $DIR/generics-gen-args-errors.rs:91:12
    |
 LL |         fn foo<'d: 'd, U, const M: bool>(self) {}
    |            ^^^         -  -------------
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/generics-gen-args-errors.rs:133:59
+   |
+LL |     reuse Trait::<Trait, Clone, _, 'static, dyn Send, _>::foo::<1, 2, 3, _, 6> as bar7;
+   |                                                           ^^^
 
 error[E0107]: function takes 3 generic arguments but 6 generic arguments were supplied
   --> $DIR/generics-gen-args-errors.rs:10:9
@@ -681,12 +789,12 @@ LL |         reuse foo::<A, B, { C }> as xd;
    |                           +   +
 
 error[E0747]: constant provided when a type was expected
-  --> $DIR/generics-gen-args-errors.rs:74:17
+  --> $DIR/generics-gen-args-errors.rs:83:17
    |
 LL |     reuse foo::<{}, {}, {}> as bar8;
    |                 ^^
 
-error: aborting due to 57 previous errors
+error: aborting due to 75 previous errors
 
 Some errors have detailed explanations: E0107, E0121, E0261, E0401, E0423, E0425, E0747.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/generics/unelided-lifetime-ice-154178.rs
+++ b/tests/ui/delegation/generics/unelided-lifetime-ice-154178.rs
@@ -7,6 +7,7 @@ fn foo<'b: 'b, const N: usize>() {}
 trait Trait {
     reuse foo::<1>;
     //~^ ERROR: function takes 1 lifetime argument but 0 lifetime arguments were supplied
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 }
 
 fn main() {}

--- a/tests/ui/delegation/generics/unelided-lifetime-ice-154178.stderr
+++ b/tests/ui/delegation/generics/unelided-lifetime-ice-154178.stderr
@@ -14,6 +14,12 @@ help: add missing lifetime argument
 LL |     reuse foo::<'b, 1>;
    |                 +++
 
-error: aborting due to 1 previous error
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/unelided-lifetime-ice-154178.rs:8:11
+   |
+LL |     reuse foo::<1>;
+   |           ^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/delegation/generics/unelided-lifetime-in-sig-ice-156848.rs
+++ b/tests/ui/delegation/generics/unelided-lifetime-in-sig-ice-156848.rs
@@ -1,0 +1,22 @@
+//@ compile-flags: -Z deduplicate-diagnostics=yes
+
+#![feature(fn_delegation)]
+
+trait Trait {
+    fn foo<'a: 'a>(&self) {}
+}
+
+struct F;
+impl Trait for F {}
+
+struct S(F);
+impl S {
+    reuse Trait::foo::<> { self.0 }
+    //~^ ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    reuse Trait::foo::<'_> as bar { self.0 }
+    //~^ ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| WARN: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}
+
+fn main() {}

--- a/tests/ui/delegation/generics/unelided-lifetime-in-sig-ice-156848.stderr
+++ b/tests/ui/delegation/generics/unelided-lifetime-in-sig-ice-156848.stderr
@@ -1,0 +1,27 @@
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/unelided-lifetime-in-sig-ice-156848.rs:14:18
+   |
+LL |     reuse Trait::foo::<> { self.0 }
+   |                  ^^^
+
+warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/unelided-lifetime-in-sig-ice-156848.rs:16:24
+   |
+LL |     fn foo<'a: 'a>(&self) {}
+   |                    - the late bound lifetime parameter is introduced here
+...
+LL |     reuse Trait::foo::<'_> as bar { self.0 }
+   |                        ^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+   = note: `#[warn(late_bound_lifetime_arguments)]` (part of `#[warn(future_incompatible)]`) on by default
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/unelided-lifetime-in-sig-ice-156848.rs:16:24
+   |
+LL |     reuse Trait::foo::<'_> as bar { self.0 }
+   |                        ^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/delegation/wrong-lifetime-rib.rs
+++ b/tests/ui/delegation/wrong-lifetime-rib.rs
@@ -15,7 +15,20 @@ mod ice_156342 {
     fn foo<T>() {}
 
     reuse foo::<&&&&&&&&&&()> as foo1;
+    //~^ ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
     reuse foo::<&std::borrow::Cow<'_, &()>> as foo2;
+    //~^ ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
+    //~| ERROR: inferred lifetimes are not allowed in delegations as we need to inherit signature
 }
 
 mod ice_156758 {

--- a/tests/ui/delegation/wrong-lifetime-rib.stderr
+++ b/tests/ui/delegation/wrong-lifetime-rib.stderr
@@ -4,8 +4,86 @@ error[E0423]: expected function, found unit variant `None`
 LL |         reuse None::<&()>;
    |               ^^^^^^^^^^^ not a function
 
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:18
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                  ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:19
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                   ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:20
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                    ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:21
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                     ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:22
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                      ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:23
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                       ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:24
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                        ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:25
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                         ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:26
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                          ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:17:27
+   |
+LL |     reuse foo::<&&&&&&&&&&()> as foo1;
+   |                           ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:28:18
+   |
+LL |     reuse foo::<&std::borrow::Cow<'_, &()>> as foo2;
+   |                  ^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:28:35
+   |
+LL |     reuse foo::<&std::borrow::Cow<'_, &()>> as foo2;
+   |                                   ^^
+
+error: inferred lifetimes are not allowed in delegations as we need to inherit signature
+  --> $DIR/wrong-lifetime-rib.rs:28:40
+   |
+LL |     reuse foo::<&std::borrow::Cow<'_, &()>> as foo2;
+   |                                        ^
+
 error[E0782]: expected a type, found a trait
-  --> $DIR/wrong-lifetime-rib.rs:26:10
+  --> $DIR/wrong-lifetime-rib.rs:39:10
    |
 LL |     impl X {
    |          ^
@@ -20,7 +98,7 @@ LL |     impl X for /* Type */ {
    |            ++++++++++++++
 
 error[E0782]: expected a type, found a trait
-  --> $DIR/wrong-lifetime-rib.rs:35:10
+  --> $DIR/wrong-lifetime-rib.rs:48:10
    |
 LL |     impl X {
    |          ^
@@ -44,7 +122,7 @@ LL |     impl Trait {
    = note: for more details about the orphan rules, see <https://doc.rust-lang.org/reference/items/implementations.html?highlight=orphan#orphan-rules>
 
 error[E0223]: ambiguous associated type
-  --> $DIR/wrong-lifetime-rib.rs:27:16
+  --> $DIR/wrong-lifetime-rib.rs:40:16
    |
 LL |         reuse<<<&Project> :: Ty> :: Ty as Iterator>::next;
    |                ^^^^^^^^^^^^^^^^
@@ -56,7 +134,7 @@ LL +         reuse<<<&() as Example>::Ty> :: Ty as Iterator>::next;
    |
 
 error[E0782]: expected a type, found a trait
-  --> $DIR/wrong-lifetime-rib.rs:37:21
+  --> $DIR/wrong-lifetime-rib.rs:50:21
    |
 LL |             let _: &X;
    |                     ^
@@ -66,7 +144,7 @@ help: you can add the `dyn` keyword if you want a trait object
 LL |             let _: &dyn X;
    |                     +++
 
-error: aborting due to 6 previous errors
+error: aborting due to 19 previous errors
 
 Some errors have detailed explanations: E0116, E0223, E0423, E0782.
 For more information about an error, try `rustc --explain E0116`.


### PR DESCRIPTION
This PR checks emit error if there as an infer lifetime anywhere in delegation's user-specified args. And `delegation_user_specified_args` is now query as we invoke it two times.

Fixes rust-lang/rust#156848. Part of rust-lang/rust#118212.
r? @petrochenkov