### PR TITLE
Support generic params in `Lift_Generic`

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1659,16 +1659,20 @@ macro_rules! nop_lift {
 
 macro_rules! nop_list_lift {
     ($set:ident; $ty:ty => $lifted:ty) => {
-        impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for &'a List<$ty> {
-            type Lifted = &'tcx List<$lifted>;
+        nop_list_lift! { $set: List; $ty => $lifted }
+    };
+    // Allows defining own list type
+    ($set:ident: $list:ident; $ty:ty => $lifted:ty) => {
+        impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for &'a $list<$ty> {
+            type Lifted = &'tcx $list<$lifted>;
             fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Self::Lifted {
                 // Assert that the set has the right type.
                 if false {
-                    let _x: &InternedSet<'tcx, List<$lifted>> = &tcx.interners.$set;
+                    let _x: &InternedSet<'tcx, $list<$lifted>> = &tcx.interners.$set;
                 }
 
                 if self.is_empty() {
-                    return List::empty();
+                    return $list::empty();
                 }
                 assert!(tcx.interners.$set.contains_pointer_to(&InternedInSet(self)));
                 // SAFETY: we just checked that `self` is interned and therefore is valid for the
@@ -1690,10 +1694,15 @@ nop_lift! { layout; Layout<'a> => Layout<'tcx> }
 nop_lift! { valtree; ValTree<'a> => ValTree<'tcx> }
 
 nop_list_lift! { type_lists; Ty<'a> => Ty<'tcx> }
+nop_list_lift! { clauses: ListWithCachedTypeInfo; Clause<'a> => Clause<'tcx> }
 nop_list_lift! {
     poly_existential_predicates; PolyExistentialPredicate<'a> => PolyExistentialPredicate<'tcx>
 }
 nop_list_lift! { bound_variable_kinds; ty::BoundVariableKind<'a> => ty::BoundVariableKind<'tcx> }
+nop_list_lift! { patterns; Pattern<'a> => Pattern<'tcx> }
+nop_list_lift! {
+    outlives; ty::ArgOutlivesPredicate<'a> => ty::ArgOutlivesPredicate<'tcx>
+}
 
 // This is the impl for `&'a GenericArgs<'a>`.
 nop_list_lift! { args; GenericArg<'a> => GenericArg<'tcx> }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -184,7 +184,6 @@ impl<'tcx> fmt::Debug for Region<'tcx> {
 // For things for which the type library provides traversal implementations
 // for all Interners, we only need to provide a Lift implementation.
 TrivialLiftImpls! {
-    (),
     bool,
     usize,
     u64,
@@ -197,6 +196,7 @@ TrivialLiftImpls! {
     rustc_abi::Size,
     rustc_hir::Safety,
     rustc_middle::mir::ConstValue,
+    rustc_span::Symbol,
     rustc_type_ir::BoundConstness,
     rustc_type_ir::PredicatePolarity,
     // tidy-alphabetical-end
@@ -268,6 +268,14 @@ TrivialTypeTraversalAndLiftImpls! {
 
 ///////////////////////////////////////////////////////////////////////////
 // Lift implementations
+
+impl<'a, 'tcx> Lift<TyCtxt<'tcx>> for ty::ParamEnv<'a> {
+    type Lifted = ty::ParamEnv<'tcx>;
+
+    fn lift_to_interner(self, tcx: TyCtxt<'tcx>) -> Self::Lifted {
+        ty::ParamEnv::new(tcx.lift(self.caller_bounds()))
+    }
+}
 
 impl<'tcx, T: Lift<TyCtxt<'tcx>>> Lift<TyCtxt<'tcx>> for Option<T> {
     type Lifted = Option<T::Lifted>;

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -27,7 +27,7 @@ use crate::{self as ty, DebruijnIndex, Interner, UniverseIndex, Unnormalized};
 ///
 /// `Decodable` and `Encodable` are implemented for `Binder<T>` using the `impl_binder_encode_decode!` macro.
 #[derive_where(Clone, Copy, Hash, PartialEq, Debug; I: Interner, T)]
-#[derive(GenericTypeVisitable)]
+#[derive(GenericTypeVisitable, Lift_Generic)]
 #[cfg_attr(feature = "nightly", derive(StableHash_NoContext))]
 pub struct Binder<I: Interner, T> {
     value: T,
@@ -35,23 +35,6 @@ pub struct Binder<I: Interner, T> {
 }
 
 impl<I: Interner, T: Eq> Eq for Binder<I, T> {}
-
-// FIXME: We manually derive `Lift` because the `derive(Lift_Generic)` doesn't
-// understand how to turn `T` to `T::Lifted` in the output `type Lifted`.
-impl<I: Interner, U: Interner, T> Lift<U> for Binder<I, T>
-where
-    T: Lift<U>,
-    I::BoundVarKinds: Lift<U, Lifted = U::BoundVarKinds>,
-{
-    type Lifted = Binder<U, T::Lifted>;
-
-    fn lift_to_interner(self, cx: U) -> Self::Lifted {
-        Binder {
-            value: self.value.lift_to_interner(cx),
-            bound_vars: self.bound_vars.lift_to_interner(cx),
-        }
-    }
-}
 
 #[cfg(feature = "nightly")]
 macro_rules! impl_binder_encode_decode {

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -14,7 +14,6 @@ use tracing::instrument;
 use crate::data_structures::SsoHashSet;
 use crate::fold::{FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable};
 use crate::inherent::*;
-use crate::lift::Lift;
 use crate::visit::{Flags, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor};
 use crate::{self as ty, DebruijnIndex, Interner, UniverseIndex, Unnormalized};
 
@@ -949,12 +948,13 @@ pub enum BoundVarIndexKind {
 /// identified by both a universe, as well as a name residing within that universe. Distinct bound
 /// regions/types/consts within the same universe simply have an unknown relationship to one
 #[derive_where(Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash; I: Interner, T)]
-#[derive(TypeVisitable_Generic, TypeFoldable_Generic, GenericTypeVisitable)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic, GenericTypeVisitable, Lift_Generic)]
 #[cfg_attr(
     feature = "nightly",
     derive(Encodable_NoContext, Decodable_NoContext, StableHash_NoContext)
 )]
 pub struct Placeholder<I: Interner, T> {
+    #[lift(identity)]
     pub universe: UniverseIndex,
     pub bound: T,
     #[type_foldable(identity)]
@@ -968,21 +968,6 @@ impl<I: Interner, T: fmt::Debug> fmt::Debug for ty::Placeholder<I, T> {
             write!(f, "!{:?}", self.bound)
         } else {
             write!(f, "!{}_{:?}", self.universe.index(), self.bound)
-        }
-    }
-}
-
-impl<I: Interner, U: Interner, T> Lift<U> for Placeholder<I, T>
-where
-    T: Lift<U>,
-{
-    type Lifted = Placeholder<U, T::Lifted>;
-
-    fn lift_to_interner(self, cx: U) -> Self::Lifted {
-        Placeholder {
-            universe: self.universe,
-            bound: self.bound.lift_to_interner(cx),
-            _tcx: PhantomData,
         }
     }
 }
@@ -1157,25 +1142,15 @@ impl<I: Interner> PlaceholderRegion<I> {
 }
 
 #[derive_where(Clone, Copy, PartialEq, Eq, Hash; I: Interner)]
-#[derive(GenericTypeVisitable)]
+#[derive(GenericTypeVisitable, Lift_Generic)]
 #[cfg_attr(
     feature = "nightly",
     derive(Encodable_NoContext, Decodable_NoContext, StableHash_NoContext)
 )]
 pub struct BoundTy<I: Interner> {
+    #[lift(identity)]
     pub var: ty::BoundVar,
     pub kind: BoundTyKind<I>,
-}
-
-impl<I: Interner, U: Interner> Lift<U> for BoundTy<I>
-where
-    BoundTyKind<I>: Lift<U, Lifted = BoundTyKind<U>>,
-{
-    type Lifted = BoundTy<U>;
-
-    fn lift_to_interner(self, cx: U) -> Self::Lifted {
-        BoundTy { var: self.var, kind: self.kind.lift_to_interner(cx) }
-    }
 }
 
 impl<I: Interner> fmt::Debug for ty::BoundTy<I> {

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -469,6 +469,52 @@ pub trait Interner:
     fn item_name(self, item_index: Self::DefId) -> Self::Symbol;
 }
 
+macro_rules! declare_lift_into {
+    ($($assoc:ident),* $(,)?) => {
+        /// An interner whose associated types can be lifted into another interner `J`.
+        ///
+        /// These are associated type bounds rather than `where` clauses so a caller with
+        /// `I: LiftInto<J>` can rely on the individual associated type `Lift` bounds being
+        /// implied.
+        pub trait LiftInto<J>: Interner<$($assoc: crate::lift::Lift<J, Lifted = J::$assoc>,)*>
+        where
+            J: Interner,
+        {}
+
+        impl<I, J> LiftInto<J> for I
+        where
+            J: Interner,
+            I: Interner<$($assoc: crate::lift::Lift<J, Lifted = J::$assoc>,)*>,
+        {}
+    };
+}
+
+declare_lift_into! {
+    BoundVarKinds,
+    Const,
+    DefId,
+    FreeConstAliasId,
+    FreeTyAliasId,
+    GenericArg,
+    GenericArgs,
+    InherentAssocConstId,
+    InherentAssocTyId,
+    OpaqueTyId,
+    ParamEnv,
+    PatList,
+    Region,
+    RegionAssumptions,
+    Symbol,
+    Term,
+    TraitAssocConstId,
+    TraitAssocTermId,
+    TraitAssocTyId,
+    TraitId,
+    Ty,
+    Tys,
+    UnevaluatedConstId,
+}
+
 /// Imagine you have a function `F: FnOnce(&[T]) -> R`, plus an iterator `iter`
 /// that produces `T` items. You could combine them with
 /// `f(&iter.collect::<Vec<_>>())`, but this requires allocating memory for the

--- a/compiler/rustc_type_ir/src/lift.rs
+++ b/compiler/rustc_type_ir/src/lift.rs
@@ -19,3 +19,9 @@ pub trait Lift<I>: std::fmt::Debug {
     type Lifted: std::fmt::Debug;
     fn lift_to_interner(self, cx: I) -> Self::Lifted;
 }
+
+impl<I> Lift<I> for () {
+    type Lifted = ();
+
+    fn lift_to_interner(self, _: I) -> Self::Lifted {}
+}

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -195,6 +195,7 @@ pub struct TraitPredicate<I: Interner> {
     /// If polarity is Negative: we are proving that a negative impl of this trait
     /// exists. (Note that coherence also checks whether negative impls of supertraits
     /// exist via a series of predicates.)
+    #[lift(identity)]
     pub polarity: PredicatePolarity,
 }
 
@@ -990,6 +991,7 @@ impl<I: Interner> fmt::Debug for NormalizesTo<I> {
 )]
 pub struct HostEffectPredicate<I: Interner> {
     pub trait_ref: ty::TraitRef<I>,
+    #[lift(identity)]
     pub constness: BoundConstness,
 }
 
@@ -1035,6 +1037,7 @@ impl<I: Interner> ty::Binder<I, HostEffectPredicate<I>> {
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
 )]
 pub struct SubtypePredicate<I: Interner> {
+    #[lift(identity)]
     pub a_is_expected: bool,
     pub a: I::Ty,
     pub b: I::Ty,

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -9,7 +9,6 @@ use rustc_type_ir_macros::{
 };
 
 use crate::inherent::*;
-use crate::lift::Lift;
 use crate::upcast::{Upcast, UpcastFrom};
 use crate::visit::TypeVisitableExt as _;
 use crate::{self as ty, AliasTyKind, Interner};
@@ -17,7 +16,7 @@ use crate::{self as ty, AliasTyKind, Interner};
 /// `A: 'region`
 #[derive_where(Clone, Hash, PartialEq, Debug; I: Interner, A)]
 #[derive_where(Copy; I: Interner, A: Copy)]
-#[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic)]
+#[derive(TypeVisitable_Generic, GenericTypeVisitable, TypeFoldable_Generic, Lift_Generic)]
 #[cfg_attr(
     feature = "nightly",
     derive(Decodable_NoContext, Encodable_NoContext, StableHash_NoContext)
@@ -25,20 +24,6 @@ use crate::{self as ty, AliasTyKind, Interner};
 pub struct OutlivesPredicate<I: Interner, A>(pub A, pub I::Region);
 
 impl<I: Interner, A: Eq> Eq for OutlivesPredicate<I, A> {}
-
-// FIXME: We manually derive `Lift` because the `derive(Lift_Generic)` doesn't
-// understand how to turn `A` to `A::Lifted` in the output `type Lifted`.
-impl<I: Interner, U: Interner, A> Lift<U> for OutlivesPredicate<I, A>
-where
-    A: Lift<U>,
-    I::Region: Lift<U, Lifted = U::Region>,
-{
-    type Lifted = OutlivesPredicate<U, A::Lifted>;
-
-    fn lift_to_interner(self, cx: U) -> Self::Lifted {
-        OutlivesPredicate(self.0.lift_to_interner(cx), self.1.lift_to_interner(cx))
-    }
-}
 
 /// `'a == 'b`.
 /// For the rationale behind having this instead of a pair of bidirectional

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -764,7 +764,7 @@ impl<I: Interner> Eq for TypeAndMut<I> {}
 /// Contains the packed non-type fields of a function signature.
 // FIXME(splat): add the splatted argument index as a u16
 #[derive_where(Copy, Clone, PartialEq, Eq, Hash; I: Interner)]
-#[derive(TypeVisitable_Generic, TypeFoldable_Generic)]
+#[derive(TypeVisitable_Generic, TypeFoldable_Generic, Lift_Generic)]
 #[cfg_attr(
     feature = "nightly",
     derive(Encodable_NoContext, Decodable_NoContext, StableHash_NoContext)
@@ -772,19 +772,13 @@ impl<I: Interner> Eq for TypeAndMut<I> {}
 pub struct FnSigKind<I: Interner> {
     /// Holds the c_variadic and safety bitflags, and 6 bits for the `ExternAbi` variant and unwind
     /// flag.
+    #[lift(identity)]
     #[type_visitable(ignore)]
     #[type_foldable(identity)]
     flags: u8,
     #[type_visitable(ignore)]
     #[type_foldable(identity)]
     _marker: PhantomData<fn() -> I>,
-}
-
-impl<I: Interner, J: Interner> crate::lift::Lift<J> for FnSigKind<I> {
-    type Lifted = FnSigKind<J>;
-    fn lift_to_interner(self, _cx: J) -> Self::Lifted {
-        FnSigKind { flags: self.flags, _marker: PhantomData }
-    }
 }
 
 impl<I: Interner> fmt::Debug for FnSigKind<I> {

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -159,9 +159,9 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     }
 
     s.add_bounds(synstructure::AddBounds::None);
-    s.add_where_predicate(parse_quote! { I: Interner });
     s.add_impl_generic(parse_quote! { J });
     s.add_where_predicate(parse_quote! { J: Interner });
+    s.add_where_predicate(parse_quote! { I: ::rustc_type_ir::LiftInto<J> });
 
     let generic_parameters =
         s.ast().generics.type_params().map(|ty| ty.ident.clone()).collect::<Vec<_>>();
@@ -186,27 +186,12 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
 
             let lifted = lift(ty.clone(), &generic_parameters);
 
+            // Field types involving ordinary generic parameters still need
+            // explicit bounds for those parameters, e.g. `Binder<I, T>` needs
+            // `T: Lift<J>` so its own derived `Lift` impl applies. Interner
+            // associated types are covered by `I: LiftInto<J>`.
             for param in lifted.generic_parameter_bounds {
                 wc.push(parse_quote! { #param: ::rustc_type_ir::lift::Lift<J> });
-            }
-
-            // `lift(ty, ...)` rewrites any bare generic params inside the
-            // field type to their lifted associated type, e.g;
-            // `T` becomes `<T as Lift<J>>::Lifted`.
-            //
-            // That, however, does not imply that the field type itself
-            // implements `Lift<J>`. The generated body calls `lift_to_interner`
-            // on each field value, so Rust needs a `Lift<J>` impl for that
-            // value's complete declared type, not just for generic parameters
-            // that appear somewhere inside it. For non parameter fields, the
-            // implementation must also produce the exact mapped field type:
-            //
-            // Example:
-            // `I::DefId: Lift<J, Lifted = J::DefId>`
-            // `Binder<I, T>: Lift<J, Lifted = Binder<J, <T as Lift<J>>::Lifted>>`
-            if !is_type_param(&ty, &generic_parameters) {
-                let lifted_ty = lifted.ty;
-                wc.push(parse_quote! { #ty: ::rustc_type_ir::lift::Lift<J, Lifted = #lifted_ty> });
             }
 
             quote! {
@@ -247,15 +232,6 @@ fn get_first_path_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
     } else {
         None
     }
-}
-
-/// Returns true only for bare generic parameters like `T`, not paths such as
-/// `I::Ty`, `Vec<T>`, or `Binder<I, T>`
-fn is_type_param(ty: &syn::Type, generic_parameters: &[syn::Ident]) -> bool {
-    get_first_path_segment(ty).is_some_and(|segment| {
-        matches!(segment.arguments, syn::PathArguments::None)
-            && generic_parameters.iter().any(|param| segment.ident == *param)
-    })
 }
 
 /// Return if the type is `PhantomData`

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -10,12 +10,17 @@ decl_derive!(
     [TypeFoldable_Generic, attributes(type_foldable)] => type_foldable_derive
 );
 decl_derive!(
-    [Lift_Generic] => lift_derive
+    [Lift_Generic, attributes(lift)] => lift_derive
 );
 #[cfg(not(feature = "nightly"))]
 decl_derive!(
     [GenericTypeVisitable] => customizable_type_visitable_derive
 );
+
+struct LiftedTy {
+    ty: syn::Type,
+    generic_parameter_bounds: Vec<syn::Ident>,
+}
 
 fn has_ignore_attr(attrs: &[Attribute], name: &'static str, meta: &'static str) -> bool {
     let mut ignored = false;
@@ -158,15 +163,32 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     s.add_impl_generic(parse_quote! { J });
     s.add_where_predicate(parse_quote! { J: Interner });
 
+    let generic_parameters =
+        s.ast().generics.type_params().map(|ty| ty.ident.clone()).collect::<Vec<_>>();
+
     let mut wc = vec![];
     s.bind_with(|_| synstructure::BindStyle::Move);
     let body_fold = s.each_variant(|vi| {
         let bindings = vi.bindings();
         vi.construct(|field, index| {
             let ty = field.ty.clone();
-            let lifted_ty = lift(ty.clone());
-            wc.push(parse_quote! { #ty: ::rustc_type_ir::lift::Lift<J, Lifted = #lifted_ty> });
             let bind = &bindings[index];
+            // Allow field to be ignored from lift
+            if has_ignore_attr(&field.attrs, "lift", "identity") {
+                return bind.to_token_stream();
+            }
+
+            let lifted = lift(ty.clone(), &generic_parameters);
+
+            for param in lifted.generic_parameter_bounds {
+                wc.push(parse_quote! { #param: ::rustc_type_ir::lift::Lift<J> });
+            }
+
+            if !is_type_param(&ty, &generic_parameters) {
+                let lifted_ty = lifted.ty;
+                wc.push(parse_quote! { #ty: ::rustc_type_ir::lift::Lift<J, Lifted = #lifted_ty> });
+            }
+
             quote! {
                 #bind.lift_to_interner(interner)
             }
@@ -179,7 +201,8 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     let (_, ty_generics, _) = s.ast().generics.split_for_impl();
     let name = s.ast().ident.clone();
     let self_ty: syn::Type = parse_quote! { #name #ty_generics };
-    let lifted_ty = lift(self_ty);
+    let lifted = lift(self_ty, &generic_parameters);
+    let lifted_ty = lifted.ty;
 
     s.bound_impl(
         quote!(::rustc_type_ir::lift::Lift<J>),
@@ -196,24 +219,52 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     )
 }
 
-fn lift(mut ty: syn::Type) -> syn::Type {
-    struct ItoJ;
-    impl VisitMut for ItoJ {
+fn is_type_param(ty: &syn::Type, generic_parameters: &[syn::Ident]) -> bool {
+    if let syn::Type::Path(ty) = ty
+        && ty.path.segments.len() == 1
+        && let Some(segment) = ty.path.segments.first()
+    {
+        matches!(segment.arguments, syn::PathArguments::None)
+            && generic_parameters.iter().any(|param| segment.ident == *param)
+    } else {
+        false
+    }
+}
+
+fn lift(mut ty: syn::Type, generic_parameters: &[syn::Ident]) -> LiftedTy {
+    struct ItoJ<'a> {
+        generic_parameters: &'a [syn::Ident],
+        generic_parameter_bounds: Vec<syn::Ident>,
+    }
+
+    impl VisitMut for ItoJ<'_> {
         fn visit_type_path_mut(&mut self, i: &mut syn::TypePath) {
             if i.qself.is_none() {
-                if let Some(first) = i.path.segments.first_mut()
-                    && first.ident == "I"
-                {
-                    *first = parse_quote! { J };
+                let segments_len = i.path.segments.len();
+                if let Some(first) = i.path.segments.first_mut() {
+                    // Turn paths from `I` into `J`
+                    if first.ident == "I" {
+                        *first = parse_quote! { J };
+                    } else if segments_len == 1
+                        && matches!(first.arguments, syn::PathArguments::None)
+                        && self.generic_parameters.iter().any(|param| first.ident == *param)
+                    {
+                        let ident = first.ident.clone();
+                        if !self.generic_parameter_bounds.iter().any(|param| *param == ident) {
+                            self.generic_parameter_bounds.push(ident.clone());
+                        }
+
+                        *i = parse_quote! { <#ident as ::rustc_type_ir::lift::Lift<J>>::Lifted };
+                        return;
+                    }
                 }
             }
             syn::visit_mut::visit_type_path_mut(self, i);
         }
     }
-
-    ItoJ.visit_type_mut(&mut ty);
-
-    ty
+    let mut visitor = ItoJ { generic_parameters, generic_parameter_bounds: Vec::new() };
+    visitor.visit_type_mut(&mut ty);
+    LiftedTy { ty, generic_parameter_bounds: visitor.generic_parameter_bounds }
 }
 
 #[cfg(not(feature = "nightly"))]

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -184,6 +184,20 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
                 wc.push(parse_quote! { #param: ::rustc_type_ir::lift::Lift<J> });
             }
 
+            // `lift(ty, ...)` rewrites any bare generic params inside the
+            // field type to their lifted associated type, e.g;
+            // `T` becomes `<T as Lift<J>>::Lifted`.
+            //
+            // That, however, does not imply that the field type itself
+            // implements `Lift<J>`. The generated body calls `lift_to_interner`
+            // on each field value, so Rust needs a `Lift<J>` impl for that
+            // value's complete declared type, not just for generic parameters
+            // that appear somewhere inside it. For non parameter fields, the
+            // implementation must also produce the exact mapped field type:
+            //
+            // Example:
+            // `I::DefId: Lift<J, Lifted = J::DefId>`
+            // `Binder<I, T>: Lift<J, Lifted = Binder<J, <T as Lift<J>>::Lifted>>`
             if !is_type_param(&ty, &generic_parameters) {
                 let lifted_ty = lifted.ty;
                 wc.push(parse_quote! { #ty: ::rustc_type_ir::lift::Lift<J, Lifted = #lifted_ty> });
@@ -219,6 +233,8 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     )
 }
 
+/// Returns true only for bare generic parameters like `T`, not paths such as
+/// `I::Ty`, `Vec<T>`, or `Binder<I, T>`
 fn is_type_param(ty: &syn::Type, generic_parameters: &[syn::Ident]) -> bool {
     if let syn::Type::Path(ty) = ty
         && ty.path.segments.len() == 1

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -178,6 +178,12 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
                 return bind.to_token_stream();
             }
 
+            if is_type_phantom(&ty) {
+                return quote! {
+                    PhantomData
+                };
+            }
+
             let lifted = lift(ty.clone(), &generic_parameters);
 
             for param in lifted.generic_parameter_bounds {
@@ -233,18 +239,28 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     )
 }
 
+fn get_first_path_segment(ty: &syn::Type) -> Option<&syn::PathSegment> {
+    if let syn::Type::Path(ty) = ty
+        && ty.path.segments.len() == 1
+    {
+        ty.path.segments.first()
+    } else {
+        None
+    }
+}
+
 /// Returns true only for bare generic parameters like `T`, not paths such as
 /// `I::Ty`, `Vec<T>`, or `Binder<I, T>`
 fn is_type_param(ty: &syn::Type, generic_parameters: &[syn::Ident]) -> bool {
-    if let syn::Type::Path(ty) = ty
-        && ty.path.segments.len() == 1
-        && let Some(segment) = ty.path.segments.first()
-    {
+    get_first_path_segment(ty).is_some_and(|segment| {
         matches!(segment.arguments, syn::PathArguments::None)
             && generic_parameters.iter().any(|param| segment.ident == *param)
-    } else {
-        false
-    }
+    })
+}
+
+/// Return if the type is `PhantomData`
+fn is_type_phantom(ty: &syn::Type) -> bool {
+    get_first_path_segment(ty).is_some_and(|segment| segment.ident == "PhantomData")
 }
 
 fn lift(mut ty: syn::Type, generic_parameters: &[syn::Ident]) -> LiftedTy {

--- a/compiler/rustc_type_ir_macros/src/lib.rs
+++ b/compiler/rustc_type_ir_macros/src/lib.rs
@@ -149,6 +149,18 @@ fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::Toke
     )
 }
 
+/// `Lift_Generic` is specialised for structs/enums parameterised by an interner
+/// `I: Interner`. It derives `Lift<J>` by rewriting interner associated types
+/// from `I::Assoc` to `J::Assoc`. The required associated type lift bounds are
+/// supplied by `I: LiftInto<J>`.
+///
+/// Ordinary generic parameters still get explicit `Lift<J>` bounds. Interner
+/// independent fields must either implement `Lift` manually or use
+/// `#[lift(identity)]`.
+///
+/// `PhantomData` is a special case that occurs enough in the code base to be
+/// handled here directly. We collect any generic bounds from the type then
+/// produce another `PhantomData`.
 fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     if let syn::Data::Union(_) = s.ast().data {
         panic!("cannot derive on union")
@@ -178,12 +190,6 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
                 return bind.to_token_stream();
             }
 
-            if is_type_phantom(&ty) {
-                return quote! {
-                    PhantomData
-                };
-            }
-
             let lifted = lift(ty.clone(), &generic_parameters);
 
             // Field types involving ordinary generic parameters still need
@@ -192,6 +198,12 @@ fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
             // associated types are covered by `I: LiftInto<J>`.
             for param in lifted.generic_parameter_bounds {
                 wc.push(parse_quote! { #param: ::rustc_type_ir::lift::Lift<J> });
+            }
+
+            if is_type_phantom(&ty) {
+                return quote! {
+                    PhantomData
+                };
             }
 
             quote! {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156956)*
<!-- homu-ignore:end -->

Handle generic type parameters, including nested occurrences, when deriving `Lift_Generic`.

This lets types like `Binder<I, T>` use `#[derive(Lift_Generic)]` instead of requiring a manual `Lift` impl.

Concretely it can now handle structs as follows;

```rs
// Generic type parameter
struct Binder<I: Interner, T> {
    // body
}

// Nested generic type parameter
pub struct Binder<I: Interner, T = SomeKind<I>> {
    //
} 
```

Split off from the `Alias` refactor work; https://github.com/rust-lang/rust/pull/156538

r? @lcnr
