### PR TITLE
[beta] Revert "Build shared LLVM lib for windows-gnullvm"

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -722,7 +722,6 @@ auto:
         --target=aarch64-pc-windows-gnullvm,i686-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
-        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
       CC_i686_pc_windows_gnullvm: i686-w64-mingw32-clang
@@ -735,7 +734,6 @@ auto:
         --build=x86_64-pc-windows-gnullvm
         --enable-full-tools
         --enable-profiler
-        --enable-llvm-link-shared
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
     <<: *job-windows


### PR DESCRIPTION
This reverts commit 1d1280aae1e31b9ae9325fddc0c57ffc5074f434.

Reapply https://github.com/rust-lang/rust/pull/155285 to the new beta because https://github.com/rust-lang/rust/pull/156229 missed the train by a couple of hours.