### PR TITLE
diagnostics: suggest generic_const_args for const ops

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -431,13 +431,16 @@ impl<'tcx> ForbidParamUsesFolder<'tcx> {
                 diag.span_note(impl_.self_ty.span, "not a concrete type");
             }
         }
-        if matches!(self.context, ForbidParamContext::ConstArgument)
-            && self.tcx.features().min_generic_const_args()
-        {
-            if !self.tcx.features().generic_const_args() {
-                diag.help("add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items");
-            } else {
+        if matches!(self.context, ForbidParamContext::ConstArgument) {
+            if self.tcx.features().generic_const_args() {
                 diag.help("consider factoring the expression into a `type const` item and use it as the const argument instead");
+            } else if self.tcx.features().min_generic_const_args() {
+                diag.help("add `#![feature(generic_const_args)]` and extract the expression into a `type const` item");
+            } else if self.tcx.sess.is_nightly_build() {
+                diag.help(
+                    "add `#![feature(generic_const_exprs)]` to allow generic const expressions",
+                );
+                diag.help("alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item");
             }
         }
         diag.emit()

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -407,6 +407,10 @@ pub(crate) struct ParamInNonTrivialAnonConst {
         "consider factoring the expression into a `type const` item and use it as the const argument instead"
     )]
     pub(crate) help_gca: bool,
+    #[help(
+        "alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item"
+    )]
+    pub(crate) help_suggest_gca: bool,
 }
 
 #[derive(Debug)]

--- a/compiler/rustc_resolve/src/error_helper.rs
+++ b/compiler/rustc_resolve/src/error_helper.rs
@@ -1288,9 +1288,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     span,
                     name,
                     param_kind: is_type,
-                    help: self.tcx.sess.is_nightly_build(),
+                    help: self.tcx.sess.is_nightly_build()
+                        && !self.tcx.features().min_generic_const_args(),
                     is_gca,
                     help_gca: is_gca,
+                    help_suggest_gca: self.tcx.sess.is_nightly_build() && !is_gca,
                 })
             }
             ResolutionError::ParamInEnumDiscriminant { name, param_kind: is_type } => {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3983,9 +3983,12 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         span: lifetime_ref.ident.span,
                         name: lifetime_ref.ident.name,
                         param_kind: diagnostics::ParamKindInNonTrivialAnonConst::Lifetime,
-                        help: self.r.tcx.sess.is_nightly_build(),
+                        help: self.r.tcx.sess.is_nightly_build()
+                            && !self.r.features.min_generic_const_args(),
                         is_gca: self.r.features.generic_const_args(),
                         help_gca: self.r.features.generic_const_args(),
+                        help_suggest_gca: self.r.tcx.sess.is_nightly_build()
+                            && !self.r.features.generic_const_args(),
                     })
                     .emit()
             }

--- a/tests/ui/associated-consts/associated-const-type-parameter-arrays.stderr
+++ b/tests/ui/associated-consts/associated-const-type-parameter-arrays.stderr
@@ -6,6 +6,7 @@ LL |     let _array: [u32; <A as Foo>::Y];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-consts/issue-47814.stderr
+++ b/tests/ui/associated-consts/issue-47814.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<'a> ArpIPv4<'a> {
    |          ^^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
+++ b/tests/ui/associated-item/associated-item-duplicate-bounds.stderr
@@ -6,6 +6,7 @@ LL |     links: [u32; A::LINKS], // Shouldn't suggest bounds already there.
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/adt_const_params/index-oob-ice-83993.stderr
+++ b/tests/ui/const-generics/adt_const_params/index-oob-ice-83993.stderr
@@ -6,6 +6,7 @@ LL |         let x: &'b ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/index-oob-ice-83993.rs:18:17
@@ -15,6 +16,7 @@ LL |         let _: &'b ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/tests/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -6,6 +6,7 @@ LL |     let _: [u8; foo::<T>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:16:23
@@ -15,6 +16,7 @@ LL |     let _: [u8; bar::<N>()];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:18:23
@@ -24,6 +26,7 @@ LL |     let _: [u8; faz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:20:23
@@ -33,6 +36,7 @@ LL |     let _: [u8; baz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:21:23
@@ -42,6 +46,7 @@ LL |     let _: [u8; faz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:23:23
@@ -51,6 +56,7 @@ LL |     let _: [u8; baz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:27:23
@@ -60,6 +66,7 @@ LL |     let _ = [0; bar::<N>()];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:29:23
@@ -69,6 +76,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:31:23
@@ -78,6 +86,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:32:23
@@ -87,6 +96,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:34:23
@@ -96,6 +106,7 @@ LL |     let _ = [0; baz::<'b>(&())];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:35:24
@@ -105,6 +116,7 @@ LL |     let _: Foo<{ foo::<T>() }>;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:36:24
@@ -114,6 +126,7 @@ LL |     let _: Foo<{ bar::<N>() }>;
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:38:24
@@ -123,6 +136,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:40:24
@@ -132,6 +146,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:41:24
@@ -141,6 +156,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:43:24
@@ -150,6 +166,7 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:44:27
@@ -159,6 +176,7 @@ LL |     let _ = Foo::<{ foo::<T>() }>;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:45:27
@@ -168,6 +186,7 @@ LL |     let _ = Foo::<{ bar::<N>() }>;
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:47:27
@@ -177,6 +196,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:49:27
@@ -186,6 +206,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:50:27
@@ -195,6 +216,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:52:27
@@ -204,6 +226,7 @@ LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/const-arg-in-const-arg.rs:16:23

--- a/tests/ui/const-generics/const-argument-if-length.min.stderr
+++ b/tests/ui/const-generics/const-argument-if-length.min.stderr
@@ -6,6 +6,7 @@ LL |     pad: [u8; is_zst::<T>()],
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/const-argument-if-length.rs:16:12

--- a/tests/ui/const-generics/const-argument-non-static-lifetime.min.stderr
+++ b/tests/ui/const-generics/const-argument-non-static-lifetime.min.stderr
@@ -6,6 +6,7 @@ LL |         let _: &'a ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/tests/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -6,6 +6,7 @@ LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-generic-default-expr.rs:9:62
@@ -15,6 +16,7 @@ LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
@@ -9,6 +9,7 @@ LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
@@ -22,6 +23,7 @@ LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: generic parameters may not be used in const operations
@@ -32,6 +34,7 @@ LL | fn bar<const N: usize>() -> [(); { empty!{}; N }] { loop {} }
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/early/macro_rules-braces.stderr
+++ b/tests/ui/const-generics/early/macro_rules-braces.stderr
@@ -28,6 +28,7 @@ LL |     let _: foo!({{ N }});
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:36:19
@@ -37,6 +38,7 @@ LL |     let _: bar!({ N });
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:41:20
@@ -46,6 +48,7 @@ LL |     let _: baz!({{ N }});
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:46:19
@@ -55,6 +58,7 @@ LL |     let _: biz!({ N });
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces-2.stderr
@@ -9,6 +9,7 @@ LL | fn foo<const N: usize>() -> A<{{ y!() }}> {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-macro-nested-braces.stderr
@@ -9,6 +9,7 @@ LL | fn foo<const N: usize>() -> A<{ y!() }> {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
    = note: this error originates in the macro `y` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
+++ b/tests/ui/const-generics/early/trivial-const-arg-nested-braces.stderr
@@ -6,6 +6,7 @@ LL | fn foo<const N: usize>() -> A<{ { N } }> {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.rs
+++ b/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.rs
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/rust-lang/rust/issues/156729
+//
+// When a generic parameter is used in a const operation, the diagnostic should
+// suggest creating a `type const` item as an alternative to `generic_const_exprs`.
+
+use std::mem::size_of;
+
+// Exact case from the issue: `Self` in a trait method.
+pub unsafe trait TrivialType: Copy {
+    fn as_bytes(&self) -> &[u8; size_of::<Self>()] {
+        //~^ ERROR generic parameters may not be used in const operations
+        todo!()
+    }
+}
+
+fn foo<T>() -> [u8; size_of::<T>()] {
+    //~^ ERROR generic parameters may not be used in const operations
+    todo!()
+}
+
+fn bar<const N: usize>() -> [u8; N + 1] {
+    //~^ ERROR generic parameters may not be used in const operations
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.stderr
+++ b/tests/ui/const-generics/gca/suggest-const-item-for-generic-expr.stderr
@@ -1,0 +1,32 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/suggest-const-item-for-generic-expr.rs:10:43
+   |
+LL |     fn as_bytes(&self) -> &[u8; size_of::<Self>()] {
+   |                                           ^^^^ cannot perform const operation using `Self`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
+
+error: generic parameters may not be used in const operations
+  --> $DIR/suggest-const-item-for-generic-expr.rs:16:31
+   |
+LL | fn foo<T>() -> [u8; size_of::<T>()] {
+   |                               ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
+
+error: generic parameters may not be used in const operations
+  --> $DIR/suggest-const-item-for-generic-expr.rs:21:34
+   |
+LL | fn bar<const N: usize>() -> [u8; N + 1] {
+   |                                  ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments here, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
@@ -6,6 +6,7 @@ LL | struct ArithArrayLen<const N: usize>([u32; 0 + N]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/array-size-in-generic-struct-param.rs:23:15
@@ -15,6 +16,7 @@ LL |     arr: [u8; CFG.arr_size],
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `CFG`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: `Config` is forbidden as the type of a const generic parameter
   --> $DIR/array-size-in-generic-struct-param.rs:21:21

--- a/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/bad-multiply.stderr
@@ -6,6 +6,7 @@ LL |     SmallVec<{ D * 2 }>:,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `D`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0747]: constant provided when a type was expected
   --> $DIR/bad-multiply.rs:7:14

--- a/tests/ui/const-generics/generic_const_exprs/dependence_lint.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dependence_lint.full.stderr
@@ -6,6 +6,7 @@ LL |     let _: [u8; size_of::<*mut T>()]; // error on stable, error with gce
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/dependence_lint.rs:22:37
@@ -15,6 +16,7 @@ LL |     let _: [u8; if true { size_of::<T>() } else { 3 }]; // error on stable,
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 warning: cannot use constants which depend on generic parameters in types
   --> $DIR/dependence_lint.rs:10:9

--- a/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-attribute-missing-in-dependent-crate-ice.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<const F: usize> aux::FromSlice for Wrapper<F> {
    |                                         ^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/feature-gate-generic_const_exprs.stderr
@@ -6,6 +6,7 @@ LL | type Arr<const N: usize> = [u8; N - 1];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -6,6 +6,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `LHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72787.rs:11:24
@@ -15,6 +16,7 @@ LL |     Condition<{ LHS <= RHS }>: True
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `RHS`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72787.rs:23:25
@@ -24,6 +26,7 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `I`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72787.rs:23:36
@@ -33,6 +36,7 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `J`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-72819-generic-in-const-eval.min.stderr
@@ -6,6 +6,7 @@ LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-74713.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-74713.stderr
@@ -6,6 +6,7 @@ LL |         let _: &'a ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0308]: mismatched types
   --> $DIR/issue-74713.rs:3:10

--- a/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/trivial-anon-const-use-cases.min.stderr
@@ -6,6 +6,7 @@ LL |     stuff: [u8; { S + 1 }], // `S + 1` is NOT a valid const expression in t
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `S`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/ice-68875.stderr
+++ b/tests/ui/const-generics/ice-68875.stderr
@@ -3,6 +3,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |     data: &'a [u8; Self::SIZE],
    |                    ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
+++ b/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
@@ -6,6 +6,7 @@ LL |     T: Trait<{ std::intrinsics::type_name::<T>() }>,
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: `&'static str` is forbidden as the type of a const generic parameter
   --> $DIR/intrinsics-type_name-as-const-argument.rs:9:22

--- a/tests/ui/const-generics/issue-46511.stderr
+++ b/tests/ui/const-generics/issue-46511.stderr
@@ -6,6 +6,7 @@ LL |     _a: [u8; std::mem::size_of::<&'a mut u8>()]
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-46511.rs:3:12

--- a/tests/ui/const-generics/issues/issue-56445-2.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-2.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<'a> OnDiskDirEntry<'a> {
    |          ^^^^^^^^^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-3.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-3.stderr
@@ -3,6 +3,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |     ram: [u8; Self::SIZE],
    |               ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-67375.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67375.min.stderr
@@ -6,6 +6,7 @@ LL |     inner: [(); { [|_: &T| {}; 0].len() }],
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/issue-67375.rs:5:12

--- a/tests/ui/const-generics/issues/issue-67945-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-1.min.stderr
@@ -6,6 +6,7 @@ LL |         let x: S = MaybeUninit::uninit();
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-67945-1.rs:13:45
@@ -15,6 +16,7 @@ LL |         let b = &*(&x as *const _ as *const S);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-1.rs:7:12

--- a/tests/ui/const-generics/issues/issue-67945-2.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-2.min.stderr
@@ -3,6 +3,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |         let x: Option<Box<Self>> = None;
    |                           ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-67945-3.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-3.min.stderr
@@ -6,6 +6,7 @@ LL |         let x: Option<S> = None;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-3.rs:9:12

--- a/tests/ui/const-generics/issues/issue-67945-4.min.stderr
+++ b/tests/ui/const-generics/issues/issue-67945-4.min.stderr
@@ -6,6 +6,7 @@ LL |         let x: Option<Box<S>> = None;
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: type parameter `S` is never used
   --> $DIR/issue-67945-4.rs:8:12

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -6,6 +6,7 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: `Option<usize>` is forbidden as the type of a const generic parameter
   --> $DIR/issue-68366.rs:9:25

--- a/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
+++ b/tests/ui/const-generics/issues/issue-76701-ty-param-in-const.stderr
@@ -6,6 +6,7 @@ LL | fn ty_param<T>() -> [u8; std::mem::size_of::<T>()] {
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/issue-76701-ty-param-in-const.rs:6:42
@@ -15,6 +16,7 @@ LL | fn const_param<const N: usize>() -> [u8; N + 1] {
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-80062.stderr
+++ b/tests/ui/const-generics/issues/issue-80062.stderr
@@ -6,6 +6,7 @@ LL |     let _: [u8; sof::<T>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-80375.stderr
+++ b/tests/ui/const-generics/issues/issue-80375.stderr
@@ -6,6 +6,7 @@ LL | struct MyArray<const COUNT: usize>([u8; COUNT + 1]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `COUNT`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/legacy-const-generics-bad.stderr
+++ b/tests/ui/const-generics/legacy-const-generics-bad.stderr
@@ -18,6 +18,7 @@ LL |     legacy_const_generics::foo(0, N + 1, 2);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
+++ b/tests/ui/const-generics/mgca/adt_expr_arg_simple.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     foo::<{ Some::<u32> { 0: const { N + 1 } } }>();
    |                                      ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.stderr
+++ b/tests/ui/const-generics/mgca/direct-const-arg-feature-gate.stderr
@@ -16,6 +16,7 @@ LL | fn foo<const N: usize>(_: [(); core::direct_const_arg!(N)]) {}
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: expected expression, found `direct_const_arg!()` constant
   --> $DIR/direct-const-arg-feature-gate.rs:1:32

--- a/tests/ui/const-generics/mgca/double-inline-const.stderr
+++ b/tests/ui/const-generics/mgca/double-inline-const.stderr
@@ -9,7 +9,7 @@ note: not a concrete type
    |
 LL | impl<const N: usize> S<N> {
    |                      ^^^^
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.stderr
+++ b/tests/ui/const-generics/mgca/double-wrapped-path-not-accidentally-stabilized.stderr
@@ -6,6 +6,7 @@ LL |     f::<{ { N } }>();
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/early-bound-param-lt-bad.stderr
+++ b/tests/ui/const-generics/mgca/early-bound-param-lt-bad.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     T: Trait<const { let a: &'a (); 1 }>
    |                              ^^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
+++ b/tests/ui/const-generics/mgca/explicit_anon_consts.stderr
@@ -40,7 +40,7 @@ error: generic parameters may not be used in const operations
 LL | type const ITEM3<const N: usize>: usize = const { N };
    |                                                   ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:60:31
@@ -48,7 +48,7 @@ error: generic parameters may not be used in const operations
 LL |     T3: Trait<ASSOC = const { N }>,
    |                               ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:69:58
@@ -56,7 +56,7 @@ error: generic parameters may not be used in const operations
 LL | struct Default3<const N: usize, const M: usize = const { N }>;
    |                                                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:28:27
@@ -64,7 +64,7 @@ error: generic parameters may not be used in const operations
 LL |     let _3 = [(); const { N }];
    |                           ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:33:26
@@ -72,7 +72,7 @@ error: generic parameters may not be used in const operations
 LL |     let _6: [(); const { N }] = todo!();
    |                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:11:41
@@ -80,7 +80,7 @@ error: generic parameters may not be used in const operations
 LL | type Adt3<const N: usize> = Foo<const { N }>;
    |                                         ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/explicit_anon_consts.rs:19:42
@@ -88,7 +88,7 @@ error: generic parameters may not be used in const operations
 LL | type Arr3<const N: usize> = [(); const { N }];
    |                                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.stderr
+++ b/tests/ui/const-generics/mgca/mixed-direct-anon-expression-diagnostics.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     f::<{ (N, 1 + 1) }>();
    |            ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/selftyalias-containing-param.stderr
+++ b/tests/ui/const-generics/mgca/selftyalias-containing-param.stderr
@@ -9,7 +9,7 @@ note: not a concrete type
    |
 LL | impl<const N: usize> S<N> {
    |                      ^^^^
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/selftyparam.stderr
+++ b/tests/ui/const-generics/mgca/selftyparam.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     fn foo() -> [(); const { let _: Self; 1 }];
    |                                     ^^^^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
+++ b/tests/ui/const-generics/mgca/size-of-generic-ptr-in-array-len.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     [0; const { size_of::<*mut T>() }];
    |                                ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
+++ b/tests/ui/const-generics/mgca/tuple_ctor_complex_args.stderr
@@ -10,7 +10,7 @@ error: generic parameters may not be used in const operations
 LL |     with_point::<{ Point(const { N + 1 }, N) }>();
    |                                  ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
+++ b/tests/ui/const-generics/mgca/tuple_expr_arg_complex.stderr
@@ -22,7 +22,7 @@ error: generic parameters may not be used in const operations
 LL |     takes_nested_tuple::<{ core::direct_const_arg!((N, (N, const { N + 1 }))) }>();
    |                                                                    ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/mgca/type_const-on-generic-expr.stderr
+++ b/tests/ui/const-generics/mgca/type_const-on-generic-expr.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | type const FREE1<T>: usize = const { std::mem::size_of::<T>() };
    |                                                          ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic-expr.rs:8:51
@@ -12,7 +12,7 @@ error: generic parameters may not be used in const operations
 LL | type const FREE2<const I: usize>: usize = const { I + 1 };
    |                                                   ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/mgca/type_const-on-generic_expr-2.stderr
+++ b/tests/ui/const-generics/mgca/type_const-on-generic_expr-2.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL |     type const N1<T>: usize = const { std::mem::size_of::<T>() };
    |                                                           ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic_expr-2.rs:15:52
@@ -12,7 +12,7 @@ error: generic parameters may not be used in const operations
 LL |     type const N2<const I: usize>: usize = const { I + 1 };
    |                                                    ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/type_const-on-generic_expr-2.rs:17:40
@@ -20,7 +20,7 @@ error: generic parameters may not be used in const operations
 LL |     type const N3: usize = const { 2 & X };
    |                                        ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -6,6 +6,7 @@ LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:13:40
@@ -15,6 +16,7 @@ LL | struct Break1<const N: usize>([u8; { { N } }]);
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:17:17
@@ -24,6 +26,7 @@ LL |     let _: [u8; N + 1];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:22:17
@@ -33,6 +36,7 @@ LL |     let _ = [0; N + 1];
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:26:45
@@ -42,6 +46,7 @@ LL | struct BreakTy0<T>(T, [u8; { size_of::<*mut T>() }]);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:29:47
@@ -51,6 +56,7 @@ LL | struct BreakTy1<T>(T, [u8; { { size_of::<*mut T>() } }]);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/complex-expression.rs:33:32
@@ -60,6 +66,7 @@ LL |     let _: [u8; size_of::<*mut T>() + 1];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 warning: cannot use constants which depend on generic parameters in types
   --> $DIR/complex-expression.rs:38:17

--- a/tests/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.stderr
+++ b/tests/ui/const-generics/min_const_generics/forbid-non-static-lifetimes.stderr
@@ -6,6 +6,7 @@ LL |     test::<{ let _: &'a (); 3 },>();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/forbid-non-static-lifetimes.rs:21:16
@@ -15,6 +16,7 @@ LL |     [(); (|_: &'a u8| (), 0).1];
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/forbid-self-no-normalize.stderr
+++ b/tests/ui/const-generics/min_const_generics/forbid-self-no-normalize.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<T> BindsParam<T> for <T as AlwaysApplicable>::Assoc {
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
+++ b/tests/ui/const-generics/min_const_generics/self-ty-in-const-1.stderr
@@ -6,6 +6,7 @@ LL |     fn t1() -> [u8; std::mem::size_of::<Self>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic `Self` types are currently not permitted in anonymous constants
   --> $DIR/self-ty-in-const-1.rs:12:41
@@ -18,6 +19,8 @@ note: not a concrete type
    |
 LL | impl<T> Bar<T> {
    |         ^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
+++ b/tests/ui/const-generics/min_const_generics/self-ty-in-const-2.stderr
@@ -9,6 +9,8 @@ note: not a concrete type
    |
 LL | impl<T> Baz for Bar<T> {
    |                 ^^^^^^
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/outer-lifetime-in-const-generic-default.stderr
+++ b/tests/ui/const-generics/outer-lifetime-in-const-generic-default.stderr
@@ -6,6 +6,7 @@ LL |         let x: &'a ();
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -12,6 +12,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21

--- a/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
+++ b/tests/ui/const-generics/repeat_expr_hack_gives_right_generics.stderr
@@ -6,6 +6,7 @@ LL |     bar::<{ [1; N] }>();
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/repeat_expr_hack_gives_right_generics.rs:22:19
@@ -15,6 +16,7 @@ LL |     bar::<{ [1; { N + 1 }] }>();
    |
    = help: const parameters may only be used as standalone arguments here, i.e. `N`
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/type-relative-path-144547.min.stderr
+++ b/tests/ui/const-generics/type-relative-path-144547.min.stderr
@@ -3,6 +3,9 @@ error: generic parameters may not be used in const operations
    |
 LL |     type SupportedArray<T> = [T; <Self::InfoType as LevelInfo>::SUPPORTED_SLOTS];
    |                                   ^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/size-of-t.stderr
+++ b/tests/ui/consts/const-eval/size-of-t.stderr
@@ -6,6 +6,7 @@ LL |     let _arr: [u8; size_of::<T>()];
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic-const-args.stderr
@@ -4,7 +4,7 @@ error: generic parameters may not be used in const operations
 LL | type const INC<const N: usize>: usize = const { N + 1 };
    |                                                 ^
    |
-   = help: add `#![feature(generic_const_args)]` to allow generic expressions as the RHS of const items
+   = help: add `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-min-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-min-generic-const-args.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0658]: `type const` syntax is experimental
   --> $DIR/feature-gate-min-generic-const-args.rs:2:5

--- a/tests/ui/generics/param-in-ct-in-ty-param-default.stderr
+++ b/tests/ui/generics/param-in-ct-in-ty-param-default.stderr
@@ -6,6 +6,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
+++ b/tests/ui/lifetimes/issue-64173-unused-lifetimes.stderr
@@ -6,6 +6,7 @@ LL |     beta: [(); foo::<&'a ()>()],
    |
    = note: lifetime parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: lifetime parameter `'s` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:3:12
@@ -20,6 +21,9 @@ error: generic `Self` types are currently not permitted in anonymous constants
    |
 LL |     array: [(); size_of::<&Self>()],
    |                            ^^^^
+   |
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/issue-64173-unused-lifetimes.rs:15:12

--- a/tests/ui/resolve/issue-39559.stderr
+++ b/tests/ui/resolve/issue-39559.stderr
@@ -6,6 +6,7 @@ LL |     entries: [T; D::dim()],
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type/pattern_types/assoc_const.default.stderr
+++ b/tests/ui/type/pattern_types/assoc_const.default.stderr
@@ -6,6 +6,7 @@ LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:17:61
@@ -15,6 +16,7 @@ LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:40
@@ -24,6 +26,7 @@ LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: generic parameters may not be used in const operations
   --> $DIR/assoc_const.rs:20:51
@@ -33,6 +36,7 @@ LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    |
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = help: alternatively, you can use `#![feature(generic_const_args)]` and extract the expression into a `type const` item
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/156968)*
<!-- homu-ignore:end -->

fixes rust-lang/rust#156729

when const ops hit generic params, like `[u8; size_of::<self>()]`, the diagnostic only points at `generic_const_exprs`. imo that's a stale nudge now that `generic_const_args` and `type const` items are the path we want people trying.

add help for `generic_const_args` and `type const` items in the resolve and hir_ty_lowering paths. also skip the old gce suggestion once `min_generic_const_args` is enabled, and emit both suggestions for the `self` alias path so the "alternatively" wording doesn't hang there by itself. includes the regression test from the issue. lgtm.