### PR TITLE
add field_projections fixme

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -898,6 +898,8 @@ where
                         predicate: TraitRef::new(ecx.cx(), sized_trait, [ty]).upcast(ecx.cx()),
                     },
                 );
+                // FIXME(field_projections): This function does some questionable incomplete stuff by
+                // returning `Err(NoSolution)` on ambiguity.
                 ecx.try_evaluate_added_goals()? == Certainty::Yes
             }
             && match base.kind() {


### PR DESCRIPTION
haven't looked at the code in detail, but I can't see a way in which this is the correct behavior. I think ideally `try_evaluate_added_goals` just doens't return the certainty as afaik it only does so because `evaluate_added_goals_and_make_canonical_response` uses it internally

r? @Nadrieril @BennoLossin 