### PR TITLE
Rename `truncate` methods on integers to `narrow`

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3985,69 +3985,69 @@ macro_rules! int_impl {
             }
         }
 
-        /// Truncate an integer to an integer of the same size or smaller, preserving the least
+        /// Narrow an integer to an integer of the same size or smaller, preserving the least
         /// significant bits.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
-        #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".truncate());")]
-        #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").truncate());")]
-        /// assert_eq!(120i8, 376i32.truncate());
+        /// #![feature(integer_widen_narrow)]
+        #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".narrow());")]
+        #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").narrow());")]
+        /// assert_eq!(120i8, 376i32.narrow());
         /// ```
-        #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[must_use = "this returns the narrowed value and does not modify the original"]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
-        pub const fn truncate<Target>(self) -> Target
-            where Self: [const] traits::TruncateTarget<Target>
+        pub const fn narrow<Target>(self) -> Target
+            where Self: [const] traits::NarrowTarget<Target>
         {
-            traits::TruncateTarget::internal_truncate(self)
+            traits::NarrowTarget::internal_narrow(self)
         }
 
-        /// Truncate an integer to an integer of the same size or smaller, saturating at numeric bounds
-        /// instead of truncating.
+        /// Narrow an integer to an integer of the same size or smaller, saturating at numeric
+        /// bounds.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
-        #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".saturating_truncate());")]
-        #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").saturating_truncate());")]
-        /// assert_eq!(127i8, 376i32.saturating_truncate());
-        /// assert_eq!(-128i8, (-1000i32).saturating_truncate());
+        /// #![feature(integer_widen_narrow)]
+        #[doc = concat!("assert_eq!(120i8, 120", stringify!($SelfT), ".saturating_narrow());")]
+        #[doc = concat!("assert_eq!(-120i8, (-120", stringify!($SelfT), ").saturating_narrow());")]
+        /// assert_eq!(127i8, 376i32.saturating_narrow());
+        /// assert_eq!(-128i8, (-1000i32).saturating_narrow());
         /// ```
-        #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[must_use = "this returns the narrowed value and does not modify the original"]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
-        pub const fn saturating_truncate<Target>(self) -> Target
-            where Self: [const] traits::TruncateTarget<Target>
+        pub const fn saturating_narrow<Target>(self) -> Target
+            where Self: [const] traits::NarrowTarget<Target>
         {
-            traits::TruncateTarget::internal_saturating_truncate(self)
+            traits::NarrowTarget::internal_saturating_narrow(self)
         }
 
-        /// Truncate an integer to an integer of the same size or smaller, returning `None` if the value
+        /// Narrow an integer to an integer of the same size or smaller, returning `None` if the value
         /// is outside the bounds of the smaller type.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
-        #[doc = concat!("assert_eq!(Some(120i8), 120", stringify!($SelfT), ".checked_truncate());")]
-        #[doc = concat!("assert_eq!(Some(-120i8), (-120", stringify!($SelfT), ").checked_truncate());")]
-        /// assert_eq!(None, 376i32.checked_truncate::<i8>());
-        /// assert_eq!(None, (-1000i32).checked_truncate::<i8>());
+        /// #![feature(integer_widen_narrow)]
+        #[doc = concat!("assert_eq!(Some(120i8), 120", stringify!($SelfT), ".checked_narrow());")]
+        #[doc = concat!("assert_eq!(Some(-120i8), (-120", stringify!($SelfT), ").checked_narrow());")]
+        /// assert_eq!(None, 376i32.checked_narrow::<i8>());
+        /// assert_eq!(None, (-1000i32).checked_narrow::<i8>());
         /// ```
-        #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[must_use = "this returns the narrowed value and does not modify the original"]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
-        pub const fn checked_truncate<Target>(self) -> Option<Target>
-            where Self: [const] traits::TruncateTarget<Target>
+        pub const fn checked_narrow<Target>(self) -> Option<Target>
+            where Self: [const] traits::NarrowTarget<Target>
         {
-            traits::TruncateTarget::internal_checked_truncate(self)
+            traits::NarrowTarget::internal_checked_narrow(self)
         }
 
         /// Widen to an integer of the same size or larger, preserving its value.
@@ -4055,13 +4055,13 @@ macro_rules! int_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
+        /// #![feature(integer_widen_narrow)]
         #[doc = concat!("assert_eq!(120i128, 120i8.widen());")]
         #[doc = concat!("assert_eq!(-120i128, (-120i8).widen());")]
         /// ```
         #[must_use = "this returns the widened value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
         pub const fn widen<Target>(self) -> Target
             where Self: [const] traits::WidenTarget<Target>

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -1,34 +1,34 @@
 /// Definitions of traits for numeric types
 // Implementation based on `num_conv` by jhpratt, under (MIT OR Apache-2.0).
 
-/// Trait for types that this type can be truncated to
+/// Trait for types that this type can be narrowed to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-#[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
-pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
+#[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
+pub const trait NarrowTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
-    fn internal_truncate(self) -> Target;
+    fn internal_narrow(self) -> Target;
 
     #[doc(hidden)]
-    fn internal_saturating_truncate(self) -> Target;
+    fn internal_saturating_narrow(self) -> Target;
 
     #[doc(hidden)]
-    fn internal_checked_truncate(self) -> Option<Target>;
+    fn internal_checked_narrow(self) -> Option<Target>;
 }
 
 /// Trait for types that this type can be widened to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-#[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+#[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
 pub const trait WidenTarget<Target>: crate::sealed::Sealed {
     #[doc(hidden)]
     fn internal_widen(self) -> Target;
 }
 
-macro_rules! impl_truncate {
+macro_rules! impl_narrow {
     ($($from:ty => $($to:ty),+;)*) => {$($(
         const _: () = assert!(
             size_of::<$from>() >= size_of::<$to>(),
             concat!(
-                "cannot truncate ",
+                "cannot narrow ",
                 stringify!($from),
                 " to ",
                 stringify!($to),
@@ -40,15 +40,15 @@ macro_rules! impl_truncate {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
-        impl const TruncateTarget<$to> for $from {
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
+        impl const NarrowTarget<$to> for $from {
             #[inline]
-            fn internal_truncate(self) -> $to {
+            fn internal_narrow(self) -> $to {
                 self as _
             }
 
             #[inline]
-            fn internal_saturating_truncate(self) -> $to {
+            fn internal_saturating_narrow(self) -> $to {
                 if self > <$to>::MAX as Self {
                     <$to>::MAX
                 } else if self < <$to>::MIN as Self {
@@ -59,7 +59,7 @@ macro_rules! impl_truncate {
             }
 
             #[inline]
-            fn internal_checked_truncate(self) -> Option<$to> {
+            fn internal_checked_narrow(self) -> Option<$to> {
                 if self > <$to>::MAX as Self || self < <$to>::MIN as Self {
                     None
                 } else {
@@ -87,7 +87,7 @@ macro_rules! impl_widen {
         );
 
         #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         impl const WidenTarget<$to> for $from {
             fn internal_widen(self) -> $to {
                 self as _
@@ -96,7 +96,7 @@ macro_rules! impl_widen {
     )+)*};
 }
 
-impl_truncate! {
+impl_narrow! {
     u8 => u8;
     u16 => u16, u8;
     u32 => u32, u16, u8;

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -4152,64 +4152,64 @@ macro_rules! uint_impl {
         #[rustc_diagnostic_item = concat!(stringify!($SelfT), "_legacy_fn_max_value")]
         pub const fn max_value() -> Self { Self::MAX }
 
-        /// Truncate an integer to an integer of the same size or smaller, preserving the least
+        /// Narrow an integer to an integer of the same size or smaller, preserving the least
         /// significant bits.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
-        #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".truncate());")]
-        /// assert_eq!(120u8, 376u32.truncate());
+        /// #![feature(integer_widen_narrow)]
+        #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".narrow());")]
+        /// assert_eq!(120u8, 376u32.narrow());
         /// ```
-        #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[must_use = "this returns the narrowed value and does not modify the original"]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
-        pub const fn truncate<Target>(self) -> Target
-            where Self: [const] traits::TruncateTarget<Target>
+        pub const fn narrow<Target>(self) -> Target
+            where Self: [const] traits::NarrowTarget<Target>
         {
-            traits::TruncateTarget::internal_truncate(self)
+            traits::NarrowTarget::internal_narrow(self)
         }
 
-        /// Truncate an integer to an integer of the same size or smaller, saturating at numeric bounds
-        /// instead of truncating.
+        /// Narrow an integer to an integer of the same size or smaller, saturating at numeric
+        /// bounds.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
-        #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".saturating_truncate());")]
-        /// assert_eq!(255u8, 376u32.saturating_truncate());
+        /// #![feature(integer_widen_narrow)]
+        #[doc = concat!("assert_eq!(120u8, 120", stringify!($SelfT), ".saturating_narrow());")]
+        /// assert_eq!(255u8, 376u32.saturating_narrow());
         /// ```
-        #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[must_use = "this returns the narrowed value and does not modify the original"]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
-        pub const fn saturating_truncate<Target>(self) -> Target
-            where Self: [const] traits::TruncateTarget<Target>
+        pub const fn saturating_narrow<Target>(self) -> Target
+            where Self: [const] traits::NarrowTarget<Target>
         {
-            traits::TruncateTarget::internal_saturating_truncate(self)
+            traits::NarrowTarget::internal_saturating_narrow(self)
         }
 
-        /// Truncate an integer to an integer of the same size or smaller, returning `None` if the value
-        /// is outside the bounds of the smaller type.
+        /// Narrow an integer to an integer of the same size or smaller, returning `None` if the
+        /// value is outside the bounds of the smaller type.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
-        #[doc = concat!("assert_eq!(Some(120u8), 120", stringify!($SelfT), ".checked_truncate());")]
-        /// assert_eq!(None, 376u32.checked_truncate::<u8>());
+        /// #![feature(integer_widen_narrow)]
+        #[doc = concat!("assert_eq!(Some(120u8), 120", stringify!($SelfT), ".checked_narrow());")]
+        /// assert_eq!(None, 376u32.checked_narrow::<u8>());
         /// ```
-        #[must_use = "this returns the truncated value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[must_use = "this returns the narrowed value and does not modify the original"]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
-        pub const fn checked_truncate<Target>(self) -> Option<Target>
-            where Self: [const] traits::TruncateTarget<Target>
+        pub const fn checked_narrow<Target>(self) -> Option<Target>
+            where Self: [const] traits::NarrowTarget<Target>
         {
-            traits::TruncateTarget::internal_checked_truncate(self)
+            traits::NarrowTarget::internal_checked_narrow(self)
         }
 
         /// Widen to an integer of the same size or larger, preserving its value.
@@ -4217,12 +4217,12 @@ macro_rules! uint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(integer_widen_truncate)]
+        /// #![feature(integer_widen_narrow)]
         #[doc = concat!("assert_eq!(120u128, 120u8.widen());")]
         /// ```
         #[must_use = "this returns the widened value and does not modify the original"]
-        #[unstable(feature = "integer_widen_truncate", issue = "154330")]
-        #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
+        #[unstable(feature = "integer_widen_narrow", issue = "154330")]
+        #[rustc_const_unstable(feature = "integer_widen_narrow", issue = "154330")]
         #[inline]
         pub const fn widen<Target>(self) -> Target
             where Self: [const] traits::WidenTarget<Target>


### PR DESCRIPTION
This makes them consistent with `widen` (formerly `extend`).
