### PR TITLE
Add frame pointer annotations to the module

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -171,10 +171,7 @@ pub(crate) fn uwtable_attr(llcx: &llvm::Context, use_sync_unwind: Option<bool>) 
     llvm::CreateUWTableAttr(llcx, async_unwind)
 }
 
-pub(crate) fn frame_pointer_type_attr<'ll>(
-    cx: &SimpleCx<'ll>,
-    sess: &Session,
-) -> Option<&'ll Attribute> {
+pub(crate) fn frame_pointer(sess: &Session) -> FramePointer {
     let mut fp = sess.target.frame_pointer;
     let opts = &sess.opts;
     // "mcount" function relies on stack pointer.
@@ -183,6 +180,14 @@ pub(crate) fn frame_pointer_type_attr<'ll>(
         fp.ratchet(FramePointer::Always);
     }
     fp.ratchet(opts.cg.force_frame_pointers);
+    fp
+}
+
+pub(crate) fn frame_pointer_type_attr<'ll>(
+    cx: &SimpleCx<'ll>,
+    sess: &Session,
+) -> Option<&'ll Attribute> {
+    let fp = frame_pointer(sess);
     let attr_value = match fp {
         FramePointer::Always => "all",
         FramePointer::NonLeaf => "non-leaf",

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -28,7 +28,8 @@ use rustc_session::config::{
 use rustc_span::{DUMMY_SP, Span, Spanned, Symbol, sym};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{
-    Arch, CfgAbi, Env, HasTargetSpec, Os, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
+    Arch, CfgAbi, Env, FramePointer, HasTargetSpec, Os, RelocModel, SmallDataThresholdSupport,
+    Target, TlsModel,
 };
 use smallvec::SmallVec;
 
@@ -487,6 +488,20 @@ pub(crate) unsafe fn create_module<'ll>(
                 1,
             );
         }
+    }
+
+    let fp = attributes::frame_pointer(sess);
+    if fp != FramePointer::MayOmit {
+        llvm::add_module_flag_u32(
+            llmod,
+            llvm::ModuleFlagMergeBehavior::Max,
+            "frame-pointer",
+            match fp {
+                FramePointer::Always => llvm::FramePointerKind::All as u32,
+                FramePointer::NonLeaf => llvm::FramePointerKind::NonLeaf as u32,
+                FramePointer::MayOmit => llvm::FramePointerKind::None as u32,
+            },
+        );
     }
 
     if sess.opts.unstable_opts.indirect_branch_cs_prefix {

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -252,6 +252,18 @@ pub(crate) enum UWTableKind {
     Async = 2,
 }
 
+/// Must match the layout of `llvm::FramePointerKind`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[expect(dead_code, reason = "Some variants are unused, but are kept to match LLVM")]
+pub(crate) enum FramePointerKind {
+    None = 0,
+    NonLeaf = 1,
+    All = 2,
+    Reserved = 3,
+    NonLeafNoReserve = 4,
+}
+
 /// Must match the layout of `LLVMRustAttributeKind`.
 /// Semantically a subset of the C++ enum llvm::Attribute::AttrKind,
 /// though it is not ABI compatible (since it's a C++ enum)

--- a/tests/codegen-llvm/force-frame-pointers.rs
+++ b/tests/codegen-llvm/force-frame-pointers.rs
@@ -16,3 +16,6 @@
 // Always: attributes #{{.*}} "frame-pointer"="all"
 // NonLeaf: attributes #{{.*}} "frame-pointer"="non-leaf"
 pub fn foo() {}
+
+// Always: !{{[0-9]+}} = !{i32 7, !"frame-pointer", i32 2}
+// NonLeaf: !{{[0-9]+}} = !{i32 7, !"frame-pointer", i32 1}


### PR DESCRIPTION
While working on rust-lang/rust#156973 I found https://github.com/llvm/llvm-project/issues/188234 which points out that the frame pointer annotation is also missing.