### PR TITLE
Limit the additional DLL to Windows

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2591,8 +2591,10 @@ pub fn maybe_install_llvm_runtime(builder: &Builder<'_>, target: TargetSelection
         // To workaround lack of rpath on Windows, we bundle another copy of
         // the LLVM DLL to make rust-lld and llvm-tools work when `sysroot/bin`
         //  is missing from PATH, i.e. when they not launched by rustc.
-        let dst_libdir = sysroot.join("lib/rustlib").join(target).join("bin");
-        maybe_install_llvm(builder, target, &dst_libdir, false);
+        if target.triple.contains("windows") {
+            let dst_libdir = sysroot.join("lib/rustlib").join(target).join("bin");
+            maybe_install_llvm(builder, target, &dst_libdir, false);
+        }
     }
 }
 


### PR DESCRIPTION
rust-lang/rust#156229 didn't limit the additional DLL copy to Windows as it was supposed to.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
