### PR TITLE
interpret/validity: properly treat zero-variant enums so that we do not have to check layout.is_uninhabited

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1354,6 +1354,16 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
     }
 
     #[inline]
+    fn visit_variantless(&mut self, val: &PlaceTy<'tcx, M::Provenance>) -> InterpResult<'tcx> {
+        let ty = val.layout.ty;
+        assert!(ty.is_enum(), "encountered non-enum variantless type `{ty}`");
+        throw_validation_failure!(
+            self.path,
+            format!("encountered a value of zero-variant enum `{ty}`")
+        );
+    }
+
+    #[inline]
     fn visit_value(&mut self, val: &PlaceTy<'tcx, M::Provenance>) -> InterpResult<'tcx> {
         trace!("visit_value: {:?}, {:?}", *val, val.layout);
 
@@ -1557,23 +1567,14 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
             }
         }
 
-        // *After* all of this, check further information stored in the layout.
-        // On leaf types like `!` or empty enums, this will raise the error.
-        // This means that for types wrapping such a type, we won't ever get here, but it's
-        // just the simplest way to check for this case.
-        //
-        // FIXME: We could avoid some redundant checks here. For newtypes wrapping
-        // scalars, we do the same check on every "level" (e.g., first we check
-        // the fields of MyNewtype, and then we check MyNewType again).
-        if val.layout.is_uninhabited() {
-            let ty = val.layout.ty;
-            throw_validation_failure!(
-                self.path,
-                format!("encountered a value of uninhabited type `{ty}`")
-            );
-        }
+        // Assert that we checked everything there is to check about this type.
+        assert!(
+            !val.layout.is_uninhabited(),
+            "a value of type `{}` passed validation but that type is uninhabited",
+            val.layout.ty
+        );
         if cfg!(debug_assertions) {
-            // Check that we don't miss any new changes to layout computation in our checks above.
+            // Only run expensive checks when debug assertions are enabled.
             match val.layout.backend_repr {
                 BackendRepr::Scalar(scalar_layout) => {
                     if !scalar_layout.is_uninit_valid() {

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -41,6 +41,11 @@ pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
     fn visit_box(&mut self, _box_ty: Ty<'tcx>, _v: &Self::V) -> InterpResult<'tcx> {
         interp_ok(())
     }
+    /// Visits the given type after it has been found to have no variants.
+    #[inline(always)]
+    fn visit_variantless(&mut self, _v: &Self::V) -> InterpResult<'tcx> {
+        interp_ok(())
+    }
 
     /// Called each time we recurse down to a field of a "product-like" aggregate
     /// (structs, tuples, arrays and the like, but not enums), passing in old (outer)
@@ -193,7 +198,11 @@ pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
                 self.visit_variant(v, idx, &inner)?;
             }
             // For single-variant layouts, we already did everything there is to do.
-            Variants::Single { .. } | Variants::Empty => {}
+            Variants::Single { .. } => {}
+            // Non-variant layouts need special treatment by the visitor.
+            Variants::Empty => {
+                self.visit_variantless(v)?;
+            }
         }
 
         interp_ok(())

--- a/src/tools/miri/tests/fail/validity/match_binder_checks_validity1.stderr
+++ b/src/tools/miri/tests/fail/validity/match_binder_checks_validity1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value of type main::Void: encountered a value of uninhabited type `main::Void`
+error: Undefined Behavior: constructing invalid value of type main::Void: encountered a value of zero-variant enum `main::Void`
   --> tests/fail/validity/match_binder_checks_validity1.rs:LL:CC
    |
 LL |             _x => println!("hi from the void!"),

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type Bar: encountered a value of uninhabited type `Bar`
+error[E0080]: constructing invalid value of type Bar: encountered a value of zero-variant enum `Bar`
   --> $DIR/ub-uninhabit.rs:20:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
@@ -15,7 +15,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type [Bar; 1]: at [0], encountered a value of uninhabited type `Bar`
+error[E0080]: constructing invalid value of type [Bar; 1]: at [0], encountered a value of zero-variant enum `Bar`
   --> $DIR/ub-uninhabit.rs:26:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -18,7 +18,7 @@ const FOO: [empty::Empty; 3] = [foo(); 3];
 //~^ ERROR value of the never type
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-//~^ ERROR value of uninhabited type
+//~^ ERROR value of zero-variant enum
 
 fn main() {
     FOO;

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -10,7 +10,7 @@ note: inside `foo`
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
-error[E0080]: constructing invalid value of type empty::Empty: at .0, encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type empty::Empty: at .0, encountered a value of zero-variant enum `Void`
   --> $DIR/validate_uninhabited_zsts.rs:20:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];

--- a/tests/ui/consts/issue-64506.rs
+++ b/tests/ui/consts/issue-64506.rs
@@ -14,7 +14,7 @@ const FOO: () = {
         b: (),
     }
     let x = unsafe { Foo { b: () }.a };
-    //~^ ERROR: value of uninhabited type
+    //~^ ERROR: value of zero-variant enum
     let x = &x.inner;
 };
 

--- a/tests/ui/consts/issue-64506.stderr
+++ b/tests/ui/consts/issue-64506.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type ChildStdin: at .inner, encountered a value of uninhabited type `AnonPipe`
+error[E0080]: constructing invalid value of type ChildStdin: at .inner, encountered a value of zero-variant enum `AnonPipe`
   --> $DIR/issue-64506.rs:16:22
    |
 LL |     let x = unsafe { Foo { b: () }.a };

--- a/tests/ui/statics/uninhabited-static.rs
+++ b/tests/ui/statics/uninhabited-static.rs
@@ -10,9 +10,9 @@ extern "C" {
 
 static VOID2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
 //~| WARN: previously accepted
-//~| ERROR value of uninhabited type `Void`
+//~| ERROR value of zero-variant enum `Void`
 static NEVER2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
 //~| WARN: previously accepted
-//~| ERROR value of uninhabited type `Void`
+//~| ERROR value of zero-variant enum `Void`
 
 fn main() {}

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -39,13 +39,13 @@ LL |     static NEVER: !;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
-error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type Void: encountered a value of zero-variant enum `Void`
   --> $DIR/uninhabited-static.rs:11:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
-error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type Void: encountered a value of zero-variant enum `Void`
   --> $DIR/uninhabited-static.rs:14:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };


### PR DESCRIPTION
I am very happy to finally remove the last of these somewhat ad-hoc checks. :)

r? @oli-obk 