### PR TITLE
Add missing --set rust.codegen-backends=["gcc"] in the gcc codegen Dockerfile for the core tests

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
@@ -44,4 +44,5 @@ ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --set rust.codegen-backends=[\\\"gcc\\\"]"
 ENV SCRIPT="python3 ../x.py \
   --stage 1 \
-  test library/coretests"
+  test library/coretests \
+  --set rust.codegen-backends=[\\\"gcc\\\"]"


### PR DESCRIPTION
The CI would use cranelift instead of the gcc codegen.
This fixes it and was tested in rust-lang/rust#156964.

r? @Kobzol 

cc @GuillaumeGomez 