### PR TITLE
[DO NOT MERGE] compiler/global_allocator: no static mut global allocator

### DIFF
--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -25,12 +25,14 @@ pub(crate) fn expand(
     // Allow using `#[global_allocator]` on an item statement
     // FIXME - if we get deref patterns, use them to reduce duplication here
     let (item, ident, is_stmt, ty_span) = if let Annotatable::Item(item) = &item
-        && let ItemKind::Static(ast::StaticItem { ident, ty, .. }) = &item.kind
+        && let ItemKind::Static(ast::StaticItem { ident, ty, mutability, .. }) = &item.kind
+        && mutability.is_not()
     {
         (item, *ident, false, ecx.with_def_site_ctxt(ty.span))
     } else if let Annotatable::Stmt(stmt) = &item
         && let StmtKind::Item(item) = &stmt.kind
-        && let ItemKind::Static(ast::StaticItem { ident, ty, .. }) = &item.kind
+        && let ItemKind::Static(ast::StaticItem { ident, ty, mutability, .. }) = &item.kind
+        && mutability.is_not()
     {
         (item, *ident, true, ecx.with_def_site_ctxt(ty.span))
     } else {


### PR DESCRIPTION
Experiment to see if forbidding `static mut` global allocators would work. cc @Amanieu 

r? @ghost