### PR TITLE
Implement FusedIterator trait on StepBy if the underlying iterator is fused

### DIFF
--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -1,5 +1,5 @@
 use crate::intrinsics;
-use crate::iter::{TrustedLen, TrustedRandomAccess, from_fn};
+use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, from_fn};
 use crate::num::NonZero;
 use crate::ops::{Range, Try};
 use crate::range::RangeIter;
@@ -135,6 +135,11 @@ where
 // StepBy can only make the iterator shorter, so the len will still fit.
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 impl<I> ExactSizeIterator for StepBy<I> where I: ExactSizeIterator {}
+
+// StepBy can be marked as a `FusedIterator` if the underlying iterator
+// is fused
+#[stable(feature = "fuse_step_by", since = "CURRENT_RUSTC_VERSION")]
+impl<I> FusedIterator for StepBy<I> where I: FusedIterator {}
 
 // SAFETY: This adapter is shortening. TrustedLen requires the upper bound to be calculated correctly.
 // These requirements can only be satisfied when the upper bound of the inner iterator's upper

--- a/library/coretests/tests/iter/adapters/step_by.rs
+++ b/library/coretests/tests/iter/adapters/step_by.rs
@@ -418,3 +418,25 @@ fn test_step_by_nth_non_fused_on_non_first_take() {
     // so we should expect `StepBy::nth` to return `None`
     assert_eq!(iter.nth(usize::MAX), None)
 }
+
+#[test]
+fn test_step_by_fused_iterator() {
+    struct TestFusedIter(usize);
+    impl Iterator for TestFusedIter {
+        type Item = usize;
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.0 > 5 {
+                let ret = self.0;
+                self.0 -= 1;
+                return Some(ret);
+            }
+            None
+        }
+    }
+    impl FusedIterator for TestFusedIter {}
+
+    let mut it = TestFusedIter(15).step_by(5);
+    assert_eq!(it.next(), Some(15));
+    assert_eq!(it.next(), Some(10));
+    assert_eq!(it.next(), None);
+}


### PR DESCRIPTION
This PR implements the `FusedIterator` trait for `StepBy` if the underlying iterator also implements `FusedIterator` as per accepted in this [ACP](https://github.com/rust-lang/libs-team/issues/757).

This would have to be insta-stable as we're implementing a trait on a stable feature.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
