### PR TITLE
std: Fix thread::available_parallelism on Redox targets

### DIFF
--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -155,6 +155,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             target_os = "aix",
             target_vendor = "apple",
             target_os = "cygwin",
+            target_os = "redox",
             target_os = "wasi",
         ) => {
             #[allow(unused_assignments)]
@@ -316,7 +317,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             }
         }
         _ => {
-            // FIXME: implement on Redox, l4re
+            // FIXME: implement on l4re
             Err(io::const_error!(io::ErrorKind::Unsupported, "getting the number of hardware threads is not supported on the target platform"))
         }
     }


### PR DESCRIPTION
This brings support to `thread::available_parallelism` on Redox targets via `sysconf`. It has been available since `libc 0.2.177` and tested for months.

References:
- [libc implementation](https://github.com/rust-lang/libc/pull/4728)
- [downstream patch](https://gitlab.redox-os.org/redox-os/rust/-/merge_requests/27)
