### PR TITLE
Avoid `unreachable_code` on required return values

### DIFF
--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -890,6 +890,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     {
                         continue;
                     }
+                    // Ignore return value plumbing. After a call returning a non-`!`
+                    // uninhabited type, a tail expression can be unreachable while
+                    // still being needed to satisfy the surrounding return type.
+                    StatementKind::Assign((place, _)) if place.as_local() == Some(RETURN_PLACE) => {
+                        continue;
+                    }
                     StatementKind::StorageLive(_) | StatementKind::StorageDead(_) => {
                         continue;
                     }

--- a/tests/ui/uninhabited/unreachable.rs
+++ b/tests/ui/uninhabited/unreachable.rs
@@ -4,6 +4,8 @@
 //@ check-pass
 #![deny(unreachable_code)]
 
+use std::process::ExitCode;
+
 enum Never {}
 
 fn make_never() -> Never {
@@ -26,6 +28,14 @@ fn branchy() {
     } else {
         make_never();
     }
+}
+
+// Regression test for https://github.com/rust-lang/rust/issues/152559.
+// The final expression is unreachable at runtime, but it cannot be removed
+// because it supplies the function's required return type.
+fn required_return_value() -> ExitCode {
+    make_never();
+    ExitCode::FAILURE
 }
 
 fn main() {


### PR DESCRIPTION
This PR skips return-place assignment plumbing when selecting user code to lint after an uninhabited call.

Fixes rust-lang/rust#152559

r? cjgillot