### PR TITLE
add `extern "tail"` calling convention

### DIFF
--- a/compiler/rustc_abi/src/canon_abi.rs
+++ b/compiler/rustc_abi/src/canon_abi.rs
@@ -28,6 +28,7 @@ pub enum CanonAbi {
     Rust,
     RustCold,
     RustPreserveNone,
+    RustTail,
 
     /// An ABI that rustc does not know how to call or define.
     Custom,
@@ -59,7 +60,10 @@ pub enum CanonAbi {
 impl CanonAbi {
     pub fn is_rustic_abi(self) -> bool {
         match self {
-            CanonAbi::Rust | CanonAbi::RustCold | CanonAbi::RustPreserveNone => true,
+            CanonAbi::Rust
+            | CanonAbi::RustCold
+            | CanonAbi::RustPreserveNone
+            | CanonAbi::RustTail => true,
             CanonAbi::C
             | CanonAbi::Custom
             | CanonAbi::Swift
@@ -81,6 +85,7 @@ impl fmt::Display for CanonAbi {
             CanonAbi::Rust => ExternAbi::Rust,
             CanonAbi::RustCold => ExternAbi::RustCold,
             CanonAbi::RustPreserveNone => ExternAbi::RustPreserveNone,
+            CanonAbi::RustTail => ExternAbi::RustTail,
             CanonAbi::Custom => ExternAbi::Custom,
             CanonAbi::Swift => ExternAbi::Swift,
             CanonAbi::Arm(arm_call) => match arm_call {

--- a/compiler/rustc_abi/src/extern_abi.rs
+++ b/compiler/rustc_abi/src/extern_abi.rs
@@ -49,6 +49,11 @@ pub enum ExternAbi {
     /// forcing callers to save all registers.
     RustPreserveNone,
 
+    /// Ensures that calls in tail position can always be optimized into a jump.
+    ///
+    /// This ABI is not stable, and relies on LLVM implementation details.
+    RustTail,
+
     /// Unstable impl detail that directly uses Rust types to describe the ABI to LLVM.
     /// Even normally-compatible Rust types can become ABI-incompatible with this ABI!
     Unadjusted,
@@ -205,6 +210,7 @@ abi_impls! {
             System { unwind: true } =><= "system-unwind",
             SysV64 { unwind: false } =><= "sysv64",
             SysV64 { unwind: true } =><= "sysv64-unwind",
+            RustTail =><= "tail",
             Thiscall { unwind: false } =><= "thiscall",
             Thiscall { unwind: true } =><= "thiscall-unwind",
             Unadjusted =><= "unadjusted",
@@ -280,7 +286,7 @@ impl ExternAbi {
     /// - are subject to change between compiler versions
     pub fn is_rustic_abi(self) -> bool {
         use ExternAbi::*;
-        matches!(self, Rust | RustCall | RustCold | RustPreserveNone)
+        matches!(self, Rust | RustCall | RustCold | RustPreserveNone | RustTail)
     }
 
     /// Returns whether the ABI supports C variadics. This only controls whether we allow *imports*
@@ -354,6 +360,7 @@ impl ExternAbi {
             | Self::SysV64 { .. }
             | Self::Win64 { .. }
             | Self::RustPreserveNone
+            | Self::RustTail
             | Self::Swift => true,
         }
     }

--- a/compiler/rustc_ast_lowering/src/stability.rs
+++ b/compiler/rustc_ast_lowering/src/stability.rs
@@ -100,6 +100,9 @@ pub fn extern_abi_stability(abi: ExternAbi) -> Result<(), UnstableAbi> {
             feature: sym::rust_preserve_none_cc,
             explain: GateReason::Experimental,
         }),
+        ExternAbi::RustTail => {
+            Err(UnstableAbi { abi, feature: sym::rust_tail_cc, explain: GateReason::Experimental })
+        }
         ExternAbi::RustInvalid => {
             Err(UnstableAbi { abi, feature: sym::rustc_attrs, explain: GateReason::ImplDetail })
         }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -424,6 +424,7 @@ impl<'a> AstValidator<'a> {
                     | CanonAbi::Rust
                     | CanonAbi::RustCold
                     | CanonAbi::RustPreserveNone
+                    | CanonAbi::RustTail
                     | CanonAbi::Swift
                     | CanonAbi::Arm(_)
                     | CanonAbi::X86(_) => { /* nothing to check */ }

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -55,8 +55,9 @@ pub(crate) fn conv_to_call_conv(
     match c {
         CanonAbi::Rust | CanonAbi::RustCold | CanonAbi::C => default_call_conv,
 
-        // Cranelift doesn't currently have anything for this.
-        CanonAbi::RustPreserveNone => default_call_conv,
+        CanonAbi::RustPreserveNone | CanonAbi::RustTail => {
+            sess.dcx().fatal(format!("call conv {c:?} is LLVM-specific"))
+        }
 
         // Functions with this calling convention can only be called from assembly, but it is
         // possible to declare an `extern "custom"` block, so the backend still needs a calling
@@ -71,7 +72,7 @@ pub(crate) fn conv_to_call_conv(
         },
 
         CanonAbi::Interrupt(_) | CanonAbi::Arm(_) | CanonAbi::Swift => {
-            sess.dcx().fatal("call conv {c:?} is not yet implemented")
+            sess.dcx().fatal(format!("call conv {c:?} is not yet implemented"))
         }
         CanonAbi::GpuKernel => {
             unreachable!("tried to use {c:?} call conv which only exists on an unsupported target")

--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -10,7 +10,7 @@ use rustc_middle::bug;
 use rustc_middle::ty::Ty;
 use rustc_middle::ty::layout::LayoutOf;
 #[cfg(feature = "master")]
-use rustc_session::config;
+use rustc_session::{Session, config};
 use rustc_target::callconv::{ArgAttributes, CastTarget, FnAbi, PassMode};
 #[cfg(feature = "master")]
 use rustc_target::spec::Arch;
@@ -230,32 +230,43 @@ impl<'gcc, 'tcx> FnAbiGccExt<'gcc, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
 
     #[cfg(feature = "master")]
     fn gcc_cconv(&self, cx: &CodegenCx<'gcc, 'tcx>) -> Option<FnAttribute<'gcc>> {
-        conv_to_fn_attribute(self.conv, &cx.tcx.sess.target.arch)
+        conv_to_fn_attribute(cx.sess(), self.conv)
     }
 }
 
 #[cfg(feature = "master")]
-pub fn conv_to_fn_attribute<'gcc>(conv: CanonAbi, arch: &Arch) -> Option<FnAttribute<'gcc>> {
+pub fn conv_to_fn_attribute<'gcc>(sess: &Session, conv: CanonAbi) -> Option<FnAttribute<'gcc>> {
     let attribute = match conv {
         CanonAbi::C | CanonAbi::Rust => return None,
-        // gcc/gccjit does not have anything for this.
-        CanonAbi::RustPreserveNone => return None,
+        CanonAbi::RustPreserveNone => {
+            // This calling convention is LLVM-specific and unspecified.
+            sess.dcx()
+                .fatal("gcc/gccjit backend does not support RustPreserveNone calling convention")
+        }
+        CanonAbi::RustTail => {
+            // This calling convention is LLVM-specific and unspecified.
+            sess.dcx().fatal("gcc/gccjit backend does not support RustTail calling convention")
+        }
         CanonAbi::RustCold => FnAttribute::Cold,
         // Functions with this calling convention can only be called from assembly, but it is
         // possible to declare an `extern "custom"` block, so the backend still needs a calling
         // convention for declaring foreign functions.
         CanonAbi::Custom => return None,
-        // gcc/gccjit does not have anything for Swift's calling convention.
-        CanonAbi::Swift => panic!("gcc/gccjit backend does not support Swift calling convention"),
+        CanonAbi::Swift => {
+            // gcc/gccjit does not have anything for Swift's calling convention.
+            sess.dcx().fatal("gcc/gccjit backend does not support Swift calling convention")
+        }
         CanonAbi::Arm(arm_call) => match arm_call {
             ArmCall::CCmseNonSecureCall => FnAttribute::ArmCmseNonsecureCall,
             ArmCall::CCmseNonSecureEntry => FnAttribute::ArmCmseNonsecureEntry,
             ArmCall::Aapcs => FnAttribute::ArmPcs("aapcs"),
         },
-        CanonAbi::GpuKernel => match arch {
+        CanonAbi::GpuKernel => match &sess.target.arch {
             &Arch::AmdGpu => FnAttribute::GcnAmdGpuHsaKernel,
             &Arch::Nvptx64 => FnAttribute::NvptxKernel,
-            arch => panic!("Arch {arch} does not support GpuKernel calling convention"),
+            arch => sess
+                .dcx()
+                .fatal(format!("Arch {arch} does not support GpuKernel calling convention")),
         },
         // FIXME(antoyo): check if those AVR attributes are mapped correctly.
         CanonAbi::Interrupt(interrupt_kind) => match interrupt_kind {

--- a/compiler/rustc_codegen_gcc/src/context.rs
+++ b/compiler/rustc_codegen_gcc/src/context.rs
@@ -486,10 +486,10 @@ impl<'gcc, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
     fn declare_c_main(&self, fn_type: Self::Type) -> Option<Self::Function> {
         let entry_name = self.sess().target.entry_name.as_ref();
         if !self.functions.borrow().contains_key(entry_name) {
-            #[cfg(feature = "master")]
-            let conv = conv_to_fn_attribute(self.sess().target.entry_abi, &self.sess().target.arch);
-            #[cfg(not(feature = "master"))]
-            let conv = None;
+            let conv = cfg_select! {
+                feature = "master" => conv_to_fn_attribute(self.sess(), self.sess().target.entry_abi),
+                _ => None,
+            };
             Some(self.declare_entry_fn(entry_name, fn_type, conv))
         } else {
             // If the symbol already exists, it is an error: for example, the user wrote

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -723,6 +723,10 @@ pub(crate) fn to_llvm_calling_convention(sess: &Session, abi: CanonAbi) -> llvm:
             Arch::X86_64 | Arch::AArch64 => llvm::PreserveNone,
             _ => llvm::CCallConv,
         },
+        CanonAbi::RustTail => match &sess.target.arch {
+            Arch::X86 | Arch::X86_64 | Arch::AArch64 => llvm::Tail,
+            _ => sess.dcx().fatal("extern \"tail\" is only supported on x86_64 and aarch64"),
+        },
         // Functions with this calling convention can only be called from assembly, but it is
         // possible to declare an `extern "custom"` block, so the backend still needs a calling
         // convention for declaring foreign functions.

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -709,6 +709,8 @@ declare_features! (
     (unstable, rust_cold_cc, "1.63.0", Some(97544)),
     /// Allows `extern "rust-preserve-none"`.
     (unstable, rust_preserve_none_cc, "1.95.0", Some(151401)),
+    /// Allows `extern "tail"`.
+    (unstable, rust_tail_cc, "CURRENT_RUSTC_VERSION", Some(157427)),
     /// Target features on s390x.
     (unstable, s390x_target_feature, "1.82.0", Some(150259)),
     /// Allows the use of the `sanitize` attribute.

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -205,6 +205,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | CanonAbi::Rust
             | CanonAbi::RustCold
             | CanonAbi::RustPreserveNone
+            | CanonAbi::RustTail
             | CanonAbi::Swift
             | CanonAbi::Arm(_)
             | CanonAbi::X86(_) => {}

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -1305,7 +1305,9 @@ pub fn fn_can_unwind(tcx: TyCtxt<'_>, fn_def_id: Option<DefId>, abi: ExternAbi) 
         | RustInvalid
         | Swift
         | Unadjusted => false,
-        Rust | RustCall | RustCold | RustPreserveNone => tcx.sess.panic_strategy().unwinds(),
+        Rust | RustCall | RustCold | RustPreserveNone | RustTail => {
+            tcx.sess.panic_strategy().unwinds()
+        }
     }
 }
 

--- a/compiler/rustc_public/src/abi.rs
+++ b/compiler/rustc_public/src/abi.rs
@@ -455,6 +455,7 @@ pub enum CallConvention {
     PreserveMost,
     PreserveAll,
     PreserveNone,
+    Tail,
 
     Custom,
 

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -1167,6 +1167,7 @@ pub enum Abi {
     RiscvInterruptM,
     RiscvInterruptS,
     RustPreserveNone,
+    RustTail,
     RustInvalid,
     Custom,
     Swift,

--- a/compiler/rustc_public/src/unstable/convert/internal.rs
+++ b/compiler/rustc_public/src/unstable/convert/internal.rs
@@ -618,6 +618,7 @@ impl RustcInternal for Abi {
             Abi::RiscvInterruptM => rustc_abi::ExternAbi::RiscvInterruptM,
             Abi::RiscvInterruptS => rustc_abi::ExternAbi::RiscvInterruptS,
             Abi::RustPreserveNone => rustc_abi::ExternAbi::RustPreserveNone,
+            Abi::RustTail => rustc_abi::ExternAbi::RustTail,
             Abi::Custom => rustc_abi::ExternAbi::Custom,
             Abi::Swift => rustc_abi::ExternAbi::Swift,
         }

--- a/compiler/rustc_public/src/unstable/convert/stable/abi.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/abi.rs
@@ -125,6 +125,7 @@ impl<'tcx> Stable<'tcx> for CanonAbi {
             CanonAbi::Rust => CallConvention::Rust,
             CanonAbi::RustCold => CallConvention::Cold,
             CanonAbi::RustPreserveNone => CallConvention::PreserveNone,
+            CanonAbi::RustTail => CallConvention::Tail,
             CanonAbi::Custom => CallConvention::Custom,
             CanonAbi::Swift => CallConvention::Swift,
             CanonAbi::Arm(arm_call) => match arm_call {

--- a/compiler/rustc_public/src/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/ty.rs
@@ -1046,6 +1046,7 @@ impl<'tcx> Stable<'tcx> for rustc_abi::ExternAbi {
             ExternAbi::Unadjusted => Abi::Unadjusted,
             ExternAbi::RustCold => Abi::RustCold,
             ExternAbi::RustPreserveNone => Abi::RustPreserveNone,
+            ExternAbi::RustTail => Abi::RustTail,
             ExternAbi::RustInvalid => Abi::RustInvalid,
             ExternAbi::RiscvInterruptM => Abi::RiscvInterruptM,
             ExternAbi::RiscvInterruptS => Abi::RiscvInterruptS,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1703,6 +1703,7 @@ symbols! {
         rust_logo,
         rust_out,
         rust_preserve_none_cc,
+        rust_tail_cc,
         rustc,
         rustc_abi,
         // FIXME(#82232, #143834): temporary name to mitigate `#[align]` nameres ambiguity

--- a/compiler/rustc_target/src/spec/abi_map.rs
+++ b/compiler/rustc_target/src/spec/abi_map.rs
@@ -100,6 +100,7 @@ impl AbiMap {
             (ExternAbi::RustCold, _) if self.os == OsKind::Windows => CanonAbi::Rust,
             (ExternAbi::RustCold, _) => CanonAbi::RustCold,
             (ExternAbi::RustPreserveNone, _) => CanonAbi::RustPreserveNone,
+            (ExternAbi::RustTail, _) => CanonAbi::RustTail,
 
             (ExternAbi::Custom, _) => CanonAbi::Custom,
 

--- a/tests/codegen-llvm/preserve-none.rs
+++ b/tests/codegen-llvm/preserve-none.rs
@@ -19,7 +19,7 @@ extern crate minicore;
 // UNSUPPORTED: define{{( dso_local)?}} void @peach(i16
 #[no_mangle]
 #[inline(never)]
-pub extern "rust-preserve-none" fn peach(x: u16) {
+pub extern "rust-preserve-none" fn peach(_: u16) {
     loop {}
 }
 

--- a/tests/codegen-llvm/tailcc.rs
+++ b/tests/codegen-llvm/tailcc.rs
@@ -1,0 +1,28 @@
+//@ add-minicore
+//@ revisions: I586 X86_64 AARCH64
+//@ [I586] compile-flags: -C no-prepopulate-passes --target=i586-unknown-linux-gnu
+//@ [I586] needs-llvm-components: x86
+//@ [X86_64] compile-flags: -C no-prepopulate-passes --target=x86_64-unknown-linux-gnu
+//@ [X86_64] needs-llvm-components: x86
+//@ [AARCH64] compile-flags: -C no-prepopulate-passes --target=aarch64-unknown-linux-gnu
+//@ [AARCH64] needs-llvm-components: aarch64
+
+#![crate_type = "lib"]
+#![feature(no_core, rust_tail_cc, explicit_tail_calls)]
+#![no_core]
+
+extern crate minicore;
+
+// CHECK: define{{( dso_local)?}} tailcc void @peach(i16
+#[no_mangle]
+#[inline(never)]
+pub extern "tail" fn peach(_: u16) {
+    loop {}
+}
+
+// CHECK: call tailcc void @peach(i16
+pub fn quince(x: u16) {
+    if let 12345u16 = x {
+        peach(54321);
+    }
+}

--- a/tests/ui/abi/rust-tail-cc.rs
+++ b/tests/ui/abi/rust-tail-cc.rs
@@ -1,8 +1,12 @@
+//@ revisions: aarch64 x32 x64
 //@ run-pass
+//@[aarch64] only-aarch64
+//@[x32] only-x86
+//@[x64] only-x86_64
 //@ needs-unwind
 //@ ignore-backends: gcc
 
-#![feature(rust_preserve_none_cc)]
+#![feature(rust_tail_cc)]
 
 struct CrateOf<'a> {
     mcintosh: f64,
@@ -12,7 +16,7 @@ struct CrateOf<'a> {
 }
 
 #[inline(never)]
-extern "rust-preserve-none" fn oven_explosion() {
+extern "tail" fn oven_explosion() {
     panic!("bad time");
 }
 
@@ -24,7 +28,7 @@ fn bite_into(yummy: u64) -> u64 {
 }
 
 #[inline(never)]
-extern "rust-preserve-none" fn lotsa_apples(
+extern "tail" fn lotsa_apples(
     honeycrisp: u64,
     gala: u32,
     fuji: f64,

--- a/tests/ui/feature-gates/feature-gate-rust-tail-cc.rs
+++ b/tests/ui/feature-gates/feature-gate-rust-tail-cc.rs
@@ -1,0 +1,21 @@
+#![crate_type = "lib"]
+
+extern "tail" fn apple() {} //~ ERROR "tail" ABI is experimental
+
+trait T {
+    extern "tail" fn banana(); //~ ERROR "tail" ABI is experimental
+    extern "tail" fn citrus() {} //~ ERROR "tail" ABI is experimental
+}
+
+struct S;
+impl T for S {
+    extern "tail" fn banana() {} //~ ERROR "tail" ABI is experimental
+}
+
+impl S {
+    extern "tail" fn durian() {} //~ ERROR "tail" ABI is experimental
+}
+
+type Fig = extern "tail" fn(); //~ ERROR "tail" ABI is experimental
+
+extern "tail" {} //~ ERROR "tail" ABI is experimental

--- a/tests/ui/feature-gates/feature-gate-rust-tail-cc.stderr
+++ b/tests/ui/feature-gates/feature-gate-rust-tail-cc.stderr
@@ -1,0 +1,73 @@
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:3:8
+   |
+LL | extern "tail" fn apple() {}
+   |        ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:6:12
+   |
+LL |     extern "tail" fn banana();
+   |            ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:7:12
+   |
+LL |     extern "tail" fn citrus() {}
+   |            ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:12:12
+   |
+LL |     extern "tail" fn banana() {}
+   |            ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:16:12
+   |
+LL |     extern "tail" fn durian() {}
+   |            ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:19:19
+   |
+LL | type Fig = extern "tail" fn();
+   |                   ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the extern "tail" ABI is experimental and subject to change
+  --> $DIR/feature-gate-rust-tail-cc.rs:21:8
+   |
+LL | extern "tail" {}
+   |        ^^^^^^
+   |
+   = note: see issue #157427 <https://github.com/rust-lang/rust/issues/157427> for more information
+   = help: add `#![feature(rust_tail_cc)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/print-request/print-calling-conventions.stdout
+++ b/tests/ui/print-request/print-calling-conventions.stdout
@@ -29,6 +29,7 @@ system
 system-unwind
 sysv64
 sysv64-unwind
+tail
 thiscall
 thiscall-unwind
 unadjusted


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157016)*
<!-- homu-ignore:end -->

Maps to LLVM's `tailcc` and hence inherits all its problems.

This calling convention at least compiles on:

- `x86_64` 
- `aarch64`

It also compiles on 

- `s390x`
- `loongarch64`

But I've been told by target maintainers that this is kind of unintentional, and it's not tested in LLVM.

For most backends LLVM does not have support and fails loudly.