### PR TITLE
cmp: reduce repetition of pass-thru impl of Ord/Eq for references

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -2170,20 +2170,6 @@ mod impls {
             PartialOrd::__chaining_ge(*self, *other)
         }
     }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    const impl<A: PointeeSized> Ord for &A
-    where
-        A: [const] Ord,
-    {
-        #[inline]
-        fn cmp(&self, other: &Self) -> Ordering {
-            Ord::cmp(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    const impl<A: PointeeSized> Eq for &A where A: [const] Eq {}
 
     // &mut pointers
 
@@ -2245,20 +2231,6 @@ mod impls {
             PartialOrd::__chaining_ge(*self, *other)
         }
     }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    const impl<A: PointeeSized> Ord for &mut A
-    where
-        A: [const] Ord,
-    {
-        #[inline]
-        fn cmp(&self, other: &Self) -> Ordering {
-            Ord::cmp(*self, *other)
-        }
-    }
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
-    const impl<A: PointeeSized> Eq for &mut A where A: [const] Eq {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
@@ -2291,4 +2263,24 @@ mod impls {
             PartialEq::ne(*self, *other)
         }
     }
+
+    macro_rules! impl_ord_eq {
+        (<$A:ident> for $($ref_A:ty),*) => ($(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+            const impl<$A: [const] Ord + PointeeSized> Ord for $ref_A
+            {
+                #[inline]
+                fn cmp(&self, other: &Self) -> Ordering {
+                    Ord::cmp(*self, *other)
+                }
+            }
+
+            #[stable(feature = "rust1", since = "1.0.0")]
+            #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]
+            const impl<$A: [const] Eq + PointeeSized> Eq for $ref_A {}
+        )*)
+    }
+
+    impl_ord_eq!(<A> for &A, &mut A);
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
