### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -165,6 +165,8 @@ pub(crate) fn uwtable_attr(llcx: &llvm::Context, use_sync_unwind: Option<bool>) 
     // NOTE: We should determine if we even need async unwind tables, as they
     // take have more overhead and if we can use sync unwind tables we
     // probably should.
+    //
+    // Similar logic exists for the per-module uwtable annotation in `context.rs`.
     let async_unwind = !use_sync_unwind.unwrap_or(false);
     llvm::CreateUWTableAttr(llcx, async_unwind)
 }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -311,6 +311,25 @@ pub(crate) unsafe fn create_module<'ll>(
         );
     }
 
+    if sess.must_emit_unwind_tables() {
+        // This assertion checks that Max is the correct merge behavior.
+        // Async unwind tables are strictly more useful than sync uwtables.
+        const {
+            assert!((llvm::UWTableKind::None as u32) < (llvm::UWTableKind::Sync as u32));
+            assert!((llvm::UWTableKind::Sync as u32) < (llvm::UWTableKind::Async as u32));
+        }
+
+        llvm::add_module_flag_u32(
+            llmod,
+            llvm::ModuleFlagMergeBehavior::Max,
+            "uwtable",
+            match sess.opts.unstable_opts.use_sync_unwind {
+                Some(true) => llvm::UWTableKind::Sync as u32,
+                Some(false) | None => llvm::UWTableKind::Async as u32,
+            },
+        );
+    }
+
     // Add "kcfi" module flag if KCFI is enabled. (See https://reviews.llvm.org/D119296.)
     if sess.is_sanitizer_kcfi_enabled() {
         llvm::add_module_flag_u32(llmod, llvm::ModuleFlagMergeBehavior::Override, "kcfi", 1);

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -240,6 +240,18 @@ pub(crate) enum DLLStorageClass {
     DllExport = 2, // Function to be accessible from DLL.
 }
 
+/// Must match the layout of `UWTableKind`.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub(crate) enum UWTableKind {
+    /// No unwind table requested
+    None = 0,
+    /// "Synchronous" unwind tables
+    Sync = 1,
+    /// "Asynchronous" unwind tables (instr precise)
+    Async = 2,
+}
+
 /// Must match the layout of `LLVMRustAttributeKind`.
 /// Semantically a subset of the C++ enum llvm::Attribute::AttrKind,
 /// though it is not ABI compatible (since it's a C++ enum)

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -240,7 +240,7 @@ pub(crate) enum DLLStorageClass {
     DllExport = 2, // Function to be accessible from DLL.
 }
 
-/// Must match the layout of `UWTableKind`.
+/// Must match the layout of `llvm::UWTableKind`.
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub(crate) enum UWTableKind {

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -1354,6 +1354,16 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
     }
 
     #[inline]
+    fn visit_variantless(&mut self, val: &PlaceTy<'tcx, M::Provenance>) -> InterpResult<'tcx> {
+        let ty = val.layout.ty;
+        assert!(ty.is_enum(), "encountered non-enum variantless type `{ty}`");
+        throw_validation_failure!(
+            self.path,
+            format!("encountered a value of zero-variant enum `{ty}`")
+        );
+    }
+
+    #[inline]
     fn visit_value(&mut self, val: &PlaceTy<'tcx, M::Provenance>) -> InterpResult<'tcx> {
         trace!("visit_value: {:?}, {:?}", *val, val.layout);
 
@@ -1557,23 +1567,14 @@ impl<'rt, 'tcx, M: Machine<'tcx>> ValueVisitor<'tcx, M> for ValidityVisitor<'rt,
             }
         }
 
-        // *After* all of this, check further information stored in the layout.
-        // On leaf types like `!` or empty enums, this will raise the error.
-        // This means that for types wrapping such a type, we won't ever get here, but it's
-        // just the simplest way to check for this case.
-        //
-        // FIXME: We could avoid some redundant checks here. For newtypes wrapping
-        // scalars, we do the same check on every "level" (e.g., first we check
-        // the fields of MyNewtype, and then we check MyNewType again).
-        if val.layout.is_uninhabited() {
-            let ty = val.layout.ty;
-            throw_validation_failure!(
-                self.path,
-                format!("encountered a value of uninhabited type `{ty}`")
-            );
-        }
+        // Assert that we checked everything there is to check about this type.
+        assert!(
+            !val.layout.is_uninhabited(),
+            "a value of type `{}` passed validation but that type is uninhabited",
+            val.layout.ty
+        );
         if cfg!(debug_assertions) {
-            // Check that we don't miss any new changes to layout computation in our checks above.
+            // Only run expensive checks when debug assertions are enabled.
             match val.layout.backend_repr {
                 BackendRepr::Scalar(scalar_layout) => {
                     if !scalar_layout.is_uninit_valid() {

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -41,6 +41,11 @@ pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
     fn visit_box(&mut self, _box_ty: Ty<'tcx>, _v: &Self::V) -> InterpResult<'tcx> {
         interp_ok(())
     }
+    /// Visits the given type after it has been found to have no variants.
+    #[inline(always)]
+    fn visit_variantless(&mut self, _v: &Self::V) -> InterpResult<'tcx> {
+        interp_ok(())
+    }
 
     /// Called each time we recurse down to a field of a "product-like" aggregate
     /// (structs, tuples, arrays and the like, but not enums), passing in old (outer)
@@ -193,7 +198,11 @@ pub trait ValueVisitor<'tcx, M: Machine<'tcx>>: Sized {
                 self.visit_variant(v, idx, &inner)?;
             }
             // For single-variant layouts, we already did everything there is to do.
-            Variants::Single { .. } | Variants::Empty => {}
+            Variants::Single { .. } => {}
+            // Non-variant layouts need special treatment by the visitor.
+            Variants::Empty => {
+                self.visit_variantless(v)?;
+            }
         }
 
         interp_ok(())

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -35,7 +35,7 @@ impl<'tcx> TypeError<'tcx> {
         }
 
         match self {
-            TypeError::CyclicTy(_) => "cyclic type of infinite size".into(),
+            TypeError::CyclicTy(_) => "recursive type with infinite-size name".into(),
             TypeError::CyclicConst(_) => "encountered a self-referencing constant".into(),
             TypeError::Mismatch => "types differ".into(),
             TypeError::PolarityMismatch(values) => {

--- a/compiler/rustc_mir_transform/src/coverage/hir_info.rs
+++ b/compiler/rustc_mir_transform/src/coverage/hir_info.rs
@@ -1,7 +1,7 @@
 use rustc_hir as hir;
 use rustc_hir::intravisit::{Visitor, walk_expr};
 use rustc_middle::hir::nested_filter;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
 
@@ -24,9 +24,16 @@ pub(crate) fn extract_hir_info<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> E
     // FIXME(#79625): Consider improving MIR to provide the information needed, to avoid going back
     // to HIR for it.
 
-    // HACK: For synthetic MIR bodies (async closures), use the def id of the HIR body.
+    // Synthetic by-move coroutine bodies don't have useful HIR of their own.
+    // Use the original coroutine body instead. These synthetic bodies are
+    // created with a coroutine type, so we can inspect that type as-is.
     if tcx.is_synthetic_mir(def_id) {
-        return extract_hir_info(tcx, tcx.local_parent(def_id));
+        let effective_def_id =
+            match *tcx.type_of(def_id).instantiate_identity().skip_normalization().kind() {
+                ty::Coroutine(coroutine_def_id, _) => coroutine_def_id.expect_local(),
+                _ => tcx.local_parent(def_id),
+            };
+        return extract_hir_info(tcx, effective_def_id);
     }
 
     let hir_node = tcx.hir_node_by_def_id(def_id);

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -23,11 +23,13 @@ pub struct IntoIter<T, const N: usize> {
 
 impl<T, const N: usize> IntoIter<T, N> {
     #[inline]
-    fn unsize(&self) -> &InnerUnsized<T> {
+    #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+    const fn unsize(&self) -> &InnerUnsized<T> {
         self.inner.deref()
     }
     #[inline]
-    fn unsize_mut(&mut self) -> &mut InnerUnsized<T> {
+    #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+    const fn unsize_mut(&mut self) -> &mut InnerUnsized<T> {
         self.inner.deref_mut()
     }
 }
@@ -219,7 +221,8 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// Returns a mutable slice of all elements that have not been yielded yet.
     #[stable(feature = "array_value_iter", since = "1.51.0")]
     #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
+    #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+    pub const fn as_mut_slice(&mut self) -> &mut [T] {
         self.unsize_mut().as_mut_slice()
     }
 }

--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -134,7 +134,8 @@ impl<T> PolymorphicIter<[MaybeUninit<T>]> {
     }
 
     #[inline]
-    pub(super) fn as_mut_slice(&mut self) -> &mut [T] {
+    #[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+    pub(super) const fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {
             let slice = self.data.get_unchecked_mut(self.alive.clone());

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -63,9 +63,11 @@ impl<I: FusedIterator + ?Sized> FusedIterator for &mut I {}
 /// of this trait must inspect [`Iterator::size_hint()`]’s upper bound.
 #[unstable(feature = "trusted_len", issue = "37572")]
 #[rustc_unsafe_specialization_marker]
-pub unsafe trait TrustedLen: Iterator {}
+#[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+pub const unsafe trait TrustedLen: [const] Iterator {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
+#[rustc_const_unstable(feature = "const_iter", issue = "92476")]
 unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
 
 /// An iterator that when yielding an item will have taken at least one element

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -427,7 +427,11 @@ impl<T> ControlFlow<T, T> {
 impl<R: ops::Try> ControlFlow<R, R::Output> {
     /// Creates a `ControlFlow` from any type implementing `Try`.
     #[inline]
-    pub(crate) fn from_try(r: R) -> Self {
+    #[rustc_const_unstable(feature = "const_control_flow", issue = "148739")]
+    pub(crate) const fn from_try(r: R) -> Self
+    where
+        R: [const] ops::Try,
+    {
         match R::branch(r) {
             ControlFlow::Continue(v) => ControlFlow::Continue(v),
             ControlFlow::Break(v) => ControlFlow::Break(R::from_residual(v)),
@@ -436,7 +440,11 @@ impl<R: ops::Try> ControlFlow<R, R::Output> {
 
     /// Converts a `ControlFlow` into any type implementing `Try`.
     #[inline]
-    pub(crate) fn into_try(self) -> R {
+    #[rustc_const_unstable(feature = "const_control_flow", issue = "148739")]
+    pub(crate) const fn into_try(self) -> R
+    where
+        R: [const] ops::Try,
+    {
         match self {
             ControlFlow::Continue(v) => R::from_output(v),
             ControlFlow::Break(v) => v,

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -416,8 +416,14 @@ impl<T> NeverShortCircuit<T> {
     }
 
     #[inline]
-    pub(crate) fn wrap_mut_2<A, B>(mut f: impl FnMut(A, B) -> T) -> impl FnMut(A, B) -> Self {
-        move |a, b| NeverShortCircuit(f(a, b))
+    #[rustc_const_unstable(feature = "const_array", issue = "147606")]
+    pub(crate) const fn wrap_mut_2<A, B, F>(
+        mut f: F,
+    ) -> impl [const] FnMut(A, B) -> Self + [const] Destruct
+    where
+        F: [const] FnMut(A, B) -> T + [const] Destruct,
+    {
+        const move |a, b| NeverShortCircuit(f(a, b))
     }
 }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1748,8 +1748,12 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, value: T) -> &mut T {
-        self.get_or_insert_with(|| value)
+    #[rustc_const_unstable(feature = "const_option_ops", issue = "143956")]
+    pub const fn get_or_insert(&mut self, value: T) -> &mut T
+    where
+        T: [const] Destruct,
+    {
+        self.get_or_insert_with(const || value)
     }
 
     /// Inserts the default value into the option if it is [`None`], then
@@ -2649,7 +2653,8 @@ impl<A> ExactSizeIterator for IntoIter<A> {}
 impl<A> FusedIterator for IntoIter<A> {}
 
 #[unstable(feature = "trusted_len", issue = "37572")]
-unsafe impl<A> TrustedLen for IntoIter<A> {}
+#[rustc_const_unstable(feature = "const_iter", issue = "92476")]
+unsafe impl<A> const TrustedLen for IntoIter<A> {}
 
 /// The iterator produced by [`Option::into_flat_iter`]. See its documentation for more.
 #[derive(Clone, Debug)]

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1682,7 +1682,12 @@ impl<T, E> Result<T, E> {
     #[inline]
     #[track_caller]
     #[stable(feature = "option_result_unwrap_unchecked", since = "1.58.0")]
-    pub unsafe fn unwrap_err_unchecked(self) -> E {
+    #[rustc_const_unstable(feature = "const_result_unwrap_unchecked", issue = "148714")]
+    pub const unsafe fn unwrap_err_unchecked(self) -> E
+    where
+        T: [const] Destruct,
+        E: [const] Destruct,
+    {
         match self {
             // SAFETY: the safety contract must be upheld by the caller.
             Ok(_) => unsafe { hint::unreachable_unchecked() },

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -120,7 +120,8 @@ macro_rules! tuple_impls {
         maybe_tuple_doc! {
             $($T)+ @
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl<$($T: Default),+> Default for ($($T,)+) {
+            #[rustc_const_unstable(feature = "const_default", issue = "143894")]
+            impl<$($T: [const] Default),+> const Default for ($($T,)+) {
                 #[inline]
                 fn default() -> ($($T,)+) {
                     ($({ let x: $T = Default::default(); x},)+)

--- a/library/std/src/sys/thread/unix.rs
+++ b/library/std/src/sys/thread/unix.rs
@@ -155,6 +155,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             target_os = "aix",
             target_vendor = "apple",
             target_os = "cygwin",
+            target_os = "redox",
             target_os = "wasi",
         ) => {
             #[allow(unused_assignments)]
@@ -316,7 +317,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             }
         }
         _ => {
-            // FIXME: implement on Redox, l4re
+            // FIXME: implement on l4re
             Err(io::const_error!(io::ErrorKind::Unsupported, "getting the number of hardware threads is not supported on the target platform"))
         }
     }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2591,8 +2591,10 @@ pub fn maybe_install_llvm_runtime(builder: &Builder<'_>, target: TargetSelection
         // To workaround lack of rpath on Windows, we bundle another copy of
         // the LLVM DLL to make rust-lld and llvm-tools work when `sysroot/bin`
         //  is missing from PATH, i.e. when they not launched by rustc.
-        let dst_libdir = sysroot.join("lib/rustlib").join(target).join("bin");
-        maybe_install_llvm(builder, target, &dst_libdir, false);
+        if target.triple.contains("windows") {
+            let dst_libdir = sysroot.join("lib/rustlib").join(target).join("bin");
+            maybe_install_llvm(builder, target, &dst_libdir, false);
+        }
     }
 }
 

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -187,6 +187,44 @@ impl Cfg {
         }
     }
 
+    /// Recursively sorts the configuration tree to ensure deterministic rendering.
+    ///
+    /// Sorting groups predicates logically: Targets first, then Target Features,
+    /// then Crate Features, and finally nested Any/All/Not groupings.
+    /// Within each group, a fallback alphabetical sort is applied.
+    pub(crate) fn sort_for_rendering(&mut self) {
+        fn sort_cfg_entry(cfg: &mut CfgEntry) {
+            match cfg {
+                CfgEntry::Any(sub_cfgs, _) | CfgEntry::All(sub_cfgs, _) => {
+                    for sub_cfg in sub_cfgs.iter_mut() {
+                        sort_cfg_entry(sub_cfg);
+                    }
+
+                    sub_cfgs.sort_by_cached_key(|a| {
+                        (
+                            cfg_category(a),
+                            Display(a, Format::LongPlain).to_string().to_ascii_lowercase(),
+                        )
+                    });
+                }
+                CfgEntry::Not(box_cfg, _) => sort_cfg_entry(box_cfg),
+                _ => {}
+            }
+        }
+
+        fn cfg_category(cfg: &CfgEntry) -> u8 {
+            match cfg {
+                CfgEntry::NameValue { name, .. } if *name == sym::feature => 2,
+                CfgEntry::NameValue { name, .. } if *name == sym::target_feature => 1,
+                CfgEntry::NameValue { .. } | CfgEntry::Bool(..) => 0,
+                CfgEntry::Any(..) | CfgEntry::All(..) | CfgEntry::Not(..) => 3,
+                _ => 4,
+            }
+        }
+
+        sort_cfg_entry(&mut self.0);
+    }
+
     fn omit_preposition(&self) -> bool {
         matches!(self.0, CfgEntry::Bool(..))
     }
@@ -843,14 +881,20 @@ pub(crate) fn extract_cfg_from_attrs<'a, I: Iterator<Item = &'a hir::Attribute> 
         if matches!(cfg_info.current_cfg.0, CfgEntry::Bool(true, _)) {
             None
         } else {
-            Some(Arc::new(cfg_info.current_cfg.clone()))
+            let mut cfg = cfg_info.current_cfg.clone();
+            cfg.sort_for_rendering();
+            Some(Arc::new(cfg))
         }
     } else {
         // If `doc(auto_cfg)` feature is enabled, we want to collect all `cfg` items, we remove the
         // hidden ones afterward.
         match strip_hidden(&cfg_info.current_cfg.0, &cfg_info.hidden_cfg) {
             None | Some(CfgEntry::Bool(true, _)) => None,
-            Some(cfg) => Some(Arc::new(Cfg(cfg))),
+            Some(cfg_entry) => {
+                let mut cfg = Cfg(cfg_entry);
+                cfg.sort_for_rendering();
+                Some(Arc::new(cfg))
+            }
         }
     }
 }

--- a/src/librustdoc/clean/cfg/tests.rs
+++ b/src/librustdoc/clean/cfg/tests.rs
@@ -418,3 +418,34 @@ fn test_simplify_with() {
         assert_eq!(foobar.simplify_with(&foobarbaz), None);
     });
 }
+
+#[test]
+fn test_sort_for_rendering() {
+    create_default_session_globals_then(|| {
+        let mut cfg = cfg_any(thin_vec![
+            name_value_cfg_e("feature", "sync"),
+            name_value_cfg_e("target_os", "linux"),
+            cfg_all_e(thin_vec![word_cfg_e("unix")]),
+            name_value_cfg_e("target_feature", "sse2"),
+            name_value_cfg_e("target_os", "android"),
+            name_value_cfg_e("feature", "alloc"),
+        ]);
+
+        cfg.sort_for_rendering();
+
+        let expected = cfg_any(thin_vec![
+            // Category 0: Targets (Sorted Alphabetically: Android -> Linux)
+            name_value_cfg_e("target_os", "android"),
+            name_value_cfg_e("target_os", "linux"),
+            // Category 1: Target Features
+            name_value_cfg_e("target_feature", "sse2"),
+            // Category 2: Crate Features (Sorted Alphabetically: alloc -> sync)
+            name_value_cfg_e("feature", "alloc"),
+            name_value_cfg_e("feature", "sync"),
+            // Category 3: Nested logic pushed to the end
+            cfg_all_e(thin_vec![word_cfg_e("unix")]),
+        ]);
+
+        assert_eq!(cfg, expected);
+    });
+}

--- a/src/tools/miri/tests/fail/validity/match_binder_checks_validity1.stderr
+++ b/src/tools/miri/tests/fail/validity/match_binder_checks_validity1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: constructing invalid value of type main::Void: encountered a value of uninhabited type `main::Void`
+error: Undefined Behavior: constructing invalid value of type main::Void: encountered a value of zero-variant enum `main::Void`
   --> tests/fail/validity/match_binder_checks_validity1.rs:LL:CC
    |
 LL |             _x => println!("hi from the void!"),

--- a/tests/codegen-llvm/force-no-unwind-tables.rs
+++ b/tests/codegen-llvm/force-no-unwind-tables.rs
@@ -9,3 +9,5 @@
 fn foo() {
     panic!();
 }
+
+// CHECK-NOT: !"uwtable"

--- a/tests/codegen-llvm/force-unwind-tables.rs
+++ b/tests/codegen-llvm/force-unwind-tables.rs
@@ -4,3 +4,5 @@
 
 // CHECK: attributes #{{.*}} uwtable
 pub fn foo() {}
+
+// CHECK: !{{[0-9]+}} = !{i32 7, !"uwtable", i32 2}

--- a/tests/coverage/async_closure2.cov-map
+++ b/tests/coverage/async_closure2.cov-map
@@ -1,0 +1,66 @@
+Function name: async_closure2::call_once::<async_closure2::main::{closure#0}>
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0c, 01, 00, 2a]
+Number of files: 1
+- file 0 => $DIR/async_closure2.rs
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 12, 1) to (start + 0, 42)
+Highest counter ID seen: c0
+
+Function name: async_closure2::call_once::<async_closure2::main::{closure#0}>::{closure#0}
+Raw bytes (21): 0x[01, 01, 01, 05, 09, 03, 01, 0c, 2b, 00, 2c, 01, 01, 05, 00, 0e, 02, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/async_closure2.rs
+Number of expressions: 1
+- expression 0 operands: lhs = Counter(1), rhs = Counter(2)
+Number of file 0 mappings: 3
+- Code(Counter(0)) at (prev + 12, 43) to (start + 0, 44)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 14)
+- Code(Expression(0, Sub)) at (prev + 1, 1) to (start + 0, 2)
+    = (c1 - c2)
+Highest counter ID seen: c0
+
+Function name: async_closure2::main
+Raw bytes (54): 0x[01, 01, 00, 0a, 01, 10, 01, 00, 0e, 01, 01, 09, 00, 16, 01, 04, 05, 00, 17, 01, 00, 18, 00, 21, 01, 00, 22, 00, 2f, 01, 01, 05, 00, 0f, 01, 00, 10, 00, 15, 01, 00, 16, 00, 1a, 01, 00, 1b, 00, 2b, 05, 01, 01, 00, 02]
+Number of files: 1
+- file 0 => $DIR/async_closure2.rs
+Number of expressions: 0
+Number of file 0 mappings: 10
+- Code(Counter(0)) at (prev + 16, 1) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 4, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 0, 24) to (start + 0, 33)
+- Code(Counter(0)) at (prev + 0, 34) to (start + 0, 47)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 15)
+- Code(Counter(0)) at (prev + 0, 16) to (start + 0, 21)
+- Code(Counter(0)) at (prev + 0, 22) to (start + 0, 26)
+- Code(Counter(0)) at (prev + 0, 27) to (start + 0, 43)
+- Code(Counter(1)) at (prev + 1, 1) to (start + 0, 2)
+Highest counter ID seen: c1
+
+Function name: async_closure2::main::{closure#0}
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 11, 22, 00, 23, 01, 03, 05, 00, 06]
+Number of files: 1
+- file 0 => $DIR/async_closure2.rs
+Number of expressions: 0
+Number of file 0 mappings: 2
+- Code(Counter(0)) at (prev + 17, 34) to (start + 0, 35)
+- Code(Counter(0)) at (prev + 3, 5) to (start + 0, 6)
+Highest counter ID seen: c0
+
+Function name: async_closure2::main::{closure#0}::{closure#0}::<_> (unused)
+Raw bytes (44): 0x[01, 01, 00, 08, 00, 11, 22, 00, 23, 00, 01, 09, 00, 0e, 00, 00, 0f, 00, 18, 00, 00, 1c, 00, 2c, 00, 01, 09, 00, 0e, 00, 00, 0f, 00, 18, 00, 00, 1c, 00, 2c, 00, 01, 05, 00, 06]
+Number of files: 1
+- file 0 => $DIR/async_closure2.rs
+Number of expressions: 0
+Number of file 0 mappings: 8
+- Code(Zero) at (prev + 17, 34) to (start + 0, 35)
+- Code(Zero) at (prev + 1, 9) to (start + 0, 14)
+- Code(Zero) at (prev + 0, 15) to (start + 0, 24)
+- Code(Zero) at (prev + 0, 28) to (start + 0, 44)
+- Code(Zero) at (prev + 1, 9) to (start + 0, 14)
+- Code(Zero) at (prev + 0, 15) to (start + 0, 24)
+- Code(Zero) at (prev + 0, 28) to (start + 0, 44)
+- Code(Zero) at (prev + 1, 5) to (start + 0, 6)
+Highest counter ID seen: (none)
+

--- a/tests/coverage/async_closure2.cov-map
+++ b/tests/coverage/async_closure2.cov-map
@@ -39,13 +39,19 @@ Number of file 0 mappings: 10
 Highest counter ID seen: c1
 
 Function name: async_closure2::main::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 11, 22, 00, 23, 01, 03, 05, 00, 06]
+Raw bytes (44): 0x[01, 01, 00, 08, 01, 11, 22, 00, 23, 01, 01, 09, 00, 0e, 01, 00, 0f, 00, 18, 01, 00, 1c, 00, 2c, 01, 01, 09, 00, 0e, 01, 00, 0f, 00, 18, 01, 00, 1c, 00, 2c, 01, 01, 05, 00, 06]
 Number of files: 1
 - file 0 => $DIR/async_closure2.rs
 Number of expressions: 0
-Number of file 0 mappings: 2
+Number of file 0 mappings: 8
 - Code(Counter(0)) at (prev + 17, 34) to (start + 0, 35)
-- Code(Counter(0)) at (prev + 3, 5) to (start + 0, 6)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 24)
+- Code(Counter(0)) at (prev + 0, 28) to (start + 0, 44)
+- Code(Counter(0)) at (prev + 1, 9) to (start + 0, 14)
+- Code(Counter(0)) at (prev + 0, 15) to (start + 0, 24)
+- Code(Counter(0)) at (prev + 0, 28) to (start + 0, 44)
+- Code(Counter(0)) at (prev + 1, 5) to (start + 0, 6)
 Highest counter ID seen: c0
 
 Function name: async_closure2::main::{closure#0}::{closure#0}::<_> (unused)

--- a/tests/coverage/async_closure2.coverage
+++ b/tests/coverage/async_closure2.coverage
@@ -1,0 +1,33 @@
+   LL|       |// Regression test for <https://github.com/rust-lang/rust/issues/151135>.
+   LL|       |
+   LL|       |//@ edition: 2021
+   LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
+   LL|       |use std::sync::atomic::{AtomicUsize, Ordering};
+   LL|       |
+   LL|       |static STEPS: AtomicUsize = AtomicUsize::new(0);
+   LL|       |
+   LL|      1|async fn call_once(f: impl AsyncFnOnce()) {
+   LL|      1|    f().await;
+   LL|      1|}
+   LL|       |
+   LL|      1|pub fn main() {
+   LL|      1|    let async_closure = async || {
+   LL|      0|        STEPS.fetch_add(1, Ordering::SeqCst);
+   LL|      0|        STEPS.fetch_add(1, Ordering::SeqCst);
+   LL|      1|    };
+  ------------------
+  | Unexecuted instantiation: async_closure2::main::{closure#0}::{closure#0}::<_>
+  ------------------
+  | async_closure2::main::{closure#0}:
+  |   LL|      1|    let async_closure = async || {
+  |   LL|       |        STEPS.fetch_add(1, Ordering::SeqCst);
+  |   LL|       |        STEPS.fetch_add(1, Ordering::SeqCst);
+  |   LL|      1|    };
+  ------------------
+   LL|      1|    executor::block_on(call_once(async_closure));
+   LL|      1|    assert_eq!(STEPS.load(Ordering::SeqCst), 2);
+   LL|      1|}
+

--- a/tests/coverage/async_closure2.coverage
+++ b/tests/coverage/async_closure2.coverage
@@ -15,16 +15,16 @@
    LL|       |
    LL|      1|pub fn main() {
    LL|      1|    let async_closure = async || {
-   LL|      0|        STEPS.fetch_add(1, Ordering::SeqCst);
-   LL|      0|        STEPS.fetch_add(1, Ordering::SeqCst);
+   LL|      1|        STEPS.fetch_add(1, Ordering::SeqCst);
+   LL|      1|        STEPS.fetch_add(1, Ordering::SeqCst);
    LL|      1|    };
   ------------------
   | Unexecuted instantiation: async_closure2::main::{closure#0}::{closure#0}::<_>
   ------------------
   | async_closure2::main::{closure#0}:
   |   LL|      1|    let async_closure = async || {
-  |   LL|       |        STEPS.fetch_add(1, Ordering::SeqCst);
-  |   LL|       |        STEPS.fetch_add(1, Ordering::SeqCst);
+  |   LL|      1|        STEPS.fetch_add(1, Ordering::SeqCst);
+  |   LL|      1|        STEPS.fetch_add(1, Ordering::SeqCst);
   |   LL|      1|    };
   ------------------
    LL|      1|    executor::block_on(call_once(async_closure));

--- a/tests/coverage/async_closure2.rs
+++ b/tests/coverage/async_closure2.rs
@@ -1,0 +1,23 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/151135>.
+
+//@ edition: 2021
+
+//@ aux-build: executor.rs
+extern crate executor;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static STEPS: AtomicUsize = AtomicUsize::new(0);
+
+async fn call_once(f: impl AsyncFnOnce()) {
+    f().await;
+}
+
+pub fn main() {
+    let async_closure = async || {
+        STEPS.fetch_add(1, Ordering::SeqCst);
+        STEPS.fetch_add(1, Ordering::SeqCst);
+    };
+    executor::block_on(call_once(async_closure));
+    assert_eq!(STEPS.load(Ordering::SeqCst), 2);
+}

--- a/tests/rustdoc-gui/item-info-overflow.goml
+++ b/tests/rustdoc-gui/item-info-overflow.goml
@@ -8,7 +8,7 @@ assert-property: (".item-info", {"scrollWidth": "940"})
 // Just to be sure we're comparing the correct "item-info":
 assert-text: (
     ".item-info",
-    "Available on Android or Linux or Emscripten or DragonFly BSD or FreeBSD or NetBSD or OpenBSD",
+    "Available on Android or DragonFly BSD or Emscripten or FreeBSD or Linux or NetBSD or OpenBSD",
     STARTS_WITH,
 )
 
@@ -26,6 +26,6 @@ assert-property: (
 // Just to be sure we're comparing the correct "item-info":
 assert-text: (
     "#impl-SimpleTrait-for-LongItemInfo2 .item-info",
-    "Available on Android or Linux or Emscripten or DragonFly BSD or FreeBSD or NetBSD or OpenBSD",
+    "Available on Android or DragonFly BSD or Emscripten or FreeBSD or Linux or NetBSD or OpenBSD",
     STARTS_WITH,
 )

--- a/tests/rustdoc-gui/item-info.goml
+++ b/tests/rustdoc-gui/item-info.goml
@@ -19,8 +19,8 @@ store-position: (
     "//*[@class='stab portability']//code[normalize-space()='Win32_System_Diagnostics']",
     {"x": second_line_x, "y": second_line_y},
 )
-assert: |first_line_x| != |second_line_x| && |first_line_x| == 521 && |second_line_x| == 277
-assert: |first_line_y| != |second_line_y| && |first_line_y| == 676 && |second_line_y| == 699
+assert: |first_line_x| != |second_line_x| && |first_line_x| == 509 && |second_line_x| == 277
+assert: |first_line_y| == |second_line_y| && |first_line_y| == 699
 
 // Now we ensure that they're not rendered on the same line.
 set-window-size: (1100, 800)

--- a/tests/rustdoc-html/doc-cfg/all-targets.rs
+++ b/tests/rustdoc-html/doc-cfg/all-targets.rs
@@ -2,10 +2,10 @@
 
 //@ has all_targets/fn.foo.html \
 //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-//  'Available on GNU or Catalyst or Managarm C Library or MSVC or musl or Newlib or \
-//  Neutrino 7.0 or Neutrino 7.1 or Neutrino 7.1 with io-sock or Neutrino 8.0 or \
-//  OpenHarmony or relibc or SGX or Simulator or WASIp1 or WASIp2 or WASIp3 or \
-//  uClibc or V5 or target_env=fake_env only.'
+//  'Available on target_env=fake_env or Catalyst or GNU or Managarm C Library \
+//  or MSVC or musl or Neutrino 7.0 or Neutrino 7.1 or Neutrino 7.1 with io-sock \
+//  or Neutrino 8.0 or Newlib or OpenHarmony or relibc or SGX or Simulator or \
+//  uClibc or V5 or WASIp1 or WASIp2 or WASIp3 only.'
 #[doc(cfg(any(
     target_env = "gnu",
     target_env = "macabi",
@@ -32,12 +32,12 @@ pub fn foo() {}
 
 //@ has all_targets/fn.bar.html \
 //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-//  'Available on AArch64 or AMD GPU or ARM or ARM64EC or AVR or BPF or C-SKY or \
-//  Hexagon or LoongArch32 or LoongArch64 or Motorola 680x0 or MIPS or MIPS release \
-//  6 or MIPS-64 or MIPS-64 release 6 or MSP430 or NVidia GPU or PowerPC or \
-//  PowerPC64 or RISC-V RV32 or RISC-V RV64 or s390x or SPARC or SPARC-64 or SPIR-V \
-//  or WebAssembly or WebAssembly or x86 or x86-64 or Xtensa or \
-//  target_arch=fake_arch only.'
+//  'Available on target_arch=fake_arch or AArch64 or AMD GPU or ARM or \
+//  ARM64EC or AVR or BPF or C-SKY or Hexagon or LoongArch32 or LoongArch64 \
+//  or MIPS or MIPS release 6 or MIPS-64 or MIPS-64 release 6 or Motorola 680x0 \
+//  or MSP430 or NVidia GPU or PowerPC or PowerPC64 or RISC-V RV32 or RISC-V RV64 \
+//  or s390x or SPARC or SPARC-64 or SPIR-V or WebAssembly or WebAssembly or x86 \
+//  or x86-64 or Xtensa only.'
 #[doc(cfg(any(
     target_arch = "aarch64",
     target_arch = "amdgpu",
@@ -75,15 +75,16 @@ pub fn bar() {}
 
 //@ has all_targets/fn.baz.html \
 //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-//  'Available on AIX and AMD HSA and Android and CUDA and Cygwin and DragonFly \
-//  BSD and Emscripten and ESP-IDF and FreeBSD and Fuchsia and Haiku and HelenOS \
-//  and Hermit and Horizon and GNU/Hurd and illumos and iOS and L4Re and Linux \
-//  and LynxOS-178 and macOS and Managarm and Motor OS and NetBSD and bare-metal \
-//  and QNX Neutrino and NuttX and OpenBSD and Play Station Portable and Play \
-//  Station 1 and QuRT and Redox OS and RTEMS OS and Solaris and SOLID ASP3 and \
-//  TEEOS and Trusty and tvOS and UEFI and VEXos and visionOS and Play Station \
-//  Vita and VxWorks and WASI and watchOS and Windows and Xous and zero knowledge \
-//  Virtual Machine and target_os=unknown and target_os=fake_os only.'
+//  'Available on target_os=fake_os and target_os=unknown and AIX and AMD HSA \
+//  and Android and bare-metal and CUDA and Cygwin and DragonFly BSD and \
+//  Emscripten and ESP-IDF and FreeBSD and Fuchsia and GNU/Hurd and Haiku \
+//  and HelenOS and Hermit and Horizon and illumos and iOS and L4Re and Linux \
+//  and LynxOS-178 and macOS and Managarm and Motor OS and NetBSD and NuttX \
+//  and OpenBSD and Play Station 1 and Play Station Portable and Play Station Vita \
+//  and QNX Neutrino and QuRT and Redox OS and RTEMS OS and Solaris and \
+//  SOLID ASP3 and TEEOS and Trusty and tvOS and UEFI and VEXos and visionOS \
+//  and VxWorks and WASI and watchOS and Windows and Xous and zero knowledge \
+//  Virtual Machine only.'
 #[doc(cfg(all(
     target_os = "aix",
     target_os = "amdhsa",

--- a/tests/rustdoc-html/doc-cfg/doc-cfg-simplification.rs
+++ b/tests/rustdoc-html/doc-cfg/doc-cfg-simplification.rs
@@ -46,7 +46,7 @@ pub mod ratel {
 
     //@ has 'globuliferous/ratel/static.NUNCIATIVE.html'
     //@ count   - '//*[@class="stab portability"]' 1
-    //@ matches - '//*[@class="stab portability"]' 'crate features ratel and nunciative'
+    //@ matches - '//*[@class="stab portability"]' 'crate features nunciative and ratel'
     #[doc(cfg(feature = "nunciative"))]
     pub static NUNCIATIVE: () = ();
 
@@ -80,7 +80,7 @@ pub mod ratel {
 
     //@ has 'globuliferous/ratel/enum.Cosmotellurian.html'
     //@ count   - '//*[@class="stab portability"]' 10
-    //@ matches - '//*[@class="stab portability"]' 'crate features ratel and cosmotellurian'
+    //@ matches - '//*[@class="stab portability"]' 'crate features cosmotellurian and ratel'
     //@ matches - '//*[@class="stab portability"]' 'crate feature biotaxy'
     //@ matches - '//*[@class="stab portability"]' 'crate feature xiphopagus'
     //@ matches - '//*[@class="stab portability"]' 'crate feature juxtapositive'
@@ -158,7 +158,7 @@ pub mod ratel {
 
     //@ has 'globuliferous/ratel/trait.Aposiopesis.html'
     //@ count   - '//*[@class="stab portability"]' 4
-    //@ matches - '//*[@class="stab portability"]' 'crate features ratel and aposiopesis'
+    //@ matches - '//*[@class="stab portability"]' 'crate features aposiopesis and ratel'
     //@ matches - '//*[@class="stab portability"]' 'crate feature umbracious'
     //@ matches - '//*[@class="stab portability"]' 'crate feature uakari'
     //@ matches - '//*[@class="stab portability"]' 'crate feature rotograph'

--- a/tests/rustdoc-html/doc-cfg/doc-cfg.rs
+++ b/tests/rustdoc-html/doc-cfg/doc-cfg.rs
@@ -3,7 +3,7 @@
 //@ has doc_cfg/struct.Portable.html
 //@ !has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' ''
 //@ has - '//*[@id="method.unix_and_arm_only_function"]' 'fn unix_and_arm_only_function()'
-//@ has - '//*[@class="stab portability"]' 'Available on Unix and ARM only.'
+//@ has - '//*[@class="stab portability"]' 'Available on ARM and Unix only.'
 //@ has - '//*[@id="method.wasi_and_wasm32_only_function"]' 'fn wasi_and_wasm32_only_function()'
 //@ has - '//*[@class="stab portability"]' 'Available on WASI and WebAssembly only.'
 pub struct Portable;
@@ -25,7 +25,7 @@ pub mod unix_only {
 
     //@ has doc_cfg/unix_only/trait.ArmOnly.html \
     //  '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-    //  'Available on Unix and ARM only.'
+    //  'Available on ARM and Unix only.'
     //@ count - '//*[@class="stab portability"]' 1
     #[doc(cfg(target_arch = "arm"))]
     pub trait ArmOnly {

--- a/tests/rustdoc-html/doc-cfg/duplicate-cfg.rs
+++ b/tests/rustdoc-html/doc-cfg/duplicate-cfg.rs
@@ -23,11 +23,11 @@ pub mod bar {
 }
 
 //@ has 'foo/baz/index.html'
-//@ has '-' '//*[@class="stab portability"]' 'Available on crate features sync and send only.'
+//@ has '-' '//*[@class="stab portability"]' 'Available on crate features send and sync only.'
 #[doc(cfg(all(feature = "sync", feature = "send")))]
 pub mod baz {
     //@ has 'foo/baz/struct.Baz.html'
-    //@ has '-' '//*[@class="stab portability"]' 'Available on crate features sync and send only.'
+    //@ has '-' '//*[@class="stab portability"]' 'Available on crate features send and sync only.'
     #[doc(cfg(feature = "sync"))]
     pub struct Baz;
 }
@@ -37,17 +37,17 @@ pub mod baz {
 #[doc(cfg(feature = "sync"))]
 pub mod qux {
     //@ has 'foo/qux/struct.Qux.html'
-    //@ has '-' '//*[@class="stab portability"]' 'Available on crate features sync and send only.'
+    //@ has '-' '//*[@class="stab portability"]' 'Available on crate features send and sync only.'
     #[doc(cfg(all(feature = "sync", feature = "send")))]
     pub struct Qux;
 }
 
 //@ has 'foo/quux/index.html'
-//@ has '-' '//*[@class="stab portability"]' 'Available on crate feature sync and crate feature send and foo only.'
+//@ has '-' '//*[@class="stab portability"]' 'Available on foo and crate feature send and crate feature sync only.'
 #[doc(cfg(all(feature = "sync", feature = "send", foo)))]
 pub mod quux {
     //@ has 'foo/quux/struct.Quux.html'
-    //@ has '-' '//*[@class="stab portability"]' 'Available on crate feature sync and crate feature send and foo and bar only.'
+    //@ has '-' '//*[@class="stab portability"]' 'Available on bar and foo and crate feature send and crate feature sync only.'
     #[doc(cfg(all(feature = "send", feature = "sync", bar)))]
     pub struct Quux;
 }

--- a/tests/rustdoc-html/doc-cfg/sort.rs
+++ b/tests/rustdoc-html/doc-cfg/sort.rs
@@ -1,0 +1,20 @@
+// Tests that target-exclusive `doc(cfg)` badges are sorted by tier and alphabetically.
+//@ edition:2021
+#![crate_name = "foo"]
+#![feature(doc_cfg)]
+
+//@ has 'foo/fn.foo.html'
+//@ has - '//*[@class="stab portability"]' 'Available on Android or Apple or Cygwin \
+// or DragonFly BSD or FreeBSD or Linux or NetBSD or OpenBSD or QNX Neutrino only.'
+#[cfg(any(
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "nto",
+    target_vendor = "apple",
+    target_os = "cygwin"
+))]
+pub fn foo() {}

--- a/tests/rustdoc-html/inline_cross/doc-auto-cfg.rs
+++ b/tests/rustdoc-html/inline_cross/doc-auto-cfg.rs
@@ -37,11 +37,11 @@ pub mod pre {
 pub mod post {
     // issue: <https://github.com/rust-lang/rust/issues/113982>
     //@ has 'it/post/index.html' '//*[@class="stab portability"]' 'extra'
-    //@ has - '//*[@class="stab portability"]' 'extra and extension'
+    //@ has - '//*[@class="stab portability"]' 'extension and extra'
     //@ has 'it/post/struct.Type.html' '//*[@class="stab portability"]' \
     //      'Available on crate feature extra only.'
     //@ has 'it/post/fn.compute.html' '//*[@class="stab portability"]' \
-    //      'Available on crate feature extra and extension only.'
+    //      'Available on extension and crate feature extra only.'
     #[cfg(feature = "extra")]
     pub use doc_auto_cfg::*;
 

--- a/tests/rustdoc-html/target-feature.rs
+++ b/tests/rustdoc-html/target-feature.rs
@@ -28,13 +28,13 @@ pub unsafe fn f2_not_safe() {}
 
 //@ has 'foo/fn.f3_multifeatures_in_attr.html'
 //@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-//        'Available on target features popcnt and avx2 only.'
+//        'Available on target features avx2 and popcnt only.'
 #[target_feature(enable = "popcnt", enable = "avx2")]
 pub fn f3_multifeatures_in_attr() {}
 
 //@ has 'foo/fn.f4_multi_attrs.html'
 //@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
-//        'Available on target features popcnt and avx2 only.'
+//        'Available on target features avx2 and popcnt only.'
 #[target_feature(enable = "popcnt")]
 #[target_feature(enable = "avx2")]
 pub fn f4_multi_attrs() {}

--- a/tests/ui/closures/closure-referencing-itself-issue-25954.stderr
+++ b/tests/ui/closures/closure-referencing-itself-issue-25954.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/closure-referencing-itself-issue-25954.rs:16:13
    |
 LL |     let q = || p.b.set(5i32);
-   |             ^^^^^^^^^^^^^^^^ cyclic type of infinite size
+   |             ^^^^^^^^^^^^^^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/generic-typed-nested-closures-59494.stderr
+++ b/tests/ui/closures/generic-typed-nested-closures-59494.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/generic-typed-nested-closures-59494.rs:21:40
    |
 LL |     let t7 = |env| |a| |b| t7p(f, g)(((env, a), b));
-   |                                        ^^^ cyclic type of infinite size
+   |                                        ^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/issue-25439.stderr
+++ b/tests/ui/closures/issue-25439.stderr
@@ -2,7 +2,7 @@ error[E0644]: closure/coroutine type that references itself
   --> $DIR/issue-25439.rs:8:9
    |
 LL |     fix(|_, x| x);
-   |         ^^^^^^ cyclic type of infinite size
+   |         ^^^^^^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/tests/ui/const-generics/occurs-check/unused-substs-2.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-2.rs
@@ -21,7 +21,7 @@ impl<T> Bind<T> for Foo<{ 6 + 1 }> {
 fn main() {
     let (mut t, foo) = Foo::bind();
     //~^ ERROR mismatched types
-    //~| NOTE cyclic type
+    //~| NOTE recursive type
 
     // `t` is `ty::Infer(TyVar(?1t))`
     // `foo` contains `ty::Infer(TyVar(?1t))` in its substs

--- a/tests/ui/const-generics/occurs-check/unused-substs-2.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-2.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/unused-substs-2.rs:22:24
    |
 LL |     let (mut t, foo) = Foo::bind();
-   |                        ^^^^^^^^^^^ cyclic type of infinite size
+   |                        ^^^^^^^^^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/occurs-check/unused-substs-3.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.rs
@@ -12,7 +12,7 @@ fn bind<T>() -> (T, [u8; 6 + 1]) {
 fn main() {
     let (mut t, foo) = bind();
     //~^ ERROR mismatched types
-    //~| NOTE cyclic type
+    //~| NOTE recursive type
 
     // `t` is `ty::Infer(TyVar(?1t))`
     // `foo` contains `ty::Infer(TyVar(?1t))` in its substs

--- a/tests/ui/const-generics/occurs-check/unused-substs-3.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/unused-substs-3.rs:13:24
    |
 LL |     let (mut t, foo) = bind();
-   |                        ^^^^^^ cyclic type of infinite size
+   |                        ^^^^^^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/occurs-check/unused-substs-5.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-5.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/unused-substs-5.rs:15:19
    |
 LL |     x = q::<_, N>(x);
-   |                   ^ cyclic type of infinite size
+   |                   ^ recursive type with infinite-size name
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type Bar: encountered a value of uninhabited type `Bar`
+error[E0080]: constructing invalid value of type Bar: encountered a value of zero-variant enum `Bar`
   --> $DIR/ub-uninhabit.rs:20:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
@@ -15,7 +15,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
                HEX_DUMP
            }
 
-error[E0080]: constructing invalid value of type [Bar; 1]: at [0], encountered a value of uninhabited type `Bar`
+error[E0080]: constructing invalid value of type [Bar; 1]: at [0], encountered a value of zero-variant enum `Bar`
   --> $DIR/ub-uninhabit.rs:26:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -18,7 +18,7 @@ const FOO: [empty::Empty; 3] = [foo(); 3];
 //~^ ERROR value of the never type
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-//~^ ERROR value of uninhabited type
+//~^ ERROR value of zero-variant enum
 
 fn main() {
     FOO;

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -10,7 +10,7 @@ note: inside `foo`
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
-error[E0080]: constructing invalid value of type empty::Empty: at .0, encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type empty::Empty: at .0, encountered a value of zero-variant enum `Void`
   --> $DIR/validate_uninhabited_zsts.rs:20:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];

--- a/tests/ui/consts/issue-64506.rs
+++ b/tests/ui/consts/issue-64506.rs
@@ -14,7 +14,7 @@ const FOO: () = {
         b: (),
     }
     let x = unsafe { Foo { b: () }.a };
-    //~^ ERROR: value of uninhabited type
+    //~^ ERROR: value of zero-variant enum
     let x = &x.inner;
 };
 

--- a/tests/ui/consts/issue-64506.stderr
+++ b/tests/ui/consts/issue-64506.stderr
@@ -1,4 +1,4 @@
-error[E0080]: constructing invalid value of type ChildStdin: at .inner, encountered a value of uninhabited type `AnonPipe`
+error[E0080]: constructing invalid value of type ChildStdin: at .inner, encountered a value of zero-variant enum `AnonPipe`
   --> $DIR/issue-64506.rs:16:22
    |
 LL |     let x = unsafe { Foo { b: () }.a };

--- a/tests/ui/coroutine/coroutine-yielding-or-returning-itself.stderr
+++ b/tests/ui/coroutine/coroutine-yielding-or-returning-itself.stderr
@@ -9,7 +9,7 @@ LL | |
 LL | |         if false { yield None.unwrap(); }
 LL | |         None.unwrap()
 LL | |     })
-   | |_____^ cyclic type of infinite size
+   | |_____^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,
@@ -34,7 +34,7 @@ LL | |
 LL | |         if false { yield None.unwrap(); }
 LL | |         None.unwrap()
 LL | |     })
-   | |_____^ cyclic type of infinite size
+   | |_____^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/tests/ui/statics/uninhabited-static.rs
+++ b/tests/ui/statics/uninhabited-static.rs
@@ -10,9 +10,9 @@ extern "C" {
 
 static VOID2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
 //~| WARN: previously accepted
-//~| ERROR value of uninhabited type `Void`
+//~| ERROR value of zero-variant enum `Void`
 static NEVER2: Void = unsafe { std::mem::transmute(()) }; //~ ERROR static of uninhabited type
 //~| WARN: previously accepted
-//~| ERROR value of uninhabited type `Void`
+//~| ERROR value of zero-variant enum `Void`
 
 fn main() {}

--- a/tests/ui/statics/uninhabited-static.stderr
+++ b/tests/ui/statics/uninhabited-static.stderr
@@ -39,13 +39,13 @@ LL |     static NEVER: !;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #74840 <https://github.com/rust-lang/rust/issues/74840>
 
-error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type Void: encountered a value of zero-variant enum `Void`
   --> $DIR/uninhabited-static.rs:11:31
    |
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `VOID2` failed here
 
-error[E0080]: constructing invalid value of type Void: encountered a value of uninhabited type `Void`
+error[E0080]: constructing invalid value of type Void: encountered a value of zero-variant enum `Void`
   --> $DIR/uninhabited-static.rs:14:32
    |
 LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };

--- a/tests/ui/typeck/cyclic_type_ice.stderr
+++ b/tests/ui/typeck/cyclic_type_ice.stderr
@@ -2,7 +2,7 @@ error[E0644]: closure/coroutine type that references itself
   --> $DIR/cyclic_type_ice.rs:3:7
    |
 LL |     f(f);
-   |       ^ cyclic type of infinite size
+   |       ^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/tests/ui/unboxed-closures/unboxed-closure-no-cyclic-sig.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-no-cyclic-sig.stderr
@@ -2,7 +2,7 @@ error[E0644]: closure/coroutine type that references itself
   --> $DIR/unboxed-closure-no-cyclic-sig.rs:8:7
    |
 LL |     g(|_| {  });
-   |       ^^^ cyclic type of infinite size
+   |       ^^^ recursive type with infinite-size name
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156970 (coverage: Use original HIR info for synthetic by-move coroutine bodies)
 - rust-lang/rust#156390 (Constify Iterator-related methods and functions)
 - rust-lang/rust#156401 (rustdoc: deterministic sorting for `doc_cfg` badges)
 - rust-lang/rust#156845 (Clarify "infinite size" in cyclic-type diagnostic refers to the type name)
 - rust-lang/rust#156973 (Add uwtable annotation to modules when required)
 - rust-lang/rust#156985 (Limit the additional DLL to Windows)
 - rust-lang/rust#156988 (interpret/validity: properly treat zero-variant enums so that we do not have to check layout.is_uninhabited)
 - rust-lang/rust#157002 (std: Fix thread::available_parallelism on Redox targets)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156970,156390,156401,156845,156973,156985,156988,157002)
<!-- homu-ignore:end -->

