### PR TITLE
Note irrefutable while let in loop type errors

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1895,11 +1895,11 @@ impl<'tcx> CoerceMany<'tcx> {
 
                         err.note(format!("{loop_type} evaluate to unit type `()`"));
                         if loop_src == hir::LoopSource::While
-                            && let Some(pat) = irrefutable_while_let_pattern(block)
+                            && let Some(pat) = irrefutable_if_let_expr(block)
                         {
                             err.span_note(
                                 pat.span,
-                                "this pattern always matches, so the loop condition never fails",
+                                "this pattern always matches, consider using `loop` instead",
                             );
                         }
                     }
@@ -2134,7 +2134,7 @@ impl<'tcx> CoerceMany<'tcx> {
     }
 }
 
-fn irrefutable_while_let_pattern<'hir>(block: &hir::Block<'hir>) -> Option<&'hir hir::Pat<'hir>> {
+fn irrefutable_if_let_expr<'hir>(block: &hir::Block<'hir>) -> Option<&'hir hir::Pat<'hir>> {
     let hir::ExprKind::If(cond, _, _) = block.expr?.kind else {
         return None;
     };

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1897,7 +1897,7 @@ impl<'tcx> CoerceMany<'tcx> {
                         if loop_src == hir::LoopSource::While
                             && let Some(pat) = irrefutable_if_let_expr(block)
                         {
-                            err.span_note(
+                            err.span_label(
                                 pat.span,
                                 "this pattern always matches, consider using `loop` instead",
                             );

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -1881,7 +1881,7 @@ impl<'tcx> CoerceMany<'tcx> {
 
                 if let Some(expr) = expression {
                     if let hir::ExprKind::Loop(
-                        _,
+                        block,
                         _,
                         loop_src @ (hir::LoopSource::While | hir::LoopSource::ForLoop),
                         _,
@@ -1894,6 +1894,14 @@ impl<'tcx> CoerceMany<'tcx> {
                         };
 
                         err.note(format!("{loop_type} evaluate to unit type `()`"));
+                        if loop_src == hir::LoopSource::While
+                            && let Some(pat) = irrefutable_while_let_pattern(block)
+                        {
+                            err.span_note(
+                                pat.span,
+                                "this pattern always matches, so the loop condition never fails",
+                            );
+                        }
                     }
 
                     fcx.emit_coerce_suggestions(
@@ -2123,6 +2131,24 @@ impl<'tcx> CoerceMany<'tcx> {
             assert!(self.expressions.is_empty());
             fcx.tcx.types.never
         }
+    }
+}
+
+fn irrefutable_while_let_pattern<'hir>(block: &hir::Block<'hir>) -> Option<&'hir hir::Pat<'hir>> {
+    let hir::ExprKind::If(cond, _, _) = block.expr?.kind else {
+        return None;
+    };
+    let hir::ExprKind::Let(let_expr) = cond.kind else {
+        return None;
+    };
+    simple_irrefutable_pattern(let_expr.pat).then_some(let_expr.pat)
+}
+
+fn simple_irrefutable_pattern(pat: &hir::Pat<'_>) -> bool {
+    match pat.kind {
+        hir::PatKind::Wild | hir::PatKind::Binding(_, _, _, None) => true,
+        hir::PatKind::Tuple(pats, _) => pats.iter().all(simple_irrefutable_pattern),
+        _ => false,
     }
 }
 

--- a/tests/ui/coercion/coerce-loop-issue-122561.rs
+++ b/tests/ui/coercion/coerce-loop-issue-122561.rs
@@ -69,6 +69,24 @@ fn while_zero_times() -> bool {
     }
 }
 
+fn while_let_binding() -> bool {
+    while let x = false {
+    //~^ ERROR mismatched types
+        if x {
+            return true;
+        }
+    }
+}
+
+fn while_let_tuple() -> bool {
+    while let (x, _) = (false, true) {
+    //~^ ERROR mismatched types
+        if x {
+            return true;
+        }
+    }
+}
+
 fn while_never_type() -> ! {
     while true {
     //~^ ERROR mismatched types

--- a/tests/ui/coercion/coerce-loop-issue-122561.stderr
+++ b/tests/ui/coercion/coerce-loop-issue-122561.stderr
@@ -173,7 +173,10 @@ error[E0308]: mismatched types
    |
 LL |   fn while_let_binding() -> bool {
    |                             ---- expected `bool` because of return type
-LL | /     while let x = false {
+LL |       while let x = false {
+   |       ^         - this pattern always matches, consider using `loop` instead
+   |  _____|
+   | |
 LL | |
 LL | |         if x {
 LL | |             return true;
@@ -182,11 +185,6 @@ LL | |     }
    | |_____^ expected `bool`, found `()`
    |
    = note: `while` loops evaluate to unit type `()`
-note: this pattern always matches, consider using `loop` instead
-  --> $DIR/coerce-loop-issue-122561.rs:73:15
-   |
-LL |     while let x = false {
-   |               ^
 help: consider returning a value here
    |
 LL ~     }
@@ -198,7 +196,10 @@ error[E0308]: mismatched types
    |
 LL |   fn while_let_tuple() -> bool {
    |                           ---- expected `bool` because of return type
-LL | /     while let (x, _) = (false, true) {
+LL |       while let (x, _) = (false, true) {
+   |       ^         ------ this pattern always matches, consider using `loop` instead
+   |  _____|
+   | |
 LL | |
 LL | |         if x {
 LL | |             return true;
@@ -207,11 +208,6 @@ LL | |     }
    | |_____^ expected `bool`, found `()`
    |
    = note: `while` loops evaluate to unit type `()`
-note: this pattern always matches, consider using `loop` instead
-  --> $DIR/coerce-loop-issue-122561.rs:82:15
-   |
-LL |     while let (x, _) = (false, true) {
-   |               ^^^^^^
 help: consider returning a value here
    |
 LL ~     }

--- a/tests/ui/coercion/coerce-loop-issue-122561.stderr
+++ b/tests/ui/coercion/coerce-loop-issue-122561.stderr
@@ -182,7 +182,7 @@ LL | |     }
    | |_____^ expected `bool`, found `()`
    |
    = note: `while` loops evaluate to unit type `()`
-note: this pattern always matches, so the loop condition never fails
+note: this pattern always matches, consider using `loop` instead
   --> $DIR/coerce-loop-issue-122561.rs:73:15
    |
 LL |     while let x = false {
@@ -207,7 +207,7 @@ LL | |     }
    | |_____^ expected `bool`, found `()`
    |
    = note: `while` loops evaluate to unit type `()`
-note: this pattern always matches, so the loop condition never fails
+note: this pattern always matches, consider using `loop` instead
   --> $DIR/coerce-loop-issue-122561.rs:82:15
    |
 LL |     while let (x, _) = (false, true) {

--- a/tests/ui/coercion/coerce-loop-issue-122561.stderr
+++ b/tests/ui/coercion/coerce-loop-issue-122561.stderr
@@ -7,7 +7,7 @@ LL |     while true {
    = note: `#[warn(while_true)]` on by default
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/coerce-loop-issue-122561.rs:73:5
+  --> $DIR/coerce-loop-issue-122561.rs:91:5
    |
 LL |     while true {
    |     ^^^^^^^^^^ help: use `loop`
@@ -171,6 +171,56 @@ LL +     /* `bool` value */
 error[E0308]: mismatched types
   --> $DIR/coerce-loop-issue-122561.rs:73:5
    |
+LL |   fn while_let_binding() -> bool {
+   |                             ---- expected `bool` because of return type
+LL | /     while let x = false {
+LL | |
+LL | |         if x {
+LL | |             return true;
+LL | |         }
+LL | |     }
+   | |_____^ expected `bool`, found `()`
+   |
+   = note: `while` loops evaluate to unit type `()`
+note: this pattern always matches, so the loop condition never fails
+  --> $DIR/coerce-loop-issue-122561.rs:73:15
+   |
+LL |     while let x = false {
+   |               ^
+help: consider returning a value here
+   |
+LL ~     }
+LL +     /* `bool` value */
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/coerce-loop-issue-122561.rs:82:5
+   |
+LL |   fn while_let_tuple() -> bool {
+   |                           ---- expected `bool` because of return type
+LL | /     while let (x, _) = (false, true) {
+LL | |
+LL | |         if x {
+LL | |             return true;
+LL | |         }
+LL | |     }
+   | |_____^ expected `bool`, found `()`
+   |
+   = note: `while` loops evaluate to unit type `()`
+note: this pattern always matches, so the loop condition never fails
+  --> $DIR/coerce-loop-issue-122561.rs:82:15
+   |
+LL |     while let (x, _) = (false, true) {
+   |               ^^^^^^
+help: consider returning a value here
+   |
+LL ~     }
+LL +     /* `bool` value */
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/coerce-loop-issue-122561.rs:91:5
+   |
 LL |   fn while_never_type() -> ! {
    |                            - expected `!` because of return type
 LL | /     while true {
@@ -188,7 +238,7 @@ LL +     /* `loop {}` or `panic!("...")` */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:87:5
+  --> $DIR/coerce-loop-issue-122561.rs:105:5
    |
 LL | /     for i in 0.. {
 LL | |
@@ -203,7 +253,7 @@ LL +     /* `i32` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:94:9
+  --> $DIR/coerce-loop-issue-122561.rs:112:9
    |
 LL | /         for i in 0..5 {
 LL | |
@@ -218,7 +268,7 @@ LL +         /* `usize` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:100:9
+  --> $DIR/coerce-loop-issue-122561.rs:118:9
    |
 LL | /         while false {
 LL | |
@@ -233,7 +283,7 @@ LL +         /* `usize` value */
    |
 
 error[E0308]: mismatched types
-  --> $DIR/coerce-loop-issue-122561.rs:106:23
+  --> $DIR/coerce-loop-issue-122561.rs:124:23
    |
 LL |     let _ = |a: &[(); for x in 0..2 {}]| {};
    |                       ^^^^^^^^^^^^^^^^ expected `usize`, found `()`
@@ -244,6 +294,6 @@ help: consider returning a value here
 LL |     let _ = |a: &[(); for x in 0..2 {} /* `usize` value */]| {};
    |                                        +++++++++++++++++++
 
-error: aborting due to 14 previous errors; 2 warnings emitted
+error: aborting due to 16 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
When a while-let loop is used where a non-unit value is expected, rustc already notes that while loops evaluate to unit. For simple irrefutable while-let patterns, add an extra note explaining that the pattern always matches and the loop condition never fails. Covers binding, wildcard, and tuples made from those patterns.

Fixes rust-lang/rust#116572.

Tested with: ```./x test tests/ui/coercion/coerce-loop-issue-122561.rs --bless```