### PR TITLE
rustdoc: correctly propagate cfgs for glob reexports

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -243,8 +243,8 @@ fn generate_item_with_correct_attrs(
             ) || (is_glob_import(tcx, import_id)
                 && (cx.document_hidden() || !tcx.is_doc_hidden(def_id)))
                 || macro_reexport_is_inline(tcx, import_id, def_id);
-            attrs.extend(get_all_import_attributes(cx, import_id, def_id, is_inline));
             is_inline = is_inline || import_is_inline;
+            attrs.extend(get_all_import_attributes(cx, import_id, def_id, is_inline));
         }
         let keep_target_cfg = is_inline || matches!(kind, ItemKind::TypeAliasItem(..));
         add_without_unwanted_attributes(&mut attrs, target_attrs, keep_target_cfg, None);

--- a/tests/rustdoc-html/reexport/glob-reexport-feature-combination.rs
+++ b/tests/rustdoc-html/reexport/glob-reexport-feature-combination.rs
@@ -1,0 +1,67 @@
+// This test ensures that `cfg`s are correctly propagated for re-export chains
+// where the outermost is a glob re-export.
+
+#![crate_name = "foo"]
+#![feature(doc_cfg)]
+
+//@ has 'foo/index.html'
+//@ count - '//*[@class="item-table"]/dt' 3
+
+//@ has 'foo/index.html'
+//@ has - '//dt/a[@title="struct foo::A"]/../*[@class="stab portability"]' 'Non-bar and non-foo'
+
+//@ has 'foo/struct.A.html'
+//@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
+//    'Available on non-crate feature bar and non-crate feature foo only.'
+
+mod a {
+    mod inner {
+        pub struct A {}
+    }
+    #[cfg(not(feature = "bar"))]
+    pub use self::inner::A;
+}
+#[cfg(not(feature = "foo"))]
+pub use a::*;
+
+//@ has 'foo/index.html'
+//@ has - '//dt/a[@title="struct foo::B"]/../*[@class="stab portability"]' 'Non-bar and non-baz and non-foo'
+
+//@ has 'foo/struct.B.html'
+//@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
+//    'Available on non-crate feature bar and non-crate feature baz and non-crate feature foo only.'
+
+mod b {
+    mod inner {
+        mod innermost {
+            pub struct B {}
+        }
+        #[cfg(not(feature = "baz"))]
+        pub use self::innermost::B;
+    }
+    #[cfg(not(feature = "bar"))]
+    pub use self::inner::*;
+}
+#[cfg(not(feature = "foo"))]
+pub use b::*;
+
+//@ has 'foo/index.html'
+//@ has - '//dt/a[@title="struct foo::C"]/../*[@class="stab portability"]' 'Non-bar and non-baz and non-foo'
+
+//@ has 'foo/struct.C.html'
+//@ has - '//*[@id="main-content"]/*[@class="item-info"]/*[@class="stab portability"]' \
+//    'Available on non-crate feature bar and non-crate feature baz and non-crate feature foo only.'
+
+mod c {
+    mod inner {
+        mod innermost {
+            #[cfg(not(feature = "baz"))]
+            pub struct C {}
+        }
+        pub use self::innermost::*;
+    }
+    #[cfg(not(feature = "bar"))]
+    pub use self::inner::*;
+}
+#[cfg(not(feature = "foo"))]
+pub use c::*;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157039)*
<!-- homu-ignore:end -->

This fixes some cases of rustdoc not surfacing the correct required feature combination when using `#[cfg(feature = ...)]` in combination with glob reexports. 

See the example cases included as tests.

Here's the generated HTML for those test cases before this change:
<img width="150" height="115" alt="Screenshot_20260528_201140" src="https://github.com/user-attachments/assets/8d611f88-7149-49f6-8ee0-530c049ea858" />

and after:
<img width="225" height="125" alt="Screenshot_20260528_201236" src="https://github.com/user-attachments/assets/85cc07c0-9a9a-455f-8ada-69d44d645516" />

My understanding is that this was basically an off-by-one type of oversight.
We need to update `is_inline` before calling `get_all_import_attributes` to immediately reflect that the outermost import we're processing shall indeed be considered as inline, as it's a glob.
Otherwise, we will end up calling `add_without_unwanted_attributes` with `is_inline == false` on the "intermediate" re-export, which will skip propagating its `cfg`s.

I believe this fixes https://github.com/rust-lang/rust/issues/96166, even though the description there is not super clear on the exact test case they used (there's a snippet but the author says their code is actually different).

Refs https://github.com/rust-lang/rust/issues/43781
@rustbot label +F-doc_cfg
@rustbot r? @GuillaumeGomez 