### PR TITLE
Eagerly resolve delegations in late resolution

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -124,7 +124,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // Delegation can be unresolved in illegal places such as function bodies in extern blocks (see #151356)
         let sig_id = if let Some(delegation_info) = self.resolver.delegation_info(self.owner.def_id)
         {
-            self.get_sig_id(delegation_info.resolution_node, span)
+            self.get_sig_id(delegation_info.resolution_id, span)
         } else {
             self.dcx().span_delayed_bug(
                 span,
@@ -223,22 +223,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
             .collect::<Vec<_>>()
     }
 
-    fn get_sig_id(&self, mut node_id: NodeId, span: Span) -> Result<DefId, ErrorGuaranteed> {
-        let mut visited: FxHashSet<NodeId> = Default::default();
+    fn get_sig_id(&self, mut def_id: DefId, span: Span) -> Result<DefId, ErrorGuaranteed> {
+        let mut visited: FxHashSet<DefId> = Default::default();
         let mut path: SmallVec<[DefId; 1]> = Default::default();
 
         loop {
-            visited.insert(node_id);
-
-            let Some(def_id) = self.get_resolution_id(node_id) else {
-                return Err(self.tcx.dcx().span_delayed_bug(
-                    span,
-                    format!(
-                        "LoweringContext: couldn't resolve node {:?} in delegation item",
-                        node_id
-                    ),
-                ));
-            };
+            visited.insert(def_id);
 
             path.push(def_id);
 
@@ -248,8 +238,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
             if let Some(local_id) = def_id.as_local()
                 && let Some(delegation_info) = self.resolver.delegation_info(local_id)
             {
-                node_id = delegation_info.resolution_node;
-                if visited.contains(&node_id) {
+                def_id = delegation_info.resolution_id;
+                if visited.contains(&def_id) {
                     // We encountered a cycle in the resolution, or delegation callee refers to non-existent
                     // entity, in this case emit an error.
                     return Err(match visited.len() {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -253,9 +253,12 @@ pub struct ResolverAstLowering<'tcx> {
 
 #[derive(Debug)]
 pub struct DelegationInfo {
-    // NodeId (either delegation.id or item_id in case of a trait impl) for signature resolution,
+    // `DefId` (either the resolution at delegation.id or item_id in case of a trait impl) for signature resolution,
     // for details see https://github.com/rust-lang/rust/issues/118212#issuecomment-2160686914
-    pub resolution_node: ast::NodeId,
+    /// Refers to the next element in a delegation resolution chain.
+    /// Usually points to the final resolution, as most "chains" are just
+    /// one step to a trait or an impl.
+    pub resolution_id: DefId,
 }
 
 #[derive(Clone, Copy, Debug, StableHash)]

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3923,12 +3923,24 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             this.visit_path(&delegation.path);
         });
 
-        self.r.delegation_infos.insert(
-            self.r.current_owner.def_id,
-            DelegationInfo {
-                resolution_node: if is_in_trait_impl { item_id } else { delegation.id },
-            },
-        );
+        let resolution_id = if is_in_trait_impl { item_id } else { delegation.id };
+        let def_id = self
+            .r
+            .partial_res_map
+            .get(&resolution_id)
+            .and_then(|r| r.expect_full_res().opt_def_id());
+        if let Some(resolution_id) = def_id {
+            self.r
+                .delegation_infos
+                .insert(self.r.current_owner.def_id, DelegationInfo { resolution_id });
+        } else {
+            self.r.tcx.dcx().span_delayed_bug(
+                delegation.path.span,
+                format!(
+                    "LoweringContext: couldn't resolve node {resolution_id:?} in delegation item",
+                ),
+            );
+        };
 
         let Some(body) = &delegation.body else { return };
         self.with_rib(ValueNS, RibKind::FnOrCoroutine, |this| {


### PR DESCRIPTION
This is necessary for allowing the `partial_res_map` to be split by owners. The current logic follows `NodeId` -> `DefId` -> `NodeId` mappings, but the resulting `NodeId` is then not under the same owner, so we can't look it up in the current owner table. After this PR everything is just a `DefId` -> `DefId` mapping, which always works fine.

cc @aerooneqq

r? @petrochenkov 

