### PR TITLE
LLVM 23: Run AssignGUIDPass in some places

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -49,6 +49,9 @@
 #include "llvm/Transforms/Instrumentation/RealtimeSanitizer.h"
 #include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/Scalar/AnnotationRemarks.h"
+#if LLVM_VERSION_GE(23, 0)
+#include "llvm/Transforms/Utils/AssignGUID.h"
+#endif
 #include "llvm/Transforms/Utils/CanonicalizeAliases.h"
 #include "llvm/Transforms/Utils/FunctionImportUtils.h"
 #include "llvm/Transforms/Utils/NameAnonGlobals.h"
@@ -915,6 +918,9 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   if (NeedThinLTOBufferPasses) {
     MPM.addPass(CanonicalizeAliasesPass());
     MPM.addPass(NameAnonGlobalPass());
+#if LLVM_VERSION_GE(23, 0)
+    MPM.addPass(AssignGUIDPass());
+#endif
   }
   // For `-Copt-level=0`, and the pre-link fat/thin LTO stages.
   if (ThinLTOBufferRef && *ThinLTOBufferRef == nullptr) {
@@ -1454,6 +1460,9 @@ extern "C" LLVMRustBuffer *LLVMRustModuleSerialize(LLVMModuleRef M,
         PB.registerLoopAnalyses(LAM);
         PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
         ModulePassManager MPM;
+#if LLVM_VERSION_GE(23, 0)
+        MPM.addPass(AssignGUIDPass());
+#endif
         MPM.addPass(ThinLTOBitcodeWriterPass(OS, nullptr));
         MPM.run(*unwrap(M), MAM);
       } else {

--- a/tests/codegen-llvm/bpf-allows-unaligned.rs
+++ b/tests/codegen-llvm/bpf-allows-unaligned.rs
@@ -5,7 +5,7 @@
 
 #[no_mangle]
 #[target_feature(enable = "allows-misaligned-mem-access")]
-// CHECK: define noundef zeroext i8 @foo(i8 noundef returned %arg) unnamed_addr #0 {
+// CHECK: define noundef zeroext i8 @foo(i8 noundef returned %arg) unnamed_addr #0
 pub unsafe fn foo(arg: u8) -> u8 {
     arg
 }

--- a/tests/codegen-llvm/bpf-alu32.rs
+++ b/tests/codegen-llvm/bpf-alu32.rs
@@ -5,7 +5,7 @@
 
 #[no_mangle]
 #[target_feature(enable = "alu32")]
-// CHECK: define i8 @foo(i8 returned %arg) unnamed_addr #0 {
+// CHECK: define i8 @foo(i8 returned %arg) unnamed_addr #0
 pub unsafe fn foo(arg: u8) -> u8 {
     arg
 }

--- a/tests/codegen-llvm/branch-protection.rs
+++ b/tests/codegen-llvm/branch-protection.rs
@@ -22,7 +22,7 @@ extern crate minicore;
 use minicore::*;
 
 // A basic test function.
-// CHECK: @test(){{.*}} [[ATTR:#[0-9]+]] {
+// CHECK: @test(){{.*}} [[ATTR:#[0-9]+]]
 #[no_mangle]
 pub fn test() {}
 

--- a/tests/codegen-llvm/frame-pointer-cli-control.rs
+++ b/tests/codegen-llvm/frame-pointer-cli-control.rs
@@ -45,7 +45,7 @@ Specific cases where platforms or tools rely on frame pointers for sound or corr
 
 extern crate minicore;
 
-// CHECK: i32 @peach{{.*}}[[PEACH_ATTRS:\#[0-9]+]] {
+// CHECK: i32 @peach{{.*}}[[PEACH_ATTRS:\#[0-9]+]]
 #[no_mangle]
 pub fn peach(x: u32) -> u32 {
     x

--- a/tests/codegen-llvm/frame-pointer.rs
+++ b/tests/codegen-llvm/frame-pointer.rs
@@ -18,7 +18,7 @@
 extern crate minicore;
 use minicore::*;
 
-// CHECK: define i32 @peach{{.*}}[[PEACH_ATTRS:\#[0-9]+]] {
+// CHECK: define i32 @peach{{.*}}[[PEACH_ATTRS:\#[0-9]+]]
 #[no_mangle]
 pub fn peach(x: u32) -> u32 {
     x

--- a/tests/codegen-llvm/gpu-convergent.rs
+++ b/tests/codegen-llvm/gpu-convergent.rs
@@ -17,7 +17,7 @@ extern "C" {
     fn ext();
 }
 
-// CHECK: define {{.*}}_kernel void @fun(i32{{.*}}) unnamed_addr #[[ATTR:[0-9]+]] {
+// CHECK: define {{.*}}_kernel void @fun(i32{{.*}}) unnamed_addr #[[ATTR:[0-9]+]]
 // CHECK: declare void @ext() unnamed_addr #[[ATTR]]
 // CHECK: attributes #[[ATTR]] = {{.*}} convergent
 #[no_mangle]

--- a/tests/codegen-llvm/instrument-coverage/testprog.rs
+++ b/tests/codegen-llvm/instrument-coverage/testprog.rs
@@ -101,7 +101,7 @@ fn main() {
 // CHECK-SAME:   @__llvm_prf_nm
 // CHECK-SAME:   section "llvm.metadata"
 
-// CHECK:        define internal { {{.*}} } @_R{{[a-zA-Z0-9_]+}}testprog14will_be_called() unnamed_addr #{{[0-9]+}} {
+// CHECK:        define internal { {{.*}} } @_R{{[a-zA-Z0-9_]+}}testprog14will_be_called() unnamed_addr #{{[0-9]+}}
 // CHECK-NEXT:   start:
 // CHECK-NOT:    define internal
 // CHECK:        atomicrmw add ptr
@@ -109,7 +109,7 @@ fn main() {
 
 // CHECK:        declare void @llvm.instrprof.increment(ptr, i64, i32, i32) #[[LLVM_INSTRPROF_INCREMENT_ATTR:[0-9]+]]
 
-// WIN:          define linkonce_odr hidden i32 @__llvm_profile_runtime_user() #[[LLVM_PROFILE_RUNTIME_USER_ATTR:[0-9]+]] comdat {{.*}}{
+// WIN:          define linkonce_odr hidden i32 @__llvm_profile_runtime_user() #[[LLVM_PROFILE_RUNTIME_USER_ATTR:[0-9]+]] comdat {{.*}}
 // WIN-NEXT:     %1 = load i32, ptr @__llvm_profile_runtime
 // WIN-NEXT:     ret i32 %1
 // WIN-NEXT:     }

--- a/tests/codegen-llvm/link_section.rs
+++ b/tests/codegen-llvm/link_section.rs
@@ -29,7 +29,7 @@ pub static VAR2: E = E::A(666);
 #[link_section = "__TEST,three"]
 pub static VAR3: E = E::B(1.);
 
-// CHECK: define {{(dso_local )?}}void @fn1() {{.*}} section "__TEST,four" {
+// CHECK: define {{(dso_local )?}}void @fn1() {{.*}} section "__TEST,four"
 #[no_mangle]
 #[link_section = "__TEST,four"]
 pub fn fn1() {}

--- a/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-normalized-generalized.rs
+++ b/tests/codegen-llvm/sanitizer/cfi/emit-type-metadata-itanium-cxx-abi-normalized-generalized.rs
@@ -7,21 +7,21 @@
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo
-    // CHECK-SAME:  {{.*}}![[TYPE1:[0-9]+]]
+    // CHECK-SAME:  {{.*}}!type ![[TYPE1:[0-9]+]]
     // CHECK:       call i1 @llvm.type.test(ptr {{%f|%0}}, metadata !"_ZTSFu3i32S_E.normalized.generalized")
     f(arg)
 }
 
 pub fn bar(f: fn(i32, i32) -> i32, arg1: i32, arg2: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}bar
-    // CHECK-SAME:  {{.*}}![[TYPE2:[0-9]+]]
+    // CHECK-SAME:  {{.*}}!type ![[TYPE2:[0-9]+]]
     // CHECK:       call i1 @llvm.type.test(ptr {{%f|%0}}, metadata !"_ZTSFu3i32S_S_E.normalized.generalized")
     f(arg1, arg2)
 }
 
 pub fn baz(f: fn(i32, i32, i32) -> i32, arg1: i32, arg2: i32, arg3: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}baz
-    // CHECK-SAME:  {{.*}}![[TYPE3:[0-9]+]]
+    // CHECK-SAME:  {{.*}}!type ![[TYPE3:[0-9]+]]
     // CHECK:       call i1 @llvm.type.test(ptr {{%f|%0}}, metadata !"_ZTSFu3i32S_S_S_E.normalized.generalized")
     f(arg1, arg2, arg3)
 }

--- a/tests/codegen-llvm/some-non-zero-from-atomic-optimization.rs
+++ b/tests/codegen-llvm/some-non-zero-from-atomic-optimization.rs
@@ -72,7 +72,7 @@ pub unsafe fn some_non_zero_from_atomic_get() -> Option<NonZeroUsize> {
 ///
 /// The way we check that the LLVM IR is correct is by making sure that neither
 /// `panic` nor `unreachable` is part of the LLVM IR:
-// CHECK-LABEL: define {{.*}} i64 @some_non_zero_from_atomic_get2() {{.*}} {
+// CHECK-LABEL: define {{.*}} i64 @some_non_zero_from_atomic_get2() {{.*}}
 // CHECK-NOT: panic
 // CHECK-NOT: unreachable
 #[no_mangle]

--- a/tests/codegen-llvm/target-feature-negative-implication.rs
+++ b/tests/codegen-llvm/target-feature-negative-implication.rs
@@ -13,7 +13,7 @@ use minicore::*;
 #[no_mangle]
 pub unsafe fn banana() {
     // CHECK-LABEL: @banana()
-    // CHECK-SAME: [[BANANAATTRS:#[0-9]+]] {
+    // CHECK-SAME: [[BANANAATTRS:#[0-9]+]]
 }
 
 // CHECK: attributes [[BANANAATTRS]]

--- a/tests/codegen-llvm/target-feature-overrides.rs
+++ b/tests/codegen-llvm/target-feature-overrides.rs
@@ -23,7 +23,7 @@ extern "C" {
 #[no_mangle]
 pub unsafe fn apple() -> u32 {
     // CHECK-LABEL: @apple()
-    // CHECK-SAME: [[APPLEATTRS:#[0-9]+]] {
+    // CHECK-SAME: [[APPLEATTRS:#[0-9]+]]
     // CHECK: {{.*}}call{{.*}}@peach
     peach()
 }
@@ -32,7 +32,7 @@ pub unsafe fn apple() -> u32 {
 #[no_mangle]
 pub unsafe fn banana() -> u32 {
     // CHECK-LABEL: @banana()
-    // CHECK-SAME: [[BANANAATTRS:#[0-9]+]] {
+    // CHECK-SAME: [[BANANAATTRS:#[0-9]+]]
     // COMPAT: {{.*}}call{{.*}}@peach
     // INCOMPAT: {{.*}}call{{.*}}@apple
     apple() // Compatible for inline in COMPAT revision and can't be inlined in INCOMPAT

--- a/tests/codegen-llvm/unwind-abis/aapcs-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/aapcs-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // `aapcs-unwind` extern functions. `aapcs-unwind` functions MUST NOT have this attribute. We
 // disable optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "aapcs" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "aapcs-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/c-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/c-unwind-abi.rs
@@ -7,11 +7,11 @@
 
 #![crate_type = "lib"]
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "C" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "C-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/cdecl-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/cdecl-unwind-abi.rs
@@ -7,11 +7,11 @@
 
 #![crate_type = "lib"]
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "cdecl" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "cdecl-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/fastcall-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/fastcall-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // `fastcall-unwind` extern functions. `fastcall-unwind` functions MUST NOT have this attribute. We
 // disable optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "fastcall" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "fastcall-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/stdcall-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/stdcall-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // extern functions. `stdcall-unwind` functions MUST NOT have this attribute. We disable
 // optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "stdcall" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "stdcall-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/system-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/system-unwind-abi.rs
@@ -7,11 +7,11 @@
 
 #![crate_type = "lib"]
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "system" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "system-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/sysv64-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/sysv64-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // `sysv64-unwind` extern functions. `sysv64-unwind` functions MUST NOT have this attribute. We
 // disable optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "sysv64" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "sysv64-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/thiscall-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/thiscall-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // `thiscall-unwind` extern functions. `thiscall-unwind` functions MUST NOT have this attribute. We
 // disable optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "thiscall" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "thiscall-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/vectorcall-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/vectorcall-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // `vectorcall-unwind` extern functions. `vectorcall-unwind` functions MUST NOT have this attribute.
 // We disable optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "vectorcall" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "vectorcall-unwind" fn rust_item_that_can_unwind() {}
 

--- a/tests/codegen-llvm/unwind-abis/win64-unwind-abi.rs
+++ b/tests/codegen-llvm/unwind-abis/win64-unwind-abi.rs
@@ -16,11 +16,11 @@ pub trait Sized: MetaSized {}
 // `win64-unwind` extern functions. `win64-unwind` functions MUST NOT have this attribute. We
 // disable optimizations above to prevent LLVM from inferring the attribute.
 
-// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0 {
+// CHECK: @rust_item_that_cannot_unwind() unnamed_addr #0
 #[no_mangle]
 pub extern "win64" fn rust_item_that_cannot_unwind() {}
 
-// CHECK: @rust_item_that_can_unwind() unnamed_addr #1 {
+// CHECK: @rust_item_that_can_unwind() unnamed_addr #1
 #[no_mangle]
 pub extern "win64-unwind" fn rust_item_that_can_unwind() {}
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/184065 introduced the new pass.

I'm not 100% confident that this is the correct patch, but it makes all the previously failing `run-make` "lto" tests pass on my machine.

I added the pass to the `if (NeedThinLTOBufferPasses)` section to match the `addRequiredLTOPreLinkPasses` changes from the LLVM PR, and to the `LLVMRustModuleSerialize` section based on the stack trace of an LLVM assertion.

The IR may now contain an additional `!guid` attribute, requiring some codegen test expectations to be updated. I mostly followed the pattern from the LLVM PR, and removed trailing `{`s. (For both, tests that were failing locally, as well as potentially problematic expectations identified via grep, in case the test wasn't being run locally).

@rustbot label llvm-main