### PR TITLE
Update Xtensa target data layouts to match upstream LLVM

### DIFF
--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-v1:8:8-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".into(),
         arch: Arch::Xtensa,
         metadata: TargetMetadata { description: None, tier: Some(3), host_tools: None, std: None },
 

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32_none_elf.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-v1:8:8-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".into(),
         arch: Arch::Xtensa,
         metadata: TargetMetadata {
             description: Some("Xtensa ESP32".into()),

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-v1:8:8-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".into(),
         arch: Arch::Xtensa,
         metadata: TargetMetadata { description: None, tier: Some(3), host_tools: None, std: None },
 

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_none_elf.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-v1:8:8-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".into(),
         arch: Arch::Xtensa,
         metadata: TargetMetadata {
             description: Some("Xtensa ESP32-S2".into()),

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-v1:8:8-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".into(),
         arch: Arch::Xtensa,
         metadata: TargetMetadata { description: None, tier: Some(3), host_tools: None, std: None },
 

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_none_elf.rs
@@ -5,7 +5,7 @@ pub(crate) fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-v1:8:8-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".into(),
         arch: Arch::Xtensa,
         metadata: TargetMetadata {
             description: Some("Xtensa ESP32-S3".into()),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Born from https://github.com/rust-lang/rust/pull/156568#issuecomment-4563228595.

We've been using a fork to distribute compiler builds that support the Xtensa arch whilst we're upstreaming. At a certain point we received some changes on our fork, which haven't been upstreamed, which I now to believe to be a mistake - therefore I'm reverting to the upstream LLVM datalayout.

r? @folkertdev 
