### PR TITLE
Avoid ICE when CoerceShared target normalization fails

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -618,14 +618,43 @@ pub(crate) fn coerce_shared_info<'tcx>(
     }
 
     assert_eq!(trait_ref.def_id, coerce_shared_trait);
-    let Some((target, _obligations)) = structurally_normalize_ty(
+    let target = if let Some((target, _obligations)) = structurally_normalize_ty(
         tcx,
         &infcx,
         impl_did,
         span,
         Unnormalized::new_wip(trait_ref.args.type_at(1)),
-    ) else {
-        todo!("something went wrong with structurally_normalize_ty");
+    ) {
+        target
+    } else {
+        let ocx = ObligationCtxt::new_with_diagnostics(&infcx);
+        let cause = traits::ObligationCause::misc(span, impl_did);
+        let target = match ocx.structurally_normalize_ty(
+            &cause,
+            tcx.param_env(impl_did),
+            Unnormalized::new_wip(trait_ref.args.type_at(1)),
+        ) {
+            Ok(normalized) => normalized,
+            Err(errors) if !errors.is_empty() => {
+                return Err(infcx.err_ctxt().report_fulfillment_errors(errors));
+            }
+            Err(_) => {
+                // Note: reusing CoerceUnsizedNonStruct error as it takes trait_name as argument.
+                return Err(tcx.dcx().emit_err(errors::CoerceUnsizedNonStruct {
+                    span,
+                    trait_name,
+                }));
+            }
+        };
+        let normalization_errors = ocx.try_evaluate_obligations();
+        if !normalization_errors.is_empty() {
+            if infcx.next_trait_solver() {
+                unreachable!();
+            }
+            debug!(?normalization_errors, "encountered errors while fulfilling");
+            return Err(infcx.err_ctxt().report_fulfillment_errors(normalization_errors));
+        }
+        target
     };
 
     let param_env = tcx.param_env(impl_did);

--- a/tests/ui/reborrow/issue-156699.rs
+++ b/tests/ui/reborrow/issue-156699.rs
@@ -1,0 +1,19 @@
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct Source<'a>(&'a mut ());
+
+impl<'a> Reborrow for Source<'a> {}
+
+impl<'a, T> CoerceShared<<T as Iterator>::Item> for Source<'a> {}
+//~^ ERROR `T` is not an iterator
+//~| ERROR the type parameter `T` is not constrained
+
+trait CustomMarker<'a> {}
+
+impl<'a, T> CoerceShared<<T as Iterator>::Item> for dyn CustomMarker<'a> {}
+//~^ ERROR `T` is not an iterator
+//~| ERROR the type parameter `T` is not constrained
+
+fn main() {}

--- a/tests/ui/reborrow/issue-156699.stderr
+++ b/tests/ui/reborrow/issue-156699.stderr
@@ -1,0 +1,41 @@
+error[E0277]: `T` is not an iterator
+  --> $DIR/issue-156699.rs:9:1
+   |
+LL | impl<'a, T> CoerceShared<<T as Iterator>::Item> for Source<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` is not an iterator
+   |
+help: consider restricting type parameter `T` with trait `Iterator`
+   |
+LL | impl<'a, T: std::iter::Iterator> CoerceShared<<T as Iterator>::Item> for Source<'a> {}
+   |           +++++++++++++++++++++
+
+error[E0277]: `T` is not an iterator
+  --> $DIR/issue-156699.rs:15:1
+   |
+LL | impl<'a, T> CoerceShared<<T as Iterator>::Item> for dyn CustomMarker<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `T` is not an iterator
+   |
+help: consider restricting type parameter `T` with trait `Iterator`
+   |
+LL | impl<'a, T: std::iter::Iterator> CoerceShared<<T as Iterator>::Item> for dyn CustomMarker<'a> {}
+   |           +++++++++++++++++++++
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-156699.rs:9:10
+   |
+LL | impl<'a, T> CoerceShared<<T as Iterator>::Item> for Source<'a> {}
+   |        --^
+   |        | |
+   |        | unconstrained type parameter
+   |        help: remove the unused type parameter `T`
+
+error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/issue-156699.rs:15:10
+   |
+LL | impl<'a, T> CoerceShared<<T as Iterator>::Item> for dyn CustomMarker<'a> {}
+   |          ^ unconstrained type parameter
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0207, E0277.
+For more information about an error, try `rustc --explain E0207`.


### PR DESCRIPTION
Fixes rust-lang/rust#156699

