### PR TITLE
Add link to RFMF Sponsors page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: rustfoundation
 custom: ["rust-lang.org/funding"]


### PR DESCRIPTION
To make the funding/sponsor link to RFMF and the Foundation's Sponsors page simpler.
