### PR TITLE
Fix compound assignments in liveness check

### DIFF
--- a/compiler/rustc_mir_transform/src/liveness.rs
+++ b/compiler/rustc_mir_transform/src/liveness.rs
@@ -12,8 +12,8 @@ use rustc_middle::mir::visit::{
 use rustc_middle::mir::*;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_mir_dataflow::fmt::DebugWithContext;
-use rustc_mir_dataflow::{Analysis, Backward, ResultsCursor};
+use rustc_mir_dataflow::fmt::{DebugWithAdapter, DebugWithContext};
+use rustc_mir_dataflow::{Analysis, Backward, JoinSemiLattice, ResultsCursor};
 use rustc_session::lint;
 use rustc_span::Span;
 use rustc_span::edit_distance::find_best_match_for_name;
@@ -136,7 +136,6 @@ pub(crate) fn check_liveness<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Den
     checked_places.record_debuginfo(&body.var_debug_info);
 
     let self_assignment = find_self_assignments(&checked_places, body);
-
     let mut live =
         MaybeLivePlaces { tcx, capture_kind, checked_places: &checked_places, self_assignment }
             .iterate_to_fixpoint(tcx, body, None)
@@ -680,8 +679,9 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
 
         for (bb, bb_data) in traversal::postorder(body) {
             cursor.seek_to_block_end(bb);
-            let live = cursor.get();
-            ever_live.union(live);
+            let live_domain = cursor.get();
+            ever_live.union(&live_domain.use_live);
+            let live = live_domain.assignments();
 
             let terminator = bb_data.terminator();
             match &terminator.kind {
@@ -718,8 +718,9 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
             for (statement_index, statement) in bb_data.statements.iter().enumerate().rev() {
                 let location = Location { block: bb, statement_index };
                 cursor.seek_before_primary_effect(location);
-                let live = cursor.get();
-                ever_live.union(live);
+                let live_domain = cursor.get();
+                ever_live.union(&live_domain.use_live);
+                let live = live_domain.assignments();
                 match &statement.kind {
                     StatementKind::Assign((place, _)) => {
                         check_place(
@@ -756,8 +757,8 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
         // Check liveness of function arguments on entry.
         {
             cursor.seek_to_block_start(START_BLOCK);
-            let live = cursor.get();
-            ever_live.union(live);
+            let live_domain = cursor.get();
+            ever_live.union(&live_domain.use_live);
 
             // Verify that arguments and captured values are useful.
             for (index, place) in checked_places.iter() {
@@ -778,7 +779,7 @@ impl<'a, 'tcx> AssignmentResult<'a, 'tcx> {
                 let access = Access {
                     kind,
                     location: Location::START,
-                    live: live.contains(index),
+                    live: live_domain.use_live.contains(index),
                     is_direct: true,
                 };
                 assignments[index].insert(source_info, access);
@@ -1232,30 +1233,117 @@ pub struct MaybeLivePlaces<'a, 'tcx> {
     self_assignment: FxHashSet<Location>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaybeLivePlacesDomain {
+    /// Places whose current value may still be observed by an ordinary user-visible use.
+    ///
+    /// This drives `unused_variables`. In the following example, the read of `a` performed by
+    /// `a += 1` is only needed to compute the new assigned value, so it does not make `a` live in
+    /// this domain:
+    ///
+    /// ```text
+    /// let mut a = 0;
+    /// a += 1;
+    /// ```
+    ///
+    /// If there is no later ordinary use of `a`, the final assignment can still be reported as
+    /// unused.
+    use_live: DenseBitSet<PlaceIndex>,
+
+    /// Places whose current value may still be read by a later assignment.
+    ///
+    /// This drives `unused_assignments`. It differs from `use_live` for self-assignments, where a
+    /// later assignment reads the old value without counting as an ordinary use. For example:
+    ///
+    /// ```text
+    /// let mut a = 0;
+    /// if cond {
+    ///     a = 1;
+    /// } else {
+    ///     a = 2;
+    /// }
+    /// a += 1;
+    /// ```
+    ///
+    /// The old-value read in `a += 1` makes both branch assignments live in this domain, even
+    /// though it does not make them live in `use_live`.
+    ///
+    /// `None` means there are no self-assignments in this body, so assignment-read liveness is the
+    /// same as ordinary use liveness and we avoid allocating a second bitset.
+    assignment_live: Option<DenseBitSet<PlaceIndex>>,
+}
+
+impl MaybeLivePlacesDomain {
+    fn new_empty(len: usize, track_assignments_separately: bool) -> Self {
+        Self {
+            use_live: DenseBitSet::new_empty(len),
+            assignment_live: track_assignments_separately.then(|| DenseBitSet::new_empty(len)),
+        }
+    }
+
+    fn assignments(&self) -> &DenseBitSet<PlaceIndex> {
+        // Without self-assignments, assignment-read liveness is identical to ordinary use
+        // liveness. Reuse `use_live` in that common case.
+        self.assignment_live.as_ref().unwrap_or(&self.use_live)
+    }
+}
+
+impl JoinSemiLattice for MaybeLivePlacesDomain {
+    fn join(&mut self, other: &Self) -> bool {
+        let use_changed = self.use_live.union(&other.use_live);
+        let assignment_changed = match (&mut self.assignment_live, &other.assignment_live) {
+            (Some(this), Some(other)) => this.union(other),
+            (None, None) => false,
+            _ => bug!("assignment-read liveness should be enabled consistently"),
+        };
+
+        use_changed | assignment_changed
+    }
+}
+
+impl DebugWithContext<MaybeLivePlaces<'_, '_>> for MaybeLivePlacesDomain {
+    fn fmt_with(
+        &self,
+        ctxt: &MaybeLivePlaces<'_, '_>,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        let mut debug = f.debug_struct("MaybeLivePlacesDomain");
+        debug.field("used_live", &DebugWithAdapter { this: &self.use_live, ctxt });
+        if let Some(assign_live) = &self.assignment_live {
+            debug.field("assignment_live", &DebugWithAdapter { this: assign_live, ctxt });
+        }
+        debug.finish()
+    }
+}
+
 impl<'tcx> MaybeLivePlaces<'_, 'tcx> {
     fn transfer_function<'a>(
         &'a self,
-        trans: &'a mut DenseBitSet<PlaceIndex>,
+        trans: &'a mut MaybeLivePlacesDomain,
     ) -> TransferFunction<'a, 'tcx> {
         TransferFunction {
             tcx: self.tcx,
             checked_places: &self.checked_places,
             capture_kind: self.capture_kind,
-            trans,
+            places: trans,
             self_assignment: &self.self_assignment,
+            mode: TransferMode::Both,
         }
     }
 }
 
 impl<'tcx> Analysis<'tcx> for MaybeLivePlaces<'_, 'tcx> {
-    type Domain = DenseBitSet<PlaceIndex>;
+    type Domain = MaybeLivePlacesDomain;
     type Direction = Backward;
 
     const NAME: &'static str = "liveness-lint";
 
     fn bottom_value(&self, _: &Body<'tcx>) -> Self::Domain {
         // bottom = not live
-        DenseBitSet::new_empty(self.checked_places.len())
+        MaybeLivePlacesDomain::new_empty(
+            self.checked_places.len(),
+            !self.self_assignment.is_empty(),
+        )
     }
 
     fn initialize_start_block(&self, _: &Body<'tcx>, _: &mut Self::Domain) {
@@ -1294,9 +1382,52 @@ impl<'tcx> Analysis<'tcx> for MaybeLivePlaces<'_, 'tcx> {
 struct TransferFunction<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     checked_places: &'a PlaceSet<'tcx>,
-    trans: &'a mut DenseBitSet<PlaceIndex>,
+    places: &'a mut MaybeLivePlacesDomain,
     capture_kind: CaptureKind,
     self_assignment: &'a FxHashSet<Location>,
+    mode: TransferMode,
+}
+
+#[derive(Copy, Clone)]
+enum TransferMode {
+    Used,
+    Assignments,
+    Both,
+}
+
+impl<'tcx> TransferFunction<'_, 'tcx> {
+    fn with_mode<R>(&mut self, mode: TransferMode, f: impl FnOnce(&mut Self) -> R) -> R {
+        let old_mode = self.mode;
+        self.mode = mode;
+        let result = f(self);
+        self.mode = old_mode;
+        result
+    }
+
+    fn update_place(&mut self, index: PlaceIndex, def_use: DefUse) {
+        match def_use {
+            DefUse::Def => {
+                if matches!(self.mode, TransferMode::Used | TransferMode::Both) {
+                    self.places.use_live.remove(index);
+                }
+                if matches!(self.mode, TransferMode::Assignments | TransferMode::Both)
+                    && let Some(assignments) = &mut self.places.assignment_live
+                {
+                    assignments.remove(index);
+                }
+            }
+            DefUse::Use => {
+                if matches!(self.mode, TransferMode::Used | TransferMode::Both) {
+                    self.places.use_live.insert(index);
+                }
+                if matches!(self.mode, TransferMode::Assignments | TransferMode::Both)
+                    && let Some(assignments) = &mut self.places.assignment_live
+                {
+                    assignments.insert(index);
+                }
+            }
+        }
+    }
 }
 
 impl<'tcx> Visitor<'tcx> for TransferFunction<'_, 'tcx> {
@@ -1312,6 +1443,14 @@ impl<'tcx> Visitor<'tcx> for TransferFunction<'_, 'tcx> {
             StatementKind::Assign((ref dest, ref rvalue))
                 if self.self_assignment.contains(&location) =>
             {
+                // A read done only to compute the next value of a self-assignment does not make the
+                // variable used, but it does make the previous assignment read. Apply the ordinary
+                // transfer to the assignment-liveness bits, then the restricted transfer to the
+                // user-visible "used" bits.
+                self.with_mode(TransferMode::Assignments, |this| {
+                    this.visit_assign(dest, rvalue, location);
+                });
+
                 if let Rvalue::BinaryOp(
                     BinOp::AddWithOverflow | BinOp::SubWithOverflow | BinOp::MulWithOverflow,
                     (_, rhs),
@@ -1320,23 +1459,29 @@ impl<'tcx> Visitor<'tcx> for TransferFunction<'_, 'tcx> {
                     // We are computing the binary operation:
                     // - the LHS will be assigned, so we don't read it;
                     // - the RHS still needs to be read.
-                    self.visit_operand(rhs, location);
-                    self.visit_place(
-                        dest,
-                        PlaceContext::MutatingUse(MutatingUseContext::Store),
-                        location,
-                    );
+                    self.with_mode(TransferMode::Used, |this| {
+                        this.visit_operand(rhs, location);
+                        this.visit_place(
+                            dest,
+                            PlaceContext::MutatingUse(MutatingUseContext::Store),
+                            location,
+                        );
+                    });
                 } else if let Rvalue::BinaryOp(_, (_, rhs)) = rvalue {
                     // We are computing the binary operation:
                     // - the LHS is being updated, so we don't read it;
                     // - the RHS still needs to be read.
-                    self.visit_operand(rhs, location);
+                    self.with_mode(TransferMode::Used, |this| {
+                        this.visit_operand(rhs, location);
+                    });
                 } else {
                     // This is the second part of a checked self-assignment,
                     // we are assigning the result.
                     // We do not consider the write to the destination as a `def`.
                     // `self_assignment` must be false if the assignment is indirect.
-                    self.visit_rvalue(rvalue, location);
+                    self.with_mode(TransferMode::Used, |this| {
+                        this.visit_rvalue(rvalue, location);
+                    });
                 }
             }
             _ => self.super_statement(statement, location),
@@ -1358,7 +1503,7 @@ impl<'tcx> Visitor<'tcx> for TransferFunction<'_, 'tcx> {
                     if place.local == ty::CAPTURE_STRUCT_LOCAL
                         && place.projection.last() == Some(&PlaceElem::Deref)
                     {
-                        self.trans.insert(index);
+                        self.update_place(index, DefUse::Use);
                     }
                 }
             }
@@ -1408,10 +1553,10 @@ impl<'tcx> Visitor<'tcx> for TransferFunction<'_, 'tcx> {
 
             match DefUse::for_place(extra_projections, context) {
                 Some(DefUse::Def) => {
-                    self.trans.remove(index);
+                    self.update_place(index, DefUse::Def);
                 }
                 Some(DefUse::Use) => {
-                    self.trans.insert(index);
+                    self.update_place(index, DefUse::Use);
                 }
                 None => {}
             }
@@ -1425,10 +1570,10 @@ impl<'tcx> Visitor<'tcx> for TransferFunction<'_, 'tcx> {
             debug_assert_eq!(_proj, &[]);
             match DefUse::for_place(&[], context) {
                 Some(DefUse::Def) => {
-                    self.trans.remove(index);
+                    self.update_place(index, DefUse::Def);
                 }
                 Some(DefUse::Use) => {
-                    self.trans.insert(index);
+                    self.update_place(index, DefUse::Use);
                 }
                 _ => {}
             }

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
@@ -26,9 +26,7 @@ pub fn f() {
     // Read and written to, but never actually used.
     (move || {
         c.x += 1; //~  WARN value captured by `c.x` is never read
-                  //~| WARN value assigned to `c.x` is never read
         a += 1; //~  WARN value captured by `a` is never read
-                //~| WARN value assigned to `a` is never read
     })();
 
     (move || {

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.stderr
@@ -1,5 +1,5 @@
 warning: value assigned to `c.x` is never read
-  --> $DIR/liveness.rs:46:9
+  --> $DIR/liveness.rs:44:9
    |
 LL |         c.x += 1;
    |         ^^^^^^^^
@@ -13,7 +13,7 @@ LL | #![warn(unused)]
    = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
 
 warning: value assigned to `a` is never read
-  --> $DIR/liveness.rs:48:9
+  --> $DIR/liveness.rs:46:9
    |
 LL |         a += 1;
    |         ^^^^^^
@@ -28,29 +28,13 @@ LL |         c.x += 1;
    |
    = help: did you mean to capture by reference instead?
 
-warning: value assigned to `c.x` is never read
-  --> $DIR/liveness.rs:28:9
-   |
-LL |         c.x += 1;
-   |         ^^^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
 warning: value captured by `a` is never read
-  --> $DIR/liveness.rs:30:9
+  --> $DIR/liveness.rs:29:9
    |
 LL |         a += 1;
    |         ^
    |
    = help: did you mean to capture by reference instead?
-
-warning: value assigned to `a` is never read
-  --> $DIR/liveness.rs:30:9
-   |
-LL |         a += 1;
-   |         ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
 
 warning: value captured by `c.x` is never read
   --> $DIR/liveness.rs:20:9
@@ -69,7 +53,7 @@ LL |         a = 1;
    = help: did you mean to capture by reference instead?
 
 warning: value captured by `e.x` is never read
-  --> $DIR/liveness.rs:74:13
+  --> $DIR/liveness.rs:72:13
    |
 LL |             e.x = Some("e1");
    |             ^^^
@@ -77,7 +61,7 @@ LL |             e.x = Some("e1");
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `e.x` is never read
-  --> $DIR/liveness.rs:74:13
+  --> $DIR/liveness.rs:72:13
    |
 LL |             e.x = Some("e1");
    |             ^^^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -86,7 +70,7 @@ LL |             e.x = Some("e2");
    |             ---------------- `e.x` is overwritten here before the previous value is read
 
 warning: value assigned to `e.x` is never read
-  --> $DIR/liveness.rs:76:13
+  --> $DIR/liveness.rs:74:13
    |
 LL |             e.x = Some("e2");
    |             ^^^^^^^^^^^^^^^^
@@ -94,7 +78,7 @@ LL |             e.x = Some("e2");
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `b` is never read
-  --> $DIR/liveness.rs:77:13
+  --> $DIR/liveness.rs:75:13
    |
 LL |             b = Some("e1");
    |             ^
@@ -102,7 +86,7 @@ LL |             b = Some("e1");
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `b` is never read
-  --> $DIR/liveness.rs:77:13
+  --> $DIR/liveness.rs:75:13
    |
 LL |             b = Some("e1");
    |             ^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -111,7 +95,7 @@ LL |             b = Some("e2");
    |             -------------- `b` is overwritten here before the previous value is read
 
 warning: value assigned to `b` is never read
-  --> $DIR/liveness.rs:79:13
+  --> $DIR/liveness.rs:77:13
    |
 LL |             b = Some("e2");
    |             ^^^^^^^^^^^^^^
@@ -119,7 +103,7 @@ LL |             b = Some("e2");
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `d.x` is never read
-  --> $DIR/liveness.rs:68:13
+  --> $DIR/liveness.rs:66:13
    |
 LL |             d.x = Some("d1");
    |             ^^^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -127,12 +111,12 @@ LL |             d.x = Some("d2");
    |             ---------------- `d.x` is overwritten here before the previous value is read
 
 warning: value assigned to `a` is never read
-  --> $DIR/liveness.rs:70:13
+  --> $DIR/liveness.rs:68:13
    |
 LL |             a = Some("d1");
    |             ^^^^^^^^^^^^^^ this value is reassigned later and never used
 LL |             a = Some("d2");
    |             -------------- `a` is overwritten here before the previous value is read
 
-warning: 16 warnings emitted
+warning: 14 warnings emitted
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.rs
@@ -36,10 +36,8 @@ pub fn unintentional_copy_two() {
     (1..10).for_each(move |x| {
         sum.b += x;
         //~^ WARN value captured by `sum.b` is never read
-        //~| WARN value assigned to `sum.b` is never read
         a += x;
         //~^ WARN value captured by `a` is never read
-        //~| WARN value assigned to `a` is never read
     });
 }
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.stderr
@@ -58,29 +58,13 @@ LL |         sum.b += x;
    |
    = help: did you mean to capture by reference instead?
 
-warning: value assigned to `sum.b` is never read
-  --> $DIR/liveness_unintentional_copy.rs:37:9
-   |
-LL |         sum.b += x;
-   |         ^^^^^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
 warning: value captured by `a` is never read
-  --> $DIR/liveness_unintentional_copy.rs:40:9
+  --> $DIR/liveness_unintentional_copy.rs:39:9
    |
 LL |         a += x;
    |         ^
    |
    = help: did you mean to capture by reference instead?
-
-warning: value assigned to `a` is never read
-  --> $DIR/liveness_unintentional_copy.rs:40:9
-   |
-LL |         a += x;
-   |         ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
 
 warning: unused variable: `a`
   --> $DIR/liveness_unintentional_copy.rs:32:9
@@ -94,5 +78,5 @@ warning: unused variable: `sum`
 LL |     let mut sum = MyStruct { a: 1, b: 0 };
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sum`
 
-warning: 12 warnings emitted
+warning: 10 warnings emitted
 

--- a/tests/ui/liveness/compound-assignment-read-issue-154457.rs
+++ b/tests/ui/liveness/compound-assignment-read-issue-154457.rs
@@ -1,0 +1,50 @@
+#![deny(unused_assignments)]
+#![deny(unused_variables)]
+#![allow(dead_code)]
+
+fn compound_assignment_chain() {
+    let mut a = 10.;
+    //~^ ERROR variable `a` is assigned to, but never used
+    let b = 13.;
+    let c = 11.;
+
+    a += b;
+    a -= c;
+    //~^ ERROR value assigned to `a` is never read
+}
+
+fn assignment_then_compound_assignment() {
+    let mut a;
+    //~^ ERROR variable `a` is assigned to, but never used
+
+    a = 10;
+    a += 1;
+    //~^ ERROR value assigned to `a` is never read
+}
+
+fn compound_assignment_chain_with_later_use() {
+    let mut a = 10;
+    let b = 13;
+    let c = 11;
+
+    a += b;
+    a -= c;
+
+    let _ = a;
+}
+
+fn compound_assignment_after_branch_join(cond: bool) {
+    let mut a = 0.0;
+    let _ = a;
+
+    if cond {
+        a = 1.0;
+    } else {
+        a = 2.0;
+    }
+
+    a += 1.0;
+    //~^ ERROR value assigned to `a` is never read
+}
+
+fn main() {}

--- a/tests/ui/liveness/compound-assignment-read-issue-154457.stderr
+++ b/tests/ui/liveness/compound-assignment-read-issue-154457.stderr
@@ -1,0 +1,52 @@
+error: variable `a` is assigned to, but never used
+  --> $DIR/compound-assignment-read-issue-154457.rs:6:9
+   |
+LL |     let mut a = 10.;
+   |         ^^^^^
+   |
+   = note: consider using `_a` instead
+note: the lint level is defined here
+  --> $DIR/compound-assignment-read-issue-154457.rs:2:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: value assigned to `a` is never read
+  --> $DIR/compound-assignment-read-issue-154457.rs:12:5
+   |
+LL |     a -= c;
+   |     ^^^^^^
+   |
+   = help: maybe it is overwritten before being read?
+note: the lint level is defined here
+  --> $DIR/compound-assignment-read-issue-154457.rs:1:9
+   |
+LL | #![deny(unused_assignments)]
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: variable `a` is assigned to, but never used
+  --> $DIR/compound-assignment-read-issue-154457.rs:17:9
+   |
+LL |     let mut a;
+   |         ^^^^^
+   |
+   = note: consider using `_a` instead
+
+error: value assigned to `a` is never read
+  --> $DIR/compound-assignment-read-issue-154457.rs:21:5
+   |
+LL |     a += 1;
+   |     ^^^^^^
+   |
+   = help: maybe it is overwritten before being read?
+
+error: value assigned to `a` is never read
+  --> $DIR/compound-assignment-read-issue-154457.rs:46:5
+   |
+LL |     a += 1.0;
+   |     ^^^^^^^^
+   |
+   = help: maybe it is overwritten before being read?
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/liveness/liveness-consts.rs
+++ b/tests/ui/liveness/liveness-consts.rs
@@ -9,13 +9,12 @@ pub static A: i32 = {
     while i < 10 {
         i += 1;
         a += 1;
-        //~^ WARN value assigned to `a` is never read
     }
     i
 };
 
 pub const B: u32 = {
-    let mut b = 1; //~ WARN value assigned to `b` is never read
+    let mut b = 1;
     b += 1; //~ WARN value assigned to `b` is never read
     b = 42;
     b

--- a/tests/ui/liveness/liveness-consts.stderr
+++ b/tests/ui/liveness/liveness-consts.stderr
@@ -1,5 +1,5 @@
 warning: unused variable: `e`
-  --> $DIR/liveness-consts.rs:26:13
+  --> $DIR/liveness-consts.rs:25:13
    |
 LL |         let e = 1;
    |             ^ help: if this is intentional, prefix it with an underscore: `_e`
@@ -12,13 +12,13 @@ LL | #![warn(unused)]
    = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
 
 warning: unused variable: `s`
-  --> $DIR/liveness-consts.rs:35:24
+  --> $DIR/liveness-consts.rs:34:24
    |
 LL | pub fn f(x: [u8; { let s = 17; 100 }]) -> [u8;  { let z = 18; 100 }] {
    |                        ^ help: if this is intentional, prefix it with an underscore: `_s`
 
 warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:35:55
+  --> $DIR/liveness-consts.rs:34:55
    |
 LL | pub fn f(x: [u8; { let s = 17; 100 }]) -> [u8;  { let z = 18; 100 }] {
    |                                                       ^ help: if this is intentional, prefix it with an underscore: `_z`
@@ -31,39 +31,24 @@ LL |     let mut a = 0;
    |
    = note: consider using `_a` instead
 
-warning: value assigned to `a` is never read
-  --> $DIR/liveness-consts.rs:11:9
-   |
-LL |         a += 1;
-   |         ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-   = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
-
 warning: value assigned to `b` is never read
-  --> $DIR/liveness-consts.rs:18:17
-   |
-LL |     let mut b = 1;
-   |                 ^ this value is reassigned later and never used
-LL |     b += 1;
-   |     ------ `b` is overwritten here before the previous value is read
-
-warning: value assigned to `b` is never read
-  --> $DIR/liveness-consts.rs:19:5
+  --> $DIR/liveness-consts.rs:18:5
    |
 LL |     b += 1;
    |     ^^^^^^ this value is reassigned later and never used
 LL |     b = 42;
    |     ------ `b` is overwritten here before the previous value is read
+   |
+   = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
 
 warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:62:13
+  --> $DIR/liveness-consts.rs:61:13
    |
 LL |         let z = 42;
    |             ^ help: if this is intentional, prefix it with an underscore: `_z`
 
 warning: value assigned to `t` is never read
-  --> $DIR/liveness-consts.rs:44:9
+  --> $DIR/liveness-consts.rs:43:9
    |
 LL |         t = t + t;
    |         ^^^^^^^^^
@@ -71,10 +56,10 @@ LL |         t = t + t;
    = help: maybe it is overwritten before being read?
 
 warning: unused variable: `w`
-  --> $DIR/liveness-consts.rs:51:13
+  --> $DIR/liveness-consts.rs:50:13
    |
 LL |         let w = 10;
    |             ^ help: if this is intentional, prefix it with an underscore: `_w`
 
-warning: 10 warnings emitted
+warning: 8 warnings emitted
 

--- a/tests/ui/liveness/liveness-unused.rs
+++ b/tests/ui/liveness/liveness-unused.rs
@@ -39,7 +39,6 @@ fn f3b() {
     //~^ ERROR variable `z` is assigned to, but never used
     loop {
         z += 4;
-        //~^ ERROR value assigned to `z` is never read
     }
 }
 
@@ -47,7 +46,6 @@ fn f3b() {
 fn f3c() {
     let mut z = 3;
     loop { z += 4; }
-    //~^ ERROR value assigned to `z` is never read
 }
 
 #[allow(unused_variables)]
@@ -63,7 +61,6 @@ fn f3e() {
     //~^ ERROR variable `z` is assigned to, but never used
     loop {
         z += a;
-        //~^ ERROR value assigned to `z` is never read
     }
 }
 
@@ -181,17 +178,11 @@ fn f9() {
     let h = 13;
 
     a += b;
-    //~^ ERROR value assigned to `a` is never read
     a -= c;
-    //~^ ERROR value assigned to `a` is never read
     a *= d;
-    //~^ ERROR value assigned to `a` is never read
     a /= e;
-    //~^ ERROR value assigned to `a` is never read
     a |= f;
-    //~^ ERROR value assigned to `a` is never read
     a &= g;
-    //~^ ERROR value assigned to `a` is never read
     a %= h;
     //~^ ERROR value assigned to `a` is never read
 }
@@ -227,13 +218,9 @@ fn f9c() {
     let f = 13.;
 
     a += b;
-    //~^ ERROR value assigned to `a` is never read
     a -= c;
-    //~^ ERROR value assigned to `a` is never read
     a *= d;
-    //~^ ERROR value assigned to `a` is never read
     a /= e;
-    //~^ ERROR value assigned to `a` is never read
     a %= f;
     //~^ ERROR value assigned to `a` is never read
 }

--- a/tests/ui/liveness/liveness-unused.stderr
+++ b/tests/ui/liveness/liveness-unused.stderr
@@ -1,5 +1,5 @@
 warning: unreachable statement
-  --> $DIR/liveness-unused.rs:120:9
+  --> $DIR/liveness-unused.rs:117:9
    |
 LL |         continue;
    |         -------- any code following this expression is unreachable
@@ -72,46 +72,22 @@ LL |     let mut z = 3;
    |
    = note: consider using `_z` instead
 
-error: value assigned to `z` is never read
-  --> $DIR/liveness-unused.rs:41:9
-   |
-LL |         z += 4;
-   |         ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
-error: value assigned to `z` is never read
-  --> $DIR/liveness-unused.rs:49:12
-   |
-LL |     loop { z += 4; }
-   |            ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
 error: variable `z` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:62:9
+  --> $DIR/liveness-unused.rs:60:9
    |
 LL |     let mut z = 3;
    |         ^^^^^
    |
    = note: consider using `_z` instead
 
-error: value assigned to `z` is never read
-  --> $DIR/liveness-unused.rs:65:9
-   |
-LL |         z += a;
-   |         ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
 error: unused variable: `i`
-  --> $DIR/liveness-unused.rs:72:12
+  --> $DIR/liveness-unused.rs:69:12
    |
 LL |       Some(i) => {
    |            ^ help: if this is intentional, prefix it with an underscore: `_i`
 
 error: unused variable: `i`
-  --> $DIR/liveness-unused.rs:85:14
+  --> $DIR/liveness-unused.rs:82:14
    |
 LL |       tri::a(i) | tri::b(i) | tri::c(i) => {
    |              ^           ^           ^
@@ -122,25 +98,25 @@ LL |       tri::a(_i) | tri::b(_i) | tri::c(_i) => {
    |              +            +            +
 
 error: unused variable: `x`
-  --> $DIR/liveness-unused.rs:107:9
+  --> $DIR/liveness-unused.rs:104:9
    |
 LL |     for x in 1..10 { }
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: unused variable: `x`
-  --> $DIR/liveness-unused.rs:112:10
+  --> $DIR/liveness-unused.rs:109:10
    |
 LL |     for (x, _) in [1, 2, 3].iter().enumerate() { }
    |          ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: unused variable: `x`
-  --> $DIR/liveness-unused.rs:117:13
+  --> $DIR/liveness-unused.rs:114:13
    |
 LL |     for (_, x) in [1, 2, 3].iter().enumerate() {
    |             ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: variable `x` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:140:9
+  --> $DIR/liveness-unused.rs:137:9
    |
 LL |     let x;
    |         ^
@@ -148,7 +124,7 @@ LL |     let x;
    = note: consider using `_x` instead
 
 error: value assigned to `x` is never read
-  --> $DIR/liveness-unused.rs:144:9
+  --> $DIR/liveness-unused.rs:141:9
    |
 LL |         x = 0;
    |         ^^^^^
@@ -156,7 +132,7 @@ LL |         x = 0;
    = help: maybe it is overwritten before being read?
 
 error: variable `a` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:173:9
+  --> $DIR/liveness-unused.rs:170:9
    |
 LL |     let mut a = 10;
    |         ^^^^^
@@ -164,61 +140,7 @@ LL |     let mut a = 10;
    = note: consider using `_a` instead
 
 error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:183:5
-   |
-LL |     a += b;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a -= c;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:185:5
-   |
-LL |     a -= c;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a *= d;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:187:5
-   |
-LL |     a *= d;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a /= e;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:189:5
-   |
-LL |     a /= e;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a |= f;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:191:5
-   |
-LL |     a |= f;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a &= g;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:193:5
-   |
-LL |     a &= g;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a %= h;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:195:5
+  --> $DIR/liveness-unused.rs:186:5
    |
 LL |     a %= h;
    |     ^^^^^^
@@ -226,7 +148,7 @@ LL |     a %= h;
    = help: maybe it is overwritten before being read?
 
 error: variable `a` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:221:9
+  --> $DIR/liveness-unused.rs:212:9
    |
 LL |     let mut a = 10.;
    |         ^^^^^
@@ -234,43 +156,7 @@ LL |     let mut a = 10.;
    = note: consider using `_a` instead
 
 error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:229:5
-   |
-LL |     a += b;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a -= c;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:231:5
-   |
-LL |     a -= c;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a *= d;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:233:5
-   |
-LL |     a *= d;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a /= e;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:235:5
-   |
-LL |     a /= e;
-   |     ^^^^^^ this value is reassigned later and never used
-LL |
-LL |     a %= f;
-   |     ------ `a` is overwritten here before the previous value is read
-
-error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:237:5
+  --> $DIR/liveness-unused.rs:224:5
    |
 LL |     a %= f;
    |     ^^^^^^
@@ -278,7 +164,7 @@ LL |     a %= f;
    = help: maybe it is overwritten before being read?
 
 error: variable `a` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:241:11
+  --> $DIR/liveness-unused.rs:228:11
    |
 LL | fn f10<T>(mut a: T, b: T) {
    |           ^^^^^
@@ -286,7 +172,7 @@ LL | fn f10<T>(mut a: T, b: T) {
    = note: consider using `_a` instead
 
 error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:243:5
+  --> $DIR/liveness-unused.rs:230:5
    |
 LL |     a = b;
    |     ^
@@ -294,7 +180,7 @@ LL |     a = b;
    = help: maybe it is overwritten before being read?
 
 error: variable `a` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:247:12
+  --> $DIR/liveness-unused.rs:234:12
    |
 LL | fn f10b<T>(mut a: Box<T>, b: Box<T>) {
    |            ^^^^^
@@ -302,12 +188,12 @@ LL | fn f10b<T>(mut a: Box<T>, b: Box<T>) {
    = note: consider using `_a` instead
 
 error: value assigned to `a` is never read
-  --> $DIR/liveness-unused.rs:248:5
+  --> $DIR/liveness-unused.rs:235:5
    |
 LL |     a = b;
    |     ^
    |
    = help: maybe it is overwritten before being read?
 
-error: aborting due to 36 previous errors; 1 warning emitted
+error: aborting due to 23 previous errors; 1 warning emitted
 

--- a/tests/ui/liveness/liveness-upvars.rs
+++ b/tests/ui/liveness/liveness-upvars.rs
@@ -21,7 +21,6 @@ pub fn unintentional_copy_two() {
     (1..10).for_each(move |x| {
         sum += x;
         //~^ WARN value captured by `sum` is never read
-        //~| WARN value assigned to `sum` is never read
     });
     dbg!(sum);
 }
@@ -43,7 +42,6 @@ pub fn f() {
     let _ = move || {
         c += 1;
         //~^ WARN value captured by `c` is never read
-        //~|  WARN value assigned to `c` is never read
     };
     let _ = async move {
         c += 1;

--- a/tests/ui/liveness/liveness-upvars.stderr
+++ b/tests/ui/liveness/liveness-upvars.stderr
@@ -28,16 +28,8 @@ LL |         sum += x;
    |
    = help: did you mean to capture by reference instead?
 
-warning: value assigned to `sum` is never read
-  --> $DIR/liveness-upvars.rs:22:9
-   |
-LL |         sum += x;
-   |         ^^^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:69:9
+  --> $DIR/liveness-upvars.rs:67:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -45,7 +37,7 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:63:9
+  --> $DIR/liveness-upvars.rs:61:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -53,7 +45,7 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:49:9
+  --> $DIR/liveness-upvars.rs:47:9
    |
 LL |         c += 1;
    |         ^
@@ -61,7 +53,7 @@ LL |         c += 1;
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:49:9
+  --> $DIR/liveness-upvars.rs:47:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -69,23 +61,15 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:44:9
+  --> $DIR/liveness-upvars.rs:43:9
    |
 LL |         c += 1;
    |         ^
    |
    = help: did you mean to capture by reference instead?
 
-warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:44:9
-   |
-LL |         c += 1;
-   |         ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
-
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:38:9
+  --> $DIR/liveness-upvars.rs:37:9
    |
 LL |         c = 1;
    |         ^
@@ -93,7 +77,7 @@ LL |         c = 1;
    = help: did you mean to capture by reference instead?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:34:9
+  --> $DIR/liveness-upvars.rs:33:9
    |
 LL |         c = 1;
    |         ^
@@ -101,7 +85,7 @@ LL |         c = 1;
    = help: did you mean to capture by reference instead?
 
 warning: value captured by `e` is never read
-  --> $DIR/liveness-upvars.rs:82:13
+  --> $DIR/liveness-upvars.rs:80:13
    |
 LL |             e = Some("e1");
    |             ^
@@ -109,7 +93,7 @@ LL |             e = Some("e1");
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `e` is never read
-  --> $DIR/liveness-upvars.rs:82:13
+  --> $DIR/liveness-upvars.rs:80:13
    |
 LL |             e = Some("e1");
    |             ^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -118,7 +102,7 @@ LL |             e = Some("e2");
    |             -------------- `e` is overwritten here before the previous value is read
 
 warning: value assigned to `e` is never read
-  --> $DIR/liveness-upvars.rs:84:13
+  --> $DIR/liveness-upvars.rs:82:13
    |
 LL |             e = Some("e2");
    |             ^^^^^^^^^^^^^^
@@ -126,7 +110,7 @@ LL |             e = Some("e2");
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `d` is never read
-  --> $DIR/liveness-upvars.rs:78:13
+  --> $DIR/liveness-upvars.rs:76:13
    |
 LL |             d = Some("d1");
    |             ^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -134,7 +118,7 @@ LL |             d = Some("d2");
    |             -------------- `d` is overwritten here before the previous value is read
 
 warning: value assigned to `v` is never read
-  --> $DIR/liveness-upvars.rs:92:13
+  --> $DIR/liveness-upvars.rs:90:13
    |
 LL |             v = T::default();
    |             ^
@@ -142,7 +126,7 @@ LL |             v = T::default();
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `z` is never read
-  --> $DIR/liveness-upvars.rs:105:17
+  --> $DIR/liveness-upvars.rs:103:17
    |
 LL |                 z = T::default();
    |                 ^
@@ -150,7 +134,7 @@ LL |                 z = T::default();
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `z` is never read
-  --> $DIR/liveness-upvars.rs:105:17
+  --> $DIR/liveness-upvars.rs:103:17
    |
 LL |                 z = T::default();
    |                 ^^^^^^^^^^^^^^^^
@@ -158,7 +142,7 @@ LL |                 z = T::default();
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `state` is never read
-  --> $DIR/liveness-upvars.rs:131:9
+  --> $DIR/liveness-upvars.rs:129:9
    |
 LL |         state = 4;
    |         ^^^^^
@@ -166,7 +150,7 @@ LL |         state = 4;
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `state` is never read
-  --> $DIR/liveness-upvars.rs:131:9
+  --> $DIR/liveness-upvars.rs:129:9
    |
 LL |         state = 4;
    |         ^^^^^^^^^ this value is reassigned later and never used
@@ -175,7 +159,7 @@ LL |         state = 5;
    |         --------- `state` is overwritten here before the previous value is read
 
 warning: value assigned to `state` is never read
-  --> $DIR/liveness-upvars.rs:134:9
+  --> $DIR/liveness-upvars.rs:132:9
    |
 LL |         state = 5;
    |         ^^^^^^^^^
@@ -183,7 +167,7 @@ LL |         state = 5;
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `s` is never read
-  --> $DIR/liveness-upvars.rs:143:9
+  --> $DIR/liveness-upvars.rs:141:9
    |
 LL |         s = 1;
    |         ^^^^^ this value is reassigned later and never used
@@ -191,12 +175,12 @@ LL |         yield (s = 2);
    |               ------- `s` is overwritten here before the previous value is read
 
 warning: value assigned to `s` is never read
-  --> $DIR/liveness-upvars.rs:145:9
+  --> $DIR/liveness-upvars.rs:143:9
    |
 LL |         s = yield ();
    |         ^^^^^^^^^^^^ this value is reassigned later and never used
 LL |         s = 3;
    |         ----- `s` is overwritten here before the previous value is read
 
-warning: 24 warnings emitted
+warning: 22 warnings emitted
 

--- a/tests/ui/unboxed-closures/unboxed-closures-move-mutable.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-move-mutable.rs
@@ -16,14 +16,12 @@ fn main() {
         //~^ WARN unused variable: `x`
         move || x += 1;
         //~^ WARN value captured by `x` is never read
-        //~| WARN value assigned to `x` is never read
     }
     {
         let mut x = 0_usize;
         //~^ WARN unused variable: `x`
         move || x += 1;
         //~^ WARN value captured by `x` is never read
-        //~| WARN value assigned to `x` is never read
     }
     {
         let mut x = 0_usize;

--- a/tests/ui/unboxed-closures/unboxed-closures-move-mutable.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-move-mutable.stderr
@@ -1,19 +1,11 @@
 warning: value captured by `x` is never read
-  --> $DIR/unboxed-closures-move-mutable.rs:24:17
+  --> $DIR/unboxed-closures-move-mutable.rs:23:17
    |
 LL |         move || x += 1;
    |                 ^
    |
    = help: did you mean to capture by reference instead?
    = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
-
-warning: value assigned to `x` is never read
-  --> $DIR/unboxed-closures-move-mutable.rs:24:17
-   |
-LL |         move || x += 1;
-   |                 ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
 
 warning: value captured by `x` is never read
   --> $DIR/unboxed-closures-move-mutable.rs:17:17
@@ -22,14 +14,6 @@ LL |         move || x += 1;
    |                 ^
    |
    = help: did you mean to capture by reference instead?
-
-warning: value assigned to `x` is never read
-  --> $DIR/unboxed-closures-move-mutable.rs:17:17
-   |
-LL |         move || x += 1;
-   |                 ^^^^^^
-   |
-   = help: maybe it is overwritten before being read?
 
 warning: unused variable: `x`
   --> $DIR/unboxed-closures-move-mutable.rs:15:13
@@ -40,10 +24,10 @@ LL |         let mut x = 0_usize;
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
 
 warning: unused variable: `x`
-  --> $DIR/unboxed-closures-move-mutable.rs:22:13
+  --> $DIR/unboxed-closures-move-mutable.rs:21:13
    |
 LL |         let mut x = 0_usize;
    |             ^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
 
-warning: 6 warnings emitted
+warning: 4 warnings emitted
 


### PR DESCRIPTION
Fixes rust-lang/rust#154457

r? @ghost

Let's do a perf run, I assume there will be some trivial regression on perf:

@bors try @rust-timer queue