### PR TITLE
Test that you can't implement Unpin for a compiler-generated future using TAIT

### DIFF
--- a/tests/ui/impl-trait/unpin-for-future.rs
+++ b/tests/ui/impl-trait/unpin-for-future.rs
@@ -1,0 +1,22 @@
+//@ edition:2024
+//
+// Tests that you can't implement Unpin for a compiler-generated future using TAIT.
+
+#![feature(type_alias_impl_trait)]
+
+use core::marker::PhantomPinned;
+use core::pin::Pin;
+
+type MyFut = impl Future<Output = ()>;
+
+async fn my_async_fn() {}
+
+#[define_opaque(MyFut)]
+fn fut() -> MyFut {
+    my_async_fn()
+}
+
+impl Unpin for MyFut {}
+//~^ ERROR: only traits defined in the current crate can be implemented for arbitrary types
+
+fn main() {}

--- a/tests/ui/impl-trait/unpin-for-future.stderr
+++ b/tests/ui/impl-trait/unpin-for-future.stderr
@@ -1,0 +1,15 @@
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/unpin-for-future.rs:19:1
+   |
+LL | impl Unpin for MyFut {}
+   | ^^^^^^^^^^^^^^^-----
+   |                |
+   |                type alias impl trait is treated as if it were foreign, because its hidden type could be from a foreign crate
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0117`.


### PR DESCRIPTION
I came up with this while trying to break pinning. Seems like a good idea to have a test that this doesn't change.

r? @RalfJung