### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -335,9 +335,7 @@ fn new_context<'gcc, 'tcx>(tcx: TyCtxt<'tcx>) -> Context<'gcc> {
 }
 
 impl ExtraBackendMethods for GccCodegenBackend {
-    fn supports_parallel(&self) -> bool {
-        false
-    }
+    type Module = GccContext;
 
     fn codegen_allocator(
         &self,
@@ -419,6 +417,10 @@ impl WriteBackendMethods for GccCodegenBackend {
     type TargetMachine = ();
     type ModuleBuffer = ModuleBuffer;
     type ThinData = ();
+
+    fn supports_parallel(&self) -> bool {
+        false
+    }
 
     fn target_machine_factory(
         &self,

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -93,6 +93,8 @@ impl Drop for TimeTraceProfiler {
 }
 
 impl ExtraBackendMethods for LlvmCodegenBackend {
+    type Module = ModuleLlvm;
+
     fn codegen_allocator<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
@@ -121,6 +123,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     type ModuleBuffer = back::lto::ModuleBuffer;
     type TargetMachine = OwnedTargetMachine;
     type ThinData = back::lto::ThinData;
+
     fn thread_profiler() -> Box<dyn Any> {
         Box::new(TimeTraceProfiler::new())
     }

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1115,18 +1115,6 @@ fn do_thin_lto<B: WriteBackendMethods>(
     compiled_modules
 }
 
-fn execute_thin_lto_work_item<B: WriteBackendMethods>(
-    cgcx: &CodegenContext,
-    prof: &SelfProfilerRef,
-    shared_emitter: SharedEmitter,
-    tm_factory: TargetMachineFactoryFn<B>,
-    module: lto::ThinModule<B>,
-) -> CompiledModule {
-    let _timer = prof.generic_activity_with_arg("codegen_module_perform_lto", module.name());
-
-    B::optimize_and_codegen_thin(cgcx, prof, &shared_emitter, tm_factory, module)
-}
-
 /// Messages sent to the coordinator.
 pub(crate) enum Message<B: WriteBackendMethods> {
     /// A jobserver token has become available. Sent from the jobserver helper
@@ -1891,7 +1879,8 @@ fn spawn_thin_lto_work<B: WriteBackendMethods>(
                 execute_copy_from_cache_work_item(&cgcx, &prof, shared_emitter, m)
             }
             ThinLtoWorkItem::ThinLto(m) => {
-                execute_thin_lto_work_item(&cgcx, &prof, shared_emitter, tm_factory, m)
+                let _timer = prof.generic_activity_with_arg("codegen_module_perform_lto", m.name());
+                B::optimize_and_codegen_thin(&cgcx, &prof, &shared_emitter, tm_factory, m)
             }
         }));
 

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -352,7 +352,7 @@ pub struct CodegenContext {
     pub incr_comp_session_dir: Option<PathBuf>,
     /// `true` if the codegen should be run in parallel.
     ///
-    /// Depends on [`ExtraBackendMethods::supports_parallel()`] and `-Zno_parallel_backend`.
+    /// Depends on [`WriteBackendMethods::supports_parallel()`] and `-Zno_parallel_backend`.
     pub parallel: bool,
 }
 
@@ -416,7 +416,7 @@ fn need_pre_lto_bitcode_for_incr_comp(sess: &Session) -> bool {
     }
 }
 
-pub(crate) fn start_async_codegen<B: ExtraBackendMethods>(
+pub(crate) fn start_async_codegen<B: WriteBackendMethods>(
     backend: B,
     tcx: TyCtxt<'_>,
     allocator_module: Option<ModuleCodegen<B::Module>>,
@@ -1208,7 +1208,7 @@ enum MainThreadState {
     Lending,
 }
 
-fn start_executing_work<B: ExtraBackendMethods>(
+fn start_executing_work<B: WriteBackendMethods>(
     backend: B,
     tcx: TyCtxt<'_>,
     shared_emitter: SharedEmitter,

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -688,7 +688,13 @@ pub fn allocator_shim_contents(tcx: TyCtxt<'_>, kind: AllocatorKind) -> Vec<Allo
     methods
 }
 
-pub fn codegen_crate<B: ExtraBackendMethods>(backend: B, tcx: TyCtxt<'_>) -> OngoingCodegen<B> {
+pub fn codegen_crate<
+    B: ExtraBackendMethods<Module = M> + WriteBackendMethods<Module = M>,
+    M: Send,
+>(
+    backend: B,
+    tcx: TyCtxt<'_>,
+) -> OngoingCodegen<B> {
     if tcx.sess.target.need_explicit_cpu && tcx.sess.opts.cg.target_cpu.is_none() {
         // The target has no default cpu, but none is set explicitly
         tcx.dcx().emit_fatal(errors::CpuRequired);

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -14,7 +14,6 @@ use rustc_session::config::{CrateType, OutputFilenames, PrintRequest};
 use rustc_span::Symbol;
 
 use super::CodegenObject;
-use super::write::WriteBackendMethods;
 use crate::back::archive::ArArchiveBuilderBuilder;
 use crate::back::link::link_binary;
 use crate::{CompiledModules, CrateInfo, ModuleCodegen, TargetConfig};
@@ -156,9 +155,9 @@ pub trait CodegenBackend {
     }
 }
 
-pub trait ExtraBackendMethods:
-    WriteBackendMethods + Sized + Send + Sync + DynSend + DynSync
-{
+pub trait ExtraBackendMethods: Send + Sync + DynSend + DynSync {
+    type Module;
+
     fn codegen_allocator<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
@@ -173,11 +172,4 @@ pub trait ExtraBackendMethods:
         tcx: TyCtxt<'_>,
         cgu_name: Symbol,
     ) -> (ModuleCodegen<Self::Module>, u64);
-
-    /// Returns `true` if this backend can be safely called from multiple threads.
-    ///
-    /// Defaults to `true`.
-    fn supports_parallel(&self) -> bool {
-        true
-    }
 }

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::convert::Infallible;
 use std::path::PathBuf;
 
 use rustc_data_structures::profiling::SelfProfilerRef;
@@ -18,6 +19,12 @@ pub trait WriteBackendMethods: Clone + 'static {
     type ModuleBuffer: ModuleBufferMethods;
     type ThinData: Send + Sync;
 
+    /// Returns `true` if this backend can be safely called from multiple threads.
+    ///
+    /// Defaults to `true`.
+    fn supports_parallel(&self) -> bool {
+        true
+    }
     fn thread_profiler() -> Box<dyn Any> {
         Box::new(())
     }

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -83,3 +83,9 @@ pub trait WriteBackendMethods: Clone + 'static {
 pub trait ModuleBufferMethods: Send + Sync {
     fn data(&self) -> &[u8];
 }
+
+impl ModuleBufferMethods for Infallible {
+    fn data(&self) -> &[u8] {
+        match *self {}
+    }
+}

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -34,6 +34,7 @@ use derive_where::derive_where;
 use rustc_data_structures::stable_hash::StableHashCtxt;
 use rustc_data_structures::{AtomicRef, outline};
 use rustc_macros::{Decodable, Encodable, StableHash};
+use rustc_serialize::opaque::mem_encoder::MemEncoder;
 use rustc_serialize::opaque::{FileEncoder, MemDecoder};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use tracing::debug;
@@ -1362,6 +1363,43 @@ pub trait SpanEncoder: Encoder {
 }
 
 impl SpanEncoder for FileEncoder {
+    fn encode_span(&mut self, span: Span) {
+        let span = span.data();
+        span.lo.encode(self);
+        span.hi.encode(self);
+    }
+
+    fn encode_symbol(&mut self, sym: Symbol) {
+        self.emit_str(sym.as_str());
+    }
+
+    fn encode_byte_symbol(&mut self, byte_sym: ByteSymbol) {
+        self.emit_byte_str(byte_sym.as_byte_str());
+    }
+
+    fn encode_expn_id(&mut self, _expn_id: ExpnId) {
+        panic!("cannot encode `ExpnId` with `FileEncoder`");
+    }
+
+    fn encode_syntax_context(&mut self, _syntax_context: SyntaxContext) {
+        panic!("cannot encode `SyntaxContext` with `FileEncoder`");
+    }
+
+    fn encode_crate_num(&mut self, crate_num: CrateNum) {
+        self.emit_u32(crate_num.as_u32());
+    }
+
+    fn encode_def_index(&mut self, _def_index: DefIndex) {
+        panic!("cannot encode `DefIndex` with `FileEncoder`");
+    }
+
+    fn encode_def_id(&mut self, def_id: DefId) {
+        def_id.krate.encode(self);
+        def_id.index.encode(self);
+    }
+}
+
+impl SpanEncoder for MemEncoder {
     fn encode_span(&mut self, span: Span) {
         let span = span.data();
         span.lo.encode(self);

--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -1,9 +1,10 @@
 //! Defines the `IntoIter` owned iterator for arrays.
 
+use crate::clone::TrivialClone;
 use crate::mem::MaybeUninit;
 use crate::num::NonZero;
 use crate::ops::{IndexRange, NeverShortCircuit, Try};
-use crate::{fmt, iter};
+use crate::{fmt, iter, ptr};
 
 #[allow(private_bounds)]
 trait PartialDrop {
@@ -99,9 +100,26 @@ impl<T, const N: usize> PolymorphicIter<[MaybeUninit<T>; N]> {
 impl<T: Clone, const N: usize> Clone for PolymorphicIter<[MaybeUninit<T>; N]> {
     #[inline]
     fn clone(&self) -> Self {
+        SpecPolymorphicIterClone::<N>::spec_clone(self)
+    }
+}
+
+trait SpecPolymorphicIterClone<const N: usize> {
+    fn spec_clone(
+        this: &PolymorphicIter<[MaybeUninit<Self>; N]>,
+    ) -> PolymorphicIter<[MaybeUninit<Self>; N]>
+    where
+        Self: Sized;
+}
+
+impl<T: Clone, const N: usize> SpecPolymorphicIterClone<N> for T {
+    #[inline]
+    default fn spec_clone(
+        this: &PolymorphicIter<[MaybeUninit<Self>; N]>,
+    ) -> PolymorphicIter<[MaybeUninit<Self>; N]> {
         // Note, we don't really need to match the exact same alive range, so
         // we can just clone into offset 0 regardless of where `self` is.
-        let mut new = Self::empty();
+        let mut new = PolymorphicIter::<[MaybeUninit<T>; N]>::empty();
 
         fn clone_into_new<U: Clone>(
             source: &PolymorphicIter<[MaybeUninit<U>]>,
@@ -118,7 +136,33 @@ impl<T: Clone, const N: usize> Clone for PolymorphicIter<[MaybeUninit<T>; N]> {
             }
         }
 
-        clone_into_new(self, &mut new);
+        clone_into_new(this, &mut new);
+        new
+    }
+}
+
+impl<T: TrivialClone, const N: usize> SpecPolymorphicIterClone<N> for T {
+    #[inline]
+    fn spec_clone(
+        this: &PolymorphicIter<[MaybeUninit<Self>; N]>,
+    ) -> PolymorphicIter<[MaybeUninit<Self>; N]> {
+        // Note, we don't really need to match the exact same alive range, so
+        // we can just clone into offset 0 regardless of where `self` is.
+        let mut new = PolymorphicIter::<[MaybeUninit<T>; N]>::empty();
+
+        let len = this.alive.len();
+
+        // SAFETY: These two allocations can not overlap since `new` is allocated
+        // on the stack of this function.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                this.data.as_ptr().add(this.alive.start()),
+                new.data.as_mut_ptr(),
+                len,
+            );
+            new.alive = IndexRange::zero_to(len);
+        }
+
         new
     }
 }

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2054,6 +2054,21 @@ pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// [allocation]: crate::ptr#allocated-object
 /// [atomic]: crate::sync::atomic#memory-model-for-atomic-accesses
 ///
+/// # Load splitting
+///
+/// Exactly which hardware loads are performed by this function is, in general, highly target-dependent.
+///
+/// For a simple scalar, such as when `T` is a thin pointer, this will typically be one load assuming
+/// your target supports a load of exactly that size and alignment.
+///
+/// For anything else, it will be split into multiple loads in some unspecified way.
+/// This can happen even for scalars: notably, on many targets loading a `u128` will still need to be split,
+/// despite being "one" scalar.  On many targets loading anything larger than a pointer will need to be split.
+/// On all current targets a load larger than 64 bytes will need to be split.
+/// Any load whose size is not a power of two will also almost certainly need to be split.
+///
+/// There is no stability guarantee on how that splitting happens.  It may change at any point.
+///
 /// # Safety
 ///
 /// Like [`read`], `read_volatile` creates a bitwise copy of `T`, regardless of whether `T` is
@@ -2146,6 +2161,21 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// [allocation]: crate::ptr#allocated-object
 /// [atomic]: crate::sync::atomic#memory-model-for-atomic-accesses
+///
+/// # Store splitting
+///
+/// Exactly which hardware stores are performed by this function is, in general, highly target-dependent.
+///
+/// For a simple scalar, such as when `T` is a thin pointer, this will typically be one store assuming
+/// your target supports a store of exactly that size and alignment.
+///
+/// For anything else, it will be split into multiple stores in some unspecified way.
+/// This can happen even for scalars: notably, on many targets storing a `u128` will still need to be split,
+/// despite being "one" scalar.  On many targets storing anything larger than a pointer will need to be split.
+/// On all current targets a store larger than 64 bytes will need to be split.
+/// Any store whose size is not a power of two will also almost certainly need to be split.
+///
+/// There is no stability guarantee on how that splitting happens.  It may change at any point.
 ///
 /// # Safety
 ///

--- a/library/coretests/tests/array.rs
+++ b/library/coretests/tests/array.rs
@@ -106,6 +106,34 @@ fn iterator_clone() {
     assert_eq!(clone.next_back(), Some(4));
     assert_eq!(it.next(), Some(2));
     assert_eq!(clone.next(), Some(2));
+    assert_eq!(it.next(), None);
+    assert_eq!(clone.next(), None);
+}
+
+#[test]
+fn iterator_clone_spec() {
+    #[derive(Debug, PartialEq)]
+    struct Foo(i32);
+
+    impl Clone for Foo {
+        fn clone(&self) -> Self {
+            // nontrivial clone
+            Foo(-self.0)
+        }
+    }
+
+    let mut it = IntoIterator::into_iter([Foo(0), Foo(2), Foo(4), Foo(6), Foo(8)]);
+    assert_eq!(it.next(), Some(Foo(0)));
+    assert_eq!(it.next_back(), Some(Foo(8)));
+    let mut clone = it.clone();
+    assert_eq!(it.next_back(), Some(Foo(6)));
+    assert_eq!(clone.next_back(), Some(Foo(-6)));
+    assert_eq!(it.next_back(), Some(Foo(4)));
+    assert_eq!(clone.next_back(), Some(Foo(-4)));
+    assert_eq!(it.next(), Some(Foo(2)));
+    assert_eq!(clone.next(), Some(Foo(-2)));
+    assert_eq!(it.next(), None);
+    assert_eq!(clone.next(), None);
 }
 
 #[test]

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -904,6 +904,54 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
     }
 }
 
+/// Runs `library/stdarch/crates/stdarch-verify`'s tests which cross-check the
+/// `core::arch` intrinsics for x86, Arm, and MIPS against the corresponding
+/// vendor references (signatures, target features, and `assert_instr` mappings).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StdarchVerify;
+
+impl Step for StdarchVerify {
+    type Output = ();
+    const IS_HOST: bool = true;
+
+    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
+        run.path("library/stdarch/crates/stdarch-verify")
+    }
+
+    fn is_default_step(_builder: &Builder<'_>) -> bool {
+        true
+    }
+
+    fn make_run(run: RunConfig<'_>) {
+        run.builder.ensure(StdarchVerify);
+    }
+
+    fn run(self, builder: &Builder<'_>) {
+        let host = builder.config.host_target;
+        let build_compiler = builder.compiler(0, host);
+
+        let cargo = tool::prepare_tool_cargo(
+            builder,
+            build_compiler,
+            Mode::ToolBootstrap,
+            host,
+            Kind::Test,
+            "library/stdarch/crates/stdarch-verify",
+            SourceType::InTree,
+            &[],
+        );
+
+        run_cargo_test(
+            cargo,
+            &[],
+            &["stdarch-verify".to_string()],
+            Some("stdarch-verify"),
+            host,
+            builder,
+        );
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Clippy {
     compilers: RustcPrivateCompilers,

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test.snap
@@ -181,6 +181,9 @@ expression: test
 [Test] test::RustcBook
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/doc/rustc})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})
 [Test] test::RustdocJSStd
     targets: [x86_64-unknown-linux-gnu]
     - Suite(test::tests/rustdoc-js-std)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_library.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_library.snap
@@ -18,3 +18,6 @@ expression: test library
     - Set({test::library/sysroot})
     - Set({test::library/test})
     - Set({test::library/unwind})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_coverage.snap
@@ -180,6 +180,9 @@ expression: test --skip=coverage
 [Test] test::RustcBook
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/doc/rustc})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})
 [Test] test::RustdocJSStd
     targets: [x86_64-unknown-linux-gnu]
     - Suite(test::tests/rustdoc-js-std)

--- a/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
+++ b/src/bootstrap/src/core/builder/cli_paths/snapshots/x_test_skip_tests.snap
@@ -144,6 +144,9 @@ expression: test --skip=tests
 [Test] test::RustcBook
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/doc/rustc})
+[Test] test::StdarchVerify
+    targets: [x86_64-unknown-linux-gnu]
+    - Set({test::library/stdarch/crates/stdarch-verify})
 [Test] test::RustdocTheme
     targets: [x86_64-unknown-linux-gnu]
     - Set({test::src/tools/rustdoc-themes})

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -910,6 +910,7 @@ impl<'a> Builder<'a> {
                 test::CargoMiri,
                 test::Clippy,
                 test::CompiletestTest,
+                test::StdarchVerify,
                 test::CrateRunMakeSupport,
                 test::CrateBuildHelper,
                 test::RustdocJSStd,

--- a/src/doc/rustdoc/src/write-documentation/re-exports.md
+++ b/src/doc/rustdoc/src/write-documentation/re-exports.md
@@ -172,7 +172,7 @@ pub use self::private_mod::Second as Visible;
 ```
 
 In this case, `Visible` will have as documentation `First Second Third` and will also have as `cfg`:
-`#[cfg(a, b, c)]`.
+`#[cfg(a)]`, `#[cfg(b)]` and `#[cfg(c)]`.
 
 [Intra-doc links](./linking-to-items-by-name.md) are resolved relative to where the doc comment is
 defined.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#153957 (Add bootstrap step for stdarch-verify)
 - rust-lang/rust#156634 (lib: specialize Clone of array IntoIter)
 - rust-lang/rust#157050 (Couple of changes to help with moving LTO to the link phase)
 - rust-lang/rust#156931 (Add splitting caveats to `{read,write}_volatile`)
 - rust-lang/rust#157071 (Fix `cfg` typo in rustdoc book)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=153957,156634,157050,156931,157071)
<!-- homu-ignore:end -->

