### PR TITLE
Document equivalence of `highest_one` and `ilog2` methods on integers

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -210,6 +210,9 @@ macro_rules! int_impl {
         /// Returns the index of the highest bit set to one in `self`, or `None`
         /// if `self` is `0`.
         ///
+        /// Note that for non-negative numbers, this is equivalent to
+        /// [`checked_ilog2`](Self::checked_ilog2).
+        ///
         /// # Examples
         ///
         /// ```
@@ -3574,6 +3577,9 @@ macro_rules! int_impl {
         /// Returns the base 2 logarithm of the number, rounded down.
         ///
         /// Returns `None` if the number is negative or zero.
+        ///
+        /// Note that for non-negative numbers, this is equivalent to
+        /// [`highest_one`](Self::highest_one).
         ///
         /// # Examples
         ///

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -708,6 +708,16 @@ macro_rules! nonzero_integer {
 
             /// Returns the index of the highest bit set to one in `self`.
             ///
+            #[doc = sign_dependent_expr!{
+                $signedness ?
+                if signed {
+                    ""
+                }
+                if unsigned {
+                    "Note that this is equivalent to [`ilog2`](Self::ilog2)."
+                }
+            }]
+            ///
             /// # Examples
             ///
             /// ```
@@ -1773,6 +1783,8 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         #[doc = concat!("[`", stringify!($Int), "::ilog2`],")]
         /// except that it has no failure cases to worry about
         /// since this value can never be zero.
+        ///
+        /// Note that this is equivalent to [`highest_one`](Self::highest_one).
         ///
         /// # Examples
         ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -289,6 +289,8 @@ macro_rules! uint_impl {
         /// Returns the index of the highest bit set to one in `self`, or `None`
         /// if `self` is `0`.
         ///
+        /// Note that this is equivalent to [`checked_ilog2`](Self::checked_ilog2).
+        ///
         /// # Examples
         ///
         /// ```
@@ -1864,6 +1866,8 @@ macro_rules! uint_impl {
         /// Returns the base 2 logarithm of the number, rounded down.
         ///
         /// Returns `None` if the number is zero.
+        ///
+        /// Note that this is equivalent to [`highest_one`](Self::highest_one).
         ///
         /// # Examples
         ///


### PR DESCRIPTION
Add notes to the primitive integer and `NonZero` types clarifying the equivalence between `highest_one` and the `ilog2`/`checked_ilog2` methods for non-negative values.

Tracking issue: rust-lang/rust#145203