### PR TITLE
Don't recover `&raw EXPR` as a missing comma

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -752,16 +752,19 @@ impl<'a> Parser<'a> {
         Err(err)
     }
 
+    pub(super) fn is_expected_raw_ref_mut(&self) -> bool {
+        self.prev_token.is_keyword(kw::Raw)
+            && self.expected_token_types.contains(TokenType::KwMut)
+            && self.expected_token_types.contains(TokenType::KwConst)
+            && self.token.can_begin_expr()
+    }
+
     /// Adds a label when `&raw EXPR` was written instead of `&raw const EXPR`/`&raw mut EXPR`.
     ///
     /// Given that not all parser diagnostics flow through `expected_one_of_not_found`, this
     /// label may need added to other diagnostics emission paths as needed.
     pub(super) fn label_expected_raw_ref(&mut self, err: &mut Diag<'_>) {
-        if self.prev_token.is_keyword(kw::Raw)
-            && self.expected_token_types.contains(TokenType::KwMut)
-            && self.expected_token_types.contains(TokenType::KwConst)
-            && self.token.can_begin_expr()
-        {
+        if self.is_expected_raw_ref_mut() {
             err.span_suggestions(
                 self.prev_token.span.shrink_to_hi(),
                 "`&raw` must be followed by `const` or `mut` to be a raw reference expression",

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -29,7 +29,7 @@ use rustc_span::{BytePos, ErrorGuaranteed, Ident, Pos, Span, Spanned, Symbol, kw
 use thin_vec::{ThinVec, thin_vec};
 use tracing::instrument;
 
-use super::diagnostics::{ConsumeClosingDelim, SnapshotParser};
+use super::diagnostics::SnapshotParser;
 use super::pat::{CommaRecoveryMode, Expected, RecoverColon, RecoverComma};
 use super::ty::{AllowPlus, RecoverQPath, RecoverReturnSign};
 use super::{
@@ -1286,10 +1286,29 @@ impl<'a> Parser<'a> {
                 let guar = err.emit();
                 // Preserve the call expression so later passes can still diagnose the callee,
                 // while treating the malformed `&raw <expr>` argument as an error expression.
-                self.consume_block(exp!(OpenParen), exp!(CloseParen), ConsumeClosingDelim::Yes);
-                let err_arg = self.mk_expr_err(err_span, guar);
-                return self
-                    .mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, thin_vec![err_arg]));
+                let mut args = thin_vec![self.mk_expr_err(err_span, guar)];
+                let mut depth = 0usize;
+                loop {
+                    if self.token == token::Eof {
+                        break;
+                    } else if depth == 0 && self.check(exp!(CloseParen)) {
+                        self.bump();
+                        break;
+                    } else if depth == 0 && self.check(exp!(Comma)) {
+                        let comma_span = self.token.span;
+                        self.bump();
+                        if !self.check(exp!(CloseParen)) {
+                            args.push(self.mk_expr_err(comma_span.shrink_to_hi(), guar));
+                        }
+                        continue;
+                    } else if self.token.kind.open_delim().is_some() {
+                        depth += 1;
+                    } else if self.token.kind.close_delim().is_some() && depth > 0 {
+                        depth -= 1;
+                    }
+                    self.bump();
+                }
+                return self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args));
             }
             Err(err) => Err(err),
         };

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1281,12 +1281,7 @@ impl<'a> Parser<'a> {
 
         let seq = match self.parse_expr_paren_seq() {
             Ok(args) => Ok(self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args))),
-            Err(err)
-                if self.prev_token.is_keyword(kw::Raw)
-                    && self.expected_token_types.contains(TokenType::KwMut)
-                    && self.expected_token_types.contains(TokenType::KwConst)
-                    && self.token.can_begin_expr() =>
-            {
+            Err(err) if self.is_expected_raw_ref_mut() => {
                 let err_span = self.prev_token.span.to(self.token.span);
                 let guar = err.emit();
                 // Preserve the call expression so later passes can still diagnose the callee,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -29,7 +29,7 @@ use rustc_span::{BytePos, ErrorGuaranteed, Ident, Pos, Span, Spanned, Symbol, kw
 use thin_vec::{ThinVec, thin_vec};
 use tracing::instrument;
 
-use super::diagnostics::SnapshotParser;
+use super::diagnostics::{ConsumeClosingDelim, SnapshotParser};
 use super::pat::{CommaRecoveryMode, Expected, RecoverColon, RecoverComma};
 use super::ty::{AllowPlus, RecoverQPath, RecoverReturnSign};
 use super::{
@@ -1279,9 +1279,25 @@ impl<'a> Parser<'a> {
         };
         let open_paren = self.token.span;
 
-        let seq = self
-            .parse_expr_paren_seq()
-            .map(|args| self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args)));
+        let seq = match self.parse_expr_paren_seq() {
+            Ok(args) => Ok(self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args))),
+            Err(err)
+                if self.prev_token.is_keyword(kw::Raw)
+                    && self.expected_token_types.contains(TokenType::KwMut)
+                    && self.expected_token_types.contains(TokenType::KwConst)
+                    && self.token.can_begin_expr() =>
+            {
+                let err_span = self.prev_token.span.to(self.token.span);
+                let guar = err.emit();
+                // Preserve the call expression so later passes can still diagnose the callee,
+                // while treating the malformed `&raw <expr>` argument as an error expression.
+                self.consume_block(exp!(OpenParen), exp!(CloseParen), ConsumeClosingDelim::Yes);
+                let err_arg = self.mk_expr_err(err_span, guar);
+                return self
+                    .mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, thin_vec![err_arg]));
+            }
+            Err(err) => Err(err),
+        };
         match self.maybe_recover_struct_lit_bad_delims(lo, open_paren, seq, snapshot) {
             Ok(expr) => expr,
             Err(err) => self.recover_seq_parse_error(exp!(OpenParen), exp!(CloseParen), lo, err),

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1282,32 +1282,10 @@ impl<'a> Parser<'a> {
         let seq = match self.parse_expr_paren_seq() {
             Ok(args) => Ok(self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args))),
             Err(err) if self.is_expected_raw_ref_mut() => {
-                let err_span = self.prev_token.span.to(self.token.span);
                 let guar = err.emit();
                 // Preserve the call expression so later passes can still diagnose the callee,
                 // while treating the malformed `&raw <expr>` argument as an error expression.
-                let mut args = thin_vec![self.mk_expr_err(err_span, guar)];
-                let mut depth = 0usize;
-                loop {
-                    if self.token == token::Eof {
-                        break;
-                    } else if depth == 0 && self.check(exp!(CloseParen)) {
-                        self.bump();
-                        break;
-                    } else if depth == 0 && self.check(exp!(Comma)) {
-                        let comma_span = self.token.span;
-                        self.bump();
-                        if !self.check(exp!(CloseParen)) {
-                            args.push(self.mk_expr_err(comma_span.shrink_to_hi(), guar));
-                        }
-                        continue;
-                    } else if self.token.kind.open_delim().is_some() {
-                        depth += 1;
-                    } else if self.token.kind.close_delim().is_some() && depth > 0 {
-                        depth -= 1;
-                    }
-                    self.bump();
-                }
+                let args = self.recover_raw_ref_call_args(guar);
                 return self.mk_expr(lo.to(self.prev_token.span), self.mk_call(fun, args));
             }
             Err(err) => Err(err),
@@ -1316,6 +1294,21 @@ impl<'a> Parser<'a> {
             Ok(expr) => expr,
             Err(err) => self.recover_seq_parse_error(exp!(OpenParen), exp!(CloseParen), lo, err),
         }
+    }
+
+    fn recover_raw_ref_call_args(&mut self, guar: ErrorGuaranteed) -> ThinVec<Box<Expr>> {
+        let err_span = self.prev_token.span.to(self.token.span);
+        let mut args = thin_vec![self.mk_expr_err(err_span, guar)];
+        while self.token != token::Eof && self.token != token::CloseParen {
+            if self.eat(exp!(Comma)) && self.token != token::Eof && self.token != token::CloseParen
+            {
+                args.push(self.mk_expr_err(self.prev_token.span.shrink_to_hi(), guar));
+            } else {
+                self.parse_token_tree();
+            }
+        }
+        let _ = self.eat(exp!(CloseParen));
+        args
     }
 
     /// If we encounter a parser state that looks like the user has written a `struct` literal with

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -920,11 +920,7 @@ impl<'a> Parser<'a> {
                             // `&raw <expr>` already has a specific suggestion for missing
                             // `const`/`mut`, so don't recover `<expr>` as the next element in
                             // a comma-separated list.
-                            if exp.token_type == TokenType::Comma
-                                && self.prev_token.is_keyword(kw::Raw)
-                                && self.expected_token_types.contains(TokenType::KwMut)
-                                && self.expected_token_types.contains(TokenType::KwConst)
-                                && self.token.can_begin_expr()
+                            if exp.token_type == TokenType::Comma && self.is_expected_raw_ref_mut()
                             {
                                 return Err(expect_err);
                             }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -917,6 +917,17 @@ impl<'a> Parser<'a> {
                             }
 
                             // Attempt to keep parsing if it was an omitted separator.
+                            // `&raw <expr>` already has a specific suggestion for missing
+                            // `const`/`mut`, so don't recover `<expr>` as the next element in
+                            // a comma-separated list.
+                            if exp.token_type == TokenType::Comma
+                                && self.prev_token.is_keyword(kw::Raw)
+                                && self.expected_token_types.contains(TokenType::KwMut)
+                                && self.expected_token_types.contains(TokenType::KwConst)
+                                && self.token.can_begin_expr()
+                            {
+                                return Err(expect_err);
+                            }
                             self.last_unexpected_token_span = None;
                             match f(self) {
                                 Ok(t) => {

--- a/tests/ui/parser/recover/raw-no-const-mut-arg-list.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut-arg-list.rs
@@ -1,9 +1,12 @@
 // Regression test for https://github.com/rust-lang/rust/issues/157015.
 
 fn takes_raw_ptr(_: *const u32) {}
+fn takes_raw_ptr_args(_: *const u32, _: *const u32) {}
 
 fn main() {
     let x = 0u32;
     takes_raw_ptr(&raw x);
+    //~^ ERROR expected one of
+    takes_raw_ptr_args(&raw x, &raw x);
     //~^ ERROR expected one of
 }

--- a/tests/ui/parser/recover/raw-no-const-mut-arg-list.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut-arg-list.rs
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/rust-lang/rust/issues/157015.
+
+fn takes_raw_ptr(_: *const u32) {}
+
+fn main() {
+    let x = 0u32;
+    takes_raw_ptr(&raw x);
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/recover/raw-no-const-mut-arg-list.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut-arg-list.stderr
@@ -1,0 +1,15 @@
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `x`
+  --> $DIR/raw-no-const-mut-arg-list.rs:7:24
+   |
+LL |     takes_raw_ptr(&raw x);
+   |                        ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     takes_raw_ptr(&raw const x);
+   |                        +++++
+LL |     takes_raw_ptr(&raw mut x);
+   |                        +++
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/recover/raw-no-const-mut-arg-list.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut-arg-list.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `x`
-  --> $DIR/raw-no-const-mut-arg-list.rs:7:24
+  --> $DIR/raw-no-const-mut-arg-list.rs:8:24
    |
 LL |     takes_raw_ptr(&raw x);
    |                        ^ expected one of 10 possible tokens
@@ -11,5 +11,18 @@ LL |     takes_raw_ptr(&raw const x);
 LL |     takes_raw_ptr(&raw mut x);
    |                        +++
 
-error: aborting due to 1 previous error
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `x`
+  --> $DIR/raw-no-const-mut-arg-list.rs:10:29
+   |
+LL |     takes_raw_ptr_args(&raw x, &raw x);
+   |                             ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     takes_raw_ptr_args(&raw const x, &raw x);
+   |                             +++++
+LL |     takes_raw_ptr_args(&raw mut x, &raw x);
+   |                             +++
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/recover/raw-no-const-mut.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut.rs
@@ -6,8 +6,6 @@ fn a() {
 fn b() {
     [&raw const 1, &raw 2]
     //~^ ERROR expected one of
-    //~| ERROR cannot find value `raw` in this scope
-    //~| ERROR cannot take address of a temporary
 }
 
 fn c() {
@@ -18,22 +16,12 @@ fn c() {
 fn d() {
     f(&raw 2);
     //~^ ERROR expected one of
-    //~| ERROR cannot find value `raw` in this scope
     //~| ERROR cannot find function `f` in this scope
 }
 
 fn e() {
     let x;
     x = &raw 1;
-    //~^ ERROR expected one of
-}
-
-fn g() {
-    fn takes_raw_ptr(_: *const u32) {}
-    
-    let x = 0u32;
-    // Regression test for https://github.com/rust-lang/rust/issues/157015.
-    takes_raw_ptr(&raw x);
     //~^ ERROR expected one of
 }
 

--- a/tests/ui/parser/recover/raw-no-const-mut.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut.rs
@@ -28,4 +28,13 @@ fn e() {
     //~^ ERROR expected one of
 }
 
+fn g() {
+    fn takes_raw_ptr(_: *const u32) {}
+    
+    let x = 0u32;
+    // Regression test for https://github.com/rust-lang/rust/issues/157015.
+    takes_raw_ptr(&raw x);
+    //~^ ERROR expected one of
+}
+
 fn main() {}

--- a/tests/ui/parser/recover/raw-no-const-mut.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut.stderr
@@ -76,6 +76,23 @@ LL |     x = &raw const 1;
 LL |     x = &raw mut 1;
    |              +++
 
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `x`
+  --> $DIR/raw-no-const-mut.rs:36:24
+   |
+LL |     takes_raw_ptr(&raw x);
+   |                        ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     takes_raw_ptr(&raw const x);
+   |                        +++++
+LL |     takes_raw_ptr(&raw mut x);
+   |                        +++
+help: missing `,`
+   |
+LL |     takes_raw_ptr(&raw, x);
+   |                       +
+
 error[E0425]: cannot find value `raw` in this scope
   --> $DIR/raw-no-const-mut.rs:7:21
    |
@@ -87,6 +104,12 @@ error[E0425]: cannot find value `raw` in this scope
    |
 LL |     f(&raw 2);
    |        ^^^ not found in this scope
+
+error[E0425]: cannot find value `raw` in this scope
+  --> $DIR/raw-no-const-mut.rs:36:20
+   |
+LL |     takes_raw_ptr(&raw x);
+   |                    ^^^ not found in this scope
 
 error[E0745]: cannot take address of a temporary
   --> $DIR/raw-no-const-mut.rs:7:17
@@ -109,7 +132,24 @@ LL -     f(&raw 2);
 LL +     a(&raw 2);
    |
 
-error: aborting due to 9 previous errors
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/raw-no-const-mut.rs:36:5
+   |
+LL |     takes_raw_ptr(&raw x);
+   |     ^^^^^^^^^^^^^      - unexpected argument #2 of type `u32`
+   |
+note: function defined here
+  --> $DIR/raw-no-const-mut.rs:32:8
+   |
+LL |     fn takes_raw_ptr(_: *const u32) {}
+   |        ^^^^^^^^^^^^^
+help: remove the extra argument
+   |
+LL -     takes_raw_ptr(&raw x);
+LL +     takes_raw_ptr(&raw);
+   |
 
-Some errors have detailed explanations: E0425, E0745.
-For more information about an error, try `rustc --explain E0425`.
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0061, E0425, E0745.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/parser/recover/raw-no-const-mut.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut.stderr
@@ -23,19 +23,15 @@ LL |     [&raw const 1, &raw const 2]
    |                         +++++
 LL |     [&raw const 1, &raw mut 2]
    |                         +++
-help: missing `,`
-   |
-LL |     [&raw const 1, &raw, 2]
-   |                        +
 
 error: expected `{`, found `z`
-  --> $DIR/raw-no-const-mut.rs:14:18
+  --> $DIR/raw-no-const-mut.rs:12:18
    |
 LL |     if x == &raw z {}
    |                  ^ expected `{`
    |
 note: the `if` expression is missing a block after this condition
-  --> $DIR/raw-no-const-mut.rs:14:8
+  --> $DIR/raw-no-const-mut.rs:12:8
    |
 LL |     if x == &raw z {}
    |        ^^^^^^^^^
@@ -47,7 +43,7 @@ LL |     if x == &raw mut z {}
    |                  +++
 
 error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `2`
-  --> $DIR/raw-no-const-mut.rs:19:12
+  --> $DIR/raw-no-const-mut.rs:17:12
    |
 LL |     f(&raw 2);
    |            ^ expected one of 10 possible tokens
@@ -58,13 +54,9 @@ LL |     f(&raw const 2);
    |            +++++
 LL |     f(&raw mut 2);
    |            +++
-help: missing `,`
-   |
-LL |     f(&raw, 2);
-   |           +
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `const`, `mut`, `{`, `}`, or an operator, found `1`
-  --> $DIR/raw-no-const-mut.rs:27:14
+  --> $DIR/raw-no-const-mut.rs:24:14
    |
 LL |     x = &raw 1;
    |              ^ expected one of 10 possible tokens
@@ -76,49 +68,8 @@ LL |     x = &raw const 1;
 LL |     x = &raw mut 1;
    |              +++
 
-error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `x`
-  --> $DIR/raw-no-const-mut.rs:36:24
-   |
-LL |     takes_raw_ptr(&raw x);
-   |                        ^ expected one of 10 possible tokens
-   |
-help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
-   |
-LL |     takes_raw_ptr(&raw const x);
-   |                        +++++
-LL |     takes_raw_ptr(&raw mut x);
-   |                        +++
-help: missing `,`
-   |
-LL |     takes_raw_ptr(&raw, x);
-   |                       +
-
-error[E0425]: cannot find value `raw` in this scope
-  --> $DIR/raw-no-const-mut.rs:7:21
-   |
-LL |     [&raw const 1, &raw 2]
-   |                     ^^^ not found in this scope
-
-error[E0425]: cannot find value `raw` in this scope
-  --> $DIR/raw-no-const-mut.rs:19:8
-   |
-LL |     f(&raw 2);
-   |        ^^^ not found in this scope
-
-error[E0425]: cannot find value `raw` in this scope
-  --> $DIR/raw-no-const-mut.rs:36:20
-   |
-LL |     takes_raw_ptr(&raw x);
-   |                    ^^^ not found in this scope
-
-error[E0745]: cannot take address of a temporary
-  --> $DIR/raw-no-const-mut.rs:7:17
-   |
-LL |     [&raw const 1, &raw 2]
-   |                 ^ temporary value
-
 error[E0425]: cannot find function `f` in this scope
-  --> $DIR/raw-no-const-mut.rs:19:5
+  --> $DIR/raw-no-const-mut.rs:17:5
    |
 LL | fn a() {
    | ------ similarly named function `a` defined here
@@ -132,24 +83,6 @@ LL -     f(&raw 2);
 LL +     a(&raw 2);
    |
 
-error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/raw-no-const-mut.rs:36:5
-   |
-LL |     takes_raw_ptr(&raw x);
-   |     ^^^^^^^^^^^^^      - unexpected argument #2 of type `u32`
-   |
-note: function defined here
-  --> $DIR/raw-no-const-mut.rs:32:8
-   |
-LL |     fn takes_raw_ptr(_: *const u32) {}
-   |        ^^^^^^^^^^^^^
-help: remove the extra argument
-   |
-LL -     takes_raw_ptr(&raw x);
-LL +     takes_raw_ptr(&raw);
-   |
+error: aborting due to 6 previous errors
 
-error: aborting due to 12 previous errors
-
-Some errors have detailed explanations: E0061, E0425, E0745.
-For more information about an error, try `rustc --explain E0061`.
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
The parser already has a targeted suggestion for `&raw EXPR`, added in rust-lang/rust#139392, telling the user that `&raw` must be followed by `const` or `mut`.

In comma-separated expression lists, the generic missing-comma recovery would then treat the expression after `raw` as the next list element. That produced follow-up diagnostics like:

- `help: missing ','`
- `cannot find value raw in this scope`
- an arity error for calls such as `takes_raw_ptr(&raw x)`

This PR avoids that comma recovery when we are already in the `&raw` missing-`const`/`mut` diagnostic path. For function calls, it preserves the call expression with a single error argument, so useful later diagnostics such as `cannot find function f` are still emitted.

Fixes rust-lang/rust#157015.