### PR TITLE
Remove minicore ping for myself

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1127,10 +1127,6 @@ cc = [
 message = "Some changes occurred in GUI tests."
 cc = ["@GuillaumeGomez"]
 
-[mentions."tests/auxiliary/minicore.rs"]
-message = "This PR modifies `tests/auxiliary/minicore.rs`."
-cc = ["@jieyouxu"]
-
 [mentions."src/rustdoc-json-types"]
 message = """
 rustdoc-json-types is a **public** (although nightly-only) API. \


### PR DESCRIPTION
It was useful initially when bootstrapping the minicore test infra to keep an close eye on how well it was working and if it ran into problems. The ping now has outlived its usefulness.

(To improve my ping/notif SNR.)

r? ghost