### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -57,7 +57,7 @@ Rustdoc
 -----
 - [Deprecation notes are now rendered like any other documentation](https://github.com/rust-lang/rust/pull/149931).  Previously they used the css `white-space: pre-wrap;` property and stripped any `<p>` elements from the rendered html, however this caused issues and unintuitive behavior.  The new behavior should be more predictable, however some multi-line deprecation notes will now be rendered as as single lines.  If this is undesirable, you can use the standard markdown method of forcing a linebreak, which is two spaces followed by a newline (`"\n"`).
 - [Don't emit rustdoc `missing_doc_code_examples` lint on impl items](https://github.com/rust-lang/rust/pull/154048)
-- [Seperate methods and associated functions in sidebar](https://github.com/rust-lang/rust/pull/154644)
+- [Separate methods and associated functions in sidebar](https://github.com/rust-lang/rust/pull/154644)
 
 <a id="1.96.0-Compatibility-Notes"></a>
 

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -1365,8 +1365,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
             {
                 fx.bcx.ins().call_indirect(f_sig, f, &[data]);
 
-                let layout = fx.layout_of(fx.tcx.types.i32);
-                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I32, 0), layout);
+                let layout = fx.layout_of(fx.tcx.types.bool);
+                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I8, 0), layout);
                 ret.write_cvalue(fx, ret_val);
 
                 fx.bcx.ins().jump(ret_block, &[]);
@@ -1399,8 +1399,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
 
                 fx.bcx.seal_block(fallthrough_block);
                 fx.bcx.switch_to_block(fallthrough_block);
-                let layout = fx.layout_of(fx.tcx.types.i32);
-                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I32, 0), layout);
+                let layout = fx.layout_of(fx.tcx.types.bool);
+                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I8, 0), layout);
                 ret.write_cvalue(fx, ret_val);
                 fx.bcx.ins().jump(ret_block, &[]);
 
@@ -1409,8 +1409,8 @@ fn codegen_regular_intrinsic_call<'tcx>(
                 fx.bcx.set_cold_block(catch_block);
                 let exception = fx.bcx.append_block_param(catch_block, pointer_ty(fx.tcx));
                 fx.bcx.ins().call_indirect(catch_fn_sig, catch_fn, &[data, exception]);
-                let layout = fx.layout_of(fx.tcx.types.i32);
-                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I32, 1), layout);
+                let layout = fx.layout_of(fx.tcx.types.bool);
+                let ret_val = CValue::by_val(fx.bcx.ins().iconst(types::I8, 1), layout);
                 ret.write_cvalue(fx, ret_val);
                 fx.bcx.ins().jump(ret_block, &[]);
             }

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -1361,7 +1361,7 @@ fn try_intrinsic<'a, 'b, 'gcc, 'tcx>(
         bx.call(bx.type_void(), None, None, try_func, &[data], None, None);
         // Return 0 unconditionally from the intrinsic call;
         // we can never unwind.
-        OperandValue::Immediate(bx.const_i32(0)).store(bx, dest);
+        OperandValue::Immediate(bx.const_bool(false)).store(bx, dest);
     } else {
         if wants_msvc_seh(bx.sess()) {
             unimplemented!();
@@ -1418,7 +1418,7 @@ fn codegen_gnu_try<'gcc, 'tcx>(
         let current_block = bx.block;
 
         bx.switch_to_block(then);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         // Type indicator for the exception being thrown.
         //
@@ -1432,7 +1432,7 @@ fn codegen_gnu_try<'gcc, 'tcx>(
         let ptr = bx.cx.context.new_call(None, eh_pointer_builtin, &[zero]);
         let catch_ty = bx.type_func(&[bx.type_i8p(), bx.type_i8p()], bx.type_void());
         bx.call(catch_ty, None, None, catch_func, &[data, ptr], None, None);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
 
         // NOTE: the blocks must be filled before adding the try/catch, otherwise gcc will not
         // generate a try/catch.
@@ -1465,7 +1465,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
     // Define the type up front for the signature of the rust_try function.
     let tcx = cx.tcx;
     let i8p = Ty::new_mut_ptr(tcx, tcx.types.i8);
-    // `unsafe fn(*mut i8) -> ()`
+    // `unsafe fn(*mut Data) -> ()`
     let try_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi(
@@ -1474,7 +1474,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
             rustc_hir::Safety::Unsafe,
         )),
     );
-    // `unsafe fn(*mut i8, *mut i8) -> ()`
+    // `unsafe fn(*mut Data, *mut i8) -> ()`
     let catch_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi(
@@ -1483,10 +1483,10 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
             rustc_hir::Safety::Unsafe,
         )),
     );
-    // `unsafe fn(unsafe fn(*mut i8) -> (), *mut i8, unsafe fn(*mut i8, *mut i8) -> ()) -> i32`
+    // `unsafe fn(unsafe fn(*mut Data) -> (), *mut Data, unsafe fn(*mut Data, *mut i8) -> ()) -> bool`
     let rust_fn_sig = ty::Binder::dummy(cx.tcx.mk_fn_sig_rust_abi(
         [try_fn_ty, i8p, catch_fn_ty],
-        tcx.types.i32,
+        tcx.types.bool,
         rustc_hir::Safety::Unsafe,
     ));
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -335,9 +335,7 @@ fn new_context<'gcc, 'tcx>(tcx: TyCtxt<'tcx>) -> Context<'gcc> {
 }
 
 impl ExtraBackendMethods for GccCodegenBackend {
-    fn supports_parallel(&self) -> bool {
-        false
-    }
+    type Module = GccContext;
 
     fn codegen_allocator(
         &self,
@@ -419,6 +417,10 @@ impl WriteBackendMethods for GccCodegenBackend {
     type TargetMachine = ();
     type ModuleBuffer = ModuleBuffer;
     type ThinData = ();
+
+    fn supports_parallel(&self) -> bool {
+        false
+    }
 
     fn target_machine_factory(
         &self,

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -171,10 +171,7 @@ pub(crate) fn uwtable_attr(llcx: &llvm::Context, use_sync_unwind: Option<bool>) 
     llvm::CreateUWTableAttr(llcx, async_unwind)
 }
 
-pub(crate) fn frame_pointer_type_attr<'ll>(
-    cx: &SimpleCx<'ll>,
-    sess: &Session,
-) -> Option<&'ll Attribute> {
+pub(crate) fn frame_pointer(sess: &Session) -> FramePointer {
     let mut fp = sess.target.frame_pointer;
     let opts = &sess.opts;
     // "mcount" function relies on stack pointer.
@@ -183,6 +180,14 @@ pub(crate) fn frame_pointer_type_attr<'ll>(
         fp.ratchet(FramePointer::Always);
     }
     fp.ratchet(opts.cg.force_frame_pointers);
+    fp
+}
+
+pub(crate) fn frame_pointer_type_attr<'ll>(
+    cx: &SimpleCx<'ll>,
+    sess: &Session,
+) -> Option<&'ll Attribute> {
+    let fp = frame_pointer(sess);
     let attr_value = match fp {
         FramePointer::Always => "all",
         FramePointer::NonLeaf => "non-leaf",

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -941,11 +941,7 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn intrinsic_call_expects_place_always(&self, name: Symbol) -> bool {
         matches!(
             name,
-            sym::autodiff
-                | sym::catch_unwind
-                | sym::volatile_load
-                | sym::unaligned_volatile_load
-                | sym::black_box
+            sym::autodiff | sym::volatile_load | sym::unaligned_volatile_load | sym::black_box
         )
     }
 }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -28,7 +28,8 @@ use rustc_session::config::{
 use rustc_span::{DUMMY_SP, Span, Spanned, Symbol, sym};
 use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{
-    Arch, CfgAbi, Env, HasTargetSpec, Os, RelocModel, SmallDataThresholdSupport, Target, TlsModel,
+    Arch, CfgAbi, Env, FramePointer, HasTargetSpec, Os, RelocModel, SmallDataThresholdSupport,
+    Target, TlsModel,
 };
 use smallvec::SmallVec;
 
@@ -487,6 +488,20 @@ pub(crate) unsafe fn create_module<'ll>(
                 1,
             );
         }
+    }
+
+    let fp = attributes::frame_pointer(sess);
+    if fp != FramePointer::MayOmit {
+        llvm::add_module_flag_u32(
+            llmod,
+            llvm::ModuleFlagMergeBehavior::Max,
+            "frame-pointer",
+            match fp {
+                FramePointer::Always => llvm::FramePointerKind::All as u32,
+                FramePointer::NonLeaf => llvm::FramePointerKind::NonLeaf as u32,
+                FramePointer::MayOmit => llvm::FramePointerKind::None as u32,
+            },
+        );
     }
 
     if sess.opts.unstable_opts.indirect_branch_cs_prefix {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -288,18 +288,12 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 }
             }
             sym::catch_unwind => {
-                let result = PlaceRef {
-                    val: result_place.unwrap(),
-                    layout: result_layout,
-                };
                 catch_unwind_intrinsic(
                     self,
                     args[0].immediate(),
                     args[1].immediate(),
                     args[2].immediate(),
-                    result,
-                );
-                return IntrinsicResult::WroteIntoPlace;
+                )
             }
             sym::breakpoint => self.call_intrinsic("llvm.debugtrap", &[], &[]),
             sym::va_arg => {
@@ -1351,22 +1345,21 @@ fn catch_unwind_intrinsic<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     if !bx.sess().panic_strategy().unwinds() {
         let try_func_ty = bx.type_func(&[bx.type_ptr()], bx.type_void());
         bx.call(try_func_ty, None, None, try_func, &[data], None, None);
         // Return 0 unconditionally from the intrinsic call;
         // we can never unwind.
-        OperandValue::Immediate(bx.const_i32(0)).store(bx, dest);
+        bx.const_bool(false)
     } else if wants_msvc_seh(bx.sess()) {
-        codegen_msvc_try(bx, try_func, data, catch_func, dest);
+        codegen_msvc_try(bx, try_func, data, catch_func)
     } else if wants_wasm_eh(bx.sess()) {
-        codegen_wasm_try(bx, try_func, data, catch_func, dest);
+        codegen_wasm_try(bx, try_func, data, catch_func)
     } else if bx.sess().target.os == Os::Emscripten {
-        codegen_emcc_try(bx, try_func, data, catch_func, dest);
+        codegen_emcc_try(bx, try_func, data, catch_func)
     } else {
-        codegen_gnu_try(bx, try_func, data, catch_func, dest);
+        codegen_gnu_try(bx, try_func, data, catch_func)
     }
 }
 
@@ -1382,8 +1375,7 @@ fn codegen_msvc_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         bx.set_personality_fn(bx.eh_personality());
 
@@ -1399,12 +1391,12 @@ fn codegen_msvc_try<'ll, 'tcx>(
 
         // We're generating an IR snippet that looks like:
         //
-        //   declare i32 @rust_try(%try_func, %data, %catch_func) {
+        //   declare bool @rust_try(%try_func, %data, %catch_func) {
         //      %slot = alloca i8*
         //      invoke %try_func(%data) to label %normal unwind label %catchswitch
         //
         //   normal:
-        //      ret i32 0
+        //      ret i1 false
         //
         //   catchswitch:
         //      %cs = catchswitch within none [%catchpad_rust, %catchpad_foreign] unwind to caller
@@ -1421,7 +1413,7 @@ fn codegen_msvc_try<'ll, 'tcx>(
         //      catchret from %tok to label %caught
         //
         //   caught:
-        //      ret i32 1
+        //      ret i1 true
         //   }
         //
         // This structure follows the basic usage of throw/try/catch in LLVM.
@@ -1459,7 +1451,7 @@ fn codegen_msvc_try<'ll, 'tcx>(
         bx.invoke(try_func_ty, None, None, try_func, &[data], normal, catchswitch, None, None);
 
         bx.switch_to_block(normal);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         bx.switch_to_block(catchswitch);
         let cs = bx.catch_switch(None, None, &[catchpad_rust, catchpad_foreign]);
@@ -1516,13 +1508,13 @@ fn codegen_msvc_try<'ll, 'tcx>(
         bx.catch_ret(&funclet, caught);
 
         bx.switch_to_block(caught);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // WASM's definition of the `rust_try` function.
@@ -1531,8 +1523,7 @@ fn codegen_wasm_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         bx.set_personality_fn(bx.eh_personality());
 
@@ -1547,12 +1538,12 @@ fn codegen_wasm_try<'ll, 'tcx>(
 
         // We're generating an IR snippet that looks like:
         //
-        //   declare i32 @rust_try(%try_func, %data, %catch_func) {
+        //   declare i1 @rust_try(%try_func, %data, %catch_func) {
         //      %slot = alloca i8*
         //      invoke %try_func(%data) to label %normal unwind label %catchswitch
         //
         //   normal:
-        //      ret i32 0
+        //      ret i1 false
         //
         //   catchswitch:
         //      %cs = catchswitch within none [%catchpad] unwind to caller
@@ -1565,14 +1556,14 @@ fn codegen_wasm_try<'ll, 'tcx>(
         //      catchret from %tok to label %caught
         //
         //   caught:
-        //      ret i32 1
+        //      ret i1 true
         //   }
         //
         let try_func_ty = bx.type_func(&[bx.type_ptr()], bx.type_void());
         bx.invoke(try_func_ty, None, None, try_func, &[data], normal, catchswitch, None, None);
 
         bx.switch_to_block(normal);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         bx.switch_to_block(catchswitch);
         let cs = bx.catch_switch(None, None, &[catchpad]);
@@ -1589,13 +1580,13 @@ fn codegen_wasm_try<'ll, 'tcx>(
         bx.catch_ret(&funclet, caught);
 
         bx.switch_to_block(caught);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // Definition of the standard `try` function for Rust using the GNU-like model
@@ -1614,8 +1605,7 @@ fn codegen_gnu_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         // Codegens the shims described above:
         //
@@ -1639,7 +1629,7 @@ fn codegen_gnu_try<'ll, 'tcx>(
         bx.invoke(try_func_ty, None, None, try_func, &[data], then, catch, None, None);
 
         bx.switch_to_block(then);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         // Type indicator for the exception being thrown.
         //
@@ -1655,13 +1645,13 @@ fn codegen_gnu_try<'ll, 'tcx>(
         let ptr = bx.extract_value(vals, 0);
         let catch_ty = bx.type_func(&[bx.type_ptr(), bx.type_ptr()], bx.type_void());
         bx.call(catch_ty, None, None, catch_func, &[data, ptr], None, None);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // Variant of codegen_gnu_try used for emscripten where Rust panics are
@@ -1672,8 +1662,7 @@ fn codegen_emcc_try<'ll, 'tcx>(
     try_func: &'ll Value,
     data: &'ll Value,
     catch_func: &'ll Value,
-    dest: PlaceRef<'tcx, &'ll Value>,
-) {
+) -> &'ll Value {
     let (llty, llfn) = get_rust_try_fn(bx, &mut |mut bx| {
         // Codegens the shims described above:
         //
@@ -1702,7 +1691,7 @@ fn codegen_emcc_try<'ll, 'tcx>(
         bx.invoke(try_func_ty, None, None, try_func, &[data], then, catch, None, None);
 
         bx.switch_to_block(then);
-        bx.ret(bx.const_i32(0));
+        bx.ret(bx.const_bool(false));
 
         // Type indicator for the exception being thrown.
         //
@@ -1737,13 +1726,13 @@ fn codegen_emcc_try<'ll, 'tcx>(
 
         let catch_ty = bx.type_func(&[bx.type_ptr(), bx.type_ptr()], bx.type_void());
         bx.call(catch_ty, None, None, catch_func, &[data, catch_data], None, None);
-        bx.ret(bx.const_i32(1));
+        bx.ret(bx.const_bool(true));
     });
 
     // Note that no invoke is used here because by definition this function
     // can't panic (that's what it's catching).
     let ret = bx.call(llty, None, None, llfn, &[try_func, data, catch_func], None, None);
-    OperandValue::Immediate(ret).store(bx, dest);
+    ret
 }
 
 // Helper function to give a Block to a closure to codegen a shim function.
@@ -1782,20 +1771,20 @@ fn get_rust_try_fn<'a, 'll, 'tcx>(
     // Define the type up front for the signature of the rust_try function.
     let tcx = cx.tcx;
     let i8p = Ty::new_mut_ptr(tcx, tcx.types.i8);
-    // `unsafe fn(*mut i8) -> ()`
+    // `unsafe fn(*mut Data) -> ()`
     let try_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi([i8p], tcx.types.unit, hir::Safety::Unsafe)),
     );
-    // `unsafe fn(*mut i8, *mut i8) -> ()`
+    // `unsafe fn(*mut Data, *mut i8) -> ()`
     let catch_fn_ty = Ty::new_fn_ptr(
         tcx,
         ty::Binder::dummy(tcx.mk_fn_sig_rust_abi([i8p, i8p], tcx.types.unit, hir::Safety::Unsafe)),
     );
-    // `unsafe fn(unsafe fn(*mut i8) -> (), *mut i8, unsafe fn(*mut i8, *mut i8) -> ()) -> i32`
+    // `unsafe fn(unsafe fn(*mut Data) -> (), *mut Data, unsafe fn(*mut Data, *mut i8) -> ()) -> bool`
     let rust_fn_sig = ty::Binder::dummy(cx.tcx.mk_fn_sig_rust_abi(
         [try_fn_ty, i8p, catch_fn_ty],
-        tcx.types.i32,
+        tcx.types.bool,
         hir::Safety::Unsafe,
     ));
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -93,6 +93,8 @@ impl Drop for TimeTraceProfiler {
 }
 
 impl ExtraBackendMethods for LlvmCodegenBackend {
+    type Module = ModuleLlvm;
+
     fn codegen_allocator<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
@@ -121,6 +123,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     type ModuleBuffer = back::lto::ModuleBuffer;
     type TargetMachine = OwnedTargetMachine;
     type ThinData = back::lto::ThinData;
+
     fn thread_profiler() -> Box<dyn Any> {
         Box::new(TimeTraceProfiler::new())
     }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -252,6 +252,18 @@ pub(crate) enum UWTableKind {
     Async = 2,
 }
 
+/// Must match the layout of `llvm::FramePointerKind`.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+#[expect(dead_code, reason = "Some variants are unused, but are kept to match LLVM")]
+pub(crate) enum FramePointerKind {
+    None = 0,
+    NonLeaf = 1,
+    All = 2,
+    Reserved = 3,
+    NonLeafNoReserve = 4,
+}
+
 /// Must match the layout of `LLVMRustAttributeKind`.
 /// Semantically a subset of the C++ enum llvm::Attribute::AttrKind,
 /// though it is not ABI compatible (since it's a C++ enum)

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1115,18 +1115,6 @@ fn do_thin_lto<B: WriteBackendMethods>(
     compiled_modules
 }
 
-fn execute_thin_lto_work_item<B: WriteBackendMethods>(
-    cgcx: &CodegenContext,
-    prof: &SelfProfilerRef,
-    shared_emitter: SharedEmitter,
-    tm_factory: TargetMachineFactoryFn<B>,
-    module: lto::ThinModule<B>,
-) -> CompiledModule {
-    let _timer = prof.generic_activity_with_arg("codegen_module_perform_lto", module.name());
-
-    B::optimize_and_codegen_thin(cgcx, prof, &shared_emitter, tm_factory, module)
-}
-
 /// Messages sent to the coordinator.
 pub(crate) enum Message<B: WriteBackendMethods> {
     /// A jobserver token has become available. Sent from the jobserver helper
@@ -1891,7 +1879,8 @@ fn spawn_thin_lto_work<B: WriteBackendMethods>(
                 execute_copy_from_cache_work_item(&cgcx, &prof, shared_emitter, m)
             }
             ThinLtoWorkItem::ThinLto(m) => {
-                execute_thin_lto_work_item(&cgcx, &prof, shared_emitter, tm_factory, m)
+                let _timer = prof.generic_activity_with_arg("codegen_module_perform_lto", m.name());
+                B::optimize_and_codegen_thin(&cgcx, &prof, &shared_emitter, tm_factory, m)
             }
         }));
 

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -352,7 +352,7 @@ pub struct CodegenContext {
     pub incr_comp_session_dir: Option<PathBuf>,
     /// `true` if the codegen should be run in parallel.
     ///
-    /// Depends on [`ExtraBackendMethods::supports_parallel()`] and `-Zno_parallel_backend`.
+    /// Depends on [`WriteBackendMethods::supports_parallel()`] and `-Zno_parallel_backend`.
     pub parallel: bool,
 }
 
@@ -416,7 +416,7 @@ fn need_pre_lto_bitcode_for_incr_comp(sess: &Session) -> bool {
     }
 }
 
-pub(crate) fn start_async_codegen<B: ExtraBackendMethods>(
+pub(crate) fn start_async_codegen<B: WriteBackendMethods>(
     backend: B,
     tcx: TyCtxt<'_>,
     allocator_module: Option<ModuleCodegen<B::Module>>,
@@ -1208,7 +1208,7 @@ enum MainThreadState {
     Lending,
 }
 
-fn start_executing_work<B: ExtraBackendMethods>(
+fn start_executing_work<B: WriteBackendMethods>(
     backend: B,
     tcx: TyCtxt<'_>,
     shared_emitter: SharedEmitter,

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -688,7 +688,13 @@ pub fn allocator_shim_contents(tcx: TyCtxt<'_>, kind: AllocatorKind) -> Vec<Allo
     methods
 }
 
-pub fn codegen_crate<B: ExtraBackendMethods>(backend: B, tcx: TyCtxt<'_>) -> OngoingCodegen<B> {
+pub fn codegen_crate<
+    B: ExtraBackendMethods<Module = M> + WriteBackendMethods<Module = M>,
+    M: Send,
+>(
+    backend: B,
+    tcx: TyCtxt<'_>,
+) -> OngoingCodegen<B> {
     if tcx.sess.target.need_explicit_cpu && tcx.sess.opts.cg.target_cpu.is_none() {
         // The target has no default cpu, but none is set explicitly
         tcx.dcx().emit_fatal(errors::CpuRequired);

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -14,7 +14,6 @@ use rustc_session::config::{CrateType, OutputFilenames, PrintRequest};
 use rustc_span::Symbol;
 
 use super::CodegenObject;
-use super::write::WriteBackendMethods;
 use crate::back::archive::ArArchiveBuilderBuilder;
 use crate::back::link::link_binary;
 use crate::{CompiledModules, CrateInfo, ModuleCodegen, TargetConfig};
@@ -156,9 +155,9 @@ pub trait CodegenBackend {
     }
 }
 
-pub trait ExtraBackendMethods:
-    WriteBackendMethods + Sized + Send + Sync + DynSend + DynSync
-{
+pub trait ExtraBackendMethods: Send + Sync + DynSend + DynSync {
+    type Module;
+
     fn codegen_allocator<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
@@ -173,11 +172,4 @@ pub trait ExtraBackendMethods:
         tcx: TyCtxt<'_>,
         cgu_name: Symbol,
     ) -> (ModuleCodegen<Self::Module>, u64);
-
-    /// Returns `true` if this backend can be safely called from multiple threads.
-    ///
-    /// Defaults to `true`.
-    fn supports_parallel(&self) -> bool {
-        true
-    }
 }

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::convert::Infallible;
 use std::path::PathBuf;
 
 use rustc_data_structures::profiling::SelfProfilerRef;
@@ -18,6 +19,12 @@ pub trait WriteBackendMethods: Clone + 'static {
     type ModuleBuffer: ModuleBufferMethods;
     type ThinData: Send + Sync;
 
+    /// Returns `true` if this backend can be safely called from multiple threads.
+    ///
+    /// Defaults to `true`.
+    fn supports_parallel(&self) -> bool {
+        true
+    }
     fn thread_profiler() -> Box<dyn Any> {
         Box::new(())
     }

--- a/compiler/rustc_codegen_ssa/src/traits/write.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/write.rs
@@ -83,3 +83,9 @@ pub trait WriteBackendMethods: Clone + 'static {
 pub trait ModuleBufferMethods: Send + Sync {
     fn data(&self) -> &[u8];
 }
+
+impl ModuleBufferMethods for Infallible {
+    fn data(&self) -> &[u8] {
+        match *self {}
+    }
+}

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -627,16 +627,18 @@ pub(crate) fn check_intrinsic_type(
         }
 
         sym::catch_unwind => {
+            let mut_data = Ty::new_mut_ptr(tcx, param(0));
             let mut_u8 = Ty::new_mut_ptr(tcx, tcx.types.u8);
             let try_fn_ty =
-                ty::Binder::dummy(tcx.mk_fn_sig_safe_rust_abi([mut_u8], tcx.types.unit));
-            let catch_fn_ty =
-                ty::Binder::dummy(tcx.mk_fn_sig_safe_rust_abi([mut_u8, mut_u8], tcx.types.unit));
+                ty::Binder::dummy(tcx.mk_fn_sig_unsafe_rust_abi([mut_data], tcx.types.unit));
+            let catch_fn_ty = ty::Binder::dummy(
+                tcx.mk_fn_sig_unsafe_rust_abi([mut_data, mut_u8], tcx.types.unit),
+            );
             (
+                1,
                 0,
-                0,
-                vec![Ty::new_fn_ptr(tcx, try_fn_ty), mut_u8, Ty::new_fn_ptr(tcx, catch_fn_ty)],
-                tcx.types.i32,
+                vec![Ty::new_fn_ptr(tcx, try_fn_ty), mut_data, Ty::new_fn_ptr(tcx, catch_fn_ty)],
+                tcx.types.bool,
             )
         }
 

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -9,7 +9,7 @@ use rustc_hir::{self as hir, AmbigArg, GenericParamKind, HirId, Node};
 use rustc_middle::span_bug;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_session::lint;
-use rustc_span::{Span, Symbol, kw};
+use rustc_span::{Span, kw, sym};
 use tracing::{debug, instrument};
 
 use crate::middle::resolve_bound_vars as rbv;
@@ -328,22 +328,18 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
     {
         // See `ClosureArgsParts`, `CoroutineArgsParts`, and `CoroutineClosureArgsParts`
         // for info on the usage of each of these fields.
-        let dummy_args = match kind {
-            ClosureKind::Closure => &["<closure_kind>", "<closure_signature>", "<upvars>"][..],
-            ClosureKind::Coroutine(_) => {
-                &["<coroutine_kind>", "<resume_ty>", "<yield_ty>", "<return_ty>", "<upvars>"][..]
-            }
-            ClosureKind::CoroutineClosure(_) => &[
-                "<closure_kind>",
-                "<closure_signature_parts>",
-                "<upvars>",
-                "<bound_captures_by_ref>",
-            ][..],
+        let len = match kind {
+            // The args are: closure_kind, closure_signature, upvars.
+            ClosureKind::Closure => 3,
+            // The args are: coroutine_kind, resume_ty, yield_ty, return_ty, upvars.
+            ClosureKind::Coroutine(_) => 5,
+            // The args are: closure_kind, closure_signature_parts, upvars, bound_captures_by_ref.
+            ClosureKind::CoroutineClosure(_) => 4,
         };
 
-        own_params.extend(dummy_args.iter().map(|&arg| ty::GenericParamDef {
+        own_params.extend((0..len).map(|_| ty::GenericParamDef {
             index: next_index(),
-            name: Symbol::intern(arg),
+            name: sym::empty, // dummy; exact value doesn't matter
             def_id: def_id.to_def_id(),
             pure_wrt_drop: false,
             kind: ty::GenericParamDefKind::Type { has_default: false, synthetic: false },

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -175,6 +175,7 @@ enum CastError<'tcx> {
     NonScalar,
     UnknownExprPtrKind,
     UnknownCastPtrKind,
+    CastEnumDrop,
     /// Cast of int to (possibly) wide raw pointer.
     ///
     /// Argument is the specific name of the metadata in plain words, such as "a vtable"
@@ -635,6 +636,12 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                 };
                 fcx.dcx().emit_err(errors::CastUnknownPointer { span, to: unknown_cast_to, sub });
             }
+            CastError::CastEnumDrop => {
+                let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
+                let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
+
+                fcx.dcx().emit_err(errors::CastEnumDrop { span: self.span, expr_ty, cast_ty });
+            }
             CastError::ForeignNonExhaustiveAdt => {
                 make_invalid_casting_error(
                     self.span,
@@ -870,11 +877,10 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             // fn-ptr-cast
             (FnPtr, Ptr(mt)) => self.check_fptr_ptr_cast(fcx, mt),
 
+            // enum -> int
+            (Int(CEnum), Int(_)) => self.check_enum_cast(fcx),
+
             // prim -> prim
-            (Int(CEnum), Int(_)) => {
-                self.err_if_cenum_impl_drop(fcx);
-                Ok(CastKind::EnumCast)
-            }
             (Int(Char) | Int(Bool), Int(_)) => Ok(CastKind::PrimIntCast),
 
             (Int(_) | Float, Int(_) | Float) => Ok(CastKind::NumericCast),
@@ -1109,21 +1115,20 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         }
     }
 
+    fn check_enum_cast(&self, fcx: &FnCtxt<'a, 'tcx>) -> Result<CastKind, CastError<'tcx>> {
+        if let ty::Adt(d, _) = self.expr_ty.kind()
+            && d.has_dtor(fcx.tcx)
+        {
+            Err(CastError::CastEnumDrop)
+        } else {
+            Ok(CastKind::EnumCast)
+        }
+    }
+
     fn try_coercion_cast(&self, fcx: &FnCtxt<'a, 'tcx>) -> Result<(), ty::error::TypeError<'tcx>> {
         match fcx.coerce(self.expr, self.expr_ty, self.cast_ty, AllowTwoPhase::No, None) {
             Ok(_) => Ok(()),
             Err(err) => Err(err),
-        }
-    }
-
-    fn err_if_cenum_impl_drop(&self, fcx: &FnCtxt<'a, 'tcx>) {
-        if let ty::Adt(d, _) = self.expr_ty.kind()
-            && d.has_dtor(fcx.tcx)
-        {
-            let expr_ty = fcx.resolve_vars_if_possible(self.expr_ty);
-            let cast_ty = fcx.resolve_vars_if_possible(self.cast_ty);
-
-            fcx.dcx().emit_err(errors::CastEnumDrop { span: self.span, expr_ty, cast_ty });
         }
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2355,6 +2355,15 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk_fn_sig(inputs, output, FnSigKind::default().set_safety(hir::Safety::Safe))
     }
 
+    /// `mk_fn_sig`, but with an **un**safe Rust ABI, and no C-variadic argument.
+    pub fn mk_fn_sig_unsafe_rust_abi<I, T>(self, inputs: I, output: I::Item) -> T::Output
+    where
+        I: IntoIterator<Item = T>,
+        T: CollectAndApply<Ty<'tcx>, ty::FnSig<'tcx>>,
+    {
+        self.mk_fn_sig(inputs, output, FnSigKind::default().set_safety(hir::Safety::Unsafe))
+    }
+
     pub fn mk_poly_existential_predicates_from_iter<I, T>(self, iter: I) -> T::Output
     where
         I: Iterator<Item = T>,

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -102,7 +102,7 @@ fn current_dll_path() -> Result<PathBuf, String> {
                 loop {
                     if libc::loadquery(
                         libc::L_GETINFO,
-                        buffer.as_mut_ptr() as *mut u8,
+                        buffer.as_mut_ptr() as *mut libc::c_void,
                         (size_of::<libc::ld_info>() * buffer.len()) as u32,
                     ) >= 0
                     {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -34,6 +34,7 @@ use derive_where::derive_where;
 use rustc_data_structures::stable_hash::StableHashCtxt;
 use rustc_data_structures::{AtomicRef, outline};
 use rustc_macros::{Decodable, Encodable, StableHash};
+use rustc_serialize::opaque::mem_encoder::MemEncoder;
 use rustc_serialize::opaque::{FileEncoder, MemDecoder};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use tracing::debug;
@@ -1362,6 +1363,43 @@ pub trait SpanEncoder: Encoder {
 }
 
 impl SpanEncoder for FileEncoder {
+    fn encode_span(&mut self, span: Span) {
+        let span = span.data();
+        span.lo.encode(self);
+        span.hi.encode(self);
+    }
+
+    fn encode_symbol(&mut self, sym: Symbol) {
+        self.emit_str(sym.as_str());
+    }
+
+    fn encode_byte_symbol(&mut self, byte_sym: ByteSymbol) {
+        self.emit_byte_str(byte_sym.as_byte_str());
+    }
+
+    fn encode_expn_id(&mut self, _expn_id: ExpnId) {
+        panic!("cannot encode `ExpnId` with `FileEncoder`");
+    }
+
+    fn encode_syntax_context(&mut self, _syntax_context: SyntaxContext) {
+        panic!("cannot encode `SyntaxContext` with `FileEncoder`");
+    }
+
+    fn encode_crate_num(&mut self, crate_num: CrateNum) {
+        self.emit_u32(crate_num.as_u32());
+    }
+
+    fn encode_def_index(&mut self, _def_index: DefIndex) {
+        panic!("cannot encode `DefIndex` with `FileEncoder`");
+    }
+
+    fn encode_def_id(&mut self, def_id: DefId) {
+        def_id.krate.encode(self);
+        def_id.index.encode(self);
+    }
+}
+
+impl SpanEncoder for MemEncoder {
     fn encode_span(&mut self, span: Span) {
         let span = span.data();
         span.lo.encode(self);

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2232,7 +2232,7 @@ pub const fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discrimina
 
 /// Rust's "try catch" construct for unwinding. Invokes the function pointer `try_fn` with the
 /// data pointer `data`, and calls `catch_fn` if unwinding occurs while `try_fn` runs.
-/// Returns `1` if unwinding occurred and `catch_fn` was called; returns `0` otherwise.
+/// Returns `true` if unwinding occurred and `catch_fn` was called; returns `false` otherwise.
 ///
 /// `catch_fn` must not unwind.
 ///
@@ -2249,11 +2249,11 @@ pub const fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discrimina
 /// version of this intrinsic, `std::panic::catch_unwind`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn catch_unwind(
-    _try_fn: fn(*mut u8),
-    _data: *mut u8,
-    _catch_fn: fn(*mut u8, *mut u8),
-) -> i32;
+pub unsafe fn catch_unwind<Data: ptr::Thin>(
+    _try_fn: unsafe fn(*mut Data),
+    _data: *mut Data,
+    _catch_fn: unsafe fn(*mut Data, *mut u8),
+) -> bool;
 
 /// Emits a `nontemporal` store, which gives a hint to the CPU that the data should not be held
 /// in cache. Except for performance, this is fully equivalent to `ptr.write(val)`.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2054,6 +2054,21 @@ pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 /// [allocation]: crate::ptr#allocated-object
 /// [atomic]: crate::sync::atomic#memory-model-for-atomic-accesses
 ///
+/// # Load splitting
+///
+/// Exactly which hardware loads are performed by this function is, in general, highly target-dependent.
+///
+/// For a simple scalar, such as when `T` is a thin pointer, this will typically be one load assuming
+/// your target supports a load of exactly that size and alignment.
+///
+/// For anything else, it will be split into multiple loads in some unspecified way.
+/// This can happen even for scalars: notably, on many targets loading a `u128` will still need to be split,
+/// despite being "one" scalar.  On many targets loading anything larger than a pointer will need to be split.
+/// On all current targets a load larger than 64 bytes will need to be split.
+/// Any load whose size is not a power of two will also almost certainly need to be split.
+///
+/// There is no stability guarantee on how that splitting happens.  It may change at any point.
+///
 /// # Safety
 ///
 /// Like [`read`], `read_volatile` creates a bitwise copy of `T`, regardless of whether `T` is
@@ -2146,6 +2161,21 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///
 /// [allocation]: crate::ptr#allocated-object
 /// [atomic]: crate::sync::atomic#memory-model-for-atomic-accesses
+///
+/// # Store splitting
+///
+/// Exactly which hardware stores are performed by this function is, in general, highly target-dependent.
+///
+/// For a simple scalar, such as when `T` is a thin pointer, this will typically be one store assuming
+/// your target supports a store of exactly that size and alignment.
+///
+/// For anything else, it will be split into multiple stores in some unspecified way.
+/// This can happen even for scalars: notably, on many targets storing a `u128` will still need to be split,
+/// despite being "one" scalar.  On many targets storing anything larger than a pointer will need to be split.
+/// On all current targets a store larger than 64 bytes will need to be split.
+/// Any store whose size is not a power of two will also almost certainly need to be split.
+///
+/// There is no stability guarantee on how that splitting happens.  It may change at any point.
 ///
 /// # Safety
 ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3906,6 +3906,7 @@ impl<T> [T] {
     ///
     /// assert_eq!(&bytes, b"Hello, Wello!");
     /// ```
+    #[inline]
     #[stable(feature = "copy_within", since = "1.37.0")]
     #[track_caller]
     pub fn copy_within<R: RangeBounds<usize>>(&mut self, src: R, dest: usize)

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -187,6 +187,7 @@ fn file_test_io_seek_and_write() {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris",
+        target_os = "android",
         target_vendor = "apple",
     )),
     should_panic
@@ -220,6 +221,7 @@ fn file_lock_multiple_shared() {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris",
+        target_os = "android",
         target_vendor = "apple",
     )),
     should_panic
@@ -254,6 +256,7 @@ fn file_lock_blocking() {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris",
+        target_os = "android",
         target_vendor = "apple",
     )),
     should_panic
@@ -285,6 +288,7 @@ fn file_lock_drop() {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris",
+        target_os = "android",
         target_vendor = "apple",
     )),
     should_panic

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -322,6 +322,7 @@ fn file_lock_dup() {
         target_os = "netbsd",
         target_os = "openbsd",
         target_os = "solaris",
+        target_os = "android",
         target_vendor = "apple",
     )),
     should_panic

--- a/library/std/src/os/aix/fs.rs
+++ b/library/std/src/os/aix/fs.rs
@@ -322,22 +322,22 @@ impl MetadataExt for Metadata {
         self.as_inner().as_inner().st_size as u64
     }
     fn st_atime(&self) -> i64 {
-        self.as_inner().as_inner().st_atime.tv_sec as i64
+        self.as_inner().as_inner().st_atim.tv_sec as i64
     }
     fn st_atime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_atime.tv_nsec as i64
+        self.as_inner().as_inner().st_atim.tv_nsec as i64
     }
     fn st_mtime(&self) -> i64 {
-        self.as_inner().as_inner().st_mtime.tv_sec as i64
+        self.as_inner().as_inner().st_mtim.tv_sec as i64
     }
     fn st_mtime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_mtime.tv_nsec as i64
+        self.as_inner().as_inner().st_mtim.tv_nsec as i64
     }
     fn st_ctime(&self) -> i64 {
-        self.as_inner().as_inner().st_ctime.tv_sec as i64
+        self.as_inner().as_inner().st_ctim.tv_sec as i64
     }
     fn st_ctime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_ctime.tv_nsec as i64
+        self.as_inner().as_inner().st_ctim.tv_nsec as i64
     }
     fn st_blksize(&self) -> u64 {
         self.as_inner().as_inner().st_blksize as u64

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -530,7 +530,6 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // method of calling a catch panic whilst juggling ownership.
     let mut data = Data { f: ManuallyDrop::new(f) };
 
-    let data_ptr = (&raw mut data) as *mut u8;
     // SAFETY:
     //
     // Access to the union's fields: this is `std` and we know that the `catch_unwind`
@@ -541,10 +540,10 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // - `do_catch`, the second argument, can be called with the `data_ptr` as well.
     // See their safety preconditions for more information
     unsafe {
-        return if intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
-            Ok(ManuallyDrop::into_inner(data.r))
-        } else {
+        return if intrinsics::catch_unwind(do_call, &raw mut data, do_catch) {
             Err(ManuallyDrop::into_inner(data.p))
+        } else {
+            Ok(ManuallyDrop::into_inner(data.r))
         };
     }
 
@@ -568,17 +567,12 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // data must be non-NUL, correctly aligned, and a pointer to a `Data<F, R>`
     // Its must contains a valid `f` (type: F) value that can be use to fill
     // `data.r`.
-    //
-    // This function cannot be marked as `unsafe` because `intrinsics::catch_unwind`
-    // expects normal function pointers.
     #[inline]
-    fn do_call<F: FnOnce() -> R, R>(data: *mut u8) {
+    unsafe fn do_call<F: FnOnce() -> R, R>(data: *mut Data<F, R>) {
         // SAFETY: this is the responsibility of the caller, see above.
         unsafe {
-            let data = data as *mut Data<F, R>;
-            let data = &mut (*data);
-            let f = ManuallyDrop::take(&mut data.f);
-            data.r = ManuallyDrop::new(f());
+            let f = ManuallyDrop::take(&mut (*data).f);
+            (*data).r = ManuallyDrop::new(f());
         }
     }
 
@@ -590,22 +584,17 @@ pub unsafe fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any +
     // data must be non-NUL, correctly aligned, and a pointer to a `Data<F, R>`
     // Since this uses `cleanup` it also hinges on a correct implementation of
     // `__rustc_panic_cleanup`.
-    //
-    // This function cannot be marked as `unsafe` because `intrinsics::catch_unwind`
-    // expects normal function pointers.
     #[inline]
     #[rustc_nounwind] // `intrinsic::catch_unwind` requires catch fn to be nounwind
-    fn do_catch<F: FnOnce() -> R, R>(data: *mut u8, payload: *mut u8) {
+    unsafe fn do_catch<F: FnOnce() -> R, R>(data: *mut Data<F, R>, payload: *mut u8) {
         // SAFETY: this is the responsibility of the caller, see above.
         //
         // When `__rustc_panic_cleaner` is correctly implemented we can rely
         // on `obj` being the correct thing to pass to `data.p` (after wrapping
         // in `ManuallyDrop`).
         unsafe {
-            let data = data as *mut Data<F, R>;
-            let data = &mut (*data);
             let obj = cleanup(payload);
-            data.p = ManuallyDrop::new(obj);
+            (*data).p = ManuallyDrop::new(obj);
         }
     }
 }

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -599,15 +599,15 @@ impl FileAttr {
 #[cfg(target_os = "aix")]
 impl FileAttr {
     pub fn modified(&self) -> io::Result<SystemTime> {
-        SystemTime::new(self.stat.st_mtime.tv_sec as i64, self.stat.st_mtime.tv_nsec as i64)
+        SystemTime::new(self.stat.st_mtim.tv_sec as i64, self.stat.st_mtim.tv_nsec as i64)
     }
 
     pub fn accessed(&self) -> io::Result<SystemTime> {
-        SystemTime::new(self.stat.st_atime.tv_sec as i64, self.stat.st_atime.tv_nsec as i64)
+        SystemTime::new(self.stat.st_atim.tv_sec as i64, self.stat.st_atim.tv_nsec as i64)
     }
 
     pub fn created(&self) -> io::Result<SystemTime> {
-        SystemTime::new(self.stat.st_ctime.tv_sec as i64, self.stat.st_ctime.tv_nsec as i64)
+        SystemTime::new(self.stat.st_ctim.tv_sec as i64, self.stat.st_ctim.tv_nsec as i64)
     }
 }
 

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -1451,6 +1451,7 @@ impl File {
         target_os = "cygwin",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     ))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1478,6 +1479,7 @@ impl File {
         target_os = "solaris",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     )))]
     pub fn lock(&self) -> io::Result<()> {
@@ -1494,6 +1496,7 @@ impl File {
         target_os = "cygwin",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     ))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1521,6 +1524,7 @@ impl File {
         target_os = "solaris",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     )))]
     pub fn lock_shared(&self) -> io::Result<()> {
@@ -1537,6 +1541,7 @@ impl File {
         target_os = "cygwin",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     ))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1580,6 +1585,7 @@ impl File {
         target_os = "solaris",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     )))]
     pub fn try_lock(&self) -> Result<(), TryLockError> {
@@ -1599,6 +1605,7 @@ impl File {
         target_os = "cygwin",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     ))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1642,6 +1649,7 @@ impl File {
         target_os = "solaris",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     )))]
     pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
@@ -1661,6 +1669,7 @@ impl File {
         target_os = "cygwin",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     ))]
     pub fn unlock(&self) -> io::Result<()> {
@@ -1688,6 +1697,7 @@ impl File {
         target_os = "solaris",
         target_os = "illumos",
         target_os = "aix",
+        target_os = "android",
         target_vendor = "apple",
     )))]
     pub fn unlock(&self) -> io::Result<()> {

--- a/src/doc/rustdoc/src/write-documentation/re-exports.md
+++ b/src/doc/rustdoc/src/write-documentation/re-exports.md
@@ -172,7 +172,7 @@ pub use self::private_mod::Second as Visible;
 ```
 
 In this case, `Visible` will have as documentation `First Second Third` and will also have as `cfg`:
-`#[cfg(a, b, c)]`.
+`#[cfg(a)]`, `#[cfg(b)]` and `#[cfg(c)]`.
 
 [Intra-doc links](./linking-to-items-by-name.md) are resolved relative to where the doc comment is
 defined.

--- a/src/tools/miri/src/shims/unix/foreign_items.rs
+++ b/src/tools/miri/src/shims/unix/foreign_items.rs
@@ -342,7 +342,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "flock" => {
                 // Currently this function does not exist on all Unixes, e.g. on Solaris.
-                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::MacOs, Os::Illumos], link_name)?;
+                this.check_target_os(&[Os::Linux, Os::Android, Os::FreeBsd, Os::MacOs, Os::Illumos], link_name)?;
 
                 let [fd, op] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32) -> i32),

--- a/src/tools/miri/src/shims/unwind.rs
+++ b/src/tools/miri/src/shims/unwind.rs
@@ -68,7 +68,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let this = self.eval_context_mut();
 
         // Signature:
-        //   fn catch_unwind(try_fn: fn(*mut u8), data: *mut u8, catch_fn: fn(*mut u8, *mut u8)) -> i32
+        //   fn catch_unwind(try_fn: unsafe fn(*mut Data), data: *mut Data, catch_fn: unsafe fn(*mut Data, *mut u8)) -> bool
         // Calls `try_fn` with `data` as argument. If that executes normally, returns 0.
         // If that unwinds, calls `catch_fn` with the first argument being `data` and
         // then second argument being a target-dependent `payload` (i.e. it is up to us to define
@@ -129,7 +129,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
 
             // We set the return value of `catch_unwind` to 1, since there was a panic.
-            this.write_scalar(Scalar::from_i32(1), &catch_unwind.dest)?;
+            this.write_scalar(Scalar::from_bool(true), &catch_unwind.dest)?;
 
             // The Thread's `panic_payload` holds what was passed to `miri_start_unwind`.
             // This is exactly the second argument we need to pass to `catch_fn`.

--- a/src/tools/miri/tests/fail/function_calls/check_callback_abi.rs
+++ b/src/tools/miri/tests/fail/function_calls/check_callback_abi.rs
@@ -11,7 +11,7 @@ fn main() {
         std::intrinsics::catch_unwind(
             //~^ ERROR: calling a function with calling convention "C" using calling convention "Rust"
             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<u8>(),
             |_, _| unreachable!(),
         );
     }

--- a/src/tools/miri/tests/fail/function_calls/check_callback_abi.stderr
+++ b/src/tools/miri/tests/fail/function_calls/check_callback_abi.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: calling a function with calling convention "C" using 
 LL | /         std::intrinsics::catch_unwind(
 LL | |
 LL | |             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
-LL | |             std::ptr::null_mut(),
+LL | |             std::ptr::null_mut::<u8>(),
 LL | |             |_, _| unreachable!(),
 LL | |         );
    | |_________^ Undefined Behavior occurred here

--- a/src/tools/miri/tests/pass-dep/libc/libc-fs-flock.rs
+++ b/src/tools/miri/tests/pass-dep/libc/libc-fs-flock.rs
@@ -1,6 +1,5 @@
-//@ignore-target: windows # File handling is not implemented yet
+//@ignore-target: windows # no libc
 //@ignore-target: solaris # Does not have flock
-//@ignore-target: android # Does not (always?) have flock
 //@compile-flags: -Zmiri-disable-isolation
 
 use std::fs::File;

--- a/src/tools/miri/tests/pass/panic/unwind_dwarf.rs
+++ b/src/tools/miri/tests/pass/panic/unwind_dwarf.rs
@@ -64,10 +64,10 @@ fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
 
     let data_ptr = ptr::addr_of_mut!(data) as *mut u8;
     unsafe {
-        return if std::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) == 0 {
-            Ok(data.r.take().unwrap())
-        } else {
+        return if std::intrinsics::catch_unwind(do_call::<F, R>, data_ptr, do_catch::<F, R>) {
             Err(data.p.take().unwrap())
+        } else {
+            Ok(data.r.take().unwrap())
         };
     }
 

--- a/src/tools/miri/tests/pass/shims/fs.rs
+++ b/src/tools/miri/tests/pass/shims/fs.rs
@@ -40,7 +40,7 @@ fn main() {
         test_canonicalize();
         #[cfg(unix)]
         test_pread_pwrite();
-        #[cfg(not(any(target_os = "solaris", target_os = "android")))]
+        #[cfg(not(target_os = "solaris"))]
         test_flock();
         test_readv_writev();
         #[cfg(all(unix, not(any(target_os = "solaris", target_os = "android"))))]
@@ -406,11 +406,9 @@ fn test_pread_pwrite() {
     assert_eq!(&buf1, b"  m");
 }
 
-// The standard library does not support this operation on Android
-// (https://github.com/rust-lang/rust/issues/148325).
 // Miri does not support the way this is implemented on Solaris
 // (https://github.com/rust-lang/miri/issues/5038).
-#[cfg(not(any(target_os = "solaris", target_os = "android")))]
+#[cfg(not(target_os = "solaris"))]
 fn test_flock() {
     let bytes = b"Hello, World!\n";
     let path = utils::prepare_with_content("miri_test_fs_flock.txt", bytes);

--- a/tests/assembly-llvm/wasm_exceptions.rs
+++ b/tests/assembly-llvm/wasm_exceptions.rs
@@ -48,7 +48,7 @@ pub fn test_rtry() {
             |_| {
                 may_panic();
             },
-            core::ptr::null_mut(),
+            core::ptr::null_mut::<u8>(),
             |data, exception| {
                 log_number(data as usize);
                 log_number(exception as usize);

--- a/tests/assembly-llvm/wasm_legacy_eh.rs
+++ b/tests/assembly-llvm/wasm_legacy_eh.rs
@@ -58,7 +58,7 @@ pub fn test_rtry() {
             |_| {
                 may_panic();
             },
-            core::ptr::null_mut(),
+            core::ptr::null_mut::<u8>(),
             |data, exception| {
                 log_number(data as usize);
                 log_number(exception as usize);

--- a/tests/codegen-llvm/emscripten-catch-unwind-js-eh.rs
+++ b/tests/codegen-llvm/emscripten-catch-unwind-js-eh.rs
@@ -30,11 +30,11 @@ const fn size_of<T>() -> usize {
 }
 
 #[rustc_intrinsic]
-unsafe fn catch_unwind(
-    try_fn: fn(_: *mut u8),
-    data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32;
+unsafe fn catch_unwind<Data>(
+    try_fn: unsafe fn(_: *mut Data),
+    data: *mut Data,
+    catch_fn: unsafe fn(_: *mut Data, _: *mut u8),
+) -> bool;
 
 // CHECK-LABEL: @ptr_size
 #[no_mangle]
@@ -46,10 +46,10 @@ pub fn ptr_size() -> usize {
 // CHECK-LABEL: @test_catch_unwind
 #[no_mangle]
 pub unsafe fn test_catch_unwind(
-    try_fn: fn(_: *mut u8),
+    try_fn: unsafe fn(_: *mut u8),
     data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32 {
+    catch_fn: unsafe fn(_: *mut u8, _: *mut u8),
+) -> bool {
     // CHECK: start:
     // CHECK: [[ALLOCA:%.*]] = alloca
 

--- a/tests/codegen-llvm/emscripten-catch-unwind-wasm-eh.rs
+++ b/tests/codegen-llvm/emscripten-catch-unwind-wasm-eh.rs
@@ -28,11 +28,11 @@ const fn size_of<T>() -> usize {
     loop {}
 }
 #[rustc_intrinsic]
-unsafe fn catch_unwind(
-    try_fn: fn(_: *mut u8),
-    data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32;
+unsafe fn catch_unwind<Data>(
+    try_fn: unsafe fn(_: *mut Data),
+    data: *mut Data,
+    catch_fn: unsafe fn(_: *mut Data, _: *mut u8),
+) -> bool;
 
 // CHECK-LABEL: @ptr_size
 #[no_mangle]
@@ -44,10 +44,10 @@ pub fn ptr_size() -> usize {
 // CHECK-LABEL: @test_catch_unwind
 #[no_mangle]
 pub unsafe fn test_catch_unwind(
-    try_fn: fn(_: *mut u8),
+    try_fn: unsafe fn(_: *mut u8),
     data: *mut u8,
-    catch_fn: fn(_: *mut u8, _: *mut u8),
-) -> i32 {
+    catch_fn: unsafe fn(_: *mut u8, _: *mut u8),
+) -> bool {
     // CHECK: start:
     // CHECK: invoke void %try_fn(ptr %data)
     // CHECK:         to label %__rust_try.exit unwind label %catchswitch.i
@@ -62,8 +62,8 @@ pub unsafe fn test_catch_unwind(
     // CHECK:   catchret from %catchpad2.i to label %__rust_try.exit
 
     // CHECK: __rust_try.exit:                                  ; preds = %start, %catchpad.i
-    // CHECK:   %common.ret.op.i = phi i32 [ 0, %start ], [ 1, %catchpad.i ]
-    // CHECK:   ret i32 %common.ret.op.i
+    // CHECK:   %common.ret.op.i = phi i1 [ false, %start ], [ true, %catchpad.i ]
+    // CHECK:   ret i1 %common.ret.op.i
 
     catch_unwind(try_fn, data, catch_fn)
 }

--- a/tests/codegen-llvm/force-frame-pointers.rs
+++ b/tests/codegen-llvm/force-frame-pointers.rs
@@ -16,3 +16,6 @@
 // Always: attributes #{{.*}} "frame-pointer"="all"
 // NonLeaf: attributes #{{.*}} "frame-pointer"="non-leaf"
 pub fn foo() {}
+
+// Always: !{{[0-9]+}} = !{i32 7, !"frame-pointer", i32 2}
+// NonLeaf: !{{[0-9]+}} = !{i32 7, !"frame-pointer", i32 1}

--- a/tests/codegen-llvm/wasm_exceptions.rs
+++ b/tests/codegen-llvm/wasm_exceptions.rs
@@ -49,7 +49,7 @@ pub fn test_rtry() {
             |_| {
                 may_panic();
             },
-            core::ptr::null_mut(),
+            core::ptr::null_mut::<u8>(),
             |data, exception| {
                 log_number(data as usize);
                 log_number(exception as usize);

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1127,10 +1127,6 @@ cc = [
 message = "Some changes occurred in GUI tests."
 cc = ["@GuillaumeGomez"]
 
-[mentions."tests/auxiliary/minicore.rs"]
-message = "This PR modifies `tests/auxiliary/minicore.rs`."
-cc = ["@jieyouxu"]
-
 [mentions."src/rustdoc-json-types"]
 message = """
 rustdoc-json-types is a **public** (although nightly-only) API. \


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156867 (Stop needing an alloca for `catch_unwind`)
 - rust-lang/rust#157050 (Couple of changes to help with moving LTO to the link phase)
 - rust-lang/rust#148345 (add inline to copy_within)
 - rust-lang/rust#156931 (Add splitting caveats to `{read,write}_volatile`)
 - rust-lang/rust#156980 (Add frame pointer annotations to the module)
 - rust-lang/rust#156991 ([AIX] Sync compiler and std with libc changes)
 - rust-lang/rust#157008 (Avoid some symbol interning)
 - rust-lang/rust#157038 (android: implement file locking by calling flock)
 - rust-lang/rust#157071 (Fix `cfg` typo in rustdoc book)
 - rust-lang/rust#157080 (Fix typo in Rustdoc release notes)
 - rust-lang/rust#157084 (Clean up error reporting for impl Drop enum casts)
 - rust-lang/rust#157091 (Remove minicore ping for myself)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156867,157050,148345,156931,156980,156991,157008,157038,157071,157080,157084,157091)
<!-- homu-ignore:end -->

