### PR TITLE
Add the `clflushopt` x86 target feature

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -454,6 +454,8 @@ declare_features! (
     (unstable, cfg_version, "1.45.0", Some(64796)),
     /// Allows to use the `#[cfi_encoding = ""]` attribute.
     (unstable, cfi_encoding, "1.71.0", Some(89653)),
+    /// The `clflushopt` target feature on x86.
+    (unstable, clflushopt_target_feature, "CURRENT_RUSTC_VERSION", Some(157096)),
     /// Allows `for<...>` on closures and coroutines.
     (unstable, closure_lifetime_binder, "1.64.0", Some(97362)),
     /// Allows `#[track_caller]` on closures and coroutines.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -600,6 +600,7 @@ symbols! {
         cfi,
         cfi_encoding,
         char,
+        clflushopt_target_feature,
         client,
         clippy,
         clobber_abi,

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -464,6 +464,7 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("avxvnniint16", Stable, &["avx2"]),
     ("bmi1", Stable, &[]),
     ("bmi2", Stable, &[]),
+    ("clflushopt", Unstable(sym::clflushopt_target_feature), &[]),
     ("cmpxchg16b", Stable, &[]),
     ("ermsb", Unstable(sym::ermsb_target_feature), &[]),
     ("f16c", Stable, &["avx"]),

--- a/library/std_detect/src/detect/arch/x86.rs
+++ b/library/std_detect/src/detect/arch/x86.rs
@@ -106,6 +106,7 @@ features! {
     /// * `"xsaves"`
     /// * `"xsavec"`
     /// * `"cmpxchg16b"`
+    /// * `"clflushopt"`
     /// * `"kl"`
     /// * `"widekl"`
     /// * `"adx"`
@@ -261,6 +262,8 @@ features! {
     /// XSAVEC (Save Processor Extended States Compacted)
     @FEATURE: #[stable(feature = "simd_x86", since = "1.27.0")] cmpxchg16b: "cmpxchg16b";
     /// CMPXCH16B (16-byte compare-and-swap instruction)
+    @FEATURE: #[unstable(feature = "clflushopt_target_feature", issue = "157096")] clflushopt: "clflushopt";
+    /// CLFLUSHOPT (Cache Line Flush Optimized)
     @FEATURE: #[stable(feature = "keylocker_x86", since = "1.89.0")] kl: "kl";
     /// Intel Key Locker
     @FEATURE: #[stable(feature = "keylocker_x86", since = "1.89.0")] widekl: "widekl";

--- a/library/std_detect/src/detect/os/x86.rs
+++ b/library/std_detect/src/detect/os/x86.rs
@@ -127,6 +127,8 @@ pub(crate) fn detect_features() -> cache::Initializer {
 
         enable(extended_features_ebx, 9, Feature::ermsb);
 
+        enable(extended_features_ebx, 23, Feature::clflushopt);
+
         enable(extended_features_eax_leaf_1, 31, Feature::movrs);
 
         // Detect if CPUID.19h available

--- a/library/std_detect/tests/x86-specific.rs
+++ b/library/std_detect/tests/x86-specific.rs
@@ -1,6 +1,12 @@
 #![cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #![allow(internal_features)]
-#![feature(stdarch_internal, x86_amx_intrinsics, xop_target_feature, movrs_target_feature)]
+#![feature(
+    stdarch_internal,
+    x86_amx_intrinsics,
+    xop_target_feature,
+    movrs_target_feature,
+    clflushopt_target_feature
+)]
 
 #[macro_use]
 extern crate std_detect;
@@ -58,6 +64,7 @@ fn dump() {
     println!("xsaves: {:?}", is_x86_feature_detected!("xsaves"));
     println!("xsavec: {:?}", is_x86_feature_detected!("xsavec"));
     println!("cmpxchg16b: {:?}", is_x86_feature_detected!("cmpxchg16b"));
+    println!("clflushopt: {:?}", is_x86_feature_detected!("clflushopt"));
     println!("adx: {:?}", is_x86_feature_detected!("adx"));
     println!("rtm: {:?}", is_x86_feature_detected!("rtm"));
     println!("movbe: {:?}", is_x86_feature_detected!("movbe"));

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -65,6 +65,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `bulk-memory`
 `c`
 `cache`
+`clflushopt`
 `cmpxchg16b`
 `concurrent-functions`
 `crc`

--- a/tests/ui/feature-gates/feature-gate-clflushopt_target_feature.rs
+++ b/tests/ui/feature-gates/feature-gate-clflushopt_target_feature.rs
@@ -1,0 +1,6 @@
+//@ only-x86_64
+#[target_feature(enable = "clflushopt")]
+//~^ ERROR: currently unstable
+unsafe fn foo() {}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-clflushopt_target_feature.stderr
+++ b/tests/ui/feature-gates/feature-gate-clflushopt_target_feature.stderr
@@ -1,0 +1,13 @@
+error[E0658]: the target feature `clflushopt` is currently unstable
+  --> $DIR/feature-gate-clflushopt_target_feature.rs:2:18
+   |
+LL | #[target_feature(enable = "clflushopt")]
+   |                  ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #157096 <https://github.com/rust-lang/rust/issues/157096> for more information
+   = help: add `#![feature(clflushopt_target_feature)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -174,7 +174,7 @@ error: the feature named `foo` is not valid for this target
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^ `foo` is not valid for this target
    |
-   = help: valid names are: `fma`, `xop`, `adx`, `aes`, and `avx` and 75 more
+   = help: valid names are: `fma`, `xop`, `adx`, `aes`, and `avx` and 76 more
 
 error[E0046]: not all trait items implemented, missing: `foo`
   --> $DIR/invalid-attribute.rs:80:1
@@ -226,7 +226,7 @@ error: the feature named `sse5` is not valid for this target
 LL | #[target_feature(enable = "sse5")]
    |                  ^^^^^^^^^^^^^^^ `sse5` is not valid for this target
    |
-   = help: valid names are: `sse`, `sse2`, `sse3`, `sse4a`, and `ssse3` and 75 more
+   = help: valid names are: `sse`, `sse2`, `sse3`, `sse4a`, and `ssse3` and 76 more
 
 error: the feature named `avx512` is not valid for this target
   --> $DIR/invalid-attribute.rs:126:18
@@ -234,7 +234,7 @@ error: the feature named `avx512` is not valid for this target
 LL | #[target_feature(enable = "avx512")]
    |                  ^^^^^^^^^^^^^^^^^ `avx512` is not valid for this target
    |
-   = help: valid names are: `avx512f`, `avx2`, `avx512bw`, `avx512cd`, and `avx512dq` and 75 more
+   = help: valid names are: `avx512f`, `avx2`, `avx512bw`, `avx512cd`, and `avx512dq` and 76 more
 
 error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Adds the unstable `clflushopt` x86 target feature, gated behind
`#![feature(clflushopt_target_feature)]`.

`CLFLUSHOPT` is a standalone x86 CPUID feature (Intel Skylake+ / AMD
Excavator+, ~2015) that is not part of any psABI microarchitecture level, so it
needs its own feature flag.

**This is the compiler half of a two-PR feature and is a hard dependency for the
stdarch side.** The `_mm_clflushopt` intrinsic (rust-lang/stdarch#1456) cannot
compile until this target feature exists, so the stdarch PR is blocked on this
one merging and syncing into stdarch's pinned toolchain.

- Tracking issue: rust-lang/rust#157096
- Unblocks intrinsic: rust-lang/stdarch#1456

This mirrors the existing unstable x86 target features (e.g. `movrs`, `apxf`).
`clflushopt` is a standard LLVM x86 feature name, so it maps 1:1 through
`to_llvm_features` with no remap entry needed.

r? compiler