### PR TITLE
Support field-wise `CoerceShared` reborrows

### DIFF
--- a/compiler/rustc_borrowck/src/borrow_set.rs
+++ b/compiler/rustc_borrowck/src/borrow_set.rs
@@ -305,15 +305,29 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'tcx> {
         } else if let &mir::Rvalue::Reborrow(target, mutability, borrowed_place) = rvalue {
             let borrowed_place_ty = borrowed_place.ty(self.body, self.tcx).ty;
             let &ty::Adt(reborrowed_adt, _reborrowed_args) = borrowed_place_ty.kind() else {
-                unreachable!()
+                self.tcx.dcx().span_delayed_bug(
+                    self.body.source_info(location).span,
+                    format!("generic reborrow source is not an ADT: {borrowed_place_ty:?}"),
+                );
+                return;
             };
-            let &ty::Adt(target_adt, assigned_args) = target.kind() else { unreachable!() };
+            let &ty::Adt(target_adt, assigned_args) = target.kind() else {
+                self.tcx.dcx().span_delayed_bug(
+                    self.body.source_info(location).span,
+                    format!("generic reborrow target is not an ADT: {target:?}"),
+                );
+                return;
+            };
             let Some(ty::GenericArgKind::Lifetime(region)) = assigned_args.get(0).map(|r| r.kind())
             else {
-                bug!(
-                    "hir-typeck passed but {} does not have a lifetime argument",
-                    if mutability == Mutability::Mut { "Reborrow" } else { "CoerceShared" }
+                self.tcx.dcx().span_delayed_bug(
+                    self.body.source_info(location).span,
+                    format!(
+                        "hir-typeck passed but {} does not have a lifetime argument",
+                        if mutability == Mutability::Mut { "Reborrow" } else { "CoerceShared" }
+                    ),
                 );
+                return;
             };
             let region = region.as_var();
             let kind = if mutability == Mutability::Mut {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -25,6 +25,7 @@ use rustc_middle::mir::*;
 use rustc_middle::traits::query::NoSolution;
 use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::cast::CastTy;
+use rustc_middle::ty::reborrow::{self, CoerceSharedFieldPairError};
 use rustc_middle::ty::{
     self, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations, CoroutineArgsExt,
     GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, UserArgs, UserTypeAnnotationIndex, fold_regions,
@@ -2489,9 +2490,23 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
         let borrowed_ty = borrowed_place.ty(self.body, tcx).ty;
 
-        let ty::Adt(dest_adt, dest_args) = dest_ty.kind() else { bug!() };
-        let [dest_arg, ..] = ***dest_args else { bug!() };
-        let ty::GenericArgKind::Lifetime(dest_region) = dest_arg.kind() else { bug!() };
+        let ty::Adt(_, dest_args) = dest_ty.kind() else {
+            span_mirbug!(
+                self,
+                borrowed_place,
+                "generic reborrow target is not an ADT: {dest_ty:?}"
+            );
+            return;
+        };
+        let Some(ty::GenericArgKind::Lifetime(dest_region)) = dest_args.get(0).map(|r| r.kind())
+        else {
+            span_mirbug!(
+                self,
+                borrowed_place,
+                "generic reborrow target does not have a lifetime argument: {dest_ty:?}"
+            );
+            return;
+        };
         constraints.liveness_constraints.add_location(dest_region.as_var(), location);
 
         // In Polonius mode, we also push a `loan_issued_at` fact
@@ -2509,65 +2524,157 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         }
 
         if mutability.is_not() {
-            // FIXME(reborrow): for CoerceShared we need to relate the types manually, field by
-            // field. We cannot just attempt to relate `T` and `<T as CoerceShared>::Target` by
-            // calling relate_types as they are (generally) two unrelated user-defined ADTs, such as
-            // `CustomMut<'a>` and `CustomRef<'a>`, or `CustomMut<'a, T>` and `CustomRef<'a, T>`.
-            // Field-by-field relate_types is expected to work based on the wf-checks that the
-            // CoerceShared trait performs.
-            let ty::Adt(borrowed_adt, borrowed_args) = borrowed_ty.kind() else { unreachable!() };
-            let borrowed_fields = borrowed_adt.all_fields().collect::<Vec<_>>();
-            for dest_field in dest_adt.all_fields() {
-                let Some(borrowed_field) =
-                    borrowed_fields.iter().find(|f| f.name == dest_field.name)
-                else {
-                    continue;
-                };
-                let dest_ty = dest_field.ty(tcx, dest_args).skip_norm_wip();
-                let borrowed_ty = borrowed_field.ty(tcx, borrowed_args).skip_norm_wip();
-                if let (
-                    ty::Ref(borrow_region, _, Mutability::Mut),
-                    ty::Ref(ref_region, _, Mutability::Not),
-                ) = (borrowed_ty.kind(), dest_ty.kind())
-                {
-                    self.relate_types(
-                        borrowed_ty.peel_refs(),
-                        ty::Variance::Covariant,
-                        dest_ty.peel_refs(),
-                        location.to_locations(),
-                        category,
-                    )
-                    .unwrap();
-                    self.constraints.outlives_constraints.push(OutlivesConstraint {
-                        sup: ref_region.as_var(),
-                        sub: borrow_region.as_var(),
-                        locations: location.to_locations(),
-                        span: location.to_locations().span(self.body),
-                        category,
-                        variance_info: ty::VarianceDiagInfo::default(),
-                        from_closure: false,
-                    });
-                } else {
-                    self.relate_types(
-                        borrowed_ty,
-                        ty::Variance::Covariant,
-                        dest_ty,
-                        location.to_locations(),
-                        category,
-                    )
-                    .unwrap();
-                }
+            // CoerceShared relates distinct ADTs field-wise. Impl validation guarantees that
+            // every target field has the corresponding source field and that each field relation
+            // is Copy-compatible, recursively CoerceShared-compatible, or `&mut T` to `&T`.
+            // The loan itself is still issued for `borrowed_place` as a whole, so source-only
+            // fields remain protected for the inferred target lifetime. Under the current
+            // single-lifetime impl model, that is the source lifetime.
+            if self
+                .add_generic_shared_reborrow_constraints(
+                    location,
+                    borrowed_place,
+                    borrowed_ty,
+                    dest_ty,
+                    category,
+                )
+                .is_err()
+            {
+                return;
             }
         } else {
             // Exclusive reborrow
-            self.relate_types(
+            if let Err(terr) = self.relate_types(
                 borrowed_ty,
                 ty::Variance::Covariant,
                 dest_ty,
                 location.to_locations(),
                 category,
-            )
-            .unwrap();
+            ) {
+                span_mirbug!(
+                    self,
+                    borrowed_place,
+                    "bad generic exclusive reborrow relation ({:?}: {:?}): {:?}",
+                    borrowed_ty,
+                    dest_ty,
+                    terr
+                );
+            }
+        }
+    }
+
+    fn add_generic_shared_reborrow_constraints(
+        &mut self,
+        location: Location,
+        borrowed_place: &Place<'tcx>,
+        borrowed_ty: Ty<'tcx>,
+        dest_ty: Ty<'tcx>,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), ()> {
+        let tcx = self.tcx();
+        let borrowed_ty = self.normalize(ty::Unnormalized::new_wip(borrowed_ty), location);
+        let dest_ty = self.normalize(ty::Unnormalized::new_wip(dest_ty), location);
+
+        if let (
+            ty::Ref(borrow_region, _, Mutability::Mut),
+            ty::Ref(ref_region, _, Mutability::Not),
+        ) = (borrowed_ty.kind(), dest_ty.kind())
+        {
+            if let Err(terr) = self.relate_types_structurally_relating_aliases(
+                borrowed_ty.peel_refs(),
+                ty::Variance::Covariant,
+                dest_ty.peel_refs(),
+                location.to_locations(),
+                category,
+            ) {
+                span_mirbug!(
+                    self,
+                    borrowed_place,
+                    "bad generic shared reborrow field relation ({:?}: {:?}): {:?}",
+                    borrowed_ty,
+                    dest_ty,
+                    terr
+                );
+                return Err(());
+            }
+
+            self.constraints.outlives_constraints.push(OutlivesConstraint {
+                sup: ref_region.as_var(),
+                sub: borrow_region.as_var(),
+                locations: location.to_locations(),
+                span: location.to_locations().span(self.body),
+                category,
+                variance_info: ty::VarianceDiagInfo::default(),
+                from_closure: false,
+            });
+            return Ok(());
+        }
+
+        match (borrowed_ty.kind(), dest_ty.kind()) {
+            (ty::Adt(borrowed_adt, borrowed_args), ty::Adt(dest_adt, dest_args))
+                if borrowed_adt.did() != dest_adt.did() =>
+            {
+                let field_pairs = match reborrow::coerce_shared_field_pairs(
+                    tcx,
+                    *borrowed_adt,
+                    *borrowed_args,
+                    *dest_adt,
+                    *dest_args,
+                ) {
+                    Ok(field_pairs) => field_pairs,
+                    Err(CoerceSharedFieldPairError::FieldStyleMismatch) => {
+                        span_mirbug!(
+                            self,
+                            borrowed_place,
+                            "generic shared reborrow has unsupported field structure: \
+                             {borrowed_ty:?} -> {dest_ty:?}"
+                        );
+                        return Err(());
+                    }
+                    Err(CoerceSharedFieldPairError::MissingSourceField { .. }) => {
+                        span_mirbug!(
+                            self,
+                            borrowed_place,
+                            "generic shared reborrow is missing a source field: \
+                             {borrowed_ty:?} -> {dest_ty:?}"
+                        );
+                        return Err(());
+                    }
+                };
+
+                for field_pair in field_pairs {
+                    self.add_generic_shared_reborrow_constraints(
+                        location,
+                        borrowed_place,
+                        field_pair.source.ty,
+                        field_pair.target.ty,
+                        category,
+                    )?;
+                }
+
+                Ok(())
+            }
+            _ => {
+                if let Err(terr) = self.relate_types_structurally_relating_aliases(
+                    borrowed_ty,
+                    ty::Variance::Covariant,
+                    dest_ty,
+                    location.to_locations(),
+                    category,
+                ) {
+                    span_mirbug!(
+                        self,
+                        borrowed_place,
+                        "bad generic shared reborrow field relation ({:?}: {:?}): {:?}",
+                        borrowed_ty,
+                        dest_ty,
+                        terr
+                    );
+                    Err(())
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -40,8 +40,35 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Result<(), NoSolution> {
-        NllTypeRelating::new(self, locations, category, UniverseInfo::relate(a, b), v)
-            .relate(a, b)?;
+        NllTypeRelating::new(
+            self,
+            locations,
+            category,
+            UniverseInfo::relate(a, b),
+            v,
+            StructurallyRelateAliases::No,
+        )
+        .relate(a, b)?;
+        Ok(())
+    }
+
+    pub(super) fn relate_types_structurally_relating_aliases(
+        &mut self,
+        a: Ty<'tcx>,
+        v: ty::Variance,
+        b: Ty<'tcx>,
+        locations: Locations,
+        category: ConstraintCategory<'tcx>,
+    ) -> Result<(), NoSolution> {
+        NllTypeRelating::new(
+            self,
+            locations,
+            category,
+            UniverseInfo::relate(a, b),
+            v,
+            StructurallyRelateAliases::Yes,
+        )
+        .relate(a, b)?;
         Ok(())
     }
 
@@ -53,8 +80,15 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         locations: Locations,
         category: ConstraintCategory<'tcx>,
     ) -> Result<(), NoSolution> {
-        NllTypeRelating::new(self, locations, category, UniverseInfo::other(), ty::Invariant)
-            .relate(a, b)?;
+        NllTypeRelating::new(
+            self,
+            locations,
+            category,
+            UniverseInfo::other(),
+            ty::Invariant,
+            StructurallyRelateAliases::No,
+        )
+        .relate(a, b)?;
         Ok(())
     }
 }
@@ -81,6 +115,8 @@ struct NllTypeRelating<'a, 'b, 'tcx> {
     ambient_variance: ty::Variance,
 
     ambient_variance_info: ty::VarianceDiagInfo<TyCtxt<'tcx>>,
+
+    structurally_relate_aliases: StructurallyRelateAliases,
 }
 
 impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
@@ -90,6 +126,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
         category: ConstraintCategory<'tcx>,
         universe_info: UniverseInfo<'tcx>,
         ambient_variance: ty::Variance,
+        structurally_relate_aliases: StructurallyRelateAliases,
     ) -> Self {
         Self {
             type_checker,
@@ -98,6 +135,7 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
             universe_info,
             ambient_variance,
             ambient_variance_info: ty::VarianceDiagInfo::default(),
+            structurally_relate_aliases,
         }
     }
 
@@ -553,7 +591,7 @@ impl<'b, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating<'_
     }
 
     fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
+        self.structurally_relate_aliases
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -12,6 +12,7 @@ use rustc_middle::ty::TypeVisitableExt;
 use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::layout::{FnAbiOf, HasTypingEnv as _};
 use rustc_middle::ty::print::with_no_trimmed_paths;
+use rustc_middle::ty::reborrow::{self, CoerceSharedFieldPairError};
 use rustc_session::config::OutputFilenames;
 use rustc_span::Symbol;
 
@@ -629,10 +630,8 @@ fn codegen_stmt<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, cur_block: Block, stmt:
                     let ref_ = place.place_ref(fx, lval.layout());
                     lval.write_cvalue(fx, ref_);
                 }
-                Rvalue::Reborrow(_, _, place) => {
-                    let cplace = codegen_place(fx, place);
-                    let val = cplace.to_cvalue(fx);
-                    lval.write_cvalue(fx, val)
+                Rvalue::Reborrow(target_ty, _, place) => {
+                    codegen_reborrow_into(fx, target_ty, place, lval);
                 }
                 Rvalue::ThreadLocalRef(def_id) => {
                     let val = crate::constant::codegen_tls_ref(fx, def_id, lval.layout());
@@ -952,6 +951,56 @@ fn codegen_stmt<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, cur_block: Block, stmt:
             }
         },
     }
+}
+
+fn codegen_reborrow_into<'tcx>(
+    fx: &mut FunctionCx<'_, '_, 'tcx>,
+    target_ty: Ty<'tcx>,
+    source_place: Place<'tcx>,
+    dest: CPlace<'tcx>,
+) {
+    let source_ty = fx.monomorphize(source_place.ty(fx.mir, fx.tcx).ty);
+    let target_ty = fx.monomorphize(target_ty);
+    let (ty::Adt(source_def, source_args), ty::Adt(target_def, target_args)) =
+        (source_ty.kind(), target_ty.kind())
+    else {
+        let source = codegen_place(fx, source_place).to_cvalue(fx);
+        dest.write_cvalue(fx, source);
+        return;
+    };
+
+    if source_def.did() == target_def.did() {
+        let source = codegen_place(fx, source_place).to_cvalue(fx);
+        dest.write_cvalue(fx, source);
+        return;
+    }
+
+    let field_pairs = match reborrow::coerce_shared_field_pairs(
+        fx.tcx,
+        *source_def,
+        *source_args,
+        *target_def,
+        *target_args,
+    ) {
+        Ok(field_pairs) => field_pairs,
+        Err(CoerceSharedFieldPairError::FieldStyleMismatch) => {
+            bug!("generic shared reborrow has mismatched field styles");
+        }
+        Err(CoerceSharedFieldPairError::MissingSourceField { .. }) => {
+            bug!("generic shared reborrow is missing a source field");
+        }
+    };
+
+    for field_pair in field_pairs {
+        let source_field_ty = fx.monomorphize(field_pair.source.ty);
+        let target_field_ty = fx.monomorphize(field_pair.target.ty);
+        let source_field_place = source_place
+            .project_deeper(&[PlaceElem::Field(field_pair.source.index, source_field_ty)], fx.tcx);
+        let field_dest = dest.place_field(fx, field_pair.target.index);
+        codegen_reborrow_into(fx, target_field_ty, source_field_place, field_dest);
+    }
+
+    crate::discriminant::codegen_set_discriminant(fx, dest, FIRST_VARIANT);
 }
 
 fn codegen_array_len<'tcx>(fx: &mut FunctionCx<'_, '_, 'tcx>, place: CPlace<'tcx>) -> Value {

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools as _;
-use rustc_abi::{self as abi, BackendRepr, FIRST_VARIANT};
+use rustc_abi::{self as abi, BackendRepr, FIRST_VARIANT, FieldIdx};
 use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::layout::{HasTyCtxt, HasTypingEnv, LayoutOf, TyAndLayout};
+use rustc_middle::ty::reborrow::{self, CoerceSharedFieldPairError};
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_session::config::OptLevel;
@@ -195,11 +196,125 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 dest.codegen_set_discr(bx, variant_index);
             }
 
+            mir::Rvalue::Reborrow(target_ty, _, place) => {
+                self.codegen_reborrow_into(bx, target_ty, place, dest);
+            }
+
             _ => {
                 let temp = self.codegen_rvalue_operand(bx, rvalue);
                 temp.store_with_annotation(bx, dest);
             }
         }
+    }
+
+    fn codegen_reborrow_into(
+        &mut self,
+        bx: &mut Bx,
+        target_ty: Ty<'tcx>,
+        source_place: mir::Place<'tcx>,
+        dest: PlaceRef<'tcx, Bx::Value>,
+    ) {
+        let source_ty = source_place.ty(self.mir, bx.tcx()).ty;
+        let Some(fields) = self.reborrow_field_pairs(source_place, source_ty, target_ty) else {
+            let op = self.codegen_reborrow_operand(bx, target_ty, source_place);
+            op.store_with_annotation(bx, dest);
+            return;
+        };
+
+        let variant_dest = dest.project_downcast(bx, FIRST_VARIANT);
+        for (target_field, target_field_ty, source_field_place) in fields {
+            let target_field_dest = variant_dest.project_field(bx, target_field.as_usize());
+            self.codegen_reborrow_into(bx, target_field_ty, source_field_place, target_field_dest);
+        }
+        dest.codegen_set_discr(bx, FIRST_VARIANT);
+    }
+
+    fn codegen_reborrow_operand(
+        &mut self,
+        bx: &mut Bx,
+        target_ty: Ty<'tcx>,
+        source_place: mir::Place<'tcx>,
+    ) -> OperandRef<'tcx, Bx::Value> {
+        let target_ty = self.monomorphize(target_ty);
+        let target_layout = self.cx.layout_of(target_ty);
+        if target_layout.is_zst() {
+            return OperandRef {
+                val: OperandValue::ZeroSized,
+                layout: target_layout,
+                move_annotation: None,
+            };
+        }
+
+        let source_ty = source_place.ty(self.mir, bx.tcx()).ty;
+        let Some(fields) = self.reborrow_field_pairs(source_place, source_ty, target_ty) else {
+            let source = self.codegen_operand(bx, &mir::Operand::Copy(source_place));
+            return OperandRef { val: source.val, layout: target_layout, move_annotation: None };
+        };
+
+        if let BackendRepr::Memory { .. } = target_layout.backend_repr {
+            let scratch = PlaceRef::alloca(bx, target_layout);
+            self.codegen_reborrow_into(bx, target_ty, source_place, scratch);
+            return OperandRef {
+                val: OperandValue::Ref(scratch.val),
+                layout: target_layout,
+                move_annotation: None,
+            };
+        }
+
+        let mut builder = OperandRefBuilder::new(target_layout);
+        for (target_field, target_field_ty, source_field_place) in fields {
+            let op = self.codegen_reborrow_operand(bx, target_field_ty, source_field_place);
+            builder.insert_field(bx, FIRST_VARIANT, target_field, op);
+        }
+        builder.build(bx.cx())
+    }
+
+    fn reborrow_field_pairs(
+        &self,
+        source_place: mir::Place<'tcx>,
+        source_ty: Ty<'tcx>,
+        target_ty: Ty<'tcx>,
+    ) -> Option<Vec<(FieldIdx, Ty<'tcx>, mir::Place<'tcx>)>> {
+        let source_ty = self.monomorphize(source_ty);
+        let target_ty = self.monomorphize(target_ty);
+        let (ty::Adt(source_def, source_args), ty::Adt(target_def, target_args)) =
+            (source_ty.kind(), target_ty.kind())
+        else {
+            return None;
+        };
+        if source_def.did() == target_def.did() {
+            return None;
+        }
+
+        let tcx = self.cx.tcx();
+        let field_pairs = match reborrow::coerce_shared_field_pairs(
+            tcx,
+            *source_def,
+            *source_args,
+            *target_def,
+            *target_args,
+        ) {
+            Ok(field_pairs) => field_pairs,
+            Err(CoerceSharedFieldPairError::FieldStyleMismatch) => {
+                bug!("generic shared reborrow has mismatched field styles");
+            }
+            Err(CoerceSharedFieldPairError::MissingSourceField { .. }) => {
+                bug!("generic shared reborrow is missing a source field");
+            }
+        };
+
+        let mut fields = Vec::new();
+        for field_pair in field_pairs {
+            let source_field_ty = self.monomorphize(field_pair.source.ty);
+            let target_field_ty = self.monomorphize(field_pair.target.ty);
+            let source_field_place = source_place.project_deeper(
+                &[mir::ProjectionElem::Field(field_pair.source.index, source_field_ty)],
+                tcx,
+            );
+            fields.push((field_pair.target.index, target_field_ty, source_field_place));
+        }
+
+        Some(fields)
     }
 
     /// Transmutes the `src` value to the destination type by writing it to `dst`.
@@ -525,12 +640,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 self.codegen_place_to_pointer(bx, place, mk_ref)
             }
 
-            // Note: Exclusive reborrowing is always equal to a memcpy, as the types do not change.
-            // Generic shared reborrowing is not (necessarily) a simple memcpy, but currently the
-            // coherence check places such restrictions on the CoerceShared trait as to guarantee
-            // that it is.
-            mir::Rvalue::Reborrow(_, _, place) => {
-                self.codegen_operand(bx, &mir::Operand::Copy(place))
+            mir::Rvalue::Reborrow(target_ty, _, place) => {
+                self.codegen_reborrow_operand(bx, target_ty, place)
             }
 
             mir::Rvalue::RawPtr(kind, place) => {

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -7,7 +7,9 @@ use std::iter;
 use either::Either;
 use rustc_abi::{FIRST_VARIANT, FieldIdx};
 use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::Mutability;
 use rustc_index::IndexSlice;
+use rustc_middle::ty::reborrow::{self, CoerceSharedFieldPairError};
 use rustc_middle::ty::{self, Instance, Ty};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_span::Spanned;
@@ -206,39 +208,16 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
 
             Ref(_, borrow_kind, place) => {
-                let src = self.eval_place(place)?;
-                let place = self.force_allocation(&src)?;
-                let mut val = ImmTy::from_immediate(place.to_ref(self), dest.layout);
-                // A fresh reference was created, make sure it gets retagged with the right mode.
                 let mode = if borrow_kind.is_two_phase_borrow() {
                     RetagMode::TwoPhase
                 } else {
                     RetagMode::Default
                 };
-                M::with_retag_mode(self, mode, |ecx| {
-                    // If validation is disabled, we still want to do this retag. This is because
-                    // const-eval disables validation for performance reasons but wants to retag
-                    // shared references. So we add a bit of a hack here to do the retag manually
-                    // if the write would not incur validation.
-                    if !M::enforce_validity(ecx, val.layout) {
-                        if let Some(new_val) = M::retag_ptr_value(ecx, &val, val.layout.ty)? {
-                            val = new_val;
-                        }
-                    }
-                    // Now do the actual write.
-                    ecx.write_immediate(*val, &dest)
-                })?;
+                self.write_ref_to_place(place, &dest, mode)?;
             }
 
-            Reborrow(_, mutability, place) => {
-                let op = self.eval_place_to_op(place, None)?;
-                if mutability.is_not() {
-                    // Shared generic reborrows use `CoerceShared`: a bitwise copy into a
-                    // distinct same-layout target ADT.
-                    self.copy_op_allow_transmute(&op, &dest)?;
-                } else {
-                    self.copy_op(&op, &dest)?;
-                }
+            Reborrow(target_ty, _, place) => {
+                self.eval_reborrow_into_place(target_ty, place, &dest)?;
             }
 
             RawPtr(kind, place) => {
@@ -289,6 +268,125 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         trace!("{:?}", self.dump_place(&dest));
 
+        interp_ok(())
+    }
+
+    fn write_ref_to_place(
+        &mut self,
+        source_place: mir::Place<'tcx>,
+        dest: &PlaceTy<'tcx, M::Provenance>,
+        mode: RetagMode,
+    ) -> InterpResult<'tcx> {
+        let src = self.eval_place(source_place)?;
+        let place = self.force_allocation(&src)?;
+        let mut val = ImmTy::from_immediate(place.to_ref(self), dest.layout);
+        // A fresh reference was created, make sure it gets retagged with the right mode.
+        M::with_retag_mode(self, mode, |ecx| {
+            // If validation is disabled, we still want to do this retag. This is because
+            // const-eval disables validation for performance reasons but wants to retag
+            // shared references. So we add a bit of a hack here to do the retag manually
+            // if the write would not incur validation.
+            if !M::enforce_validity(ecx, val.layout) {
+                if let Some(new_val) = M::retag_ptr_value(ecx, &val, val.layout.ty)? {
+                    val = new_val;
+                }
+            }
+            // Now do the actual write.
+            ecx.write_immediate(*val, dest)
+        })
+    }
+
+    fn eval_reborrow_into_place(
+        &mut self,
+        target_ty: Ty<'tcx>,
+        source_place: mir::Place<'tcx>,
+        dest: &PlaceTy<'tcx, M::Provenance>,
+    ) -> InterpResult<'tcx> {
+        let tcx = *self.tcx;
+        let source_ty = self.instantiate_from_current_frame_and_normalize_erasing_regions(
+            source_place.ty(self.body(), tcx).ty,
+        )?;
+        let target_ty =
+            self.instantiate_from_current_frame_and_normalize_erasing_regions(target_ty)?;
+        let (ty::Adt(source_def, source_args), ty::Adt(target_def, target_args)) =
+            (source_ty.kind(), target_ty.kind())
+        else {
+            let is_mut_to_shared_ref = if let (
+                ty::Ref(_, source_pointee, Mutability::Mut),
+                ty::Ref(_, target_pointee, Mutability::Not),
+            ) = (source_ty.kind(), target_ty.kind())
+            {
+                util::relate_types(
+                    tcx,
+                    self.typing_env,
+                    ty::Variance::Covariant,
+                    *source_pointee,
+                    *target_pointee,
+                )
+            } else {
+                false
+            };
+            if is_mut_to_shared_ref {
+                // Leaf `&mut T` to `&T` CoerceShared creates a fresh shared reborrow of the
+                // referent. It must not copy the `&mut T` value into an `&T` destination, because
+                // that would bypass reference retagging and validity checks.
+                let deref_source = source_place.project_deeper(&[mir::ProjectionElem::Deref], tcx);
+                self.write_ref_to_place(deref_source, dest, RetagMode::Default)?;
+                return interp_ok(());
+            }
+
+            let op = self.eval_place_to_op(source_place, Some(dest.layout))?;
+            self.copy_op(&op, dest)?;
+            return interp_ok(());
+        };
+
+        if source_def.did() == target_def.did() {
+            let op = self.eval_place_to_op(source_place, Some(dest.layout))?;
+            self.copy_op(&op, dest)?;
+            return interp_ok(());
+        }
+
+        let field_pairs = match reborrow::coerce_shared_field_pairs(
+            tcx,
+            *source_def,
+            *source_args,
+            *target_def,
+            *target_args,
+        ) {
+            Ok(field_pairs) => field_pairs,
+            Err(CoerceSharedFieldPairError::FieldStyleMismatch) => {
+                bug!("generic shared reborrow has mismatched field styles");
+            }
+            Err(CoerceSharedFieldPairError::MissingSourceField { .. }) => {
+                bug!("generic shared reborrow is missing a source field");
+            }
+        };
+
+        for field_pair in field_pairs {
+            let source_field_ty = self
+                .instantiate_from_current_frame_and_normalize_erasing_regions(
+                    field_pair.source.ty,
+                )?;
+            let target_field_ty = self
+                .instantiate_from_current_frame_and_normalize_erasing_regions(
+                    field_pair.target.ty,
+                )?;
+            let source_field_place = source_place.project_deeper(
+                &[mir::ProjectionElem::Field(field_pair.source.index, source_field_ty)],
+                tcx,
+            );
+            let field_dest = self.project_field(dest, field_pair.target.index)?;
+            self.eval_reborrow_into_place(target_field_ty, source_field_place, &field_dest)?;
+        }
+
+        self.write_discriminant(FIRST_VARIANT, dest)?;
+        if M::enforce_validity(self, dest.layout()) {
+            self.validate_operand(
+                dest,
+                M::enforce_validity_recursively(self, dest.layout()),
+                /*reset_provenance_and_padding*/ true,
+            )?;
+        }
         interp_ok(())
     }
 

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -569,7 +569,7 @@ pub(crate) fn reborrow_info<'tcx>(
         }
 
         // Field does not implement Reborrow: it must be Copy.
-        assert_field_type_is_copy(tcx, &infcx, impl_did, param_env, field.ty, field.span)?;
+        assert_field_type_is_copy(tcx, impl_did, param_env, field.ty, field.span)?;
     }
 
     Ok(())
@@ -672,7 +672,6 @@ pub(crate) fn coerce_shared_info<'tcx>(
 
             validate_coerce_shared_fields(
                 tcx,
-                &infcx,
                 impl_did,
                 param_env,
                 coerce_shared_trait,
@@ -730,7 +729,6 @@ fn validate_reborrow_field_access(
 
 fn validate_coerce_shared_fields<'tcx>(
     tcx: TyCtxt<'tcx>,
-    infcx: &InferCtxt<'tcx>,
     impl_did: LocalDefId,
     param_env: ty::ParamEnv<'tcx>,
     coerce_shared_trait: DefId,
@@ -764,7 +762,6 @@ fn validate_coerce_shared_fields<'tcx>(
     for field_pair in field_pairs {
         validate_coerce_shared_field(
             tcx,
-            infcx,
             impl_did,
             param_env,
             coerce_shared_trait,
@@ -780,7 +777,6 @@ fn validate_coerce_shared_fields<'tcx>(
 
 fn validate_coerce_shared_field<'tcx>(
     tcx: TyCtxt<'tcx>,
-    infcx: &InferCtxt<'tcx>,
     impl_did: LocalDefId,
     param_env: ty::ParamEnv<'tcx>,
     coerce_shared_trait: DefId,
@@ -789,26 +785,37 @@ fn validate_coerce_shared_field<'tcx>(
     source: ReborrowField<'tcx>,
     target: ReborrowField<'tcx>,
 ) -> Result<(), ErrorGuaranteed> {
-    if source.ty.ref_mutability() == Some(ty::Mutability::Mut)
-        && target.ty.ref_mutability() == Some(ty::Mutability::Not)
-        && infcx
-            .eq_structurally_relating_aliases(
-                param_env,
-                source.ty.peel_refs(),
-                target.ty.peel_refs(),
-                source.span,
-            )
-            .is_ok()
-    {
+    if matches!(
+        (source.ty.kind(), target.ty.kind()),
+        (&ty::Ref(_, _, ty::Mutability::Mut), &ty::Ref(_, _, ty::Mutability::Not))
+            | (&ty::Alias(..), _)
+            | (_, &ty::Alias(..))
+    ) && field_tys_satisfy_relation_after_normalization_and_resolution(
+        tcx,
+        impl_did,
+        param_env,
+        source.ty,
+        target.ty,
+        source.span,
+        FieldRelation::MutRefToSharedRef,
+    ) {
         return Ok(());
     }
 
-    if infcx.eq_structurally_relating_aliases(param_env, source.ty, target.ty, source.span).is_ok()
-    {
-        return assert_field_type_is_copy(tcx, infcx, impl_did, param_env, source.ty, source.span);
+    if field_tys_satisfy_relation_after_normalization_and_resolution(
+        tcx,
+        impl_did,
+        param_env,
+        source.ty,
+        target.ty,
+        source.span,
+        FieldRelation::Equal,
+    ) {
+        return assert_field_type_is_copy(tcx, impl_did, param_env, source.ty, source.span);
     }
 
-    let ocx = ObligationCtxt::new_with_diagnostics(infcx);
+    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let ocx = ObligationCtxt::new_with_diagnostics(&infcx);
     let cause = traits::ObligationCause::misc(span, impl_did);
     ocx.register_obligation(Obligation::new(
         tcx,
@@ -833,16 +840,84 @@ fn validate_coerce_shared_field<'tcx>(
     ocx.resolve_regions_and_report_errors(impl_did, param_env, [])
 }
 
+enum FieldRelation {
+    Equal,
+    MutRefToSharedRef,
+}
+
+fn field_tys_satisfy_relation_after_normalization_and_resolution<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    impl_did: LocalDefId,
+    param_env: ty::ParamEnv<'tcx>,
+    source_ty: Ty<'tcx>,
+    target_ty: Ty<'tcx>,
+    span: Span,
+    relation: FieldRelation,
+) -> bool {
+    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
+    let cause = traits::ObligationCause::misc(span, impl_did);
+    let ocx = ObligationCtxt::new(&infcx);
+
+    let Ok(source_ty) =
+        ocx.structurally_normalize_ty(&cause, param_env, Unnormalized::new_wip(source_ty))
+    else {
+        return false;
+    };
+    let Ok(target_ty) =
+        ocx.structurally_normalize_ty(&cause, param_env, Unnormalized::new_wip(target_ty))
+    else {
+        return false;
+    };
+
+    if !ocx.evaluate_obligations_error_on_ambiguity().is_empty() {
+        return false;
+    }
+
+    let (source_ty, target_ty) = match relation {
+        FieldRelation::Equal => (source_ty, target_ty),
+        FieldRelation::MutRefToSharedRef => {
+            let (
+                &ty::Ref(source_region, source_referent_ty, ty::Mutability::Mut),
+                &ty::Ref(target_region, target_referent_ty, ty::Mutability::Not),
+            ) = (source_ty.kind(), target_ty.kind())
+            else {
+                return false;
+            };
+            infcx.sub_regions(
+                SubregionOrigin::RelateObjectBound(span),
+                target_region,
+                source_region,
+                ty::VisibleForLeakCheck::Yes,
+            );
+            (source_referent_ty, target_referent_ty)
+        }
+    };
+
+    let Ok(goals) = infcx.eq_structurally_relating_aliases(param_env, source_ty, target_ty, span)
+    else {
+        return false;
+    };
+
+    ocx.register_obligations(
+        goals
+            .into_iter()
+            .map(|goal| Obligation::new(tcx, cause.clone(), goal.param_env, goal.predicate)),
+    );
+
+    ocx.evaluate_obligations_error_on_ambiguity().is_empty()
+        && ocx.resolve_regions(impl_did, param_env, []).is_empty()
+}
+
 fn assert_field_type_is_copy<'tcx>(
     tcx: TyCtxt<'tcx>,
-    infcx: &InferCtxt<'tcx>,
     impl_did: LocalDefId,
     param_env: ty::ParamEnv<'tcx>,
     ty: Ty<'tcx>,
     span: Span,
 ) -> Result<(), ErrorGuaranteed> {
+    let infcx = tcx.infer_ctxt().build(TypingMode::non_body_analysis());
     let copy_trait = tcx.require_lang_item(LangItem::Copy, span);
-    let ocx = ObligationCtxt::new_with_diagnostics(infcx);
+    let ocx = ObligationCtxt::new_with_diagnostics(&infcx);
     let cause = traits::ObligationCause::misc(span, impl_did);
     let obligation =
         Obligation::new(tcx, cause, param_env, ty::TraitRef::new(tcx, copy_trait, [ty]));
@@ -852,7 +927,7 @@ fn assert_field_type_is_copy<'tcx>(
     if !errors.is_empty() {
         Err(infcx.err_ctxt().report_fulfillment_errors(errors))
     } else {
-        Ok(())
+        ocx.resolve_regions_and_report_errors(impl_did, param_env, [])
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -13,6 +13,7 @@ use rustc_infer::infer::{self, InferCtxt, RegionResolutionError, SubregionOrigin
 use rustc_infer::traits::{Obligation, PredicateObligations};
 use rustc_middle::ty::adjustment::CoerceUnsizedInfo;
 use rustc_middle::ty::print::PrintTraitRefExt as _;
+use rustc_middle::ty::reborrow::{self, CoerceSharedFieldPairError, ReborrowField};
 use rustc_middle::ty::relate::solver_relating::RelateExt;
 use rustc_middle::ty::{
     self, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized, suggest_constraining_type_params,
@@ -533,7 +534,7 @@ pub(crate) fn reborrow_info<'tcx>(
     };
 
     let lifetimes_count = generic_lifetime_params_count(args);
-    let data_fields = collect_struct_data_fields(tcx, def, args);
+    let data_fields = reborrow::reborrow_data_fields(tcx, def, args);
 
     if lifetimes_count != 1 {
         let item = tcx.hir_expect_item(impl_did);
@@ -551,15 +552,15 @@ pub(crate) fn reborrow_info<'tcx>(
     }
 
     // We've found some data fields. They must all be either be Copy or Reborrow.
-    for (field, span) in data_fields {
+    for field in data_fields {
         if assert_field_type_is_reborrow(
             tcx,
             &infcx,
             reborrow_trait,
             impl_did,
             param_env,
-            field,
-            span,
+            field.ty,
+            field.span,
         )
         .is_ok()
         {
@@ -568,7 +569,7 @@ pub(crate) fn reborrow_info<'tcx>(
         }
 
         // Field does not implement Reborrow: it must be Copy.
-        assert_field_type_is_copy(tcx, &infcx, impl_did, param_env, field, span)?;
+        assert_field_type_is_copy(tcx, &infcx, impl_did, param_env, field.ty, field.span)?;
     }
 
     Ok(())
@@ -631,26 +632,14 @@ pub(crate) fn coerce_shared_info<'tcx>(
     let param_env = tcx.param_env(impl_did);
     assert!(!source.has_escaping_bound_vars());
 
-    let data = match (source.kind(), target.kind()) {
+    match (source.kind(), target.kind()) {
         (&ty::Adt(def_a, args_a), &ty::Adt(def_b, args_b))
             if def_a.is_struct() && def_b.is_struct() =>
         {
-            // Check that both A and B have exactly one lifetime argument, and that they have the
-            // same number of data fields that is not more than 1. The eventual intention is to
-            // support multiple lifetime arguments (with the reborrowed lifetimes inferred from
-            // usage one way or another) and multiple data fields with B allowed to leave out fields
-            // from A. The current state is just the simplest choice.
-            let a_lifetimes_count = generic_lifetime_params_count(args_a);
-            let a_data_fields = collect_struct_data_fields(tcx, def_a, args_a);
-            let b_lifetimes_count = generic_lifetime_params_count(args_b);
-            let b_data_fields = collect_struct_data_fields(tcx, def_b, args_b);
+            let a_lifetime = reborrow::single_lifetime_arg(args_a);
+            let b_lifetime = reborrow::single_lifetime_arg(args_b);
 
-            if a_lifetimes_count != 1
-                || b_lifetimes_count != 1
-                || a_data_fields.len() > 1
-                || b_data_fields.len() > 1
-                || a_data_fields.len() != b_data_fields.len()
-            {
+            if a_lifetime.is_none() || b_lifetime.is_none() {
                 let item = tcx.hir_expect_item(impl_did);
                 let span = if let ItemKind::Impl(hir::Impl { of_trait: Some(of_trait), .. }) =
                     &item.kind
@@ -663,77 +652,44 @@ pub(crate) fn coerce_shared_info<'tcx>(
                 return Err(tcx.dcx().emit_err(errors::CoerceSharedMulti { span, trait_name }));
             }
 
-            if a_data_fields.len() == 1 {
-                // We found one data field for both: we'll attempt to perform CoerceShared between
-                // them below.
-                let (a, span_a) = a_data_fields[0];
-                let (b, span_b) = b_data_fields[0];
+            if a_lifetime != b_lifetime {
+                let item = tcx.hir_expect_item(impl_did);
+                let span = if let ItemKind::Impl(hir::Impl { of_trait: Some(of_trait), .. }) =
+                    &item.kind
+                {
+                    of_trait.trait_ref.path.span
+                } else {
+                    tcx.def_span(impl_did)
+                };
 
-                Some((a, b, coerce_shared_trait, span_a, span_b))
-            } else {
-                // We found no data fields in either: this is a reborrowable marker type being
-                // coerced into a shared marker. That is fine too.
-                None
+                return Err(tcx
+                    .dcx()
+                    .emit_err(errors::CoerceSharedLifetimeMismatch { span, trait_name }));
             }
+
+            validate_reborrow_field_access(tcx, impl_did, def_a, trait_name, span)?;
+            validate_reborrow_field_access(tcx, impl_did, def_b, trait_name, span)?;
+
+            validate_coerce_shared_fields(
+                tcx,
+                &infcx,
+                impl_did,
+                param_env,
+                coerce_shared_trait,
+                trait_name,
+                span,
+                def_a,
+                args_a,
+                def_b,
+                args_b,
+            )
         }
 
         _ => {
             // Note: reusing CoerceUnsizedNonStruct error as it takes trait_name as argument.
-            return Err(tcx.dcx().emit_err(errors::CoerceUnsizedNonStruct { span, trait_name }));
-        }
-    };
-
-    // We've proven that we have two types with one lifetime each and 0 or 1 data fields each.
-    if let Some((source, target, trait_def_id, source_field_span, _target_field_span)) = data {
-        // struct Source(SourceData);
-        // struct Target(TargetData);
-        //
-        // 1 data field each; they must be the same type and Copy, or relate to one another using
-        // CoerceShared.
-        if source.ref_mutability() == Some(ty::Mutability::Mut)
-            && target.ref_mutability() == Some(ty::Mutability::Not)
-            && infcx
-                .eq_structurally_relating_aliases(
-                    param_env,
-                    source.peel_refs(),
-                    target.peel_refs(),
-                    source_field_span,
-                )
-                .is_ok()
-        {
-            // &mut T implements CoerceShared to &T, except not really.
-            return Ok(());
-        }
-        if infcx
-            .eq_structurally_relating_aliases(param_env, source, target, source_field_span)
-            .is_err()
-        {
-            // The two data fields don't agree on a common type; this means
-            // that they must be `A: CoerceShared<B>`. Register an obligation
-            // for that.
-            let ocx = ObligationCtxt::new_with_diagnostics(&infcx);
-            let cause = traits::ObligationCause::misc(span, impl_did);
-            let obligation = Obligation::new(
-                tcx,
-                cause,
-                param_env,
-                ty::TraitRef::new(tcx, trait_def_id, [source, target]),
-            );
-            ocx.register_obligation(obligation);
-            let errors = ocx.evaluate_obligations_error_on_ambiguity();
-
-            if !errors.is_empty() {
-                return Err(infcx.err_ctxt().report_fulfillment_errors(errors));
-            }
-            // Finally, resolve all regions.
-            ocx.resolve_regions_and_report_errors(impl_did, param_env, [])?;
-        } else {
-            // Types match: check that it is Copy.
-            assert_field_type_is_copy(tcx, &infcx, impl_did, param_env, source, source_field_span)?;
+            Err(tcx.dcx().emit_err(errors::CoerceUnsizedNonStruct { span, trait_name }))
         }
     }
-
-    Ok(())
 }
 
 fn trait_impl_lifetime_params_count(tcx: TyCtxt<'_>, did: LocalDefId) -> usize {
@@ -748,24 +704,133 @@ fn generic_lifetime_params_count(args: &[ty::GenericArg<'_>]) -> usize {
     args.iter().filter(|arg| arg.as_region().is_some()).count()
 }
 
-// FIXME(#155345): This should return `Unnormalized`
-fn collect_struct_data_fields<'tcx>(
+fn validate_reborrow_field_access(
+    tcx: TyCtxt<'_>,
+    impl_did: LocalDefId,
+    def: ty::AdtDef<'_>,
+    trait_name: &'static str,
+    span: Span,
+) -> Result<(), ErrorGuaranteed> {
+    let module = tcx.parent_module_from_def_id(impl_did);
+    let variant = def.non_enum_variant();
+    if variant.field_list_has_applicable_non_exhaustive() {
+        return Err(tcx.dcx().emit_err(errors::CoerceSharedInaccessibleField { span, trait_name }));
+    }
+
+    for field in &variant.fields {
+        if !field.vis.is_accessible_from(module, tcx) {
+            return Err(tcx
+                .dcx()
+                .emit_err(errors::CoerceSharedInaccessibleField { span, trait_name }));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_coerce_shared_fields<'tcx>(
     tcx: TyCtxt<'tcx>,
-    def: ty::AdtDef<'tcx>,
-    args: ty::GenericArgsRef<'tcx>,
-) -> Vec<(Ty<'tcx>, Span)> {
-    def.non_enum_variant()
-        .fields
-        .iter()
-        .filter_map(|f| {
-            // Ignore PhantomData fields
-            let ty = f.ty(tcx, args).skip_norm_wip();
-            if ty.is_phantom_data() {
-                return None;
-            }
-            Some((ty, tcx.def_span(f.did)))
-        })
-        .collect()
+    infcx: &InferCtxt<'tcx>,
+    impl_did: LocalDefId,
+    param_env: ty::ParamEnv<'tcx>,
+    coerce_shared_trait: DefId,
+    trait_name: &'static str,
+    span: Span,
+    source_def: ty::AdtDef<'tcx>,
+    source_args: ty::GenericArgsRef<'tcx>,
+    target_def: ty::AdtDef<'tcx>,
+    target_args: ty::GenericArgsRef<'tcx>,
+) -> Result<(), ErrorGuaranteed> {
+    let field_pairs = match reborrow::coerce_shared_field_pairs(
+        tcx,
+        source_def,
+        source_args,
+        target_def,
+        target_args,
+    ) {
+        Ok(field_pairs) => field_pairs,
+        Err(CoerceSharedFieldPairError::FieldStyleMismatch) => {
+            return Err(tcx
+                .dcx()
+                .emit_err(errors::CoerceSharedFieldStyleMismatch { span, trait_name }));
+        }
+        Err(CoerceSharedFieldPairError::MissingSourceField { target }) => {
+            return Err(tcx
+                .dcx()
+                .emit_err(errors::CoerceSharedMissingField { span: target.span, trait_name }));
+        }
+    };
+
+    for field_pair in field_pairs {
+        validate_coerce_shared_field(
+            tcx,
+            infcx,
+            impl_did,
+            param_env,
+            coerce_shared_trait,
+            trait_name,
+            span,
+            field_pair.source,
+            field_pair.target,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_coerce_shared_field<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    infcx: &InferCtxt<'tcx>,
+    impl_did: LocalDefId,
+    param_env: ty::ParamEnv<'tcx>,
+    coerce_shared_trait: DefId,
+    trait_name: &'static str,
+    span: Span,
+    source: ReborrowField<'tcx>,
+    target: ReborrowField<'tcx>,
+) -> Result<(), ErrorGuaranteed> {
+    if source.ty.ref_mutability() == Some(ty::Mutability::Mut)
+        && target.ty.ref_mutability() == Some(ty::Mutability::Not)
+        && infcx
+            .eq_structurally_relating_aliases(
+                param_env,
+                source.ty.peel_refs(),
+                target.ty.peel_refs(),
+                source.span,
+            )
+            .is_ok()
+    {
+        return Ok(());
+    }
+
+    if infcx.eq_structurally_relating_aliases(param_env, source.ty, target.ty, source.span).is_ok()
+    {
+        return assert_field_type_is_copy(tcx, infcx, impl_did, param_env, source.ty, source.span);
+    }
+
+    let ocx = ObligationCtxt::new_with_diagnostics(infcx);
+    let cause = traits::ObligationCause::misc(span, impl_did);
+    ocx.register_obligation(Obligation::new(
+        tcx,
+        cause,
+        param_env,
+        ty::TraitRef::new(tcx, coerce_shared_trait, [source.ty, target.ty]),
+    ));
+    let errors = ocx.evaluate_obligations_error_on_ambiguity();
+
+    if !errors.is_empty() {
+        return Err(tcx.dcx().emit_err(errors::CoerceSharedFieldMismatch {
+            span: target.span,
+            source_span: source.span,
+            source_name: source.name,
+            source_ty: source.ty,
+            target_name: target.name,
+            target_ty: target.ty,
+            trait_name,
+        }));
+    }
+
+    ocx.resolve_regions_and_report_errors(impl_did, param_env, [])
 }
 
 fn assert_field_type_is_copy<'tcx>(

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1371,8 +1371,70 @@ pub(crate) struct CoerceSharedNotSingleLifetimeParam {
 }
 
 #[derive(Diagnostic)]
-#[diag("implementing `{$trait_name}` does not allow multiple lifetimes or fields to be coerced")]
+#[diag(
+    "implementing `{$trait_name}` requires exactly one lifetime argument in the reborrowed type"
+)]
 pub(crate) struct CoerceSharedMulti {
+    #[primary_span]
+    pub span: Span,
+    pub trait_name: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "implementing `{$trait_name}` requires source and target to use the same reborrow lifetime \
+     argument"
+)]
+pub(crate) struct CoerceSharedLifetimeMismatch {
+    #[primary_span]
+    pub span: Span,
+    pub trait_name: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "implementing `{$trait_name}` requires corresponding fields to match, \
+     be reborrowable with `CoerceShared`, or coerce a mutable reference field \
+     to a shared reference field"
+)]
+pub(crate) struct CoerceSharedFieldMismatch<'tcx> {
+    #[primary_span]
+    #[label("target field `{$target_name}` has type `{$target_ty}`")]
+    pub span: Span,
+    #[label("source field `{$source_name}` has type `{$source_ty}`")]
+    pub source_span: Span,
+    pub source_name: Symbol,
+    pub source_ty: Ty<'tcx>,
+    pub target_name: Symbol,
+    pub target_ty: Ty<'tcx>,
+    pub trait_name: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "implementing `{$trait_name}` requires every target field to have a corresponding source field"
+)]
+pub(crate) struct CoerceSharedMissingField {
+    #[primary_span]
+    pub span: Span,
+    pub trait_name: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "implementing `{$trait_name}` requires source and target structs to use the same field style"
+)]
+pub(crate) struct CoerceSharedFieldStyleMismatch {
+    #[primary_span]
+    pub span: Span,
+    pub trait_name: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    "implementing `{$trait_name}` requires all source and target fields to be accessible from the impl"
+)]
+pub(crate) struct CoerceSharedInaccessibleField {
     #[primary_span]
     pub span: Span,
     pub trait_name: &'static str,

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -54,7 +54,7 @@ use rustc_middle::ty::adjustment::{
     PointerCoercion,
 };
 use rustc_middle::ty::error::TypeError;
-use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, Unnormalized, reborrow};
 use rustc_span::{BytePos, DUMMY_SP, Span};
 use rustc_trait_selection::infer::InferCtxtExt as _;
 use rustc_trait_selection::solve::inspect::{self, InferCtxtProofTreeExt, ProofTreeVisitor};
@@ -963,7 +963,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         Ok(coerce)
     }
 
-    /// Applies generic exclusive reborrowing on type implementing `Reborrow`.
+    /// Applies generic shared reborrowing on types implementing `CoerceShared`.
     #[instrument(skip(self), level = "trace")]
     fn coerce_reborrow(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> CoerceResult<'tcx> {
         debug_assert!(self.shallow_resolve(a) == a);
@@ -1005,6 +1005,11 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         let Some(coerce_shared_trait_did) = self.tcx.lang_items().coerce_shared() else {
             return Err(TypeError::Mismatch);
         };
+        // This is only a shape guard for producing well-formed MIR adjustments. The field-type
+        // relation remains owned by the `CoerceShared` obligation and builtin impl validation.
+        if !self.coerce_shared_reborrow_structurally_well_formed(a, b) {
+            return Err(TypeError::Mismatch);
+        }
         let coerce_shared_trait_ref = ty::TraitRef::new(self.tcx, coerce_shared_trait_did, [a, b]);
         let obligation = traits::Obligation::new(
             self.tcx,
@@ -1029,6 +1034,22 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         } else {
             Err(TypeError::Mismatch)
         }
+    }
+
+    fn coerce_shared_reborrow_structurally_well_formed(&self, a: Ty<'tcx>, b: Ty<'tcx>) -> bool {
+        let (ty::Adt(a_def, a_args), ty::Adt(b_def, b_args)) = (a.kind(), b.kind()) else {
+            return false;
+        };
+        if !a_def.is_struct() || !b_def.is_struct() {
+            return false;
+        }
+        if reborrow::single_lifetime_arg(a_args).is_none()
+            || reborrow::single_lifetime_arg(b_args).is_none()
+        {
+            return false;
+        }
+
+        reborrow::coerce_shared_field_pairs(self.tcx, *a_def, *a_args, *b_def, *b_args).is_ok()
     }
 
     fn coerce_from_fn_pointer(

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1462,19 +1462,19 @@ pub enum Rvalue<'tcx> {
     /// Wraps a value in an unsafe binder.
     WrapUnsafeBinder(Operand<'tcx>, Ty<'tcx>),
 
-    /// Creates a bitwise copy of the indicated place with the same type (if Mut) or its
-    /// CoerceShared target type (if Not). The type is known to be an ADT with exactly one lifetime
-    /// parameter, and it is known to implement the Reborrow trait (for Mut), and the CoerceShared
-    /// trait (only if Not). The CoerceShared target type is known to also have exactly one lifetime
-    /// parameter, implement Copy and (currently) have the same memory layout as the source type.
+    /// Creates a copy of the indicated place with the same type (if Mut) or its CoerceShared
+    /// target type (if Not). The type is known to be an ADT with exactly one lifetime parameter,
+    /// and it is known to implement the Reborrow trait (for Mut), and the CoerceShared trait
+    /// (only if Not). The CoerceShared target type is known to also have exactly one lifetime
+    /// parameter and implement Copy.
     ///
     /// The borrow checker uses the single lifetime in the source and target types to create a
     /// Covariant outlives-bound between the source and target with the Mutability of the Reborrow.
     /// This makes accessing the source value for writes (and reads if Mut) for the lifetime of the
     /// target value a borrow check error, imitating `&mut T` and `&T`'s reborrowing on user ADTs.
     ///
-    /// Future work may add support for multiple lifetimes and changing memory layout as part of
-    /// CoerceShared. These may be end up implemented as multiple MIR operations.
+    /// Generic shared reborrows are lowered field-wise according to the validated CoerceShared
+    /// source-to-target field correspondence.
     ///
     /// This is produced by the [`ExprKind::Reborrow`].
     ///

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -141,6 +141,7 @@ pub mod normalize_erasing_regions;
 pub mod offload_meta;
 pub mod pattern;
 pub mod print;
+pub mod reborrow;
 pub mod relate;
 pub mod significant_drop_order;
 pub mod trait_def;

--- a/compiler/rustc_middle/src/ty/reborrow.rs
+++ b/compiler/rustc_middle/src/ty/reborrow.rs
@@ -1,12 +1,13 @@
 use rustc_abi::FieldIdx;
 use rustc_hir::def::CtorKind;
-use rustc_span::{Span, Symbol};
+use rustc_span::{Ident, Span, Symbol};
 
 use crate::ty::{self, Ty, TyCtxt};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ReborrowField<'tcx> {
     pub index: FieldIdx,
+    pub ident: Ident,
     pub name: Symbol,
     pub ty: Ty<'tcx>,
     pub span: Span,
@@ -43,6 +44,7 @@ pub fn reborrow_data_fields<'tcx>(
             let ty = field.ty(tcx, args).skip_norm_wip();
             (!ty.is_phantom_data()).then_some(ReborrowField {
                 index,
+                ident: field.ident(tcx),
                 name: field.name,
                 ty,
                 span: tcx.def_span(field.did),
@@ -53,9 +55,9 @@ pub fn reborrow_data_fields<'tcx>(
 
 /// Canonical CoerceShared source-to-target field correspondence.
 ///
-/// Named structs match non-`PhantomData` data fields by name. Tuple structs match
-/// non-`PhantomData` data fields by their filtered ordinal position. `PhantomData` fields are
-/// ignored on both sides for matching, but the returned fields preserve their original field
+/// Named structs match non-`PhantomData` data fields by hygienic field identity. Tuple structs
+/// match non-`PhantomData` data fields by their filtered ordinal position. `PhantomData` fields
+/// are ignored on both sides for matching, but the returned fields preserve their original field
 /// indices for projection. The field types are instantiated but intentionally not normalized here:
 /// validation, borrowck, interpretation, and codegen each need to normalize or relate aliases with
 /// their phase-specific inference or monomorphization context before deciding whether to copy or
@@ -94,7 +96,9 @@ pub fn coerce_shared_field_pairs<'tcx>(
                 let source = source_fields
                     .iter()
                     .copied()
-                    .find(|source| source.name == target.name)
+                    .find(|source| {
+                        tcx.hygienic_eq(target.ident, source.ident, source_variant.def_id)
+                    })
                     .ok_or(CoerceSharedFieldPairError::MissingSourceField { target })?;
 
                 Ok(CoerceSharedFieldPair { source, target })

--- a/compiler/rustc_middle/src/ty/reborrow.rs
+++ b/compiler/rustc_middle/src/ty/reborrow.rs
@@ -1,0 +1,104 @@
+use rustc_abi::FieldIdx;
+use rustc_hir::def::CtorKind;
+use rustc_span::{Span, Symbol};
+
+use crate::ty::{self, Ty, TyCtxt};
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReborrowField<'tcx> {
+    pub index: FieldIdx,
+    pub name: Symbol,
+    pub ty: Ty<'tcx>,
+    pub span: Span,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct CoerceSharedFieldPair<'tcx> {
+    pub source: ReborrowField<'tcx>,
+    pub target: ReborrowField<'tcx>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum CoerceSharedFieldPairError<'tcx> {
+    FieldStyleMismatch,
+    MissingSourceField { target: ReborrowField<'tcx> },
+}
+
+pub fn single_lifetime_arg<'tcx>(args: ty::GenericArgsRef<'tcx>) -> Option<ty::Region<'tcx>> {
+    let mut lifetimes = args.iter().filter_map(|arg| arg.as_region());
+    let lifetime = lifetimes.next()?;
+    lifetimes.next().is_none().then_some(lifetime)
+}
+
+/// Returns the instantiated non-`PhantomData` fields that participate in generic reborrows.
+pub fn reborrow_data_fields<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def: ty::AdtDef<'tcx>,
+    args: ty::GenericArgsRef<'tcx>,
+) -> Vec<ReborrowField<'tcx>> {
+    def.non_enum_variant()
+        .fields
+        .iter_enumerated()
+        .filter_map(|(index, field)| {
+            let ty = field.ty(tcx, args).skip_norm_wip();
+            (!ty.is_phantom_data()).then_some(ReborrowField {
+                index,
+                name: field.name,
+                ty,
+                span: tcx.def_span(field.did),
+            })
+        })
+        .collect()
+}
+
+/// Canonical CoerceShared source-to-target field correspondence.
+///
+/// Named structs match non-`PhantomData` data fields by name. Tuple structs match
+/// non-`PhantomData` data fields by their filtered ordinal position. `PhantomData` fields are
+/// ignored on both sides for matching, but the returned fields preserve their original field
+/// indices for projection. The field types are instantiated but intentionally not normalized here:
+/// validation, borrowck, interpretation, and codegen each need to normalize or relate aliases with
+/// their phase-specific inference or monomorphization context before deciding whether to copy or
+/// recurse.
+pub fn coerce_shared_field_pairs<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    source_def: ty::AdtDef<'tcx>,
+    source_args: ty::GenericArgsRef<'tcx>,
+    target_def: ty::AdtDef<'tcx>,
+    target_args: ty::GenericArgsRef<'tcx>,
+) -> Result<Vec<CoerceSharedFieldPair<'tcx>>, CoerceSharedFieldPairError<'tcx>> {
+    let source_variant = source_def.non_enum_variant();
+    let target_variant = target_def.non_enum_variant();
+    if source_variant.ctor_kind() != target_variant.ctor_kind() {
+        return Err(CoerceSharedFieldPairError::FieldStyleMismatch);
+    }
+
+    let by_position = matches!(target_variant.ctor_kind(), Some(CtorKind::Fn));
+    let source_fields = reborrow_data_fields(tcx, source_def, source_args);
+    let target_fields = reborrow_data_fields(tcx, target_def, target_args);
+
+    if by_position {
+        target_fields
+            .into_iter()
+            .zip(source_fields.into_iter().map(Some).chain(std::iter::repeat(None)))
+            .map(|(target, source)| {
+                let source =
+                    source.ok_or(CoerceSharedFieldPairError::MissingSourceField { target })?;
+                Ok(CoerceSharedFieldPair { source, target })
+            })
+            .collect()
+    } else {
+        target_fields
+            .into_iter()
+            .map(|target| {
+                let source = source_fields
+                    .iter()
+                    .copied()
+                    .find(|source| source.name == target.name)
+                    .ok_or(CoerceSharedFieldPairError::MissingSourceField { target })?;
+
+                Ok(CoerceSharedFieldPair { source, target })
+            })
+            .collect()
+    }
+}

--- a/tests/ui/reborrow/auxiliary/reborrow_foreign_private.rs
+++ b/tests/ui/reborrow/auxiliary/reborrow_foreign_private.rs
@@ -1,0 +1,22 @@
+#![allow(dead_code)]
+
+use std::marker::PhantomData;
+
+#[derive(Clone, Copy)]
+pub struct ForeignRef<'a> {
+    value: &'a i32,
+}
+
+// SAFETY invariant: the pointer is valid as `&'a i32`.
+#[derive(Clone, Copy)]
+pub struct ForeignPtrRef<'a>((*const i32, PhantomData<&'a ()>));
+
+impl<'a> ForeignPtrRef<'a> {
+    pub fn new(r: &'a i32) -> Self {
+        ForeignPtrRef((r, PhantomData))
+    }
+
+    pub fn to_ref(self) -> &'a i32 {
+        unsafe { &*self.0.0 }
+    }
+}

--- a/tests/ui/reborrow/coerce-shared-alias-projection.rs
+++ b/tests/ui/reborrow/coerce-shared-alias-projection.rs
@@ -1,0 +1,111 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+// This test combines alias/projection normalization with the leaf `&mut T` to `&T`
+// shared reborrow path.
+
+struct InnerMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for InnerMut<'a, T> {}
+
+struct InnerRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> Clone for InnerRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for InnerRef<'a, T> {}
+
+impl<'a, T> CoerceShared<InnerRef<'a, T>> for InnerMut<'a, T> {}
+
+type DirectInnerRef<'a, T> = InnerRef<'a, T>;
+
+trait RefFamily<'a, T> {
+    type Ref;
+}
+
+struct Projected;
+
+impl<'a, T: 'a> RefFamily<'a, T> for Projected {
+    type Ref = InnerRef<'a, T>;
+}
+
+type ProjectedInnerRef<'a, T> = <Projected as RefFamily<'a, T>>::Ref;
+
+struct OuterMut<'a, T> {
+    inner: InnerMut<'a, T>,
+    tag: usize,
+}
+
+impl<'a, T> Reborrow for OuterMut<'a, T> {}
+
+struct OuterAliasRef<'a, T> {
+    inner: DirectInnerRef<'a, T>,
+    tag: usize,
+}
+
+impl<'a, T> Clone for OuterAliasRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for OuterAliasRef<'a, T> {}
+
+impl<'a, T> CoerceShared<OuterAliasRef<'a, T>> for OuterMut<'a, T> {}
+
+struct OuterProjectionRef<'a, T: 'a> {
+    inner: ProjectedInnerRef<'a, T>,
+    tag: usize,
+}
+
+impl<'a, T: 'a> Clone for OuterProjectionRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T: 'a> Copy for OuterProjectionRef<'a, T> {}
+
+impl<'a, T: 'a> CoerceShared<OuterProjectionRef<'a, T>> for OuterMut<'a, T> {}
+
+fn read_alias<'a>(outer: OuterAliasRef<'a, u32>) -> (&'a u32, usize) {
+    (outer.inner.value, outer.tag)
+}
+
+fn read_projection<'a>(outer: OuterProjectionRef<'a, u32>) -> (&'a u32, usize) {
+    (outer.inner.value, outer.tag)
+}
+
+const fn const_accept_projection(_outer: OuterProjectionRef<'_, u32>) {}
+
+const fn consteval_projection_reborrow() {
+    let mut value = 11;
+    const_accept_projection(OuterMut {
+        inner: InnerMut { value: &mut value },
+        tag: 5,
+    });
+}
+
+fn main() {
+    const { consteval_projection_reborrow(); }
+
+    let mut value = 22;
+    let outer = OuterMut { inner: InnerMut { value: &mut value }, tag: 7 };
+
+    let (alias_value, alias_tag) = read_alias(outer);
+    assert_eq!((*alias_value, alias_tag), (22, 7));
+
+    let (projection_value, projection_tag) = read_projection(outer);
+    assert_eq!((*projection_value, projection_tag), (22, 7));
+}

--- a/tests/ui/reborrow/coerce-shared-associated-type-field.rs
+++ b/tests/ui/reborrow/coerce-shared-associated-type-field.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+trait Trait {
+    type Assoc;
+}
+
+impl Trait for i32 {
+    type Assoc = i64;
+}
+
+struct MyMut<'a> {
+    x: &'a (),
+    y: i64,
+}
+
+#[derive(Copy, Clone)]
+struct MyRef<'a> {
+    x: &'a (),
+    y: <i32 as Trait>::Assoc,
+}
+
+impl Reborrow for MyMut<'_> {}
+
+impl<'a> CoerceShared<MyRef<'a>> for MyMut<'a> {}
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-decl-macro-hygiene.rs
+++ b/tests/ui/reborrow/coerce-shared-decl-macro-hygiene.rs
@@ -1,0 +1,27 @@
+//@ check-pass
+
+#![feature(reborrow, decl_macro)]
+#![allow(incomplete_features)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+macro my_macro($field:ident) {
+    pub struct MyMut<'a> {
+        $field: &'a i32,
+        field: &'a i64,
+    }
+
+    #[derive(Clone, Copy)]
+    pub struct MyRef<'a> {
+        $field: &'a i32,
+        field: &'a i64,
+    }
+
+    impl Reborrow for MyMut<'_> {}
+
+    impl<'a> CoerceShared<MyRef<'a>> for MyMut<'a> {}
+}
+
+my_macro!(field);
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-different-layout.rs
+++ b/tests/ui/reborrow/coerce-shared-different-layout.rs
@@ -1,0 +1,42 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+use std::ptr::NonNull;
+
+struct ImbrisMut<'a, T> {
+    ptr: NonNull<T>,
+    metadata: usize,
+    marker: PhantomData<&'a mut T>,
+}
+
+impl<'a, T> Reborrow for ImbrisMut<'a, T> {}
+
+struct ImbrisRef<'a, T> {
+    ptr: NonNull<T>,
+    marker: PhantomData<&'a T>,
+}
+
+impl<'a, T> Clone for ImbrisRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for ImbrisRef<'a, T> {}
+
+impl<'a, T> CoerceShared<ImbrisRef<'a, T>> for ImbrisMut<'a, T> {}
+
+fn ptr(value: ImbrisRef<'_, i32>) -> NonNull<i32> {
+    value.ptr
+}
+
+fn main() {
+    let mut value = 1;
+    let raw = NonNull::from(&mut value);
+    let wrapped = ImbrisMut { ptr: raw, metadata: 32, marker: PhantomData };
+
+    assert_eq!(ptr(wrapped), raw);
+}

--- a/tests/ui/reborrow/coerce-shared-extra-marker.rs
+++ b/tests/ui/reborrow/coerce-shared-extra-marker.rs
@@ -1,0 +1,37 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct MarkerExtraMut<'a, T> {
+    value: &'a mut T,
+    marker: PhantomData<&'a mut T>,
+}
+
+impl<'a, T> Reborrow for MarkerExtraMut<'a, T> {}
+
+struct MarkerExtraRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> Clone for MarkerExtraRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for MarkerExtraRef<'a, T> {}
+
+impl<'a, T> CoerceShared<MarkerExtraRef<'a, T>> for MarkerExtraMut<'a, T> {}
+
+fn get<'a>(value: MarkerExtraRef<'a, i32>) -> &'a i32 {
+    value.value
+}
+
+fn main() {
+    let mut value = 1;
+    let wrapped = MarkerExtraMut { value: &mut value, marker: PhantomData };
+    assert_eq!(*get(wrapped), 1);
+}

--- a/tests/ui/reborrow/coerce-shared-field-lifetime-swap.rs
+++ b/tests/ui/reborrow/coerce-shared-field-lifetime-swap.rs
@@ -1,0 +1,23 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct MyMut<'a> {
+    x: &'static (),
+    y: &'a (),
+}
+
+impl Reborrow for MyMut<'_> {}
+
+#[derive(Copy, Clone)]
+struct MyRef<'a> {
+    x: &'a (),
+    //~^ ERROR
+    y: &'static (),
+}
+
+impl<'a> CoerceShared<MyRef<'a>> for MyMut<'a> {}
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-field-lifetime-swap.stderr
+++ b/tests/ui/reborrow/coerce-shared-field-lifetime-swap.stderr
@@ -1,0 +1,10 @@
+error: implementing `CoerceShared` requires corresponding fields to match, be reborrowable with `CoerceShared`, or coerce a mutable reference field to a shared reference field
+  --> $DIR/coerce-shared-field-lifetime-swap.rs:16:5
+   |
+LL |     x: &'static (),
+   |     -------------- source field `x` has type `&'static ()`
+...
+LL |     x: &'a (),
+   |     ^^^^^^^^^ target field `x` has type `&'a ()`
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/coerce-shared-field-relations.rs
+++ b/tests/ui/reborrow/coerce-shared-field-relations.rs
@@ -1,0 +1,54 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct CustomMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+
+#[derive(Clone, Copy)]
+struct CustomRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+struct RenamedMut<'a, T> {
+    source: &'a mut T,
+}
+
+impl<'a, T> Reborrow for RenamedMut<'a, T> {}
+
+#[derive(Clone, Copy)]
+struct RenamedRef<'a, T> {
+    target: &'a T,
+    //~^ ERROR
+}
+
+impl<'a, T> CoerceShared<RenamedRef<'a, T>> for RenamedMut<'a, T> {}
+
+struct BadMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for BadMut<'a, T> {}
+
+#[derive(Clone, Copy)]
+struct BadRef<'a, T> {
+    value: &'a u32,
+    //~^ ERROR
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<'a, T> CoerceShared<BadRef<'a, T>> for BadMut<'a, T> {}
+
+fn good(_value: CustomRef<'_, u32>) {}
+
+fn main() {
+    let mut value = 1;
+    good(CustomMut { value: &mut value });
+}

--- a/tests/ui/reborrow/coerce-shared-field-relations.stderr
+++ b/tests/ui/reborrow/coerce-shared-field-relations.stderr
@@ -1,0 +1,16 @@
+error: implementing `CoerceShared` requires every target field to have a corresponding source field
+  --> $DIR/coerce-shared-field-relations.rs:28:5
+   |
+LL |     target: &'a T,
+   |     ^^^^^^^^^^^^^
+
+error: implementing `CoerceShared` requires corresponding fields to match, be reborrowable with `CoerceShared`, or coerce a mutable reference field to a shared reference field
+  --> $DIR/coerce-shared-field-relations.rs:42:5
+   |
+LL |     value: &'a mut T,
+   |     ---------------- source field `value` has type `&'a mut T`
+...
+LL |     value: &'a u32,
+   |     ^^^^^^^^^^^^^^ target field `value` has type `&'a u32`
+
+error: aborting due to 2 previous errors

--- a/tests/ui/reborrow/coerce-shared-foreign-private-field.rs
+++ b/tests/ui/reborrow/coerce-shared-foreign-private-field.rs
@@ -1,0 +1,21 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+//@ aux-build: reborrow_foreign_private.rs
+
+#![feature(reborrow)]
+
+extern crate reborrow_foreign_private;
+
+use reborrow_foreign_private::ForeignRef;
+use std::marker::{CoerceShared, Reborrow};
+
+struct LocalMut<'a> {
+    value: &'a mut i32,
+}
+
+impl<'a> Reborrow for LocalMut<'a> {}
+
+impl<'a> CoerceShared<ForeignRef<'a>> for LocalMut<'a> {}
+//~^ ERROR
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-foreign-private-field.stderr
+++ b/tests/ui/reborrow/coerce-shared-foreign-private-field.stderr
@@ -1,0 +1,7 @@
+error: implementing `CoerceShared` requires all source and target fields to be accessible from the impl
+  --> $DIR/coerce-shared-foreign-private-field.rs:18:1
+   |
+LL | impl<'a> CoerceShared<ForeignRef<'a>> for LocalMut<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/coerce-shared-foreign-private-tuple-field.rs
+++ b/tests/ui/reborrow/coerce-shared-foreign-private-tuple-field.rs
@@ -1,0 +1,24 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+//@ aux-build: reborrow_foreign_private.rs
+
+#![feature(reborrow)]
+
+extern crate reborrow_foreign_private;
+
+use reborrow_foreign_private::ForeignPtrRef;
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+use std::ptr;
+
+struct LocalPtrMut<'a>((*const i32, PhantomData<&'a ()>));
+
+impl<'a> Reborrow for LocalPtrMut<'a> {}
+
+impl<'a> CoerceShared<ForeignPtrRef<'a>> for LocalPtrMut<'a> {}
+//~^ ERROR
+
+fn main() {
+    let local = LocalPtrMut((ptr::null(), PhantomData));
+    let foreign: ForeignPtrRef<'_> = local;
+    let _ = foreign.to_ref();
+}

--- a/tests/ui/reborrow/coerce-shared-foreign-private-tuple-field.stderr
+++ b/tests/ui/reborrow/coerce-shared-foreign-private-tuple-field.stderr
@@ -1,0 +1,7 @@
+error: implementing `CoerceShared` requires all source and target fields to be accessible from the impl
+  --> $DIR/coerce-shared-foreign-private-tuple-field.rs:17:1
+   |
+LL | impl<'a> CoerceShared<ForeignPtrRef<'a>> for LocalPtrMut<'a> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/coerce-shared-generics.rs
+++ b/tests/ui/reborrow/coerce-shared-generics.rs
@@ -1,0 +1,42 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct BufferMut<'a, T, U, const N: usize> {
+    data: &'a mut [T; N],
+    meta: U,
+}
+
+impl<'a, T, U: Copy, const N: usize> Reborrow for BufferMut<'a, T, U, N> {}
+
+struct BufferRef<'a, T, U, const N: usize> {
+    data: &'a [T; N],
+    meta: U,
+}
+
+impl<'a, T, U: Copy, const N: usize> Clone for BufferRef<'a, T, U, N> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T, U: Copy, const N: usize> Copy for BufferRef<'a, T, U, N> {}
+
+impl<'a, T, U: Copy, const N: usize> CoerceShared<BufferRef<'a, T, U, N>>
+    for BufferMut<'a, T, U, N>
+{
+}
+
+fn inspect<const N: usize>(buffer: BufferRef<'_, u8, u16, N>) -> (usize, u16) {
+    (buffer.data.len(), buffer.meta)
+}
+
+fn main() {
+    let mut data = [1, 2, 3, 4];
+    let buffer = BufferMut { data: &mut data, meta: 9_u16 };
+
+    assert_eq!(inspect(buffer), (4, 9));
+}

--- a/tests/ui/reborrow/coerce-shared-lifetime-mismatch.rs
+++ b/tests/ui/reborrow/coerce-shared-lifetime-mismatch.rs
@@ -1,0 +1,21 @@
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct CustomMarker<'a>(PhantomData<&'a ()>);
+
+impl<'a> Reborrow for CustomMarker<'a> {}
+
+#[derive(Clone, Copy)]
+struct StaticMarkerRef<'a>(PhantomData<&'a ()>);
+
+impl<'a> CoerceShared<StaticMarkerRef<'static>> for CustomMarker<'a> {}
+//~^ ERROR
+
+fn method(_a: StaticMarkerRef<'static>) {}
+
+fn main() {
+    let a = CustomMarker(PhantomData);
+    method(a);
+    //~^ ERROR
+}

--- a/tests/ui/reborrow/coerce-shared-lifetime-mismatch.stderr
+++ b/tests/ui/reborrow/coerce-shared-lifetime-mismatch.stderr
@@ -1,0 +1,23 @@
+error: implementing `CoerceShared` requires source and target to use the same reborrow lifetime argument
+  --> $DIR/coerce-shared-lifetime-mismatch.rs:12:10
+   |
+LL | impl<'a> CoerceShared<StaticMarkerRef<'static>> for CustomMarker<'a> {}
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0597]: `a` does not live long enough
+  --> $DIR/coerce-shared-lifetime-mismatch.rs:19:12
+   |
+LL |     let a = CustomMarker(PhantomData);
+   |         - binding `a` declared here
+LL |     method(a);
+   |     -------^-
+   |     |      |
+   |     |      borrowed value does not live long enough
+   |     argument requires that `a` is borrowed for `'static`
+LL |
+LL | }
+   | - `a` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/reborrow/coerce-shared-marker-no-target-lifetime.rs
+++ b/tests/ui/reborrow/coerce-shared-marker-no-target-lifetime.rs
@@ -1,0 +1,20 @@
+//@ edition: 2024
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct CustomMarker<'a>(PhantomData<&'a ()>);
+struct CustomMarkerRef;
+
+impl<'a> Reborrow for CustomMarker<'a> {}
+impl<'a> CoerceShared<CustomMarkerRef> for CustomMarker<'a> {}
+//~^ ERROR
+
+fn method(_a: CustomMarkerRef) {}
+
+fn main() {
+    let a = CustomMarker(PhantomData);
+    method(a);
+    //~^ ERROR
+}

--- a/tests/ui/reborrow/coerce-shared-marker-no-target-lifetime.stderr
+++ b/tests/ui/reborrow/coerce-shared-marker-no-target-lifetime.stderr
@@ -1,0 +1,23 @@
+error: implementing `CoerceShared` requires exactly one lifetime argument in the reborrowed type
+  --> $DIR/coerce-shared-marker-no-target-lifetime.rs:11:10
+   |
+LL | impl<'a> CoerceShared<CustomMarkerRef> for CustomMarker<'a> {}
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/coerce-shared-marker-no-target-lifetime.rs:18:12
+   |
+LL |     method(a);
+   |     ------ ^ expected `CustomMarkerRef`, found `CustomMarker<'_>`
+   |     |
+   |     arguments to this function are incorrect
+   |
+note: function defined here
+  --> $DIR/coerce-shared-marker-no-target-lifetime.rs:14:4
+   |
+LL | fn method(_a: CustomMarkerRef) {}
+   |    ^^^^^^ -------------------
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/reborrow/coerce-shared-missing-target-field.rs
+++ b/tests/ui/reborrow/coerce-shared-missing-target-field.rs
@@ -1,0 +1,22 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct MissingSourceMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for MissingSourceMut<'a, T> {}
+
+#[derive(Clone, Copy)]
+struct MissingSourceRef<'a, T> {
+    value: &'a T,
+    len: usize,
+    //~^ ERROR
+}
+
+impl<'a, T> CoerceShared<MissingSourceRef<'a, T>> for MissingSourceMut<'a, T> {}
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-missing-target-field.stderr
+++ b/tests/ui/reborrow/coerce-shared-missing-target-field.stderr
@@ -1,0 +1,7 @@
+error: implementing `CoerceShared` requires every target field to have a corresponding source field
+  --> $DIR/coerce-shared-missing-target-field.rs:16:5
+   |
+LL |     len: usize,
+   |     ^^^^^^^^^^
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/coerce-shared-multi-field.rs
+++ b/tests/ui/reborrow/coerce-shared-multi-field.rs
@@ -1,0 +1,59 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+use std::ptr::NonNull;
+
+struct MatMut<'a, T> {
+    ptr: NonNull<T>,
+    rows: usize,
+    cols: usize,
+    row_stride: usize,
+    col_stride: usize,
+    marker: PhantomData<&'a mut T>,
+}
+
+impl<'a, T> Reborrow for MatMut<'a, T> {}
+
+struct MatRef<'a, T> {
+    ptr: NonNull<T>,
+    rows: usize,
+    cols: usize,
+    row_stride: usize,
+    col_stride: usize,
+    marker: PhantomData<&'a T>,
+}
+
+impl<'a, T> Clone for MatRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for MatRef<'a, T> {}
+
+impl<'a, T> CoerceShared<MatRef<'a, T>> for MatMut<'a, T> {}
+
+fn dims<T>(mat: MatRef<'_, T>) -> (usize, usize, usize, usize) {
+    let _ = mat.ptr;
+    (mat.rows, mat.cols, mat.row_stride, mat.col_stride)
+}
+
+fn main() {
+    let mut value = 0;
+    let mat = MatMut {
+        ptr: NonNull::from(&mut value),
+        rows: 2,
+        cols: 3,
+        row_stride: 4,
+        col_stride: 5,
+        marker: PhantomData,
+    };
+
+    assert_eq!(dims(mat), (2, 3, 4, 5));
+    // Reusing the same source proves repeated shared reborrows keep source-only data protected
+    // without consuming the reborrowable value.
+    assert_eq!(dims(mat), (2, 3, 4, 5));
+}

--- a/tests/ui/reborrow/coerce-shared-mut-ref-field-validation.rs
+++ b/tests/ui/reborrow/coerce-shared-mut-ref-field-validation.rs
@@ -1,0 +1,45 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+trait Trait {
+    type Assoc;
+}
+
+impl Trait for i32 {
+    type Assoc = u32;
+}
+
+type AliasMutField<'a> = &'a mut <i32 as Trait>::Assoc;
+type AliasRefField<'a> = &'a u32;
+
+struct AliasMut<'a> {
+    value: AliasMutField<'a>,
+}
+
+impl Reborrow for AliasMut<'_> {}
+
+#[derive(Copy, Clone)]
+struct AliasRef<'a> {
+    value: AliasRefField<'a>,
+}
+
+impl<'a> CoerceShared<AliasRef<'a>> for AliasMut<'a> {}
+
+struct InnerLifetimeMut<'a> {
+    value: &'a mut &'static (),
+}
+
+impl Reborrow for InnerLifetimeMut<'_> {}
+
+#[derive(Copy, Clone)]
+struct InnerLifetimeRef<'a> {
+    value: &'a &'a (),
+    //~^ ERROR
+}
+
+impl<'a> CoerceShared<InnerLifetimeRef<'a>> for InnerLifetimeMut<'a> {}
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-mut-ref-field-validation.stderr
+++ b/tests/ui/reborrow/coerce-shared-mut-ref-field-validation.stderr
@@ -1,0 +1,10 @@
+error: implementing `CoerceShared` requires corresponding fields to match, be reborrowable with `CoerceShared`, or coerce a mutable reference field to a shared reference field
+  --> $DIR/coerce-shared-mut-ref-field-validation.rs:39:5
+   |
+LL |     value: &'a mut &'static (),
+   |     -------------------------- source field `value` has type `&'a mut &'static ()`
+...
+LL |     value: &'a &'a (),
+   |     ^^^^^^^^^^^^^^^^^ target field `value` has type `&'a &'a ()`
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/coerce-shared-nested.rs
+++ b/tests/ui/reborrow/coerce-shared-nested.rs
@@ -1,0 +1,63 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct InnerMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for InnerMut<'a, T> {}
+
+struct InnerRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> Clone for InnerRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for InnerRef<'a, T> {}
+
+impl<'a, T> CoerceShared<InnerRef<'a, T>> for InnerMut<'a, T> {}
+
+struct OuterMut<'a, T> {
+    inner: InnerMut<'a, T>,
+    tag: usize,
+}
+
+impl<'a, T> Reborrow for OuterMut<'a, T> {}
+
+struct OuterRef<'a, T> {
+    inner: InnerRef<'a, T>,
+    tag: usize,
+}
+
+impl<'a, T> Clone for OuterRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for OuterRef<'a, T> {}
+
+impl<'a, T> CoerceShared<OuterRef<'a, T>> for OuterMut<'a, T> {}
+
+fn get<'a>(outer: OuterRef<'a, i32>) -> (&'a i32, usize) {
+    (outer.inner.value, outer.tag)
+}
+
+fn main() {
+    let mut value = 22;
+    let outer = OuterMut { inner: InnerMut { value: &mut value }, tag: 7 };
+
+    let (first, tag) = get(outer);
+    assert_eq!((*first, tag), (22, 7));
+
+    let (second, tag) = get(outer);
+    assert_eq!((*second, tag), (22, 7));
+}

--- a/tests/ui/reborrow/coerce-shared-omitted-reborrow-field-after-dead.rs
+++ b/tests/ui/reborrow/coerce-shared-omitted-reborrow-field-after-dead.rs
@@ -1,0 +1,52 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct ExtraMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for ExtraMut<'a, T> {}
+
+struct OmitMut<'a, T> {
+    value: &'a mut T,
+    extra: ExtraMut<'a, T>,
+}
+
+impl<'a, T> Reborrow for OmitMut<'a, T> {}
+
+struct OmitRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> Clone for OmitRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for OmitRef<'a, T> {}
+
+impl<'a, T> CoerceShared<OmitRef<'a, T>> for OmitMut<'a, T> {}
+
+fn read(value: OmitRef<'_, i32>) {
+    assert_eq!(*value.value, 1);
+}
+
+fn main() {
+    let mut value = 1;
+    let mut extra_value = 2;
+
+    {
+        let extra = ExtraMut { value: &mut extra_value };
+        let wrapped = OmitMut { value: &mut value, extra };
+
+        read(wrapped);
+    }
+
+    extra_value = 3;
+    assert_eq!(extra_value, 3);
+}

--- a/tests/ui/reborrow/coerce-shared-omitted-reborrow-field-locked.rs
+++ b/tests/ui/reborrow/coerce-shared-omitted-reborrow-field-locked.rs
@@ -1,0 +1,52 @@
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct ExtraMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for ExtraMut<'a, T> {}
+
+struct OmitMut<'a, T> {
+    value: &'a mut T,
+    extra: ExtraMut<'a, T>,
+}
+
+impl<'a, T> Reborrow for OmitMut<'a, T> {}
+
+struct OmitRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> Clone for OmitRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for OmitRef<'a, T> {}
+
+impl<'a, T> CoerceShared<OmitRef<'a, T>> for OmitMut<'a, T> {}
+
+fn get<'a>(value: OmitRef<'a, i32>) -> &'a i32 {
+    value.value
+}
+
+fn main() {
+    let mut value = 1;
+    let mut extra_value = 2;
+    let extra = ExtraMut { value: &mut extra_value };
+
+    let mut wrapped = OmitMut {
+        value: &mut value,
+        extra,
+    };
+
+    let shared = get(wrapped);
+
+    *wrapped.extra.value = 3;
+    //~^ ERROR cannot assign to `*wrapped.extra.value` because it is borrowed
+
+    let _ = shared;
+}

--- a/tests/ui/reborrow/coerce-shared-omitted-reborrow-field-locked.stderr
+++ b/tests/ui/reborrow/coerce-shared-omitted-reborrow-field-locked.stderr
@@ -1,0 +1,15 @@
+error[E0506]: cannot assign to `*wrapped.extra.value` because it is borrowed
+  --> $DIR/coerce-shared-omitted-reborrow-field-locked.rs:48:5
+   |
+LL |     let shared = get(wrapped);
+   |                      ------- `*wrapped.extra.value` is borrowed here
+LL |
+LL |     *wrapped.extra.value = 3;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `*wrapped.extra.value` is assigned to here but it was already borrowed
+   |     borrow later used here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0506`.

--- a/tests/ui/reborrow/coerce-shared-omitted-reborrow-field.rs
+++ b/tests/ui/reborrow/coerce-shared-omitted-reborrow-field.rs
@@ -1,0 +1,46 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct ExtraMut<'a, T> {
+    value: &'a mut T,
+}
+
+impl<'a, T> Reborrow for ExtraMut<'a, T> {}
+
+struct OmitMut<'a, T> {
+    value: &'a mut T,
+    extra: ExtraMut<'a, T>,
+}
+
+impl<'a, T> Reborrow for OmitMut<'a, T> {}
+
+struct OmitRef<'a, T> {
+    value: &'a T,
+}
+
+impl<'a, T> Clone for OmitRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for OmitRef<'a, T> {}
+
+impl<'a, T> CoerceShared<OmitRef<'a, T>> for OmitMut<'a, T> {}
+
+fn get<'a>(value: OmitRef<'a, i32>) -> &'a i32 {
+    value.value
+}
+
+fn main() {
+    let mut value = 1;
+    let mut extra = 2;
+    let extra = ExtraMut { value: &mut extra };
+    let wrapped = OmitMut { value: &mut value, extra };
+
+    assert_eq!(*get(wrapped), 1);
+}

--- a/tests/ui/reborrow/coerce-shared-reordered-field.rs
+++ b/tests/ui/reborrow/coerce-shared-reordered-field.rs
@@ -1,0 +1,33 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct ReorderMut<'a> {
+    a: &'a mut u8,
+    b: &'a mut u16,
+}
+
+impl<'a> Reborrow for ReorderMut<'a> {}
+
+#[derive(Clone, Copy)]
+struct ReorderRef<'a> {
+    b: &'a u16,
+    a: &'a u8,
+}
+
+impl<'a> CoerceShared<ReorderRef<'a>> for ReorderMut<'a> {}
+
+fn read(value: ReorderRef<'_>) -> (u16, u8) {
+    (*value.b, *value.a)
+}
+
+fn main() {
+    let mut a = 1;
+    let mut b = 2;
+    let wrapped = ReorderMut { a: &mut a, b: &mut b };
+
+    assert_eq!(read(wrapped), (2, 1));
+}

--- a/tests/ui/reborrow/coerce-shared-tuple-phantom-position.rs
+++ b/tests/ui/reborrow/coerce-shared-tuple-phantom-position.rs
@@ -1,0 +1,87 @@
+//@ run-pass
+
+#![feature(reborrow)]
+#![allow(dead_code)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct SourceLeadingMut<'a, T>(PhantomData<&'a mut T>, &'a mut T);
+
+impl<'a, T> Reborrow for SourceLeadingMut<'a, T> {}
+
+struct SourceLeadingRef<'a, T>(&'a T);
+
+impl<'a, T> Clone for SourceLeadingRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for SourceLeadingRef<'a, T> {}
+
+impl<'a, T> CoerceShared<SourceLeadingRef<'a, T>> for SourceLeadingMut<'a, T> {}
+
+struct TargetLeadingMut<'a, T>(&'a mut T);
+
+impl<'a, T> Reborrow for TargetLeadingMut<'a, T> {}
+
+struct TargetLeadingRef<'a, T>(PhantomData<&'a T>, &'a T);
+
+impl<'a, T> Clone for TargetLeadingRef<'a, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T> Copy for TargetLeadingRef<'a, T> {}
+
+impl<'a, T> CoerceShared<TargetLeadingRef<'a, T>> for TargetLeadingMut<'a, T> {}
+
+struct InterleavedMut<'a, T, U>(
+    PhantomData<&'a mut T>,
+    &'a mut T,
+    PhantomData<&'a mut U>,
+    &'a mut U,
+);
+
+impl<'a, T, U> Reborrow for InterleavedMut<'a, T, U> {}
+
+struct InterleavedRef<'a, T, U>(&'a T, PhantomData<&'a T>, &'a U, PhantomData<&'a U>);
+
+impl<'a, T, U> Clone for InterleavedRef<'a, T, U> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, T, U> Copy for InterleavedRef<'a, T, U> {}
+
+impl<'a, T, U> CoerceShared<InterleavedRef<'a, T, U>> for InterleavedMut<'a, T, U> {}
+
+fn read_source_leading<'a>(value: SourceLeadingRef<'a, i32>) -> &'a i32 {
+    value.0
+}
+
+fn read_target_leading<'a>(value: TargetLeadingRef<'a, i32>) -> &'a i32 {
+    value.1
+}
+
+fn read_interleaved<'a>(value: InterleavedRef<'a, i32, i64>) -> (&'a i32, &'a i64) {
+    (value.0, value.2)
+}
+
+fn main() {
+    let mut source_leading = 10;
+    let wrapped = SourceLeadingMut(PhantomData, &mut source_leading);
+    assert_eq!(*read_source_leading(wrapped), 10);
+
+    let mut target_leading = 20;
+    let wrapped = TargetLeadingMut(&mut target_leading);
+    assert_eq!(*read_target_leading(wrapped), 20);
+
+    let mut first = 30;
+    let mut second = 40_i64;
+    let wrapped = InterleavedMut(PhantomData, &mut first, PhantomData, &mut second);
+    let (first, second) = read_interleaved(wrapped);
+    assert_eq!((*first, *second), (30, 40));
+}

--- a/tests/ui/reborrow/coerce-shared-wrong-generic.rs
+++ b/tests/ui/reborrow/coerce-shared-wrong-generic.rs
@@ -1,0 +1,23 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct GenericMut<'a, T, U> {
+    value: &'a mut T,
+    marker: PhantomData<U>,
+}
+
+impl<'a, T, U> Reborrow for GenericMut<'a, T, U> {}
+
+#[derive(Clone, Copy)]
+struct GenericRef<'a, T, U> {
+    value: &'a U,
+    //~^ ERROR
+    marker: PhantomData<T>,
+}
+
+impl<'a, T, U> CoerceShared<GenericRef<'a, T, U>> for GenericMut<'a, T, U> {}
+
+fn main() {}

--- a/tests/ui/reborrow/coerce-shared-wrong-generic.stderr
+++ b/tests/ui/reborrow/coerce-shared-wrong-generic.stderr
@@ -1,0 +1,10 @@
+error: implementing `CoerceShared` requires corresponding fields to match, be reborrowable with `CoerceShared`, or coerce a mutable reference field to a shared reference field
+  --> $DIR/coerce-shared-wrong-generic.rs:16:5
+   |
+LL |     value: &'a mut T,
+   |     ---------------- source field `value` has type `&'a mut T`
+...
+LL |     value: &'a U,
+   |     ^^^^^^^^^^^^ target field `value` has type `&'a U`
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/coerce_shared_consteval.rs
+++ b/tests/ui/reborrow/coerce_shared_consteval.rs
@@ -7,7 +7,7 @@
 
 use std::marker::{CoerceShared, Reborrow};
 
-pub struct MyMut<'a>(&'a u8);
+pub struct MyMut<'a>(&'a mut u8);
 
 impl Reborrow for MyMut<'_> {}
 
@@ -17,11 +17,11 @@ pub struct MyRef<'a>(&'a u8);
 impl<'a> CoerceShared<MyRef<'a>> for MyMut<'a> {}
 
 const fn consteval_reproducer() {
-    let value = 1;
-    foo(MyMut(&value));
+    let mut value = 1;
+    foo(MyMut(&mut value));
 }
 
-const fn foo(x: MyRef<'_>) {}
+const fn foo(_x: MyRef<'_>) {}
 
 fn main() {
     const { consteval_reproducer(); }

--- a/tests/ui/reborrow/corrected-field-mismatch-coerce-shared-issue-156315.rs
+++ b/tests/ui/reborrow/corrected-field-mismatch-coerce-shared-issue-156315.rs
@@ -1,0 +1,21 @@
+//@ normalize-stderr: "\n\n\z" -> "\n"
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct CustomMut<'a, T>(&'a mut T);
+
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+
+struct CustomRef<'a, T>(&'a CustomMut<'a, T>);
+//~^ ERROR
+
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+fn method(_a: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+    method(a);
+}

--- a/tests/ui/reborrow/corrected-field-mismatch-coerce-shared-issue-156315.stderr
+++ b/tests/ui/reborrow/corrected-field-mismatch-coerce-shared-issue-156315.stderr
@@ -1,0 +1,10 @@
+error: implementing `CoerceShared` requires corresponding fields to match, be reborrowable with `CoerceShared`, or coerce a mutable reference field to a shared reference field
+  --> $DIR/corrected-field-mismatch-coerce-shared-issue-156315.rs:11:25
+   |
+LL | struct CustomMut<'a, T>(&'a mut T);
+   |                         --------- source field `0` has type `&'a mut T`
+...
+LL | struct CustomRef<'a, T>(&'a CustomMut<'a, T>);
+   |                         ^^^^^^^^^^^^^^^^^^^^ target field `0` has type `&'a CustomMut<'a, T>`
+
+error: aborting due to 1 previous error

--- a/tests/ui/reborrow/malformed-marker-coerce-shared-issue-156309.rs
+++ b/tests/ui/reborrow/malformed-marker-coerce-shared-issue-156309.rs
@@ -1,0 +1,29 @@
+//@ edition: 2024
+
+#![feature(reborrow)]
+
+// Malformed no-ICE regression: the unrelated name and signature errors are intentional because the
+// original issue combined them with CoerceShared validation.
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct CustomMarker<'a>(PhantomData<&'a ()>);
+
+struct CustomMarkerRef<'a>(PhantomData<(Debug, Clone, Copy)>);
+//~^ ERROR
+//~| ERROR
+//~| ERROR
+
+impl<'a> Reborrow for CustomMarker<'a> {}
+impl<'a> CoerceShared<CustomMarkerRef<'a>> for CustomMarker<'a> {}
+//~^ ERROR
+
+fn method<'a>(_a: CustomMarkerRef<'a>) -> 'a () {
+    //~^ ERROR
+    &()
+}
+
+fn main() {
+    let a = CustomMarker(PhantomData);
+    let b = method(a);
+}

--- a/tests/ui/reborrow/malformed-marker-coerce-shared-issue-156309.stderr
+++ b/tests/ui/reborrow/malformed-marker-coerce-shared-issue-156309.stderr
@@ -1,0 +1,62 @@
+error: expected type, found lifetime
+  --> $DIR/malformed-marker-coerce-shared-issue-156309.rs:21:43
+   |
+LL | fn method<'a>(_a: CustomMarkerRef<'a>) -> 'a () {
+   |                                           ^^ expected type
+   |
+help: you might have meant to write a reference type here
+   |
+LL | fn method<'a>(_a: CustomMarkerRef<'a>) -> &'a () {
+   |                                           +
+
+error[E0573]: expected type, found derive macro `Debug`
+  --> $DIR/malformed-marker-coerce-shared-issue-156309.rs:12:41
+   |
+LL | struct CustomMarkerRef<'a>(PhantomData<(Debug, Clone, Copy)>);
+   |                                         ^^^^^ not a type
+   |
+help: consider importing this trait instead
+   |
+LL + use std::fmt::Debug;
+   |
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/malformed-marker-coerce-shared-issue-156309.rs:12:48
+   |
+LL | struct CustomMarkerRef<'a>(PhantomData<(Debug, Clone, Copy)>);
+   |                                                ^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | struct CustomMarkerRef<'a>(PhantomData<(Debug, dyn Clone, Copy)>);
+   |                                                +++
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/malformed-marker-coerce-shared-issue-156309.rs:12:55
+   |
+LL | struct CustomMarkerRef<'a>(PhantomData<(Debug, Clone, Copy)>);
+   |                                                       ^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | struct CustomMarkerRef<'a>(PhantomData<(Debug, Clone, dyn Copy)>);
+   |                                                       +++
+
+error[E0277]: the trait bound `CustomMarkerRef<'a>: Copy` is not satisfied
+  --> $DIR/malformed-marker-coerce-shared-issue-156309.rs:18:10
+   |
+LL | impl<'a> CoerceShared<CustomMarkerRef<'a>> for CustomMarker<'a> {}
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `CustomMarkerRef<'a>`
+   |
+note: required by a bound in `CoerceShared`
+  --> $SRC_DIR/core/src/marker.rs:LL:COL
+help: consider annotating `CustomMarkerRef<'a>` with `#[derive(Copy)]`
+   |
+LL + #[derive(Copy)]
+LL | struct CustomMarkerRef<'a>(PhantomData<(Debug, Clone, Copy)>);
+   |
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0277, E0573, E0782.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/reborrow/marker-coerce-shared-corrected-issue-156309.rs
+++ b/tests/ui/reborrow/marker-coerce-shared-corrected-issue-156309.rs
@@ -1,0 +1,25 @@
+//@ run-pass
+//@ edition: 2024
+
+#![feature(reborrow)]
+
+use std::marker::{CoerceShared, PhantomData, Reborrow};
+
+struct CustomMarker<'a>(PhantomData<&'a ()>);
+
+#[derive(Clone, Copy, Debug)]
+struct CustomMarkerRef<'a>(PhantomData<&'a ()>);
+
+impl<'a> Reborrow for CustomMarker<'a> {}
+impl<'a> CoerceShared<CustomMarkerRef<'a>> for CustomMarker<'a> {}
+
+fn method<'a>(_a: CustomMarkerRef<'a>) -> &'a () {
+    &()
+}
+
+fn main() {
+    let a = CustomMarker(PhantomData);
+    let b = method(a);
+    let c = method(a);
+    let _ = (&a, b, c);
+}

--- a/tests/ui/reborrow/missing-generic-args-coerce-shared-issue-156315.rs
+++ b/tests/ui/reborrow/missing-generic-args-coerce-shared-issue-156315.rs
@@ -1,0 +1,23 @@
+#![feature(reborrow)]
+
+// Malformed no-ICE regression: this intentionally keeps the missing generic arguments from the
+// original reproducer while the corrected test isolates the CoerceShared field error.
+
+use std::marker::{CoerceShared, Reborrow};
+
+struct CustomMut<'a, T>(&'a mut T);
+
+impl<'a, T> Reborrow for CustomMut<'a, T> {}
+impl<'a, T> CoerceShared<CustomRef<'a, T>> for CustomMut<'a, T> {}
+
+struct CustomRef<'a, T>(&'a CustomMut);
+//~^ ERROR
+//~| ERROR
+//~| ERROR
+
+fn method(_a: CustomRef<'_, ()>) {}
+
+fn main() {
+    let a = CustomMut(&mut ());
+    method(a);
+}

--- a/tests/ui/reborrow/missing-generic-args-coerce-shared-issue-156315.stderr
+++ b/tests/ui/reborrow/missing-generic-args-coerce-shared-issue-156315.stderr
@@ -1,0 +1,40 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-generic-args-coerce-shared-issue-156315.rs:13:29
+   |
+LL | struct CustomRef<'a, T>(&'a CustomMut);
+   |                             ^^^^^^^^^ expected named lifetime parameter
+   |
+help: consider using the `'a` lifetime
+   |
+LL | struct CustomRef<'a, T>(&'a CustomMut<'a>);
+   |                                      ++++
+
+error[E0107]: missing generics for struct `CustomMut`
+  --> $DIR/missing-generic-args-coerce-shared-issue-156315.rs:13:29
+   |
+LL | struct CustomRef<'a, T>(&'a CustomMut);
+   |                             ^^^^^^^^^ expected 1 generic argument
+   |
+note: struct defined here, with 1 generic parameter: `T`
+  --> $DIR/missing-generic-args-coerce-shared-issue-156315.rs:8:8
+   |
+LL | struct CustomMut<'a, T>(&'a mut T);
+   |        ^^^^^^^^^     -
+help: add missing generic argument
+   |
+LL | struct CustomRef<'a, T>(&'a CustomMut<T>);
+   |                                      +++
+
+error: implementing `CoerceShared` requires corresponding fields to match, be reborrowable with `CoerceShared`, or coerce a mutable reference field to a shared reference field
+  --> $DIR/missing-generic-args-coerce-shared-issue-156315.rs:13:25
+   |
+LL | struct CustomMut<'a, T>(&'a mut T);
+   |                         --------- source field `0` has type `&'a mut T`
+...
+LL | struct CustomRef<'a, T>(&'a CustomMut);
+   |                         ^^^^^^^^^^^^^ target field `0` has type `&'a CustomMut<'_, {type error}>`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0107.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157101)*
<!-- homu-ignore:end -->

This PR extends generic shared reborrows so that `CoerceShared` validates and lowers source-to-target structs field by field, rather than relying on a same-layout, transmute-like copy.

The core change is a shared `rustc_middle::ty::reborrow` helper that computes the field correspondence used by `CoerceShared` validation, borrow checking, const-eval, and codegen.

The correspondence rules are:

* Named structs match non-`PhantomData` data fields by name.
* Tuple structs match non-`PhantomData` data fields by position.
* `PhantomData` fields are ignored.
* Every target data field must correspond to a source data field.

`CoerceShared` impl validation now checks each corresponding field relation. A field relation is accepted when the field is:

* Copy-compatible,
* recursively `CoerceShared`-compatible, or
* a mutable-reference-to-shared-reference reborrow.

The validation also rejects mismatched field styles, missing source fields, mismatched reborrow lifetimes, and inaccessible fields with targeted diagnostics.

Borrowck now adds shared generic reborrow constraints recursively through the validated field relations, while still issuing the loan for the original source place as a whole. This ensures source-only fields remain protected for the inferred target lifetime when the target omits fields from the source.

Const-eval and codegen now lower shared generic reborrows recursively into the target fields instead of treating the operation as a transmute-like copy. This covers nested `CoerceShared` fields and layout-changing source/target pairs.

## Fixes

Fixes rust-lang/rust#156566.
Fixes rust-lang/rust#156309.
Fixes rust-lang/rust#156315.

## PR scope

I did not split these into smaller PRs because the issues mostly share the same root cause: `CoerceShared` needed a field-by-field validation and lowering model. So when making this, I just decided to write it in a way that will fix the issues anyway.

## Tracking
https://github.com/rust-lang/rust/issues/145612
https://rust-lang.github.io/rust-project-goals/2025h2/autoreborrow-traits.html

CC. @aapoalas, @dingxiangfei2009
r? @RalfJung
