### PR TITLE
Add reproducibly failing tests for parallel frontend

### DIFF
--- a/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
@@ -1,6 +1,6 @@
 //@ edition:2021
-
 //@ check-pass
+//@ ignore-parallel-frontend unstable liveness diagnostics
 #![allow(unreachable_code)]
 #![warn(unused)]
 #![allow(dead_code)]

--- a/tests/ui/lint/unused/unused-assign-148960.rs
+++ b/tests/ui/lint/unused/unused-assign-148960.rs
@@ -1,4 +1,5 @@
 //@ check-fail
+//@ ignore-parallel-frontend unstable liveness diagnostics
 #![deny(unused)]
 #![allow(dead_code)]
 

--- a/tests/ui/lint/unused/unused-assign-148960.stderr
+++ b/tests/ui/lint/unused/unused-assign-148960.stderr
@@ -1,5 +1,5 @@
 error: value assigned to `value` is never read
-  --> $DIR/unused-assign-148960.rs:6:21
+  --> $DIR/unused-assign-148960.rs:7:21
    |
 LL |     let mut value = b"0".to_vec();
    |                     ^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -7,14 +7,14 @@ LL |     value = b"1".to_vec();
    |     ----- `value` is overwritten here before the previous value is read
    |
 note: the lint level is defined here
-  --> $DIR/unused-assign-148960.rs:2:9
+  --> $DIR/unused-assign-148960.rs:3:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_assignments)]` implied by `#[deny(unused)]`
 
 error: value assigned to `x` is never read
-  --> $DIR/unused-assign-148960.rs:12:17
+  --> $DIR/unused-assign-148960.rs:13:17
    |
 LL |     let mut x = 1;
    |                 ^ this value is reassigned later and never used
@@ -22,7 +22,7 @@ LL |     x = 2;
    |     ----- `x` is overwritten here before the previous value is read
 
 error: value assigned to `x` is never read
-  --> $DIR/unused-assign-148960.rs:13:5
+  --> $DIR/unused-assign-148960.rs:14:5
    |
 LL |     x = 2;
    |     ^^^^^ this value is reassigned later and never used
@@ -30,7 +30,7 @@ LL |     x = 3;
    |     ----- `x` is overwritten here before the previous value is read
 
 error: value assigned to `p` is never read
-  --> $DIR/unused-assign-148960.rs:24:17
+  --> $DIR/unused-assign-148960.rs:25:17
    |
 LL |     let mut p = Point { x: 1, y: 1 };
    |                 ^^^^^^^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -38,7 +38,7 @@ LL |     p = Point { x: 2, y: 2 };
    |     ------------------------ `p` is overwritten here before the previous value is read
 
 error: variable `foo` is assigned to, but never used
-  --> $DIR/unused-assign-148960.rs:38:9
+  --> $DIR/unused-assign-148960.rs:39:9
    |
 LL |     let mut foo = Foo;
    |         ^^^^^^^
@@ -52,7 +52,7 @@ LL +     let Foo = Foo;
    |
 
 error: value assigned to `foo` is never read
-  --> $DIR/unused-assign-148960.rs:39:5
+  --> $DIR/unused-assign-148960.rs:40:5
    |
 LL |     foo = Foo;
    |     ^^^

--- a/tests/ui/liveness/liveness-consts.rs
+++ b/tests/ui/liveness/liveness-consts.rs
@@ -1,4 +1,5 @@
 //@ check-pass
+//@ ignore-parallel-frontend unstable liveness diagnostics
 #![warn(unused)]
 #![allow(unreachable_code)]
 

--- a/tests/ui/liveness/liveness-consts.stderr
+++ b/tests/ui/liveness/liveness-consts.stderr
@@ -1,30 +1,30 @@
 warning: unused variable: `e`
-  --> $DIR/liveness-consts.rs:26:13
+  --> $DIR/liveness-consts.rs:27:13
    |
 LL |         let e = 1;
    |             ^ help: if this is intentional, prefix it with an underscore: `_e`
    |
 note: the lint level is defined here
-  --> $DIR/liveness-consts.rs:2:9
+  --> $DIR/liveness-consts.rs:3:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
 
 warning: unused variable: `s`
-  --> $DIR/liveness-consts.rs:35:24
+  --> $DIR/liveness-consts.rs:36:24
    |
 LL | pub fn f(x: [u8; { let s = 17; 100 }]) -> [u8;  { let z = 18; 100 }] {
    |                        ^ help: if this is intentional, prefix it with an underscore: `_s`
 
 warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:35:55
+  --> $DIR/liveness-consts.rs:36:55
    |
 LL | pub fn f(x: [u8; { let s = 17; 100 }]) -> [u8;  { let z = 18; 100 }] {
    |                                                       ^ help: if this is intentional, prefix it with an underscore: `_z`
 
 warning: variable `a` is assigned to, but never used
-  --> $DIR/liveness-consts.rs:7:9
+  --> $DIR/liveness-consts.rs:8:9
    |
 LL |     let mut a = 0;
    |         ^^^^^
@@ -32,7 +32,7 @@ LL |     let mut a = 0;
    = note: consider using `_a` instead
 
 warning: value assigned to `a` is never read
-  --> $DIR/liveness-consts.rs:11:9
+  --> $DIR/liveness-consts.rs:12:9
    |
 LL |         a += 1;
    |         ^^^^^^
@@ -41,7 +41,7 @@ LL |         a += 1;
    = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
 
 warning: value assigned to `b` is never read
-  --> $DIR/liveness-consts.rs:18:17
+  --> $DIR/liveness-consts.rs:19:17
    |
 LL |     let mut b = 1;
    |                 ^ this value is reassigned later and never used
@@ -49,7 +49,7 @@ LL |     b += 1;
    |     ------ `b` is overwritten here before the previous value is read
 
 warning: value assigned to `b` is never read
-  --> $DIR/liveness-consts.rs:19:5
+  --> $DIR/liveness-consts.rs:20:5
    |
 LL |     b += 1;
    |     ^^^^^^ this value is reassigned later and never used
@@ -57,13 +57,13 @@ LL |     b = 42;
    |     ------ `b` is overwritten here before the previous value is read
 
 warning: unused variable: `z`
-  --> $DIR/liveness-consts.rs:62:13
+  --> $DIR/liveness-consts.rs:63:13
    |
 LL |         let z = 42;
    |             ^ help: if this is intentional, prefix it with an underscore: `_z`
 
 warning: value assigned to `t` is never read
-  --> $DIR/liveness-consts.rs:44:9
+  --> $DIR/liveness-consts.rs:45:9
    |
 LL |         t = t + t;
    |         ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |         t = t + t;
    = help: maybe it is overwritten before being read?
 
 warning: unused variable: `w`
-  --> $DIR/liveness-consts.rs:51:13
+  --> $DIR/liveness-consts.rs:52:13
    |
 LL |         let w = 10;
    |             ^ help: if this is intentional, prefix it with an underscore: `_w`

--- a/tests/ui/liveness/liveness-dead.rs
+++ b/tests/ui/liveness/liveness-dead.rs
@@ -1,3 +1,4 @@
+//@ ignore-parallel-frontend unstable liveness diagnostics
 #![allow(dead_code)]
 #![deny(unused_assignments)]
 

--- a/tests/ui/liveness/liveness-dead.stderr
+++ b/tests/ui/liveness/liveness-dead.stderr
@@ -1,5 +1,5 @@
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:9:24
+  --> $DIR/liveness-dead.rs:10:24
    |
 LL |     let mut x: isize = 3;
    |                        ^ this value is reassigned later and never used
@@ -7,13 +7,13 @@ LL |     x = 4;
    |     ----- `x` is overwritten here before the previous value is read
    |
 note: the lint level is defined here
-  --> $DIR/liveness-dead.rs:2:9
+  --> $DIR/liveness-dead.rs:3:9
    |
 LL | #![deny(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:17:5
+  --> $DIR/liveness-dead.rs:18:5
    |
 LL |     x = 4;
    |     ^^^^^
@@ -21,7 +21,7 @@ LL |     x = 4;
    = help: maybe it is overwritten before being read?
 
 error: value passed to `x` is never read
-  --> $DIR/liveness-dead.rs:20:7
+  --> $DIR/liveness-dead.rs:21:7
    |
 LL | fn f4(mut x: i32) {
    |       ^^^^^
@@ -29,7 +29,7 @@ LL | fn f4(mut x: i32) {
    = help: maybe it is overwritten before being read?
 
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:27:5
+  --> $DIR/liveness-dead.rs:28:5
    |
 LL |     x = 4;
    |     ^^^^^

--- a/tests/ui/liveness/liveness-upvars.rs
+++ b/tests/ui/liveness/liveness-upvars.rs
@@ -1,5 +1,6 @@
 //@ edition:2018
 //@ check-pass
+//@ ignore-parallel-frontend unstable liveness diagnostics
 #![feature(coroutines, stmt_expr_attributes)]
 #![warn(unused)]
 #![allow(unreachable_code)]

--- a/tests/ui/liveness/liveness-upvars.stderr
+++ b/tests/ui/liveness/liveness-upvars.stderr
@@ -1,19 +1,19 @@
 warning: value captured by `last` is never read
-  --> $DIR/liveness-upvars.rs:10:9
+  --> $DIR/liveness-upvars.rs:11:9
    |
 LL |         last = Some(s);
    |         ^^^^
    |
    = help: did you mean to capture by reference instead?
 note: the lint level is defined here
-  --> $DIR/liveness-upvars.rs:4:9
+  --> $DIR/liveness-upvars.rs:5:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
 
 warning: value assigned to `last` is never read
-  --> $DIR/liveness-upvars.rs:10:9
+  --> $DIR/liveness-upvars.rs:11:9
    |
 LL |         last = Some(s);
    |         ^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL |         last = Some(s);
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `sum` is never read
-  --> $DIR/liveness-upvars.rs:22:9
+  --> $DIR/liveness-upvars.rs:23:9
    |
 LL |         sum += x;
    |         ^^^
@@ -29,7 +29,7 @@ LL |         sum += x;
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `sum` is never read
-  --> $DIR/liveness-upvars.rs:22:9
+  --> $DIR/liveness-upvars.rs:23:9
    |
 LL |         sum += x;
    |         ^^^^^^^^
@@ -37,7 +37,7 @@ LL |         sum += x;
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:69:9
+  --> $DIR/liveness-upvars.rs:70:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -45,7 +45,7 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:63:9
+  --> $DIR/liveness-upvars.rs:64:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -53,7 +53,7 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:49:9
+  --> $DIR/liveness-upvars.rs:50:9
    |
 LL |         c += 1;
    |         ^
@@ -61,7 +61,7 @@ LL |         c += 1;
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:49:9
+  --> $DIR/liveness-upvars.rs:50:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -69,7 +69,7 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:44:9
+  --> $DIR/liveness-upvars.rs:45:9
    |
 LL |         c += 1;
    |         ^
@@ -77,7 +77,7 @@ LL |         c += 1;
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `c` is never read
-  --> $DIR/liveness-upvars.rs:44:9
+  --> $DIR/liveness-upvars.rs:45:9
    |
 LL |         c += 1;
    |         ^^^^^^
@@ -85,7 +85,7 @@ LL |         c += 1;
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:38:9
+  --> $DIR/liveness-upvars.rs:39:9
    |
 LL |         c = 1;
    |         ^
@@ -93,7 +93,7 @@ LL |         c = 1;
    = help: did you mean to capture by reference instead?
 
 warning: value captured by `c` is never read
-  --> $DIR/liveness-upvars.rs:34:9
+  --> $DIR/liveness-upvars.rs:35:9
    |
 LL |         c = 1;
    |         ^
@@ -101,7 +101,7 @@ LL |         c = 1;
    = help: did you mean to capture by reference instead?
 
 warning: value captured by `e` is never read
-  --> $DIR/liveness-upvars.rs:82:13
+  --> $DIR/liveness-upvars.rs:83:13
    |
 LL |             e = Some("e1");
    |             ^
@@ -109,7 +109,7 @@ LL |             e = Some("e1");
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `e` is never read
-  --> $DIR/liveness-upvars.rs:82:13
+  --> $DIR/liveness-upvars.rs:83:13
    |
 LL |             e = Some("e1");
    |             ^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -118,7 +118,7 @@ LL |             e = Some("e2");
    |             -------------- `e` is overwritten here before the previous value is read
 
 warning: value assigned to `e` is never read
-  --> $DIR/liveness-upvars.rs:84:13
+  --> $DIR/liveness-upvars.rs:85:13
    |
 LL |             e = Some("e2");
    |             ^^^^^^^^^^^^^^
@@ -126,7 +126,7 @@ LL |             e = Some("e2");
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `d` is never read
-  --> $DIR/liveness-upvars.rs:78:13
+  --> $DIR/liveness-upvars.rs:79:13
    |
 LL |             d = Some("d1");
    |             ^^^^^^^^^^^^^^ this value is reassigned later and never used
@@ -134,7 +134,7 @@ LL |             d = Some("d2");
    |             -------------- `d` is overwritten here before the previous value is read
 
 warning: value assigned to `v` is never read
-  --> $DIR/liveness-upvars.rs:92:13
+  --> $DIR/liveness-upvars.rs:93:13
    |
 LL |             v = T::default();
    |             ^
@@ -142,7 +142,7 @@ LL |             v = T::default();
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `z` is never read
-  --> $DIR/liveness-upvars.rs:105:17
+  --> $DIR/liveness-upvars.rs:106:17
    |
 LL |                 z = T::default();
    |                 ^
@@ -150,7 +150,7 @@ LL |                 z = T::default();
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `z` is never read
-  --> $DIR/liveness-upvars.rs:105:17
+  --> $DIR/liveness-upvars.rs:106:17
    |
 LL |                 z = T::default();
    |                 ^^^^^^^^^^^^^^^^
@@ -158,7 +158,7 @@ LL |                 z = T::default();
    = help: maybe it is overwritten before being read?
 
 warning: value captured by `state` is never read
-  --> $DIR/liveness-upvars.rs:131:9
+  --> $DIR/liveness-upvars.rs:132:9
    |
 LL |         state = 4;
    |         ^^^^^
@@ -166,7 +166,7 @@ LL |         state = 4;
    = help: did you mean to capture by reference instead?
 
 warning: value assigned to `state` is never read
-  --> $DIR/liveness-upvars.rs:131:9
+  --> $DIR/liveness-upvars.rs:132:9
    |
 LL |         state = 4;
    |         ^^^^^^^^^ this value is reassigned later and never used
@@ -175,7 +175,7 @@ LL |         state = 5;
    |         --------- `state` is overwritten here before the previous value is read
 
 warning: value assigned to `state` is never read
-  --> $DIR/liveness-upvars.rs:134:9
+  --> $DIR/liveness-upvars.rs:135:9
    |
 LL |         state = 5;
    |         ^^^^^^^^^
@@ -183,7 +183,7 @@ LL |         state = 5;
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `s` is never read
-  --> $DIR/liveness-upvars.rs:143:9
+  --> $DIR/liveness-upvars.rs:144:9
    |
 LL |         s = 1;
    |         ^^^^^ this value is reassigned later and never used
@@ -191,7 +191,7 @@ LL |         yield (s = 2);
    |               ------- `s` is overwritten here before the previous value is read
 
 warning: value assigned to `s` is never read
-  --> $DIR/liveness-upvars.rs:145:9
+  --> $DIR/liveness-upvars.rs:146:9
    |
 LL |         s = yield ();
    |         ^^^^^^^^^^^^ this value is reassigned later and never used

--- a/tests/ui/liveness/unused-assignments-diverging-branch-issue-156416.rs
+++ b/tests/ui/liveness/unused-assignments-diverging-branch-issue-156416.rs
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ ignore-parallel-frontend unstable liveness diagnostics
 #![allow(dead_code)]
 #![warn(unused_assignments)]
 

--- a/tests/ui/liveness/unused-assignments-diverging-branch-issue-156416.stderr
+++ b/tests/ui/liveness/unused-assignments-diverging-branch-issue-156416.stderr
@@ -1,18 +1,18 @@
 warning: value assigned to `x` is never read
-  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:10:9
+  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:11:9
    |
 LL |         x = 35;
    |         ^^^^^^
    |
    = help: maybe it is overwritten before being read?
 note: the lint level is defined here
-  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:3:9
+  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:4:9
    |
 LL | #![warn(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
 
 warning: value assigned to `x` is never read
-  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:21:13
+  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:22:13
    |
 LL |             x = 35;
    |             ^^^^^^
@@ -20,7 +20,7 @@ LL |             x = 35;
    = help: maybe it is overwritten before being read?
 
 warning: value assigned to `x` is never read
-  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:36:9
+  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:37:9
    |
 LL |         x = 42;
    |         ^^^^^^ this value is reassigned later and never used
@@ -29,7 +29,7 @@ LL |     x = 99;
    |     ------ `x` is overwritten here before the previous value is read
 
 warning: value assigned to `x` is never read
-  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:33:9
+  --> $DIR/unused-assignments-diverging-branch-issue-156416.rs:34:9
    |
 LL |         x = 35;
    |         ^^^^^^ this value is reassigned later and never used

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-types.rs:47:9
+  --> $DIR/empty-types.rs:48:9
    |
 LL |         _ => {}
    |         ^------
@@ -9,13 +9,13 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:13:9
+  --> $DIR/empty-types.rs:14:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:50:9
+  --> $DIR/empty-types.rs:51:9
    |
 LL |         _x => {}
    |         ^^------
@@ -26,7 +26,7 @@ LL |         _x => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
-  --> $DIR/empty-types.rs:54:11
+  --> $DIR/empty-types.rs:55:11
    |
 LL |     match ref_never {}
    |           ^^^^^^^^^
@@ -41,7 +41,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:68:9
+  --> $DIR/empty-types.rs:69:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^------
@@ -52,7 +52,7 @@ LL |         (_, _) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:74:9
+  --> $DIR/empty-types.rs:75:9
    |
 LL |         _ => {}
    |         ^------
@@ -63,7 +63,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:77:9
+  --> $DIR/empty-types.rs:78:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^------
@@ -74,7 +74,7 @@ LL |         (_, _) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:81:9
+  --> $DIR/empty-types.rs:82:9
    |
 LL |         _ => {}
    |         ^------
@@ -85,7 +85,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
-  --> $DIR/empty-types.rs:85:11
+  --> $DIR/empty-types.rs:86:11
    |
 LL |     match res_u32_never {}
    |           ^^^^^^^^^^^^^ pattern `Ok(_)` not covered
@@ -104,7 +104,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:92:9
+  --> $DIR/empty-types.rs:93:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^------
@@ -115,7 +115,7 @@ LL |         Err(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:97:9
+  --> $DIR/empty-types.rs:98:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^------
@@ -126,7 +126,7 @@ LL |         Err(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
-  --> $DIR/empty-types.rs:94:11
+  --> $DIR/empty-types.rs:95:11
    |
 LL |     match res_u32_never {
    |           ^^^^^^^^^^^^^ pattern `Ok(1_u32..=u32::MAX)` not covered
@@ -144,7 +144,7 @@ LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:100:9
+  --> $DIR/empty-types.rs:101:9
    |
 LL |     let Ok(_x) = res_u32_never.as_ref();
    |         ^^^^^^ pattern `Err(_)` not covered
@@ -158,7 +158,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:110:9
+  --> $DIR/empty-types.rs:111:9
    |
 LL |         _ => {}
    |         ^------
@@ -169,18 +169,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:113:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^------
-   |         |
-   |         matches no values because `Result<!, !>` is uninhabited
-   |         help: remove the match arm
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:116:9
+  --> $DIR/empty-types.rs:114:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^------
@@ -193,6 +182,17 @@ LL |         Ok(_) => {}
 error: unreachable pattern
   --> $DIR/empty-types.rs:117:9
    |
+LL |         Ok(_) => {}
+   |         ^^^^^------
+   |         |
+   |         matches no values because `Result<!, !>` is uninhabited
+   |         help: remove the match arm
+   |
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
+
+error: unreachable pattern
+  --> $DIR/empty-types.rs:118:9
+   |
 LL |         _ => {}
    |         ^------
    |         |
@@ -202,7 +202,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:120:9
+  --> $DIR/empty-types.rs:121:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^------
@@ -213,7 +213,7 @@ LL |         Ok(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:121:9
+  --> $DIR/empty-types.rs:122:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^------
@@ -224,7 +224,7 @@ LL |         Err(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:130:13
+  --> $DIR/empty-types.rs:131:13
    |
 LL |             _ => {}
    |             ^------
@@ -235,7 +235,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:133:13
+  --> $DIR/empty-types.rs:134:13
    |
 LL |             _ if false => {}
    |             ^---------------
@@ -246,7 +246,7 @@ LL |             _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:141:13
+  --> $DIR/empty-types.rs:142:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^------
@@ -257,7 +257,7 @@ LL |             Some(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:145:13
+  --> $DIR/empty-types.rs:146:13
    |
 LL |             None => {}
    |             ---- matches all the relevant values
@@ -265,7 +265,7 @@ LL |             _ => {}
    |             ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:197:13
+  --> $DIR/empty-types.rs:198:13
    |
 LL |             _ => {}
    |             ^------
@@ -276,7 +276,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:202:13
+  --> $DIR/empty-types.rs:203:13
    |
 LL |             _ => {}
    |             ^------
@@ -287,7 +287,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:207:13
+  --> $DIR/empty-types.rs:208:13
    |
 LL |             _ => {}
    |             ^------
@@ -298,7 +298,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:212:13
+  --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^------
@@ -309,7 +309,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:218:13
+  --> $DIR/empty-types.rs:219:13
    |
 LL |             _ => {}
    |             ^------
@@ -320,7 +320,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:279:9
+  --> $DIR/empty-types.rs:280:9
    |
 LL |         _ => {}
    |         ^------
@@ -331,7 +331,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:282:9
+  --> $DIR/empty-types.rs:283:9
    |
 LL |         (_, _) => {}
    |         ^^^^^^------
@@ -342,7 +342,7 @@ LL |         (_, _) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:285:9
+  --> $DIR/empty-types.rs:286:9
    |
 LL |         Ok(_) => {}
    |         ^^^^^------
@@ -353,7 +353,7 @@ LL |         Ok(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:286:9
+  --> $DIR/empty-types.rs:287:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^------
@@ -364,7 +364,7 @@ LL |         Err(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
-  --> $DIR/empty-types.rs:325:11
+  --> $DIR/empty-types.rs:326:11
    |
 LL |     match slice_never {}
    |           ^^^^^^^^^^^
@@ -378,7 +378,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` not covered
-  --> $DIR/empty-types.rs:336:11
+  --> $DIR/empty-types.rs:337:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[]` not covered
@@ -391,7 +391,7 @@ LL +         &[] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` not covered
-  --> $DIR/empty-types.rs:350:11
+  --> $DIR/empty-types.rs:351:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[]` not covered
@@ -405,7 +405,7 @@ LL +         &[] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `[!]` is non-empty
-  --> $DIR/empty-types.rs:357:11
+  --> $DIR/empty-types.rs:358:11
    |
 LL |     match *slice_never {}
    |           ^^^^^^^^^^^^
@@ -419,7 +419,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:366:9
+  --> $DIR/empty-types.rs:367:9
    |
 LL |         _ => {}
    |         ^------
@@ -430,7 +430,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:369:9
+  --> $DIR/empty-types.rs:370:9
    |
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^------
@@ -441,7 +441,7 @@ LL |         [_, _, _] => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:372:9
+  --> $DIR/empty-types.rs:373:9
    |
 LL |         [_, ..] => {}
    |         ^^^^^^^------
@@ -452,7 +452,7 @@ LL |         [_, ..] => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-types.rs:386:11
+  --> $DIR/empty-types.rs:387:11
    |
 LL |     match array_0_never {}
    |           ^^^^^^^^^^^^^
@@ -466,7 +466,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:393:9
+  --> $DIR/empty-types.rs:394:9
    |
 LL |         [] => {}
    |         -- matches all the relevant values
@@ -474,7 +474,7 @@ LL |         _ => {}
    |         ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-types.rs:395:11
+  --> $DIR/empty-types.rs:396:11
    |
 LL |     match array_0_never {
    |           ^^^^^^^^^^^^^ pattern `[]` not covered
@@ -488,7 +488,7 @@ LL +         [] => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:414:9
+  --> $DIR/empty-types.rs:415:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^------
@@ -499,7 +499,7 @@ LL |         Some(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:419:9
+  --> $DIR/empty-types.rs:420:9
    |
 LL |         Some(_a) => {}
    |         ^^^^^^^^------
@@ -510,7 +510,7 @@ LL |         Some(_a) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:424:9
+  --> $DIR/empty-types.rs:425:9
    |
 LL |         None => {}
    |         ---- matches all the relevant values
@@ -519,7 +519,7 @@ LL |         _ => {}
    |         ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:429:9
+  --> $DIR/empty-types.rs:430:9
    |
 LL |         None => {}
    |         ---- matches all the relevant values
@@ -528,7 +528,7 @@ LL |         _a => {}
    |         ^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:601:9
+  --> $DIR/empty-types.rs:602:9
    |
 LL |         _ => {}
    |         ^------
@@ -539,7 +539,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:604:9
+  --> $DIR/empty-types.rs:605:9
    |
 LL |         _x => {}
    |         ^^------
@@ -550,7 +550,7 @@ LL |         _x => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:607:9
+  --> $DIR/empty-types.rs:608:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -561,7 +561,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:610:9
+  --> $DIR/empty-types.rs:611:9
    |
 LL |         _x if false => {}
    |         ^^---------------

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-types.rs:47:9
+  --> $DIR/empty-types.rs:48:9
    |
 LL |         _ => {}
    |         ^------
@@ -9,13 +9,13 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:13:9
+  --> $DIR/empty-types.rs:14:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:50:9
+  --> $DIR/empty-types.rs:51:9
    |
 LL |         _x => {}
    |         ^^------
@@ -26,7 +26,7 @@ LL |         _x => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
-  --> $DIR/empty-types.rs:54:11
+  --> $DIR/empty-types.rs:55:11
    |
 LL |     match ref_never {}
    |           ^^^^^^^^^
@@ -41,7 +41,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:81:9
+  --> $DIR/empty-types.rs:82:9
    |
 LL |         _ => {}
    |         ^------
@@ -52,7 +52,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
-  --> $DIR/empty-types.rs:85:11
+  --> $DIR/empty-types.rs:86:11
    |
 LL |     match res_u32_never {}
    |           ^^^^^^^^^^^^^ pattern `Ok(_)` not covered
@@ -71,7 +71,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
-  --> $DIR/empty-types.rs:94:11
+  --> $DIR/empty-types.rs:95:11
    |
 LL |     match res_u32_never {
    |           ^^^^^^^^^^^^^ pattern `Ok(1_u32..=u32::MAX)` not covered
@@ -89,7 +89,7 @@ LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:100:9
+  --> $DIR/empty-types.rs:101:9
    |
 LL |     let Ok(_x) = res_u32_never.as_ref();
    |         ^^^^^^ pattern `Err(_)` not covered
@@ -103,7 +103,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:104:9
+  --> $DIR/empty-types.rs:105:9
    |
 LL |     let Ok(_x) = &res_u32_never;
    |         ^^^^^^ pattern `&Err(!)` not covered
@@ -117,7 +117,7 @@ LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:130:13
+  --> $DIR/empty-types.rs:131:13
    |
 LL |             _ => {}
    |             ^------
@@ -128,7 +128,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:133:13
+  --> $DIR/empty-types.rs:134:13
    |
 LL |             _ if false => {}
    |             ^---------------
@@ -139,7 +139,7 @@ LL |             _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
-  --> $DIR/empty-types.rs:154:15
+  --> $DIR/empty-types.rs:155:15
    |
 LL |         match *ref_opt_void {
    |               ^^^^^^^^^^^^^ pattern `Some(!)` not covered
@@ -158,7 +158,7 @@ LL +             Some(!)
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:197:13
+  --> $DIR/empty-types.rs:198:13
    |
 LL |             _ => {}
    |             ^------
@@ -169,7 +169,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:202:13
+  --> $DIR/empty-types.rs:203:13
    |
 LL |             _ => {}
    |             ^------
@@ -180,7 +180,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:207:13
+  --> $DIR/empty-types.rs:208:13
    |
 LL |             _ => {}
    |             ^------
@@ -191,7 +191,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:212:13
+  --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^------
@@ -202,7 +202,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:218:13
+  --> $DIR/empty-types.rs:219:13
    |
 LL |             _ => {}
    |             ^------
@@ -213,7 +213,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:279:9
+  --> $DIR/empty-types.rs:280:9
    |
 LL |         _ => {}
    |         ^------
@@ -224,7 +224,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:295:13
+  --> $DIR/empty-types.rs:296:13
    |
 LL |         let Ok(_) = *ptr_result_never_err;
    |             ^^^^^ pattern `Err(!)` not covered
@@ -238,7 +238,7 @@ LL |         if let Ok(_) = *ptr_result_never_err { todo!() };
    |         ++                                   +++++++++++
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
-  --> $DIR/empty-types.rs:314:11
+  --> $DIR/empty-types.rs:315:11
    |
 LL |     match *x {}
    |           ^^
@@ -252,7 +252,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `(!, !)` is non-empty
-  --> $DIR/empty-types.rs:316:11
+  --> $DIR/empty-types.rs:317:11
    |
 LL |     match *x {}
    |           ^^
@@ -266,7 +266,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(!)` and `Err(!)` not covered
-  --> $DIR/empty-types.rs:318:11
+  --> $DIR/empty-types.rs:319:11
    |
 LL |     match *x {}
    |           ^^ patterns `Ok(!)` and `Err(!)` not covered
@@ -288,7 +288,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 3]` is non-empty
-  --> $DIR/empty-types.rs:320:11
+  --> $DIR/empty-types.rs:321:11
    |
 LL |     match *x {}
    |           ^^
@@ -302,7 +302,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
-  --> $DIR/empty-types.rs:325:11
+  --> $DIR/empty-types.rs:326:11
    |
 LL |     match slice_never {}
    |           ^^^^^^^^^^^
@@ -316,7 +316,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[!, ..]` not covered
-  --> $DIR/empty-types.rs:327:11
+  --> $DIR/empty-types.rs:328:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[!, ..]` not covered
@@ -330,7 +330,7 @@ LL +         &[!, ..]
    |
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[!]` and `&[!, !]` not covered
-  --> $DIR/empty-types.rs:336:11
+  --> $DIR/empty-types.rs:337:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ patterns `&[]`, `&[!]` and `&[!, !]` not covered
@@ -343,7 +343,7 @@ LL +         &[] | &[!] | &[!, !] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` and `&[!, ..]` not covered
-  --> $DIR/empty-types.rs:350:11
+  --> $DIR/empty-types.rs:351:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ patterns `&[]` and `&[!, ..]` not covered
@@ -357,7 +357,7 @@ LL +         &[] | &[!, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `[!]` is non-empty
-  --> $DIR/empty-types.rs:357:11
+  --> $DIR/empty-types.rs:358:11
    |
 LL |     match *slice_never {}
    |           ^^^^^^^^^^^^
@@ -371,7 +371,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-types.rs:386:11
+  --> $DIR/empty-types.rs:387:11
    |
 LL |     match array_0_never {}
    |           ^^^^^^^^^^^^^
@@ -385,7 +385,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:393:9
+  --> $DIR/empty-types.rs:394:9
    |
 LL |         [] => {}
    |         -- matches all the relevant values
@@ -393,7 +393,7 @@ LL |         _ => {}
    |         ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-types.rs:395:11
+  --> $DIR/empty-types.rs:396:11
    |
 LL |     match array_0_never {
    |           ^^^^^^^^^^^^^ pattern `[]` not covered
@@ -407,7 +407,7 @@ LL +         [] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
-  --> $DIR/empty-types.rs:449:11
+  --> $DIR/empty-types.rs:450:11
    |
 LL |     match ref_opt_never {
    |           ^^^^^^^^^^^^^ pattern `&Some(!)` not covered
@@ -426,7 +426,7 @@ LL +         &Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
-  --> $DIR/empty-types.rs:490:11
+  --> $DIR/empty-types.rs:491:11
    |
 LL |     match *ref_opt_never {
    |           ^^^^^^^^^^^^^^ pattern `Some(!)` not covered
@@ -445,7 +445,7 @@ LL +         Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Err(!)` not covered
-  --> $DIR/empty-types.rs:538:11
+  --> $DIR/empty-types.rs:539:11
    |
 LL |     match *ref_res_never {
    |           ^^^^^^^^^^^^^^ pattern `Err(!)` not covered
@@ -464,7 +464,7 @@ LL +         Err(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Err(!)` not covered
-  --> $DIR/empty-types.rs:549:11
+  --> $DIR/empty-types.rs:550:11
    |
 LL |     match *ref_res_never {
    |           ^^^^^^^^^^^^^^ pattern `Err(!)` not covered
@@ -483,7 +483,7 @@ LL +         Err(!)
    |
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
-  --> $DIR/empty-types.rs:568:11
+  --> $DIR/empty-types.rs:569:11
    |
 LL |     match *ref_tuple_half_never {}
    |           ^^^^^^^^^^^^^^^^^^^^^
@@ -497,7 +497,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:601:9
+  --> $DIR/empty-types.rs:602:9
    |
 LL |         _ => {}
    |         ^------
@@ -508,7 +508,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:604:9
+  --> $DIR/empty-types.rs:605:9
    |
 LL |         _x => {}
    |         ^^------
@@ -519,7 +519,7 @@ LL |         _x => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:607:9
+  --> $DIR/empty-types.rs:608:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -530,7 +530,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:610:9
+  --> $DIR/empty-types.rs:611:9
    |
 LL |         _x if false => {}
    |         ^^---------------
@@ -541,7 +541,7 @@ LL |         _x if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `&!` not covered
-  --> $DIR/empty-types.rs:635:11
+  --> $DIR/empty-types.rs:636:11
    |
 LL |     match ref_never {
    |           ^^^^^^^^^ pattern `&!` not covered
@@ -557,7 +557,7 @@ LL +         &!
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(!)` not covered
-  --> $DIR/empty-types.rs:651:11
+  --> $DIR/empty-types.rs:652:11
    |
 LL |     match *ref_result_never {
    |           ^^^^^^^^^^^^^^^^^ pattern `Ok(!)` not covered
@@ -577,7 +577,7 @@ LL +         Ok(!)
    |
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
-  --> $DIR/empty-types.rs:671:11
+  --> $DIR/empty-types.rs:672:11
    |
 LL |     match *x {
    |           ^^ pattern `Some(!)` not covered

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/empty-types.rs:47:9
+  --> $DIR/empty-types.rs:48:9
    |
 LL |         _ => {}
    |         ^------
@@ -9,13 +9,13 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:13:9
+  --> $DIR/empty-types.rs:14:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:50:9
+  --> $DIR/empty-types.rs:51:9
    |
 LL |         _x => {}
    |         ^^------
@@ -26,7 +26,7 @@ LL |         _x => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
-  --> $DIR/empty-types.rs:54:11
+  --> $DIR/empty-types.rs:55:11
    |
 LL |     match ref_never {}
    |           ^^^^^^^^^
@@ -41,7 +41,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:81:9
+  --> $DIR/empty-types.rs:82:9
    |
 LL |         _ => {}
    |         ^------
@@ -52,7 +52,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
-  --> $DIR/empty-types.rs:85:11
+  --> $DIR/empty-types.rs:86:11
    |
 LL |     match res_u32_never {}
    |           ^^^^^^^^^^^^^ pattern `Ok(_)` not covered
@@ -71,7 +71,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
-  --> $DIR/empty-types.rs:94:11
+  --> $DIR/empty-types.rs:95:11
    |
 LL |     match res_u32_never {
    |           ^^^^^^^^^^^^^ pattern `Ok(1_u32..=u32::MAX)` not covered
@@ -89,7 +89,7 @@ LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:100:9
+  --> $DIR/empty-types.rs:101:9
    |
 LL |     let Ok(_x) = res_u32_never.as_ref();
    |         ^^^^^^ pattern `Err(_)` not covered
@@ -103,7 +103,7 @@ LL |     let Ok(_x) = res_u32_never.as_ref() else { todo!() };
    |                                         ++++++++++++++++
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:104:9
+  --> $DIR/empty-types.rs:105:9
    |
 LL |     let Ok(_x) = &res_u32_never;
    |         ^^^^^^ pattern `&Err(_)` not covered
@@ -117,7 +117,7 @@ LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:130:13
+  --> $DIR/empty-types.rs:131:13
    |
 LL |             _ => {}
    |             ^------
@@ -128,7 +128,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:133:13
+  --> $DIR/empty-types.rs:134:13
    |
 LL |             _ if false => {}
    |             ^---------------
@@ -139,7 +139,7 @@ LL |             _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:154:15
+  --> $DIR/empty-types.rs:155:15
    |
 LL |         match *ref_opt_void {
    |               ^^^^^^^^^^^^^ pattern `Some(_)` not covered
@@ -158,7 +158,7 @@ LL +             Some(_) => todo!()
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:197:13
+  --> $DIR/empty-types.rs:198:13
    |
 LL |             _ => {}
    |             ^------
@@ -169,7 +169,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:202:13
+  --> $DIR/empty-types.rs:203:13
    |
 LL |             _ => {}
    |             ^------
@@ -180,7 +180,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:207:13
+  --> $DIR/empty-types.rs:208:13
    |
 LL |             _ => {}
    |             ^------
@@ -191,7 +191,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:212:13
+  --> $DIR/empty-types.rs:213:13
    |
 LL |             _ => {}
    |             ^------
@@ -202,7 +202,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:218:13
+  --> $DIR/empty-types.rs:219:13
    |
 LL |             _ => {}
    |             ^------
@@ -213,7 +213,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:279:9
+  --> $DIR/empty-types.rs:280:9
    |
 LL |         _ => {}
    |         ^------
@@ -224,7 +224,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-types.rs:295:13
+  --> $DIR/empty-types.rs:296:13
    |
 LL |         let Ok(_) = *ptr_result_never_err;
    |             ^^^^^ pattern `Err(_)` not covered
@@ -238,7 +238,7 @@ LL |         if let Ok(_) = *ptr_result_never_err { todo!() };
    |         ++                                   +++++++++++
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
-  --> $DIR/empty-types.rs:314:11
+  --> $DIR/empty-types.rs:315:11
    |
 LL |     match *x {}
    |           ^^
@@ -252,7 +252,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `(!, !)` is non-empty
-  --> $DIR/empty-types.rs:316:11
+  --> $DIR/empty-types.rs:317:11
    |
 LL |     match *x {}
    |           ^^
@@ -266,7 +266,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` and `Err(_)` not covered
-  --> $DIR/empty-types.rs:318:11
+  --> $DIR/empty-types.rs:319:11
    |
 LL |     match *x {}
    |           ^^ patterns `Ok(_)` and `Err(_)` not covered
@@ -288,7 +288,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 3]` is non-empty
-  --> $DIR/empty-types.rs:320:11
+  --> $DIR/empty-types.rs:321:11
    |
 LL |     match *x {}
    |           ^^
@@ -302,7 +302,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
-  --> $DIR/empty-types.rs:325:11
+  --> $DIR/empty-types.rs:326:11
    |
 LL |     match slice_never {}
    |           ^^^^^^^^^^^
@@ -316,7 +316,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
-  --> $DIR/empty-types.rs:327:11
+  --> $DIR/empty-types.rs:328:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ pattern `&[_, ..]` not covered
@@ -330,7 +330,7 @@ LL +         &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[_]` and `&[_, _]` not covered
-  --> $DIR/empty-types.rs:336:11
+  --> $DIR/empty-types.rs:337:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ patterns `&[]`, `&[_]` and `&[_, _]` not covered
@@ -343,7 +343,7 @@ LL +         &[] | &[_] | &[_, _] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` and `&[_, ..]` not covered
-  --> $DIR/empty-types.rs:350:11
+  --> $DIR/empty-types.rs:351:11
    |
 LL |     match slice_never {
    |           ^^^^^^^^^^^ patterns `&[]` and `&[_, ..]` not covered
@@ -357,7 +357,7 @@ LL +         &[] | &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `[!]` is non-empty
-  --> $DIR/empty-types.rs:357:11
+  --> $DIR/empty-types.rs:358:11
    |
 LL |     match *slice_never {}
    |           ^^^^^^^^^^^^
@@ -371,7 +371,7 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-types.rs:386:11
+  --> $DIR/empty-types.rs:387:11
    |
 LL |     match array_0_never {}
    |           ^^^^^^^^^^^^^
@@ -385,7 +385,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:393:9
+  --> $DIR/empty-types.rs:394:9
    |
 LL |         [] => {}
    |         -- matches all the relevant values
@@ -393,7 +393,7 @@ LL |         _ => {}
    |         ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-types.rs:395:11
+  --> $DIR/empty-types.rs:396:11
    |
 LL |     match array_0_never {
    |           ^^^^^^^^^^^^^ pattern `[]` not covered
@@ -407,7 +407,7 @@ LL +         [] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&Some(_)` not covered
-  --> $DIR/empty-types.rs:449:11
+  --> $DIR/empty-types.rs:450:11
    |
 LL |     match ref_opt_never {
    |           ^^^^^^^^^^^^^ pattern `&Some(_)` not covered
@@ -426,7 +426,7 @@ LL +         &Some(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:490:11
+  --> $DIR/empty-types.rs:491:11
    |
 LL |     match *ref_opt_never {
    |           ^^^^^^^^^^^^^^ pattern `Some(_)` not covered
@@ -445,7 +445,7 @@ LL +         Some(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Err(_)` not covered
-  --> $DIR/empty-types.rs:538:11
+  --> $DIR/empty-types.rs:539:11
    |
 LL |     match *ref_res_never {
    |           ^^^^^^^^^^^^^^ pattern `Err(_)` not covered
@@ -464,7 +464,7 @@ LL +         Err(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Err(_)` not covered
-  --> $DIR/empty-types.rs:549:11
+  --> $DIR/empty-types.rs:550:11
    |
 LL |     match *ref_res_never {
    |           ^^^^^^^^^^^^^^ pattern `Err(_)` not covered
@@ -483,7 +483,7 @@ LL +         Err(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `(u32, !)` is non-empty
-  --> $DIR/empty-types.rs:568:11
+  --> $DIR/empty-types.rs:569:11
    |
 LL |     match *ref_tuple_half_never {}
    |           ^^^^^^^^^^^^^^^^^^^^^
@@ -497,7 +497,7 @@ LL ~     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:601:9
+  --> $DIR/empty-types.rs:602:9
    |
 LL |         _ => {}
    |         ^------
@@ -508,7 +508,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:604:9
+  --> $DIR/empty-types.rs:605:9
    |
 LL |         _x => {}
    |         ^^------
@@ -519,7 +519,7 @@ LL |         _x => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:607:9
+  --> $DIR/empty-types.rs:608:9
    |
 LL |         _ if false => {}
    |         ^---------------
@@ -530,7 +530,7 @@ LL |         _ if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:610:9
+  --> $DIR/empty-types.rs:611:9
    |
 LL |         _x if false => {}
    |         ^^---------------
@@ -541,7 +541,7 @@ LL |         _x if false => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
-  --> $DIR/empty-types.rs:635:11
+  --> $DIR/empty-types.rs:636:11
    |
 LL |     match ref_never {
    |           ^^^^^^^^^ pattern `&_` not covered
@@ -557,7 +557,7 @@ LL +         &_ => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
-  --> $DIR/empty-types.rs:651:11
+  --> $DIR/empty-types.rs:652:11
    |
 LL |     match *ref_result_never {
    |           ^^^^^^^^^^^^^^^^^ pattern `Ok(_)` not covered
@@ -577,7 +577,7 @@ LL +         Ok(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
-  --> $DIR/empty-types.rs:671:11
+  --> $DIR/empty-types.rs:672:11
    |
 LL |     match *x {
    |           ^^ pattern `Some(_)` not covered

--- a/tests/ui/pattern/usefulness/empty-types.rs
+++ b/tests/ui/pattern/usefulness/empty-types.rs
@@ -1,5 +1,6 @@
 //@ revisions: normal exhaustive_patterns never_pats
 //@ edition: 2024
+//@ ignore-parallel-frontend pattern matching error message mismatch
 //
 // This tests correct handling of empty types in exhaustiveness checking.
 //


### PR DESCRIPTION
Some tests keep fail with `--parallel-frontend-threads=n`. This PR marks them for tracking and to filter those out for regular tests of the parallel frontend. There are two new similar categories for test failures: `unstable liveness diagnostics` and `pattern matching error message mismatch`. Both of them appear to be just printed diagnostic inconsistencies.