### PR TITLE
add ABI check logic for wasm

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -3582,6 +3582,19 @@ impl Target {
                     "invalid `target_abi` for CSky"
                 );
             }
+            Arch::Wasm32 | Arch::Wasm64 => {
+                check!(
+                    self.llvm_abiname == LlvmAbi::Unspecified,
+                    "`llvm_abiname` is unused on wasm"
+                );
+                check!(self.llvm_floatabi.is_none(), "`llvm_floatabi` is unused on wasm");
+                check!(self.rustc_abi.is_none(), "`rustc_abi` is unused on wasm");
+                check_matches!(
+                    self.cfg_abi,
+                    CfgAbi::Unspecified | CfgAbi::Other(_),
+                    "invalid `target_abi` for wasm"
+                );
+            }
             ref arch => {
                 check!(self.rustc_abi.is_none(), "`rustc_abi` is unused on {arch}");
                 // Ensure consistency among built-in targets, but give JSON targets the opportunity

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -1312,10 +1312,16 @@ impl Target {
                 }
             }
             Arch::Avr => {
+                // We only support one ABI on AVR at the moment.
                 // SRAM is minimum requirement for C/C++ in both avr-gcc and Clang,
                 // and backends of them only support assembly for devices have no SRAM.
                 // See the discussion in https://github.com/rust-lang/rust/pull/146900 for more.
                 FeatureConstraints { required: &["sram"], incompatible: &[] }
+            }
+            Arch::Wasm32 | Arch::Wasm64 => {
+                // We only support one ABI on wasm at the moment.
+                // No ABI-relevant target features have been identified thus far.
+                NOTHING
             }
             _ => NOTHING,
         }


### PR DESCRIPTION
As far as I can tell, this logic is trivial: the only registers that are just conditionally available are SIMD registers, which are already handled by `WASM_FEATURES_FOR_CORRECT_FIXED_LENGTH_VECTOR_ABI`.

Cc @alexcrichton @rylev @loganek