### PR TITLE
Create a `sve_zeroinitializer` compiler intrinsic

### DIFF
--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -811,6 +811,16 @@ impl<'ll, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                 )
             }
 
+            sym::sve_zeroinitializer => {
+                assert_matches!(
+                    self.layout_of(fn_args.type_at(0)).backend_repr,
+                    BackendRepr::SimdScalableVector {
+                        ..
+                    }
+                );
+                self.const_null(self.layout_of(fn_args.type_at(0)).immediate_llvm_type(self))
+            }
+
             _ if name.as_str().starts_with("simd_") => {
                 // Unpack non-power-of-2 #[repr(packed, simd)] arguments.
                 // This gives them the expected layout of a regular #[repr(simd)] vector.

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -124,6 +124,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 | sym::atomic_fence
                 | sym::atomic_singlethreadfence
                 | sym::caller_location
+                | sym::sve_zeroinitializer
                 | sym::return_address => {}
                 _ => {
                     span_bug!(

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -781,6 +781,7 @@ pub(crate) fn check_intrinsic_type(
         sym::sve_tuple_create4 => (2, 0, vec![param(0), param(0), param(0), param(0)], param(1)),
         sym::sve_tuple_get => (2, 1, vec![param(0)], param(1)),
         sym::sve_tuple_set => (2, 1, vec![param(0), param(1)], param(0)),
+        sym::sve_zeroinitializer => (1, 0, vec![], param(0)),
 
         sym::atomic_cxchg | sym::atomic_cxchgweak => (
             1,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2011,6 +2011,7 @@ symbols! {
         sve_tuple_create4,
         sve_tuple_get,
         sve_tuple_set,
+        sve_zeroinitializer,
         sym,
         sync,
         synthetic,

--- a/library/core/src/intrinsics/simd/scalable.rs
+++ b/library/core/src/intrinsics/simd/scalable.rs
@@ -64,3 +64,9 @@ pub unsafe fn sve_tuple_get<SVecTup, SVec, const IDX: i32>(tuple: SVecTup) -> SV
 #[rustc_intrinsic]
 #[rustc_nounwind]
 pub unsafe fn sve_tuple_set<SVecTup, SVec, const IDX: i32>(tuple: SVecTup, x: SVec) -> SVecTup;
+
+/// Returns a zeroed `SVec`, similar to `mem::zeroed()` but with support for scalable vector types.
+/// The LLVM backend will typically lower this to `zeroinitializer`.
+#[rustc_intrinsic]
+#[rustc_nounwind]
+pub unsafe fn sve_zeroinitializer<SVec>() -> SVec;

--- a/tests/assembly-llvm/sve_zeroinitializer.rs
+++ b/tests/assembly-llvm/sve_zeroinitializer.rs
@@ -1,0 +1,62 @@
+//@ assembly-output: emit-asm
+//@ needs-llvm-components: aarch64
+//@ compile-flags: --target aarch64-unknown-linux-gnu -C target-feature=+sve
+
+#![allow(incomplete_features, internal_features)]
+#![feature(simd_ffi, rustc_attrs, link_llvm_intrinsics, core_intrinsics)]
+#![crate_type = "lib"]
+
+#[rustc_scalable_vector(16)]
+#[allow(non_camel_case_types)]
+pub struct svbool_t(bool);
+
+#[rustc_scalable_vector(8)]
+#[allow(non_camel_case_types)]
+pub struct svint16_t(i16);
+
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svfloat32_t(f32);
+
+#[rustc_scalable_vector]
+#[allow(non_camel_case_types)]
+pub struct svfloat32x2_t(svfloat32_t, svfloat32_t);
+
+#[target_feature(enable = "sve")]
+fn svbool_zeroinitializer() -> svbool_t {
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+#[target_feature(enable = "sve")]
+pub fn svint16_zeroinitializer() -> svint16_t {
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+#[target_feature(enable = "sve")]
+pub fn svfloat32x2_zeroinitializer() -> svfloat32x2_t {
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+// CHECK-LABEL: svbool_false
+#[no_mangle]
+#[target_feature(enable = "sve")]
+pub unsafe extern "C" fn svbool_false() -> svbool_t {
+    // CHECK: pfalse p0.b
+    svbool_zeroinitializer()
+}
+
+// CHECK-LABEL: svint_zero
+#[no_mangle]
+#[target_feature(enable = "sve")]
+pub unsafe extern "C" fn svint_zero() -> svint16_t {
+    // CHECK: movi v0.2d, #0000000000000000
+    svint16_zeroinitializer()
+}
+
+// CHECK-LABEL: svfloat_tuple_zero
+#[no_mangle]
+#[target_feature(enable = "sve")]
+pub unsafe extern "C" fn svfloat_tuple_zero() -> svfloat32x2_t {
+    // CHECK: movi v0.2d, #0000000000000000
+    svfloat32x2_zeroinitializer()
+}

--- a/tests/codegen-llvm/scalable-vectors/zeroinitializer-intrinsic.rs
+++ b/tests/codegen-llvm/scalable-vectors/zeroinitializer-intrinsic.rs
@@ -1,0 +1,70 @@
+//@ edition: 2021
+//@ only-aarch64
+#![crate_type = "lib"]
+#![allow(incomplete_features, internal_features)]
+#![feature(simd_ffi, rustc_attrs, link_llvm_intrinsics, core_intrinsics)]
+
+#[rustc_scalable_vector(16)]
+#[allow(non_camel_case_types)]
+pub struct svbool_t(bool);
+
+#[rustc_scalable_vector(8)]
+#[allow(non_camel_case_types)]
+pub struct svint16_t(i16);
+
+#[rustc_scalable_vector(4)]
+#[allow(non_camel_case_types)]
+pub struct svfloat32_t(f32);
+
+#[rustc_scalable_vector(2)]
+#[allow(non_camel_case_types)]
+pub struct svfloat64_t(f64);
+
+#[rustc_scalable_vector]
+#[allow(non_camel_case_types)]
+pub struct svfloat32x2_t(svfloat32_t, svfloat32_t);
+
+#[no_mangle]
+#[target_feature(enable = "sve")]
+// CHECK-LABEL: svbool_zeroinitializer
+pub fn svbool_zeroinitializer() -> svbool_t {
+    // CHECK: start:
+    // CHECK: ret <vscale x 16 x i1> zeroinitializer
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+#[no_mangle]
+#[target_feature(enable = "sve")]
+// CHECK-LABEL: svint16_zeroinitializer
+pub fn svint16_zeroinitializer() -> svint16_t {
+    // CHECK: start:
+    // CHECK: ret <vscale x 8 x i16> zeroinitializer
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+#[no_mangle]
+#[target_feature(enable = "sve")]
+// CHECK-LABEL: svfloat32_zeroinitializer
+pub fn svfloat32_zeroinitializer() -> svfloat32_t {
+    // CHECK: start:
+    // CHECK: ret <vscale x 4 x float> zeroinitializer
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+#[no_mangle]
+#[target_feature(enable = "sve")]
+// CHECK-LABEL: svfloat64_zeroinitializer
+pub fn svfloat64_zeroinitializer() -> svfloat64_t {
+    // CHECK: start:
+    // CHECK: ret <vscale x 2 x double> zeroinitializer
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}
+
+#[no_mangle]
+#[target_feature(enable = "sve")]
+// CHECK-LABEL: svfloat32x2_zeroinitializer
+pub fn svfloat32x2_zeroinitializer() -> svfloat32x2_t {
+    // CHECK: start:
+    // CHECK: ret { <vscale x 4 x float>, <vscale x 4 x float> } zeroinitializer
+    unsafe { std::intrinsics::simd::scalable::sve_zeroinitializer() }
+}


### PR DESCRIPTION
Part 1 of addressing:
> `svpfalse` is missing an `assert_instr` annotation because its current implementation doesn't generate a `pfalse`
from #145052

Adds a new compiler intrinsic `sve_zeroinitializer()` that returns a zeroed `SVec` using LLVM's `zeroinitalizer` IR.