### PR TITLE
Update target maintainer for x86_64-unknown-linux-none

### DIFF
--- a/src/doc/rustc/src/platform-support/x86_64-unknown-linux-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-linux-none.md
@@ -6,7 +6,7 @@ Freestanding x86-64 linux binary with no dependency on libc.
 
 ## Target maintainers
 
-[@morr0ne](https://github.com/morr0ne)
+[@rosymati](https://github.com/rosymati)
 
 ## Requirements
 


### PR DESCRIPTION
The x86_64-unknown-linux-none target docs were pointing to my old username. I'm still the designated maintainer, this just updates to the correct url