### PR TITLE
Update aarch64-unknown-freebsd target description

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_freebsd.rs
@@ -7,7 +7,7 @@ pub(crate) fn target() -> Target {
         llvm_target: "aarch64-unknown-freebsd".into(),
         metadata: TargetMetadata {
             description: Some("ARM64 FreeBSD".into()),
-            tier: Some(3),
+            tier: Some(2),
             host_tools: Some(true),
             std: Some(true),
         },

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -89,6 +89,7 @@ so Rustup may install the documentation for a similar tier 1 target instead.
 target | notes
 -------|-------
 [`aarch64-pc-windows-gnullvm`](platform-support/windows-gnullvm.md) | ARM64 MinGW (Windows 10+), LLVM ABI
+[`aarch64-unknown-freebsd`](platform-support/freebsd.md) | ARM64 FreeBSD
 [`aarch64-unknown-linux-musl`](platform-support/aarch64-unknown-linux-musl.md) | ARM64 Linux with musl 1.2.5
 [`aarch64-unknown-linux-ohos`](platform-support/openharmony.md) | ARM64 OpenHarmony
 `arm-unknown-linux-gnueabi` | Armv6 Linux (kernel 3.2+, glibc 2.17)
@@ -261,7 +262,6 @@ target | std | host | notes
 -------|:---:|:----:|-------
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
-[`aarch64-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | ARM64 FreeBSD
 [`aarch64-unknown-helenos`](platform-support/helenos.md) | ✓ |  | ARM64 HelenOS
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit
 [`aarch64-unknown-illumos`](platform-support/illumos.md) | ✓ | ✓ | ARM64 illumos

--- a/src/doc/rustc/src/platform-support/freebsd.md
+++ b/src/doc/rustc/src/platform-support/freebsd.md
@@ -11,8 +11,9 @@
 
 ## Requirements
 
-The `x86_64-unknown-freebsd` target is Tier 2 with host tools.
-`i686-unknown-freebsd` is Tier 2 without host tools.  Other targets are Tier 3.
+The `x86_64-unknown-freebsd` and `aarch64-unknown-freebsd` targets are Tier 2
+with host tools. `i686-unknown-freebsd` is Tier 2 without host tools.
+Other targets are Tier 3.
 See [platform-support.md](../platform-support.md) for the full list.
 
 We commit that rustc will run on all currently supported releases of
@@ -34,9 +35,10 @@ FreeBSD OS binaries use the ELF file format.
 
 ## Building Rust programs
 
-The `x86_64-unknown-freebsd` and `i686-unknown-freebsd` artifacts are
-distributed by the rust project and may be installed with rustup.  Other
-targets are built by the ports system and may be installed with
+The `x86_64-unknown-freebsd`, `aarch64-unknown-freebsd` and
+`i686-unknown-freebsd` artifacts are distributed by the rust
+project and may be installed with rustup.  Other targets are
+built by the ports system and may be installed with
 [pkg(7)][pkg] or [ports(7)][ports].
 
 By default the `i686-unknown-freebsd` target uses SSE2 instructions.  To build


### PR DESCRIPTION
Update the target spec & relevant documentation for aarch64-unknown-freebsd to reflect it being promoted to Tier 2.

Implements MCP: https://github.com/rust-lang/compiler-team/issues/961