### PR TITLE
[rustdoc] Fix foreign items macro expansion

### DIFF
--- a/src/librustdoc/html/macro_expansion.rs
+++ b/src/librustdoc/html/macro_expansion.rs
@@ -2,7 +2,7 @@ use rustc_ast::visit::{
     AssocCtxt, Visitor, walk_assoc_item, walk_crate, walk_expr, walk_item, walk_pat, walk_stmt,
     walk_ty,
 };
-use rustc_ast::{AssocItem, Crate, Expr, Item, Pat, Stmt, Ty};
+use rustc_ast::{AssocItem, Crate, Expr, ForeignItem, Item, Pat, Stmt, Ty};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, Span};
@@ -172,6 +172,16 @@ impl<'ast> Visitor<'ast> for ExpandedCodeVisitor<'ast> {
             });
         } else {
             walk_assoc_item(self, item, ctxt);
+        }
+    }
+
+    fn visit_foreign_item(&mut self, item: &'ast ForeignItem) -> Self::Result {
+        if item.span.from_expansion() {
+            self.handle_new_span(item.span, || {
+                rustc_ast_pretty::pprust::foreign_item_to_string(item)
+            });
+        } else {
+            walk_item(self, item);
         }
     }
 }

--- a/tests/rustdoc-html/macro-expansion/c-var-args.rs
+++ b/tests/rustdoc-html/macro-expansion/c-var-args.rs
@@ -1,0 +1,19 @@
+// Ensure that C var args (`va_list`) work.
+// Regression test for <https://github.com/rust-lang/rust/issues/156486>.
+
+//@ compile-flags: -Zunstable-options --generate-macro-expansion
+
+#![crate_name = "foo"]
+
+//@ has 'src/foo/c-var-args.rs.html'
+
+macro_rules! print {
+    () => {
+        fn printf(...);
+    };
+}
+
+//@ has - '//*[@class="expansion"]/*[@class="expanded"]' 'fn printf(...);'
+extern "C" {
+    print! {}
+}


### PR DESCRIPTION
Fixes rust-lang/rust#156486.

The ICE was coming from ast pretty printing not handling `...` (C var args). To handle that, I added a `CVarArgs` variants for all `PatKind` enums.

Second part (and second commits) was to correctly handle foreign items in rustdoc.

r? @Urgau 