### PR TITLE
ast_lowering: Simplify `resolve_pin_drop_sugar_impl_item`

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1192,50 +1192,34 @@ impl<'hir> LoweringContext<'_, 'hir> {
         })
     }
 
-    fn resolve_pin_drop_sugar_impl_item(
+    fn check_pin_drop_sugar_impl_item(
         &self,
         i: &AssocItem,
         ident: Ident,
-        span: Span,
-    ) -> (Ident, Result<DefId, ErrorGuaranteed>) {
-        let trait_item_def_id = self
-            .get_partial_res(i.id)
-            .and_then(|r| r.expect_full_res().opt_def_id())
-            .ok_or_else(|| {
-                self.dcx().span_delayed_bug(span, "could not resolve trait item being implemented")
-            });
-
-        let is_pin_drop_sugar = match &i.kind {
-            AssocItemKind::Fn(fn_kind) => fn_kind.is_pin_drop_sugar(),
-            _ => false,
-        };
-        let def_id = match trait_item_def_id {
-            Ok(def_id) => def_id,
-            Err(guar) => return (ident, Err(guar)),
-        };
-        if !is_pin_drop_sugar {
-            return (ident, Ok(def_id));
+        trait_item: Result<DefId, ErrorGuaranteed>,
+    ) -> Ident {
+        if let AssocItemKind::Fn(fn_kind) = &i.kind
+            && fn_kind.is_pin_drop_sugar()
+        {
+            if let Ok(trait_item) = trait_item
+                && self
+                    .tcx
+                    .lang_items()
+                    .drop_trait()
+                    .is_none_or(|drop_trait| self.tcx.parent(trait_item) != drop_trait)
+            {
+                self.dcx()
+                    .struct_span_err(
+                        i.span,
+                        "method `drop` with `&pin mut self` is only supported for the `Drop` trait",
+                    )
+                    .with_span_label(i.span, "not a `Drop::pin_drop` implementation")
+                    .emit();
+            }
+            return Ident::new(sym::pin_drop, ident.span);
         }
 
-        let is_drop_pin_drop = self
-            .tcx
-            .lang_items()
-            .drop_trait()
-            .is_some_and(|drop_trait| self.tcx.parent(def_id) == drop_trait);
-        if is_drop_pin_drop {
-            // Associated item collection still derives the impl item's name from HIR.
-            return (Ident::new(sym::pin_drop, ident.span), Ok(def_id));
-        }
-
-        let guar = self
-            .dcx()
-            .struct_span_err(
-                i.span,
-                "method `drop` with `&pin mut self` is only supported for the `Drop` trait",
-            )
-            .with_span_label(i.span, "not a `Drop::pin_drop` implementation")
-            .emit();
-        (ident, Err(guar))
+        ident
     }
 
     fn lower_impl_item(
@@ -1356,8 +1340,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let span = self.lower_span(i.span);
         let (effective_ident, impl_kind) = if is_in_trait_impl {
-            let (effective_ident, trait_item_def_id) =
-                self.resolve_pin_drop_sugar_impl_item(i, ident, span);
+            let trait_item_def_id = self
+                .get_partial_res(i.id)
+                .and_then(|r| r.expect_full_res().opt_def_id())
+                .ok_or_else(|| {
+                    self.dcx()
+                        .span_delayed_bug(span, "could not resolve trait item being implemented")
+                });
+            let effective_ident = self.check_pin_drop_sugar_impl_item(i, ident, trait_item_def_id);
             (effective_ident, ImplItemImplKind::Trait { defaultness, trait_item_def_id })
         } else {
             (ident, ImplItemImplKind::Inherent { vis_span: self.lower_span(i.vis.span) })

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.rs
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.rs
@@ -12,7 +12,6 @@ trait NeedsPinDrop {
 }
 
 impl NeedsPinDrop for S {
-    //~^ ERROR not all trait items implemented, missing: `pin_drop` [E0046]
     fn drop(&pin mut self) {}
     //~^ ERROR method `drop` with `&pin mut self` is only supported for the `Drop` trait
 }
@@ -53,7 +52,6 @@ mod local_drop_trait {
     }
 
     impl Drop for S {
-        //~^ ERROR not all trait items implemented, missing: `pin_drop` [E0046]
         fn drop(&pin mut self) {}
         //~^ ERROR method `drop` with `&pin mut self` is only supported for the `Drop` trait
     }

--- a/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.stderr
+++ b/tests/ui/pin-ergonomics/pinned-drop-sugar-not-other-traits.stderr
@@ -1,5 +1,5 @@
 error[E0407]: method `drop` is not a member of trait `HasDrop`
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:26:5
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:25:5
    |
 LL |     fn drop(&pin mut self) {}
    |     ^^^----^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     fn drop(&pin mut self) {}
    |     not a member of trait `HasDrop`
 
 error[E0407]: method `drop` is not a member of trait `HasPinnedDropReceiver`
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:36:5
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:35:5
    |
 LL |     fn drop(&pin mut self) {}
    |     ^^^----^^^^^^^^^^^^^^^^^^
@@ -17,28 +17,19 @@ LL |     fn drop(&pin mut self) {}
    |     not a member of trait `HasPinnedDropReceiver`
 
 error: method `drop` with `&pin mut self` is only supported for the `Drop` trait
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:16:5
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:15:5
    |
 LL |     fn drop(&pin mut self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ not a `Drop::pin_drop` implementation
 
 error: method `drop` with `&pin mut self` is only supported for the `Drop` trait
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:57:9
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:55:9
    |
 LL |         fn drop(&pin mut self) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ not a `Drop::pin_drop` implementation
 
-error[E0046]: not all trait items implemented, missing: `pin_drop`
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:14:1
-   |
-LL |     fn pin_drop(self: Pin<&mut Self>);
-   |     ---------------------------------- `pin_drop` from trait
-...
-LL | impl NeedsPinDrop for S {
-   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `pin_drop` in implementation
-
 error[E0046]: not all trait items implemented, missing: `drop`
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:24:1
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:23:1
    |
 LL |     fn drop(self: Pin<&mut Self>);
    |     ------------------------------ `drop` from trait
@@ -47,7 +38,7 @@ LL | impl HasDrop for S {
    | ^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
 
 error[E0046]: not all trait items implemented, missing: `drop`
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:34:1
+  --> $DIR/pinned-drop-sugar-not-other-traits.rs:33:1
    |
 LL |     fn drop(self: &pin mut Self);
    |     ----------------------------- `drop` from trait
@@ -55,16 +46,7 @@ LL |     fn drop(self: &pin mut Self);
 LL | impl HasPinnedDropReceiver for S {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `drop` in implementation
 
-error[E0046]: not all trait items implemented, missing: `pin_drop`
-  --> $DIR/pinned-drop-sugar-not-other-traits.rs:55:5
-   |
-LL |         fn pin_drop(self: Pin<&mut Self>);
-   |         ---------------------------------- `pin_drop` from trait
-...
-LL |     impl Drop for S {
-   |     ^^^^^^^^^^^^^^^ missing `pin_drop` in implementation
-
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0046, E0407.
 For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
The `trait_item_def_id` and `effective_ident` parts are independent of each other and don't need to interact.

Follow up to https://github.com/rust-lang/rust/pull/156452.