### PR TITLE
library: optimize truncate method

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1449,8 +1449,8 @@ impl<T, A: Allocator> VecDeque<T, A> {
         // Safe because:
         //
         // * Any slice passed to `drop_in_place` is valid; the second case has
-        //   `len <= front.len()` and returning on `len > self.len()` ensures
-        //   `begin <= back.len()` in the first case
+        //   `len <= front.len()` and returning on `len >= self.len()` ensures
+        //   `begin < back.len()` in the first case
         // * The head of the VecDeque is moved before calling `drop_in_place`,
         //   so no value is dropped twice if `drop_in_place` panics
         unsafe {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1457,8 +1457,8 @@ impl String {
 
     /// Shortens this `String` to the specified length.
     ///
-    /// If `new_len` is greater than or equal to the string's current length, this has no
-    /// effect.
+    /// If `new_len` is greater than or equal to the string's current length,
+    /// this has no effect.
     ///
     /// Note that this method has no effect on the allocated capacity
     /// of the string
@@ -1480,10 +1480,11 @@ impl String {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[track_caller]
     pub fn truncate(&mut self, new_len: usize) {
-        if new_len <= self.len() {
-            assert!(self.is_char_boundary(new_len));
-            self.vec.truncate(new_len)
+        if new_len >= self.len() {
+            return;
         }
+        assert!(self.is_char_boundary(new_len));
+        self.vec.truncate(new_len)
     }
 
     /// Removes the last character from the string buffer and returns it.

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1790,8 +1790,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     ///
-    /// No truncation occurs when `len` is greater than the vector's current
-    /// length:
+    /// No truncation occurs when `len` is greater than or equal to the
+    /// vector's current length:
     ///
     /// ```
     /// let mut vec = vec![1, 2, 3];
@@ -1817,16 +1817,13 @@ impl<T, A: Allocator> Vec<T, A> {
 
         // This is safe because:
         //
-        // * the slice passed to `drop_in_place` is valid; the `len > self.len`
+        // * the slice passed to `drop_in_place` is valid; the `len >= self.len`
         //   case avoids creating an invalid slice, and
         // * the `len` of the vector is shrunk before calling `drop_in_place`,
         //   such that no value will be dropped twice in case `drop_in_place`
         //   were to panic once (if it panics twice, the program aborts).
         unsafe {
-            // Note: It's intentional that this is `>` and not `>=`.
-            //       Changing it to `>=` has negative performance
-            //       implications in some cases. See #78884 for more.
-            if len > self.len {
+            if len >= self.len {
                 return;
             }
             let remaining_len = self.len - len;
@@ -3151,7 +3148,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// calling the closure `f`. The return values from `f` will end up
     /// in the `Vec` in the order they have been generated.
     ///
-    /// If `new_len` is less than `len`, the `Vec` is simply truncated.
+    /// If `new_len` is less than or equal to `len`, the `Vec` is simply
+    /// truncated.
     ///
     /// This method uses a closure to create new values on every push. If
     /// you'd rather [`Clone`] a given value, use [`Vec::resize`]. If you
@@ -3501,7 +3499,8 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
     ///
     /// If `new_len` is greater than `len`, the `Vec` is extended by the
     /// difference, with each additional slot filled with `value`.
-    /// If `new_len` is less than `len`, the `Vec` is simply truncated.
+    /// If `new_len` is less than or equal to `len`, the `Vec` is simply
+    /// truncated.
     ///
     /// This method requires `T` to implement [`Clone`],
     /// in order to be able to clone the passed value.

--- a/library/alloc/src/wtf8/mod.rs
+++ b/library/alloc/src/wtf8/mod.rs
@@ -342,18 +342,19 @@ impl Wtf8Buf {
 
     /// Shortens a string to the specified length.
     ///
-    /// If `new_len` is greater than the string's current length, this has no
-    /// effect.
+    /// If `new_len` is greater than or equal to the string's current length,
+    /// this has no effect.
     ///
     /// # Panics
     ///
     /// Panics if `new_len` does not lie on a code point boundary.
     #[inline]
     pub fn truncate(&mut self, new_len: usize) {
-        if new_len <= self.len() {
-            assert!(self.is_code_point_boundary(new_len));
-            self.bytes.truncate(new_len)
+        if new_len >= self.len() {
+            return;
         }
+        assert!(self.is_code_point_boundary(new_len));
+        self.bytes.truncate(new_len)
     }
 
     /// Consumes the WTF-8 string and tries to convert it to a vec of bytes.

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -576,8 +576,8 @@ impl OsString {
 
     /// Truncate the `OsString` to the specified length.
     ///
-    /// If `new_len` is greater than the string's current length, this has no
-    /// effect.
+    /// If `new_len` is greater than or equal to the string's current length,
+    /// this has no effect.
     ///
     /// # Panics
     ///
@@ -586,11 +586,12 @@ impl OsString {
     #[inline]
     #[unstable(feature = "os_string_truncate", issue = "133262")]
     pub fn truncate(&mut self, len: usize) {
-        if len <= self.len() {
-            self.as_os_str().inner.check_public_boundary(len);
-            // SAFETY: The length was just checked to be at a valid boundary.
-            unsafe { self.inner.truncate_unchecked(len) };
+        if len >= self.len() {
+            return;
         }
+        self.as_os_str().inner.check_public_boundary(len);
+        // SAFETY: The length was just checked to be at a valid boundary.
+        unsafe { self.inner.truncate_unchecked(len) };
     }
 
     /// Provides plumbing to `Vec::extend_from_slice` without giving full


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/76089

[Slightly better code](https://play.rust-lang.org/?version=nightly&mode=release&edition=2018&gist=2e44cfb473fe7ed00c00c3993baf9768) when the elements have drop glue, see https://github.com/rust-lang/rust/pull/74172#issuecomment-655886630.

Slightly worse code for `truncate(0)`, see https://github.com/rust-lang/rust/pull/78884#issuecomment-735308848. However, this is mitigated by the new [`clippy::manual_clear`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_clear) lint which is warn-by-default.
