### PR TITLE
Avoid redundant note when a #[derive] is already suggested

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -448,8 +448,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         if let Some((msg, span)) = type_def {
                             err.span_label(span, msg);
                         }
+                        // `#[rustc_on_unimplemented]` notes for derivable traits (e.g. `Debug`'s
+                        // "add `#[derive(Debug)]` to `X` or manually `impl Debug for X`") duplicate
+                        // the `consider annotating X with #[derive(..)]` suggestion that
+                        // `suggest_derive` emits below, so skip them when that suggestion will be
+                        // shown. We keep the note otherwise (e.g. when a field isn't `Debug`, so
+                        // the derive can't be suggested) to avoid leaving the diagnostic without
+                        // actionable guidance.
+                        let derive_suggestion_will_be_shown = main_trait_predicate
+                            == leaf_trait_predicate
+                            && self.can_suggest_derive(&obligation, leaf_trait_predicate);
                         for note in notes {
                             // If it has a custom `#[rustc_on_unimplemented]` note, let's display it
+                            if derive_suggestion_will_be_shown {
+                                continue;
+                            }
                             err.note(note);
                         }
                         if let Some(s) = parent_label {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -458,12 +458,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         let derive_suggestion_will_be_shown = main_trait_predicate
                             == leaf_trait_predicate
                             && self.can_suggest_derive(&obligation, leaf_trait_predicate);
-                        for note in notes {
-                            // If it has a custom `#[rustc_on_unimplemented]` note, let's display it
-                            if derive_suggestion_will_be_shown {
-                                continue;
+                        if !derive_suggestion_will_be_shown {
+                            for note in notes {
+                                // If it has a custom `#[rustc_on_unimplemented]` note, let's display
+                                // it.
+                                err.note(note);
                             }
-                            err.note(note);
                         }
                         if let Some(s) = parent_label {
                             let body = obligation.cause.body_id;

--- a/tests/ui/derives/debug/derives-span-Debug.stderr
+++ b/tests/ui/derives/debug/derives-span-Debug.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Debug)]
 LL |         x: Error,
    |         ^^^^^^^^ the trait `Debug` is not implemented for `Error`
    |
-   = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -23,7 +22,6 @@ LL | #[derive(Debug)]
 LL |         Error,
    |         ^^^^^ the trait `Debug` is not implemented for `Error`
    |
-   = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -39,7 +37,6 @@ LL | struct Struct {
 LL |     x: Error,
    |     ^^^^^^^^ the trait `Debug` is not implemented for `Error`
    |
-   = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -55,7 +52,6 @@ LL | struct TupleStruct(
 LL |     Error,
    |     ^^^^^ the trait `Debug` is not implemented for `Error`
    |
-   = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/derives/redundant-derive-note-on-unimplemented.rs
+++ b/tests/ui/derives/redundant-derive-note-on-unimplemented.rs
@@ -1,0 +1,15 @@
+// Regression test for the redundant `note: add `#[derive(Debug)]` to `X` or manually
+// `impl Debug for X`` that was emitted alongside the `consider annotating X with
+// `#[derive(Debug)]`` suggestion. When the derive suggestion is shown, the note is
+// redundant and should be suppressed.
+//
+// See https://github.com/rust-lang/rust/issues/157118
+
+#[derive(Debug)]
+struct S<T>(T);
+
+struct X;
+
+fn main() {
+    println!("{:?}", S(X)); //~ ERROR `X` doesn't implement `Debug`
+}

--- a/tests/ui/derives/redundant-derive-note-on-unimplemented.stderr
+++ b/tests/ui/derives/redundant-derive-note-on-unimplemented.stderr
@@ -1,0 +1,31 @@
+error[E0277]: `X` doesn't implement `Debug`
+  --> $DIR/redundant-derive-note-on-unimplemented.rs:14:22
+   |
+LL |     println!("{:?}", S(X));
+   |               ----   ^^^^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |               |
+   |               required by this formatting parameter
+   |
+   = help: the trait `Debug` is not implemented for `X`
+help: the trait `Debug` is implemented for `S<T>`
+  --> $DIR/redundant-derive-note-on-unimplemented.rs:8:10
+   |
+LL | #[derive(Debug)]
+   |          ^^^^^
+note: required for `S<X>` to implement `Debug`
+  --> $DIR/redundant-derive-note-on-unimplemented.rs:9:8
+   |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+LL | struct S<T>(T);
+   |        ^ - type parameter would need to implement `Debug`
+   = help: consider manually implementing `Debug` to avoid undesired bounds
+help: consider annotating `X` with `#[derive(Debug)]`
+   |
+LL + #[derive(Debug)]
+LL | struct X;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/fmt/format-args-argument-span.stderr
+++ b/tests/ui/fmt/format-args-argument-span.stderr
@@ -25,7 +25,6 @@ LL |     println!("{x} {x:?} {x}");
    |                   ^^^^^ `DisplayOnly` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `DisplayOnly`
-   = note: add `#[derive(Debug)]` to `DisplayOnly` or manually `impl Debug for DisplayOnly`
 help: consider annotating `DisplayOnly` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -41,7 +40,6 @@ LL |     println!("{x} {x:?} {x}", x = DisplayOnly);
    |                   required by this formatting parameter
    |
    = help: the trait `Debug` is not implemented for `DisplayOnly`
-   = note: add `#[derive(Debug)]` to `DisplayOnly` or manually `impl Debug for DisplayOnly`
 help: consider annotating `DisplayOnly` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/fmt/non-source-literals.stderr
+++ b/tests/ui/fmt/non-source-literals.stderr
@@ -31,7 +31,6 @@ LL |     let _ = format!(concat!("{:", "?}"), NonDebug);
    |                                          ^^^^^^^^ `NonDebug` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `NonDebug`
-   = note: add `#[derive(Debug)]` to `NonDebug` or manually `impl Debug for NonDebug`
 help: consider annotating `NonDebug` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]
@@ -45,7 +44,6 @@ LL |     let _ = format!(concat!("{", "0", ":?}"), NonDebug);
    |                                               ^^^^^^^^ `NonDebug` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `NonDebug`
-   = note: add `#[derive(Debug)]` to `NonDebug` or manually `impl Debug for NonDebug`
 help: consider annotating `NonDebug` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/mismatched_types/method-help-unsatisfied-bound.stderr
+++ b/tests/ui/mismatched_types/method-help-unsatisfied-bound.stderr
@@ -4,7 +4,6 @@ error[E0277]: `Foo` doesn't implement `Debug`
 LL |     a.unwrap();
    |       ^^^^^^ the trait `Debug` is not implemented for `Foo`
    |
-   = note: add `#[derive(Debug)]` to `Foo` or manually `impl Debug for Foo`
 note: required by a bound in `Result::<T, E>::unwrap`
   --> $SRC_DIR/core/src/result.rs:LL:COL
 help: consider annotating `Foo` with `#[derive(Debug)]`

--- a/tests/ui/modules/issue-107649.stderr
+++ b/tests/ui/modules/issue-107649.stderr
@@ -4,7 +4,6 @@ error[E0277]: `Dummy` doesn't implement `Debug`
 105 |     dbg!(lib::Dummy);
     |     ^^^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `Dummy`
     |
-    = note: add `#[derive(Debug)]` to `Dummy` or manually `impl Debug for Dummy`
 help: consider annotating `Dummy` with `#[derive(Debug)]`
    --> $DIR/auxiliary/dummy_lib.rs:2:1
     |

--- a/tests/ui/on-unimplemented/no-debug.stderr
+++ b/tests/ui/on-unimplemented/no-debug.stderr
@@ -7,7 +7,6 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |               required by this formatting parameter
    |
    = help: the trait `Debug` is not implemented for `Foo`
-   = note: add `#[derive(Debug)]` to `Foo` or manually `impl Debug for Foo`
 help: consider annotating `Foo` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -4,7 +4,6 @@ error[E0277]: `NotDebug` doesn't implement `Debug`
 LL |     let _: NotDebug = dbg!(NotDebug);
    |                       ^^^^^^^^^^^^^^ the trait `Debug` is not implemented for `NotDebug`
    |
-   = note: add `#[derive(Debug)]` to `NotDebug` or manually `impl Debug for NotDebug`
 help: consider annotating `NotDebug` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/span/issue-71363.stderr
+++ b/tests/ui/span/issue-71363.stderr
@@ -18,7 +18,6 @@ error[E0277]: `MyError` doesn't implement `Debug`
 4 | impl std::error::Error for MyError {}
   |                            ^^^^^^^ the trait `Debug` is not implemented for `MyError`
   |
-  = note: add `#[derive(Debug)]` to `MyError` or manually `impl Debug for MyError`
 note: required by a bound in `std::error::Error`
  --> $SRC_DIR/core/src/error.rs:LL:COL
 help: consider annotating `MyError` with `#[derive(Debug)]`

--- a/tests/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/tests/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -6,7 +6,6 @@ LL |     #[derive(Debug)]
 LL |     struct Outer<T>(Inner<T>);
    |                     ^^^^^^^^ the trait `Debug` is not implemented for `a::Inner<T>`
    |
-   = note: add `#[derive(Debug)]` to `a::Inner<T>` or manually `impl Debug for a::Inner<T>`
 help: consider annotating `a::Inner<T>` with `#[derive(Debug)]`
    |
 LL +     #[derive(Debug)]


### PR DESCRIPTION
Fixes rust-lang/rust#157118

The `Debug` `#[rustc_on_unimplemented]` note ("add `#[derive(Debug)]` to `X` or manually `impl Debug for X`") just repeats the `consider annotating X with #[derive(..)]` suggestion that `suggest_derive` already emits, so on these bound errors it's pure noise.

Now the note only gets dropped when that suggestion will actually show, which is whenever `can_suggest_derive` holds: a crate-local ADT, not a union, with every field already implementing the trait. Deleting the note from the attribute outright would be too blunt, since when `can_suggest_derive` is false there's no suggestion and the note is the only hint the user gets. A crate-local struct with a non-`Debug` field still ends up with just:

```
error[E0277]: `Outer` doesn't implement `Debug`
   = note: add `#[derive(Debug)]` to `Outer` or manually `impl Debug for Outer`
```

Same story when `main_trait_predicate != leaf_trait_predicate`, since the note comes from the main predicate and the suggestion from the leaf.
