### PR TITLE
Use a `ArrayVec` in `CastTarget`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,6 +4756,7 @@ dependencies = [
 name = "rustc_target"
 version = "0.0.0"
 dependencies = [
+ "arrayvec",
  "bitflags",
  "object 0.37.3",
  "rustc_abi",

--- a/compiler/rustc_codegen_cranelift/src/abi/pass_mode.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/pass_mode.rs
@@ -44,9 +44,9 @@ fn apply_attrs_to_abi_param(param: AbiParam, arg_attrs: ArgAttributes) -> AbiPar
 
 fn cast_target_to_abi_params(cast: &CastTarget) -> SmallVec<[(Size, AbiParam); 2]> {
     if let Some(offset_from_start) = cast.rest_offset {
-        assert!(cast.prefix[1..].iter().all(|p| p.is_none()));
+        assert_eq!(cast.prefix.len(), 1);
         assert_eq!(cast.rest.unit.size, cast.rest.total);
-        let first = cast.prefix[0].unwrap();
+        let first = cast.prefix[0];
         let second = cast.rest.unit;
         return smallvec![
             (Size::ZERO, reg_to_abi_param(first)),
@@ -71,7 +71,6 @@ fn cast_target_to_abi_params(cast: &CastTarget) -> SmallVec<[(Size, AbiParam); 2
     let args = cast
         .prefix
         .iter()
-        .flatten()
         .map(|&reg| reg_to_abi_param(reg))
         .chain((0..rest_count).map(|_| reg_to_abi_param(cast.rest.unit)));
 

--- a/compiler/rustc_codegen_gcc/src/abi.rs
+++ b/compiler/rustc_codegen_gcc/src/abi.rs
@@ -46,7 +46,7 @@ impl GccType for CastTarget {
             )
         };
 
-        if self.prefix.iter().all(|x| x.is_none()) {
+        if self.prefix.is_empty() {
             // Simplify to a single unit when there is no prefix and size <= unit size
             if self.rest.total <= self.rest.unit.size {
                 return rest_gcc_unit;
@@ -62,7 +62,7 @@ impl GccType for CastTarget {
         let mut args: Vec<_> = self
             .prefix
             .iter()
-            .flat_map(|option_reg| option_reg.map(|reg| reg.gcc_type(cx)))
+            .map(|reg| reg.gcc_type(cx))
             .chain((0..rest_count).map(|_| rest_gcc_unit))
             .collect();
 

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -187,7 +187,7 @@ impl LlvmType for CastTarget {
 
         // Simplify to a single unit or an array if there's no prefix.
         // This produces the same layout, but using a simpler type.
-        if self.prefix.iter().all(|x| x.is_none()) {
+        if self.prefix.is_empty() {
             // We can't do this if is_consecutive is set and the unit would get
             // split on the target. Currently, this is only relevant for i128
             // registers.
@@ -199,8 +199,7 @@ impl LlvmType for CastTarget {
         }
 
         // Generate a struct type with the prefix and the "rest" arguments.
-        let prefix_args =
-            self.prefix.iter().flat_map(|option_reg| option_reg.map(|reg| reg.llvm_type(cx)));
+        let prefix_args = self.prefix.iter().map(|reg| reg.llvm_type(cx));
         let rest_args = (0..rest_count).map(|_| rest_ll_unit);
         let args: Vec<_> = prefix_args.chain(rest_args).collect();
         cx.type_struct(&args, false)

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -2233,9 +2233,9 @@ fn load_cast<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 ) -> Bx::Value {
     let cast_ty = bx.cast_backend_type(cast);
     if let Some(offset_from_start) = cast.rest_offset {
-        assert!(cast.prefix[1..].iter().all(|p| p.is_none()));
+        assert_eq!(cast.prefix.len(), 1);
         assert_eq!(cast.rest.unit.size, cast.rest.total);
-        let first_ty = bx.reg_backend_type(&cast.prefix[0].unwrap());
+        let first_ty = bx.reg_backend_type(&cast.prefix[0]);
         let second_ty = bx.reg_backend_type(&cast.rest.unit);
         let first = bx.load(first_ty, ptr, align);
         let second_ptr = bx.inbounds_ptradd(ptr, bx.const_usize(offset_from_start.bytes()));
@@ -2256,9 +2256,8 @@ pub fn store_cast<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     align: Align,
 ) {
     if let Some(offset_from_start) = cast.rest_offset {
-        assert!(cast.prefix[1..].iter().all(|p| p.is_none()));
+        assert_eq!(cast.prefix.len(), 1);
         assert_eq!(cast.rest.unit.size, cast.rest.total);
-        assert!(cast.prefix[0].is_some());
         let first = bx.extract_value(value, 0);
         let second = bx.extract_value(value, 1);
         bx.store(first, ptr, align);

--- a/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
@@ -451,7 +451,7 @@ fn wasm_type<'tcx>(signature: &mut String, arg_abi: &ArgAbi<'_, Ty<'tcx>>, ptr_t
         PassMode::Cast { pad_i32, ref cast } => {
             // For wasm, Cast is used for single-field primitive wrappers like `struct Wrapper(i64);`
             assert!(!pad_i32, "not currently used by wasm calling convention");
-            assert!(cast.prefix[0].is_none(), "no prefix");
+            assert!(cast.prefix.is_empty(), "no prefix");
             assert_eq!(cast.rest.total, arg_abi.layout.size, "single item");
 
             let wrapped_wasm_type = match cast.rest.unit.kind {

--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -25,10 +25,7 @@ fn passes_vectors_by_value(mode: &PassMode, repr: &BackendRepr) -> UsesVectorReg
     match mode {
         PassMode::Ignore | PassMode::Indirect { .. } => UsesVectorRegisters::No,
         PassMode::Cast { pad_i32: _, cast }
-            if cast
-                .prefix
-                .iter()
-                .any(|r| r.is_some_and(|x| matches!(x.kind, RegKind::Vector { .. })))
+            if cast.prefix.iter().any(|x| matches!(x.kind, RegKind::Vector { .. }))
                 || matches!(cast.rest.unit.kind, RegKind::Vector { .. }) =>
         {
             UsesVectorRegisters::FixedVector

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
+arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
 object = { version = "0.37.0", default-features = false, features = ["elf", "macho"] }
 rustc_abi = { path = "../rustc_abi" }

--- a/compiler/rustc_target/src/callconv/mips64.rs
+++ b/compiler/rustc_target/src/callconv/mips64.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use rustc_abi::{
     BackendRepr, FieldsShape, Float, HasDataLayout, Primitive, Reg, Size, TyAbiInterface,
 };
@@ -81,8 +82,7 @@ where
 {
     let dl = cx.data_layout();
     let size = arg.layout.size;
-    let mut prefix = [None; 8];
-    let mut prefix_index = 0;
+    let mut prefix = ArrayVec::new();
 
     // Detect need for padding
     let align = Ord::clamp(arg.layout.align.abi, dl.i64_align, dl.i128_align);
@@ -107,7 +107,7 @@ where
                 // doubles not part of another aggregate are passed as floats.
                 let mut last_offset = Size::ZERO;
 
-                for i in 0..arg.layout.fields.count() {
+                'outer: for i in 0..arg.layout.fields.count() {
                     let field = arg.layout.field(cx, i);
                     let offset = arg.layout.fields.offset(i);
 
@@ -117,19 +117,15 @@ where
                             if offset.is_aligned(dl.f64_align) {
                                 // Insert enough integers to cover [last_offset, offset)
                                 assert!(last_offset.is_aligned(dl.f64_align));
-                                for _ in 0..((offset - last_offset).bits() / 64)
-                                    .min((prefix.len() - prefix_index) as u64)
-                                {
-                                    prefix[prefix_index] = Some(Reg::i64());
-                                    prefix_index += 1;
+                                for _ in 0..((offset - last_offset).bits() / 64) {
+                                    if prefix.try_push(Reg::i64()).is_err() {
+                                        break 'outer;
+                                    }
                                 }
 
-                                if prefix_index == prefix.len() {
+                                if prefix.try_push(Reg::f64()).is_err() {
                                     break;
                                 }
-
-                                prefix[prefix_index] = Some(Reg::f64());
-                                prefix_index += 1;
                                 last_offset = offset + Reg::f64().size;
                             }
                         }
@@ -139,7 +135,7 @@ where
         };
 
         // Extract first 8 chunks as the prefix
-        let rest_size = size - Size::from_bytes(8) * prefix_index as u64;
+        let rest_size = size - Size::from_bytes(8) * prefix.len() as u64;
         arg.cast_to_and_pad_i32(
             CastTarget::prefixed(prefix, Uniform::new(Reg::i64(), rest_size)),
             pad_i32,

--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -1,5 +1,6 @@
 use std::{fmt, iter};
 
+use arrayvec::ArrayVec;
 use rustc_abi::{
     AddressSpace, Align, BackendRepr, CanonAbi, ExternAbi, FieldsShape, HasDataLayout, Primitive,
     Reg, RegKind, Scalar, Size, TyAbiInterface, TyAndLayout, Variants,
@@ -264,7 +265,11 @@ impl Uniform {
 /// (and all data in the padding between the registers is dropped).
 #[derive(Clone, PartialEq, Eq, Hash, Debug, StableHash)]
 pub struct CastTarget {
-    pub prefix: [Option<Reg>; 8],
+    // Note that this is fixed to 8 elements for now as ABIs currently don't
+    // need anything further beyond that, and when this code was originally
+    // refactored to use `ArrayVec` it was already using 8, so that stuck
+    // around.
+    pub prefix: ArrayVec<Reg, 8>,
     /// The offset of `rest` from the start of the value. Currently only implemented for a `Reg`
     /// pair created by the `offset_pair` method.
     pub rest_offset: Option<Size>,
@@ -280,18 +285,20 @@ impl From<Reg> for CastTarget {
 
 impl From<Uniform> for CastTarget {
     fn from(uniform: Uniform) -> CastTarget {
-        Self::prefixed([None; 8], uniform)
+        Self::prefixed(Default::default(), uniform)
     }
 }
 
 impl CastTarget {
-    pub fn prefixed(prefix: [Option<Reg>; 8], rest: Uniform) -> Self {
+    pub fn prefixed(prefix: ArrayVec<Reg, 8>, rest: Uniform) -> Self {
         Self { prefix, rest_offset: None, rest, attrs: ArgAttributes::new() }
     }
 
     pub fn offset_pair(a: Reg, offset_from_start: Size, b: Reg) -> Self {
+        let mut prefix = ArrayVec::new();
+        prefix.push(a);
         Self {
-            prefix: [Some(a), None, None, None, None, None, None, None],
+            prefix,
             rest_offset: Some(offset_from_start),
             rest: b.into(),
             attrs: ArgAttributes::new(),
@@ -304,7 +311,9 @@ impl CastTarget {
     }
 
     pub fn pair(a: Reg, b: Reg) -> CastTarget {
-        Self::prefixed([Some(a), None, None, None, None, None, None, None], Uniform::from(b))
+        let mut prefix = ArrayVec::new();
+        prefix.push(a);
+        Self::prefixed(prefix, Uniform::from(b))
     }
 
     /// When you only access the range containing valid data, you can use this unaligned size;
@@ -314,10 +323,7 @@ impl CastTarget {
         let prefix_size = if let Some(offset_from_start) = self.rest_offset {
             offset_from_start
         } else {
-            self.prefix
-                .iter()
-                .filter_map(|x| x.map(|reg| reg.size))
-                .fold(Size::ZERO, |acc, size| acc + size)
+            self.prefix.iter().map(|reg| reg.size).fold(Size::ZERO, |acc, size| acc + size)
         };
         // Remaining arguments are passed in chunks of the unit size
         let rest_size =
@@ -333,7 +339,7 @@ impl CastTarget {
     pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
         self.prefix
             .iter()
-            .filter_map(|x| x.map(|reg| reg.align(cx)))
+            .map(|reg| reg.align(cx))
             .fold(cx.data_layout().aggregate_align.max(self.rest.align(cx)), |acc, align| {
                 acc.max(align)
             })

--- a/compiler/rustc_target/src/callconv/nvptx64.rs
+++ b/compiler/rustc_target/src/callconv/nvptx64.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use rustc_abi::{HasDataLayout, Reg, Size, TyAbiInterface};
 
 use super::CastTarget;
@@ -41,10 +42,9 @@ fn classify_aggregate<Ty>(arg: &mut ArgAbi<'_, Ty>) {
     };
 
     if align_bytes == size.bytes() {
-        arg.cast_to(CastTarget::prefixed(
-            [Some(reg), None, None, None, None, None, None, None],
-            Uniform::new(Reg::i8(), Size::ZERO),
-        ));
+        let mut prefix = ArrayVec::new();
+        prefix.push(reg);
+        arg.cast_to(CastTarget::prefixed(prefix, Uniform::new(Reg::i8(), Size::ZERO)));
     } else {
         arg.cast_to(Uniform::new(reg, size));
     }
@@ -79,10 +79,9 @@ where
     };
     if arg.layout.size.bytes() / align_bytes == 1 {
         // Make sure we pass the struct as array at the LLVM IR level and not as a single integer.
-        arg.cast_to(CastTarget::prefixed(
-            [Some(unit), None, None, None, None, None, None, None],
-            Uniform::new(unit, Size::ZERO),
-        ));
+        let mut prefix = ArrayVec::new();
+        prefix.push(unit);
+        arg.cast_to(CastTarget::prefixed(prefix, Uniform::new(unit, Size::ZERO)));
     } else {
         arg.cast_to(Uniform::new(unit, arg.layout.size));
     }

--- a/compiler/rustc_target/src/callconv/sparc64.rs
+++ b/compiler/rustc_target/src/callconv/sparc64.rs
@@ -1,3 +1,4 @@
+use arrayvec::ArrayVec;
 use rustc_abi::{
     Align, BackendRepr, FieldsShape, Float, HasDataLayout, Primitive, Reg, Size, TyAbiInterface,
     TyAndLayout, Variants,
@@ -147,12 +148,7 @@ fn classify_arg<'a, Ty, C>(
     let mut double_words = [DoubleWord::Words([Word::Integer; 2]); ARGUMENT_REGISTERS / 2];
     classify(cx, &arg.layout, Size::ZERO, &mut double_words);
 
-    let mut regs = [None; ARGUMENT_REGISTERS];
-    let mut i = 0;
-    let mut push = |reg| {
-        regs[i] = Some(reg);
-        i += 1;
-    };
+    let mut regs = ArrayVec::new();
     let mut attrs = ArgAttribute::empty();
 
     for (index, double_word) in double_words.into_iter().enumerate() {
@@ -162,7 +158,7 @@ fn classify_arg<'a, Ty, C>(
         match double_word {
             // `f128` must be aligned to be assigned a float register.
             DoubleWord::F128Start if (start_double_word_count + index).is_multiple_of(2) => {
-                push(Reg::f128());
+                regs.push(Reg::f128());
             }
             DoubleWord::F128Start => {
                 // Clang currently handles this case nonsensically, always returning a packed
@@ -170,30 +166,27 @@ fn classify_arg<'a, Ty, C>(
                 // the `long double` isn't aligned on the stack, which also makes all future
                 // arguments get passed in the wrong registers. This passes the `f128` in integer
                 // registers when it is unaligned, same as with `f32` and `f64`.
-                push(Reg::i64());
-                push(Reg::i64());
+                regs.push(Reg::i64());
+                regs.push(Reg::i64());
             }
             DoubleWord::F128End => {} // Already handled by `F128Start`
-            DoubleWord::F64 => push(Reg::f64()),
-            DoubleWord::Words([Word::Integer, Word::Integer]) => push(Reg::i64()),
+            DoubleWord::F64 => regs.push(Reg::f64()),
+            DoubleWord::Words([Word::Integer, Word::Integer]) => regs.push(Reg::i64()),
             DoubleWord::Words(words) => {
                 attrs |= ArgAttribute::InReg;
                 for word in words {
                     match word {
-                        Word::F32 => push(Reg::f32()),
-                        Word::Integer => push(Reg::i32()),
+                        Word::F32 => regs.push(Reg::f32()),
+                        Word::Integer => regs.push(Reg::i32()),
                     }
                 }
             }
         }
     }
 
-    let cast_target = match regs {
-        [Some(reg), None, rest @ ..] => {
-            // Just a single register is needed for this value.
-            debug_assert!(rest.iter().all(|x| x.is_none()));
-            CastTarget::from(reg)
-        }
+    let cast_target = match regs.as_slice() {
+        // Just a single register is needed for this value.
+        [reg] => CastTarget::from(*reg),
         _ => CastTarget::prefixed(regs, Uniform::new(Reg::i8(), Size::ZERO)),
     };
 

--- a/tests/ui/abi/pass-indirectly-attr.stderr
+++ b/tests/ui/abi/pass-indirectly-attr.stderr
@@ -123,16 +123,7 @@ error: fn_abi_of(extern_rust) = FnAbi {
                    mode: Cast {
                        pad_i32: false,
                        cast: CastTarget {
-                           prefix: [
-                               None,
-                               None,
-                               None,
-                               None,
-                               None,
-                               None,
-                               None,
-                               None,
-                           ],
+                           prefix: [],
                            rest_offset: None,
                            rest: Uniform {
                                unit: Reg {


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157130)*
<!-- homu-ignore:end -->

This commit switches a fixed-size list of `[Option<Reg>; 8]` to instead
holding `ArrayVec<Reg, 8>` in the `CastTarget` type used when
calculating ABIs. This is inspired by [discussion on Zulip][link] where
I'm hoping to in the near future extend the usage of this to possibly
beyond 8 elements for a new WebAssembly ABI taking advantage of
multi-value. For now though this mostly just switches to
array/slice-like idioms of accessors rather than dealing with
`Option<Reg>` as the unit.

[link]: https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Using.20.60ArgAbi.3A.3Amake_direct_deprecated.60/with/598607139

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
