### PR TITLE
fix armv7a-none-eabihf tier doc

### DIFF
--- a/src/doc/rustc/src/platform-support/arm-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/arm-none-eabi.md
@@ -12,7 +12,7 @@ their own document.
 ### Tier 2 Target List
 
 - Arm A-Profile Architectures
-  - [`armv7a-none-eabi`](armv7a-none-eabi.md)
+  - [`armv7a-none-eabi` and `armv7a-none-eabihf`](armv7a-none-eabi.md)
   - [`thumbv7a-none-eabi` and `thumbv7a-none-eabihf`](armv7a-none-eabi.md)
 - Arm R-Profile Architectures
   - [`armv7r-none-eabi` and `armv7r-none-eabihf`](armv7r-none-eabi.md)
@@ -32,7 +32,7 @@ their own document.
 ### Tier 3 Target List
 
 - Arm A-Profile Architectures
-  - [`armv7a-none-eabihf`](armv7a-none-eabi.md)
+  - None
 - Arm R-Profile Architectures
   - None
 - Arm M-Profile Architectures


### PR DESCRIPTION
I found that PR rust-lang/rust#146522 promoted `armv7a-none-eabihf` from Tier 3 to Tier 2, updating the target spec, `armv7a-none-eabi.md` and `platform-support.md`, but missed updating `arm-none-eabi.md`. The target remained listed under Tier 3 in that file.

So I move `armv7a-none-eabihf` from Tier 3 to Tier 2 in `arm-none-eabi.md`, merging it with the existing `armv7a-none-eabi` entry.

This makes the documentation consistent with the actual tier in the target spec and `platform-support.md`.

r? @wesleywiser 
