### PR TITLE
rustc_target: Use +spe for powerpcspe targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::Spe,
             endian: Endian::Big,
-            features: "+secure-plt,+msync".into(),
+            features: "+secure-plt,+msync,+spe".into(),
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
@@ -25,7 +25,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cfg_abi: CfgAbi::Spe,
             endian: Endian::Big,
-            features: "+msync".into(),
+            features: "+msync,+spe".into(),
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/spec/targets/powerpc_wrs_vxworks_spe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_wrs_vxworks_spe.rs
@@ -26,7 +26,7 @@ pub(crate) fn target() -> Target {
             cfg_abi: CfgAbi::Spe,
             endian: Endian::Big,
             // feature msync would disable instruction 'fsync' which is not supported by fsl_p1p2
-            features: "+secure-plt,+msync".into(),
+            features: "+secure-plt,+msync,+spe".into(),
             ..base
         },
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

LLVM does not infer this from the target name and `abi: "spe"` is just for cfg.  To actually generate the correct instructions for these targets (without `-C target-cpu`), we need to pass `+spe` to LLVM.

Fixes https://github.com/rust-lang/rust/issues/138960
See also https://github.com/rust-lang/rust/pull/157085
Related https://github.com/rust-lang/rust/pull/137860

cc @RalfJung 
cc @BKPepe ([powerpc-unknown-linux-muslspe target maintainer](https://doc.rust-lang.org/nightly/rustc/platform-support/powerpc-unknown-linux-muslspe.html#target-maintainers))
cc @glaubitz (who added powerpc-unknown-linux-gnuspe in https://github.com/rust-lang/rust/pull/48484)
cc @biabbas @hax0kartik ([*-wrs-vxworks target maintainers](https://doc.rust-lang.org/nightly/rustc/platform-support/vxworks.html#target-maintainers))

@rustbot label +O-PowerPC +A-target-feature