### PR TITLE
Add doc comment to `Vec::clone`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3810,6 +3810,11 @@ unsafe impl<T, A: Allocator> ops::DerefPure for Vec<T, A> {}
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone, A: Allocator + Clone> Clone for Vec<T, A> {
+    /// Creates a new `Vec` by deep-copying the contents of an existing `Vec`.
+    ///
+    /// This method will allocate a new `Vec` and `clone` all of `self`'s contents
+    /// into it. The capacity of the duplicate `Vec` is not forced to match the
+    /// capacity of the original.
     fn clone(&self) -> Self {
         let alloc = self.allocator().clone();
         <[T]>::to_vec_in(&**self, alloc)


### PR DESCRIPTION
I read about Clippy's [`repeat_vec_with_capacity`](https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#repeat_vec_with_capacity) lint and figured it was worth adding a note about the relevant behavior to the documentation of `Vec::clone` itself, which previously did not have its own doc comment.