### PR TITLE
 rustc_target: Use rustc_abi instead of cfg_abi to detect powerpcspe 

### DIFF
--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_macros::{Decodable, Encodable, StableHash};
 use rustc_span::Symbol;
 
-use crate::spec::{Arch, CfgAbi, RelocModel, Target};
+use crate::spec::{Arch, RelocModel, Target};
 
 pub struct ModifierInfo {
     pub modifier: char,
@@ -1001,7 +1001,7 @@ impl InlineAsmClobberAbi {
                 _ => Err(&["C", "system", "efiapi"]),
             },
             InlineAsmArch::PowerPC | InlineAsmArch::PowerPC64 => match name {
-                "C" | "system" => Ok(if target.cfg_abi == CfgAbi::Spe {
+                "C" | "system" => Ok(if powerpc::is_spe(target) {
                     InlineAsmClobberAbi::PowerPCSPE
                 } else {
                     InlineAsmClobberAbi::PowerPC

--- a/compiler/rustc_target/src/asm/powerpc.rs
+++ b/compiler/rustc_target/src/asm/powerpc.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxIndexSet;
 use rustc_span::Symbol;
 
 use super::{InlineAsmArch, InlineAsmType, ModifierInfo};
-use crate::spec::{CfgAbi, RelocModel, Target};
+use crate::spec::{CfgAbi, RelocModel, RustcAbi, Target};
 
 def_reg_class! {
     PowerPC PowerPCInlineAsmRegClass {
@@ -115,6 +115,10 @@ fn reserved_v20to31(
     }
 }
 
+pub(crate) fn is_spe(target: &Target) -> bool {
+    target.rustc_abi == Some(RustcAbi::PowerPcSpe)
+}
+
 fn spe_acc_target_check(
     _arch: InlineAsmArch,
     _reloc_model: RelocModel,
@@ -122,11 +126,7 @@ fn spe_acc_target_check(
     target: &Target,
     _is_clobber: bool,
 ) -> Result<(), &'static str> {
-    if target.cfg_abi == CfgAbi::Spe {
-        Ok(())
-    } else {
-        Err("spe_acc is only available on spe targets")
-    }
+    if is_spe(target) { Ok(()) } else { Err("spe_acc is only available on spe targets") }
 }
 
 def_regs! {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


When self-reviewing https://github.com/rust-lang/rust/pull/157137, I recalled a previous my comment (https://github.com/rust-lang/rust/issues/153876#issuecomment-4100938835) about a case where cfg_abi is referred but rustc_abi should be referred.

> There is another powerpc code that [refers to `abi` field](https://github.com/rust-lang/rust/blob/bfc05d6b072585dfd0c792ec1b8728c08a3511fe/compiler/rustc_target/src/asm/powerpc.rs#L125), but it should be changed to refer to the target feature.

`tests/codegen-llvm/asm/powerpc-clobbers.rs` contains a test to check whether this detection is working properly:
https://github.com/rust-lang/rust/blob/6368fd52cb9f230dfb156097625993e7a8891800/tests/codegen-llvm/asm/powerpc-clobbers.rs#L123

r? @RalfJung 

@rustbot label +O-PowerPC +A-target-feature