### PR TITLE
JSON target specs: remove 'x86-softfloat' compatibility alias

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -993,7 +993,7 @@ crate::target_spec_enum! {
         /// On x86-32 only: make use of SSE and SSE2 for ABI purposes.
         X86Sse2 = "x86-sse2",
         /// On x86-32/64, aarch64, and S390x: do not use any FPU or SIMD registers for the ABI.
-        Softfloat = "softfloat", "x86-softfloat",
+        Softfloat = "softfloat",
     }
 
     parse_error_type = "rustc abi";

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-LINUX_VERSION=v7.1-rc1
+# https://github.com/rust-lang/rust/pull/157151
+LINUX_VERSION=40bc55834bc15896f4438b0936c679ef32e20df1
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt

--- a/src/tools/miri/tests/x86_64-unknown-kernel.json
+++ b/src/tools/miri/tests/x86_64-unknown-kernel.json
@@ -10,7 +10,7 @@
   "vendor": "unknown",
   "linker": "rust-lld",
   "linker-flavor": "gnu-lld",
-  "rustc-abi": "x86-softfloat",
+  "rustc-abi": "softfloat",
   "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2,+soft-float",
   "dynamic-linking": false,
   "executables": true,


### PR DESCRIPTION
This got introduced in https://github.com/rust-lang/rust/pull/151154 as a compatibility alias.  It's been a few months, so seems fine to remove the compatibility alias now. JSON targets are anyway unstable.

Cc @Darksonn @ojeda as this may affect Linux