### PR TITLE
Revert workaround used to select the gcc codegen in the coretests CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-gcc-core-tests/Dockerfile
@@ -43,5 +43,4 @@ ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu \
  --set llvm.libzstd=true"
 ENV SCRIPT="python3 ../x.py \
   --stage 1 \
-  test library/coretests \
-  --set rust.codegen-backends=[\\\"gcc\\\"]"
+  test library/coretests"


### PR DESCRIPTION
Now that rust-lang/rust#157007 is merged, this is not needed anymore.

I made a test (see [here](https://github.com/rust-lang/rust/pull/157154#issuecomment-4582840385)) to make sure this still uses the GCC codegen.

r? @Kobzol 