### PR TITLE
Expose an API for polymorphic drop glue translation

### DIFF
--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -495,7 +495,8 @@ impl<'tcx> ProjectedMaybeOwner<'tcx> {
                 delayed_lints: &o.delayed_lints,
             }),
             MaybeOwner::NonOwner(hir_id) => ProjectedMaybeOwner::NonOwner(hir_id),
-            MaybeOwner::Phantom => bug!("No HirId for {:?}", def_id),
+            // Can't debug fmt `def_id` since it doesn't exist.
+            MaybeOwner::Phantom => bug!("No HirId for {:?}", def_id.local_def_index),
         }
     }
 

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -151,6 +151,9 @@ pub enum InstanceKind<'tcx> {
     ///
     /// The `DefId` is for `core::ptr::drop_glue`.
     /// The `Option<Ty<'tcx>>` is either `Some(T)`, or `None` for empty drop glue.
+    ///
+    /// The type must be monomorphic; for polymorphic drop glue use
+    /// `rustc_mir_transform::build_drop_shim`.
     DropGlue(DefId, Option<Ty<'tcx>>),
 
     /// Compiler-generated `<T as Clone>::clone` implementation.

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -51,6 +51,9 @@ mod shim;
 mod ssa;
 mod trivial_const;
 
+/// Exposed for rustc drivers.
+pub use shim::build_drop_shim;
+
 /// We import passes via this macro so that we can have a static list of pass names
 /// (used to verify CLI arguments). It takes a list of modules, followed by the passes
 /// declared within them.

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -160,7 +160,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
                 return body;
             }
 
-            build_drop_shim(tcx, def_id, ty)
+            build_drop_shim(tcx, def_id, ty, ty::TypingEnv::post_analysis(tcx, def_id))
         }
         ty::InstanceKind::ThreadLocalShim(..) => build_thread_local_shim(tcx, instance),
         ty::InstanceKind::CloneShim(def_id, ty) => build_clone_shim(tcx, def_id, ty),
@@ -296,7 +296,16 @@ fn local_decls_for_sig<'tcx>(
         .collect()
 }
 
-fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>) -> Body<'tcx> {
+/// Builds the drop glue for the provided type. The `def_id` is that of `core::ptr::drop_glue`.
+///
+/// Inside rustc this is only called on a monomorphic type, but we expose the function for
+/// rustc_driver writers to be able to generate drop glue for a polymorphic type.
+pub fn build_drop_shim<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    ty: Option<Ty<'tcx>>,
+    typing_env: ty::TypingEnv<'tcx>,
+) -> Body<'tcx> {
     debug!("build_drop_shim(def_id={:?}, ty={:?})", def_id, ty);
 
     assert!(!matches!(ty, Some(ty) if ty.is_coroutine()));
@@ -368,7 +377,6 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
         });
     } else {
         let patch = {
-            let typing_env = ty::TypingEnv::post_analysis(tcx, def_id);
             let mut elaborator = DropShimElaborator {
                 body: &body,
                 patch: MirPatch::new(&body),

--- a/tests/ui-fulldeps/polymorphic-drop-glue.rs
+++ b/tests/ui-fulldeps/polymorphic-drop-glue.rs
@@ -1,0 +1,73 @@
+//@ run-fail
+//@ error-pattern:internal compiler error
+//@ run-flags: --sysroot {{sysroot-base}} --edition=2021
+//@ ignore-stage1 (requires matching sysroot built with in-tree compiler)
+//@ ignore-cross-compile
+//@ ignore-remote
+#![feature(rustc_private)]
+
+extern crate rustc_driver;
+extern crate rustc_hir;
+extern crate rustc_interface;
+extern crate rustc_middle;
+extern crate rustc_span;
+
+use std::process::ExitCode;
+
+use rustc_driver::Compilation;
+use rustc_hir::LangItem;
+use rustc_hir::def::DefKind;
+use rustc_interface::interface::Compiler;
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::DUMMY_SP;
+
+fn main() -> ExitCode {
+    rustc_driver::catch_with_exit_code(move || {
+        std::fs::write(
+            "drop_glue_polymorphic_const_generic_input.rs",
+            r#"
+                struct Unit;
+
+                struct ContainsArray<const K: usize> {
+                    array: [Unit; K],
+                    make_non_trivial_drop: Box<u32>,
+                }
+
+                fn foo(_: ContainsArray<42>) {}
+            "#,
+        )
+        .unwrap();
+
+        let mut args: Vec<_> = std::env::args().collect();
+        args.push("--crate-type=lib".to_owned());
+        args.push("drop_glue_polymorphic_const_generic_input.rs".to_owned());
+
+        rustc_driver::run_compiler(&args, &mut CompilerCalls);
+    })
+}
+
+struct CompilerCalls;
+
+impl rustc_driver::Callbacks for CompilerCalls {
+    fn after_analysis<'tcx>(&mut self, _compiler: &Compiler, tcx: TyCtxt<'tcx>) -> Compilation {
+        tcx.sess.dcx().abort_if_errors();
+
+        let drop_glue = tcx.require_lang_item(LangItem::DropGlue, DUMMY_SP);
+        let contains_array = tcx
+            .hir_crate_items(())
+            .free_items()
+            .map(|id| id.owner_id.to_def_id())
+            .find(|&def_id| {
+                tcx.def_kind(def_id) == DefKind::Struct
+                    && tcx.def_path_str(def_id).ends_with("ContainsArray")
+            })
+            .unwrap();
+
+        // Regression test for ICE due to the drop glue code not correctly handling generic
+        // contexts.
+        let ty = tcx.type_of(contains_array).instantiate_identity().skip_norm_wip();
+        tcx.instance_mir(ty::InstanceKind::DropGlue(drop_glue, Some(ty)));
+
+        Compilation::Stop
+    }
+}

--- a/tests/ui-fulldeps/polymorphic-drop-glue.rs
+++ b/tests/ui-fulldeps/polymorphic-drop-glue.rs
@@ -3,6 +3,7 @@
 //@ ignore-stage1 (requires matching sysroot built with in-tree compiler)
 //@ ignore-cross-compile
 //@ ignore-remote
+//@ ignore-backends: gcc
 #![feature(rustc_private)]
 
 extern crate rustc_driver;

--- a/tests/ui-fulldeps/polymorphic-drop-glue.rs
+++ b/tests/ui-fulldeps/polymorphic-drop-glue.rs
@@ -1,5 +1,4 @@
-//@ run-fail
-//@ error-pattern:internal compiler error
+//@ run-pass
 //@ run-flags: --sysroot {{sysroot-base}} --edition=2021
 //@ ignore-stage1 (requires matching sysroot built with in-tree compiler)
 //@ ignore-cross-compile
@@ -10,6 +9,7 @@ extern crate rustc_driver;
 extern crate rustc_hir;
 extern crate rustc_interface;
 extern crate rustc_middle;
+extern crate rustc_mir_transform;
 extern crate rustc_span;
 
 use std::process::ExitCode;
@@ -66,7 +66,8 @@ impl rustc_driver::Callbacks for CompilerCalls {
         // Regression test for ICE due to the drop glue code not correctly handling generic
         // contexts.
         let ty = tcx.type_of(contains_array).instantiate_identity().skip_norm_wip();
-        tcx.instance_mir(ty::InstanceKind::DropGlue(drop_glue, Some(ty)));
+        let typing_env = ty::TypingEnv::post_analysis(tcx, contains_array);
+        rustc_mir_transform::build_drop_shim(tcx, drop_glue, Some(ty), typing_env);
 
         Compilation::Stop
     }


### PR DESCRIPTION
At my $dayjob I work on a rustc driver called [Charon](https://github.com/AeneasVerif/charon), whose main selling point is its ability to accurately represent polymorphic Rust code. In adding support for drops I ran into an issue: the code that generates drop glue shim expects monomorphized types and ICEs when used in some polymorphic contexts. Example output:

```
error: internal compiler error: compiler/rustc_middle/src/ty/sty.rs:373:13: cannot find `K/#0` in param-env: ParamEnv {
    caller_bounds: [
        Binder { value: HostEffectPredicate { trait_ref: <T as std::marker::Destruct>, constness: Maybe }, bound_vars: [] },
        Binder { value: TraitPredicate(<T as std::marker::Destruct>, polarity:Positive), bound_vars: [] },
    ],
}

thread 'rustc' panicked at compiler/rustc_middle/src/ty/sty.rs:373:13:
```

I recall a Zulip discussion about this but cannot find it. 

This PR exposes `build_drop_shim` and gives it a `TypingEnv` argument, for use in rustc drivers like mine.

Disclosure: I used LLM assistance to make this very complicated PR. This consisted in me repeatedly telling it to do something simpler until I eventually cleaned it up myself. I like the test it wrote tho.