### PR TITLE
Fix CI free-disk-space-linux script

### DIFF
--- a/src/ci/scripts/free-disk-space-linux.sh
+++ b/src/ci/scripts/free-disk-space-linux.sh
@@ -277,6 +277,10 @@ cleanPackages() {
     fi
 
     WAIT_DPKG_LOCK="-o DPkg::Lock::Timeout=60"
+    # This update is intended to fix any broken state of the index and make
+    # sure it is fresh. Otherwise we've had problems with missing mirror
+    # entries.
+    sudo apt-get update -qq
     sudo apt-get ${WAIT_DPKG_LOCK} -qq remove -y --fix-missing "${packages[@]}"
 
     sudo apt-get ${WAIT_DPKG_LOCK} autoremove -y \


### PR DESCRIPTION
Occasionally we've been having jobs running on systems with limited free disk space, triggering this script to run. However, it has recently been failing with the error:

E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/o/openjdk-21/openjdk-21-jre-headless_21.0.10%2b7-1%7e24.04_amd64.deb 404 Not Found [IP: 52.252.163.49 80]
E: Unable to correct problems, you have held broken packages.
E: Aborting install.

This adds an `apt-get update` to try to repair the index before trying to remove any packages. This seems to work in my testing, but I am far from an expert on apt.
