### PR TITLE
Add regression test for issue #87290

### DIFF
--- a/tests/ui/closures/explicit-closure-lifetime-issue-87290.rs
+++ b/tests/ui/closures/explicit-closure-lifetime-issue-87290.rs
@@ -1,0 +1,17 @@
+// Regression test for #87290.
+
+//@ check-pass
+
+#![crate_type = "lib"]
+
+pub fn f<'a>(_: &'a i32, _: impl FnOnce(&mut &mut &'a i32)) {}
+
+pub fn g<'a>(p: &'a i32) {
+    f(p, |_: &mut &mut &'a i32| {})
+}
+
+pub fn h<'a>(p: &'a i32) {
+    f(p, |x: &mut &mut &'a i32| {
+        let _: &mut &mut &'a i32 = x;
+    })
+}

--- a/tests/ui/closures/explicit-closure-lifetime-issue-87290.rs
+++ b/tests/ui/closures/explicit-closure-lifetime-issue-87290.rs
@@ -1,4 +1,4 @@
-// Regression test for #87290.
+// Regression test for <https://github.com/rust-lang/rust/issues/87290>.
 
 //@ check-pass
 


### PR DESCRIPTION
Issue rust-lang/rust#87290 is labeled E-needs-test for explicit non-`'static` lifetimes in closure argument types.

This adds a check-pass UI test for explicit lifetimes in closure argument types.

Fixes rust-lang/rust#87290.