### PR TITLE
Improve error messages for invalid syntax in attributes

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -1,9 +1,10 @@
-use rustc_ast::LitKind;
+use rustc_ast::{LitKind, MetaItemLit};
 use rustc_hir::attrs::{DeprecatedSince, Deprecation};
 use rustc_hir::{RustcVersion, VERSION_PLACEHOLDER};
 
 use super::prelude::*;
 use super::util::parse_version;
+use crate::context::AttributeDiagnosticContext;
 use crate::session_diagnostics::{
     DeprecatedItemSuggestion, InvalidSince, MissingNote, MissingSince,
 };
@@ -82,30 +83,17 @@ impl SingleAttributeParser for DeprecatedParser {
                 // otherwise, suggest using NameValue syntax
                 if let Some(elem) = list.as_single()
                     && let Some(lit) = elem.as_lit()
-                    && let LitKind::Str(text, _) = lit.kind
                 {
-                    let mut adcx = cx.adcx();
-
-                    match parse_since(text, true) {
-                        DeprecatedSince::Future | DeprecatedSince::RustcVersion(_) => {
-                            adcx.push_suggestion(
-                                String::from("try specifying a deprecated since version"),
-                                elem.span(),
-                                format!("since = {}", lit.kind),
-                            );
+                    match lit.kind {
+                        LitKind::Str(text, _) => {
+                            expected_not_str_literal(&mut cx.adcx(), args, elem, lit, text)
                         }
-                        _ => {
-                            if let Some(span) = args.span() {
-                                adcx.push_suggestion(
-                                    String::from("try using `=` instead"),
-                                    span,
-                                    format!(" = {}", lit.kind),
-                                );
-                            }
+                        LitKind::Err(_) => {
+                            expected_not_err_literal(&mut cx.adcx(), args, elem, lit.symbol);
                         }
-                    };
+                        _ => {}
+                    }
 
-                    adcx.expected_not_literal(elem.span());
                     return None;
                 }
 
@@ -202,4 +190,60 @@ fn parse_since(since: Symbol, is_rustc: bool) -> DeprecatedSince {
     } else {
         DeprecatedSince::Err
     }
+}
+
+fn expected_not_str_literal<'a, 'f, 'sess>(
+    adcx: &mut AttributeDiagnosticContext<'a, 'f, 'sess>,
+    args: &ArgParser,
+    elem: &MetaItemOrLitParser,
+    lit: &MetaItemLit,
+    text: Symbol,
+) {
+    if is_version_shaped(text) {
+        adcx.push_suggestion(
+            String::from("try specifying a deprecated since version"),
+            elem.span(),
+            format!("since = {}", lit.kind),
+        );
+    } else {
+        if let Some(span) = args.span() {
+            adcx.push_suggestion(
+                String::from("try using `=` instead"),
+                span,
+                format!(" = {}", lit.kind),
+            );
+        }
+    }
+
+    adcx.expected_not_literal(elem.span());
+}
+
+fn expected_not_err_literal<'a, 'f, 'sess>(
+    adcx: &mut AttributeDiagnosticContext<'a, 'f, 'sess>,
+    args: &ArgParser,
+    elem: &MetaItemOrLitParser,
+    text: Symbol,
+) {
+    let escaped = text.as_str().escape_debug().to_string();
+    if is_version_shaped(text) {
+        adcx.push_suggestion(
+            String::from("try specifying a deprecated since version"),
+            elem.span(),
+            format!(r#"since = "{}""#, escaped),
+        );
+    } else {
+        if let Some(span) = args.span() {
+            adcx.push_suggestion(
+                String::from("try using `=` instead"),
+                span,
+                format!(r#" = "{}""#, escaped),
+            );
+        }
+    }
+
+    adcx.expected_not_literal(elem.span());
+}
+
+fn is_version_shaped(text: Symbol) -> bool {
+    matches!(parse_since(text, true), DeprecatedSince::Future | DeprecatedSince::RustcVersion(_))
 }

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -7,6 +7,7 @@ use rustc_hir::attrs::diagnostic::{
     Directive, Filter, FilterFormatString, Flag, FormatArg, FormatString, LitOrArg, Name,
     NameValue, Piece, Predicate,
 };
+use rustc_lexer::{LiteralKind, Token, TokenKind, tokenize};
 use rustc_macros::Diagnostic;
 use rustc_parse_format::{
     Argument, FormatSpec, ParseError, ParseMode, Parser, Piece as RpfPiece, Position,
@@ -208,14 +209,16 @@ fn parse_directive_items<'p>(
     let mut filters = ThinVec::new();
 
     for item in items {
-        // Minimum required to avoid delayed bug ICE
-        // TODO provide enhanced error message
         if let MetaItemOrLitParser::Lit(lit @ MetaItemLit { kind: LitKind::Err(_), .. }) = item {
-            cx.emit_err(WrappedParserError {
-                description: "Expected `,`".to_string(),
-                span: lit.span,
-                label: "contains unexpected token".to_string(),
-            });
+            let span = if let Some(offset) = missing_comma_offset(lit.symbol.as_str()) {
+                let (_, after) = item.span().split_at(offset);
+                after.shrink_to_lo()
+            } else {
+                item.span()
+            };
+
+            cx.adcx().expected_comma(span);
+            continue;
         }
 
         let span = item.span();
@@ -384,6 +387,34 @@ fn parse_directive_items<'p>(
         notes,
         parent_label,
     })
+}
+
+fn missing_comma_offset(text: &str) -> Option<u32> {
+    let mut offset = 0;
+    let mut tokens = tokenize(text, rustc_lexer::FrontmatterAllowed::No).peekable();
+    loop {
+        let Some(Token { len, kind: TokenKind::Ident }) = tokens.next() else {
+            return None;
+        };
+        offset += len;
+        let Some(Token { len, kind: TokenKind::Eq }) = tokens.next() else {
+            return None;
+        };
+        offset += len;
+        let Some(Token {
+            len,
+            kind: TokenKind::Literal { kind: LiteralKind::Str { terminated: true }, .. },
+        }) = tokens.next()
+        else {
+            return None;
+        };
+        offset += len;
+        match tokens.peek() {
+            Some(Token { len, kind: TokenKind::Comma }) => offset += len,
+            Some(_) => return Some(offset),
+            None => return None,
+        }
+    }
 }
 
 pub(crate) fn parse_format_string(

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/mod.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use rustc_ast::{LitKind, MetaItemLit};
 use rustc_errors::E0232;
 use rustc_hir::AttrPath;
 use rustc_hir::attrs::diagnostic::{
@@ -207,6 +208,16 @@ fn parse_directive_items<'p>(
     let mut filters = ThinVec::new();
 
     for item in items {
+        // Minimum required to avoid delayed bug ICE
+        // TODO provide enhanced error message
+        if let MetaItemOrLitParser::Lit(lit @ MetaItemLit { kind: LitKind::Err(_), .. }) = item {
+            cx.emit_err(WrappedParserError {
+                description: "Expected `,`".to_string(),
+                span: lit.span,
+                label: "contains unexpected token".to_string(),
+            });
+        }
+
         let span = item.span();
 
         macro malformed() {{

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -1096,6 +1096,10 @@ impl<'a, 'f, 'sess: 'f> AttributeDiagnosticContext<'a, 'f, 'sess> {
     pub(crate) fn expected_integer_literal(&mut self, span: Span) -> ErrorGuaranteed {
         self.emit_parse_error(span, AttributeParseErrorReason::ExpectedIntegerLiteral)
     }
+
+    pub(crate) fn expected_comma(&mut self, span: Span) -> ErrorGuaranteed {
+        self.emit_parse_error(span, AttributeParseErrorReason::ExpectedComma)
+    }
 }
 
 impl<'a, 'f, 'sess: 'f> Deref for AttributeDiagnosticContext<'a, 'f, 'sess> {

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -19,7 +19,7 @@ use rustc_parse::parser::{ForceCollect, Parser, PathStyle, Recovery, token_descr
 use rustc_session::errors::create_lit_error;
 use rustc_session::parse::ParseSess;
 use rustc_span::{Ident, Span, Symbol, sym};
-use thin_vec::ThinVec;
+use thin_vec::{ThinVec, thin_vec};
 
 use crate::ShouldEmit;
 use crate::session_diagnostics::{
@@ -124,6 +124,7 @@ impl ArgParser {
                         psess,
                         ShouldEmit::ErrorsAndLints { recovery: Recovery::Forbidden },
                         allow_expr_metavar,
+                        true,
                     ) {
                         Ok(p) => return Some(ArgParser::List(p)),
                         Err(e) => {
@@ -155,6 +156,7 @@ impl ArgParser {
                         psess,
                         should_emit,
                         allow_expr_metavar,
+                        false,
                     )
                     .map_err(|e| should_emit.emit_err(e))
                     .ok()?,
@@ -643,7 +645,11 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         span: Span,
         should_emit: ShouldEmit,
         allow_expr_metavar: AllowExprMetavar,
+        diagnostic: bool,
     ) -> PResult<'sess, MetaItemListParser> {
+        let inner_span = tokens
+            .get(0)
+            .and_then(|start| tokens.get(tokens.len() - 1).map(|end| start.span().to(end.span())));
         let mut parser = Parser::new(psess, tokens, None);
         if let ShouldEmit::ErrorsAndLints { recovery } = should_emit {
             parser = parser.recovery(recovery);
@@ -663,7 +669,24 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         }
 
         if parser.token != token::Eof {
-            parser.unexpected()?;
+            let unexpected = parser.unexpected();
+            if !diagnostic
+                && let Some(inner_span) = inner_span
+                && let Ok(symbol) = &psess.source_map().span_to_snippet(inner_span)
+                && let Err(e) = unexpected
+            {
+                return Ok(MetaItemListParser {
+                    sub_parsers: thin_vec![MetaItemOrLitParser::Lit(MetaItemLit {
+                        symbol: Symbol::intern(symbol),
+                        suffix: None,
+                        kind: LitKind::Err(e.delay_as_bug()),
+                        span: inner_span
+                    })],
+                    span,
+                });
+            } else {
+                unexpected?;
+            }
         }
 
         Ok(MetaItemListParser { sub_parsers, span })
@@ -683,6 +706,7 @@ impl MetaItemListParser {
         psess: &'sess ParseSess,
         should_emit: ShouldEmit,
         allow_expr_metavar: AllowExprMetavar,
+        diagnostic: bool,
     ) -> Result<Self, Diag<'sess>> {
         MetaItemListParserContext::parse(
             tokens.clone(),
@@ -690,6 +714,7 @@ impl MetaItemListParser {
             span,
             should_emit,
             allow_expr_metavar,
+            diagnostic,
         )
     }
 

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -583,6 +583,7 @@ pub(crate) enum AttributeParseErrorReason<'a> {
         list: bool,
     },
     ExpectedIdentifier,
+    ExpectedComma,
 }
 
 /// A description of a thing that can be parsed using an attribute parser.
@@ -849,6 +850,9 @@ impl<'a, G: EmissionGuarantee> Diagnostic<'a, G> for AttributeParseError<'_> {
             }
             AttributeParseErrorReason::ExpectedIdentifier => {
                 diag.span_label(self.span, "expected a valid identifier here");
+            }
+            AttributeParseErrorReason::ExpectedComma => {
+                diag.span_label(self.span, "expected `,` here");
             }
         }
 

--- a/tests/ui/deprecation/deprecation-sanity.rs
+++ b/tests/ui/deprecation/deprecation-sanity.rs
@@ -26,6 +26,12 @@ mod bogus_attribute_types_1 {
 
     #[deprecated("1.2.3")] //~ ERROR malformed `deprecated` attribute input [E0565]
     fn f9() { }
+
+    #[deprecated(deprecation "reason")] //~ ERROR malformed `deprecated` attribute input
+    fn f10() { }
+
+    #[deprecated(1.2.3)] //~ ERROR malformed `deprecated` attribute input
+    fn f11() { }
 }
 
 #[deprecated(since = "a", note = "b")]

--- a/tests/ui/deprecation/deprecation-sanity.stderr
+++ b/tests/ui/deprecation/deprecation-sanity.stderr
@@ -75,20 +75,48 @@ help: try specifying a deprecated since version
 LL |     #[deprecated(since = "1.2.3")]
    |                  +++++++
 
+error[E0565]: malformed `deprecated` attribute input
+  --> $DIR/deprecation-sanity.rs:30:5
+   |
+LL |     #[deprecated(deprecation "reason")]
+   |     ^^^^^^^^^^^^^--------------------^^
+   |                  |
+   |                  didn't expect a literal here
+   |
+help: try using `=` instead
+   |
+LL -     #[deprecated(deprecation "reason")]
+LL +     #[deprecated = "deprecation \"reason\""]
+   |
+
+error[E0565]: malformed `deprecated` attribute input
+  --> $DIR/deprecation-sanity.rs:33:5
+   |
+LL |     #[deprecated(1.2.3)]
+   |     ^^^^^^^^^^^^^-----^^
+   |                  |
+   |                  didn't expect a literal here
+   |
+help: try specifying a deprecated since version
+   |
+LL -     #[deprecated(1.2.3)]
+LL +     #[deprecated(since = "1.2.3")]
+   |
+
 error: multiple `deprecated` attributes
-  --> $DIR/deprecation-sanity.rs:32:1
+  --> $DIR/deprecation-sanity.rs:38:1
    |
 LL | #[deprecated(since = "a", note = "b")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/deprecation-sanity.rs:31:1
+  --> $DIR/deprecation-sanity.rs:37:1
    |
 LL | #[deprecated(since = "a", note = "b")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0538]: malformed `deprecated` attribute input
-  --> $DIR/deprecation-sanity.rs:35:1
+  --> $DIR/deprecation-sanity.rs:41:1
    |
 LL | #[deprecated(since = "a", since = "b", note = "c")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^-----------^^^^^^^^^^^^^^
@@ -96,7 +124,7 @@ LL | #[deprecated(since = "a", since = "b", note = "c")]
    |                           found `since` used as a key more than once
 
 error: `#[deprecated]` attribute cannot be used on trait impl blocks
-  --> $DIR/deprecation-sanity.rs:40:1
+  --> $DIR/deprecation-sanity.rs:46:1
    |
 LL | #[deprecated = "hello"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,7 +133,7 @@ LL | #[deprecated = "hello"]
    = help: `#[deprecated]` can be applied to associated consts, associated types, constants, crates, data types, enum variants, foreign statics, functions, inherent impl blocks, macro defs, modules, statics, struct fields, traits, type aliases, and use statements
    = note: `#[deny(useless_deprecated)]` on by default
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0538, E0539, E0565.
 For more information about an error, try `rustc --explain E0538`.

--- a/tests/ui/on-unimplemented/expected-comma-found-token.rs
+++ b/tests/ui/on-unimplemented/expected-comma-found-token.rs
@@ -3,8 +3,8 @@
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 
-#[rustc_on_unimplemented(
+#[rustc_on_unimplemented( //~ ERROR malformed `rustc_on_unimplemented` attribute input [E0539]
     message="the message"
-    label="the label" //~ ERROR expected `,`, found `label`
+    label="the label"
 )]
 trait T {}

--- a/tests/ui/on-unimplemented/expected-comma-found-token.stderr
+++ b/tests/ui/on-unimplemented/expected-comma-found-token.stderr
@@ -1,10 +1,22 @@
-error: expected `,`, found `label`
-  --> $DIR/expected-comma-found-token.rs:8:5
+error[E0539]: malformed `rustc_on_unimplemented` attribute input
+  --> $DIR/expected-comma-found-token.rs:6:1
    |
-LL |     message="the message"
-   |                          - expected `,`
-LL |     label="the label"
-   |     ^^^^^ unexpected token
+LL | / #[rustc_on_unimplemented(
+LL | |     message="the message"
+   | |                          - expected `,` here
+LL | |     label="the label"
+LL | | )]
+   | |__^
+   |
+help: must be of the form
+   |
+LL - #[rustc_on_unimplemented(
+LL -     message="the message"
+LL -     label="the label"
+LL - )]
+LL + #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
+   |
 
 error: aborting due to 1 previous error
 
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/parser/attribute/attr-incomplete.rs
+++ b/tests/ui/parser/attribute/attr-incomplete.rs
@@ -1,5 +1,5 @@
 #[cfg(target-os = "windows")]
-//~^ ERROR expected one of `(`, `,`, `::`, or `=`, found `-`
+//~^ ERROR malformed `cfg` attribute input
 pub fn test1() { }
 
 #[cfg(target_os = %)]
@@ -7,7 +7,7 @@ pub fn test1() { }
 pub fn test2() { }
 
 #[cfg(target_os?)]
-//~^ ERROR expected one of `(`, `,`, `::`, or `=`, found `?`
+//~^ ERROR malformed `cfg` attribute input
 pub fn test3() { }
 
 #[cfg[target_os]]

--- a/tests/ui/parser/attribute/attr-incomplete.stderr
+++ b/tests/ui/parser/attribute/attr-incomplete.stderr
@@ -1,8 +1,17 @@
-error: expected one of `(`, `,`, `::`, or `=`, found `-`
-  --> $DIR/attr-incomplete.rs:1:13
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/attr-incomplete.rs:1:1
    |
 LL | #[cfg(target-os = "windows")]
-   |             ^ expected one of `(`, `,`, `::`, or `=`
+   | ^^^^^^---------------------^^
+   |       |
+   |       expected a valid identifier here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target-os = "windows")]
+LL + #[cfg(predicate)]
+   |
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `%`
   --> $DIR/attr-incomplete.rs:5:19
@@ -10,11 +19,20 @@ error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `%`
 LL | #[cfg(target_os = %)]
    |                   ^
 
-error: expected one of `(`, `,`, `::`, or `=`, found `?`
-  --> $DIR/attr-incomplete.rs:9:16
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/attr-incomplete.rs:9:1
    |
 LL | #[cfg(target_os?)]
-   |                ^ expected one of `(`, `,`, `::`, or `=`
+   | ^^^^^^----------^^
+   |       |
+   |       expected a valid identifier here
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(target_os?)]
+LL + #[cfg(predicate)]
+   |
 
 error: wrong meta list delimiters
   --> $DIR/attr-incomplete.rs:13:6
@@ -30,3 +48,4 @@ LL + #[cfg(target_os)]
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0539`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Instead of immediately throwing a parse error when encountering invalid syntax inside a `MetaItemList`, delay and return a list with a `Lit::Err` so later parsers can produce better error messages.

We can identify that these two numeric literals were probably meant to be a version string:
```
error[E0565]: malformed `deprecated` attribute input
  --> $DIR/deprecation-sanity.rs:33:5
   |
LL |     #[deprecated(1.2.3)]
   |     ^^^^^^^^^^^^^-----^^
   |                  |
   |                  didn't expect a literal here
   |
help: try specifying a deprecated since version
   |
LL -     #[deprecated(1.2.3)]
LL +     #[deprecated(since = "1.2.3")]
   |
```

We can identify that this identifier followed by a string literal was probably meant to be a reason string:
```
error[E0565]: malformed `deprecated` attribute input
  --> $DIR/deprecation-sanity.rs:30:5
   |
LL |     #[deprecated(deprecation "reason")]
   |     ^^^^^^^^^^^^^--------------------^^
   |                  |
   |                  didn't expect a literal here
   |
help: try using `=` instead
   |
LL -     #[deprecated(deprecation "reason")]
LL +     #[deprecated = "deprecation \"reason\""]
   |
```

We can provide the correct forms inside help:
```
error[E0539]: malformed `rustc_on_unimplemented` attribute input
  --> $DIR/expected-comma-found-token.rs:6:1
   |
LL | / #[rustc_on_unimplemented(
LL | |     message="the message"
   | |                          - expected `,` here
LL | |     label="the label"
LL | | )]
   | |__^
   |
help: must be of the form
   |
LL - #[rustc_on_unimplemented(
LL -     message="the message"
LL -     label="the label"
LL - )]
LL + #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
   |
```

I think that the approach of handling malformed syntax inside the `AttributeParser`s rather than at the `MetaItemList` parser is good and will let us provide better error messages. However, I don't think that using `Lit::Err` is quite the right approach because it throws away lexing information that will need to be [reconstructed to provide good error messages in some cases.](https://github.com/rust-lang/rust/commit/38a885103d0859eafac766b6c773038d204e0885#diff-c30633c670520b774611061b0ea81714646c437aad757e673cb6c362341ed371R392-R419) 

I also think that there are two distinct concerns here:
1. Parsing syntactically correct MetaItems and determining if they are correct for the particular attributes.
2. Parsing syntactically incorrect MetaItems and determining what was likely intended and how they could be transformed into syntactically correct input.

Maybe there should be a separate method on the `AttributeParser`s for generating error messages from malformed attribute inputs? The flow would go:
1. Try to parse the `MetaItemList`, but encounter an error.
2. Give up and re-parse the token stream with a permissive `MalformedMetaItemListParser`
3. Pass that to a new method on the parsers for already malformed inputs to generate a high quality error message. 