### PR TITLE
Change type of async context parameter after state transform.

### DIFF
--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -308,6 +308,10 @@ pub(super) fn create_coroutine_drop_shim_async<'tcx>(
     // Run derefer to fix Derefs that are not in the first place
     deref_finder(tcx, &mut body, false);
 
+    if transform.coroutine_kind.is_async_desugaring() {
+        transform_async_context(tcx, &mut body);
+    }
+
     if let Some(dumper) = MirDumper::new(tcx, "coroutine_drop_async", &body) {
         dumper.dump_mir(&body);
     }
@@ -320,6 +324,7 @@ pub(super) fn create_coroutine_drop_shim_async<'tcx>(
 pub(super) fn create_coroutine_drop_shim_proxy_async<'tcx>(
     tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
+    coroutine_kind: CoroutineKind,
 ) -> Body<'tcx> {
     let mut body = body.clone();
     // Take the coroutine info out of the body, since the drop shim is
@@ -356,6 +361,10 @@ pub(super) fn create_coroutine_drop_shim_proxy_async<'tcx>(
 
     // Run derefer to fix Derefs that are not in the first place
     deref_finder(tcx, &mut body, false);
+
+    if coroutine_kind.is_async_desugaring() {
+        transform_async_context(tcx, &mut body);
+    }
 
     if let Some(dumper) = MirDumper::new(tcx, "coroutine_drop_proxy_async", &body) {
         dumper.dump_mir(&body);

--- a/compiler/rustc_mir_transform/src/coroutine/mod.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/mod.rs
@@ -551,18 +551,14 @@ fn make_coroutine_state_argument_pinned<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body
     );
 }
 
-/// Transforms the `body` of the coroutine applying the following transforms:
-///
-/// - Eliminates all the `get_context` calls that async lowering created.
-/// - Replace all `Local` `ResumeTy` types with `&mut Context<'_>` (`context_mut_ref`).
-///
-/// The `Local`s that have their types replaced are:
-/// - The `resume` argument itself.
-/// - The argument to `get_context`.
-/// - The yielded value of a `yield`.
-///
+/// Async desugaring uses an unsafe binder type `ResumeTy` to circumvert borrow-checking.
 /// The `ResumeTy` hides a `&mut Context<'_>` behind an unsafe raw pointer, and the
 /// `get_context` function is being used to convert that back to a `&mut Context<'_>`.
+///
+/// The actual should be `&mut Context<'_>`. This performs the substitution:
+/// - create a new local `_r` of type `ResumeTy`;
+/// - assign `ResumeTy(transmute::<&mut Context<'_>, NonNull<Context<'_>>>(_2))` to that local;
+/// - let all the code use `_r` instead of `_2`.
 ///
 /// Ideally the async lowering would not use the `ResumeTy`/`get_context` indirection,
 /// but rather directly use `&mut Context<'_>`, however that would currently
@@ -575,91 +571,88 @@ fn make_coroutine_state_argument_pinned<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body
 #[tracing::instrument(level = "trace", skip(tcx, body), ret)]
 fn transform_async_context<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
     let context_mut_ref = Ty::new_task_context(tcx);
+    let resume_ty_def_id = tcx.require_lang_item(LangItem::ResumeTy, body.span);
+    let resume_nonnull_ty = tcx.instantiate_and_normalize_erasing_regions(
+        ty::GenericArgs::empty(),
+        body.typing_env(tcx),
+        tcx.type_of(tcx.adt_def(resume_ty_def_id).non_enum_variant().fields[FieldIdx::ZERO].did),
+    );
 
-    // replace the type of the `resume` argument
-    replace_resume_ty_local(tcx, body, CTX_ARG, context_mut_ref);
+    // Replace all occurrences of `CTX_ARG` with `resume_local: ResumeTy`,
+    // and set `CTX_ARG: &mut Context<'_>`.
+    let resume_local = body.local_decls.push(LocalDecl::new(context_mut_ref, body.span));
+    body.local_decls.swap(CTX_ARG, resume_local);
+    RenameLocalVisitor { from: CTX_ARG, to: resume_local, tcx }.visit_body(body);
+
+    // Now `CTX_ARG` is `&mut Context` and `resume_local` is a `ResumeTy`.
+    // Insert a `resume_local = ResumeTy(CTX_ARG as *mut Context<'static>)`
+    // at the function entry to make the bridge.
+    let source_info = SourceInfo::outermost(body.span);
+    let nonnull_local = body.local_decls.push(LocalDecl::new(resume_nonnull_ty, body.span));
+    let nonnull_rhs =
+        Rvalue::Cast(CastKind::Transmute, Operand::Move(CTX_ARG.into()), resume_nonnull_ty);
+    let nonnull_assign = StatementKind::Assign(Box::new((nonnull_local.into(), nonnull_rhs)));
+    let resume_rhs = Rvalue::Aggregate(
+        Box::new(AggregateKind::Adt(
+            resume_ty_def_id,
+            VariantIdx::ZERO,
+            ty::GenericArgs::empty(),
+            None,
+            None,
+        )),
+        indexvec![Operand::Move(nonnull_local.into())],
+    );
+    let resume_assign = StatementKind::Assign(Box::new((resume_local.into(), resume_rhs)));
+    body.basic_blocks.as_mut_preserves_cfg()[START_BLOCK].statements.splice(
+        0..0,
+        [Statement::new(source_info, nonnull_assign), Statement::new(source_info, resume_assign)],
+    );
+}
+
+/// HIR uses `get_context` to unwrap a `&mut Context<'_>` from a `ResumeTy`.
+/// Both types are just a single pointer, but liveness analysis does not know that and
+/// supposes that the operand and the destination are live at the same time.
+/// Forcibly inline those calls to avoid this.
+fn eliminate_get_context_calls<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+    let context_mut_ref = Ty::new_task_context(tcx);
+    let resume_ty_def_id = tcx.require_lang_item(LangItem::ResumeTy, body.span);
+    let resume_nonnull_ty = tcx.instantiate_and_normalize_erasing_regions(
+        ty::GenericArgs::empty(),
+        body.typing_env(tcx),
+        tcx.type_of(tcx.adt_def(resume_ty_def_id).non_enum_variant().fields[FieldIdx::ZERO].did),
+    );
 
     let get_context_def_id = tcx.require_lang_item(LangItem::GetContext, body.span);
-
-    for bb in body.basic_blocks.indices() {
-        let bb_data = &body[bb];
+    for bb_data in body.basic_blocks.as_mut().iter_mut() {
         if bb_data.is_cleanup {
             continue;
         }
 
-        match &bb_data.terminator().kind {
-            TerminatorKind::Call { func, .. } => {
-                let func_ty = func.ty(body, tcx);
-                if let ty::FnDef(def_id, _) = *func_ty.kind()
-                    && def_id == get_context_def_id
-                {
-                    let local = eliminate_get_context_call(&mut body[bb]);
-                    replace_resume_ty_local(tcx, body, local, context_mut_ref);
-                }
-            }
-            TerminatorKind::Yield { resume_arg, .. } => {
-                replace_resume_ty_local(tcx, body, resume_arg.local, context_mut_ref);
-            }
-            _ => {}
+        let terminator = bb_data.terminator_mut();
+        if let TerminatorKind::Call { func, args, destination, target, .. } = &terminator.kind
+            && let func_ty = func.ty(&body.local_decls, tcx)
+            && let ty::FnDef(def_id, _) = *func_ty.kind()
+            && def_id == get_context_def_id
+            && let [arg] = &**args
+            && let Some(place) = arg.node.place()
+        {
+            let arg =
+                Rvalue::Cast(
+                    CastKind::Transmute,
+                    Operand::Copy(place.project_deeper(
+                        &[PlaceElem::Field(FieldIdx::ZERO, resume_nonnull_ty)],
+                        tcx,
+                    )),
+                    context_mut_ref,
+                );
+            let assign = Statement::new(
+                terminator.source_info,
+                StatementKind::Assign(Box::new((*destination, arg))),
+            );
+            terminator.kind = TerminatorKind::Goto { target: target.unwrap() };
+            bb_data.statements.push(assign);
         }
     }
-}
-
-fn eliminate_get_context_call<'tcx>(bb_data: &mut BasicBlockData<'tcx>) -> Local {
-    let terminator = bb_data.terminator.take().unwrap();
-    let TerminatorKind::Call { args, destination, target, .. } = terminator.kind else {
-        bug!();
-    };
-    let [arg] = *Box::try_from(args).unwrap();
-    let local = arg.node.place().unwrap().local;
-
-    let arg = Rvalue::Use(arg.node, WithRetag::Yes);
-    let assign =
-        Statement::new(terminator.source_info, StatementKind::Assign(Box::new((destination, arg))));
-    bb_data.statements.push(assign);
-    bb_data.terminator = Some(Terminator {
-        source_info: terminator.source_info,
-        kind: TerminatorKind::Goto { target: target.unwrap() },
-    });
-    local
-}
-
-#[cfg_attr(not(debug_assertions), allow(unused))]
-#[tracing::instrument(level = "trace", skip(tcx, body), ret)]
-fn replace_resume_ty_local<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    body: &mut Body<'tcx>,
-    local: Local,
-    context_mut_ref: Ty<'tcx>,
-) {
-    let local_ty = std::mem::replace(&mut body.local_decls[local].ty, context_mut_ref);
-    // We have to replace the `ResumeTy` that is used for type and borrow checking
-    // with `&mut Context<'_>` in MIR.
-    #[cfg(debug_assertions)]
-    {
-        if let ty::Adt(resume_ty_adt, _) = local_ty.kind() {
-            let expected_adt = tcx.adt_def(tcx.require_lang_item(LangItem::ResumeTy, body.span));
-            assert_eq!(*resume_ty_adt, expected_adt);
-        } else {
-            panic!("expected `ResumeTy`, found `{:?}`", local_ty);
-        };
-    }
-}
-
-/// Transforms the `body` of the coroutine applying the following transform:
-///
-/// - Remove the `resume` argument.
-///
-/// Ideally the async lowering would not add the `resume` argument.
-///
-/// The async lowering step and the type / lifetime inference / checking are
-/// still using the `resume` argument for the time being. After this transform,
-/// the coroutine body doesn't have the `resume` argument.
-fn transform_gen_context<'tcx>(body: &mut Body<'tcx>) {
-    // This leaves the local representing the `resume` argument in place,
-    // but turns it into a regular local variable. This is cheaper than
-    // adjusting all local references in the body after removing it.
-    body.arg_count = 1;
 }
 
 /// Replaces the entry point of `body` with a block that switches on the coroutine discriminant and
@@ -883,6 +876,10 @@ fn create_coroutine_resume_function<'tcx>(
     // Run derefer to fix Derefs that are not in the first place
     deref_finder(tcx, body, false);
 
+    if transform.coroutine_kind.is_async_desugaring() {
+        transform_async_context(tcx, body);
+    }
+
     if let Some(dumper) = MirDumper::new(tcx, "coroutine_resume", body) {
         dumper.dump_mir(body);
     }
@@ -1025,12 +1022,10 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
         // (finally in open_drop_for_tuple) before async drop expansion.
         // Async drops, produced by this drop elaboration, will be expanded,
         // and corresponding futures kept in layout.
-        let coroutine_is_async = coroutine_kind.is_async_desugaring();
         let has_async_drops = has_async_drops(body);
 
-        // Replace all occurrences of `ResumeTy` with `&mut Context<'_>` within async bodies.
-        if coroutine_is_async {
-            transform_async_context(tcx, body);
+        if coroutine_kind.is_async_desugaring() {
+            eliminate_get_context_calls(tcx, body);
         }
 
         let always_live_locals = always_storage_live_locals(body);
@@ -1097,13 +1092,9 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
             }),
         );
 
-        // Update our MIR struct to reflect the changes we've made
-        body.arg_count = 2; // self, resume arg
-        body.spread_arg = None;
-
         // Remove the context argument within generator bodies.
         if matches!(coroutine_kind, CoroutineKind::Desugared(CoroutineDesugaring::Gen, _)) {
-            transform_gen_context(body);
+            body.arg_count = 1;
         }
 
         // The original arguments to the function are no longer arguments, mark them as such.
@@ -1150,7 +1141,7 @@ impl<'tcx> crate::MirPass<'tcx> for StateTransform {
             body.coroutine.as_mut().unwrap().coroutine_drop = Some(drop_shim);
 
             // For coroutine with sync drop, generating async proxy for `future_drop_poll` call
-            let proxy_shim = create_coroutine_drop_shim_proxy_async(tcx, body);
+            let proxy_shim = create_coroutine_drop_shim_proxy_async(tcx, body, coroutine_kind);
             body.coroutine.as_mut().unwrap().coroutine_drop_proxy_async = Some(proxy_shim);
         }
 

--- a/tests/mir-opt/coroutine/async_await.a-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_await.a-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn a::{closure#0}(_1: {async fn body of a()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn a::{closure#0}(_1: Pin<&mut {async fn body of a()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         variant_fields = {
@@ -13,16 +15,19 @@
 +         }
 +         storage_conflicts = BitMatrix(0x0) {}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _6;
 +     let mut _0: std::task::Poll<()>;
 +     let mut _3: ();
 +     let mut _4: u32;
 +     let mut _5: &mut {async fn body of a()};
++     let mut _6: std::future::ResumeTy;
++     let mut _7: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _0 = const ();
 -         drop(_1) -> [return: bb1, unwind: bb2];
++         _7 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _6 = std::future::ResumeTy(move _7);
 +         _5 = copy (_1.0: &mut {async fn body of a()});
 +         _4 = discriminant((*_5));
 +         switchInt(move _4) -> [0: bb5, 1: bb3, otherwise: bb4];

--- a/tests/mir-opt/coroutine/async_await.b-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_await.b-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn b::{closure#0}(_1: {async fn body of b()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn b::{closure#0}(_1: Pin<&mut {async fn body of b()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         field _s0: {async fn body of a()};
@@ -17,8 +19,7 @@
 +         }
 +         storage_conflicts = BitMatrix(2x2) {(_s0, _s0), (_s1, _s1)}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _40;
 +     coroutine debug __awaitee => _s0;
 +     coroutine debug __awaitee => _s1;
 +     let mut _0: std::task::Poll<()>;
@@ -34,12 +35,10 @@
       let mut _12: &mut {async fn body of a()};
       let mut _13: &mut std::task::Context<'_>;
       let mut _14: &mut std::task::Context<'_>;
--     let mut _15: std::future::ResumeTy;
-+     let mut _15: &mut std::task::Context<'_>;
+      let mut _15: std::future::ResumeTy;
       let mut _16: isize;
       let mut _18: !;
--     let mut _19: std::future::ResumeTy;
-+     let mut _19: &mut std::task::Context<'_>;
+      let mut _19: std::future::ResumeTy;
       let mut _20: ();
       let mut _21: {async fn body of a()};
       let mut _22: {async fn body of a()};
@@ -51,16 +50,16 @@
       let mut _28: &mut {async fn body of a()};
       let mut _29: &mut std::task::Context<'_>;
       let mut _30: &mut std::task::Context<'_>;
--     let mut _31: std::future::ResumeTy;
-+     let mut _31: &mut std::task::Context<'_>;
+      let mut _31: std::future::ResumeTy;
       let mut _32: isize;
       let mut _34: !;
--     let mut _35: std::future::ResumeTy;
-+     let mut _35: &mut std::task::Context<'_>;
+      let mut _35: std::future::ResumeTy;
       let mut _36: ();
 +     let mut _37: ();
 +     let mut _38: u32;
 +     let mut _39: &mut {async fn body of b()};
++     let mut _40: std::future::ResumeTy;
++     let mut _41: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug __awaitee => _6;
 +         debug __awaitee => (((*_39) as variant#3).0: {async fn body of a()});
@@ -83,6 +82,8 @@
 -         StorageLive(_4);
 -         StorageLive(_5);
 -         _5 = a() -> [return: bb1, unwind: bb47];
++         _41 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _40 = std::future::ResumeTy(move _41);
 +         _39 = copy (_1.0: &mut {async fn body of b()});
 +         _38 = discriminant((*_39));
 +         switchInt(move _38) -> [0: bb47, 1: bb46, 2: bb45, 3: bb43, 4: bb44, otherwise: bb7];
@@ -121,9 +122,10 @@
           StorageLive(_13);
           StorageLive(_14);
           StorageLive(_15);
-          _15 = copy _2;
+-         _15 = copy _2;
 -         _14 = std::future::get_context::<'_, '_>(move _15) -> [return: bb5, unwind: bb41];
-+         _14 = move _15;
++         _15 = copy _40;
++         _14 = copy (_15.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb5;
       }
   
@@ -180,7 +182,8 @@
   
       bb10: {
           StorageDead(_20);
-          _2 = move _19;
+-         _2 = move _19;
++         _40 = move _19;
           StorageDead(_19);
           _7 = const ();
           goto -> bb3;
@@ -234,9 +237,10 @@
           StorageLive(_29);
           StorageLive(_30);
           StorageLive(_31);
-          _31 = copy _2;
+-         _31 = copy _2;
 -         _30 = std::future::get_context::<'_, '_>(move _31) -> [return: bb17, unwind: bb33];
-+         _30 = move _31;
++         _31 = copy _40;
++         _30 = copy (_31.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb17;
       }
   
@@ -289,7 +293,8 @@
   
       bb21: {
           StorageDead(_36);
-          _2 = move _35;
+-         _2 = move _35;
++         _40 = move _35;
           StorageDead(_35);
           _7 = const ();
           goto -> bb15;
@@ -501,7 +506,7 @@
 +         StorageLive(_4);
 +         StorageLive(_19);
 +         StorageLive(_20);
-+         _19 = move _2;
++         _19 = move _40;
 +         goto -> bb10;
       }
   
@@ -512,7 +517,7 @@
 +         StorageLive(_21);
 +         StorageLive(_35);
 +         StorageLive(_36);
-+         _35 = move _2;
++         _35 = move _40;
 +         goto -> bb21;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncEnum.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncEnum.StateTransform.diff
@@ -26,35 +26,29 @@
 +     let mut _0: std::task::Poll<()>;
       let mut _3: &mut AsyncEnum;
       let mut _4: impl std::future::Future<Output = ()>;
--     let mut _5: std::future::ResumeTy;
-+     let mut _5: &mut std::task::Context<'_>;
+      let mut _5: std::future::ResumeTy;
       let mut _6: std::task::Poll<()>;
       let mut _7: isize;
       let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _9: &mut std::task::Context<'_>;
--     let mut _10: std::future::ResumeTy;
-+     let mut _10: &mut std::task::Context<'_>;
+      let mut _10: std::future::ResumeTy;
       let mut _11: &mut impl std::future::Future<Output = ()>;
       let mut _12: std::pin::Pin<&mut AsyncInt>;
       let mut _13: &mut AsyncInt;
       let mut _14: impl std::future::Future<Output = ()>;
--     let mut _15: std::future::ResumeTy;
-+     let mut _15: &mut std::task::Context<'_>;
+      let mut _15: std::future::ResumeTy;
       let mut _16: std::task::Poll<()>;
       let mut _17: isize;
       let mut _18: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _19: &mut std::task::Context<'_>;
--     let mut _20: std::future::ResumeTy;
-+     let mut _20: &mut std::task::Context<'_>;
+      let mut _20: std::future::ResumeTy;
       let mut _21: &mut impl std::future::Future<Output = ()>;
--     let mut _22: std::future::ResumeTy;
-+     let mut _22: &mut std::task::Context<'_>;
+      let mut _22: std::future::ResumeTy;
       let mut _23: std::task::Poll<()>;
       let mut _24: isize;
       let mut _25: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _26: &mut std::task::Context<'_>;
--     let mut _27: std::future::ResumeTy;
-+     let mut _27: &mut std::task::Context<'_>;
+      let mut _27: std::future::ResumeTy;
       let mut _28: &mut impl std::future::Future<Output = ()>;
       let mut _29: std::pin::Pin<&mut AsyncInt>;
       let mut _30: &mut AsyncInt;
@@ -62,23 +56,19 @@
       let mut _32: isize;
       let mut _33: isize;
       let mut _34: impl std::future::Future<Output = ()>;
--     let mut _35: std::future::ResumeTy;
-+     let mut _35: &mut std::task::Context<'_>;
+      let mut _35: std::future::ResumeTy;
       let mut _36: std::task::Poll<()>;
       let mut _37: isize;
       let mut _38: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _39: &mut std::task::Context<'_>;
--     let mut _40: std::future::ResumeTy;
-+     let mut _40: &mut std::task::Context<'_>;
+      let mut _40: std::future::ResumeTy;
       let mut _41: &mut impl std::future::Future<Output = ()>;
--     let mut _42: std::future::ResumeTy;
-+     let mut _42: &mut std::task::Context<'_>;
+      let mut _42: std::future::ResumeTy;
       let mut _43: std::task::Poll<()>;
       let mut _44: isize;
       let mut _45: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _46: &mut std::task::Context<'_>;
--     let mut _47: std::future::ResumeTy;
-+     let mut _47: &mut std::task::Context<'_>;
+      let mut _47: std::future::ResumeTy;
       let mut _48: &mut impl std::future::Future<Output = ()>;
       let mut _49: std::pin::Pin<&mut AsyncEnum>;
       let mut _50: &mut AsyncEnum;
@@ -92,11 +82,15 @@
 +     let mut _58: &mut AsyncEnum;
 +     let mut _59: &mut AsyncEnum;
 +     let mut _60: &mut AsyncEnum;
++     let _61: std::future::ResumeTy;
++     let mut _62: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _3 = move (_1.0: &mut AsyncEnum);
 -         _50 = &mut (*_3);
 -         _49 = Pin::<&mut AsyncEnum>::new_unchecked(move _50) -> [return: bb59, unwind: bb40];
++         _62 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _61 = std::future::ResumeTy(move _62);
 +         _53 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<AsyncEnum>()});
 +         _52 = discriminant((*_53));
 +         switchInt(move _52) -> [0: bb42, 1: bb41, 2: bb40, 3: bb35, 4: bb36, 5: bb37, 6: bb38, 7: bb39, otherwise: bb7];
@@ -136,7 +130,7 @@
   
       bb6: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
-+         _2 = move _5;
++         _61 = move _5;
 +         StorageDead(_5);
 +         goto -> bb5;
       }
@@ -172,14 +166,14 @@
       bb11: {
 -         _7 = discriminant(_6);
 -         switchInt(move _7) -> [0: bb4, 1: bb9, otherwise: bb10];
-+         _2 = move _15;
++         _61 = move _15;
 +         StorageDead(_15);
 +         goto -> bb10;
       }
   
       bb12: {
 -         _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb11, unwind: bb5];
-+         _2 = move _22;
++         _61 = move _22;
 +         StorageDead(_22);
 +         goto -> bb17;
       }
@@ -210,8 +204,8 @@
       bb16: {
 -         _13 = &mut (((*_3) as A).0: AsyncInt);
 -         _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb15, unwind: bb2];
-+         _27 = move _2;
-+         _26 = move _27;
++         _27 = move _61;
++         _26 = copy (_27.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb15;
       }
   
@@ -288,7 +282,7 @@
       bb26: {
 -         _20 = move _2;
 -         _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb25, unwind: bb19];
-+         _2 = move _35;
++         _61 = move _35;
 +         StorageDead(_35);
 +         goto -> bb25;
       }
@@ -296,7 +290,7 @@
       bb27: {
 -         _21 = &mut _14;
 -         _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb26, unwind: bb19];
-+         _2 = move _42;
++         _61 = move _42;
 +         StorageDead(_42);
 +         goto -> bb32;
       }
@@ -329,8 +323,8 @@
       bb31: {
 -         _24 = discriminant(_23);
 -         switchInt(move _24) -> [0: bb17, 1: bb30, otherwise: bb10];
-+         _47 = move _2;
-+         _46 = move _47;
++         _47 = move _61;
++         _46 = copy (_47.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb30;
       }
   
@@ -359,7 +353,7 @@
 -         StorageLive(_14);
 -         _14 = async_drop_in_place::<AsyncInt>(copy (_29.0: &mut AsyncInt)) -> [return: bb34, unwind: bb19];
 +         StorageLive(_5);
-+         _5 = move _2;
++         _5 = move _61;
 +         goto -> bb6;
       }
   
@@ -367,7 +361,7 @@
 -         _30 = &mut (((*_3) as A).0: AsyncInt);
 -         _29 = Pin::<&mut AsyncInt>::new_unchecked(move _30) -> [return: bb35, unwind: bb2];
 +         StorageLive(_15);
-+         _15 = move _2;
++         _15 = move _61;
 +         goto -> bb11;
       }
   
@@ -375,21 +369,21 @@
 -         drop((((*_3) as B).0: SyncInt)) -> [return: bb2, unwind terminate(cleanup)];
 +     bb37: {
 +         StorageLive(_22);
-+         _22 = move _2;
++         _22 = move _61;
 +         goto -> bb12;
       }
   
       bb38: {
 -         drop((((*_3) as B).0: SyncInt)) -> [return: bb1, unwind: bb2];
 +         StorageLive(_35);
-+         _35 = move _2;
++         _35 = move _61;
 +         goto -> bb26;
       }
   
       bb39: {
 -         drop((((*_3) as B).0: SyncInt)) -> [return: bb1, unwind: bb2];
 +         StorageLive(_42);
-+         _42 = move _2;
++         _42 = move _61;
 +         goto -> bb27;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncInt.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncInt.StateTransform.diff
@@ -20,34 +20,34 @@
 +     let mut _0: std::task::Poll<()>;
       let mut _3: &mut AsyncInt;
       let mut _4: impl std::future::Future<Output = ()>;
--     let mut _5: std::future::ResumeTy;
-+     let mut _5: &mut std::task::Context<'_>;
+      let mut _5: std::future::ResumeTy;
       let mut _6: std::task::Poll<()>;
       let mut _7: isize;
       let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _9: &mut std::task::Context<'_>;
--     let mut _10: std::future::ResumeTy;
-+     let mut _10: &mut std::task::Context<'_>;
+      let mut _10: std::future::ResumeTy;
       let mut _11: &mut impl std::future::Future<Output = ()>;
--     let mut _12: std::future::ResumeTy;
-+     let mut _12: &mut std::task::Context<'_>;
+      let mut _12: std::future::ResumeTy;
       let mut _13: std::task::Poll<()>;
       let mut _14: isize;
       let mut _15: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _16: &mut std::task::Context<'_>;
--     let mut _17: std::future::ResumeTy;
-+     let mut _17: &mut std::task::Context<'_>;
+      let mut _17: std::future::ResumeTy;
       let mut _18: &mut impl std::future::Future<Output = ()>;
       let mut _19: std::pin::Pin<&mut AsyncInt>;
       let mut _20: &mut AsyncInt;
 +     let mut _21: ();
 +     let mut _22: u32;
 +     let mut _23: &mut {async fn body of std::future::async_drop_in_place<AsyncInt>()};
++     let _24: std::future::ResumeTy;
++     let mut _25: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _3 = move (_1.0: &mut AsyncInt);
 -         _20 = &mut (*_3);
 -         _19 = Pin::<&mut AsyncInt>::new_unchecked(move _20) -> [return: bb22, unwind: bb2];
++         _25 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _24 = std::future::ResumeTy(move _25);
 +         _23 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<AsyncInt>()});
 +         _22 = discriminant((*_23));
 +         switchInt(move _22) -> [0: bb20, 1: bb19, 2: bb18, 3: bb16, 4: bb17, otherwise: bb7];
@@ -87,7 +87,7 @@
   
       bb6: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
-+         _2 = move _5;
++         _24 = move _5;
 +         StorageDead(_5);
 +         goto -> bb5;
       }
@@ -103,7 +103,7 @@
 -         _2 = move _5;
 -         StorageDead(_5);
 -         goto -> bb14;
-+         _2 = move _12;
++         _24 = move _12;
 +         StorageDead(_12);
 +         goto -> bb13;
       }
@@ -132,8 +132,8 @@
   
       bb12: {
 -         _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb11, unwind: bb5];
-+         _17 = move _2;
-+         _16 = move _17;
++         _17 = move _24;
++         _16 = copy (_17.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb11;
       }
   
@@ -165,14 +165,14 @@
 -         StorageDead(_12);
 -         goto -> bb14;
 +         StorageLive(_5);
-+         _5 = move _2;
++         _5 = move _24;
 +         goto -> bb6;
       }
   
       bb17: {
           StorageLive(_12);
 -         _12 = yield(const ()) -> [resume: bb15, drop: bb16];
-+         _12 = move _2;
++         _12 = move _24;
 +         goto -> bb8;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncReference_'__.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncReference_'__.StateTransform.diff
@@ -20,34 +20,34 @@
 +     let mut _0: std::task::Poll<()>;
       let mut _3: &mut AsyncReference<'_>;
       let mut _4: impl std::future::Future<Output = ()>;
--     let mut _5: std::future::ResumeTy;
-+     let mut _5: &mut std::task::Context<'_>;
+      let mut _5: std::future::ResumeTy;
       let mut _6: std::task::Poll<()>;
       let mut _7: isize;
       let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _9: &mut std::task::Context<'_>;
--     let mut _10: std::future::ResumeTy;
-+     let mut _10: &mut std::task::Context<'_>;
+      let mut _10: std::future::ResumeTy;
       let mut _11: &mut impl std::future::Future<Output = ()>;
--     let mut _12: std::future::ResumeTy;
-+     let mut _12: &mut std::task::Context<'_>;
+      let mut _12: std::future::ResumeTy;
       let mut _13: std::task::Poll<()>;
       let mut _14: isize;
       let mut _15: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _16: &mut std::task::Context<'_>;
--     let mut _17: std::future::ResumeTy;
-+     let mut _17: &mut std::task::Context<'_>;
+      let mut _17: std::future::ResumeTy;
       let mut _18: &mut impl std::future::Future<Output = ()>;
       let mut _19: std::pin::Pin<&mut AsyncReference<'_>>;
       let mut _20: &mut AsyncReference<'_>;
 +     let mut _21: ();
 +     let mut _22: u32;
 +     let mut _23: &mut {async fn body of std::future::async_drop_in_place<AsyncReference<'_>>()};
++     let _24: std::future::ResumeTy;
++     let mut _25: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _3 = move (_1.0: &mut AsyncReference<'_>);
 -         _20 = &mut (*_3);
 -         _19 = Pin::<&mut AsyncReference<'_>>::new_unchecked(move _20) -> [return: bb22, unwind: bb2];
++         _25 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _24 = std::future::ResumeTy(move _25);
 +         _23 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<AsyncReference<'_>>()});
 +         _22 = discriminant((*_23));
 +         switchInt(move _22) -> [0: bb20, 1: bb19, 2: bb18, 3: bb16, 4: bb17, otherwise: bb7];
@@ -87,7 +87,7 @@
   
       bb6: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb6, unwind: bb5];
-+         _2 = move _5;
++         _24 = move _5;
 +         StorageDead(_5);
 +         goto -> bb5;
       }
@@ -103,7 +103,7 @@
 -         _2 = move _5;
 -         StorageDead(_5);
 -         goto -> bb14;
-+         _2 = move _12;
++         _24 = move _12;
 +         StorageDead(_12);
 +         goto -> bb13;
       }
@@ -132,8 +132,8 @@
   
       bb12: {
 -         _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb11, unwind: bb5];
-+         _17 = move _2;
-+         _16 = move _17;
++         _17 = move _24;
++         _16 = copy (_17.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb11;
       }
   
@@ -165,14 +165,14 @@
 -         StorageDead(_12);
 -         goto -> bb14;
 +         StorageLive(_5);
-+         _5 = move _2;
++         _5 = move _24;
 +         goto -> bb6;
       }
   
       bb17: {
           StorageLive(_12);
 -         _12 = yield(const ()) -> [resume: bb15, drop: bb16];
-+         _12 = move _2;
++         _12 = move _24;
 +         goto -> bb8;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncStruct.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.AsyncStruct.StateTransform.diff
@@ -31,89 +31,73 @@
 +     let mut _0: std::task::Poll<()>;
       let mut _3: &mut AsyncStruct;
       let mut _4: impl std::future::Future<Output = ()>;
--     let mut _5: std::future::ResumeTy;
-+     let mut _5: &mut std::task::Context<'_>;
+      let mut _5: std::future::ResumeTy;
       let mut _6: std::task::Poll<()>;
       let mut _7: isize;
       let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _9: &mut std::task::Context<'_>;
--     let mut _10: std::future::ResumeTy;
-+     let mut _10: &mut std::task::Context<'_>;
+      let mut _10: std::future::ResumeTy;
       let mut _11: &mut impl std::future::Future<Output = ()>;
       let mut _12: std::pin::Pin<&mut AsyncInt>;
       let mut _13: &mut AsyncInt;
       let mut _14: impl std::future::Future<Output = ()>;
--     let mut _15: std::future::ResumeTy;
-+     let mut _15: &mut std::task::Context<'_>;
+      let mut _15: std::future::ResumeTy;
       let mut _16: std::task::Poll<()>;
       let mut _17: isize;
       let mut _18: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _19: &mut std::task::Context<'_>;
--     let mut _20: std::future::ResumeTy;
-+     let mut _20: &mut std::task::Context<'_>;
+      let mut _20: std::future::ResumeTy;
       let mut _21: &mut impl std::future::Future<Output = ()>;
       let mut _22: std::pin::Pin<&mut AsyncInt>;
       let mut _23: &mut AsyncInt;
       let mut _24: impl std::future::Future<Output = ()>;
--     let mut _25: std::future::ResumeTy;
-+     let mut _25: &mut std::task::Context<'_>;
+      let mut _25: std::future::ResumeTy;
       let mut _26: std::task::Poll<()>;
       let mut _27: isize;
       let mut _28: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _29: &mut std::task::Context<'_>;
--     let mut _30: std::future::ResumeTy;
-+     let mut _30: &mut std::task::Context<'_>;
+      let mut _30: std::future::ResumeTy;
       let mut _31: &mut impl std::future::Future<Output = ()>;
--     let mut _32: std::future::ResumeTy;
-+     let mut _32: &mut std::task::Context<'_>;
+      let mut _32: std::future::ResumeTy;
       let mut _33: std::task::Poll<()>;
       let mut _34: isize;
       let mut _35: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _36: &mut std::task::Context<'_>;
--     let mut _37: std::future::ResumeTy;
-+     let mut _37: &mut std::task::Context<'_>;
+      let mut _37: std::future::ResumeTy;
       let mut _38: &mut impl std::future::Future<Output = ()>;
       let mut _39: std::pin::Pin<&mut AsyncInt>;
       let mut _40: &mut AsyncInt;
       let mut _41: impl std::future::Future<Output = ()>;
--     let mut _42: std::future::ResumeTy;
-+     let mut _42: &mut std::task::Context<'_>;
+      let mut _42: std::future::ResumeTy;
       let mut _43: std::task::Poll<()>;
       let mut _44: isize;
       let mut _45: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _46: &mut std::task::Context<'_>;
--     let mut _47: std::future::ResumeTy;
-+     let mut _47: &mut std::task::Context<'_>;
+      let mut _47: std::future::ResumeTy;
       let mut _48: &mut impl std::future::Future<Output = ()>;
--     let mut _49: std::future::ResumeTy;
-+     let mut _49: &mut std::task::Context<'_>;
+      let mut _49: std::future::ResumeTy;
       let mut _50: std::task::Poll<()>;
       let mut _51: isize;
       let mut _52: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _53: &mut std::task::Context<'_>;
--     let mut _54: std::future::ResumeTy;
-+     let mut _54: &mut std::task::Context<'_>;
+      let mut _54: std::future::ResumeTy;
       let mut _55: &mut impl std::future::Future<Output = ()>;
       let mut _56: std::pin::Pin<&mut AsyncInt>;
       let mut _57: &mut AsyncInt;
       let mut _58: impl std::future::Future<Output = ()>;
--     let mut _59: std::future::ResumeTy;
-+     let mut _59: &mut std::task::Context<'_>;
+      let mut _59: std::future::ResumeTy;
       let mut _60: std::task::Poll<()>;
       let mut _61: isize;
       let mut _62: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _63: &mut std::task::Context<'_>;
--     let mut _64: std::future::ResumeTy;
-+     let mut _64: &mut std::task::Context<'_>;
+      let mut _64: std::future::ResumeTy;
       let mut _65: &mut impl std::future::Future<Output = ()>;
--     let mut _66: std::future::ResumeTy;
-+     let mut _66: &mut std::task::Context<'_>;
+      let mut _66: std::future::ResumeTy;
       let mut _67: std::task::Poll<()>;
       let mut _68: isize;
       let mut _69: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _70: &mut std::task::Context<'_>;
--     let mut _71: std::future::ResumeTy;
-+     let mut _71: &mut std::task::Context<'_>;
+      let mut _71: std::future::ResumeTy;
       let mut _72: &mut impl std::future::Future<Output = ()>;
       let mut _73: std::pin::Pin<&mut AsyncStruct>;
       let mut _74: &mut AsyncStruct;
@@ -125,11 +109,15 @@
 +     let mut _80: &mut AsyncStruct;
 +     let mut _81: &mut AsyncStruct;
 +     let mut _82: &mut AsyncStruct;
++     let _83: std::future::ResumeTy;
++     let mut _84: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _3 = move (_1.0: &mut AsyncStruct);
 -         _74 = &mut (*_3);
 -         _73 = Pin::<&mut AsyncStruct>::new_unchecked(move _74) -> [return: bb85, unwind: bb4];
++         _84 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _83 = std::future::ResumeTy(move _84);
 +         _77 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<AsyncStruct>()});
 +         _76 = discriminant((*_77));
 +         switchInt(move _76) -> [0: bb56, 1: bb55, 2: bb54, 3: bb46, 4: bb47, 5: bb48, 6: bb49, 7: bb50, 8: bb51, 9: bb52, 10: bb53, otherwise: bb8];
@@ -175,7 +163,7 @@
   
       bb7: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb7, unwind: bb6];
-+         _2 = move _5;
++         _83 = move _5;
 +         StorageDead(_5);
 +         goto -> bb6;
       }
@@ -204,7 +192,7 @@
   
       bb11: {
 -         unreachable;
-+         _2 = move _15;
++         _83 = move _15;
 +         StorageDead(_15);
 +         goto -> bb10;
       }
@@ -232,7 +220,7 @@
       bb15: {
 -         _11 = &mut _4;
 -         _8 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _11) -> [return: bb14, unwind: bb6];
-+         _2 = move _25;
++         _83 = move _25;
 +         StorageDead(_25);
 +         goto -> bb14;
       }
@@ -240,7 +228,7 @@
       bb16: {
 -         StorageLive(_4);
 -         _4 = async_drop_in_place::<AsyncInt>(copy (_12.0: &mut AsyncInt)) -> [return: bb15, unwind: bb6];
-+         _2 = move _32;
++         _83 = move _32;
 +         StorageDead(_32);
 +         goto -> bb21;
       }
@@ -271,8 +259,8 @@
   
       bb20: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb20, unwind: bb19];
-+         _37 = move _2;
-+         _36 = move _37;
++         _37 = move _83;
++         _36 = copy (_37.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb19;
       }
   
@@ -317,7 +305,7 @@
       bb26: {
 -         _20 = move _2;
 -         _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb25, unwind: bb19];
-+         _2 = move _42;
++         _83 = move _42;
 +         StorageDead(_42);
 +         goto -> bb25;
       }
@@ -325,7 +313,7 @@
       bb27: {
 -         _21 = &mut _14;
 -         _18 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _21) -> [return: bb26, unwind: bb19];
-+         _2 = move _49;
++         _83 = move _49;
 +         StorageDead(_49);
 +         goto -> bb32;
       }
@@ -357,8 +345,8 @@
 -         StorageDead(_24);
 -         goto -> bb2;
 +     bb31: {
-+         _54 = move _2;
-+         _53 = move _54;
++         _54 = move _83;
++         _53 = copy (_54.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb30;
       }
   
@@ -402,7 +390,7 @@
   
       bb37: {
 -         _26 = <impl Future<Output = ()> as Future>::poll(move _28, move _29) -> [return: bb36, unwind: bb31];
-+         _2 = move _59;
++         _83 = move _59;
 +         StorageDead(_59);
 +         goto -> bb36;
       }
@@ -410,7 +398,7 @@
       bb38: {
 -         _30 = move _2;
 -         _29 = std::future::get_context::<'_, '_>(move _30) -> [return: bb37, unwind: bb31];
-+         _2 = move _66;
++         _83 = move _66;
 +         StorageDead(_66);
 +         goto -> bb43;
       }
@@ -443,8 +431,8 @@
       bb42: {
 -         StorageLive(_32);
 -         _32 = yield(const ()) -> [resume: bb40, drop: bb41];
-+         _71 = move _2;
-+         _70 = move _71;
++         _71 = move _83;
++         _70 = copy (_71.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb41;
       }
   
@@ -473,7 +461,7 @@
 -         _38 = &mut _24;
 -         _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb45, unwind: bb31];
 +         StorageLive(_5);
-+         _5 = move _2;
++         _5 = move _83;
 +         goto -> bb7;
       }
   
@@ -481,7 +469,7 @@
 -         StorageLive(_24);
 -         _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb46, unwind: bb31];
 +         StorageLive(_15);
-+         _15 = move _2;
++         _15 = move _83;
 +         goto -> bb11;
       }
   
@@ -490,7 +478,7 @@
 -         _40 = &mut ((*_3).2: AsyncInt);
 -         _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb47, unwind: bb2];
 +         StorageLive(_25);
-+         _25 = move _2;
++         _25 = move _83;
 +         goto -> bb15;
       }
   
@@ -498,7 +486,7 @@
 -         StorageDead(_41);
 -         goto -> bb17;
 +         StorageLive(_32);
-+         _32 = move _2;
++         _32 = move _83;
 +         goto -> bb16;
       }
   
@@ -507,14 +495,14 @@
 -         goto -> bb3;
 +     bb50: {
 +         StorageLive(_42);
-+         _42 = move _2;
++         _42 = move _83;
 +         goto -> bb26;
       }
   
       bb51: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb51, unwind: bb50];
 +         StorageLive(_49);
-+         _49 = move _2;
++         _49 = move _83;
 +         goto -> bb27;
       }
   
@@ -523,7 +511,7 @@
 -         StorageDead(_42);
 -         goto -> bb51;
 +         StorageLive(_59);
-+         _59 = move _2;
++         _59 = move _83;
 +         goto -> bb37;
       }
   
@@ -532,7 +520,7 @@
 -         StorageDead(_42);
 -         goto -> bb58;
 +         StorageLive(_66);
-+         _66 = move _2;
++         _66 = move _83;
 +         goto -> bb38;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.Int.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.Int.StateTransform.diff
@@ -18,8 +18,12 @@
 +     let mut _3: ();
 +     let mut _4: u32;
 +     let mut _5: &mut {async fn body of std::future::async_drop_in_place<Int>()};
++     let _6: std::future::ResumeTy;
++     let mut _7: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
++         _7 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _6 = std::future::ResumeTy(move _7);
 +         _5 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<Int>()});
 +         _4 = discriminant((*_5));
 +         switchInt(move _4) -> [0: bb3, 1: bb1, otherwise: bb2];

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.SyncInt.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.SyncInt.StateTransform.diff
@@ -19,10 +19,14 @@
 +     let mut _4: ();
 +     let mut _5: u32;
 +     let mut _6: &mut {async fn body of std::future::async_drop_in_place<SyncInt>()};
++     let _7: std::future::ResumeTy;
++     let mut _8: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _3 = no_retag copy (_1.0: &mut SyncInt);
 -         drop((*_3)) -> [return: bb1, unwind continue];
++         _8 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _7 = std::future::ResumeTy(move _8);
 +         _6 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<SyncInt>()});
 +         _5 = discriminant((*_6));
 +         switchInt(move _5) -> [0: bb6, 1: bb4, 2: bb3, otherwise: bb5];

--- a/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.SyncThenAsync.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.core.future-async_drop-async_drop_in_place-{closure#0}.SyncThenAsync.StateTransform.diff
@@ -26,14 +26,12 @@
 +     let mut _0: std::task::Poll<()>;
       let mut _3: &mut SyncThenAsync;
       let mut _4: impl std::future::Future<Output = ()>;
--     let mut _5: std::future::ResumeTy;
-+     let mut _5: &mut std::task::Context<'_>;
+      let mut _5: std::future::ResumeTy;
       let mut _6: std::task::Poll<()>;
       let mut _7: isize;
       let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _9: &mut std::task::Context<'_>;
--     let mut _10: std::future::ResumeTy;
-+     let mut _10: &mut std::task::Context<'_>;
+      let mut _10: std::future::ResumeTy;
       let mut _11: &mut impl std::future::Future<Output = ()>;
       let mut _12: std::pin::Pin<&mut AsyncInt>;
       let mut _13: &mut AsyncInt;
@@ -48,44 +46,36 @@
       let mut _22: std::pin::Pin<&mut AsyncInt>;
       let mut _23: &mut AsyncInt;
       let mut _24: impl std::future::Future<Output = ()>;
--     let mut _25: std::future::ResumeTy;
-+     let mut _25: &mut std::task::Context<'_>;
+      let mut _25: std::future::ResumeTy;
       let mut _26: std::task::Poll<()>;
       let mut _27: isize;
       let mut _28: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _29: &mut std::task::Context<'_>;
--     let mut _30: std::future::ResumeTy;
-+     let mut _30: &mut std::task::Context<'_>;
+      let mut _30: std::future::ResumeTy;
       let mut _31: &mut impl std::future::Future<Output = ()>;
--     let mut _32: std::future::ResumeTy;
-+     let mut _32: &mut std::task::Context<'_>;
+      let mut _32: std::future::ResumeTy;
       let mut _33: std::task::Poll<()>;
       let mut _34: isize;
       let mut _35: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _36: &mut std::task::Context<'_>;
--     let mut _37: std::future::ResumeTy;
-+     let mut _37: &mut std::task::Context<'_>;
+      let mut _37: std::future::ResumeTy;
       let mut _38: &mut impl std::future::Future<Output = ()>;
       let mut _39: std::pin::Pin<&mut AsyncInt>;
       let mut _40: &mut AsyncInt;
       let mut _41: impl std::future::Future<Output = ()>;
--     let mut _42: std::future::ResumeTy;
-+     let mut _42: &mut std::task::Context<'_>;
+      let mut _42: std::future::ResumeTy;
       let mut _43: std::task::Poll<()>;
       let mut _44: isize;
       let mut _45: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _46: &mut std::task::Context<'_>;
--     let mut _47: std::future::ResumeTy;
-+     let mut _47: &mut std::task::Context<'_>;
+      let mut _47: std::future::ResumeTy;
       let mut _48: &mut impl std::future::Future<Output = ()>;
--     let mut _49: std::future::ResumeTy;
-+     let mut _49: &mut std::task::Context<'_>;
+      let mut _49: std::future::ResumeTy;
       let mut _50: std::task::Poll<()>;
       let mut _51: isize;
       let mut _52: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _53: &mut std::task::Context<'_>;
--     let mut _54: std::future::ResumeTy;
-+     let mut _54: &mut std::task::Context<'_>;
+      let mut _54: std::future::ResumeTy;
       let mut _55: &mut impl std::future::Future<Output = ()>;
       let mut _56: std::pin::Pin<&mut AsyncInt>;
       let mut _57: &mut AsyncInt;
@@ -101,11 +91,15 @@
 +     let mut _67: &mut SyncThenAsync;
 +     let mut _68: &mut SyncThenAsync;
 +     let mut _69: &mut SyncThenAsync;
++     let _70: std::future::ResumeTy;
++     let mut _71: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         _3 = move (_1.0: &mut SyncThenAsync);
 -         _58 = &mut (*_3);
 -         _59 = <SyncThenAsync as Drop>::drop(move _58) -> [return: bb58, unwind: bb5];
++         _71 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _70 = std::future::ResumeTy(move _71);
 +         _62 = copy (_1.0: &mut {async fn body of std::future::async_drop_in_place<SyncThenAsync>()});
 +         _61 = discriminant((*_62));
 +         switchInt(move _61) -> [0: bb42, 1: bb41, 2: bb40, 3: bb35, 4: bb36, 5: bb37, 6: bb38, 7: bb39, otherwise: bb9];
@@ -157,7 +151,7 @@
   
       bb8: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb8, unwind: bb7];
-+         _2 = move _5;
++         _70 = move _5;
 +         StorageDead(_5);
 +         goto -> bb7;
       }
@@ -193,14 +187,14 @@
       bb13: {
 -         _7 = discriminant(_6);
 -         switchInt(move _7) -> [0: bb6, 1: bb11, otherwise: bb12];
-+         _2 = move _25;
++         _70 = move _25;
 +         StorageDead(_25);
 +         goto -> bb12;
       }
   
       bb14: {
 -         _6 = <impl Future<Output = ()> as Future>::poll(move _8, move _9) -> [return: bb13, unwind: bb7];
-+         _2 = move _32;
++         _70 = move _32;
 +         StorageDead(_32);
 +         goto -> bb19;
       }
@@ -231,8 +225,8 @@
       bb18: {
 -         _13 = &mut ((*_3).3: AsyncInt);
 -         _12 = Pin::<&mut AsyncInt>::new_unchecked(move _13) -> [return: bb17, unwind: bb2];
-+         _37 = move _2;
-+         _36 = move _37;
++         _37 = move _70;
++         _36 = copy (_37.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb17;
       }
   
@@ -285,7 +279,7 @@
       bb25: {
 -         StorageLive(_25);
 -         _25 = yield(const ()) -> [resume: bb23, drop: bb24];
-+         _2 = move _42;
++         _70 = move _42;
 +         StorageDead(_42);
 +         goto -> bb24;
       }
@@ -293,7 +287,7 @@
       bb26: {
 -         _27 = discriminant(_26);
 -         switchInt(move _27) -> [0: bb20, 1: bb25, otherwise: bb12];
-+         _2 = move _49;
++         _70 = move _49;
 +         StorageDead(_49);
 +         goto -> bb31;
       }
@@ -324,8 +318,8 @@
 -         _2 = move _32;
 -         StorageDead(_32);
 -         goto -> bb36;
-+         _54 = move _2;
-+         _53 = move _54;
++         _54 = move _70;
++         _53 = copy (_54.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb29;
       }
   
@@ -363,7 +357,7 @@
 -         _37 = move _2;
 -         _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb34, unwind: bb21];
 +         StorageLive(_5);
-+         _5 = move _2;
++         _5 = move _70;
 +         goto -> bb8;
       }
   
@@ -371,7 +365,7 @@
 -         _38 = &mut _24;
 -         _35 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _38) -> [return: bb35, unwind: bb21];
 +         StorageLive(_25);
-+         _25 = move _2;
++         _25 = move _70;
 +         goto -> bb13;
       }
   
@@ -379,7 +373,7 @@
 -         StorageLive(_24);
 -         _24 = async_drop_in_place::<AsyncInt>(copy (_39.0: &mut AsyncInt)) -> [return: bb36, unwind: bb21];
 +         StorageLive(_32);
-+         _32 = move _2;
++         _32 = move _70;
 +         goto -> bb14;
       }
   
@@ -387,7 +381,7 @@
 -         _40 = &mut ((*_3).3: AsyncInt);
 -         _39 = Pin::<&mut AsyncInt>::new_unchecked(move _40) -> [return: bb37, unwind: bb2];
 +         StorageLive(_42);
-+         _42 = move _2;
++         _42 = move _70;
 +         goto -> bb25;
       }
   
@@ -395,7 +389,7 @@
 -         StorageDead(_41);
 -         drop(((*_3).2: SyncInt)) -> [return: bb38, unwind: bb3];
 +         StorageLive(_49);
-+         _49 = move _2;
++         _49 = move _70;
 +         goto -> bb26;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.double-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.double-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn double::{closure#0}(_1: {async fn body of double()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         field _s0: ();
@@ -23,56 +25,49 @@
 +         }
 +         storage_conflicts = BitMatrix(6x6) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s0, _s4), (_s0, _s5), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s1, _s4), (_s1, _s5), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s2, _s4), (_s2, _s5), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3), (_s3, _s4), (_s4, _s0), (_s4, _s1), (_s4, _s2), (_s4, _s3), (_s4, _s4), (_s5, _s0), (_s5, _s1), (_s5, _s2), (_s5, _s5)}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _43;
 +     coroutine debug sync_int => _s1;
 +     let mut _0: std::task::Poll<()>;
       let _3: SyncInt;
       let mut _6: impl std::future::Future<Output = ()>;
--     let mut _7: std::future::ResumeTy;
-+     let mut _7: &mut std::task::Context<'_>;
+      let mut _7: std::future::ResumeTy;
       let mut _8: std::task::Poll<()>;
       let mut _9: isize;
       let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _11: &mut std::task::Context<'_>;
--     let mut _12: std::future::ResumeTy;
-+     let mut _12: &mut std::task::Context<'_>;
+      let mut _12: std::future::ResumeTy;
       let mut _13: &mut impl std::future::Future<Output = ()>;
--     let mut _14: std::future::ResumeTy;
-+     let mut _14: &mut std::task::Context<'_>;
+      let mut _14: std::future::ResumeTy;
       let mut _15: std::task::Poll<()>;
       let mut _16: isize;
       let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _18: &mut std::task::Context<'_>;
--     let mut _19: std::future::ResumeTy;
-+     let mut _19: &mut std::task::Context<'_>;
+      let mut _19: std::future::ResumeTy;
       let mut _20: &mut impl std::future::Future<Output = ()>;
       let mut _21: std::pin::Pin<&mut AsyncInt>;
       let mut _22: &mut AsyncInt;
       let mut _23: impl std::future::Future<Output = ()>;
--     let mut _24: std::future::ResumeTy;
-+     let mut _24: &mut std::task::Context<'_>;
+      let mut _24: std::future::ResumeTy;
       let mut _25: std::task::Poll<()>;
       let mut _26: isize;
       let mut _27: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _28: &mut std::task::Context<'_>;
--     let mut _29: std::future::ResumeTy;
-+     let mut _29: &mut std::task::Context<'_>;
+      let mut _29: std::future::ResumeTy;
       let mut _30: &mut impl std::future::Future<Output = ()>;
--     let mut _31: std::future::ResumeTy;
-+     let mut _31: &mut std::task::Context<'_>;
+      let mut _31: std::future::ResumeTy;
       let mut _32: std::task::Poll<()>;
       let mut _33: isize;
       let mut _34: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _35: &mut std::task::Context<'_>;
--     let mut _36: std::future::ResumeTy;
-+     let mut _36: &mut std::task::Context<'_>;
+      let mut _36: std::future::ResumeTy;
       let mut _37: &mut impl std::future::Future<Output = ()>;
       let mut _38: std::pin::Pin<&mut AsyncInt>;
       let mut _39: &mut AsyncInt;
 +     let mut _40: ();
 +     let mut _41: u32;
 +     let mut _42: &mut {async fn body of double()};
++     let mut _43: std::future::ResumeTy;
++     let mut _44: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug sync_int => _3;
 +         debug sync_int => (((*_42) as variant#6).1: SyncInt);
@@ -99,6 +94,8 @@
 -         _5 = AsyncInt(const 0_i32);
 -         _0 = const ();
 -         goto -> bb33;
++         _44 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _43 = std::future::ResumeTy(move _44);
 +         _42 = copy (_1.0: &mut {async fn body of double()});
 +         _41 = discriminant((*_42));
 +         switchInt(move _41) -> [0: bb42, 1: bb41, 2: bb40, 3: bb36, 4: bb37, 5: bb38, 6: bb39, otherwise: bb13];
@@ -185,7 +182,7 @@
 -     bb12 (cleanup): {
 -         resume;
 +     bb12: {
-+         _2 = move _7;
++         _43 = move _7;
 +         StorageDead(_7);
 +         goto -> bb11;
       }
@@ -199,7 +196,7 @@
       bb14: {
 -         StorageDead(_6);
 -         goto -> bb5;
-+         _2 = move _14;
++         _43 = move _14;
 +         StorageDead(_14);
 +         goto -> bb19;
       }
@@ -232,8 +229,8 @@
 -         _2 = move _7;
 -         StorageDead(_7);
 -         goto -> bb24;
-+         _19 = move _2;
-+         _18 = move _19;
++         _19 = move _43;
++         _18 = copy (_19.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb17;
       }
   
@@ -281,7 +278,7 @@
 -         _2 = move _14;
 -         StorageDead(_14);
 -         goto -> bb31;
-+         _2 = move _24;
++         _43 = move _24;
 +         StorageDead(_24);
 +         goto -> bb24;
       }
@@ -290,7 +287,7 @@
 -         _2 = move _14;
 -         StorageDead(_14);
 -         goto -> bb24;
-+         _2 = move _31;
++         _43 = move _31;
 +         StorageDead(_31);
 +         goto -> bb31;
       }
@@ -320,8 +317,8 @@
       bb30: {
 -         _19 = move _2;
 -         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb29, unwind: bb15];
-+         _36 = move _2;
-+         _35 = move _36;
++         _36 = move _43;
++         _35 = copy (_36.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb29;
       }
   
@@ -365,14 +362,14 @@
 -         goto -> bb10;
 +     bb36: {
 +         StorageLive(_7);
-+         _7 = move _2;
++         _7 = move _43;
 +         goto -> bb12;
       }
   
       bb37: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb37, unwind: bb36];
 +         StorageLive(_14);
-+         _14 = move _2;
++         _14 = move _43;
 +         goto -> bb14;
       }
   
@@ -381,7 +378,7 @@
 -         StorageDead(_24);
 -         goto -> bb37;
 +         StorageLive(_24);
-+         _24 = move _2;
++         _24 = move _43;
 +         goto -> bb25;
       }
   
@@ -390,7 +387,7 @@
 -         StorageDead(_24);
 -         goto -> bb44;
 +         StorageLive(_31);
-+         _31 = move _2;
++         _31 = move _43;
 +         goto -> bb26;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.double-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.double-{closure#0}.coroutine_drop_async.0.mir
@@ -1,46 +1,48 @@
 // MIR for `double::{closure#0}` 0 coroutine_drop_async
 
 fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Context<'_>) -> Poll<()> {
-    debug _task_context => _2;
+    debug _task_context => _43;
     let mut _0: std::task::Poll<()>;
     let _3: SyncInt;
     let mut _6: impl std::future::Future<Output = ()>;
-    let mut _7: &mut std::task::Context<'_>;
+    let mut _7: std::future::ResumeTy;
     let mut _8: std::task::Poll<()>;
     let mut _9: isize;
     let mut _10: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _11: &mut std::task::Context<'_>;
-    let mut _12: &mut std::task::Context<'_>;
+    let mut _12: std::future::ResumeTy;
     let mut _13: &mut impl std::future::Future<Output = ()>;
-    let mut _14: &mut std::task::Context<'_>;
+    let mut _14: std::future::ResumeTy;
     let mut _15: std::task::Poll<()>;
     let mut _16: isize;
     let mut _17: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _18: &mut std::task::Context<'_>;
-    let mut _19: &mut std::task::Context<'_>;
+    let mut _19: std::future::ResumeTy;
     let mut _20: &mut impl std::future::Future<Output = ()>;
     let mut _21: std::pin::Pin<&mut AsyncInt>;
     let mut _22: &mut AsyncInt;
     let mut _23: impl std::future::Future<Output = ()>;
-    let mut _24: &mut std::task::Context<'_>;
+    let mut _24: std::future::ResumeTy;
     let mut _25: std::task::Poll<()>;
     let mut _26: isize;
     let mut _27: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _28: &mut std::task::Context<'_>;
-    let mut _29: &mut std::task::Context<'_>;
+    let mut _29: std::future::ResumeTy;
     let mut _30: &mut impl std::future::Future<Output = ()>;
-    let mut _31: &mut std::task::Context<'_>;
+    let mut _31: std::future::ResumeTy;
     let mut _32: std::task::Poll<()>;
     let mut _33: isize;
     let mut _34: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _35: &mut std::task::Context<'_>;
-    let mut _36: &mut std::task::Context<'_>;
+    let mut _36: std::future::ResumeTy;
     let mut _37: &mut impl std::future::Future<Output = ()>;
     let mut _38: std::pin::Pin<&mut AsyncInt>;
     let mut _39: &mut AsyncInt;
     let mut _40: ();
     let mut _41: u32;
     let mut _42: &mut {async fn body of double()};
+    let mut _43: std::future::ResumeTy;
+    let mut _44: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         debug sync_int => (((*_42) as variant#6).1: SyncInt);
         let _4: AsyncInt;
@@ -54,6 +56,8 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb0: {
+        _44 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _43 = std::future::ResumeTy(move _44);
         _42 = copy (_1.0: &mut {async fn body of double()});
         _41 = discriminant((*_42));
         switchInt(move _41) -> [0: bb29, 2: bb36, 3: bb32, 4: bb33, 5: bb34, 6: bb35, otherwise: bb37];
@@ -109,7 +113,7 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb11: {
-        _2 = move _7;
+        _43 = move _7;
         StorageDead(_7);
         goto -> bb17;
     }
@@ -136,8 +140,8 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb16: {
-        _12 = move _2;
-        _11 = move _12;
+        _12 = move _43;
+        _11 = copy (_12.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
         goto -> bb15;
     }
 
@@ -147,7 +151,7 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb18: {
-        _2 = move _14;
+        _43 = move _14;
         StorageDead(_14);
         goto -> bb17;
     }
@@ -163,7 +167,7 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb21: {
-        _2 = move _24;
+        _43 = move _24;
         StorageDead(_24);
         goto -> bb26;
     }
@@ -186,8 +190,8 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb25: {
-        _29 = move _2;
-        _28 = move _29;
+        _29 = move _43;
+        _28 = copy (_29.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
         goto -> bb24;
     }
 
@@ -197,7 +201,7 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
     }
 
     bb27: {
-        _2 = move _31;
+        _43 = move _31;
         StorageDead(_31);
         goto -> bb26;
     }
@@ -222,25 +226,25 @@ fn double::{closure#0}(_1: Pin<&mut {async fn body of double()}>, _2: &mut Conte
 
     bb32: {
         StorageLive(_7);
-        _7 = move _2;
+        _7 = move _43;
         goto -> bb11;
     }
 
     bb33: {
         StorageLive(_14);
-        _14 = move _2;
+        _14 = move _43;
         goto -> bb18;
     }
 
     bb34: {
         StorageLive(_24);
-        _24 = move _2;
+        _24 = move _43;
         goto -> bb21;
     }
 
     bb35: {
         StorageLive(_31);
-        _31 = move _2;
+        _31 = move _43;
         goto -> bb27;
     }
 

--- a/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.elaborate_drops-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn elaborate_drops::{closure#0}(_1: {async fn body of elaborate_drops()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn elaborate_drops::{closure#0}(_1: Pin<&mut {async fn body of elaborate_drops()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         field _s0: ();
@@ -51,8 +53,7 @@
 +         }
 +         storage_conflicts = BitMatrix(20x20) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s0, _s4), (_s0, _s5), (_s0, _s6), (_s0, _s7), (_s0, _s8), (_s0, _s9), (_s0, _s10), (_s0, _s11), (_s0, _s12), (_s0, _s13), (_s0, _s14), (_s0, _s15), (_s0, _s16), (_s0, _s17), (_s0, _s18), (_s0, _s19), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s1, _s4), (_s1, _s5), (_s1, _s6), (_s1, _s7), (_s1, _s8), (_s1, _s9), (_s1, _s10), (_s1, _s11), (_s1, _s12), (_s1, _s13), (_s1, _s14), (_s1, _s15), (_s1, _s16), (_s1, _s17), (_s1, _s18), (_s1, _s19), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s2, _s4), (_s2, _s5), (_s2, _s6), (_s2, _s7), (_s2, _s8), (_s2, _s9), (_s2, _s10), (_s2, _s11), (_s2, _s12), (_s2, _s13), (_s2, _s14), (_s2, _s15), (_s2, _s16), (_s2, _s17), (_s2, _s18), (_s2, _s19), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3), (_s3, _s4), (_s3, _s5), (_s3, _s6), (_s3, _s7), (_s3, _s8), (_s3, _s9), (_s3, _s10), (_s3, _s11), (_s3, _s12), (_s3, _s13), (_s3, _s14), (_s3, _s15), (_s3, _s16), (_s3, _s17), (_s3, _s18), (_s4, _s0), (_s4, _s1), (_s4, _s2), (_s4, _s3), (_s4, _s4), (_s4, _s5), (_s4, _s6), (_s4, _s7), (_s4, _s8), (_s4, _s9), (_s4, _s10), (_s4, _s11), (_s4, _s12), (_s4, _s13), (_s4, _s14), (_s4, _s15), (_s4, _s16), (_s4, _s17), (_s5, _s0), (_s5, _s1), (_s5, _s2), (_s5, _s3), (_s5, _s4), (_s5, _s5), (_s5, _s6), (_s5, _s7), (_s5, _s8), (_s5, _s9), (_s5, _s10), (_s5, _s11), (_s5, _s12), (_s5, _s13), (_s5, _s14), (_s5, _s15), (_s5, _s16), (_s6, _s0), (_s6, _s1), (_s6, _s2), (_s6, _s3), (_s6, _s4), (_s6, _s5), (_s6, _s6), (_s6, _s7), (_s6, _s8), (_s6, _s9), (_s6, _s10), (_s6, _s11), (_s6, _s12), (_s6, _s13), (_s6, _s14), (_s6, _s15), (_s7, _s0), (_s7, _s1), (_s7, _s2), (_s7, _s3), (_s7, _s4), (_s7, _s5), (_s7, _s6), (_s7, _s7), (_s7, _s8), (_s7, _s9), (_s7, _s10), (_s7, _s11), (_s7, _s12), (_s7, _s13), (_s7, _s14), (_s8, _s0), (_s8, _s1), (_s8, _s2), (_s8, _s3), (_s8, _s4), (_s8, _s5), (_s8, _s6), (_s8, _s7), (_s8, _s8), (_s8, _s9), (_s8, _s10), (_s8, _s11), (_s8, _s12), (_s8, _s13), (_s9, _s0), (_s9, _s1), (_s9, _s2), (_s9, _s3), (_s9, _s4), (_s9, _s5), (_s9, _s6), (_s9, _s7), (_s9, _s8), (_s9, _s9), (_s9, _s10), (_s9, _s11), (_s9, _s12), (_s10, _s0), (_s10, _s1), (_s10, _s2), (_s10, _s3), (_s10, _s4), (_s10, _s5), (_s10, _s6), (_s10, _s7), (_s10, _s8), (_s10, _s9), (_s10, _s10), (_s10, _s11), (_s11, _s0), (_s11, _s1), (_s11, _s2), (_s11, _s3), (_s11, _s4), (_s11, _s5), (_s11, _s6), (_s11, _s7), (_s11, _s8), (_s11, _s9), (_s11, _s10), (_s11, _s11), (_s12, _s0), (_s12, _s1), (_s12, _s2), (_s12, _s3), (_s12, _s4), (_s12, _s5), (_s12, _s6), (_s12, _s7), (_s12, _s8), (_s12, _s9), (_s12, _s12), (_s13, _s0), (_s13, _s1), (_s13, _s2), (_s13, _s3), (_s13, _s4), (_s13, _s5), (_s13, _s6), (_s13, _s7), (_s13, _s8), (_s13, _s13), (_s14, _s0), (_s14, _s1), (_s14, _s2), (_s14, _s3), (_s14, _s4), (_s14, _s5), (_s14, _s6), (_s14, _s7), (_s14, _s14), (_s15, _s0), (_s15, _s1), (_s15, _s2), (_s15, _s3), (_s15, _s4), (_s15, _s5), (_s15, _s6), (_s15, _s15), (_s16, _s0), (_s16, _s1), (_s16, _s2), (_s16, _s3), (_s16, _s4), (_s16, _s5), (_s16, _s16), (_s17, _s0), (_s17, _s1), (_s17, _s2), (_s17, _s3), (_s17, _s4), (_s17, _s17), (_s18, _s0), (_s18, _s1), (_s18, _s2), (_s18, _s3), (_s18, _s18), (_s19, _s0), (_s19, _s1), (_s19, _s2), (_s19, _s19)}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _183;
 +     coroutine debug sync_int => _s1;
 +     let mut _0: std::task::Poll<()>;
       let _3: SyncInt;
@@ -68,197 +69,163 @@
       let mut _21: &AsyncInt;
       let _22: &AsyncInt;
       let mut _27: impl std::future::Future<Output = ()>;
--     let mut _28: std::future::ResumeTy;
-+     let mut _28: &mut std::task::Context<'_>;
+      let mut _28: std::future::ResumeTy;
       let mut _29: std::task::Poll<()>;
       let mut _30: isize;
       let mut _31: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _32: &mut std::task::Context<'_>;
--     let mut _33: std::future::ResumeTy;
-+     let mut _33: &mut std::task::Context<'_>;
+      let mut _33: std::future::ResumeTy;
       let mut _34: &mut impl std::future::Future<Output = ()>;
--     let mut _35: std::future::ResumeTy;
-+     let mut _35: &mut std::task::Context<'_>;
+      let mut _35: std::future::ResumeTy;
       let mut _36: std::task::Poll<()>;
       let mut _37: isize;
       let mut _38: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _39: &mut std::task::Context<'_>;
--     let mut _40: std::future::ResumeTy;
-+     let mut _40: &mut std::task::Context<'_>;
+      let mut _40: std::future::ResumeTy;
       let mut _41: &mut impl std::future::Future<Output = ()>;
       let mut _42: std::pin::Pin<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>;
       let mut _43: &mut {async closure@$DIR/async_drop.rs:78:27: 78:35};
       let mut _44: impl std::future::Future<Output = ()>;
--     let mut _45: std::future::ResumeTy;
-+     let mut _45: &mut std::task::Context<'_>;
+      let mut _45: std::future::ResumeTy;
       let mut _46: std::task::Poll<()>;
       let mut _47: isize;
       let mut _48: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _49: &mut std::task::Context<'_>;
--     let mut _50: std::future::ResumeTy;
-+     let mut _50: &mut std::task::Context<'_>;
+      let mut _50: std::future::ResumeTy;
       let mut _51: &mut impl std::future::Future<Output = ()>;
--     let mut _52: std::future::ResumeTy;
-+     let mut _52: &mut std::task::Context<'_>;
+      let mut _52: std::future::ResumeTy;
       let mut _53: std::task::Poll<()>;
       let mut _54: isize;
       let mut _55: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _56: &mut std::task::Context<'_>;
--     let mut _57: std::future::ResumeTy;
-+     let mut _57: &mut std::task::Context<'_>;
+      let mut _57: std::future::ResumeTy;
       let mut _58: &mut impl std::future::Future<Output = ()>;
       let mut _59: std::pin::Pin<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>;
       let mut _60: &mut {closure@$DIR/async_drop.rs:70:25: 70:27};
       let mut _61: impl std::future::Future<Output = ()>;
--     let mut _62: std::future::ResumeTy;
-+     let mut _62: &mut std::task::Context<'_>;
+      let mut _62: std::future::ResumeTy;
       let mut _63: std::task::Poll<()>;
       let mut _64: isize;
       let mut _65: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _66: &mut std::task::Context<'_>;
--     let mut _67: std::future::ResumeTy;
-+     let mut _67: &mut std::task::Context<'_>;
+      let mut _67: std::future::ResumeTy;
       let mut _68: &mut impl std::future::Future<Output = ()>;
--     let mut _69: std::future::ResumeTy;
-+     let mut _69: &mut std::task::Context<'_>;
+      let mut _69: std::future::ResumeTy;
       let mut _70: std::task::Poll<()>;
       let mut _71: isize;
       let mut _72: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _73: &mut std::task::Context<'_>;
--     let mut _74: std::future::ResumeTy;
-+     let mut _74: &mut std::task::Context<'_>;
+      let mut _74: std::future::ResumeTy;
       let mut _75: &mut impl std::future::Future<Output = ()>;
       let mut _76: std::pin::Pin<&mut AsyncReference<'_>>;
       let mut _77: &mut AsyncReference<'_>;
       let mut _78: impl std::future::Future<Output = ()>;
--     let mut _79: std::future::ResumeTy;
-+     let mut _79: &mut std::task::Context<'_>;
+      let mut _79: std::future::ResumeTy;
       let mut _80: std::task::Poll<()>;
       let mut _81: isize;
       let mut _82: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _83: &mut std::task::Context<'_>;
--     let mut _84: std::future::ResumeTy;
-+     let mut _84: &mut std::task::Context<'_>;
+      let mut _84: std::future::ResumeTy;
       let mut _85: &mut impl std::future::Future<Output = ()>;
--     let mut _86: std::future::ResumeTy;
-+     let mut _86: &mut std::task::Context<'_>;
+      let mut _86: std::future::ResumeTy;
       let mut _87: std::task::Poll<()>;
       let mut _88: isize;
       let mut _89: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _90: &mut std::task::Context<'_>;
--     let mut _91: std::future::ResumeTy;
-+     let mut _91: &mut std::task::Context<'_>;
+      let mut _91: std::future::ResumeTy;
       let mut _92: &mut impl std::future::Future<Output = ()>;
       let mut _93: std::pin::Pin<&mut AsyncInt>;
       let mut _94: &mut AsyncInt;
       let mut _95: impl std::future::Future<Output = ()>;
--     let mut _96: std::future::ResumeTy;
-+     let mut _96: &mut std::task::Context<'_>;
+      let mut _96: std::future::ResumeTy;
       let mut _97: std::task::Poll<()>;
       let mut _98: isize;
       let mut _99: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _100: &mut std::task::Context<'_>;
--     let mut _101: std::future::ResumeTy;
-+     let mut _101: &mut std::task::Context<'_>;
+      let mut _101: std::future::ResumeTy;
       let mut _102: &mut impl std::future::Future<Output = ()>;
--     let mut _103: std::future::ResumeTy;
-+     let mut _103: &mut std::task::Context<'_>;
+      let mut _103: std::future::ResumeTy;
       let mut _104: std::task::Poll<()>;
       let mut _105: isize;
       let mut _106: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _107: &mut std::task::Context<'_>;
--     let mut _108: std::future::ResumeTy;
-+     let mut _108: &mut std::task::Context<'_>;
+      let mut _108: std::future::ResumeTy;
       let mut _109: &mut impl std::future::Future<Output = ()>;
       let mut _110: std::pin::Pin<&mut AsyncEnum>;
       let mut _111: &mut AsyncEnum;
       let mut _112: impl std::future::Future<Output = ()>;
--     let mut _113: std::future::ResumeTy;
-+     let mut _113: &mut std::task::Context<'_>;
+      let mut _113: std::future::ResumeTy;
       let mut _114: std::task::Poll<()>;
       let mut _115: isize;
       let mut _116: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _117: &mut std::task::Context<'_>;
--     let mut _118: std::future::ResumeTy;
-+     let mut _118: &mut std::task::Context<'_>;
+      let mut _118: std::future::ResumeTy;
       let mut _119: &mut impl std::future::Future<Output = ()>;
--     let mut _120: std::future::ResumeTy;
-+     let mut _120: &mut std::task::Context<'_>;
+      let mut _120: std::future::ResumeTy;
       let mut _121: std::task::Poll<()>;
       let mut _122: isize;
       let mut _123: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _124: &mut std::task::Context<'_>;
--     let mut _125: std::future::ResumeTy;
-+     let mut _125: &mut std::task::Context<'_>;
+      let mut _125: std::future::ResumeTy;
       let mut _126: &mut impl std::future::Future<Output = ()>;
       let mut _127: std::pin::Pin<&mut SyncThenAsync>;
       let mut _128: &mut SyncThenAsync;
       let mut _129: impl std::future::Future<Output = ()>;
--     let mut _130: std::future::ResumeTy;
-+     let mut _130: &mut std::task::Context<'_>;
+      let mut _130: std::future::ResumeTy;
       let mut _131: std::task::Poll<()>;
       let mut _132: isize;
       let mut _133: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _134: &mut std::task::Context<'_>;
--     let mut _135: std::future::ResumeTy;
-+     let mut _135: &mut std::task::Context<'_>;
+      let mut _135: std::future::ResumeTy;
       let mut _136: &mut impl std::future::Future<Output = ()>;
--     let mut _137: std::future::ResumeTy;
-+     let mut _137: &mut std::task::Context<'_>;
+      let mut _137: std::future::ResumeTy;
       let mut _138: std::task::Poll<()>;
       let mut _139: isize;
       let mut _140: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _141: &mut std::task::Context<'_>;
--     let mut _142: std::future::ResumeTy;
-+     let mut _142: &mut std::task::Context<'_>;
+      let mut _142: std::future::ResumeTy;
       let mut _143: &mut impl std::future::Future<Output = ()>;
       let mut _144: std::pin::Pin<&mut AsyncStruct>;
       let mut _145: &mut AsyncStruct;
       let mut _146: impl std::future::Future<Output = ()>;
--     let mut _147: std::future::ResumeTy;
-+     let mut _147: &mut std::task::Context<'_>;
+      let mut _147: std::future::ResumeTy;
       let mut _148: std::task::Poll<()>;
       let mut _149: isize;
       let mut _150: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _151: &mut std::task::Context<'_>;
--     let mut _152: std::future::ResumeTy;
-+     let mut _152: &mut std::task::Context<'_>;
+      let mut _152: std::future::ResumeTy;
       let mut _153: &mut impl std::future::Future<Output = ()>;
--     let mut _154: std::future::ResumeTy;
-+     let mut _154: &mut std::task::Context<'_>;
+      let mut _154: std::future::ResumeTy;
       let mut _155: std::task::Poll<()>;
       let mut _156: isize;
       let mut _157: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _158: &mut std::task::Context<'_>;
--     let mut _159: std::future::ResumeTy;
-+     let mut _159: &mut std::task::Context<'_>;
+      let mut _159: std::future::ResumeTy;
       let mut _160: &mut impl std::future::Future<Output = ()>;
       let mut _161: std::pin::Pin<&mut [AsyncInt; 2]>;
       let mut _162: &mut [AsyncInt; 2];
       let mut _163: impl std::future::Future<Output = ()>;
--     let mut _164: std::future::ResumeTy;
-+     let mut _164: &mut std::task::Context<'_>;
+      let mut _164: std::future::ResumeTy;
       let mut _165: std::task::Poll<()>;
       let mut _166: isize;
       let mut _167: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _168: &mut std::task::Context<'_>;
--     let mut _169: std::future::ResumeTy;
-+     let mut _169: &mut std::task::Context<'_>;
+      let mut _169: std::future::ResumeTy;
       let mut _170: &mut impl std::future::Future<Output = ()>;
--     let mut _171: std::future::ResumeTy;
-+     let mut _171: &mut std::task::Context<'_>;
+      let mut _171: std::future::ResumeTy;
       let mut _172: std::task::Poll<()>;
       let mut _173: isize;
       let mut _174: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _175: &mut std::task::Context<'_>;
--     let mut _176: std::future::ResumeTy;
-+     let mut _176: &mut std::task::Context<'_>;
+      let mut _176: std::future::ResumeTy;
       let mut _177: &mut impl std::future::Future<Output = ()>;
       let mut _178: std::pin::Pin<&mut AsyncInt>;
       let mut _179: &mut AsyncInt;
 +     let mut _180: ();
 +     let mut _181: u32;
 +     let mut _182: &mut {async fn body of elaborate_drops()};
++     let mut _183: std::future::ResumeTy;
++     let mut _184: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug sync_int => _3;
 +         debug sync_int => (((*_182) as variant#20).1: SyncInt);
@@ -342,6 +309,8 @@
 -         _7 = AsyncInt(const 2_i32);
 -         _5 = [move _6, move _7];
 -         goto -> bb1;
++         _184 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _183 = std::future::ResumeTy(move _184);
 +         _182 = copy (_1.0: &mut {async fn body of elaborate_drops()});
 +         _181 = discriminant((*_182));
 +         switchInt(move _181) -> [0: bb170, 1: bb169, 2: bb168, 3: bb150, 4: bb151, 5: bb152, 6: bb153, 7: bb154, 8: bb155, 9: bb156, 10: bb157, 11: bb158, 12: bb159, 13: bb160, 14: bb161, 15: bb162, 16: bb163, 17: bb164, 18: bb165, 19: bb166, 20: bb167, otherwise: bb43];
@@ -679,7 +648,7 @@
 -     bb42 (cleanup): {
 -         goto -> bb43;
 +     bb42: {
-+         _2 = move _28;
++         _183 = move _28;
 +         StorageDead(_28);
 +         goto -> bb41;
       }
@@ -695,7 +664,7 @@
 -         StorageDead(_17);
 -         drop(_15) -> [return: bb45, unwind terminate(cleanup)];
 +     bb44: {
-+         _2 = move _35;
++         _183 = move _35;
 +         StorageDead(_35);
 +         goto -> bb49;
       }
@@ -733,8 +702,8 @@
 -         StorageDead(_5);
 -         drop(_4) -> [return: bb49, unwind terminate(cleanup)];
 +     bb48: {
-+         _40 = move _2;
-+         _39 = move _40;
++         _40 = move _183;
++         _39 = copy (_40.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb47;
       }
   
@@ -785,7 +754,7 @@
   
       bb55: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb55, unwind: bb54];
-+         _2 = move _45;
++         _183 = move _45;
 +         StorageDead(_45);
 +         goto -> bb54;
       }
@@ -794,7 +763,7 @@
 -         _2 = move _28;
 -         StorageDead(_28);
 -         goto -> bb55;
-+         _2 = move _52;
++         _183 = move _52;
 +         StorageDead(_52);
 +         goto -> bb61;
       }
@@ -827,8 +796,8 @@
       bb60: {
 -         _30 = discriminant(_29);
 -         switchInt(move _30) -> [0: bb53, 1: bb58, otherwise: bb59];
-+         _57 = move _2;
-+         _56 = move _57;
++         _57 = move _183;
++         _56 = copy (_57.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb59;
       }
   
@@ -878,14 +847,14 @@
       bb67: {
 -         _37 = discriminant(_36);
 -         switchInt(move _37) -> [0: bb52, 1: bb66, otherwise: bb59];
-+         _2 = move _62;
++         _183 = move _62;
 +         StorageDead(_62);
 +         goto -> bb66;
       }
   
       bb68: {
 -         _36 = <impl Future<Output = ()> as Future>::poll(move _38, move _39) -> [return: bb67, unwind: bb54];
-+         _2 = move _69;
++         _183 = move _69;
 +         StorageDead(_69);
 +         goto -> bb73;
       }
@@ -917,8 +886,8 @@
       bb72: {
 -         _43 = &mut _26;
 -         _42 = Pin::<&mut {async closure@$DIR/async_drop.rs:78:27: 78:35}>::new_unchecked(move _43) -> [return: bb71, unwind: bb36];
-+         _74 = move _2;
-+         _73 = move _74;
++         _74 = move _183;
++         _73 = copy (_74.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb71;
       }
   
@@ -969,7 +938,7 @@
       bb79: {
 -         StorageLive(_45);
 -         _45 = yield(const ()) -> [resume: bb77, drop: bb78];
-+         _2 = move _79;
++         _183 = move _79;
 +         StorageDead(_79);
 +         goto -> bb78;
       }
@@ -977,7 +946,7 @@
       bb80: {
 -         _47 = discriminant(_46);
 -         switchInt(move _47) -> [0: bb74, 1: bb79, otherwise: bb59];
-+         _2 = move _86;
++         _183 = move _86;
 +         StorageDead(_86);
 +         goto -> bb85;
       }
@@ -1009,8 +978,8 @@
 -         _2 = move _52;
 -         StorageDead(_52);
 -         goto -> bb90;
-+         _91 = move _2;
-+         _90 = move _91;
++         _91 = move _183;
++         _90 = copy (_91.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb83;
       }
   
@@ -1059,7 +1028,7 @@
       bb91: {
 -         StorageLive(_44);
 -         _44 = async_drop_in_place::<{closure@$DIR/async_drop.rs:70:25: 70:27}>(copy (_59.0: &mut {closure@$DIR/async_drop.rs:70:25: 70:27})) -> [return: bb90, unwind: bb75];
-+         _2 = move _96;
++         _183 = move _96;
 +         StorageDead(_96);
 +         goto -> bb90;
       }
@@ -1067,7 +1036,7 @@
       bb92: {
 -         _60 = &mut _24;
 -         _59 = Pin::<&mut {closure@$DIR/async_drop.rs:70:25: 70:27}>::new_unchecked(move _60) -> [return: bb91, unwind: bb38];
-+         _2 = move _103;
++         _183 = move _103;
 +         StorageDead(_103);
 +         goto -> bb97;
       }
@@ -1098,8 +1067,8 @@
   
       bb96: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb96, unwind: bb95];
-+         _108 = move _2;
-+         _107 = move _108;
++         _108 = move _183;
++         _107 = copy (_108.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb95;
       }
   
@@ -1149,7 +1118,7 @@
       bb103: {
 -         _68 = &mut _61;
 -         _65 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _68) -> [return: bb102, unwind: bb95];
-+         _2 = move _113;
++         _183 = move _113;
 +         StorageDead(_113);
 +         goto -> bb102;
       }
@@ -1158,7 +1127,7 @@
 -         _2 = move _69;
 -         StorageDead(_69);
 -         goto -> bb110;
-+         _2 = move _120;
++         _183 = move _120;
 +         StorageDead(_120);
 +         goto -> bb109;
       }
@@ -1189,8 +1158,8 @@
   
       bb108: {
 -         _70 = <impl Future<Output = ()> as Future>::poll(move _72, move _73) -> [return: bb107, unwind: bb95];
-+         _125 = move _2;
-+         _124 = move _125;
++         _125 = move _183;
++         _124 = copy (_125.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb107;
       }
   
@@ -1240,14 +1209,14 @@
 -         StorageDead(_78);
 -         goto -> bb41;
 +     bb115: {
-+         _2 = move _130;
++         _183 = move _130;
 +         StorageDead(_130);
 +         goto -> bb114;
       }
   
       bb116: {
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb116, unwind: bb115];
-+         _2 = move _137;
++         _183 = move _137;
 +         StorageDead(_137);
 +         goto -> bb121;
       }
@@ -1280,8 +1249,8 @@
       bb120: {
 -         _81 = discriminant(_80);
 -         switchInt(move _81) -> [0: bb114, 1: bb119, otherwise: bb59];
-+         _142 = move _2;
-+         _141 = move _142;
++         _142 = move _183;
++         _141 = copy (_142.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb119;
       }
   
@@ -1331,14 +1300,14 @@
       bb127: {
 -         _88 = discriminant(_87);
 -         switchInt(move _88) -> [0: bb113, 1: bb126, otherwise: bb59];
-+         _2 = move _147;
++         _183 = move _147;
 +         StorageDead(_147);
 +         goto -> bb126;
       }
   
       bb128: {
 -         _87 = <impl Future<Output = ()> as Future>::poll(move _89, move _90) -> [return: bb127, unwind: bb115];
-+         _2 = move _154;
++         _183 = move _154;
 +         StorageDead(_154);
 +         goto -> bb133;
       }
@@ -1369,8 +1338,8 @@
       bb132: {
 -         _94 = &mut _19;
 -         _93 = Pin::<&mut AsyncInt>::new_unchecked(move _94) -> [return: bb131, unwind: bb41];
-+         _159 = move _2;
-+         _158 = move _159;
++         _159 = move _183;
++         _158 = copy (_159.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb131;
       }
   
@@ -1421,7 +1390,7 @@
       bb139: {
 -         StorageLive(_96);
 -         _96 = yield(const ()) -> [resume: bb137, drop: bb138];
-+         _2 = move _164;
++         _183 = move _164;
 +         StorageDead(_164);
 +         goto -> bb138;
       }
@@ -1429,7 +1398,7 @@
       bb140: {
 -         _98 = discriminant(_97);
 -         switchInt(move _98) -> [0: bb134, 1: bb139, otherwise: bb59];
-+         _2 = move _171;
++         _183 = move _171;
 +         StorageDead(_171);
 +         goto -> bb145;
       }
@@ -1460,8 +1429,8 @@
 -         _2 = move _103;
 -         StorageDead(_103);
 -         goto -> bb150;
-+         _176 = move _2;
-+         _175 = move _176;
++         _176 = move _183;
++         _175 = copy (_176.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb143;
       }
   
@@ -1507,7 +1476,7 @@
 +         StorageLive(_23);
 +         StorageLive(_25);
 +         StorageLive(_28);
-+         _28 = move _2;
++         _28 = move _183;
 +         goto -> bb42;
       }
   
@@ -1518,7 +1487,7 @@
 +         StorageLive(_23);
 +         StorageLive(_25);
 +         StorageLive(_35);
-+         _35 = move _2;
++         _35 = move _183;
 +         goto -> bb44;
       }
   
@@ -1528,7 +1497,7 @@
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_45);
-+         _45 = move _2;
++         _45 = move _183;
 +         goto -> bb55;
       }
   
@@ -1538,7 +1507,7 @@
 +         StorageLive(_17);
 +         StorageLive(_23);
 +         StorageLive(_52);
-+         _52 = move _2;
++         _52 = move _183;
 +         goto -> bb56;
       }
   
@@ -1547,7 +1516,7 @@
 -         goto -> bb30;
 +         StorageLive(_17);
 +         StorageLive(_62);
-+         _62 = move _2;
++         _62 = move _183;
 +         goto -> bb67;
       }
   
@@ -1557,7 +1526,7 @@
 +     bb155: {
 +         StorageLive(_17);
 +         StorageLive(_69);
-+         _69 = move _2;
++         _69 = move _183;
 +         goto -> bb68;
       }
   
@@ -1565,7 +1534,7 @@
 -         assert(const false, "`async fn` resumed after async drop") -> [success: bb156, unwind: bb155];
 +         StorageLive(_17);
 +         StorageLive(_79);
-+         _79 = move _2;
++         _79 = move _183;
 +         goto -> bb79;
       }
   
@@ -1575,7 +1544,7 @@
 -         goto -> bb156;
 +         StorageLive(_17);
 +         StorageLive(_86);
-+         _86 = move _2;
++         _86 = move _183;
 +         goto -> bb80;
       }
   
@@ -1584,7 +1553,7 @@
 -         StorageDead(_113);
 -         goto -> bb163;
 +         StorageLive(_96);
-+         _96 = move _2;
++         _96 = move _183;
 +         goto -> bb91;
       }
   
@@ -1592,7 +1561,7 @@
 -         StorageLive(_113);
 -         _113 = yield(const ()) -> [resume: bb157, drop: bb158];
 +         StorageLive(_103);
-+         _103 = move _2;
++         _103 = move _183;
 +         goto -> bb92;
       }
   
@@ -1600,14 +1569,14 @@
 -         _115 = discriminant(_114);
 -         switchInt(move _115) -> [0: bb154, 1: bb159, otherwise: bb59];
 +         StorageLive(_113);
-+         _113 = move _2;
++         _113 = move _183;
 +         goto -> bb103;
       }
   
       bb161: {
 -         _114 = <impl Future<Output = ()> as Future>::poll(move _116, move _117) -> [return: bb160, unwind: bb155];
 +         StorageLive(_120);
-+         _120 = move _2;
++         _120 = move _183;
 +         goto -> bb104;
       }
   
@@ -1615,7 +1584,7 @@
 -         _118 = move _2;
 -         _117 = std::future::get_context::<'_, '_>(move _118) -> [return: bb161, unwind: bb155];
 +         StorageLive(_130);
-+         _130 = move _2;
++         _130 = move _183;
 +         goto -> bb115;
       }
   
@@ -1623,7 +1592,7 @@
 -         _119 = &mut _112;
 -         _116 = Pin::<&mut impl Future<Output = ()>>::new_unchecked(move _119) -> [return: bb162, unwind: bb155];
 +         StorageLive(_137);
-+         _137 = move _2;
++         _137 = move _183;
 +         goto -> bb116;
       }
   
@@ -1632,7 +1601,7 @@
 -         StorageDead(_120);
 -         goto -> bb170;
 +         StorageLive(_147);
-+         _147 = move _2;
++         _147 = move _183;
 +         goto -> bb127;
       }
   
@@ -1641,7 +1610,7 @@
 -         StorageDead(_120);
 -         goto -> bb163;
 +         StorageLive(_154);
-+         _154 = move _2;
++         _154 = move _183;
 +         goto -> bb128;
       }
   
@@ -1649,7 +1618,7 @@
 -         StorageLive(_120);
 -         _120 = yield(const ()) -> [resume: bb164, drop: bb165];
 +         StorageLive(_164);
-+         _164 = move _2;
++         _164 = move _183;
 +         goto -> bb139;
       }
   
@@ -1657,7 +1626,7 @@
 -         _122 = discriminant(_121);
 -         switchInt(move _122) -> [0: bb153, 1: bb166, otherwise: bb59];
 +         StorageLive(_171);
-+         _171 = move _2;
++         _171 = move _183;
 +         goto -> bb140;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn simple::{closure#0}(_1: {async fn body of simple()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         field _s0: ();
@@ -19,35 +21,32 @@
 +         }
 +         storage_conflicts = BitMatrix(4x4) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3)}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _25;
 +     coroutine debug sync_int => _s1;
 +     let mut _0: std::task::Poll<()>;
       let _3: SyncInt;
       let mut _5: impl std::future::Future<Output = ()>;
--     let mut _6: std::future::ResumeTy;
-+     let mut _6: &mut std::task::Context<'_>;
+      let mut _6: std::future::ResumeTy;
       let mut _7: std::task::Poll<()>;
       let mut _8: isize;
       let mut _9: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _10: &mut std::task::Context<'_>;
--     let mut _11: std::future::ResumeTy;
-+     let mut _11: &mut std::task::Context<'_>;
+      let mut _11: std::future::ResumeTy;
       let mut _12: &mut impl std::future::Future<Output = ()>;
--     let mut _13: std::future::ResumeTy;
-+     let mut _13: &mut std::task::Context<'_>;
+      let mut _13: std::future::ResumeTy;
       let mut _14: std::task::Poll<()>;
       let mut _15: isize;
       let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
       let mut _17: &mut std::task::Context<'_>;
--     let mut _18: std::future::ResumeTy;
-+     let mut _18: &mut std::task::Context<'_>;
+      let mut _18: std::future::ResumeTy;
       let mut _19: &mut impl std::future::Future<Output = ()>;
       let mut _20: std::pin::Pin<&mut AsyncInt>;
       let mut _21: &mut AsyncInt;
 +     let mut _22: ();
 +     let mut _23: u32;
 +     let mut _24: &mut {async fn body of simple()};
++     let mut _25: std::future::ResumeTy;
++     let mut _26: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug sync_int => _3;
 +         debug sync_int => (((*_24) as variant#4).1: SyncInt);
@@ -66,6 +65,8 @@
 -         _4 = AsyncInt(const 0_i32);
 -         _0 = const ();
 -         goto -> bb30;
++         _26 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _25 = std::future::ResumeTy(move _26);
 +         _24 = copy (_1.0: &mut {async fn body of simple()});
 +         _23 = discriminant((*_24));
 +         switchInt(move _23) -> [0: bb26, 1: bb25, 2: bb24, 3: bb22, 4: bb23, otherwise: bb11];
@@ -136,7 +137,7 @@
       bb10: {
 -         StorageDead(_5);
 -         goto -> bb1;
-+         _2 = move _6;
++         _25 = move _6;
 +         StorageDead(_6);
 +         goto -> bb9;
       }
@@ -151,7 +152,7 @@
 -         StorageDead(_5);
 -         goto -> bb7;
 +     bb12: {
-+         _2 = move _13;
++         _25 = move _13;
 +         StorageDead(_13);
 +         goto -> bb17;
       }
@@ -183,8 +184,8 @@
       bb16: {
 -         StorageLive(_6);
 -         _6 = yield(const ()) -> [resume: bb14, drop: bb15];
-+         _18 = move _2;
-+         _17 = move _18;
++         _18 = move _25;
++         _17 = copy (_18.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb15;
       }
   
@@ -226,7 +227,7 @@
 -         StorageDead(_13);
 -         goto -> bb28;
 +         StorageLive(_6);
-+         _6 = move _2;
++         _6 = move _25;
 +         goto -> bb10;
       }
   
@@ -235,7 +236,7 @@
 -         StorageDead(_13);
 -         goto -> bb21;
 +         StorageLive(_13);
-+         _13 = move _2;
++         _13 = move _25;
 +         goto -> bb12;
       }
   

--- a/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.coroutine_drop_async.0.mir
+++ b/tests/mir-opt/coroutine/async_drop.simple-{closure#0}.coroutine_drop_async.0.mir
@@ -1,29 +1,31 @@
 // MIR for `simple::{closure#0}` 0 coroutine_drop_async
 
 fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Context<'_>) -> Poll<()> {
-    debug _task_context => _2;
+    debug _task_context => _25;
     let mut _0: std::task::Poll<()>;
     let _3: SyncInt;
     let mut _5: impl std::future::Future<Output = ()>;
-    let mut _6: &mut std::task::Context<'_>;
+    let mut _6: std::future::ResumeTy;
     let mut _7: std::task::Poll<()>;
     let mut _8: isize;
     let mut _9: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _10: &mut std::task::Context<'_>;
-    let mut _11: &mut std::task::Context<'_>;
+    let mut _11: std::future::ResumeTy;
     let mut _12: &mut impl std::future::Future<Output = ()>;
-    let mut _13: &mut std::task::Context<'_>;
+    let mut _13: std::future::ResumeTy;
     let mut _14: std::task::Poll<()>;
     let mut _15: isize;
     let mut _16: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _17: &mut std::task::Context<'_>;
-    let mut _18: &mut std::task::Context<'_>;
+    let mut _18: std::future::ResumeTy;
     let mut _19: &mut impl std::future::Future<Output = ()>;
     let mut _20: std::pin::Pin<&mut AsyncInt>;
     let mut _21: &mut AsyncInt;
     let mut _22: ();
     let mut _23: u32;
     let mut _24: &mut {async fn body of simple()};
+    let mut _25: std::future::ResumeTy;
+    let mut _26: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         debug sync_int => (((*_24) as variant#4).1: SyncInt);
         let _4: AsyncInt;
@@ -33,6 +35,8 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
     }
 
     bb0: {
+        _26 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _25 = std::future::ResumeTy(move _26);
         _24 = copy (_1.0: &mut {async fn body of simple()});
         _23 = discriminant((*_24));
         switchInt(move _23) -> [0: bb18, 2: bb23, 3: bb21, 4: bb22, otherwise: bb24];
@@ -78,7 +82,7 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
     }
 
     bb9: {
-        _2 = move _6;
+        _25 = move _6;
         StorageDead(_6);
         goto -> bb15;
     }
@@ -105,8 +109,8 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
     }
 
     bb14: {
-        _11 = move _2;
-        _10 = move _11;
+        _11 = move _25;
+        _10 = copy (_11.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
         goto -> bb13;
     }
 
@@ -116,7 +120,7 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
     }
 
     bb16: {
-        _2 = move _13;
+        _25 = move _13;
         StorageDead(_13);
         goto -> bb15;
     }
@@ -141,13 +145,13 @@ fn simple::{closure#0}(_1: Pin<&mut {async fn body of simple()}>, _2: &mut Conte
 
     bb21: {
         StorageLive(_6);
-        _6 = move _2;
+        _6 = move _25;
         goto -> bb9;
     }
 
     bb22: {
         StorageLive(_13);
-        _13 = move _2;
+        _13 = move _25;
         goto -> bb16;
     }
 

--- a/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
+++ b/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-abort.mir
@@ -1,35 +1,39 @@
 // MIR for `a::{closure#0}` 0 coroutine_drop_async
 
 fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
-    debug _task_context => _2;
+    debug _task_context => _24;
     debug x => ((*_23).0: T);
     let mut _0: std::task::Poll<()>;
     let _3: T;
     let mut _4: impl std::future::Future<Output = ()>;
-    let mut _5: &mut std::task::Context<'_>;
+    let mut _5: std::future::ResumeTy;
     let mut _6: std::task::Poll<()>;
     let mut _7: isize;
     let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _9: &mut std::task::Context<'_>;
-    let mut _10: &mut std::task::Context<'_>;
+    let mut _10: std::future::ResumeTy;
     let mut _11: &mut impl std::future::Future<Output = ()>;
-    let mut _12: &mut std::task::Context<'_>;
+    let mut _12: std::future::ResumeTy;
     let mut _13: std::task::Poll<()>;
     let mut _14: isize;
     let mut _15: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _16: &mut std::task::Context<'_>;
-    let mut _17: &mut std::task::Context<'_>;
+    let mut _17: std::future::ResumeTy;
     let mut _18: &mut impl std::future::Future<Output = ()>;
     let mut _19: std::pin::Pin<&mut T>;
     let mut _20: &mut T;
     let mut _21: ();
     let mut _22: u32;
     let mut _23: &mut {async fn body of a<T>()};
+    let mut _24: std::future::ResumeTy;
+    let mut _25: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         debug x => (((*_23) as variant#4).1: T);
     }
 
     bb0: {
+        _25 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _24 = std::future::ResumeTy(move _25);
         _23 = copy (_1.0: &mut {async fn body of a<T>()});
         _22 = discriminant((*_23));
         switchInt(move _22) -> [0: bb13, 3: bb16, 4: bb17, otherwise: bb18];
@@ -51,7 +55,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb4: {
-        _2 = move _5;
+        _24 = move _5;
         StorageDead(_5);
         goto -> bb10;
     }
@@ -78,8 +82,8 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb9: {
-        _10 = move _2;
-        _9 = move _10;
+        _10 = move _24;
+        _9 = copy (_10.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
         goto -> bb8;
     }
 
@@ -89,7 +93,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb11: {
-        _2 = move _12;
+        _24 = move _12;
         StorageDead(_12);
         goto -> bb10;
     }
@@ -113,13 +117,13 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
 
     bb16: {
         StorageLive(_5);
-        _5 = move _2;
+        _5 = move _24;
         goto -> bb4;
     }
 
     bb17: {
         StorageLive(_12);
-        _12 = move _2;
+        _12 = move _24;
         goto -> bb11;
     }
 

--- a/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
+++ b/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
@@ -1,35 +1,39 @@
 // MIR for `a::{closure#0}` 0 coroutine_drop_async
 
 fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>) -> Poll<()> {
-    debug _task_context => _2;
+    debug _task_context => _24;
     debug x => ((*_23).0: T);
     let mut _0: std::task::Poll<()>;
     let _3: T;
     let mut _4: impl std::future::Future<Output = ()>;
-    let mut _5: &mut std::task::Context<'_>;
+    let mut _5: std::future::ResumeTy;
     let mut _6: std::task::Poll<()>;
     let mut _7: isize;
     let mut _8: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _9: &mut std::task::Context<'_>;
-    let mut _10: &mut std::task::Context<'_>;
+    let mut _10: std::future::ResumeTy;
     let mut _11: &mut impl std::future::Future<Output = ()>;
-    let mut _12: &mut std::task::Context<'_>;
+    let mut _12: std::future::ResumeTy;
     let mut _13: std::task::Poll<()>;
     let mut _14: isize;
     let mut _15: std::pin::Pin<&mut impl std::future::Future<Output = ()>>;
     let mut _16: &mut std::task::Context<'_>;
-    let mut _17: &mut std::task::Context<'_>;
+    let mut _17: std::future::ResumeTy;
     let mut _18: &mut impl std::future::Future<Output = ()>;
     let mut _19: std::pin::Pin<&mut T>;
     let mut _20: &mut T;
     let mut _21: ();
     let mut _22: u32;
     let mut _23: &mut {async fn body of a<T>()};
+    let mut _24: std::future::ResumeTy;
+    let mut _25: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         debug x => (((*_23) as variant#4).1: T);
     }
 
     bb0: {
+        _25 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _24 = std::future::ResumeTy(move _25);
         _23 = copy (_1.0: &mut {async fn body of a<T>()});
         _22 = discriminant((*_23));
         switchInt(move _22) -> [0: bb17, 2: bb23, 3: bb21, 4: bb22, otherwise: bb24];
@@ -65,7 +69,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb7: {
-        _2 = move _5;
+        _24 = move _5;
         StorageDead(_5);
         goto -> bb13;
     }
@@ -92,8 +96,8 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb12: {
-        _10 = move _2;
-        _9 = move _10;
+        _10 = move _24;
+        _9 = copy (_10.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
         goto -> bb11;
     }
 
@@ -103,7 +107,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
     }
 
     bb14: {
-        _2 = move _12;
+        _24 = move _12;
         StorageDead(_12);
         goto -> bb13;
     }
@@ -136,13 +140,13 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
 
     bb21: {
         StorageLive(_5);
-        _5 = move _2;
+        _5 = move _24;
         goto -> bb7;
     }
 
     bb22: {
         StorageLive(_12);
-        _12 = move _2;
+        _12 = move _24;
         goto -> bb14;
     }
 

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.StateTransform.diff
@@ -4,6 +4,10 @@
 - fn add::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:34:13: 34:18}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (*(_1.0: &u32));
+-     debug y => (*(_1.1: &u32));
+-     let mut _0: u32;
 + fn add::{closure#0}::{closure#0}(_1: Pin<&mut {async block@$DIR/async_fn.rs:34:13: 34:18}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         variant_fields = {
@@ -13,10 +17,7 @@
 +         }
 +         storage_conflicts = BitMatrix(0x0) {}
 +     }
-      debug _task_context => _2;
--     debug x => (*(_1.0: &u32));
--     debug y => (*(_1.1: &u32));
--     let mut _0: u32;
++     debug _task_context => _10;
 +     debug x => (*((*_9).0: &u32));
 +     debug y => (*((*_9).1: &u32));
 +     let mut _0: std::task::Poll<u32>;
@@ -27,6 +28,8 @@
 +     let mut _7: u32;
 +     let mut _8: u32;
 +     let mut _9: &mut {async block@$DIR/async_fn.rs:34:13: 34:18};
++     let mut _10: std::future::ResumeTy;
++     let mut _11: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         StorageLive(_3);
@@ -39,6 +42,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb1, unwind: bb2];
++         _11 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:34:13: 34:18});
 +         _8 = discriminant((*_9));
 +         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -5,7 +5,7 @@ fn add::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs:34:13: 3
     debug x => (*((*_1).0: &u32));
     debug y => (*((*_1).1: &u32));
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let mut _3: u32;
     let mut _4: u32;
     let mut _5: &u32;

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,8 +2,12 @@
 
 fn add::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:34:13: 34:18}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}.StateTransform.diff
@@ -4,6 +4,10 @@
 - fn add::{closure#0}(_1: {async fn body of add()}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (_1.0: u32);
+-     debug y => (_1.1: u32);
+-     let mut _0: u32;
 + fn add::{closure#0}(_1: Pin<&mut {async fn body of add()}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         field _s0: u32;
@@ -17,10 +21,7 @@
 +         }
 +         storage_conflicts = BitMatrix(3x3) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s2, _s0), (_s2, _s1), (_s2, _s2)}
 +     }
-      debug _task_context => _2;
--     debug x => (_1.0: u32);
--     debug y => (_1.1: u32);
--     let mut _0: u32;
++     debug _task_context => _28;
 +     debug x => ((*_27).0: u32);
 +     debug y => ((*_27).1: u32);
 +     coroutine debug x => _s0;
@@ -38,16 +39,16 @@
       let mut _16: &mut {async block@$DIR/async_fn.rs:34:13: 34:18};
       let mut _17: &mut std::task::Context<'_>;
       let mut _18: &mut std::task::Context<'_>;
--     let mut _19: std::future::ResumeTy;
-+     let mut _19: &mut std::task::Context<'_>;
+      let mut _19: std::future::ResumeTy;
       let mut _20: isize;
       let mut _22: !;
--     let mut _23: std::future::ResumeTy;
-+     let mut _23: &mut std::task::Context<'_>;
+      let mut _23: std::future::ResumeTy;
       let mut _24: ();
 +     let mut _25: u32;
 +     let mut _26: u32;
 +     let mut _27: &mut {async fn body of add()};
++     let mut _28: std::future::ResumeTy;
++     let mut _29: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug x => _3;
 +         debug x => (((*_27) as variant#3).0: u32);
@@ -90,6 +91,8 @@
 -         StorageLive(_9);
 -         _9 = move _5;
 -         _8 = <{async block@$DIR/async_fn.rs:34:13: 34:18} as IntoFuture>::into_future(move _9) -> [return: bb1, unwind: bb24];
++         _29 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _28 = std::future::ResumeTy(move _29);
 +         _27 = copy (_1.0: &mut {async fn body of add()});
 +         _26 = discriminant((*_27));
 +         switchInt(move _26) -> [0: bb28, 1: bb27, 2: bb26, 3: bb25, otherwise: bb6];
@@ -123,9 +126,10 @@
           StorageLive(_17);
           StorageLive(_18);
           StorageLive(_19);
-          _19 = copy _2;
+-         _19 = copy _2;
 -         _18 = std::future::get_context::<'_, '_>(move _19) -> [return: bb4, unwind: bb19];
-+         _18 = move _19;
++         _19 = copy _28;
++         _18 = copy (_19.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb4;
       }
   
@@ -181,7 +185,8 @@
   
       bb9: {
           StorageDead(_24);
-          _2 = move _23;
+-         _2 = move _23;
++         _28 = move _23;
           StorageDead(_23);
           _11 = const ();
           goto -> bb2;
@@ -310,7 +315,7 @@
 +         StorageLive(_8);
 +         StorageLive(_23);
 +         StorageLive(_24);
-+         _23 = move _2;
++         _23 = move _28;
 +         goto -> bb9;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}.coroutine_drop.0.mir
@@ -5,7 +5,7 @@ fn add::{closure#0}(_1: &mut {async fn body of add()}) -> () {
     debug x => ((*_1).0: u32);
     debug y => ((*_1).1: u32);
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: u32;
     let mut _6: &u32;
     let mut _7: &u32;
@@ -19,10 +19,10 @@ fn add::{closure#0}(_1: &mut {async fn body of add()}) -> () {
     let mut _16: &mut {async block@$DIR/async_fn.rs:34:13: 34:18};
     let mut _17: &mut std::task::Context<'_>;
     let mut _18: &mut std::task::Context<'_>;
-    let mut _19: &mut std::task::Context<'_>;
+    let mut _19: std::future::ResumeTy;
     let mut _20: isize;
     let mut _22: !;
-    let mut _23: &mut std::task::Context<'_>;
+    let mut _23: std::future::ResumeTy;
     let mut _24: ();
     let mut _25: u32;
     let mut _26: u32;

--- a/tests/mir-opt/coroutine/async_fn.add-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.add-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn add::{closure#0}(_1: {async fn body of add()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
             scope 3 {
@@ -14,6 +16,8 @@ fn add::{closure#0}(_1: {async fn body of add()}, _2: &mut Context<'_>) -> Poll<
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.StateTransform.diff
@@ -4,6 +4,12 @@
 - fn build_aggregate::{closure#0}(_1: {async fn body of build_aggregate()}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug a => (_1.0: u32);
+-     debug b => (_1.1: u32);
+-     debug c => (_1.2: u32);
+-     debug d => (_1.3: u32);
+-     let mut _0: u32;
 + fn build_aggregate::{closure#0}(_1: Pin<&mut {async fn body of build_aggregate()}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         field _s0: u32;
@@ -20,12 +26,7 @@
 +         }
 +         storage_conflicts = BitMatrix(5x5) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s0, _s4), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s1, _s4), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s2, _s4), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3), (_s4, _s0), (_s4, _s1), (_s4, _s2), (_s4, _s4)}
 +     }
-      debug _task_context => _2;
--     debug a => (_1.0: u32);
--     debug b => (_1.1: u32);
--     debug c => (_1.2: u32);
--     debug d => (_1.3: u32);
--     let mut _0: u32;
++     debug _task_context => _52;
 +     debug a => ((*_51).0: u32);
 +     debug b => ((*_51).1: u32);
 +     debug c => ((*_51).2: u32);
@@ -45,12 +46,10 @@
       let mut _19: &mut {async fn body of add()};
       let mut _20: &mut std::task::Context<'_>;
       let mut _21: &mut std::task::Context<'_>;
--     let mut _22: std::future::ResumeTy;
-+     let mut _22: &mut std::task::Context<'_>;
+      let mut _22: std::future::ResumeTy;
       let mut _23: isize;
       let mut _25: !;
--     let mut _26: std::future::ResumeTy;
-+     let mut _26: &mut std::task::Context<'_>;
+      let mut _26: std::future::ResumeTy;
       let mut _27: ();
       let mut _28: u32;
       let mut _29: {async fn body of add()};
@@ -64,18 +63,18 @@
       let mut _38: &mut {async fn body of add()};
       let mut _39: &mut std::task::Context<'_>;
       let mut _40: &mut std::task::Context<'_>;
--     let mut _41: std::future::ResumeTy;
-+     let mut _41: &mut std::task::Context<'_>;
+      let mut _41: std::future::ResumeTy;
       let mut _42: isize;
       let mut _44: !;
--     let mut _45: std::future::ResumeTy;
-+     let mut _45: &mut std::task::Context<'_>;
+      let mut _45: std::future::ResumeTy;
       let mut _46: ();
       let mut _47: u32;
       let mut _48: u32;
 +     let mut _49: u32;
 +     let mut _50: u32;
 +     let mut _51: &mut {async fn body of build_aggregate()};
++     let mut _52: std::future::ResumeTy;
++     let mut _53: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
           debug a => _3;
           let _4: u32;
@@ -138,6 +137,8 @@
 -         StorageLive(_12);
 -         _12 = copy _4;
 -         _10 = add(move _11, move _12) -> [return: bb1, unwind: bb49];
++         _53 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _52 = std::future::ResumeTy(move _53);
 +         _51 = copy (_1.0: &mut {async fn body of build_aggregate()});
 +         _50 = discriminant((*_51));
 +         switchInt(move _50) -> [0: bb49, 1: bb48, 2: bb47, 3: bb45, 4: bb46, otherwise: bb7];
@@ -178,9 +179,10 @@
           StorageLive(_20);
           StorageLive(_21);
           StorageLive(_22);
-          _22 = copy _2;
+-         _22 = copy _2;
 -         _21 = std::future::get_context::<'_, '_>(move _22) -> [return: bb5, unwind: bb42];
-+         _21 = move _22;
++         _22 = copy _52;
++         _21 = copy (_22.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb5;
       }
   
@@ -238,7 +240,8 @@
   
       bb10: {
           StorageDead(_27);
-          _2 = move _26;
+-         _2 = move _26;
++         _52 = move _26;
           StorageDead(_26);
           _14 = const ();
           goto -> bb3;
@@ -295,9 +298,10 @@
           StorageLive(_39);
           StorageLive(_40);
           StorageLive(_41);
-          _41 = copy _2;
+-         _41 = copy _2;
 -         _40 = std::future::get_context::<'_, '_>(move _41) -> [return: bb16, unwind: bb33];
-+         _40 = move _41;
++         _41 = copy _52;
++         _40 = copy (_41.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb16;
       }
   
@@ -352,7 +356,8 @@
   
       bb20: {
           StorageDead(_46);
-          _2 = move _45;
+-         _2 = move _45;
++         _52 = move _45;
           StorageDead(_45);
           _14 = const ();
           goto -> bb14;
@@ -630,7 +635,7 @@
 +         StorageLive(_9);
 +         StorageLive(_26);
 +         StorageLive(_27);
-+         _26 = move _2;
++         _26 = move _52;
 +         goto -> bb10;
       }
   
@@ -646,7 +651,7 @@
 +         StorageLive(_29);
 +         StorageLive(_45);
 +         StorageLive(_46);
-+         _45 = move _2;
++         _45 = move _52;
 +         goto -> bb20;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.coroutine_drop.0.mir
@@ -7,7 +7,7 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
     debug c => ((*_1).2: u32);
     debug d => ((*_1).3: u32);
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: u32;
     let mut _8: u32;
     let mut _9: {async fn body of add()};
@@ -22,10 +22,10 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
     let mut _19: &mut {async fn body of add()};
     let mut _20: &mut std::task::Context<'_>;
     let mut _21: &mut std::task::Context<'_>;
-    let mut _22: &mut std::task::Context<'_>;
+    let mut _22: std::future::ResumeTy;
     let mut _23: isize;
     let mut _25: !;
-    let mut _26: &mut std::task::Context<'_>;
+    let mut _26: std::future::ResumeTy;
     let mut _27: ();
     let mut _28: u32;
     let mut _29: {async fn body of add()};
@@ -39,10 +39,10 @@ fn build_aggregate::{closure#0}(_1: &mut {async fn body of build_aggregate()}) -
     let mut _38: &mut {async fn body of add()};
     let mut _39: &mut std::task::Context<'_>;
     let mut _40: &mut std::task::Context<'_>;
-    let mut _41: &mut std::task::Context<'_>;
+    let mut _41: std::future::ResumeTy;
     let mut _42: isize;
     let mut _44: !;
-    let mut _45: &mut std::task::Context<'_>;
+    let mut _45: std::future::ResumeTy;
     let mut _46: ();
     let mut _47: u32;
     let mut _48: u32;

--- a/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.build_aggregate-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn build_aggregate::{closure#0}(_1: {async fn body of build_aggregate()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
             scope 3 {
@@ -22,6 +24,8 @@ fn build_aggregate::{closure#0}(_1: {async fn body of build_aggregate()}, _2: &m
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.StateTransform.diff
@@ -4,6 +4,10 @@
 - fn foo::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:21:13: 21:18}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug y => (*(_1.0: &u32));
+-     debug z => (*(_1.1: &u32));
+-     let mut _0: u32;
 + fn foo::{closure#0}::{closure#0}(_1: Pin<&mut {async block@$DIR/async_fn.rs:21:13: 21:18}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         variant_fields = {
@@ -13,10 +17,7 @@
 +         }
 +         storage_conflicts = BitMatrix(0x0) {}
 +     }
-      debug _task_context => _2;
--     debug y => (*(_1.0: &u32));
--     debug z => (*(_1.1: &u32));
--     let mut _0: u32;
++     debug _task_context => _10;
 +     debug y => (*((*_9).0: &u32));
 +     debug z => (*((*_9).1: &u32));
 +     let mut _0: std::task::Poll<u32>;
@@ -27,6 +28,8 @@
 +     let mut _7: u32;
 +     let mut _8: u32;
 +     let mut _9: &mut {async block@$DIR/async_fn.rs:21:13: 21:18};
++     let mut _10: std::future::ResumeTy;
++     let mut _11: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         StorageLive(_3);
@@ -39,6 +42,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb1, unwind: bb2];
++         _11 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:21:13: 21:18});
 +         _8 = discriminant((*_9));
 +         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -5,7 +5,7 @@ fn foo::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs:21:13: 2
     debug y => (*((*_1).0: &u32));
     debug z => (*((*_1).1: &u32));
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let mut _3: u32;
     let mut _4: u32;
     let mut _5: &u32;

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,8 +2,12 @@
 
 fn foo::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:21:13: 21:18}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.StateTransform.diff
@@ -4,6 +4,10 @@
 - fn foo::{closure#0}(_1: {async fn body of foo()}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (_1.0: &u32);
+-     debug y => (_1.1: u32);
+-     let mut _0: u32;
 + fn foo::{closure#0}(_1: Pin<&mut {async fn body of foo()}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         field _s0: &u32;
@@ -18,10 +22,7 @@
 +         }
 +         storage_conflicts = BitMatrix(4x4) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3)}
 +     }
-      debug _task_context => _2;
--     debug x => (_1.0: &u32);
--     debug y => (_1.1: u32);
--     let mut _0: u32;
++     debug _task_context => _38;
 +     debug x => ((*_36).0: &u32);
 +     debug y => ((*_36).1: u32);
 +     coroutine debug x => _s0;
@@ -39,12 +40,10 @@
       let mut _19: &mut {async block@$DIR/async_fn.rs:21:13: 21:18};
       let mut _20: &mut std::task::Context<'_>;
       let mut _21: &mut std::task::Context<'_>;
--     let mut _22: std::future::ResumeTy;
-+     let mut _22: &mut std::task::Context<'_>;
+      let mut _22: std::future::ResumeTy;
       let mut _23: isize;
       let mut _25: !;
--     let mut _26: std::future::ResumeTy;
-+     let mut _26: &mut std::task::Context<'_>;
+      let mut _26: std::future::ResumeTy;
       let mut _27: ();
       let mut _30: u32;
       let mut _31: u32;
@@ -54,6 +53,8 @@
 +     let mut _35: u32;
 +     let mut _36: &mut {async fn body of foo()};
 +     let mut _37: &u32;
++     let mut _38: std::future::ResumeTy;
++     let mut _39: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug x => _3;
 +         debug x => (((*_36) as variant#3).0: &u32);
@@ -123,6 +124,8 @@
 -         StorageDead(_12);
 -         StorageDead(_11);
 -         _9 = <{async block@$DIR/async_fn.rs:21:13: 21:18} as IntoFuture>::into_future(move _10) -> [return: bb1, unwind: bb22];
++         _39 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _38 = std::future::ResumeTy(move _39);
 +         _36 = copy (_1.0: &mut {async fn body of foo()});
 +         _35 = discriminant((*_36));
 +         switchInt(move _35) -> [0: bb26, 1: bb25, 2: bb24, 3: bb23, otherwise: bb6];
@@ -156,9 +159,10 @@
           StorageLive(_20);
           StorageLive(_21);
           StorageLive(_22);
-          _22 = copy _2;
+-         _22 = copy _2;
 -         _21 = std::future::get_context::<'_, '_>(move _22) -> [return: bb4, unwind: bb17];
-+         _21 = move _22;
++         _22 = copy _38;
++         _21 = copy (_22.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb4;
       }
   
@@ -215,7 +219,8 @@
   
       bb9: {
           StorageDead(_27);
-          _2 = move _26;
+-         _2 = move _26;
++         _38 = move _26;
           StorageDead(_26);
           _14 = const ();
           goto -> bb2;
@@ -368,7 +373,7 @@
 +         StorageLive(_9);
 +         StorageLive(_26);
 +         StorageLive(_27);
-+         _26 = move _2;
++         _26 = move _38;
 +         goto -> bb9;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.coroutine_drop.0.mir
@@ -5,7 +5,7 @@ fn foo::{closure#0}(_1: &mut {async fn body of foo()}) -> () {
     debug x => ((*_1).0: &u32);
     debug y => ((*_1).1: u32);
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: &u32;
     let mut _9: {async block@$DIR/async_fn.rs:21:13: 21:18};
     let mut _10: {async block@$DIR/async_fn.rs:21:13: 21:18};
@@ -19,10 +19,10 @@ fn foo::{closure#0}(_1: &mut {async fn body of foo()}) -> () {
     let mut _19: &mut {async block@$DIR/async_fn.rs:21:13: 21:18};
     let mut _20: &mut std::task::Context<'_>;
     let mut _21: &mut std::task::Context<'_>;
-    let mut _22: &mut std::task::Context<'_>;
+    let mut _22: std::future::ResumeTy;
     let mut _23: isize;
     let mut _25: !;
-    let mut _26: &mut std::task::Context<'_>;
+    let mut _26: std::future::ResumeTy;
     let mut _27: ();
     let mut _30: u32;
     let mut _31: u32;

--- a/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.foo-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn foo::{closure#0}(_1: {async fn body of foo()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
             scope 3 {
@@ -24,6 +26,8 @@ fn foo::{closure#0}(_1: {async fn body of foo()}, _2: &mut Context<'_>) -> Poll<
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn hello_world::{closure#0}(_1: {async fn body of hello_world()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn hello_world::{closure#0}(_1: Pin<&mut {async fn body of hello_world()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         field _s0: [u8; 1];
@@ -18,8 +20,7 @@
 +         }
 +         storage_conflicts = BitMatrix(4x4) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s0, _s3), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s1, _s3), (_s2, _s0), (_s2, _s1), (_s2, _s2), (_s2, _s3), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3)}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _36;
 +     coroutine debug data => _s0;
 +     let mut _0: std::task::Poll<()>;
       let _3: [u8; 1];
@@ -43,16 +44,16 @@
       let mut _24: &mut {async fn body of read_exact()};
       let mut _25: &mut std::task::Context<'_>;
       let mut _26: &mut std::task::Context<'_>;
--     let mut _27: std::future::ResumeTy;
-+     let mut _27: &mut std::task::Context<'_>;
+      let mut _27: std::future::ResumeTy;
       let mut _28: isize;
       let mut _30: !;
--     let mut _31: std::future::ResumeTy;
-+     let mut _31: &mut std::task::Context<'_>;
+      let mut _31: std::future::ResumeTy;
       let mut _32: ();
 +     let mut _33: ();
 +     let mut _34: u32;
 +     let mut _35: &mut {async fn body of hello_world()};
++     let mut _36: std::future::ResumeTy;
++     let mut _37: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug data => _3;
 +         debug data => (((*_35) as variant#3).0: [u8; 1]);
@@ -90,6 +91,8 @@
 -         StorageLive(_7);
 -         _7 = RangeFull;
 -         _5 = <[u8; 1] as Index<RangeFull>>::index(move _6, move _7) -> [return: bb1, unwind: bb30];
++         _37 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _36 = std::future::ResumeTy(move _37);
 +         _35 = copy (_1.0: &mut {async fn body of hello_world()});
 +         _34 = discriminant((*_35));
 +         switchInt(move _34) -> [0: bb33, 1: bb32, 2: bb31, 3: bb30, otherwise: bb8];
@@ -160,9 +163,10 @@
           StorageLive(_25);
           StorageLive(_26);
           StorageLive(_27);
-          _27 = copy _2;
+-         _27 = copy _2;
 -         _26 = std::future::get_context::<'_, '_>(move _27) -> [return: bb6, unwind: bb20];
-+         _26 = move _27;
++         _27 = copy _36;
++         _26 = copy (_27.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb6;
       }
   
@@ -221,7 +225,8 @@
   
       bb11: {
           StorageDead(_32);
-          _2 = move _31;
+-         _2 = move _31;
++         _36 = move _31;
           StorageDead(_31);
           _19 = const ();
           goto -> bb4;
@@ -416,7 +421,7 @@
 +         StorageLive(_17);
 +         StorageLive(_31);
 +         StorageLive(_32);
-+         _31 = move _2;
++         _31 = move _36;
 +         goto -> bb11;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.coroutine_drop.0.mir
@@ -3,7 +3,7 @@
 fn hello_world::{closure#0}(_1: &mut {async fn body of hello_world()}) -> () {
     debug _task_context => _2;
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: [u8; 1];
     let _5: &[u8];
     let mut _6: &[u8; 1];
@@ -25,10 +25,10 @@ fn hello_world::{closure#0}(_1: &mut {async fn body of hello_world()}) -> () {
     let mut _24: &mut {async fn body of read_exact()};
     let mut _25: &mut std::task::Context<'_>;
     let mut _26: &mut std::task::Context<'_>;
-    let mut _27: &mut std::task::Context<'_>;
+    let mut _27: std::future::ResumeTy;
     let mut _28: isize;
     let mut _30: !;
-    let mut _31: &mut std::task::Context<'_>;
+    let mut _31: std::future::ResumeTy;
     let mut _32: ();
     let mut _33: ();
     let mut _34: u32;

--- a/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.hello_world-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn hello_world::{closure#0}(_1: {async fn body of hello_world()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
             scope 3 {
@@ -14,6 +16,8 @@ fn hello_world::{closure#0}(_1: {async fn body of hello_world()}, _2: &mut Conte
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.StateTransform.diff
@@ -4,6 +4,9 @@
 - fn includes_never::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:61:18: 61:23}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (*(_1.0: &u32));
+-     let mut _0: u32;
 + fn includes_never::{closure#0}::{closure#0}(_1: Pin<&mut {async block@$DIR/async_fn.rs:61:18: 61:23}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         variant_fields = {
@@ -13,9 +16,7 @@
 +         }
 +         storage_conflicts = BitMatrix(0x0) {}
 +     }
-      debug _task_context => _2;
--     debug x => (*(_1.0: &u32));
--     let mut _0: u32;
++     debug _task_context => _10;
 +     debug x => (*((*_9).0: &u32));
 +     let mut _0: std::task::Poll<u32>;
       let mut _3: u32;
@@ -25,6 +26,8 @@
 +     let mut _7: u32;
 +     let mut _8: u32;
 +     let mut _9: &mut {async block@$DIR/async_fn.rs:61:18: 61:23};
++     let mut _10: std::future::ResumeTy;
++     let mut _11: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         StorageLive(_3);
@@ -37,6 +40,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb1, unwind: bb2];
++         _11 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:61:18: 61:23});
 +         _8 = discriminant((*_9));
 +         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -4,7 +4,7 @@ fn includes_never::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.
     debug _task_context => _2;
     debug x => (*((*_1).0: &u32));
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let mut _3: u32;
     let mut _4: u32;
     let mut _5: &u32;

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,8 +2,12 @@
 
 fn includes_never::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:61:18: 61:23}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.StateTransform.diff
@@ -4,6 +4,9 @@
 - fn includes_never::{closure#0}::{closure#1}(_1: {async block@$DIR/async_fn.rs:67:15: 67:20}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (*(_1.0: &u32));
+-     let mut _0: u32;
 + fn includes_never::{closure#0}::{closure#1}(_1: Pin<&mut {async block@$DIR/async_fn.rs:67:15: 67:20}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         variant_fields = {
@@ -13,9 +16,7 @@
 +         }
 +         storage_conflicts = BitMatrix(0x0) {}
 +     }
-      debug _task_context => _2;
--     debug x => (*(_1.0: &u32));
--     let mut _0: u32;
++     debug _task_context => _10;
 +     debug x => (*((*_9).0: &u32));
 +     let mut _0: std::task::Poll<u32>;
       let mut _3: u32;
@@ -25,6 +26,8 @@
 +     let mut _7: u32;
 +     let mut _8: u32;
 +     let mut _9: &mut {async block@$DIR/async_fn.rs:67:15: 67:20};
++     let mut _10: std::future::ResumeTy;
++     let mut _11: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         StorageLive(_3);
@@ -37,6 +40,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb1, unwind: bb2];
++         _11 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:67:15: 67:20});
 +         _8 = discriminant((*_9));
 +         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.coroutine_drop.0.mir
@@ -4,7 +4,7 @@ fn includes_never::{closure#0}::{closure#1}(_1: &mut {async block@$DIR/async_fn.
     debug _task_context => _2;
     debug x => (*((*_1).0: &u32));
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let mut _3: u32;
     let mut _4: u32;
     let mut _5: &u32;

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}-{closure#1}.coroutine_drop_proxy_async.0.mir
@@ -2,8 +2,12 @@
 
 fn includes_never::{closure#0}::{closure#1}(_1: {async block@$DIR/async_fn.rs:67:15: 67:20}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.StateTransform.diff
@@ -4,6 +4,10 @@
 - fn includes_never::{closure#0}(_1: {async fn body of includes_never()}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug crash => (_1.0: bool);
+-     debug x => (_1.1: u32);
+-     let mut _0: u32;
 + fn includes_never::{closure#0}(_1: Pin<&mut {async fn body of includes_never()}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         field _s0: bool;
@@ -17,10 +21,7 @@
 +         }
 +         storage_conflicts = BitMatrix(3x3) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s2, _s0), (_s2, _s1), (_s2, _s2)}
 +     }
-      debug _task_context => _2;
--     debug crash => (_1.0: bool);
--     debug x => (_1.1: u32);
--     let mut _0: u32;
++     debug _task_context => _51;
 +     debug crash => ((*_50).0: bool);
 +     debug x => ((*_50).1: u32);
 +     coroutine debug crash => _s0;
@@ -37,12 +38,10 @@
       let mut _15: &mut {async block@$DIR/async_fn.rs:61:18: 61:23};
       let mut _16: &mut std::task::Context<'_>;
       let mut _17: &mut std::task::Context<'_>;
--     let mut _18: std::future::ResumeTy;
-+     let mut _18: &mut std::task::Context<'_>;
+      let mut _18: std::future::ResumeTy;
       let mut _19: isize;
       let mut _21: !;
--     let mut _22: std::future::ResumeTy;
-+     let mut _22: &mut std::task::Context<'_>;
+      let mut _22: std::future::ResumeTy;
       let mut _23: ();
       let _24: ();
       let mut _25: bool;
@@ -68,6 +67,8 @@
 +     let mut _48: u32;
 +     let mut _49: u32;
 +     let mut _50: &mut {async fn body of includes_never()};
++     let mut _51: std::future::ResumeTy;
++     let mut _52: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug crash => _3;
 +         debug crash => (((*_50) as variant#3).0: bool);
@@ -120,6 +121,8 @@
 -         _7 = {coroutine@$DIR/async_fn.rs:61:18: 61:23 (#0)} { x: move _8 };
 -         StorageDead(_8);
 -         _6 = <{async block@$DIR/async_fn.rs:61:18: 61:23} as IntoFuture>::into_future(move _7) -> [return: bb1, unwind: bb25];
++         _52 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _51 = std::future::ResumeTy(move _52);
 +         _50 = copy (_1.0: &mut {async fn body of includes_never()});
 +         _49 = discriminant((*_50));
 +         switchInt(move _49) -> [0: bb30, 1: bb29, 2: bb28, 3: bb27, otherwise: bb6];
@@ -153,9 +156,10 @@
           StorageLive(_16);
           StorageLive(_17);
           StorageLive(_18);
-          _18 = copy _2;
+-         _18 = copy _2;
 -         _17 = std::future::get_context::<'_, '_>(move _18) -> [return: bb4, unwind: bb20];
-+         _17 = move _18;
++         _18 = copy _51;
++         _17 = copy (_18.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb4;
       }
   
@@ -210,7 +214,8 @@
   
       bb9: {
           StorageDead(_23);
-          _2 = move _22;
+-         _2 = move _22;
++         _51 = move _22;
           StorageDead(_22);
           _10 = const ();
           goto -> bb2;
@@ -364,7 +369,7 @@
 +         StorageLive(_6);
 +         StorageLive(_22);
 +         StorageLive(_23);
-+         _22 = move _2;
++         _22 = move _51;
 +         goto -> bb9;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.coroutine_drop.0.mir
@@ -5,7 +5,7 @@ fn includes_never::{closure#0}(_1: &mut {async fn body of includes_never()}) -> 
     debug crash => ((*_1).0: bool);
     debug x => ((*_1).1: u32);
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: bool;
     let mut _6: {async block@$DIR/async_fn.rs:61:18: 61:23};
     let mut _7: {async block@$DIR/async_fn.rs:61:18: 61:23};
@@ -18,10 +18,10 @@ fn includes_never::{closure#0}(_1: &mut {async fn body of includes_never()}) -> 
     let mut _15: &mut {async block@$DIR/async_fn.rs:61:18: 61:23};
     let mut _16: &mut std::task::Context<'_>;
     let mut _17: &mut std::task::Context<'_>;
-    let mut _18: &mut std::task::Context<'_>;
+    let mut _18: std::future::ResumeTy;
     let mut _19: isize;
     let mut _21: !;
-    let mut _22: &mut std::task::Context<'_>;
+    let mut _22: std::future::ResumeTy;
     let mut _23: ();
     let _24: ();
     let mut _25: bool;

--- a/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.includes_never-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn includes_never::{closure#0}(_1: {async fn body of includes_never()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
             scope 3 {
@@ -22,6 +24,8 @@ fn includes_never::{closure#0}(_1: {async fn body of includes_never()}, _2: &mut
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.StateTransform.diff
@@ -4,6 +4,9 @@
 - fn partial_init::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:80:50: 80:55}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (*(_1.0: &u32));
+-     let mut _0: u32;
 + fn partial_init::{closure#0}::{closure#0}(_1: Pin<&mut {async block@$DIR/async_fn.rs:80:50: 80:55}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         variant_fields = {
@@ -13,9 +16,7 @@
 +         }
 +         storage_conflicts = BitMatrix(0x0) {}
 +     }
-      debug _task_context => _2;
--     debug x => (*(_1.0: &u32));
--     let mut _0: u32;
++     debug _task_context => _10;
 +     debug x => (*((*_9).0: &u32));
 +     let mut _0: std::task::Poll<u32>;
       let mut _3: u32;
@@ -25,6 +26,8 @@
 +     let mut _7: u32;
 +     let mut _8: u32;
 +     let mut _9: &mut {async block@$DIR/async_fn.rs:80:50: 80:55};
++     let mut _10: std::future::ResumeTy;
++     let mut _11: std::ptr::NonNull<std::task::Context<'_>>;
   
       bb0: {
 -         StorageLive(_3);
@@ -37,6 +40,8 @@
 -         StorageDead(_4);
 -         StorageDead(_3);
 -         drop(_1) -> [return: bb1, unwind: bb2];
++         _11 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _10 = std::future::ResumeTy(move _11);
 +         _9 = copy (_1.0: &mut {async block@$DIR/async_fn.rs:80:50: 80:55});
 +         _8 = discriminant((*_9));
 +         switchInt(move _8) -> [0: bb5, 1: bb3, otherwise: bb4];

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.coroutine_drop.0.mir
@@ -4,7 +4,7 @@ fn partial_init::{closure#0}::{closure#0}(_1: &mut {async block@$DIR/async_fn.rs
     debug _task_context => _2;
     debug x => (*((*_1).0: &u32));
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let mut _3: u32;
     let mut _4: u32;
     let mut _5: &u32;

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,8 +2,12 @@
 
 fn partial_init::{closure#0}::{closure#0}(_1: {async block@$DIR/async_fn.rs:80:50: 80:55}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.StateTransform.diff
@@ -4,6 +4,9 @@
 - fn partial_init::{closure#0}(_1: {async fn body of partial_init()}, _2: std::future::ResumeTy) -> u32
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     debug x => (_1.0: u32);
+-     let mut _0: u32;
 + fn partial_init::{closure#0}(_1: Pin<&mut {async fn body of partial_init()}>, _2: &mut Context<'_>) -> Poll<u32> {
 +     coroutine layout {
 +         field _s0: u32;
@@ -17,9 +20,7 @@
 +         }
 +         storage_conflicts = BitMatrix(3x3) {(_s0, _s0), (_s0, _s1), (_s0, _s2), (_s1, _s0), (_s1, _s1), (_s1, _s2), (_s2, _s0), (_s2, _s1), (_s2, _s2)}
 +     }
-      debug _task_context => _2;
--     debug x => (_1.0: u32);
--     let mut _0: u32;
++     debug _task_context => _29;
 +     debug x => ((*_28).0: u32);
 +     coroutine debug x => _s0;
 +     let mut _0: std::task::Poll<u32>;
@@ -38,16 +39,16 @@
       let mut _17: &mut {async block@$DIR/async_fn.rs:80:50: 80:55};
       let mut _18: &mut std::task::Context<'_>;
       let mut _19: &mut std::task::Context<'_>;
--     let mut _20: std::future::ResumeTy;
-+     let mut _20: &mut std::task::Context<'_>;
+      let mut _20: std::future::ResumeTy;
       let mut _21: isize;
       let mut _23: !;
--     let mut _24: std::future::ResumeTy;
-+     let mut _24: &mut std::task::Context<'_>;
+      let mut _24: std::future::ResumeTy;
       let mut _25: ();
 +     let mut _26: u32;
 +     let mut _27: u32;
 +     let mut _28: &mut {async fn body of partial_init()};
++     let mut _29: std::future::ResumeTy;
++     let mut _30: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug x => _3;
 +         debug x => (((*_28) as variant#3).0: u32);
@@ -76,6 +77,8 @@
 -         StorageLive(_5);
 -         StorageLive(_6);
 -         _6 = String::new() -> [return: bb1, unwind: bb30];
++         _30 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _29 = std::future::ResumeTy(move _30);
 +         _28 = copy (_1.0: &mut {async fn body of partial_init()});
 +         _27 = discriminant((*_28));
 +         switchInt(move _27) -> [0: bb32, 1: bb31, 2: bb30, 3: bb29, otherwise: bb7];
@@ -121,9 +124,10 @@
           StorageLive(_18);
           StorageLive(_19);
           StorageLive(_20);
-          _20 = copy _2;
+-         _20 = copy _2;
 -         _19 = std::future::get_context::<'_, '_>(move _20) -> [return: bb5, unwind: bb20];
-+         _19 = move _20;
++         _20 = copy _29;
++         _19 = copy (_20.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb5;
       }
   
@@ -180,7 +184,8 @@
   
       bb10: {
           StorageDead(_25);
-          _2 = move _24;
+-         _2 = move _24;
++         _29 = move _24;
           StorageDead(_24);
           _12 = const ();
           goto -> bb3;
@@ -335,7 +340,7 @@
 +         StorageLive(_8);
 +         StorageLive(_24);
 +         StorageLive(_25);
-+         _24 = move _2;
++         _24 = move _29;
 +         goto -> bb10;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.coroutine_drop.0.mir
@@ -4,7 +4,7 @@ fn partial_init::{closure#0}(_1: &mut {async fn body of partial_init()}) -> () {
     debug _task_context => _2;
     debug x => ((*_1).0: u32);
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: u32;
     let mut _4: !;
     let mut _6: std::string::String;
@@ -20,10 +20,10 @@ fn partial_init::{closure#0}(_1: &mut {async fn body of partial_init()}) -> () {
     let mut _17: &mut {async block@$DIR/async_fn.rs:80:50: 80:55};
     let mut _18: &mut std::task::Context<'_>;
     let mut _19: &mut std::task::Context<'_>;
-    let mut _20: &mut std::task::Context<'_>;
+    let mut _20: std::future::ResumeTy;
     let mut _21: isize;
     let mut _23: !;
-    let mut _24: &mut std::task::Context<'_>;
+    let mut _24: std::future::ResumeTy;
     let mut _25: ();
     let mut _26: u32;
     let mut _27: u32;

--- a/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.partial_init-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn partial_init::{closure#0}(_1: {async fn body of partial_init()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
         }
@@ -14,6 +16,8 @@ fn partial_init::{closure#0}(_1: {async fn body of partial_init()}, _2: &mut Con
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.StateTransform.diff
+++ b/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.StateTransform.diff
@@ -4,6 +4,8 @@
 - fn uninhabited_variant::{closure#0}(_1: {async fn body of uninhabited_variant()}, _2: std::future::ResumeTy) -> ()
 - yields ()
 -  {
+-     debug _task_context => _2;
+-     let mut _0: ();
 + fn uninhabited_variant::{closure#0}(_1: Pin<&mut {async fn body of uninhabited_variant()}>, _2: &mut Context<'_>) -> Poll<()> {
 +     coroutine layout {
 +         field _s0: {async block@$DIR/async_fn.rs:106:13: 106:18};
@@ -19,8 +21,7 @@
 +         }
 +         storage_conflicts = BitMatrix(4x4) {(_s0, _s0), (_s0, _s2), (_s0, _s3), (_s1, _s1), (_s1, _s3), (_s2, _s0), (_s2, _s2), (_s2, _s3), (_s3, _s0), (_s3, _s1), (_s3, _s2), (_s3, _s3)}
 +     }
-      debug _task_context => _2;
--     let mut _0: ();
++     debug _task_context => _47;
 +     coroutine debug c => _s0;
 +     let mut _0: std::task::Poll<()>;
       let _3: {async block@$DIR/async_fn.rs:106:13: 106:18};
@@ -37,12 +38,10 @@
       let mut _15: &mut {async block@$DIR/async_fn.rs:106:13: 106:18};
       let mut _16: &mut std::task::Context<'_>;
       let mut _17: &mut std::task::Context<'_>;
--     let mut _18: std::future::ResumeTy;
-+     let mut _18: &mut std::task::Context<'_>;
+      let mut _18: std::future::ResumeTy;
       let mut _19: isize;
       let mut _21: !;
--     let mut _22: std::future::ResumeTy;
-+     let mut _22: &mut std::task::Context<'_>;
+      let mut _22: std::future::ResumeTy;
       let mut _23: ();
       let _25: ();
       let mut _26: {async fn body of uninhabited_variant::{closure#0}::unreachable()};
@@ -55,17 +54,17 @@
       let mut _34: &mut {async fn body of uninhabited_variant::{closure#0}::unreachable()};
       let mut _35: &mut std::task::Context<'_>;
       let mut _36: &mut std::task::Context<'_>;
--     let mut _37: std::future::ResumeTy;
-+     let mut _37: &mut std::task::Context<'_>;
+      let mut _37: std::future::ResumeTy;
       let mut _38: isize;
       let mut _40: !;
--     let mut _41: std::future::ResumeTy;
-+     let mut _41: &mut std::task::Context<'_>;
+      let mut _41: std::future::ResumeTy;
       let mut _42: ();
       let mut _43: bool;
 +     let mut _44: ();
 +     let mut _45: u32;
 +     let mut _46: &mut {async fn body of uninhabited_variant()};
++     let mut _47: std::future::ResumeTy;
++     let mut _48: std::ptr::NonNull<std::task::Context<'_>>;
       scope 1 {
 -         debug c => _3;
 +         debug c => (((*_46) as variant#4).0: {async block@$DIR/async_fn.rs:106:13: 106:18});
@@ -105,6 +104,8 @@
 -         PlaceMention(_4);
 -         _5 = discriminant(_4);
 -         switchInt(move _5) -> [0: bb3, 1: bb2, otherwise: bb1];
++         _48 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _47 = std::future::ResumeTy(move _48);
 +         _46 = copy (_1.0: &mut {async fn body of uninhabited_variant()});
 +         _45 = discriminant((*_46));
 +         switchInt(move _45) -> [0: bb56, 1: bb55, 2: bb54, 3: bb52, 4: bb53, otherwise: bb1];
@@ -166,9 +167,10 @@
           StorageLive(_16);
           StorageLive(_17);
           StorageLive(_18);
-          _18 = copy _2;
+-         _18 = copy _2;
 -         _17 = std::future::get_context::<'_, '_>(move _18) -> [return: bb7, unwind: bb46];
-+         _17 = move _18;
++         _18 = copy _47;
++         _17 = copy (_18.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb7;
       }
   
@@ -220,7 +222,8 @@
   
       bb11: {
           StorageDead(_23);
-          _2 = move _22;
+-         _2 = move _22;
++         _47 = move _22;
           StorageDead(_22);
           _10 = const ();
           goto -> bb5;
@@ -274,9 +277,10 @@
           StorageLive(_35);
           StorageLive(_36);
           StorageLive(_37);
-          _37 = copy _2;
+-         _37 = copy _2;
 -         _36 = std::future::get_context::<'_, '_>(move _37) -> [return: bb18, unwind: bb37];
-+         _36 = move _37;
++         _37 = copy _47;
++         _36 = copy (_37.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         goto -> bb18;
       }
   
@@ -329,7 +333,8 @@
   
       bb22: {
           StorageDead(_42);
-          _2 = move _41;
+-         _2 = move _41;
++         _47 = move _41;
           StorageDead(_41);
           _10 = const ();
           goto -> bb16;
@@ -625,7 +630,7 @@
 +         StorageLive(_7);
 +         StorageLive(_22);
 +         StorageLive(_23);
-+         _22 = move _2;
++         _22 = move _47;
 +         goto -> bb11;
       }
   
@@ -638,7 +643,7 @@
 +         StorageLive(_26);
 +         StorageLive(_41);
 +         StorageLive(_42);
-+         _41 = move _2;
++         _41 = move _47;
 +         goto -> bb22;
       }
   

--- a/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.coroutine_drop.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.coroutine_drop.0.mir
@@ -3,7 +3,7 @@
 fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_variant()}) -> () {
     debug _task_context => _2;
     let mut _0: ();
-    let mut _2: &mut std::task::Context<'_>;
+    let mut _2: std::future::ResumeTy;
     let _3: {async block@$DIR/async_fn.rs:106:13: 106:18};
     let mut _4: std::option::Option<Never>;
     let mut _5: isize;
@@ -18,10 +18,10 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
     let mut _15: &mut {async block@$DIR/async_fn.rs:106:13: 106:18};
     let mut _16: &mut std::task::Context<'_>;
     let mut _17: &mut std::task::Context<'_>;
-    let mut _18: &mut std::task::Context<'_>;
+    let mut _18: std::future::ResumeTy;
     let mut _19: isize;
     let mut _21: !;
-    let mut _22: &mut std::task::Context<'_>;
+    let mut _22: std::future::ResumeTy;
     let mut _23: ();
     let _25: ();
     let mut _26: {async fn body of uninhabited_variant::{closure#0}::unreachable()};
@@ -34,10 +34,10 @@ fn uninhabited_variant::{closure#0}(_1: &mut {async fn body of uninhabited_varia
     let mut _34: &mut {async fn body of uninhabited_variant::{closure#0}::unreachable()};
     let mut _35: &mut std::task::Context<'_>;
     let mut _36: &mut std::task::Context<'_>;
-    let mut _37: &mut std::task::Context<'_>;
+    let mut _37: std::future::ResumeTy;
     let mut _38: isize;
     let mut _40: !;
-    let mut _41: &mut std::task::Context<'_>;
+    let mut _41: std::future::ResumeTy;
     let mut _42: ();
     let mut _43: bool;
     let mut _44: ();

--- a/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.coroutine_drop_proxy_async.0.mir
+++ b/tests/mir-opt/coroutine/async_fn.uninhabited_variant-{closure#0}.coroutine_drop_proxy_async.0.mir
@@ -2,6 +2,8 @@
 
 fn uninhabited_variant::{closure#0}(_1: {async fn body of uninhabited_variant()}, _2: &mut Context<'_>) -> Poll<()> {
     let mut _0: std::task::Poll<()>;
+    let mut _3: std::future::ResumeTy;
+    let mut _4: std::ptr::NonNull<std::task::Context<'_>>;
     scope 1 {
         scope 2 {
             scope 3 {
@@ -16,6 +18,8 @@ fn uninhabited_variant::{closure#0}(_1: {async fn body of uninhabited_variant()}
     }
 
     bb0: {
+        _4 = move _2 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
+        _3 = std::future::ResumeTy(move _4);
         drop(_1) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/inline/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
@@ -33,14 +33,16 @@
 +                 let mut _21: &mut std::future::Ready<()>;
 +                 let mut _22: &mut std::task::Context<'_>;
 +                 let mut _23: &mut std::task::Context<'_>;
-+                 let mut _24: &mut std::task::Context<'_>;
++                 let mut _24: std::future::ResumeTy;
 +                 let mut _25: isize;
 +                 let mut _27: !;
-+                 let mut _28: &mut std::task::Context<'_>;
++                 let mut _28: std::future::ResumeTy;
 +                 let mut _29: ();
 +                 let mut _30: ();
 +                 let mut _31: u32;
 +                 let mut _32: &mut {async fn body of ActionPermit<'_, T>::perform()};
++                 let mut _33: std::future::ResumeTy;
++                 let mut _34: std::ptr::NonNull<std::task::Context<'_>>;
 +                 scope 7 {
 +                     let mut _15: std::future::Ready<()>;
 +                     scope 8 {
@@ -50,30 +52,30 @@
 +                         scope 11 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
 +                         }
 +                         scope 12 (inlined <std::future::Ready<()> as Future>::poll) {
-+                             let mut _33: ();
-+                             let mut _34: std::option::Option<()>;
-+                             let mut _35: &mut std::option::Option<()>;
-+                             let mut _36: &mut std::future::Ready<()>;
-+                             let mut _37: &mut std::pin::Pin<&mut std::future::Ready<()>>;
++                             let mut _35: ();
++                             let mut _36: std::option::Option<()>;
++                             let mut _37: &mut std::option::Option<()>;
++                             let mut _38: &mut std::future::Ready<()>;
++                             let mut _39: &mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                             scope 13 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
-+                                 let mut _38: *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>>;
-+                                 let mut _39: *mut std::pin::Pin<&mut std::future::Ready<()>>;
++                                 let mut _40: *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>>;
++                                 let mut _41: *mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                                 scope 14 (inlined <pin::helper::PinHelper<&mut std::future::Ready<()>> as pin::helper::PinDerefMutHelper>::deref_mut) {
-+                                     let mut _40: &mut &mut std::future::Ready<()>;
++                                     let mut _42: &mut &mut std::future::Ready<()>;
 +                                     scope 15 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
 +                                     }
 +                                 }
 +                             }
 +                             scope 16 (inlined Option::<()>::take) {
-+                                 let mut _41: std::option::Option<()>;
++                                 let mut _43: std::option::Option<()>;
 +                                 scope 17 (inlined std::mem::replace::<Option<()>>) {
 +                                     scope 18 {
 +                                     }
 +                                 }
 +                             }
 +                             scope 19 (inlined #[track_caller] Option::<()>::expect) {
-+                                 let mut _42: isize;
-+                                 let mut _43: !;
++                                 let mut _44: isize;
++                                 let mut _45: !;
 +                                 scope 20 {
 +                                 }
 +                             }
@@ -82,7 +84,7 @@
 +                     scope 10 (inlined <std::future::Ready<()> as IntoFuture>::into_future) {
 +                     }
 +                     scope 21 (inlined ready::<()>) {
-+                         let mut _44: std::option::Option<()>;
++                         let mut _46: std::option::Option<()>;
 +                     }
 +                 }
 +             }
@@ -125,6 +127,10 @@
 +         StorageLive(_30);
 +         StorageLive(_31);
 +         StorageLive(_32);
++         StorageLive(_33);
++         StorageLive(_34);
++         _34 = move _9 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _33 = std::future::ResumeTy(move _34);
 +         _32 = copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _31 = discriminant((*_32));
 +         switchInt(move _31) -> [0: bb10, 1: bb9, 3: bb8, otherwise: bb4];
@@ -137,6 +143,8 @@
 +     }
 + 
 +     bb2: {
++         StorageDead(_34);
++         StorageDead(_33);
 +         StorageDead(_32);
 +         StorageDead(_31);
 +         StorageDead(_30);
@@ -166,28 +174,28 @@
 +         StorageLive(_22);
 +         StorageLive(_23);
 +         StorageLive(_24);
-+         _24 = copy _9;
-+         _23 = move _24;
++         _24 = copy _33;
++         _23 = copy (_24.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         _22 = &mut (*_23);
 +         StorageDead(_24);
-+         StorageLive(_36);
 +         StorageLive(_38);
-+         StorageLive(_43);
-+         StorageLive(_33);
-+         StorageLive(_34);
-+         StorageLive(_39);
-+         _39 = &raw mut _19;
-+         _38 = copy _39 as *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>> (PtrToPtr);
-+         StorageDead(_39);
-+         _36 = no_retag copy ((*_38).0: &mut std::future::Ready<()>);
++         StorageLive(_40);
++         StorageLive(_45);
++         StorageLive(_35);
++         StorageLive(_36);
 +         StorageLive(_41);
-+         _41 = Option::<()>::None;
-+         _34 = copy ((*_36).0: std::option::Option<()>);
-+         ((*_36).0: std::option::Option<()>) = move _41;
++         _41 = &raw mut _19;
++         _40 = copy _41 as *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>> (PtrToPtr);
 +         StorageDead(_41);
-+         StorageLive(_42);
-+         _42 = discriminant(_34);
-+         switchInt(move _42) -> [0: bb11, 1: bb12, otherwise: bb4];
++         _38 = no_retag copy ((*_40).0: &mut std::future::Ready<()>);
++         StorageLive(_43);
++         _43 = Option::<()>::None;
++         _36 = copy ((*_38).0: std::option::Option<()>);
++         ((*_38).0: std::option::Option<()>) = move _43;
++         StorageDead(_43);
++         StorageLive(_44);
++         _44 = discriminant(_36);
++         switchInt(move _44) -> [0: bb11, 1: bb12, otherwise: bb4];
 +     }
 + 
       bb4: {
@@ -236,9 +244,9 @@
 +         StorageLive(_12);
 +         StorageLive(_28);
 +         StorageLive(_29);
-+         _28 = move _9;
++         _28 = move _33;
 +         StorageDead(_29);
-+         _9 = move _28;
++         _33 = move _28;
 +         StorageDead(_28);
 +         _16 = const ();
 +         goto -> bb3;
@@ -254,10 +262,10 @@
 +         StorageLive(_13);
 +         StorageLive(_14);
 +         _14 = ();
-+         StorageLive(_44);
-+         _44 = Option::<()>::Some(copy _14);
-+         _13 = std::future::Ready::<()>(move _44);
-+         StorageDead(_44);
++         StorageLive(_46);
++         _46 = Option::<()>::Some(copy _14);
++         _13 = std::future::Ready::<()>(move _46);
++         StorageDead(_46);
 +         StorageDead(_14);
 +         _12 = move _13;
 +         StorageDead(_13);
@@ -266,18 +274,18 @@
 +     }
 + 
 +     bb11: {
-+         _43 = option::expect_failed(const "`Ready` polled after completion") -> unwind unreachable;
++         _45 = option::expect_failed(const "`Ready` polled after completion") -> unwind unreachable;
 +     }
 + 
 +     bb12: {
-+         _33 = move ((_34 as Some).0: ());
-+         StorageDead(_42);
-+         StorageDead(_34);
-+         _18 = Poll::<()>::Ready(move _33);
-+         StorageDead(_33);
-+         StorageDead(_43);
-+         StorageDead(_38);
++         _35 = move ((_36 as Some).0: ());
++         StorageDead(_44);
 +         StorageDead(_36);
++         _18 = Poll::<()>::Ready(move _35);
++         StorageDead(_35);
++         StorageDead(_45);
++         StorageDead(_40);
++         StorageDead(_38);
 +         StorageDead(_22);
 +         StorageDead(_19);
 +         _25 = discriminant(_18);

--- a/tests/mir-opt/inline/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
@@ -33,14 +33,16 @@
 +                 let mut _21: &mut std::future::Ready<()>;
 +                 let mut _22: &mut std::task::Context<'_>;
 +                 let mut _23: &mut std::task::Context<'_>;
-+                 let mut _24: &mut std::task::Context<'_>;
++                 let mut _24: std::future::ResumeTy;
 +                 let mut _25: isize;
 +                 let mut _27: !;
-+                 let mut _28: &mut std::task::Context<'_>;
++                 let mut _28: std::future::ResumeTy;
 +                 let mut _29: ();
 +                 let mut _30: ();
 +                 let mut _31: u32;
 +                 let mut _32: &mut {async fn body of ActionPermit<'_, T>::perform()};
++                 let mut _33: std::future::ResumeTy;
++                 let mut _34: std::ptr::NonNull<std::task::Context<'_>>;
 +                 scope 7 {
 +                     let mut _15: std::future::Ready<()>;
 +                     scope 8 {
@@ -50,30 +52,30 @@
 +                         scope 11 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
 +                         }
 +                         scope 12 (inlined <std::future::Ready<()> as Future>::poll) {
-+                             let mut _33: ();
-+                             let mut _34: std::option::Option<()>;
-+                             let mut _35: &mut std::option::Option<()>;
-+                             let mut _36: &mut std::future::Ready<()>;
-+                             let mut _37: &mut std::pin::Pin<&mut std::future::Ready<()>>;
++                             let mut _35: ();
++                             let mut _36: std::option::Option<()>;
++                             let mut _37: &mut std::option::Option<()>;
++                             let mut _38: &mut std::future::Ready<()>;
++                             let mut _39: &mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                             scope 13 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
-+                                 let mut _38: *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>>;
-+                                 let mut _39: *mut std::pin::Pin<&mut std::future::Ready<()>>;
++                                 let mut _40: *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>>;
++                                 let mut _41: *mut std::pin::Pin<&mut std::future::Ready<()>>;
 +                                 scope 14 (inlined <pin::helper::PinHelper<&mut std::future::Ready<()>> as pin::helper::PinDerefMutHelper>::deref_mut) {
-+                                     let mut _40: &mut &mut std::future::Ready<()>;
++                                     let mut _42: &mut &mut std::future::Ready<()>;
 +                                     scope 15 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
 +                                     }
 +                                 }
 +                             }
 +                             scope 16 (inlined Option::<()>::take) {
-+                                 let mut _41: std::option::Option<()>;
++                                 let mut _43: std::option::Option<()>;
 +                                 scope 17 (inlined std::mem::replace::<Option<()>>) {
 +                                     scope 18 {
 +                                     }
 +                                 }
 +                             }
 +                             scope 19 (inlined #[track_caller] Option::<()>::expect) {
-+                                 let mut _42: isize;
-+                                 let mut _43: !;
++                                 let mut _44: isize;
++                                 let mut _45: !;
 +                                 scope 20 {
 +                                 }
 +                             }
@@ -82,7 +84,7 @@
 +                     scope 10 (inlined <std::future::Ready<()> as IntoFuture>::into_future) {
 +                     }
 +                     scope 21 (inlined ready::<()>) {
-+                         let mut _44: std::option::Option<()>;
++                         let mut _46: std::option::Option<()>;
 +                     }
 +                 }
 +             }
@@ -125,6 +127,10 @@
 +         StorageLive(_30);
 +         StorageLive(_31);
 +         StorageLive(_32);
++         StorageLive(_33);
++         StorageLive(_34);
++         _34 = move _9 as std::ptr::NonNull<std::task::Context<'_>> (Transmute);
++         _33 = std::future::ResumeTy(move _34);
 +         _32 = copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _31 = discriminant((*_32));
 +         switchInt(move _31) -> [0: bb15, 1: bb14, 2: bb13, 3: bb12, otherwise: bb6];
@@ -145,6 +151,8 @@
 +     }
 + 
 +     bb4: {
++         StorageDead(_34);
++         StorageDead(_33);
 +         StorageDead(_32);
 +         StorageDead(_31);
 +         StorageDead(_30);
@@ -177,28 +185,28 @@
 +         StorageLive(_22);
 +         StorageLive(_23);
 +         StorageLive(_24);
-+         _24 = copy _9;
-+         _23 = move _24;
++         _24 = copy _33;
++         _23 = copy (_24.0: std::ptr::NonNull<std::task::Context<'_>>) as &mut std::task::Context<'_> (Transmute);
 +         _22 = &mut (*_23);
 +         StorageDead(_24);
-+         StorageLive(_36);
 +         StorageLive(_38);
-+         StorageLive(_43);
-+         StorageLive(_33);
-+         StorageLive(_34);
-+         StorageLive(_39);
-+         _39 = &raw mut _19;
-+         _38 = copy _39 as *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>> (PtrToPtr);
-+         StorageDead(_39);
-+         _36 = no_retag copy ((*_38).0: &mut std::future::Ready<()>);
++         StorageLive(_40);
++         StorageLive(_45);
++         StorageLive(_35);
++         StorageLive(_36);
 +         StorageLive(_41);
-+         _41 = Option::<()>::None;
-+         _34 = copy ((*_36).0: std::option::Option<()>);
-+         ((*_36).0: std::option::Option<()>) = move _41;
++         _41 = &raw mut _19;
++         _40 = copy _41 as *mut std::pin::helper::PinHelper<&mut std::future::Ready<()>> (PtrToPtr);
 +         StorageDead(_41);
-+         StorageLive(_42);
-+         _42 = discriminant(_34);
-+         switchInt(move _42) -> [0: bb16, 1: bb17, otherwise: bb6];
++         _38 = no_retag copy ((*_40).0: &mut std::future::Ready<()>);
++         StorageLive(_43);
++         _43 = Option::<()>::None;
++         _36 = copy ((*_38).0: std::option::Option<()>);
++         ((*_38).0: std::option::Option<()>) = move _43;
++         StorageDead(_43);
++         StorageLive(_44);
++         _44 = discriminant(_36);
++         switchInt(move _44) -> [0: bb16, 1: bb17, otherwise: bb6];
       }
   
 -     bb5 (cleanup): {
@@ -265,9 +273,9 @@
 +         StorageLive(_12);
 +         StorageLive(_28);
 +         StorageLive(_29);
-+         _28 = move _9;
++         _28 = move _33;
 +         StorageDead(_29);
-+         _9 = move _28;
++         _33 = move _28;
 +         StorageDead(_28);
 +         _16 = const ();
 +         goto -> bb5;
@@ -287,10 +295,10 @@
 +         StorageLive(_13);
 +         StorageLive(_14);
 +         _14 = ();
-+         StorageLive(_44);
-+         _44 = Option::<()>::Some(copy _14);
-+         _13 = std::future::Ready::<()>(move _44);
-+         StorageDead(_44);
++         StorageLive(_46);
++         _46 = Option::<()>::Some(copy _14);
++         _13 = std::future::Ready::<()>(move _46);
++         StorageDead(_46);
 +         StorageDead(_14);
 +         _12 = move _13;
 +         StorageDead(_13);
@@ -299,18 +307,18 @@
 +     }
 + 
 +     bb16: {
-+         _43 = option::expect_failed(const "`Ready` polled after completion") -> bb10;
++         _45 = option::expect_failed(const "`Ready` polled after completion") -> bb10;
 +     }
 + 
 +     bb17: {
-+         _33 = move ((_34 as Some).0: ());
-+         StorageDead(_42);
-+         StorageDead(_34);
-+         _18 = Poll::<()>::Ready(move _33);
-+         StorageDead(_33);
-+         StorageDead(_43);
-+         StorageDead(_38);
++         _35 = move ((_36 as Some).0: ());
++         StorageDead(_44);
 +         StorageDead(_36);
++         _18 = Poll::<()>::Ready(move _35);
++         StorageDead(_35);
++         StorageDead(_45);
++         StorageDead(_40);
++         StorageDead(_38);
 +         StorageDead(_22);
 +         StorageDead(_19);
 +         _25 = discriminant(_18);

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.rs
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.rs
@@ -5,7 +5,7 @@
 //@ edition:2021
 //@ build-pass
 //@ no-pass-override (codegen affects -Zprint-type-sizes)
-//@ only-x86_64
+//@ only-64bit
 
 async fn wait() {}
 

--- a/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
+++ b/tests/ui/async-await/future-sizes/async-awaiting-fut.stdout
@@ -72,6 +72,8 @@ print-type-size type: `std::panic::AssertUnwindSafe<core::task::wake::ExtData<'_
 print-type-size     field `.0`: 16 bytes
 print-type-size type: `std::ptr::NonNull<str>`: 16 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 16 bytes
+print-type-size type: `std::future::ResumeTy`: 8 bytes, alignment: 8 bytes
+print-type-size     field `.0`: 8 bytes
 print-type-size type: `std::pin::Pin<&mut {async fn body of big_fut()}>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
 print-type-size type: `std::pin::Pin<&mut {async fn body of calls_fut<{async fn body of big_fut()}>()}>`: 8 bytes, alignment: 8 bytes
@@ -84,6 +86,8 @@ print-type-size type: `std::ptr::DynMetadata<dyn std::any::Any>`: 8 bytes, align
 print-type-size     field `._vtable_ptr`: 8 bytes
 print-type-size     field `._phantom`: 0 bytes
 print-type-size type: `std::ptr::NonNull<std::ptr::metadata::VTable>`: 8 bytes, alignment: 8 bytes
+print-type-size     field `.pointer`: 8 bytes
+print-type-size type: `std::ptr::NonNull<std::task::Context<'_>>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
 print-type-size type: `std::mem::ManuallyDrop<bool>`: 1 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1 bytes

--- a/tests/ui/async-await/future-sizes/large-arg.rs
+++ b/tests/ui/async-await/future-sizes/large-arg.rs
@@ -5,7 +5,7 @@
 //@ edition: 2021
 //@ build-pass
 //@ no-pass-override (codegen affects -Zprint-type-sizes)
-//@ only-x86_64
+//@ only-64bit
 
 pub async fn test() {
     let _ = a([0u8; 1024]).await;

--- a/tests/ui/async-await/future-sizes/large-arg.stdout
+++ b/tests/ui/async-await/future-sizes/large-arg.stdout
@@ -84,6 +84,8 @@ print-type-size type: `std::panic::AssertUnwindSafe<core::task::wake::ExtData<'_
 print-type-size     field `.0`: 16 bytes
 print-type-size type: `std::ptr::NonNull<str>`: 16 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 16 bytes
+print-type-size type: `std::future::ResumeTy`: 8 bytes, alignment: 8 bytes
+print-type-size     field `.0`: 8 bytes
 print-type-size type: `std::pin::Pin<&mut {async fn body of a<[u8; 1024]>()}>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
 print-type-size type: `std::pin::Pin<&mut {async fn body of b<[u8; 1024]>()}>`: 8 bytes, alignment: 8 bytes
@@ -96,6 +98,8 @@ print-type-size type: `std::ptr::DynMetadata<dyn std::any::Any>`: 8 bytes, align
 print-type-size     field `._vtable_ptr`: 8 bytes
 print-type-size     field `._phantom`: 0 bytes
 print-type-size type: `std::ptr::NonNull<std::ptr::metadata::VTable>`: 8 bytes, alignment: 8 bytes
+print-type-size     field `.pointer`: 8 bytes
+print-type-size type: `std::ptr::NonNull<std::task::Context<'_>>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
 print-type-size type: `std::task::Poll<()>`: 1 bytes, alignment: 1 bytes
 print-type-size     discriminant: 1 bytes

--- a/tests/ui/print_type_sizes/async.rs
+++ b/tests/ui/print_type_sizes/async.rs
@@ -5,7 +5,7 @@
 //@ edition:2021
 //@ build-pass
 //@ no-pass-override (codegen affects -Zprint-type-sizes)
-//@ only-x86_64
+//@ only-64bit
 
 #![allow(dropping_copy_types)]
 

--- a/tests/ui/print_type_sizes/async.stdout
+++ b/tests/ui/print_type_sizes/async.stdout
@@ -38,6 +38,8 @@ print-type-size type: `std::panic::AssertUnwindSafe<core::task::wake::ExtData<'_
 print-type-size     field `.0`: 16 bytes
 print-type-size type: `std::ptr::NonNull<str>`: 16 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 16 bytes
+print-type-size type: `std::future::ResumeTy`: 8 bytes, alignment: 8 bytes
+print-type-size     field `.0`: 8 bytes
 print-type-size type: `std::pin::Pin<&mut {async fn body of test()}>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
 print-type-size type: `std::pin::Pin<&mut {async fn body of wait()}>`: 8 bytes, alignment: 8 bytes
@@ -46,6 +48,8 @@ print-type-size type: `std::ptr::DynMetadata<dyn std::any::Any>`: 8 bytes, align
 print-type-size     field `._vtable_ptr`: 8 bytes
 print-type-size     field `._phantom`: 0 bytes
 print-type-size type: `std::ptr::NonNull<std::ptr::metadata::VTable>`: 8 bytes, alignment: 8 bytes
+print-type-size     field `.pointer`: 8 bytes
+print-type-size type: `std::ptr::NonNull<std::task::Context<'_>>`: 8 bytes, alignment: 8 bytes
 print-type-size     field `.pointer`: 8 bytes
 print-type-size type: `std::mem::ManuallyDrop<{async fn body of wait()}>`: 1 bytes, alignment: 1 bytes
 print-type-size     field `.value`: 1 bytes

--- a/tests/ui/rustc_public-ir-print/async-closure.stdout
+++ b/tests/ui/rustc_public-ir-print/async-closure.stdout
@@ -42,10 +42,14 @@ fn foo::{closure#0}::{closure#0}(_1: Pin<&mut {async closure body@$DIR/async-clo
     let mut _5: ();
     let mut _6: u32;
     let mut _7: &mut {async closure body@$DIR/async-closure.rs:9:22: 11:6};
-    debug _task_context => _2;
+    let mut _8: std::future::ResumeTy;
+    let mut _9: NonNull<Context<'_>>;
+    debug _task_context => _8;
     debug y => (*((*_7).0: &i32));
     debug y => _3;
     bb0: {
+        _9 = move _2 as NonNull<Context<'_>>;
+        _8 = ResumeTy(move _9);
         _7 = (_1.0: &mut {async closure body@$DIR/async-closure.rs:9:22: 11:6});
         _6 = discriminant((*_7));
         switchInt(move _6) -> [0: bb3, 1: bb1, otherwise: bb2];
@@ -74,10 +78,14 @@ fn foo::{closure#0}::{synthetic#0}(_1: Pin<&mut {async closure body@$DIR/async-c
     let mut _5: ();
     let mut _6: u32;
     let mut _7: &mut {async closure body@$DIR/async-closure.rs:9:22: 11:6};
-    debug _task_context => _2;
+    let mut _8: std::future::ResumeTy;
+    let mut _9: NonNull<Context<'_>>;
+    debug _task_context => _8;
     debug y => (*((*_7).0: &i32));
     debug y => _3;
     bb0: {
+        _9 = move _2 as NonNull<Context<'_>>;
+        _8 = ResumeTy(move _9);
         _7 = (_1.0: &mut {async closure body@$DIR/async-closure.rs:9:22: 11:6});
         _6 = discriminant((*_7));
         switchInt(move _6) -> [0: bb3, 1: bb1, otherwise: bb2];


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157166)*
<!-- homu-ignore:end -->

`Future::poll` expects a `&mut std::task::Context<'_>`. Meanwhile, async coroutines use `std::future::ResumeTy` as resume parameter. This is meant to workaround the limitations of borrowck, which cannot prove that coroutines implement `for<'a, 'b> CoroutineTrait<&'a mut Context<'b>>`.

In the coroutine state transform, we need to change the signature from `ResumeTy` to the proper `&mut Context<'_>`. The current code attempts to find locals that have type `ResumeTy` to change their type. This is needlessly complex and relies on undocumented behaviour of the MIR builder.

Instead, this PR proposes to replace the `ResumeTy` argument with a new local, with value `ResumeTy(transmute(context))`.

Based on https://github.com/rust-lang/rust/pull/156875.
