### PR TITLE
Stabilize `Rng` and `SystemRng`

### DIFF
--- a/library/core/src/random.rs
+++ b/library/core/src/random.rs
@@ -3,7 +3,7 @@
 use crate::ops::RangeFull;
 
 /// A source of randomness.
-#[unstable(feature = "random", issue = "130703")]
+#[stable(feature = "random_source", since = "CURRENT_RUSTC_VERSION")]
 pub trait Rng {
     /// Fills `bytes` with random bytes.
     ///
@@ -11,6 +11,7 @@ pub trait Rng {
     /// with a larger buffer. An `Rng` is allowed to return different bytes for those two cases. For
     /// instance, this allows an `Rng` to generate a word at a time and throw part of it away if not
     /// needed.
+    #[stable(feature = "random_source", since = "CURRENT_RUSTC_VERSION")]
     fn fill_bytes(&mut self, bytes: &mut [u8]);
 }
 

--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -1,7 +1,9 @@
 //! Random value generation.
 
 #[unstable(feature = "random", issue = "130703")]
-pub use core::random::*;
+pub use core::random::Distribution;
+#[stable(feature = "random_source", since = "CURRENT_RUSTC_VERSION")]
+pub use core::random::Rng;
 
 use crate::sys::random as sys;
 
@@ -61,10 +63,10 @@ use crate::sys::random as sys;
 /// [`get-random-bytes`]: https://github.com/WebAssembly/WASI/blob/main/proposals/random/imports.md#get-random-bytes-func
 #[doc(alias = "getrandom", alias = "getentropy", alias = "arc4random")]
 #[derive(Default, Debug, Clone, Copy)]
-#[unstable(feature = "random", issue = "130703")]
+#[stable(feature = "random_source", since = "CURRENT_RUSTC_VERSION")]
 pub struct SystemRng;
 
-#[unstable(feature = "random", issue = "130703")]
+#[stable(feature = "random_source", since = "CURRENT_RUSTC_VERSION")]
 impl Rng for SystemRng {
     fn fill_bytes(&mut self, bytes: &mut [u8]) {
         sys::fill_bytes(bytes)


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157168)*
<!-- homu-ignore:end -->

# Stabilization report

This partial stabilization provides enough of an interface for people to obtain random bytes, which is a common need in the ecosystem, currently fulfilled via the `getrandom` crate.

There have been many requests for a `fill_bytes` interface in the standard library. Per previous libs-api discussions, `SystemRng.fill_bytes` can serve that function, rather than adding a separate free function.

## Alternatives and Future Work

### Uninitialized buffers

We're likely to add a `fill_buf` function to fill a `BorrowedCursor<'_, u8>`. We can do so once `BorrowedBuf`/`BorrowedCursor` is stable. Deferring this means we will need to support trait impls that provide `fill_bytes` but not `fill_buf`, which we might not need to if we waited until after `BorrowedBuf`/`BorrowedCursor` is stable. However, that isn't any worse of a problem than we already have with `io::Read`, and we don't necessarily want to couple the stabilization of `BorrowedBuf`/`BorrowedCursor` with

### Distributions

The `Distribution` trait and the `random` function remain unstable; those don't need to block stabilization of `Rng` and `SystemRng`.

### Optimized paths for `u32`/`u64`

Some RNGs can provide faster results for generating a whole `u32`/`u64` rather than individual bytes.

The definition and documentation of `fill_bytes` says:

> Note that calling `fill_bytes` multiple times is not equivalent to calling `fill_bytes` once
> with a larger buffer. A `RandomSource` is allowed to return different bytes for those two
> For instance, this allows a `RandomSource` to generate a word at a time and throw
> of it away if not needed.

We hope that this will allow RNGs that can generate whole words to do so efficiently as a fast path in `fill_bytes`/`fill_buf`. If dedicated `next_u32`/`next_u64` functions still end up being substantially faster, we can always add them as optional trait methods in the future.

[Some experimentation suggests](https://github.com/hanna-kruppe/chacha8rand/pull/1) that it's possible to match the performance.

### `Result` versus panicking

There's been extensive discussion about whether the function should return a `Result` rather than panicking, or providing an additional such function. The previous conclusion from libs-api was that while it's possible for the *first* such call to fail (e.g. because the OS or sandbox provides no access to randomness at all), subsequent calls should never fail, and user code will not be prepared to deal with such failure.

Furthermore, an API returning `Result` would propagate throughout higher-level calls, forcing operations as simple as "roll a d20" to either return `Result` or call `expect`/`unwrap`. And even providing a `try` variant will lead to higher-level APIs having to consider which variant to call. We should, instead, make the guarantee that a well-behaved underlying OS won't panic after the first call.

Note, in particular, that `HashMap` already fails via panic if it can't get data from its `RandomState`.

If there's a need to allow error recovery for the "no OS/sandbox support" case, we could provide a one-time call to check for an error. Or, such users could continue using `getrandom` or the underlying OS APIs.

If we *did* want to make every call fallible, we have the capability, using upcoming language features ("supertrait auto impl"), to add a `TryRng` supertrait without breaking backwards compatibility.