### PR TITLE
Use `impl` restrictions in `std`, `core`

### DIFF
--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -1,17 +1,9 @@
 use crate::num::{IntErrorKind, TryFromIntError};
 
-mod private {
-    /// This trait being unreachable from outside the crate
-    /// prevents other implementations of the `FloatToInt` trait,
-    /// which allows potentially adding more trait methods after the trait is `#[stable]`.
-    #[unstable(feature = "convert_float_to_int", issue = "67057")]
-    pub trait Sealed {}
-}
-
 /// Supporting trait for inherent methods of `f32` and `f64` such as `to_int_unchecked`.
 /// Typically doesn’t need to be used directly.
 #[unstable(feature = "convert_float_to_int", issue = "67057")]
-pub trait FloatToInt<Int>: private::Sealed + Sized {
+pub impl(self) trait FloatToInt<Int>: Sized {
     #[unstable(feature = "convert_float_to_int", issue = "67057")]
     #[doc(hidden)]
     unsafe fn to_int_unchecked(self) -> Int;
@@ -19,8 +11,6 @@ pub trait FloatToInt<Int>: private::Sealed + Sized {
 
 macro_rules! impl_float_to_int {
     ($Float:ty => $($Int:ty),+) => {
-        #[unstable(feature = "convert_float_to_int", issue = "67057")]
-        impl private::Sealed for $Float {}
         $(
             #[unstable(feature = "convert_float_to_int", issue = "67057")]
             impl FloatToInt<$Int> for $Float {

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -279,26 +279,6 @@ const impl<'f> Drop for VaList<'f> {
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-
-    impl Sealed for i16 {}
-    impl Sealed for i32 {}
-    impl Sealed for i64 {}
-    impl Sealed for isize {}
-
-    impl Sealed for u16 {}
-    impl Sealed for u32 {}
-    impl Sealed for u64 {}
-    impl Sealed for usize {}
-
-    impl Sealed for f32 {}
-    impl Sealed for f64 {}
-
-    impl<T> Sealed for *mut T {}
-    impl<T> Sealed for *const T {}
-}
-
 /// Types that are valid to read using [`VaList::next_arg`].
 ///
 /// This trait is implemented for primitive types that have a variable argument application-binary
@@ -333,7 +313,7 @@ mod sealed {
 // types with an alignment larger than 8, or with a non-scalar layout. Inline assembly can be used
 // to accept unsupported types in the meantime.
 #[lang = "va_arg_safe"]
-pub unsafe trait VaArgSafe: Copy + sealed::Sealed {}
+pub impl(self) unsafe trait VaArgSafe: Copy {}
 
 crate::cfg_select! {
     any(target_arch = "avr", target_arch = "msp430") => {

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -110,7 +110,6 @@
 #![feature(offset_of_enum)]
 #![feature(panic_internals)]
 #![feature(pattern_type_macro)]
-#![feature(sealed)]
 #![feature(ub_checks)]
 // tidy-alphabetical-end
 //
@@ -141,6 +140,7 @@
 #![feature(freeze_impls)]
 #![feature(fundamental)]
 #![feature(funnel_shifts)]
+#![feature(impl_restriction)]
 #![feature(intra_doc_pointers)]
 #![feature(intrinsics)]
 #![feature(lang_items)]
@@ -216,14 +216,6 @@ pub use crate::macros::{assert_matches, debug_assert_matches};
 pub mod from {
     #[unstable(feature = "derive_from", issue = "144889")]
     pub use crate::macros::builtin::From;
-}
-
-mod sealed {
-    /// This trait being unreachable from outside the crate
-    /// prevents outside implementations of our extension traits.
-    /// This allows adding more trait methods in the future.
-    #[unstable(feature = "sealed", issue = "none")]
-    pub trait Sealed {}
 }
 
 // We don't export this through #[macro_export] for now, to avoid breakage.

--- a/library/core/src/marker/variance.rs
+++ b/library/core/src/marker/variance.rs
@@ -30,7 +30,7 @@ macro_rules! phantom_type {
             }
         }
 
-        impl<T> self::sealed::Sealed for $name<T> where T: ?Sized {
+        impl<T> self::private_items::PrivateItems for $name<T> where T: ?Sized {
             const VALUE: Self = Self::new();
         }
         impl<T> Variance for $name<T> where T: ?Sized {}
@@ -114,7 +114,7 @@ macro_rules! phantom_lifetime {
             }
         }
 
-        impl self::sealed::Sealed for $name<'_> {
+        impl self::private_items::PrivateItems for $name<'_> {
             const VALUE: Self = Self::new();
         }
         impl Variance for $name<'_> {}
@@ -233,14 +233,14 @@ phantom_type! {
     pub struct PhantomInvariant<T>(PhantomData<fn(T) -> T>);
 }
 
-mod sealed {
-    pub trait Sealed {
+mod private_items {
+    pub trait PrivateItems {
         const VALUE: Self;
     }
 }
 
 /// A marker trait for phantom variance types.
-pub trait Variance: sealed::Sealed + Default {}
+pub trait Variance: private_items::PrivateItems + Default {}
 
 /// Construct a variance marker; equivalent to [`Default::default`].
 ///

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1848,12 +1848,3 @@ macro_rules! from_str_int_impl {
 
 from_str_int_impl! { signed isize i8 i16 i32 i64 i128 }
 from_str_int_impl! { unsigned usize u8 u16 u32 u64 u128 }
-
-macro_rules! impl_sealed {
-    ($($t:ty)*) => {$(
-        /// Allows extension traits within `core`.
-        #[unstable(feature = "sealed", issue = "none")]
-        impl crate::sealed::Sealed for $t {}
-    )*}
-}
-impl_sealed! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -31,30 +31,14 @@ use crate::{fmt, intrinsics, ptr, ub_checks};
     reason = "implementation detail which may disappear or be replaced at any time",
     issue = "none"
 )]
-pub unsafe trait ZeroablePrimitive: Sized + Copy + private::Sealed {
+pub impl(self) unsafe trait ZeroablePrimitive: Sized + Copy {
     /// A type like `Self` but with a niche that includes zero.
     type NonZeroInner: Sized + Copy;
 }
 
 macro_rules! impl_zeroable_primitive {
     ($($NonZeroInner:ident ( $primitive:ty )),+ $(,)?) => {
-        mod private {
-            #[unstable(
-                feature = "nonzero_internals",
-                reason = "implementation detail which may disappear or be replaced at any time",
-                issue = "none"
-            )]
-            pub trait Sealed {}
-        }
-
         $(
-            #[unstable(
-                feature = "nonzero_internals",
-                reason = "implementation detail which may disappear or be replaced at any time",
-                issue = "none"
-            )]
-            impl private::Sealed for $primitive {}
-
             #[unstable(
                 feature = "nonzero_internals",
                 reason = "implementation detail which may disappear or be replaced at any time",

--- a/library/core/src/num/traits.rs
+++ b/library/core/src/num/traits.rs
@@ -4,7 +4,7 @@
 /// Trait for types that this type can be truncated to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
 #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
-pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
+pub impl(self) const trait TruncateTarget<Target> {
     #[doc(hidden)]
     fn internal_truncate(self) -> Target;
 
@@ -18,7 +18,7 @@ pub const trait TruncateTarget<Target>: crate::sealed::Sealed {
 /// Trait for types that this type can be widened to
 #[unstable(feature = "num_internals", reason = "internal implementation detail", issue = "none")]
 #[rustc_const_unstable(feature = "integer_widen_truncate", issue = "154330")]
-pub const trait WidenTarget<Target>: crate::sealed::Sealed {
+pub impl(self) const trait WidenTarget<Target> {
     #[doc(hidden)]
     fn internal_widen(self) -> Target;
 }

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -102,46 +102,6 @@ const unsafe fn get_offset_len_mut_noubcheck<T>(
     crate::intrinsics::aggregate_raw_ptr(ptr, len)
 }
 
-mod private_slice_index {
-    use super::{ops, range};
-
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    pub trait Sealed {}
-
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for usize {}
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for ops::Range<usize> {}
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for ops::RangeTo<usize> {}
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for ops::RangeFrom<usize> {}
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for ops::RangeFull {}
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for ops::RangeInclusive<usize> {}
-    #[stable(feature = "slice_get_slice", since = "1.28.0")]
-    impl Sealed for ops::RangeToInclusive<usize> {}
-    #[stable(feature = "slice_index_with_ops_bound_pair", since = "1.53.0")]
-    impl Sealed for (ops::Bound<usize>, ops::Bound<usize>) {}
-
-    #[stable(feature = "new_range_api", since = "1.96.0")]
-    impl Sealed for range::Range<usize> {}
-    #[stable(feature = "new_range_inclusive_api", since = "1.95.0")]
-    impl Sealed for range::RangeInclusive<usize> {}
-    #[stable(feature = "new_range_to_inclusive_api", since = "1.96.0")]
-    impl Sealed for range::RangeToInclusive<usize> {}
-    #[stable(feature = "new_range_from_api", since = "1.96.0")]
-    impl Sealed for range::RangeFrom<usize> {}
-
-    impl Sealed for ops::IndexRange {}
-
-    #[unstable(feature = "sliceindex_wrappers", issue = "146179")]
-    impl Sealed for crate::index::Last {}
-    #[unstable(feature = "sliceindex_wrappers", issue = "146179")]
-    impl<T> Sealed for crate::index::Clamp<T> where T: Sealed {}
-}
-
 /// A helper trait used for indexing operations.
 ///
 /// Implementations of this trait have to promise that if the argument
@@ -160,7 +120,7 @@ mod private_slice_index {
     label = "slice indices are of type `usize` or ranges of `usize`"
 )]
 #[rustc_const_unstable(feature = "const_index", issue = "143775")]
-pub const unsafe trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
+pub impl(crate) const unsafe trait SliceIndex<T: ?Sized> {
     /// The output type returned by methods.
     #[stable(feature = "slice_get_slice", since = "1.28.0")]
     type Output: ?Sized;

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -5740,24 +5740,6 @@ impl fmt::Display for GetDisjointMutError {
     }
 }
 
-mod private_get_disjoint_mut_index {
-    use super::{Range, RangeInclusive, range};
-
-    #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-    pub trait Sealed {}
-
-    #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-    impl Sealed for usize {}
-    #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-    impl Sealed for Range<usize> {}
-    #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-    impl Sealed for RangeInclusive<usize> {}
-    #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-    impl Sealed for range::Range<usize> {}
-    #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-    impl Sealed for range::RangeInclusive<usize> {}
-}
-
 /// A helper trait for `<[T]>::get_disjoint_mut()`.
 ///
 /// # Safety
@@ -5765,9 +5747,7 @@ mod private_get_disjoint_mut_index {
 /// If `is_in_bounds()` returns `true` and `is_overlapping()` returns `false`,
 /// it must be safe to index the slice with the indices.
 #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
-pub unsafe trait GetDisjointMutIndex:
-    Clone + private_get_disjoint_mut_index::Sealed
-{
+pub impl(self) unsafe trait GetDisjointMutIndex: Clone {
     /// Returns `true` if `self` is in bounds for `len` slice elements.
     #[unstable(feature = "get_disjoint_mut_helpers", issue = "none")]
     fn is_in_bounds(&self, len: usize) -> bool;

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -257,8 +257,6 @@ use crate::{fmt, intrinsics};
 )]
 #[expect(missing_debug_implementations)]
 mod private {
-    pub(super) trait Sealed {}
-
     #[cfg(target_has_atomic_load_store = "8")]
     #[repr(C, align(1))]
     pub struct Align1<T>(T);
@@ -291,8 +289,7 @@ mod private {
     reason = "implementation detail which may disappear or be replaced at any time",
     issue = "none"
 )]
-#[expect(private_bounds)]
-pub unsafe trait AtomicPrimitive: Sized + Copy + private::Sealed {
+pub impl(self) unsafe trait AtomicPrimitive: Sized + Copy {
     /// Temporary implementation detail.
     type Storage: Sized;
 }
@@ -300,8 +297,6 @@ pub unsafe trait AtomicPrimitive: Sized + Copy + private::Sealed {
 macro impl_atomic_primitive(
     [$($T:ident)?] $Primitive:ty as $Storage:ident<$Operand:ty>, size($size:literal)
 ) {
-    impl $(<$T>)? private::Sealed for $Primitive {}
-
     #[unstable(
         feature = "atomic_internals",
         reason = "implementation detail which may disappear or be replaced at any time",

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -94,10 +94,6 @@ pub struct OsString {
     inner: Buf,
 }
 
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for OsString {}
-
 /// Borrowed reference to an OS string (see [`OsString`]).
 ///
 /// This type represents a borrowed reference to a string in the operating system's preferred
@@ -119,10 +115,6 @@ impl crate::sealed::Sealed for OsString {}
 pub struct OsStr {
     inner: Slice,
 }
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for OsStr {}
 
 impl OsString {
     /// Constructs a new empty `OsString`.

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -44,7 +44,6 @@ mod tests;
 use crate::ffi::OsString;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write};
 use crate::path::{Path, PathBuf};
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner, fs as fs_imp};
 use crate::time::SystemTime;
 use crate::{error, fmt};
@@ -2189,10 +2188,6 @@ impl AsInnerMut<fs_imp::FileTimes> for FileTimes {
         &mut self.0
     }
 }
-
-// For implementing OS extension traits in `std::os`
-#[stable(feature = "file_set_times", since = "1.75.0")]
-impl Sealed for FileTimes {}
 
 impl Permissions {
     /// Returns `true` if these permissions describe a readonly (unwritable) file.

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1195,7 +1195,7 @@ pub(crate) fn attempt_print_to_stderr(args: fmt::Arguments<'_>) {
 
 /// Trait to determine if a descriptor/handle refers to a terminal/tty.
 #[stable(feature = "is_terminal", since = "1.70.0")]
-pub trait IsTerminal: crate::sealed::Sealed {
+pub impl(crate) trait IsTerminal {
     /// Returns `true` if the descriptor/handle refers to a terminal/tty.
     ///
     /// On platforms where Rust does not know how to detect a terminal yet, this will return
@@ -1250,9 +1250,6 @@ pub trait IsTerminal: crate::sealed::Sealed {
 
 macro_rules! impl_is_terminal {
     ($($t:ty),*$(,)?) => {$(
-        #[unstable(feature = "sealed", issue = "none")]
-        impl crate::sealed::Sealed for $t {}
-
         #[stable(feature = "is_terminal", since = "1.70.0")]
         impl IsTerminal for $t {
             #[inline]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -290,6 +290,7 @@
 #![feature(f128)]
 #![feature(ffi_const)]
 #![feature(gpu_offload)]
+#![feature(impl_restriction)]
 #![feature(intra_doc_pointers)]
 #![feature(lang_items)]
 #![feature(link_cfg)]
@@ -785,6 +786,8 @@ include!("keyword_docs.rs");
 #[unstable(feature = "restricted_std", issue = "none")]
 mod __restricted_std_workaround {}
 
+// FIXME(jhpratt) This is currently only used by portable SIMD. Once rust-lang/portable-simd#529 is
+// merged, this should be able to be removed.
 mod sealed {
     /// This trait being unreachable from outside the crate
     /// prevents outside implementations of our extension traits.

--- a/library/std/src/os/darwin/fs.rs
+++ b/library/std/src/os/darwin/fs.rs
@@ -4,7 +4,6 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::{self, Metadata};
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, AsInnerMut, IntoInner};
 use crate::time::SystemTime;
 
@@ -157,7 +156,7 @@ impl MetadataExt for Metadata {
 
 /// OS-specific extensions to [`fs::FileTimes`].
 #[stable(feature = "file_set_times", since = "1.75.0")]
-pub trait FileTimesExt: Sealed {
+pub impl(self) trait FileTimesExt {
     /// Set the creation time of a file.
     #[stable(feature = "file_set_times", since = "1.75.0")]
     fn set_created(self, t: SystemTime) -> Self;

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -237,9 +237,6 @@ impl fmt::Debug for OwnedFd {
 
 macro_rules! impl_is_terminal {
     ($($t:ty),*$(,)?) => {$(
-        #[unstable(feature = "sealed", issue = "none")]
-        impl crate::sealed::Sealed for $t {}
-
         #[stable(feature = "is_terminal", since = "1.70.0")]
         impl io::IsTerminal for $t {
             #[inline]

--- a/library/std/src/os/freebsd/net.rs
+++ b/library/std/src/os/freebsd/net.rs
@@ -5,7 +5,6 @@
 use crate::ffi::CStr;
 use crate::io;
 use crate::os::unix::net;
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 
 /// FreeBSD-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
@@ -14,7 +13,7 @@ use crate::sys::AsInner;
 /// [`UnixDatagram`]: net::UnixDatagram
 /// [`UnixStream`]: net::UnixStream
 #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
-pub trait UnixSocketExt: Sealed {
+pub impl(self) trait UnixSocketExt {
     /// Query the current setting of socket option `LOCAL_CREDS_PERSISTENT`.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     fn local_creds_persistent(&self) -> io::Result<bool>;

--- a/library/std/src/os/illumos/net.rs
+++ b/library/std/src/os/illumos/net.rs
@@ -4,7 +4,6 @@
 
 use crate::io;
 use crate::os::unix::net;
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 
 /// illumos-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
@@ -13,7 +12,7 @@ use crate::sys::AsInner;
 /// [`UnixDatagram`]: net::UnixDatagram
 /// [`UnixStream`]: net::UnixStream
 #[unstable(feature = "unix_socket_exclbind", issue = "123481")]
-pub trait UnixSocketExt: Sealed {
+pub impl(self) trait UnixSocketExt {
     /// Enables exclusive binding on the socket.
     ///
     /// If true and if the socket had been set with `SO_REUSEADDR`,

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -7,7 +7,6 @@
 use crate::io::Result;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::process::{self, ExitStatus};
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner};
 #[cfg(not(doc))]
 use crate::sys::{fd::FileDesc, linux::pidfd::PidFd as InnerPidFd};
@@ -147,7 +146,7 @@ impl From<PidFd> for OwnedFd {
 /// Os-specific extensions for [`Child`]
 ///
 /// [`Child`]: process::Child
-pub trait ChildExt: Sealed {
+pub impl(crate) trait ChildExt {
     /// Obtains a reference to the [`PidFd`] created for this [`Child`], if available.
     ///
     /// A pidfd will only be available if its creation was requested with
@@ -186,7 +185,7 @@ pub trait ChildExt: Sealed {
 /// Os-specific extensions for [`Command`]
 ///
 /// [`Command`]: process::Command
-pub trait CommandExt: Sealed {
+pub impl(self) trait CommandExt {
     /// Sets whether a [`PidFd`](struct@PidFd) should be created for the [`Child`]
     /// spawned by this [`Command`].
     /// By default, no pidfd will be created.

--- a/library/std/src/os/motor/ffi.rs
+++ b/library/std/src/os/motor/ffi.rs
@@ -2,14 +2,13 @@
 #![unstable(feature = "motor_ext", issue = "147456")]
 
 use crate::ffi::{OsStr, OsString};
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, IntoInner};
 
 /// Motor OS–specific extensions to [`OsString`].
 ///
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
-pub trait OsStringExt: Sealed {
+pub impl(self) trait OsStringExt {
     /// Yields the underlying UTF-8 string of this [`OsString`].
     ///
     /// OS strings on Motor OS are guaranteed to be UTF-8, so are just strings.
@@ -27,7 +26,7 @@ impl OsStringExt for OsString {
 ///
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
-pub trait OsStrExt: Sealed {
+pub impl(self) trait OsStrExt {
     /// Gets the underlying UTF-8 string view of the [`OsStr`] slice.
     ///
     /// OS strings on Motor OS are guaranteed to be UTF-8, so are just strings.

--- a/library/std/src/os/motor/process.rs
+++ b/library/std/src/os/motor/process.rs
@@ -1,9 +1,8 @@
 #![unstable(feature = "motor_ext", issue = "147456")]
 
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 
-pub trait ChildExt: Sealed {
+pub impl(self) trait ChildExt {
     /// Extracts the main thread raw handle, without taking ownership
     fn sys_handle(&self) -> u64;
 }

--- a/library/std/src/os/net/linux_ext/addr.rs
+++ b/library/std/src/os/net/linux_ext/addr.rs
@@ -1,11 +1,10 @@
 //! Linux and Android-specific extensions to socket addresses.
 
 use crate::os::unix::net::SocketAddr;
-use crate::sealed::Sealed;
 
 /// Platform-specific extensions to [`SocketAddr`].
 #[stable(feature = "unix_socket_abstract", since = "1.70.0")]
-pub trait SocketAddrExt: Sealed {
+pub impl(in crate::os) trait SocketAddrExt {
     /// Creates a Unix socket address in the abstract namespace.
     ///
     /// The abstract namespace is a Linux-specific extension that allows Unix

--- a/library/std/src/os/net/linux_ext/socket.rs
+++ b/library/std/src/os/net/linux_ext/socket.rs
@@ -2,7 +2,6 @@
 
 use crate::io;
 use crate::os::unix::net;
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 
 /// Linux-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
@@ -11,7 +10,7 @@ use crate::sys::AsInner;
 /// [`UnixDatagram`]: net::UnixDatagram
 /// [`UnixStream`]: net::UnixStream
 #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
-pub trait UnixSocketExt: Sealed {
+pub impl(self) trait UnixSocketExt {
     /// Query the current setting of socket option `SO_PASSCRED`.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     fn passcred(&self) -> io::Result<bool>;

--- a/library/std/src/os/net/linux_ext/tcp.rs
+++ b/library/std/src/os/net/linux_ext/tcp.rs
@@ -2,7 +2,6 @@
 //!
 //! [`std::net`]: crate::net
 
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 #[cfg(target_os = "linux")]
 use crate::time::Duration;
@@ -12,7 +11,7 @@ use crate::{io, net};
 ///
 /// [`TcpStream`]: net::TcpStream
 #[stable(feature = "tcp_quickack", since = "1.89.0")]
-pub trait TcpStreamExt: Sealed {
+pub impl(self) trait TcpStreamExt {
     /// Enable or disable `TCP_QUICKACK`.
     ///
     /// This flag causes Linux to eagerly send ACKs rather than delaying them.
@@ -108,9 +107,6 @@ pub trait TcpStreamExt: Sealed {
     #[cfg(target_os = "linux")]
     fn deferaccept(&self) -> io::Result<Duration>;
 }
-
-#[stable(feature = "tcp_quickack", since = "1.89.0")]
-impl Sealed for net::TcpStream {}
 
 #[stable(feature = "tcp_quickack", since = "1.89.0")]
 impl TcpStreamExt for net::TcpStream {

--- a/library/std/src/os/netbsd/net.rs
+++ b/library/std/src/os/netbsd/net.rs
@@ -5,7 +5,6 @@
 use crate::ffi::CStr;
 use crate::io;
 use crate::os::unix::net;
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 
 /// NetBSD-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
@@ -14,7 +13,7 @@ use crate::sys::AsInner;
 /// [`UnixDatagram`]: net::UnixDatagram
 /// [`UnixStream`]: net::UnixStream
 #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
-pub trait UnixSocketExt: Sealed {
+pub impl(self) trait UnixSocketExt {
     /// Query the current setting of socket option `LOCAL_CREDS`.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     fn local_creds(&self) -> io::Result<bool>;

--- a/library/std/src/os/solaris/net.rs
+++ b/library/std/src/os/solaris/net.rs
@@ -4,7 +4,6 @@
 
 use crate::io;
 use crate::os::unix::net;
-use crate::sealed::Sealed;
 use crate::sys::AsInner;
 
 /// solaris-specific functionality for `AF_UNIX` sockets [`UnixDatagram`]
@@ -13,7 +12,7 @@ use crate::sys::AsInner;
 /// [`UnixDatagram`]: net::UnixDatagram
 /// [`UnixStream`]: net::UnixStream
 #[unstable(feature = "unix_socket_exclbind", issue = "123481")]
-pub trait UnixSocketExt: Sealed {
+pub impl(self) trait UnixSocketExt {
     /// Enables exclusive binding on the socket.
     ///
     /// If true and if the socket had been set with `SO_REUSEADDR`,

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -180,9 +180,6 @@ impl fmt::Debug for OwnedFd {
 
 macro_rules! impl_is_terminal {
     ($($t:ty),*$(,)?) => {$(
-        #[unstable(feature = "sealed", issue = "none")]
-        impl crate::sealed::Sealed for $t {}
-
         #[stable(feature = "is_terminal", since = "1.70.0")]
         impl io::IsTerminal for $t {
             #[inline]

--- a/library/std/src/os/unix/ffi/os_str.rs
+++ b/library/std/src/os/unix/ffi/os_str.rs
@@ -1,6 +1,5 @@
 use crate::ffi::{OsStr, OsString};
 use crate::mem;
-use crate::sealed::Sealed;
 use crate::sys::os_str::Buf;
 use crate::sys::{AsInner, FromInner, IntoInner};
 
@@ -12,7 +11,7 @@ use crate::sys::{AsInner, FromInner, IntoInner};
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStringExt: Sealed {
+pub impl(self) trait OsStringExt {
     /// Creates an [`OsString`] from a byte vector.
     ///
     /// See the module documentation for an example.
@@ -43,7 +42,7 @@ impl OsStringExt for OsString {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStrExt: Sealed {
+pub impl(self) trait OsStrExt {
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Creates an [`OsStr`] from a byte slice.
     ///

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -14,7 +14,6 @@ use crate::fs::{self, OpenOptions, Permissions};
 use crate::io::BorrowedCursor;
 use crate::os::unix::io::{AsFd, AsRawFd};
 use crate::path::Path;
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, AsInnerMut, FromInner};
 use crate::{io, sys};
 
@@ -1011,7 +1010,7 @@ impl DirEntryExt for fs::DirEntry {
 
 /// Sealed Unix-specific extension methods for [`fs::DirEntry`].
 #[unstable(feature = "dir_entry_ext2", issue = "85573")]
-pub trait DirEntryExt2: Sealed {
+pub impl(self) trait DirEntryExt2 {
     /// Returns a reference to the underlying `OsStr` of this entry's filename.
     ///
     /// # Examples
@@ -1034,10 +1033,6 @@ pub trait DirEntryExt2: Sealed {
     /// ```
     fn file_name_ref(&self) -> &OsStr;
 }
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl Sealed for fs::DirEntry {}
 
 #[unstable(feature = "dir_entry_ext2", issue = "85573")]
 impl DirEntryExt2 for fs::DirEntry {

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -103,7 +103,7 @@ use crate::sys::cvt;
 mod tests;
 
 #[unstable(feature = "stdio_swap", issue = "150667")]
-pub trait StdioExt: crate::sealed::Sealed {
+pub impl(self) trait StdioExt {
     /// Redirects the stdio file descriptor to point to the file description underpinning `fd`.
     ///
     /// Rust std::io write buffers (if any) are flushed, but other runtimes

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -4,7 +4,6 @@ use crate::ffi::OsStr;
 use crate::os::net::linux_ext;
 use crate::os::unix::ffi::OsStrExt;
 use crate::path::Path;
-use crate::sealed::Sealed;
 use crate::sys::cvt;
 use crate::{fmt, io, mem, ptr};
 
@@ -252,9 +251,6 @@ impl SocketAddr {
         }
     }
 }
-
-#[stable(feature = "unix_socket_abstract", since = "1.70.0")]
-impl Sealed for SocketAddr {}
 
 #[doc(cfg(any(target_os = "android", target_os = "linux", target_os = "cygwin")))]
 #[cfg(any(doc, target_os = "android", target_os = "linux", target_os = "cygwin"))]

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -21,7 +21,6 @@ use crate::io::{IoSlice, IoSliceMut};
 use crate::net::Shutdown;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::path::Path;
-use crate::sealed::Sealed;
 use crate::sys::net::Socket;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt};
 use crate::time::Duration;
@@ -59,10 +58,6 @@ const MSG_NOSIGNAL: core::ffi::c_int = 0x0;
 /// ```
 #[stable(feature = "unix_socket", since = "1.10.0")]
 pub struct UnixDatagram(Socket);
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl Sealed for UnixDatagram {}
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl fmt::Debug for UnixDatagram {

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -35,7 +35,6 @@ use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::Shutdown;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::path::Path;
-use crate::sealed::Sealed;
 use crate::sys::net::Socket;
 use crate::sys::{AsInner, FromInner, cvt};
 use crate::time::Duration;
@@ -72,10 +71,6 @@ use crate::time::Duration;
 /// In some cases getting a `SIGPIPE` would trigger process termination.
 #[stable(feature = "unix_socket", since = "1.10.0")]
 pub struct UnixStream(pub(super) Socket);
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl Sealed for UnixStream {}
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl fmt::Debug for UnixStream {

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -7,7 +7,6 @@
 use crate::ffi::OsStr;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::path::Path;
-use crate::sealed::Sealed;
 use crate::sys::process::ChildPipe;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::{io, process, sys};
@@ -35,7 +34,7 @@ cfg_select! {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait CommandExt: Sealed {
+pub impl(self) trait CommandExt {
     /// Sets the child process's user ID. This translates to a
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.
@@ -291,7 +290,7 @@ impl CommandExt for process::Command {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait ExitStatusExt: Sealed {
+pub impl(self) trait ExitStatusExt {
     /// Creates a new `ExitStatus` or `ExitStatusError` from the raw underlying integer status
     /// value from `wait`
     ///
@@ -393,7 +392,7 @@ impl ExitStatusExt for process::ExitStatusError {
 }
 
 #[unstable(feature = "unix_send_signal", issue = "141975")]
-pub trait ChildExt: Sealed {
+pub impl(self) trait ChildExt {
     /// Sends a signal to a child process.
     ///
     /// # Errors

--- a/library/std/src/os/windows/ffi.rs
+++ b/library/std/src/os/windows/ffi.rs
@@ -58,7 +58,6 @@ use alloc::wtf8::Wtf8Buf;
 use crate::ffi::{OsStr, OsString};
 use crate::fmt;
 use crate::iter::FusedIterator;
-use crate::sealed::Sealed;
 use crate::sys::os_str::Buf;
 use crate::sys::{AsInner, FromInner};
 
@@ -67,7 +66,7 @@ use crate::sys::{AsInner, FromInner};
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStringExt: Sealed {
+pub impl(self) trait OsStringExt {
     /// Creates an `OsString` from a potentially ill-formed UTF-16 slice of
     /// 16-bit code units.
     ///
@@ -101,7 +100,7 @@ impl OsStringExt for OsString {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStrExt: Sealed {
+pub impl(self) trait OsStrExt {
     /// Re-encodes an `OsStr` as a wide character sequence, i.e., potentially
     /// ill-formed UTF-16.
     ///

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -7,7 +7,6 @@
 use crate::fs::{self, Metadata, OpenOptions, Permissions};
 use crate::io::BorrowedCursor;
 use crate::path::Path;
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::time::SystemTime;
 use crate::{io, sys};
@@ -338,7 +337,7 @@ impl OpenOptionsExt for OpenOptions {
 }
 
 #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
-pub trait OpenOptionsExt2: Sealed {
+pub impl(self) trait OpenOptionsExt2 {
     /// If set to `true`, prevent the "last access time" of the file from being changed.
     ///
     /// Default to `false`.
@@ -351,9 +350,6 @@ pub trait OpenOptionsExt2: Sealed {
     #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
     fn freeze_last_write_time(&mut self, freeze: bool) -> &mut Self;
 }
-
-#[unstable(feature = "sealed", issue = "none")]
-impl Sealed for OpenOptions {}
 
 #[unstable(feature = "windows_freeze_file_times", issue = "149715")]
 impl OpenOptionsExt2 for OpenOptions {
@@ -398,7 +394,7 @@ impl OpenOptionsExt2 for OpenOptions {
 /// assert_eq!(permissions.file_attributes(), new_file_attr);
 /// ```
 #[unstable(feature = "windows_permissions_ext", issue = "152956")]
-pub trait PermissionsExt: Sealed {
+pub impl(self) trait PermissionsExt {
     /// Returns the file attribute bits.
     #[unstable(feature = "windows_permissions_ext", issue = "152956")]
     fn file_attributes(&self) -> u32;
@@ -411,9 +407,6 @@ pub trait PermissionsExt: Sealed {
     #[unstable(feature = "windows_permissions_ext", issue = "152956")]
     fn from_file_attributes(mask: u32) -> Self;
 }
-
-#[unstable(feature = "windows_permissions_ext", issue = "152956")]
-impl Sealed for fs::Permissions {}
 
 #[unstable(feature = "windows_permissions_ext", issue = "152956")]
 impl PermissionsExt for fs::Permissions {
@@ -656,7 +649,7 @@ impl MetadataExt for Metadata {
 ///
 /// On Windows, a symbolic link knows whether it is a file or directory.
 #[stable(feature = "windows_file_type_ext", since = "1.64.0")]
-pub trait FileTypeExt: Sealed {
+pub impl(self) trait FileTypeExt {
     /// Returns `true` if this file type is a symbolic link that is also a directory.
     #[stable(feature = "windows_file_type_ext", since = "1.64.0")]
     fn is_symlink_dir(&self) -> bool;
@@ -664,9 +657,6 @@ pub trait FileTypeExt: Sealed {
     #[stable(feature = "windows_file_type_ext", since = "1.64.0")]
     fn is_symlink_file(&self) -> bool;
 }
-
-#[stable(feature = "windows_file_type_ext", since = "1.64.0")]
-impl Sealed for fs::FileType {}
 
 #[stable(feature = "windows_file_type_ext", since = "1.64.0")]
 impl FileTypeExt for fs::FileType {
@@ -680,7 +670,7 @@ impl FileTypeExt for fs::FileType {
 
 /// Windows-specific extensions to [`fs::FileTimes`].
 #[stable(feature = "file_set_times", since = "1.75.0")]
-pub trait FileTimesExt: Sealed {
+pub impl(self) trait FileTimesExt {
     /// Set the creation time of a file.
     #[stable(feature = "file_set_times", since = "1.75.0")]
     fn set_created(self, t: SystemTime) -> Self;

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -405,9 +405,6 @@ impl fmt::Debug for OwnedHandle {
 
 macro_rules! impl_is_terminal {
     ($($t:ty),*$(,)?) => {$(
-        #[unstable(feature = "sealed", issue = "none")]
-        impl crate::sealed::Sealed for $t {}
-
         #[stable(feature = "is_terminal", since = "1.70.0")]
         impl io::IsTerminal for $t {
             #[inline]

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -9,7 +9,6 @@ use crate::mem::MaybeUninit;
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
 };
-use crate::sealed::Sealed;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::{io, marker, process, ptr, sys};
 
@@ -153,7 +152,7 @@ impl From<OwnedHandle> for process::ChildStderr {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "exit_status_from", since = "1.12.0")]
-pub trait ExitStatusExt: Sealed {
+pub impl(self) trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `u32` return value of
     /// a process.
     #[stable(feature = "exit_status_from", since = "1.12.0")]
@@ -172,7 +171,7 @@ impl ExitStatusExt for process::ExitStatus {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
-pub trait CommandExt: Sealed {
+pub impl(self) trait CommandExt {
     /// Sets the [process creation flags][1] to be passed to `CreateProcess`.
     ///
     /// These will always be ORed with `CREATE_UNICODE_ENVIRONMENT`.
@@ -443,7 +442,7 @@ impl CommandExt for process::Command {
 }
 
 #[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
-pub trait ChildExt: Sealed {
+pub impl(self) trait ChildExt {
     /// Extracts the main thread raw handle, without taking ownership
     #[unstable(feature = "windows_process_extensions_main_thread_handle", issue = "96723")]
     fn main_thread_handle(&self) -> BorrowedHandle<'_>;
@@ -461,7 +460,7 @@ impl ChildExt for process::Child {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[unstable(feature = "windows_process_exit_code_from", issue = "111688")]
-pub trait ExitCodeExt: Sealed {
+pub impl(self) trait ExitCodeExt {
     /// Creates a new `ExitCode` from the raw underlying `u32` return value of
     /// a process.
     ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -256,10 +256,6 @@ pub struct Child {
     pub stderr: Option<ChildStderr>,
 }
 
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for Child {}
-
 impl AsInner<imp::Process> for Child {
     #[inline]
     fn as_inner(&self) -> &imp::Process {
@@ -596,10 +592,6 @@ impl fmt::Debug for ChildStderr {
 pub struct Command {
     inner: imp::Command,
 }
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for Command {}
 
 impl Command {
     /// Constructs a new `Command` for launching the program at
@@ -1893,10 +1885,6 @@ impl Default for ExitStatus {
     }
 }
 
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for ExitStatus {}
-
 impl ExitStatus {
     /// Was termination successful?  Returns a `Result`.
     ///
@@ -1998,10 +1986,6 @@ impl fmt::Display for ExitStatus {
         self.0.fmt(f)
     }
 }
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for ExitStatusError {}
 
 /// Describes the result of a process after it has failed
 ///
@@ -2170,10 +2154,6 @@ impl crate::error::Error for ExitStatusError {}
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 pub struct ExitCode(imp::ExitCode);
-
-/// Allows extension traits within `std`.
-#[unstable(feature = "sealed", issue = "none")]
-impl crate::sealed::Sealed for ExitCode {}
 
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 impl ExitCode {

--- a/library/std/src/sys/stdio/motor.rs
+++ b/library/std/src/sys/stdio/motor.rs
@@ -28,8 +28,6 @@ impl Stderr {
     }
 }
 
-impl crate::sealed::Sealed for Stdin {}
-
 impl crate::io::IsTerminal for Stdin {
     fn is_terminal(&self) -> bool {
         moto_rt::fs::is_terminal(moto_rt::FD_STDIN)

--- a/tests/ui/privacy/sealed-traits/auxiliary/private-trait-non-local-aux.rs
+++ b/tests/ui/privacy/sealed-traits/auxiliary/private-trait-non-local-aux.rs
@@ -1,0 +1,5 @@
+pub mod a {
+    mod b {
+        pub trait Sealed {}
+    }
+}

--- a/tests/ui/privacy/sealed-traits/private-trait-non-local.rs
+++ b/tests/ui/privacy/sealed-traits/private-trait-non-local.rs
@@ -1,4 +1,6 @@
-extern crate core;
-use core::slice::index::private_slice_index::Sealed; //~ ERROR module `index` is private
-fn main() {
-}
+//@ aux-build: private-trait-non-local-aux.rs
+
+extern crate private_trait_non_local_aux as aux;
+use aux::a::b::Sealed; //~ ERROR module `b` is private
+
+fn main() {}

--- a/tests/ui/privacy/sealed-traits/private-trait-non-local.stderr
+++ b/tests/ui/privacy/sealed-traits/private-trait-non-local.stderr
@@ -1,11 +1,16 @@
-error[E0603]: module `index` is private
-  --> $DIR/private-trait-non-local.rs:2:18
+error[E0603]: module `b` is private
+  --> $DIR/private-trait-non-local.rs:4:13
    |
-LL | use core::slice::index::private_slice_index::Sealed;
-   |                  ^^^^^ private module        ------ trait `Sealed` is not publicly re-exported
+LL | use aux::a::b::Sealed;
+   |             ^  ------ trait `Sealed` is not publicly re-exported
+   |             |
+   |             private module
    |
-note: the module `index` is defined here
-  --> $SRC_DIR/core/src/slice/mod.rs:LL:COL
+note: the module `b` is defined here
+  --> $DIR/auxiliary/private-trait-non-local-aux.rs:2:5
+   |
+LL |     mod b {
+   |     ^^^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This should all be quite self-explanatory. I've used the tightest module permitted by current implementation, which is overwhelmingly `self` as I had expected.

r? @Urgau