### PR TITLE
Don't suggest semicolon after if expression closing brace

### DIFF
--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -2051,7 +2051,10 @@ impl<'tcx> CoerceMany<'tcx> {
                     err.span_label(cond_expr.span, "expected this to be `()`");
                 }
                 if expr.can_have_side_effects() {
-                    fcx.suggest_semicolon_at_end(cond_expr.span, &mut err);
+                    // Don't suggest semicolon after if expressions as it does not fix the issue
+                    if !matches!(cond_expr.kind, hir::ExprKind::If(..)) {
+                        fcx.suggest_semicolon_at_end(cond_expr.span, &mut err);
+                    }
                 }
             }
         }

--- a/tests/ui/parser/expr-as-stmt-2.stderr
+++ b/tests/ui/parser/expr-as-stmt-2.stderr
@@ -136,10 +136,6 @@ help: parentheses are required to parse this as an expression
    |
 LL |     (if true { bar() } else { bar() }) && if true { bar() } else { bar() };
    |     +                                +
-help: consider using a semicolon here
-   |
-LL |     if true { bar() } else { bar() }; && if true { bar() } else { bar() };
-   |                                     +
 
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt-2.rs:24:30
@@ -154,46 +150,26 @@ help: parentheses are required to parse this as an expression
    |
 LL |     (if true { bar() } else { bar() }) && if true { bar() } else { bar() };
    |     +                                +
-help: consider using a semicolon here
-   |
-LL |     if true { bar() } else { bar() }; && if true { bar() } else { bar() };
-   |                                     +
 
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt-2.rs:27:15
    |
 LL |     if true { bar() } else { bar() } if true { bar() } else { bar() };
    |     ----------^^^^^-----------------
-   |     |         |
+   |     |         |    |
+   |     |         |    help: consider using a semicolon here: `;`
    |     |         expected `()`, found `bool`
    |     expected this to be `()`
-   |
-help: consider using a semicolon here
-   |
-LL |     if true { bar(); } else { bar() } if true { bar() } else { bar() };
-   |                    +
-help: consider using a semicolon here
-   |
-LL |     if true { bar() } else { bar() }; if true { bar() } else { bar() };
-   |                                     +
 
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt-2.rs:27:30
    |
 LL |     if true { bar() } else { bar() } if true { bar() } else { bar() };
    |     -------------------------^^^^^--
-   |     |                        |
+   |     |                        |    |
+   |     |                        |    help: consider using a semicolon here: `;`
    |     |                        expected `()`, found `bool`
    |     expected this to be `()`
-   |
-help: consider using a semicolon here
-   |
-LL |     if true { bar() } else { bar(); } if true { bar() } else { bar() };
-   |                                   +
-help: consider using a semicolon here
-   |
-LL |     if true { bar() } else { bar() }; if true { bar() } else { bar() };
-   |                                     +
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/return/issue-82612-return-mutable-reference.stderr
+++ b/tests/ui/return/issue-82612-return-mutable-reference.stderr
@@ -14,10 +14,6 @@ help: consider using a semicolon here
    |
 LL |             value.get_or_insert_with(func);
    |                                           +
-help: consider using a semicolon here
-   |
-LL |         };
-   |          +
 help: you might have meant to return this value
    |
 LL |             return value.get_or_insert_with(func);

--- a/tests/ui/suggestions/try-operator-dont-suggest-semicolon.rs
+++ b/tests/ui/suggestions/try-operator-dont-suggest-semicolon.rs
@@ -18,7 +18,6 @@ fn main() -> Result<(), ()> {
         //~| NOTE: expected `()`, found integer
         //~| HELP: consider using a semicolon here
     }
-    //~^ HELP: consider using a semicolon here
 
     Ok(())
 }

--- a/tests/ui/suggestions/try-operator-dont-suggest-semicolon.stderr
+++ b/tests/ui/suggestions/try-operator-dont-suggest-semicolon.stderr
@@ -12,19 +12,12 @@ error[E0308]: mismatched types
 LL | /     if true {
 LL | |
 LL | |         x?
-   | |         ^^ expected `()`, found integer
+   | |         ^^- help: consider using a semicolon here: `;`
+   | |         |
+   | |         expected `()`, found integer
 ...  |
 LL | |     }
    | |_____- `if` expressions without `else` arms expect their inner expression to be `()`
-   |
-help: consider using a semicolon here
-   |
-LL |         x?;
-   |           +
-help: consider using a semicolon here
-   |
-LL |     };
-   |      +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/issue-112007-leaked-writeln-macro-internals.stderr
+++ b/tests/ui/typeck/issue-112007-leaked-writeln-macro-internals.stderr
@@ -12,10 +12,6 @@ LL | |     }
    |
    = note: expected unit type `()`
                    found enum `Result<(), std::fmt::Error>`
-help: consider using a semicolon here
-   |
-LL |     };
-   |      +
 help: you might have meant to return this value
    |
 LL |         return writeln!(w, "but not here");
@@ -42,10 +38,6 @@ LL | |     }
    = note: expected unit type `()`
                    found enum `Result<(), std::fmt::Error>`
    = note: this error originates in the macro `writeln` which comes from the expansion of the macro `baz` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider using a semicolon here
-   |
-LL |     };
-   |      +
 help: you might have meant to return this value
    |
 LL |         return baz!(w);

--- a/tests/ui/typeck/question-mark-operator-suggestion-span.stderr
+++ b/tests/ui/typeck/question-mark-operator-suggestion-span.stderr
@@ -12,10 +12,6 @@ LL | |     }
    |
    = note: expected unit type `()`
                    found enum `Result<(), std::fmt::Error>`
-help: consider using a semicolon here
-   |
-LL |     };
-   |      +
 help: you might have meant to return this value
    |
 LL |         return writeln!(w, "but not here");


### PR DESCRIPTION
When a type mismatch occurs inside an if expression, the compiler incorrectly suggests adding a semicolon after the closing brace. This doesn't fix the error. The fix excludes all if expressions from the suggest_semicolon_at_end suggestion in coercion.rs.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fix: rust-lang/rust#156621