### PR TITLE
rustdoc: optimize impl sorting

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -4,8 +4,7 @@
 //! various types in `rustdoc::clean`.
 //!
 //! These implementations all emit HTML. As an internal implementation detail,
-//! some of them support an alternate format that emits text, but that should
-//! not be used external to this module.
+//! some of them support an alternate format that emits plain text.
 
 use std::cmp::Ordering;
 use std::fmt::{self, Display, Write};

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -184,9 +184,9 @@ pub(crate) fn print_where_clause(
 
         let clause = if f.alternate() {
             if ending == Ending::Newline {
-                format!(" where{where_preds},")
+                format!(" where{where_preds:#},")
             } else {
-                format!(" where{where_preds}")
+                format!(" where{where_preds:#}")
             }
         } else {
             let mut br_with_padding = String::with_capacity(6 * indent + 28);

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -2324,7 +2324,9 @@ where
 
 #[derive(PartialEq, Eq)]
 struct ImplString {
-    rendered: String,
+    // Plain text (not HTML text) because this is only used for sorting purposes, and the plain
+    // text is much shorter and thus faster to compare.
+    cmp_text: String,
     is_negative: bool,
 }
 
@@ -2333,7 +2335,7 @@ impl ImplString {
         let impl_ = i.inner_impl();
         ImplString {
             is_negative: impl_.is_negative_trait_impl(),
-            rendered: format!("{}", print_impl(impl_, false, cx)),
+            cmp_text: format!("{:#}", print_impl(impl_, false, cx)),
         }
     }
 }
@@ -2350,7 +2352,7 @@ impl Ord for ImplString {
         match (self.is_negative, other.is_negative) {
             (false, true) => Ordering::Greater,
             (true, false) => Ordering::Less,
-            _ => compare_names(&self.rendered, &other.rendered),
+            _ => compare_names(&self.cmp_text, &other.cmp_text),
         }
     }
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -2327,16 +2327,12 @@ struct ImplString {
     // Plain text (not HTML text) because this is only used for sorting purposes, and the plain
     // text is much shorter and thus faster to compare.
     cmp_text: String,
-    is_negative: bool,
 }
 
 impl ImplString {
     fn new(i: &Impl, cx: &Context<'_>) -> ImplString {
         let impl_ = i.inner_impl();
-        ImplString {
-            is_negative: impl_.is_negative_trait_impl(),
-            cmp_text: format!("{:#}", print_impl(impl_, false, cx)),
-        }
+        ImplString { cmp_text: format!("{:#}", print_impl(impl_, false, cx)) }
     }
 }
 
@@ -2348,12 +2344,9 @@ impl PartialOrd for ImplString {
 
 impl Ord for ImplString {
     fn cmp(&self, other: &Self) -> Ordering {
-        // We sort negative impls first.
-        match (self.is_negative, other.is_negative) {
-            (false, true) => Ordering::Greater,
-            (true, false) => Ordering::Less,
-            _ => compare_names(&self.cmp_text, &other.cmp_text),
-        }
+        // Negative impls are naturally sorted first, because `impl !A` is less than `impl B` for
+        // any value of `B`, because `!` is less than any identifier-starting char.
+        compare_names(&self.cmp_text, &other.cmp_text)
     }
 }
 

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -730,8 +730,10 @@ impl TraitAliasPart {
                         None
                     } else {
                         let impl_ = imp.inner_impl();
+                        let print = print_impl(impl_, false, cx);
                         Some(Implementor {
-                            text: print_impl(impl_, false, cx).to_string(),
+                            text: format!("{}", print),
+                            cmp_text: format!("{:#}", print),
                             synthetic: imp.inner_impl().kind.is_auto(),
                             types: collect_paths_for_type(&imp.inner_impl().for_, cache),
                             is_negative: impl_.is_negative_trait_impl(),
@@ -759,7 +761,7 @@ impl TraitAliasPart {
                 match (a.is_negative, b.is_negative) {
                     (false, true) => Ordering::Greater,
                     (true, false) => Ordering::Less,
-                    _ => compare_names(&a.text, &b.text),
+                    _ => compare_names(&a.cmp_text, &b.cmp_text),
                 }
             });
 
@@ -777,7 +779,11 @@ impl TraitAliasPart {
 }
 
 struct Implementor {
+    // HTML text used in generated output.
     text: String,
+    // Plain text used just for sorting output. This is a performance win, because this plain text
+    // is much shorter than the HTML output and sorting is hot.
+    cmp_text: String,
     synthetic: bool,
     types: Vec<String>,
     is_negative: bool,

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -14,7 +14,6 @@
 //!    or contains "invocation-specific".
 
 use std::cell::RefCell;
-use std::cmp::Ordering;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{self, Write as _};
@@ -756,14 +755,9 @@ impl TraitAliasPart {
             path.push(format!("{remote_item_type}.{}.js", remote_path[remote_path.len() - 1]));
 
             let mut implementors = implementors.collect::<Vec<_>>();
-            implementors.sort_unstable_by(|a, b| {
-                // We sort negative impls first.
-                match (a.is_negative, b.is_negative) {
-                    (false, true) => Ordering::Greater,
-                    (true, false) => Ordering::Less,
-                    _ => compare_names(&a.cmp_text, &b.cmp_text),
-                }
-            });
+            // Negative impls are naturally sorted first, because `impl !A` is less than `impl B`
+            // for any value of `B`, because `!` is less than any identifier-starting char.
+            implementors.sort_unstable_by(|a, b| compare_names(&a.cmp_text, &b.cmp_text));
 
             let part = OrderedJson::array_unsorted(
                 implementors


### PR DESCRIPTION
Currently rustdoc sorts impls in a couple of places using long HTML string representations of the impls. Using plain text representations instead speeds things up. Details in individual commits.