### PR TITLE
Mark a test as binary for git

### DIFF
--- a/tests/ui/issues/.gitattributes
+++ b/tests/ui/issues/.gitattributes
@@ -1,1 +1,0 @@
-issue-16278.rs -text

--- a/tests/ui/lexer/.gitattributes
+++ b/tests/ui/lexer/.gitattributes
@@ -1,0 +1,1 @@
+crlf-in-byte-string-literal.rs -text


### PR DESCRIPTION
Otherwise git will keep changing the CRLF back to LF.

Regression from https://github.com/rust-lang/rust/pull/157176