### PR TITLE
Record & write back resolution of type-relative type-level paths in bodies

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -512,8 +512,12 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
         ty.ty_adt_def()
     }
 
-    fn record_ty(&self, _hir_id: hir::HirId, _ty: Ty<'tcx>, _span: Span) {
-        // There's no place to record types from signatures?
+    fn record_ty(&self, _: hir::HirId, _: Ty<'tcx>, _: Span) {
+        // There's no place to record types from signatures.
+    }
+
+    fn record_res(&self, _: HirId, _: Result<(DefKind, DefId), ErrorGuaranteed>) {
+        // FIXME(#156711): There's no place to record resolutions from signatures.
     }
 
     fn infcx(&self) -> Option<&InferCtxt<'tcx>> {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -218,6 +218,9 @@ pub trait HirTyLowerer<'tcx> {
     /// Record the lowered type of a HIR node in this context.
     fn record_ty(&self, hir_id: HirId, ty: Ty<'tcx>, span: Span);
 
+    /// Record the resolution of a type-dependent HIR node.
+    fn record_res(&self, hir_id: HirId, res: Result<(DefKind, DefId), ErrorGuaranteed>);
+
     /// The inference context of the lowering context if applicable.
     fn infcx(&self) -> Option<&InferCtxt<'tcx>>;
 
@@ -1338,7 +1341,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     // NOTE: When this function starts resolving `Trait::AssocTy` successfully
     // it should also start reporting the `BARE_TRAIT_OBJECTS` lint.
     #[instrument(level = "debug", skip_all, ret)]
-    pub fn lower_type_relative_ty_path(
+    fn lower_type_relative_ty_path(
         &self,
         self_ty: Ty<'tcx>,
         hir_self_ty: &'tcx hir::Ty<'tcx>,
@@ -1488,6 +1491,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 mode.assoc_tag(),
             )? {
+                self.record_res(qpath_hir_id, Ok((tcx.def_kind(did), did)));
                 return Ok(TypeRelativePath::AssocItem(did, args));
             }
         }
@@ -1589,6 +1593,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let assoc_item = self
             .probe_assoc_item(segment.ident, assoc_tag, qpath_hir_id, span, bound.def_id())
             .expect("failed to find associated item");
+
+        self.record_res(qpath_hir_id, Ok((assoc_item.kind.as_def_kind(), assoc_item.def_id)));
 
         Ok((assoc_item.def_id, bound))
     }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -228,15 +228,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    pub(crate) fn write_resolution(
-        &self,
-        hir_id: HirId,
-        r: Result<(DefKind, DefId), ErrorGuaranteed>,
-    ) {
-        self.typeck_results.borrow_mut().type_dependent_defs_mut().insert(hir_id, r);
-    }
-
-    #[instrument(level = "debug", skip(self))]
     pub(crate) fn write_method_call_and_enforce_effects(
         &self,
         hir_id: HirId,
@@ -244,7 +235,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         method: MethodCallee<'tcx>,
     ) {
         self.enforce_context_effects(Some(hir_id), span, method.def_id, method.args);
-        self.write_resolution(hir_id, Ok((DefKind::AssocFn, method.def_id)));
+        self.record_res(hir_id, Ok((DefKind::AssocFn, method.def_id)));
         self.write_args(hir_id, method.args);
     }
 
@@ -806,7 +797,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             });
 
         // Write back the new resolution.
-        self.write_resolution(hir_id, result);
+        self.record_res(hir_id, result);
         (
             result.map_or(Res::Err, |(kind, def_id)| Res::Def(kind, def_id)),
             Some(ty),

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1263,15 +1263,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> (Res, LoweredTy<'tcx>) {
         let ResolvedStructPath { res: result, ty } =
             self.lowerer().lower_path_for_struct_expr(*qpath, path_span, hir_id);
-        match *qpath {
+        match qpath {
             QPath::Resolved(_, path) => (path.res, LoweredTy::from_raw(self, path_span, ty)),
             QPath::TypeRelative(_, _) => {
                 let ty = LoweredTy::from_raw(self, path_span, ty);
+
+                // FIXME(fmease): Get rid of this. For some reason this is still
+                // necessary in some cases (e.g., pattern(!) `Self::X {}`). Note
+                // that we're currently double-registering certain resolutions.
                 let resolution =
                     result.map(|res: Res| (self.tcx().def_kind(res.def_id()), res.def_id()));
-
                 // Write back the new resolution.
-                self.write_resolution(hir_id, resolution);
+                self.record_res(hir_id, resolution);
 
                 (result.unwrap_or(Res::Err), ty)
             }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/mod.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 
 use rustc_errors::DiagCtxtHandle;
 use rustc_hir::attrs::{DivergingBlockBehavior, DivergingFallbackBehavior};
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, HirId, ItemLocalMap, find_attr};
 use rustc_hir_analysis::hir_ty_lowering::{
@@ -446,6 +447,11 @@ impl<'tcx> HirTyLowerer<'tcx> for FnCtxt<'_, 'tcx> {
             ty
         };
         self.write_ty(hir_id, ty)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn record_res(&self, hir_id: hir::HirId, res: Result<(DefKind, DefId), ErrorGuaranteed>) {
+        self.typeck_results.borrow_mut().type_dependent_defs_mut().insert(hir_id, res);
     }
 
     fn infcx(&self) -> Option<&infer::InferCtxt<'tcx>> {

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -347,6 +347,13 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
 
     fn visit_ty(&mut self, hir_ty: &'tcx hir::Ty<'tcx, AmbigArg>) {
         intravisit::walk_ty(self, hir_ty);
+        // HACK:
+        if let hir::TyKind::Path(hir::QPath::TypeRelative(..)) = hir_ty.kind
+            && let Some(def) =
+                self.fcx.typeck_results.borrow_mut().type_dependent_defs_mut().remove(hir_ty.hir_id)
+        {
+            self.typeck_results.type_dependent_defs_mut().insert(hir_ty.hir_id, def);
+        }
         // If there are type checking errors, Type privacy pass will stop,
         // so we may not get the type from hid_id, see #104513
         if let Some(ty) = self.fcx.node_ty_opt(hir_ty.hir_id) {

--- a/src/librustdoc/html/span_map.rs
+++ b/src/librustdoc/html/span_map.rs
@@ -268,9 +268,6 @@ impl<'tcx> Visitor<'tcx> for SpanMapVisitor<'tcx> {
     fn visit_qpath(&mut self, qpath: &QPath<'tcx>, id: HirId, _span: rustc_span::Span) {
         match *qpath {
             QPath::TypeRelative(qself, segment) => {
-                // FIXME: This doesn't work for paths in *types* since HIR ty lowering currently
-                //        doesn't write back the resolution of type-relative paths. Updating it to
-                //        do so should be a simple fix.
                 // FIXME: This obviously doesn't support item signatures / non-bodies. Sadly, rustc
                 //        currently doesn't keep around that information & thus can't provide an API
                 //        for it.

--- a/tests/rustdoc-html/jump-to-def/assoc-items.rs
+++ b/tests/rustdoc-html/jump-to-def/assoc-items.rs
@@ -38,18 +38,16 @@ fn expr<T: Trait0>() {
 
     //@ has - '//a[@href="#12"]' 'Ty0'
     let _: <T as Trait0>::Ty0;      // Expr, AssocTy,    Resolved
-    // FIXME: Support this:
-    //@ !has - '//a[@href="#13"]' 'Ty1'
+    //@ has - '//a[@href="#13"]' 'Ty1'
     let _: T::Ty1;                  // Expr, AssocTy,    TypeRelative
 
     //@ has - '//a[@href="#14"]' 'Ty2'
     //@ has - '//a[@href="#19"]' 'fn0'
     let _ = <T as Trait0>::Ty2::fn0();
 
-    // FIXME: Support this:
-    //@ !has - '//a[@href="#14"]' 'Ty3'
+    //@ has - '//a[@href="#15"]' 'Ty3'
     //@ has - '//a[@href="#20"]' 'CT0'
-    let _ = T::Ty2::CT0;
+    let _ = T::Ty3::CT0;
 }
 
 trait Trait1 {
@@ -62,11 +60,11 @@ trait Trait1 {
 
 
 fn pat() {
-    //@ has - '//a[@href="#56"]' 'CT0'
+    //@ has - '//a[@href="#54"]' 'CT0'
     if let <() as Trait1>::CT0 = 0 {}   // Pat,  AssocConst, Resolved
 
     match 0 {
-        //@ has - '//a[@href="#57"]' 'CT1'
+        //@ has - '//a[@href="#55"]' 'CT1'
         <() as Trait1>::CT1 => {}       // Pat,  AssocConst, Resolved
         _ => {}
     }
@@ -78,7 +76,7 @@ impl Trait1 for () {
     const CT2: usize = 2;
 
     fn scope() {
-        //@ has - '//a[@href="#58"]' 'CT2'
+        //@ has - '//a[@href="#56"]' 'CT2'
         if let Self::CT2 = 0 {}         // Pat,  AssocConst, TypeRelative
     }
 }
@@ -96,11 +94,11 @@ impl Trait2 for () {
 }
 
 struct Item<T: Trait2> {
-    //@ has - '//a[@href="#87"]' 'CT0'
+    //@ has - '//a[@href="#85"]' 'CT0'
     f0: [(); <() as Trait2>::CT0],   // Item, AssocConst, Resolved
-    //@ has - '//a[@href="#88"]' 'Ty0'
+    //@ has - '//a[@href="#86"]' 'Ty0'
     f1: <T as Trait2>::Ty0,          // Item, AssocTy,    Resolved
     // FIXME: Support this:
-    //@ !has - '//a[@href="#89"]' 'Ty1'
+    //@ !has - '//a[@href="#87"]' 'Ty1'
     f2: T::Ty1,                      // Item, AssocTy,    TypeRelative
 }


### PR DESCRIPTION
Record the type-dependent resolution of `TypeRelative` HIR paths in bodies that refer to type-level entities (associated types, type-level associated constants, RTN etc.) and write them back (i.e., persist them) to the `TypeckResults` of the containing body.

This was cobbled together rather quickly, this might need some restructuring.

TODO:

- [x] Perf-check this
- [ ] Avoid double-registering the resolution for type-relative type paths in struct lit exprs
- [ ] Self-audit write-back changes; the HACK is very sussy, we likely don't write back the res of gca & rtn thingies
- [ ] Add rustdoc LTD IAT test
- [ ] Register resolution of associated item bindings, too, and add rustdoc support to exercise it

cc @mu001999 (https://github.com/rust-lang/rust/pull/148654#issuecomment-4585869145)