### PR TITLE
mGCA: error on region vars lowering 

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2307,7 +2307,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // up as a region variable in mir borrowck. It would also be somewhat concerning if
             // hir typeck was using equality but mir borrowck wound up using subtyping as that could
             // result in a non-infer in hir typeck but a region variable in borrowck.
-            if tcx.features().generic_const_parameter_types()
+            if (tcx.features().generic_const_parameter_types()
+                || tcx.features().min_generic_const_args())
                 && (ty.has_free_regions() || ty.has_erased_regions())
             {
                 let e = self.dcx().span_err(

--- a/tests/ui/const-generics/mgca/region_vars_hashed.rs
+++ b/tests/ui/const-generics/mgca/region_vars_hashed.rs
@@ -1,0 +1,13 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/157147.
+//!
+//! It used to ICE when trying to process region vars in const arguments,
+//! Since it tries to hash intentionally un-hashable `ReVar` inference var.
+
+//@ compile-flags: --crate-type=lib
+//@ incremental
+#![feature(min_generic_const_args)]
+
+fn foo<const N: usize>() {
+    foo::<{ Some::<&u8> { 0: const { &0_u8 } } }>()
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+}

--- a/tests/ui/const-generics/mgca/region_vars_hashed.stderr
+++ b/tests/ui/const-generics/mgca/region_vars_hashed.stderr
@@ -1,0 +1,8 @@
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/region_vars_hashed.rs:11:30
+   |
+LL |     foo::<{ Some::<&u8> { 0: const { &0_u8 } } }>()
+   |                              ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157188)*
<!-- homu-ignore:end -->

This also needs to error on `min_generic_const_args` feature

cc @BoxyUwU (didn't r her as she is unavailable rn)

Fixes rust-lang/rust#157147