### PR TITLE
Fix ICE on standard constants in type constraints (min_generic_const_args)

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -468,16 +468,19 @@ impl<'a, 'b, 'tcx> TypeFolder<TyCtxt<'tcx>> for AssocTypeNormalizer<'a, 'b, 'tcx
         // if it was marked with `type const`. Using this attribute without the mgca
         // feature gate causes a parse error.
         let ct = match uv.kind {
-            ty::UnevaluatedConstKind::Projection { .. } => {
+            ty::UnevaluatedConstKind::Projection { .. } if tcx.is_type_const(uv.kind.def_id()) => {
                 self.normalize_trait_projection(uv.into()).expect_const()
             }
-            ty::UnevaluatedConstKind::Inherent { .. } => {
+            ty::UnevaluatedConstKind::Inherent { .. } if tcx.is_type_const(uv.kind.def_id()) => {
                 self.normalize_inherent_projection(uv.into()).expect_const()
             }
-            ty::UnevaluatedConstKind::Free { .. } => {
+            ty::UnevaluatedConstKind::Free { .. } if tcx.is_type_const(uv.kind.def_id()) => {
                 self.normalize_free_alias(uv.into()).expect_const()
             }
-            ty::UnevaluatedConstKind::Anon { .. } => {
+            ty::UnevaluatedConstKind::Anon { .. }
+            | ty::UnevaluatedConstKind::Projection { .. }
+            | ty::UnevaluatedConstKind::Inherent { .. }
+            | ty::UnevaluatedConstKind::Free { .. } => {
                 let ct = ct.super_fold_with(self);
                 super::with_replaced_escaping_bound_vars(
                     self.selcx.infcx,

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.next.stderr
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.next.stderr
@@ -15,19 +15,19 @@ LL |     let (mut arr, mut arr_with_weird_len): ([_; N], _) = free();
    |                                          +++++++++++++
 
 error[E0271]: type mismatch resolving `10 == 2`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:35:45
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:36:45
    |
 LL |     let (mut arr, mut arr_with_weird_len) = free();
    |                                             ^^^^^^ types differ
 
 error[E0284]: type annotations needed for `([(); _], [(); 10])`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:46:9
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:48:9
    |
 LL |     let (mut arr, mut arr_with_weird_len) = proj();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ------ type must be known at this point
    |
 note: required by a const generic parameter in `proj`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:41:9
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:43:9
    |
 LL | fn proj<const N: usize>() -> ([(); N], [(); <S as Trait>::PROJ::<N>]) {
    |         ^^^^^^^^^^^^^^ required by this const generic parameter in `proj`
@@ -37,7 +37,7 @@ LL |     let (mut arr, mut arr_with_weird_len): ([_; N], _) = proj();
    |                                          +++++++++++++
 
 error[E0271]: type mismatch resolving `10 == 2`
-  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:52:45
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:55:45
    |
 LL |     let (mut arr, mut arr_with_weird_len) = proj();
    |                                             ^^^^^^ types differ

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.old.stderr
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.old.stderr
@@ -6,5 +6,30 @@ LL | #![feature(generic_const_args)]
    |
    = help: enable all of these features
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:31:26
+   |
+LL |     arr_with_weird_len = [(); 10];
+   |                          ^^^^^^^^ expected an array with a size of FREE::<_>, found one with a size of 10
 
+error[E0308]: mismatched types
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:38:26
+   |
+LL |     arr_with_weird_len = [(); 2];
+   |                          ^^^^^^^ expected an array with a size of FREE::<_>, found one with a size of 2
+
+error[E0308]: mismatched types
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:50:26
+   |
+LL |     arr_with_weird_len = [(); 10];
+   |                          ^^^^^^^^ expected an array with a size of <S as Trait>::PROJ::<_>, found one with a size of 10
+
+error[E0308]: mismatched types
+  --> $DIR/ambiguous-on-failed-eval-with-vars-fail.rs:57:26
+   |
+LL |     arr_with_weird_len = [(); 2];
+   |                          ^^^^^^^ expected an array with a size of <S as Trait>::PROJ::<_>, found one with a size of 2
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.rs
+++ b/tests/ui/const-generics/gca/ambiguous-on-failed-eval-with-vars-fail.rs
@@ -29,12 +29,14 @@ fn test_free() {
     let (mut arr, mut arr_with_weird_len) = free();
     //[next]~^ ERROR type annotations needed
     arr_with_weird_len = [(); 10];
+    //[old]~^ ERROR mismatched types
 }
 
 fn test_free_mismatch() {
     let (mut arr, mut arr_with_weird_len) = free();
     //[next]~^ ERROR type mismatch resolving `10 == 2`
     arr_with_weird_len = [(); 2];
+    //[old]~^ ERROR mismatched types
     arr = [(); 10];
 }
 
@@ -46,12 +48,14 @@ fn test_proj() {
     let (mut arr, mut arr_with_weird_len) = proj();
     //[next]~^ ERROR type annotations needed
     arr_with_weird_len = [(); 10];
+    //[old]~^ ERROR mismatched types
 }
 
 fn test_proj_mismatch() {
     let (mut arr, mut arr_with_weird_len) = proj();
     //[next]~^ ERROR type mismatch resolving `10 == 2`
     arr_with_weird_len = [(); 2];
+    //[old]~^ ERROR mismatched types
     arr = [(); 10];
 }
 


### PR DESCRIPTION
This PR fixes an internal compiler error (ICE) where `tcx.def_kind` panics when attempting to resolve un-evaluated constant aliases whose parent definition is not a type const. 

By adding explicit `tcx.is_type_const(uv.def)` guards to `DefKind::AssocConst` and `DefKind::Const`, and explicitly capturing `DefKind::AnonConst | DefKind::Const { .. } | DefKind::AssocConst { .. }` in the fallback block, we ensure that constants without the `min_generic_const_args` attribute are handled gracefully rather than triggering an unreachable panic.
