### PR TITLE
directory handles: add Dir::metadata

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1598,6 +1598,25 @@ impl Dir {
             .open_file(path.as_ref(), &OpenOptions::new().read(true).0)
             .map(|f| File { inner: f })
     }
+
+    /// Queries metadata about the underlying directory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::fs::Dir;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let dir = Dir::open("foo")?;
+    ///     let metadata = dir.metadata()?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn metadata(&self) -> io::Result<Metadata> {
+        self.inner.metadata().map(Metadata)
+    }
 }
 
 impl AsInner<fs_imp::Dir> for Dir {
@@ -2144,6 +2163,12 @@ impl fmt::Debug for Metadata {
             debug.field("created", &created);
         }
         debug.finish_non_exhaustive()
+    }
+}
+
+impl IntoInner<fs_imp::FileAttr> for Metadata {
+    fn into_inner(self) -> fs_imp::FileAttr {
+        self.0
     }
 }
 

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2545,3 +2545,11 @@ fn test_dir_read_file() {
     let buf = check!(io::read_to_string(f));
     assert_eq!("bar", &buf);
 }
+
+#[test]
+fn test_dir_metadata() {
+    let tmpdir = tmpdir();
+    let dir = check!(Dir::open(tmpdir.path()));
+    let metadata = check!(dir.metadata());
+    assert!(metadata.is_dir());
+}

--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -2,7 +2,8 @@
 
 use crate::io::{self, Error, ErrorKind};
 use crate::path::{Path, PathBuf};
-use crate::sys::fs::{File, OpenOptions};
+use crate::sys::IntoInner;
+use crate::sys::fs::{File, FileAttr, OpenOptions};
 use crate::sys::helpers::ignore_notfound;
 use crate::{fmt, fs};
 
@@ -71,6 +72,10 @@ impl Dir {
 
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
         File::open(&self.path.join(path), &opts)
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        self.path.metadata().map(|m| m.into_inner())
     }
 }
 

--- a/library/std/src/sys/fs/unix/dir.rs
+++ b/library/std/src/sys/fs/unix/dir.rs
@@ -25,7 +25,7 @@ use crate::os::wasi::io::{AsRawFd, FromRawFd};
 use crate::path::Path;
 use crate::sys::fd::FileDesc;
 use crate::sys::fs::OpenOptions;
-use crate::sys::fs::unix::{File, debug_path_fd};
+use crate::sys::fs::unix::{File, FileAttr, debug_path_fd};
 use crate::sys::helpers::run_path_with_cstr;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt_r};
 use crate::{fmt, fs, io};
@@ -39,6 +39,16 @@ impl Dir {
 
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
         run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, &opts))
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        // Reuse the implementation for files, which should work for all FDs.
+        let fd = self.0.as_raw_fd();
+        let f = core::mem::ManuallyDrop::new(File(
+            // SAFETY: we borrowed `self` so the FD will not be closed while this function runs.
+            unsafe { FileDesc::from_raw_fd(fd) },
+        ));
+        f.file_attr()
     }
 
     pub fn open_with_c(path: &CStr, opts: &OpenOptions) -> io::Result<Self> {

--- a/library/std/src/sys/fs/windows/dir.rs
+++ b/library/std/src/sys/fs/windows/dir.rs
@@ -5,7 +5,7 @@ use crate::os::windows::io::{
 use crate::path::Path;
 use crate::sys::api::{UnicodeStrRef, WinError};
 use crate::sys::fs::windows::debug_path_handle;
-use crate::sys::fs::{File, OpenOptions};
+use crate::sys::fs::{File, FileAttr, OpenOptions};
 use crate::sys::handle::Handle;
 use crate::sys::path::{WCStr, with_native_path};
 use crate::sys::{AsInner, FromInner, IntoInner, IoResult, c, to_u16s};
@@ -100,6 +100,16 @@ impl Dir {
             ..c::OBJECT_ATTRIBUTES::with_length()
         };
         unsafe { nt_create_file(opts, &object_attributes, c::FILE_NON_DIRECTORY_FILE) }
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        // Reuse the implementation for files, which should work for all handles.
+        let handle = self.handle.as_raw_handle();
+        let f = core::mem::ManuallyDrop::new(File {
+            // SAFETY: we borrowed `self` so the handle will not be closed while this function runs.
+            handle: unsafe { Handle::from_raw_handle(handle) },
+        });
+        f.file_attr()
     }
 }
 


### PR DESCRIPTION
Adds a `metadata` method to the `fs::Dir` type so that one can fetch the metadata of a directory directly from a handle. This is very similar to `File::metadata`. In fact we reuse the existing implementation, which reduces code duplication but also is a bit hacky.

r? @the8472 
Tracking issue: https://github.com/rust-lang/rust/issues/120426
