### PR TITLE
add `RandomSource::next_u{32,64}` methods

### DIFF
--- a/library/core/src/random.rs
+++ b/library/core/src/random.rs
@@ -12,6 +12,30 @@ pub trait RandomSource {
     /// cases. For instance, this allows a `RandomSource` to generate a word at a time and throw
     /// part of it away if not needed.
     fn fill_bytes(&mut self, bytes: &mut [u8]);
+
+    /// Returns a random 32-bit integer.
+    ///
+    /// The default implementation uses `fill_bytes` and interprets those bytes as integer, but this
+    /// is not guaranteed. A `RandomSource` can override this method to behave differently, e.g., it
+    /// may skip parts of its internal buffer to avoid the need for an unaligned load.
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        let mut buf = [0; size_of::<u32>()];
+        self.fill_bytes(&mut buf);
+        u32::from_ne_bytes(buf)
+    }
+
+    /// Returns a random 64-bit integer.
+    ///
+    /// The default implementation uses `fill_bytes` and interprets those bytes as integer, but this
+    /// is not guaranteed. A `RandomSource` can override this method to behave differently, e.g., it
+    /// may skip parts of its internal buffer to avoid the need for an unaligned load.
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        let mut buf = [0; size_of::<u64>()];
+        self.fill_bytes(&mut buf);
+        u64::from_ne_bytes(buf)
+    }
 }
 
 /// A trait representing a distribution of random values for a type.
@@ -35,6 +59,13 @@ impl Distribution<bool> for RangeFull {
 }
 
 macro_rules! impl_primitive {
+    ($t:ty, $method:ident) => {
+        impl Distribution<$t> for RangeFull {
+            fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> $t {
+                source.$method() as $t
+            }
+        }
+    };
     ($t:ty) => {
         impl Distribution<$t> for RangeFull {
             fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> $t {
@@ -50,10 +81,10 @@ impl_primitive!(u8);
 impl_primitive!(i8);
 impl_primitive!(u16);
 impl_primitive!(i16);
-impl_primitive!(u32);
-impl_primitive!(i32);
-impl_primitive!(u64);
-impl_primitive!(i64);
+impl_primitive!(u32, next_u32);
+impl_primitive!(i32, next_u32);
+impl_primitive!(u64, next_u64);
+impl_primitive!(i64, next_u64);
 impl_primitive!(u128);
 impl_primitive!(i128);
 impl_primitive!(usize);

--- a/library/core/src/random.rs
+++ b/library/core/src/random.rs
@@ -22,7 +22,7 @@ pub trait RandomSource {
     fn next_u32(&mut self) -> u32 {
         let mut buf = [0; size_of::<u32>()];
         self.fill_bytes(&mut buf);
-        u32::from_ne_bytes(buf)
+        u32::from_le_bytes(buf)
     }
 
     /// Returns a random 64-bit integer.
@@ -34,7 +34,7 @@ pub trait RandomSource {
     fn next_u64(&mut self) -> u64 {
         let mut buf = [0; size_of::<u64>()];
         self.fill_bytes(&mut buf);
-        u64::from_ne_bytes(buf)
+        u64::from_le_bytes(buf)
     }
 }
 
@@ -71,7 +71,7 @@ macro_rules! impl_primitive {
             fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> $t {
                 let mut bytes = (0 as $t).to_ne_bytes();
                 source.fill_bytes(&mut bytes);
-                <$t>::from_ne_bytes(bytes)
+                <$t>::from_le_bytes(bytes)
             }
         }
     };


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157193)*
<!-- homu-ignore:end -->

If we're going to add these methods at any point, it's better to add them before stabilization. Since they should be allowed to behave differently from `fill_bytes` calls, existing code that calls `fill_bytes` (including the standard library's `Distribution` impls) would break reproducibility by switching to `next_uN` later. Similarly, `RandomSource` implementations that want to guarantee reproducibility either have to override these methods from the start or never override them.

The main reason why we should add these methods is, of course, performance. The existing contract of `fill_bytes` helps when an `impl RandomSource` generates one word at a time since `fill_bytes` calls that generate exactly one word's worth of data can be inlined and simplified to avoid the general loop. However, with `dyn RandomSource`, the `fill_bytes` call can't be inlined, so the desired optimization doesn't kick in. In contrast, `next_uN` methods in the vtable make direct, inlinable calls to `fill_bytes`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#130703

r? @joshtriplett 