### PR TITLE
Move feature gating to the new attr parsing infrastructure

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -2,7 +2,7 @@ use rustc_ast::visit::{self, AssocCtxt, FnCtxt, FnKind, Visitor};
 use rustc_ast::{self as ast, AttrVec, GenericBound, NodeId, PatKind, attr, token};
 use rustc_attr_parsing::AttributeParser;
 use rustc_errors::msg;
-use rustc_feature::{AttributeGate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute, Features};
+use rustc_feature::Features;
 use rustc_hir::Attribute;
 use rustc_hir::attrs::AttributeKind;
 use rustc_session::Session;
@@ -155,15 +155,6 @@ impl<'a> PostExpansionVisitor<'a> {
 
 impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_attribute(&mut self, attr: &ast::Attribute) {
-        let attr_info = attr.name().and_then(|name| BUILTIN_ATTRIBUTE_MAP.get(&name));
-        // Check feature gates for built-in attributes.
-        if let Some(BuiltinAttribute {
-            gate: AttributeGate::Gated { feature, message, check, notes, .. },
-            ..
-        }) = attr_info
-        {
-            gate_alt!(self, check(self.features), *feature, attr.span, *message, *notes);
-        }
         // Check unstable flavors of the `#[doc]` attribute.
         if attr.has_name(sym::doc) {
             for meta_item_inner in attr.meta_item_list().unwrap_or_default() {

--- a/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/allow_unstable.rs
@@ -1,5 +1,7 @@
 use std::iter;
 
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 use crate::session_diagnostics;
 
@@ -16,6 +18,7 @@ impl CombineAttributeParser for AllowInternalUnstableParser {
         Warn(Target::Arm),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
+    const STABILITY: AttributeStability = unstable!(allow_internal_unstable);
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -32,6 +35,7 @@ impl CombineAttributeParser for UnstableFeatureBoundParser {
     const PATH: &[rustc_span::Symbol] = &[sym::unstable_feature_bound];
     type Item = (Symbol, Span);
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::UnstableFeatureBound(items);
+    const STABILITY: AttributeStability = unstable!(staged_api);
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Impl { of_trait: true }),
@@ -43,9 +47,6 @@ impl CombineAttributeParser for UnstableFeatureBoundParser {
         cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
     ) -> impl IntoIterator<Item = Self::Item> {
-        if !cx.features().staged_api() {
-            cx.emit_err(session_diagnostics::StabilityOutsideStd { span: cx.attr_span });
-        }
         parse_unstable(cx, args, <Self as CombineAttributeParser>::PATH[0])
             .into_iter()
             .zip(iter::repeat(cx.attr_span))
@@ -65,6 +66,10 @@ impl CombineAttributeParser for RustcAllowConstFnUnstableParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["feat1, feat2, ..."]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
+    );
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,

--- a/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/autodiff.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use rustc_ast::LitKind;
 use rustc_ast::expand::autodiff_attrs::{DiffActivity, DiffMode};
-use rustc_feature::{AttributeTemplate, template};
+use rustc_feature::{AttributeStability, AttributeTemplate, template};
 use rustc_hir::attrs::{AttributeKind, RustcAutodiff};
 use rustc_hir::{MethodKind, Target};
 use rustc_span::{Symbol, sym};
@@ -13,6 +13,7 @@ use crate::attributes::prelude::Allow;
 use crate::context::AcceptContext;
 use crate::parser::{ArgParser, MetaItemOrLitParser};
 use crate::target_checking::AllowedTargets;
+use crate::unstable;
 
 pub(crate) struct RustcAutodiffParser;
 
@@ -29,6 +30,7 @@ impl SingleAttributeParser for RustcAutodiffParser {
         List: &["MODE", "WIDTH", "INPUT_ACTIVITIES", "OUTPUT_ACTIVITY"],
         "https://doc.rust-lang.org/std/autodiff/index.html"
     );
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = match args {

--- a/compiler/rustc_attr_parsing/src/attributes/body.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/body.rs
@@ -1,5 +1,7 @@
 //! Attributes that can be found in function body.
 
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct CoroutineParser;
@@ -7,5 +9,6 @@ pub(crate) struct CoroutineParser;
 impl NoArgsAttributeParser for CoroutineParser {
     const PATH: &[Symbol] = &[sym::coroutine];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Closure)]);
+    const STABILITY: AttributeStability = unstable!(coroutines);
     const CREATE: fn(rustc_span::Span) -> AttributeKind = |_| AttributeKind::Coroutine;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfi_encoding.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 pub(crate) struct CfiEncodingParser;
 impl SingleAttributeParser for CfiEncodingParser {
@@ -9,6 +11,7 @@ impl SingleAttributeParser for CfiEncodingParser {
         Allow(Target::Union),
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "encoding");
+    const STABILITY: AttributeStability = unstable!(cfi_encoding);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let name_value = cx.expect_name_value(args, cx.attr_span, Some(sym::cfi_encoding))?;

--- a/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/codegen_attrs.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{CoverageAttrKind, OptimizeAttr, RtsanSetting, SanitizerSet, UsedBy};
 use rustc_session::errors::feature_err;
 use rustc_span::edition::Edition::Edition2024;
@@ -22,6 +23,7 @@ impl SingleAttributeParser for OptimizeParser {
         Allow(Target::Method(MethodKind::Inherent)),
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &["size", "speed", "none"]);
+    const STABILITY: AttributeStability = unstable!(optimize_attribute);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
@@ -54,6 +56,7 @@ impl NoArgsAttributeParser for ColdParser {
         Allow(Target::ForeignFn),
         Allow(Target::Closure),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Cold;
 }
 
@@ -73,6 +76,7 @@ impl SingleAttributeParser for CoverageParser {
         Allow(Target::Crate),
     ]);
     const TEMPLATE: AttributeTemplate = template!(OneOf: &[sym::off, sym::on]);
+    const STABILITY: AttributeStability = unstable!(coverage_attribute);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let arg = cx.expect_single_element_list(args, cx.attr_span)?;
@@ -116,6 +120,7 @@ impl SingleAttributeParser for ExportNameParser {
         Warn(Target::MacroCall),
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -143,6 +148,7 @@ impl SingleAttributeParser for RustcObjcClassParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "ClassName");
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -170,6 +176,7 @@ impl SingleAttributeParser for RustcObjcSelectorParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignStatic)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "methodName");
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -197,7 +204,7 @@ pub(crate) struct NakedParser {
 
 impl AttributeParser for NakedParser {
     const ATTRIBUTES: AcceptMapping<Self> =
-        &[(&[sym::naked], template!(Word), |this, cx, args| {
+        &[(&[sym::naked], template!(Word), AttributeStability::Stable, |this, cx, args| {
             let Some(()) = cx.expect_no_args(args) else {
                 return;
             };
@@ -331,6 +338,7 @@ impl NoArgsAttributeParser for TrackCallerParser {
         Warn(Target::Field),
         Warn(Target::MacroCall),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::TrackCaller;
 }
 
@@ -347,6 +355,7 @@ impl NoArgsAttributeParser for NoMangleParser {
         AllowSilent(Target::Const), // Handled in the `InvalidNoMangleItems` pass
         Error(Target::Closure),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NoMangle;
 }
 
@@ -365,6 +374,7 @@ impl AttributeParser for UsedParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::used],
         template!(Word, List: &["compiler", "linker"]),
+        AttributeStability::Stable,
         |group: &mut Self, cx, args| {
             let used_by = match args {
                 ArgParser::NoArgs => UsedBy::Default,
@@ -502,6 +512,7 @@ impl CombineAttributeParser for TargetFeatureParser {
         was_forced: false,
     };
     const TEMPLATE: AttributeTemplate = template!(List: &["enable = \"feat1, feat2\""]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -541,6 +552,7 @@ impl CombineAttributeParser for ForceTargetFeatureParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(effective_target_features);
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -554,10 +566,8 @@ pub(crate) struct SanitizeParser;
 
 impl SingleAttributeParser for SanitizeParser {
     const PATH: &[Symbol] = &[sym::sanitize];
-
     // FIXME: still checked in check_attrs.rs
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
-
     const TEMPLATE: AttributeTemplate = template!(List: &[
         r#"address = "on|off""#,
         r#"kernel_address = "on|off""#,
@@ -571,6 +581,7 @@ impl SingleAttributeParser for SanitizeParser {
         r#"thread = "on|off""#,
         r#"realtime = "nonblocking|blocking|caller""#,
     ]);
+    const STABILITY: AttributeStability = unstable!(sanitize);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
@@ -667,6 +678,7 @@ impl NoArgsAttributeParser for ThreadLocalParser {
     const PATH: &[Symbol] = &[sym::thread_local];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Static), Allow(Target::ForeignStatic)]);
+    const STABILITY: AttributeStability = unstable!(thread_local);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ThreadLocal;
 }
 
@@ -675,6 +687,7 @@ pub(crate) struct RustcPassIndirectlyInNonRusticAbisParser;
 impl NoArgsAttributeParser for RustcPassIndirectlyInNonRusticAbisParser {
     const PATH: &[Symbol] = &[sym::rustc_pass_indirectly_in_non_rustic_abis];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcPassIndirectlyInNonRusticAbis;
 }
 
@@ -684,6 +697,7 @@ impl NoArgsAttributeParser for RustcEiiForeignItemParser {
     const PATH: &[Symbol] = &[sym::rustc_eii_foreign_item];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::ForeignFn), Allow(Target::ForeignStatic)]);
+    const STABILITY: AttributeStability = unstable!(eii_internals);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcEiiForeignItem;
 }
 
@@ -693,6 +707,7 @@ impl SingleAttributeParser for PatchableFunctionEntryParser {
     const PATH: &[Symbol] = &[sym::patchable_function_entry];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["prefix_nops = m, entry_nops = n"]);
+    const STABILITY: AttributeStability = unstable!(patchable_function_entry);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let meta_item_list = cx.expect_list(args, cx.attr_span)?;

--- a/compiler/rustc_attr_parsing/src/attributes/confusables.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/confusables.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 use crate::session_diagnostics::EmptyConfusables;
 
@@ -11,6 +13,7 @@ impl AttributeParser for ConfusablesParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::rustc_confusables],
         template!(List: &[r#""name1", "name2", ..."#]),
+        unstable!(rustc_attrs),
         |this, cx, args| {
             let Some(list) = cx.expect_list(args, cx.attr_span) else { return };
 

--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{CrateType, WindowsSubsystemKind};
 use rustc_session::lint::builtin::UNKNOWN_CRATE_TYPES;
 use rustc_span::Symbol;
@@ -13,6 +14,7 @@ impl SingleAttributeParser for CrateNameParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let n = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -29,11 +31,10 @@ impl CombineAttributeParser for CrateTypeParser {
     const PATH: &[Symbol] = &[sym::crate_type];
     type Item = CrateType;
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::CrateType(items);
-
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
-
     const TEMPLATE: AttributeTemplate =
         template!(NameValueStr: "crate type", "https://doc.rust-lang.org/reference/linkage.html");
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -74,6 +75,7 @@ impl SingleAttributeParser for RecursionLimitParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N", "https://doc.rust-lang.org/reference/attributes/limits.html#the-recursion_limit-attribute");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -88,6 +90,7 @@ impl SingleAttributeParser for MoveSizeLimitParser {
     const PATH: &[Symbol] = &[sym::move_size_limit];
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(large_assignments);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -103,6 +106,7 @@ impl SingleAttributeParser for TypeLengthLimitParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -117,6 +121,10 @@ impl SingleAttributeParser for PatternComplexityLimitParser {
     const PATH: &[Symbol] = &[sym::pattern_complexity_limit];
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[pattern_complexity_limit]` attribute is used for rustc unit tests"
+    );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -130,6 +138,7 @@ pub(crate) struct NoCoreParser;
 impl NoArgsAttributeParser for NoCoreParser {
     const PATH: &[Symbol] = &[sym::no_core];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(no_core);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoCore;
 }
 
@@ -139,6 +148,7 @@ impl NoArgsAttributeParser for NoStdParser {
     const PATH: &[Symbol] = &[sym::no_std];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoStd;
 }
 
@@ -148,6 +158,7 @@ impl NoArgsAttributeParser for NoMainParser {
     const PATH: &[Symbol] = &[sym::no_main];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoMain;
 }
 
@@ -156,6 +167,7 @@ pub(crate) struct RustcCoherenceIsCoreParser;
 impl NoArgsAttributeParser for RustcCoherenceIsCoreParser {
     const PATH: &[Symbol] = &[sym::rustc_coherence_is_core];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCoherenceIsCore;
 }
 
@@ -166,6 +178,7 @@ impl SingleAttributeParser for WindowsSubsystemParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: ["windows", "console"], "https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute");
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.inner_span, Some(sym::windows_subsystem))?;
@@ -191,6 +204,7 @@ pub(crate) struct PanicRuntimeParser;
 impl NoArgsAttributeParser for PanicRuntimeParser {
     const PATH: &[Symbol] = &[sym::panic_runtime];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(panic_runtime);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PanicRuntime;
 }
 
@@ -199,6 +213,7 @@ pub(crate) struct NeedsPanicRuntimeParser;
 impl NoArgsAttributeParser for NeedsPanicRuntimeParser {
     const PATH: &[Symbol] = &[sym::needs_panic_runtime];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(needs_panic_runtime);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NeedsPanicRuntime;
 }
 
@@ -207,6 +222,7 @@ pub(crate) struct ProfilerRuntimeParser;
 impl NoArgsAttributeParser for ProfilerRuntimeParser {
     const PATH: &[Symbol] = &[sym::profiler_runtime];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(profiler_runtime);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProfilerRuntime;
 }
 
@@ -216,6 +232,7 @@ impl NoArgsAttributeParser for NoBuiltinsParser {
     const PATH: &[Symbol] = &[sym::no_builtins];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoBuiltins;
 }
 
@@ -224,6 +241,7 @@ pub(crate) struct RustcPreserveUbChecksParser;
 impl NoArgsAttributeParser for RustcPreserveUbChecksParser {
     const PATH: &[Symbol] = &[sym::rustc_preserve_ub_checks];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcPreserveUbChecks;
 }
 
@@ -232,6 +250,7 @@ pub(crate) struct RustcNoImplicitBoundsParser;
 impl NoArgsAttributeParser for RustcNoImplicitBoundsParser {
     const PATH: &[Symbol] = &[sym::rustc_no_implicit_bounds];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoImplicitBounds;
 }
 
@@ -240,6 +259,7 @@ pub(crate) struct DefaultLibAllocatorParser;
 impl NoArgsAttributeParser for DefaultLibAllocatorParser {
     const PATH: &[Symbol] = &[sym::default_lib_allocator];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(allocator_internals);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::DefaultLibAllocator;
 }
 
@@ -251,6 +271,7 @@ impl CombineAttributeParser for FeatureParser {
     const CONVERT: ConvertFn<Self::Item> = AttributeKind::Feature;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["feature1, feature2, ..."]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -295,6 +316,7 @@ impl CombineAttributeParser for RegisterToolParser {
     const CONVERT: ConvertFn<Self::Item> = |tools, _span| AttributeKind::RegisterTool(tools);
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(List: &["tool1, tool2, ..."]);
+    const STABILITY: AttributeStability = unstable!(register_tool);
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{DebugVisualizer, DebuggerVisualizerType};
 
 use super::prelude::*;
@@ -12,6 +13,7 @@ impl CombineAttributeParser for DebuggerViualizerParser {
         List: &[r#"natvis_file = "...", gdb_script_file = "...""#],
         "https://doc.rust-lang.org/reference/attributes/debugger.html#the-debugger_visualizer-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     type Item = DebugVisualizer;
     const CONVERT: ConvertFn<Self::Item> = |v, _| AttributeKind::DebuggerVisualizer(v);

--- a/compiler/rustc_attr_parsing/src/attributes/debugger.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/debugger.rs
@@ -3,9 +3,9 @@ use rustc_hir::attrs::{DebugVisualizer, DebuggerVisualizerType};
 
 use super::prelude::*;
 
-pub(crate) struct DebuggerViualizerParser;
+pub(crate) struct DebuggerVisualizerParser;
 
-impl CombineAttributeParser for DebuggerViualizerParser {
+impl CombineAttributeParser for DebuggerVisualizerParser {
     const PATH: &[Symbol] = &[sym::debugger_visualizer];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Mod), Allow(Target::Crate)]);

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -1,4 +1,5 @@
 use rustc_ast::LitKind;
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{DeprecatedSince, Deprecation};
 use rustc_hir::{RustcVersion, VERSION_PLACEHOLDER};
 
@@ -62,6 +63,7 @@ impl SingleAttributeParser for DeprecatedParser {
         List: &[r#"since = "version""#, r#"note = "reason""#, r#"since = "version", note = "reason""#],
         NameValueStr: "reason"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let features = cx.features();

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/do_not_recommend.rs
@@ -1,4 +1,4 @@
-use rustc_feature::{AttributeTemplate, template};
+use rustc_feature::{AttributeStability, AttributeTemplate, template};
 use rustc_hir::Target;
 use rustc_hir::attrs::AttributeKind;
 use rustc_session::lint::builtin::{
@@ -19,6 +19,7 @@ impl SingleAttributeParser for DoNotRecommendParser {
     // "Allowed" on any target, noop on all but trait impls
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word /*doesn't matter */);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let attr_span = cx.attr_span;

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_const.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -14,6 +15,7 @@ impl AttributeParser for OnConstParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_const],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
+        AttributeStability::Stable, // Unstable, stability checked manually in the parser
         |this, cx, args| {
             if !cx.features().diagnostic_on_const() {
                 // `UnknownDiagnosticAttribute` is emitted in rustc_resolve/macros.rs

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_move.rs
@@ -1,4 +1,4 @@
-use rustc_feature::template;
+use rustc_feature::{AttributeStability, template};
 use rustc_hir::attrs::AttributeKind;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 use rustc_span::sym;
@@ -42,6 +42,7 @@ impl AttributeParser for OnMoveParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_move],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
+        AttributeStability::Stable, // Unstable, stability checked manually in the parser
         |this, cx, args| {
             this.parse(cx, args, Mode::DiagnosticOnMove);
         },

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unimplemented.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -38,6 +39,7 @@ impl AttributeParser for OnUnimplementedParser {
         (
             &[sym::diagnostic, sym::on_unimplemented],
             template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
+            AttributeStability::Stable,
             |this, cx, args| {
                 this.parse(cx, args, Mode::DiagnosticOnUnimplemented);
             },
@@ -45,6 +47,10 @@ impl AttributeParser for OnUnimplementedParser {
         (
             &[sym::rustc_on_unimplemented],
             template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
+            unstable!(
+                rustc_attrs,
+                "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
+            ),
             |this, cx, args| {
                 this.parse(cx, args, Mode::RustcOnUnimplemented);
             },

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unknown.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -49,6 +50,7 @@ impl AttributeParser for OnUnknownParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_unknown],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
+        AttributeStability::Stable, // Unstable, stability checked manually in the parser
         |this, cx, args| {
             this.parse(cx, args, Mode::DiagnosticOnUnknown);
         },

--- a/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/diagnostic/on_unmatch_args.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_session::lint::builtin::MISPLACED_DIAGNOSTIC_ATTRIBUTES;
 
@@ -15,6 +16,7 @@ impl AttributeParser for OnUnmatchArgsParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::diagnostic, sym::on_unmatch_args],
         template!(List: &[r#"/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...""#]),
+        AttributeStability::Stable, // Unstable, stability checked manually in the parser
         |this, cx, args| {
             if !cx.features().diagnostic_on_unmatch_args() {
                 return;

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -1,6 +1,6 @@
 use rustc_ast::ast::{AttrStyle, LitKind, MetaItemLit};
 use rustc_errors::{Applicability, msg};
-use rustc_feature::template;
+use rustc_feature::{AttributeStability, template};
 use rustc_hir::Target;
 use rustc_hir::attrs::{
     AttributeKind, CfgEntry, CfgHideShow, CfgInfo, DocAttribute, DocInline, HideOrShow,
@@ -702,6 +702,7 @@ impl AttributeParser for DocParser {
             ],
             NameValueStr: "string"
         ),
+        AttributeStability::Stable, // Some parts of the attribute are unstable, manually checked in parser
         |this, cx, args| {
             this.accept_single_doc_attr(cx, args);
         },

--- a/compiler/rustc_attr_parsing/src/attributes/doc.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/doc.rs
@@ -41,7 +41,7 @@ fn check_keyword(cx: &mut AcceptContext<'_, '_>, keyword: Symbol, span: Span) ->
 
 fn check_attribute(cx: &mut AcceptContext<'_, '_>, attribute: Symbol, span: Span) -> bool {
     // FIXME: This should support attributes with namespace like `diagnostic::do_not_recommend`.
-    if rustc_feature::BUILTIN_ATTRIBUTE_MAP.contains_key(&attribute) {
+    if rustc_feature::BUILTIN_ATTRIBUTE_MAP.contains(&attribute) {
         return true;
     }
     cx.emit_err(DocAttributeNotAttribute { span, attribute });

--- a/compiler/rustc_attr_parsing/src/attributes/dummy.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/dummy.rs
@@ -1,4 +1,4 @@
-use rustc_feature::{AttributeTemplate, template};
+use rustc_feature::{AttributeStability, AttributeTemplate, template};
 use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Symbol, sym};
 
@@ -6,6 +6,7 @@ use crate::attributes::{OnDuplicate, SingleAttributeParser};
 use crate::context::AcceptContext;
 use crate::parser::ArgParser;
 use crate::target_checking::{ALL_TARGETS, AllowedTargets};
+use crate::unstable;
 
 pub(crate) struct RustcDummyParser;
 impl SingleAttributeParser for RustcDummyParser {
@@ -13,6 +14,8 @@ impl SingleAttributeParser for RustcDummyParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Ignore;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
     const TEMPLATE: AttributeTemplate = template!(Word); // Anything, really
+    const STABILITY: AttributeStability =
+        unstable!(rustc_attrs, "the `#[rustc_dummy]` attribute is used for rustc unit tests");
 
     fn convert(_: &mut AcceptContext<'_, '_>, _: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::RustcDummy)

--- a/compiler/rustc_attr_parsing/src/attributes/inline.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/inline.rs
@@ -2,6 +2,7 @@
 //                      note: need to model better how duplicate attr errors work when not using
 //                      SingleAttributeParser which is what we have two of here.
 
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{AttributeKind, InlineAttr};
 use rustc_session::lint::builtin::ILL_FORMED_ATTRIBUTE_INPUT;
 
@@ -32,6 +33,7 @@ impl SingleAttributeParser for InlineParser {
         List: &["always", "never"],
         "https://doc.rust-lang.org/reference/attributes/codegen.html#the-inline-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         match args {
@@ -68,7 +70,8 @@ impl SingleAttributeParser for RustcForceInlineParser {
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
     ]);
-
+    const STABILITY: AttributeStability =
+        unstable!(rustc_attrs, "`#[rustc_force_inline]` forces a free function to be inlined");
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["reason"], NameValueStr: "reason");
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/instruction_set.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::InstructionSetAttr;
 
 use super::prelude::*;
@@ -15,6 +16,7 @@ impl SingleAttributeParser for InstructionSetParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &["set"], "https://doc.rust-lang.org/reference/attributes/codegen.html#the-instruction_set-attribute");
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         const POSSIBLE_SYMBOLS: &[Symbol] = &[sym::arm_a32, sym::arm_t32];

--- a/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/link_attrs.rs
@@ -1,5 +1,5 @@
 use rustc_errors::msg;
-use rustc_feature::Features;
+use rustc_feature::{AttributeStability, Features};
 use rustc_hir::attrs::AttributeKind::{LinkName, LinkOrdinal, LinkSection};
 use rustc_hir::attrs::*;
 use rustc_session::Session;
@@ -34,6 +34,7 @@ impl SingleAttributeParser for LinkNameParser {
         NameValueStr: "name",
         "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_name-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -70,6 +71,7 @@ impl CombineAttributeParser for LinkParser {
             r#"name = "...", kind = "dylib|static|...", wasm_import_module = "...", import_name_type = "decorated|noprefix|undecorated""#,
         ], "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute");
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -487,6 +489,7 @@ impl SingleAttributeParser for LinkSectionParser {
     const PATH: &[Symbol] = &[sym::link_section];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::WarnButFutureError;
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: Some(Edition2024) };
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
         Allow(Target::Static),
         Allow(Target::Fn),
@@ -529,6 +532,7 @@ pub(crate) struct ExportStableParser;
 impl NoArgsAttributeParser for ExportStableParser {
     const PATH: &[Symbol] = &[sym::export_stable];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
+    const STABILITY: AttributeStability = unstable!(export_stable);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ExportStable;
 }
 
@@ -537,6 +541,7 @@ impl NoArgsAttributeParser for FfiConstParser {
     const PATH: &[Symbol] = &[sym::ffi_const];
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: None };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
+    const STABILITY: AttributeStability = unstable!(ffi_const);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::FfiConst;
 }
 
@@ -545,6 +550,7 @@ impl NoArgsAttributeParser for FfiPureParser {
     const PATH: &[Symbol] = &[sym::ffi_pure];
     const SAFETY: AttributeSafety = AttributeSafety::Unsafe { unsafe_since: None };
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::ForeignFn)]);
+    const STABILITY: AttributeStability = unstable!(ffi_pure);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::FfiPure;
 }
 
@@ -557,6 +563,7 @@ impl NoArgsAttributeParser for RustcStdInternalSymbolParser {
         Allow(Target::Static),
         Allow(Target::ForeignStatic),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcStdInternalSymbol;
 }
 
@@ -573,6 +580,7 @@ impl SingleAttributeParser for LinkOrdinalParser {
         List: &["ordinal"],
         "https://doc.rust-lang.org/reference/items/external-blocks.html#the-link_ordinal-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let ordinal = parse_single_integer(cx, args)?;
@@ -603,7 +611,6 @@ pub(crate) struct LinkageParser;
 
 impl SingleAttributeParser for LinkageParser {
     const PATH: &[Symbol] = &[sym::linkage];
-
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -614,7 +621,6 @@ impl SingleAttributeParser for LinkageParser {
         Allow(Target::ForeignFn),
         Warn(Target::Method(MethodKind::Trait { body: false })), // Not inherited
     ]);
-
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: [
         "available_externally",
         "common",
@@ -626,6 +632,7 @@ impl SingleAttributeParser for LinkageParser {
         "weak",
         "weak_odr",
     ]);
+    const STABILITY: AttributeStability = unstable!(linkage);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let name_value = cx.expect_name_value(args, cx.attr_span, Some(sym::linkage))?;
@@ -681,6 +688,7 @@ pub(crate) struct NeedsAllocatorParser;
 impl NoArgsAttributeParser for NeedsAllocatorParser {
     const PATH: &[Symbol] = &[sym::needs_allocator];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(allocator_internals);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NeedsAllocator;
 }
 
@@ -689,5 +697,6 @@ pub(crate) struct CompilerBuiltinsParser;
 impl NoArgsAttributeParser for CompilerBuiltinsParser {
     const PATH: &[Symbol] = &[sym::compiler_builtins];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(compiler_builtins);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::CompilerBuiltins;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct RustcAsPtrParser;
@@ -10,6 +12,7 @@ impl NoArgsAttributeParser for RustcAsPtrParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcAsPtr;
 }
 
@@ -21,6 +24,7 @@ impl NoArgsAttributeParser for RustcPubTransparentParser {
         Allow(Target::Enum),
         Allow(Target::Union),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcPubTransparent;
 }
 
@@ -32,6 +36,7 @@ impl NoArgsAttributeParser for RustcPassByValueParser {
         Allow(Target::Enum),
         Allow(Target::TyAlias),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcPassByValue;
 }
 
@@ -42,6 +47,7 @@ impl NoArgsAttributeParser for RustcShouldNotBeCalledOnConstItemsParser {
         Allow(Target::Method(MethodKind::Inherent)),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcShouldNotBeCalledOnConstItems;
 }
 
@@ -54,5 +60,6 @@ impl NoArgsAttributeParser for AutomaticallyDerivedParser {
         Error(Target::Crate),
         Error(Target::WherePredicate),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::AutomaticallyDerived;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
@@ -1,9 +1,12 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct LoopMatchParser;
 impl NoArgsAttributeParser for LoopMatchParser {
     const PATH: &[Symbol] = &[sym::loop_match];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Expression)]);
+    const STABILITY: AttributeStability = unstable!(loop_match);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::LoopMatch;
 }
 
@@ -11,5 +14,6 @@ pub(crate) struct ConstContinueParser;
 impl NoArgsAttributeParser for ConstContinueParser {
     const PATH: &[Symbol] = &[sym::const_continue];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Expression)]);
+    const STABILITY: AttributeStability = unstable!(loop_match);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::ConstContinue;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{CollapseMacroDebuginfo, MacroUseArgs};
 use rustc_session::lint::builtin::INVALID_MACRO_EXPORT_ARGUMENTS;
 
@@ -8,6 +9,7 @@ impl NoArgsAttributeParser for MacroEscapeParser {
     const PATH: &[Symbol] = &[sym::macro_escape];
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets = MACRO_USE_ALLOWED_TARGETS;
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::MacroEscape;
 }
 
@@ -41,6 +43,7 @@ impl AttributeParser for MacroUseParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::macro_use],
         MACRO_USE_TEMPLATE,
+        AttributeStability::Stable,
         |group: &mut Self, cx: &mut AcceptContext<'_, '_>, args| {
             let span = cx.attr_span;
             group.first_span.get_or_insert(span);
@@ -122,6 +125,7 @@ impl NoArgsAttributeParser for AllowInternalUnsafeParser {
         Warn(Target::Field),
         Warn(Target::Arm),
     ]);
+    const STABILITY: AttributeStability = unstable!(allow_internal_unsafe);
     const CREATE: fn(Span) -> AttributeKind = |span| AttributeKind::AllowInternalUnsafe(span);
 }
 
@@ -136,6 +140,7 @@ impl SingleAttributeParser for MacroExportParser {
         Error(Target::WherePredicate),
         Error(Target::Crate),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let local_inner_macros = match args {
@@ -171,6 +176,7 @@ impl SingleAttributeParser for CollapseDebugInfoParser {
         "https://doc.rust-lang.org/reference/attributes/debugger.html#the-collapse_debuginfo-attribute"
     );
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
@@ -200,5 +206,6 @@ pub(crate) struct RustcProcMacroDeclsParser;
 impl NoArgsAttributeParser for RustcProcMacroDeclsParser {
     const PATH: &[Symbol] = &[sym::rustc_proc_macro_decls];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Static)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcProcMacroDecls;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -16,7 +16,7 @@
 
 use std::marker::PhantomData;
 
-use rustc_feature::{AttributeTemplate, template};
+use rustc_feature::{AttributeStability, AttributeTemplate, template};
 use rustc_hir::attrs::AttributeKind;
 use rustc_span::edition::Edition;
 use rustc_span::{Span, Symbol};
@@ -71,7 +71,8 @@ pub(crate) mod transparency;
 pub(crate) mod util;
 
 type AcceptFn<T> = for<'sess> fn(&mut T, &mut AcceptContext<'_, 'sess>, &ArgParser);
-type AcceptMapping<T> = &'static [(&'static [Symbol], AttributeTemplate, AcceptFn<T>)];
+type AcceptMapping<T> =
+    &'static [(&'static [Symbol], AttributeTemplate, AttributeStability, AcceptFn<T>)];
 
 /// An [`AttributeParser`] is a type which searches for syntactic attributes.
 ///
@@ -130,6 +131,7 @@ pub(crate) trait SingleAttributeParser: 'static {
     /// applied more than once on the same syntax node.
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
+    const STABILITY: AttributeStability;
 
     const ALLOWED_TARGETS: AllowedTargets;
 
@@ -151,8 +153,11 @@ impl<T: SingleAttributeParser> Default for Single<T> {
 }
 
 impl<T: SingleAttributeParser> AttributeParser for Single<T> {
-    const ATTRIBUTES: AcceptMapping<Self> =
-        &[(T::PATH, <T as SingleAttributeParser>::TEMPLATE, |group: &mut Single<T>, cx, args| {
+    const ATTRIBUTES: AcceptMapping<Self> = &[(
+        T::PATH,
+        <T as SingleAttributeParser>::TEMPLATE,
+        T::STABILITY,
+        |group: &mut Single<T>, cx, args| {
             if let Some(pa) = T::convert(cx, args) {
                 if let Some((_, used)) = group.1 {
                     T::ON_DUPLICATE.exec::<T>(cx, used, cx.attr_span);
@@ -160,7 +165,8 @@ impl<T: SingleAttributeParser> AttributeParser for Single<T> {
                     group.1 = Some((pa, cx.attr_span));
                 }
             }
-        })];
+        },
+    )];
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const SAFETY: AttributeSafety = T::SAFETY;
 
@@ -237,6 +243,7 @@ pub(crate) trait NoArgsAttributeParser: 'static {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Error;
     const ALLOWED_TARGETS: AllowedTargets;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
+    const STABILITY: AttributeStability;
 
     /// Create the [`AttributeKind`] given attribute's [`Span`].
     const CREATE: fn(Span) -> AttributeKind;
@@ -254,6 +261,7 @@ impl<T: NoArgsAttributeParser> SingleAttributeParser for WithoutArgs<T> {
     const PATH: &[Symbol] = T::PATH;
     const ON_DUPLICATE: OnDuplicate = T::ON_DUPLICATE;
     const SAFETY: AttributeSafety = T::SAFETY;
+    const STABILITY: AttributeStability = T::STABILITY;
     const ALLOWED_TARGETS: AllowedTargets = T::ALLOWED_TARGETS;
     const TEMPLATE: AttributeTemplate = template!(Word);
 
@@ -282,6 +290,7 @@ pub(crate) trait CombineAttributeParser: 'static {
     ///  where `x` is a vec of these individual reprs.
     const CONVERT: ConvertFn<Self::Item>;
     const SAFETY: AttributeSafety = AttributeSafety::Normal;
+    const STABILITY: AttributeStability;
 
     const ALLOWED_TARGETS: AllowedTargets;
 
@@ -317,7 +326,7 @@ impl<T: CombineAttributeParser> Default for Combine<T> {
 
 impl<T: CombineAttributeParser> AttributeParser for Combine<T> {
     const ATTRIBUTES: AcceptMapping<Self> =
-        &[(T::PATH, T::TEMPLATE, |group: &mut Combine<T>, cx, args| {
+        &[(T::PATH, T::TEMPLATE, T::STABILITY, |group: &mut Combine<T>, cx, args| {
             // Keep track of the span of the first attribute, for diagnostics
             group.first_span.get_or_insert(cx.attr_span);
             group.items.extend(T::extend(cx, args))

--- a/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_not_suspend.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct MustNotSuspendParser;
@@ -11,6 +13,7 @@ impl SingleAttributeParser for MustNotSuspendParser {
         Allow(Target::Trait),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
+    const STABILITY: AttributeStability = unstable!(must_not_suspend);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let reason = match args {

--- a/compiler/rustc_attr_parsing/src/attributes/must_use.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/must_use.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct MustUseParser;
@@ -24,6 +26,7 @@ impl SingleAttributeParser for MustUseParser {
         Word, NameValueStr: "reason",
         "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::MustUse {

--- a/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_implicit_prelude.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct NoImplicitPreludeParser;
@@ -7,5 +9,6 @@ impl NoArgsAttributeParser for NoImplicitPreludeParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Warn;
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowListWarnRest(&[Allow(Target::Mod), Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoImplicitPrelude;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/no_link.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/no_link.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct NoLinkParser;
@@ -10,5 +12,6 @@ impl NoArgsAttributeParser for NoLinkParser {
         Warn(Target::Arm),
         Warn(Target::MacroDef),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::NoLink;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/non_exhaustive.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/non_exhaustive.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::Target;
 use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Span, Symbol, sym};
@@ -20,5 +21,6 @@ impl NoArgsAttributeParser for NonExhaustiveParser {
         Warn(Target::MacroDef),
         Warn(Target::MacroCall),
     ]);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::NonExhaustive;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/path.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/path.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct PathParser;
@@ -11,6 +13,7 @@ impl SingleAttributeParser for PathParser {
         NameValueStr: "file",
         "https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;

--- a/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/pin_v2.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::Target;
 use rustc_hir::attrs::AttributeKind;
 use rustc_span::{Span, Symbol, sym};
@@ -5,6 +6,7 @@ use rustc_span::{Span, Symbol, sym};
 use crate::attributes::NoArgsAttributeParser;
 use crate::target_checking::AllowedTargets;
 use crate::target_checking::Policy::Allow;
+use crate::unstable;
 
 pub(crate) struct PinV2Parser;
 
@@ -15,5 +17,6 @@ impl NoArgsAttributeParser for PinV2Parser {
         Allow(Target::Struct),
         Allow(Target::Union),
     ]);
+    const STABILITY: AttributeStability = unstable!(pin_ergonomics);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::PinV2;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/prelude.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prelude.rs
@@ -25,3 +25,5 @@ pub(super) use crate::parser::*;
 pub(super) use crate::target_checking::Policy::{Allow, Error, Warn};
 #[doc(hidden)]
 pub(super) use crate::target_checking::{ALL_TARGETS, AllowedTargets};
+#[doc(hidden)]
+pub(super) use crate::unstable;

--- a/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/proc_macro_attrs.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_session::lint::builtin::AMBIGUOUS_DERIVE_HELPERS;
 
 use super::prelude::*;
@@ -9,6 +10,7 @@ pub(crate) struct ProcMacroParser;
 impl NoArgsAttributeParser for ProcMacroParser {
     const PATH: &[Symbol] = &[sym::proc_macro];
     const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProcMacro;
 }
 
@@ -16,6 +18,7 @@ pub(crate) struct ProcMacroAttributeParser;
 impl NoArgsAttributeParser for ProcMacroAttributeParser {
     const PATH: &[Symbol] = &[sym::proc_macro_attribute];
     const ALLOWED_TARGETS: AllowedTargets = PROC_MACRO_ALLOWED_TARGETS;
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::ProcMacroAttribute;
 }
 
@@ -27,6 +30,7 @@ impl SingleAttributeParser for ProcMacroDeriveParser {
         List: &["TraitName", "TraitName, attributes(name1, name2, ...)"],
         "https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let (trait_name, helper_attrs) = parse_derive_like(cx, args, true)?;
@@ -43,6 +47,7 @@ impl SingleAttributeParser for RustcBuiltinMacroParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
         template!(List: &["TraitName", "TraitName, attributes(name1, name2, ...)"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let (builtin_name, helper_attrs) = parse_derive_like(cx, args, false)?;

--- a/compiler/rustc_attr_parsing/src/attributes/prototype.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/prototype.rs
@@ -1,6 +1,6 @@
 //! Attributes that are only used on function prototypes.
 
-use rustc_feature::{AttributeTemplate, template};
+use rustc_feature::{AttributeStability, AttributeTemplate, template};
 use rustc_hir::Target;
 use rustc_hir::attrs::{AttributeKind, MirDialect, MirPhase};
 use rustc_span::{Span, Symbol, sym};
@@ -8,14 +8,15 @@ use rustc_span::{Span, Symbol, sym};
 use crate::attributes::SingleAttributeParser;
 use crate::context::AcceptContext;
 use crate::parser::{ArgParser, NameValueParser};
-use crate::session_diagnostics;
 use crate::target_checking::AllowedTargets;
 use crate::target_checking::Policy::Allow;
+use crate::{session_diagnostics, unstable};
 
 pub(crate) struct CustomMirParser;
 
 impl SingleAttributeParser for CustomMirParser {
     const PATH: &[rustc_span::Symbol] = &[sym::custom_mir];
+    const STABILITY: AttributeStability = unstable!(custom_mir);
 
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/repr.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/repr.rs
@@ -1,5 +1,6 @@
 use rustc_abi::{Align, Size};
 use rustc_ast::{IntTy, LitIntType, LitKind, UintTy};
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::IntType::{SignedInt, UnsignedInt};
 use rustc_hir::attrs::ReprAttr;
 
@@ -55,6 +56,7 @@ impl CombineAttributeParser for ReprParser {
     //FIXME Still checked fully in `check_attr.rs`
     //This one is slightly more complicated because the allowed targets depend on the arguments
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 }
 
 fn parse_repr(cx: &mut AcceptContext<'_, '_>, param: &MetaItemParser) -> Option<ReprAttr> {
@@ -223,7 +225,8 @@ impl RustcAlignParser {
 }
 
 impl AttributeParser for RustcAlignParser {
-    const ATTRIBUTES: AcceptMapping<Self> = &[(Self::PATH, Self::TEMPLATE, Self::parse)];
+    const ATTRIBUTES: AcceptMapping<Self> =
+        &[(Self::PATH, Self::TEMPLATE, unstable!(fn_align), Self::parse)];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -252,7 +255,8 @@ impl RustcAlignStaticParser {
 }
 
 impl AttributeParser for RustcAlignStaticParser {
-    const ATTRIBUTES: AcceptMapping<Self> = &[(Self::PATH, Self::TEMPLATE, Self::parse)];
+    const ATTRIBUTES: AcceptMapping<Self> =
+        &[(Self::PATH, Self::TEMPLATE, unstable!(static_align), Self::parse)];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Static), Allow(Target::ForeignStatic)]);
 

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_allocator.rs
@@ -1,3 +1,5 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct RustcAllocatorParser;
@@ -6,6 +8,7 @@ impl NoArgsAttributeParser for RustcAllocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcAllocator;
 }
 
@@ -15,6 +18,7 @@ impl NoArgsAttributeParser for RustcAllocatorZeroedParser {
     const PATH: &[Symbol] = &[sym::rustc_allocator_zeroed];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcAllocatorZeroed;
 }
 
@@ -25,6 +29,7 @@ impl SingleAttributeParser for RustcAllocatorZeroedVariantParser {
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "function");
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
         let name = cx.expect_string_literal(nv)?;
@@ -39,6 +44,7 @@ impl NoArgsAttributeParser for RustcDeallocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_deallocator];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDeallocator;
 }
 
@@ -48,5 +54,6 @@ impl NoArgsAttributeParser for RustcReallocatorParser {
     const PATH: &[Symbol] = &[sym::rustc_reallocator];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Fn), Allow(Target::ForeignFn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcReallocator;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_dump.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::{AttributeKind, RustcDumpLayoutKind};
 use rustc_hir::{MethodKind, Target};
 use rustc_span::{Span, Symbol, sym};
@@ -10,6 +11,7 @@ pub(crate) struct RustcDumpUserArgsParser;
 impl NoArgsAttributeParser for RustcDumpUserArgsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_user_args];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpUserArgs;
 }
 
@@ -18,6 +20,7 @@ pub(crate) struct RustcDumpDefParentsParser;
 impl NoArgsAttributeParser for RustcDumpDefParentsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_def_parents];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpDefParents;
 }
 
@@ -35,6 +38,7 @@ impl SingleAttributeParser for RustcDumpDefPathParser {
         Allow(Target::Impl { of_trait: false }),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         cx.expect_no_args(args)?;
         Some(AttributeKind::RustcDumpDefPath(cx.attr_span))
@@ -46,6 +50,7 @@ pub(crate) struct RustcDumpHiddenTypeOfOpaquesParser;
 impl NoArgsAttributeParser for RustcDumpHiddenTypeOfOpaquesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_hidden_type_of_opaques];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpHiddenTypeOfOpaques;
 }
 
@@ -59,6 +64,7 @@ impl NoArgsAttributeParser for RustcDumpInferredOutlivesParser {
         Allow(Target::Union),
         Allow(Target::TyAlias),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpInferredOutlives;
 }
 
@@ -67,6 +73,7 @@ pub(crate) struct RustcDumpItemBoundsParser;
 impl NoArgsAttributeParser for RustcDumpItemBoundsParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_item_bounds];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::AssocTy)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpItemBounds;
 }
 
@@ -88,6 +95,8 @@ impl CombineAttributeParser for RustcDumpLayoutParser {
 
     const TEMPLATE: AttributeTemplate =
         template!(List: &["abi", "align", "size", "homogenous_aggregate", "debug"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
+
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
         args: &ArgParser,
@@ -155,6 +164,7 @@ impl NoArgsAttributeParser for RustcDumpObjectLifetimeDefaultsParser {
         Allow(Target::TyAlias),
         Allow(Target::Union),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpObjectLifetimeDefaults;
 }
 
@@ -182,6 +192,7 @@ impl NoArgsAttributeParser for RustcDumpPredicatesParser {
         Allow(Target::TyAlias),
         Allow(Target::Union),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpPredicates;
 }
 
@@ -199,6 +210,7 @@ impl SingleAttributeParser for RustcDumpSymbolNameParser {
         Allow(Target::Impl { of_trait: false }),
     ]);
     const TEMPLATE: AttributeTemplate = template!(Word);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         cx.expect_no_args(args)?;
         Some(AttributeKind::RustcDumpSymbolName(cx.attr_span))
@@ -219,6 +231,10 @@ impl NoArgsAttributeParser for RustcDumpVariancesParser {
         Allow(Target::Struct),
         Allow(Target::Union),
     ]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[rustc_dump_variances]` attribute is used for rustc unit tests"
+    );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpVariances;
 }
 
@@ -227,6 +243,7 @@ pub(crate) struct RustcDumpVariancesOfOpaquesParser;
 impl NoArgsAttributeParser for RustcDumpVariancesOfOpaquesParser {
     const PATH: &[Symbol] = &[sym::rustc_dump_variances_of_opaques];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDumpVariancesOfOpaques;
 }
 
@@ -238,5 +255,6 @@ impl NoArgsAttributeParser for RustcDumpVtableParser {
         Allow(Target::Impl { of_trait: true }),
         Allow(Target::TyAlias),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcDumpVtable;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/rustc_internal.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use rustc_ast::{LitIntType, LitKind, MetaItemLit};
+use rustc_feature::AttributeStability;
 use rustc_hir::LangItem;
 use rustc_hir::attrs::{
     BorrowckGraphvizFormatKind, CguFields, CguKind, DivergingBlockBehavior,
@@ -20,6 +21,10 @@ pub(crate) struct RustcMainParser;
 impl NoArgsAttributeParser for RustcMainParser {
     const PATH: &[Symbol] = &[sym::rustc_main];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[rustc_main]` attribute is used internally to specify test entry point function"
+    );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcMain;
 }
 
@@ -28,6 +33,10 @@ pub(crate) struct RustcMustImplementOneOfParser;
 impl SingleAttributeParser for RustcMustImplementOneOfParser {
     const PATH: &[Symbol] = &[sym::rustc_must_implement_one_of];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait. Its syntax and semantics are highly experimental and will be subject to change before stabilization"
+    );
     const TEMPLATE: AttributeTemplate = template!(List: &["function1, function2, ..."]);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
@@ -75,6 +84,8 @@ impl NoArgsAttributeParser for RustcNeverReturnsNullPtrParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
+
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNeverReturnsNullPtr;
 }
 pub(crate) struct RustcNoImplicitAutorefsParser;
@@ -88,6 +99,7 @@ impl NoArgsAttributeParser for RustcNoImplicitAutorefsParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoImplicitAutorefs;
 }
@@ -98,6 +110,7 @@ impl SingleAttributeParser for RustcLegacyConstGenericsParser {
     const PATH: &[Symbol] = &[sym::rustc_legacy_const_generics];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["N"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let meta_items = cx.expect_list(args, cx.attr_span)?;
@@ -141,6 +154,7 @@ impl NoArgsAttributeParser for RustcInheritOverflowChecksParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
         Allow(Target::Closure),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcInheritOverflowChecks;
 }
 
@@ -150,6 +164,7 @@ impl SingleAttributeParser for RustcLintOptDenyFieldAccessParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_deny_field_access];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Field)]);
     const TEMPLATE: AttributeTemplate = template!(Word);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let arg = cx.expect_single_element_list(args, cx.attr_span)?;
         let lint_message = cx.expect_string_literal(arg)?;
@@ -163,6 +178,7 @@ pub(crate) struct RustcLintOptTyParser;
 impl NoArgsAttributeParser for RustcLintOptTyParser {
     const PATH: &[Symbol] = &[sym::rustc_lint_opt_ty];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcLintOptTy;
 }
 
@@ -258,6 +274,7 @@ impl AttributeParser for RustcCguTestAttributeParser {
         (
             &[sym::rustc_partition_reused],
             template!(List: &[r#"cfg = "...", module = "...""#]),
+            unstable!(rustc_attrs),
             |this, cx, args| {
                 this.items.extend(parse_cgu_fields(cx, args, false).map(|(cfg, module, _)| {
                     (cx.attr_span, CguFields::PartitionReused { cfg, module })
@@ -267,6 +284,7 @@ impl AttributeParser for RustcCguTestAttributeParser {
         (
             &[sym::rustc_partition_codegened],
             template!(List: &[r#"cfg = "...", module = "...""#]),
+            unstable!(rustc_attrs),
             |this, cx, args| {
                 this.items.extend(parse_cgu_fields(cx, args, false).map(|(cfg, module, _)| {
                     (cx.attr_span, CguFields::PartitionCodegened { cfg, module })
@@ -276,6 +294,7 @@ impl AttributeParser for RustcCguTestAttributeParser {
         (
             &[sym::rustc_expected_cgu_reuse],
             template!(List: &[r#"cfg = "...", module = "...", kind = "...""#]),
+            unstable!(rustc_attrs),
             |this, cx, args| {
                 this.items.extend(parse_cgu_fields(cx, args, true).map(|(cfg, module, kind)| {
                     // unwrap ok because if not given, we return None in `parse_cgu_fields`.
@@ -305,6 +324,7 @@ impl SingleAttributeParser for RustcDeprecatedSafe2024Parser {
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
     const TEMPLATE: AttributeTemplate = template!(List: &[r#"audit_that = "...""#]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
@@ -333,6 +353,7 @@ impl NoArgsAttributeParser for RustcConversionSuggestionParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcConversionSuggestion;
 }
 
@@ -341,6 +362,7 @@ pub(crate) struct RustcCaptureAnalysisParser;
 impl NoArgsAttributeParser for RustcCaptureAnalysisParser {
     const PATH: &[Symbol] = &[sym::rustc_capture_analysis];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Closure)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCaptureAnalysis;
 }
 
@@ -353,6 +375,10 @@ impl SingleAttributeParser for RustcNeverTypeOptionsParser {
         r#"fallback = "unit", "never", "no""#,
         r#"diverging_block_default = "unit", "never""#,
     ]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "`rustc_never_type_options` is used to experiment with never type fallback and work on never type stabilization"
+    );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let list = cx.expect_list(args, cx.attr_span)?;
@@ -418,6 +444,7 @@ pub(crate) struct RustcTrivialFieldReadsParser;
 impl NoArgsAttributeParser for RustcTrivialFieldReadsParser {
     const PATH: &[Symbol] = &[sym::rustc_trivial_field_reads];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcTrivialFieldReads;
 }
 
@@ -432,6 +459,7 @@ impl NoArgsAttributeParser for RustcNoMirInlineParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoMirInline;
 }
 
@@ -447,6 +475,7 @@ impl NoArgsAttributeParser for RustcNoWritableParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNoWritable;
 }
 
@@ -461,6 +490,7 @@ impl NoArgsAttributeParser for RustcLintQueryInstabilityParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcLintQueryInstability;
 }
 
@@ -475,7 +505,7 @@ impl NoArgsAttributeParser for RustcRegionsParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
-
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcRegions;
 }
 
@@ -490,7 +520,7 @@ impl NoArgsAttributeParser for RustcLintUntrackedQueryInformationParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
-
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcLintUntrackedQueryInformation;
 }
 
@@ -500,6 +530,7 @@ impl SingleAttributeParser for RustcSimdMonomorphizeLaneLimitParser {
     const PATH: &[Symbol] = &[sym::rustc_simd_monomorphize_lane_limit];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "N");
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -513,6 +544,7 @@ impl SingleAttributeParser for RustcScalableVectorParser {
     const PATH: &[Symbol] = &[sym::rustc_scalable_vector];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["count"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if args.as_no_args().is_ok() {
@@ -534,6 +566,7 @@ impl SingleAttributeParser for LangParser {
     const PATH: &[Symbol] = &[sym::lang];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
+    const STABILITY: AttributeStability = unstable!(lang_items);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -557,6 +590,7 @@ impl NoArgsAttributeParser for RustcHasIncoherentInherentImplsParser {
         Allow(Target::Union),
         Allow(Target::ForeignTy),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcHasIncoherentInherentImpls;
 }
 
@@ -565,6 +599,7 @@ pub(crate) struct PanicHandlerParser;
 impl NoArgsAttributeParser for PanicHandlerParser {
     const PATH: &[Symbol] = &[sym::panic_handler];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); // Targets are checked per lang item in `rustc_passes`
+    const STABILITY: AttributeStability = AttributeStability::Stable;
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Lang(LangItem::PanicImpl);
 }
 
@@ -579,6 +614,7 @@ impl NoArgsAttributeParser for RustcNounwindParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
         Allow(Target::Method(MethodKind::Trait { body: true })),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNounwind;
 }
 
@@ -587,6 +623,7 @@ pub(crate) struct RustcOffloadKernelParser;
 impl NoArgsAttributeParser for RustcOffloadKernelParser {
     const PATH: &[Symbol] = &[sym::rustc_offload_kernel];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcOffloadKernel;
 }
 
@@ -598,7 +635,6 @@ impl CombineAttributeParser for RustcMirParser {
     type Item = RustcMirKind;
 
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::RustcMir(items);
-
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
@@ -606,8 +642,8 @@ impl CombineAttributeParser for RustcMirParser {
         Allow(Target::Method(MethodKind::Trait { body: false })),
         Allow(Target::Method(MethodKind::Trait { body: true })),
     ]);
-
     const TEMPLATE: AttributeTemplate = template!(List: &["arg1, arg2, ..."]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -679,6 +715,10 @@ impl NoArgsAttributeParser for RustcNonConstTraitMethodParser {
         Allow(Target::Method(MethodKind::Trait { body: true })),
         Allow(Target::Method(MethodKind::Trait { body: false })),
     ]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods as non-const to allow large traits an easier transition to const"
+    );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNonConstTraitMethod;
 }
 
@@ -690,7 +730,6 @@ impl CombineAttributeParser for RustcCleanParser {
     type Item = RustcCleanAttribute;
 
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::RustcClean(items);
-
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         // tidy-alphabetical-start
         Allow(Target::AssocConst),
@@ -715,7 +754,7 @@ impl CombineAttributeParser for RustcCleanParser {
         Allow(Target::Union),
         // tidy-alphabetical-end
     ]);
-
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const TEMPLATE: AttributeTemplate =
         template!(List: &[r#"cfg = "...", /*opt*/ label = "...", /*opt*/ except = "...""#]);
 
@@ -784,7 +823,6 @@ pub(crate) struct RustcIfThisChangedParser;
 
 impl SingleAttributeParser for RustcIfThisChangedParser {
     const PATH: &[Symbol] = &[sym::rustc_if_this_changed];
-
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
         // tidy-alphabetical-start
         Allow(Target::AssocConst),
@@ -809,8 +847,8 @@ impl SingleAttributeParser for RustcIfThisChangedParser {
         Allow(Target::Union),
         // tidy-alphabetical-end
     ]);
-
     const TEMPLATE: AttributeTemplate = template!(Word, List: &["DepNode"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         if !cx.cx.sess.opts.unstable_opts.query_dep_graph {
@@ -867,8 +905,8 @@ impl CombineAttributeParser for RustcThenThisWouldNeedParser {
         Allow(Target::Union),
         // tidy-alphabetical-end
     ]);
-
     const TEMPLATE: AttributeTemplate = template!(List: &["DepNode"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn extend(
         cx: &mut AcceptContext<'_, '_>,
@@ -895,6 +933,7 @@ impl NoArgsAttributeParser for RustcInsignificantDtorParser {
         Allow(Target::Struct),
         Allow(Target::ForeignTy),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcInsignificantDtor;
 }
 
@@ -933,6 +972,7 @@ impl NoArgsAttributeParser for RustcEffectiveVisibilityParser {
         Allow(Target::PatField),
         Allow(Target::Crate),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcEffectiveVisibility;
 }
 
@@ -959,6 +999,10 @@ impl SingleAttributeParser for RustcDiagnosticItemParser {
         Allow(Target::Crate),
     ]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types from the standard library for diagnostic purposes"
+    );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -978,6 +1022,10 @@ impl NoArgsAttributeParser for RustcDoNotConstCheckParser {
         Allow(Target::Method(MethodKind::Trait { body: false })),
         Allow(Target::Method(MethodKind::Trait { body: true })),
     ]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "`#[rustc_do_not_const_check]` skips const-check for this function's body"
+    );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDoNotConstCheck;
 }
 
@@ -986,6 +1034,11 @@ pub(crate) struct RustcNonnullOptimizationGuaranteedParser;
 impl NoArgsAttributeParser for RustcNonnullOptimizationGuaranteedParser {
     const PATH: &[Symbol] = &[sym::rustc_nonnull_optimization_guaranteed];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Struct)]);
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document guaranteed niche optimizations in the standard library",
+        "the compiler does not even check whether the type indeed is being non-null-optimized; it is your responsibility to ensure that the attribute is only used on types that are optimized"
+    );
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcNonnullOptimizationGuaranteed;
 }
 
@@ -1000,6 +1053,7 @@ impl NoArgsAttributeParser for RustcStrictCoherenceParser {
         Allow(Target::Union),
         Allow(Target::ForeignTy),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcStrictCoherence;
 }
 
@@ -1009,8 +1063,8 @@ impl SingleAttributeParser for RustcReservationImplParser {
     const PATH: &[Symbol] = &[sym::rustc_reservation_impl];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Impl { of_trait: true })]);
-
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "reservation message");
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -1025,6 +1079,7 @@ pub(crate) struct PreludeImportParser;
 impl NoArgsAttributeParser for PreludeImportParser {
     const PATH: &[Symbol] = &[sym::prelude_import];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Use)]);
+    const STABILITY: AttributeStability = unstable!(prelude_import);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::PreludeImport;
 }
 
@@ -1034,6 +1089,10 @@ impl SingleAttributeParser for RustcDocPrimitiveParser {
     const PATH: &[Symbol] = &[sym::rustc_doc_primitive];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Mod)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "primitive name");
+    const STABILITY: AttributeStability = unstable!(
+        rustc_attrs,
+        "the `#[rustc_doc_primitive]` attribute is used by the standard library to provide a way to generate documentation for primitive types"
+    );
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(args, cx.attr_span, None)?;
@@ -1048,6 +1107,7 @@ pub(crate) struct RustcIntrinsicParser;
 impl NoArgsAttributeParser for RustcIntrinsicParser {
     const PATH: &[Symbol] = &[sym::rustc_intrinsic];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(intrinsics);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcIntrinsic;
 }
 
@@ -1056,6 +1116,7 @@ pub(crate) struct RustcIntrinsicConstStableIndirectParser;
 impl NoArgsAttributeParser for RustcIntrinsicConstStableIndirectParser {
     const PATH: &'static [Symbol] = &[sym::rustc_intrinsic_const_stable_indirect];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcIntrinsicConstStableIndirect;
 }
 
@@ -1064,5 +1125,6 @@ pub(crate) struct RustcExhaustiveParser;
 impl NoArgsAttributeParser for RustcExhaustiveParser {
     const PATH: &'static [Symbol] = &[sym::rustc_must_match_exhaustively];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Enum)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcMustMatchExhaustively;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/semantics.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/semantics.rs
@@ -1,8 +1,11 @@
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 
 pub(crate) struct MayDangleParser;
 impl NoArgsAttributeParser for MayDangleParser {
     const PATH: &[Symbol] = &[sym::may_dangle];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS); //FIXME Still checked fully in `check_attr.rs`
+    const STABILITY: AttributeStability = unstable!(dropck_eyepatch);
     const CREATE: fn(span: Span) -> AttributeKind = AttributeKind::MayDangle;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -1,7 +1,7 @@
 use std::num::NonZero;
 
 use rustc_errors::ErrorGuaranteed;
-use rustc_feature::ACCEPTED_LANG_FEATURES;
+use rustc_feature::{ACCEPTED_LANG_FEATURES, AttributeStability};
 use rustc_hir::attrs::UnstableRemovedFeature;
 use rustc_hir::target::GenericParamKind;
 use rustc_hir::{
@@ -12,16 +12,6 @@ use rustc_hir::{
 use super::prelude::*;
 use super::util::parse_version;
 use crate::session_diagnostics;
-
-macro_rules! reject_outside_std {
-    ($cx: ident) => {
-        // Emit errors for non-staged-api crates.
-        if !$cx.features().staged_api() {
-            $cx.emit_err(session_diagnostics::StabilityOutsideStd { span: $cx.attr_span });
-            return;
-        }
-    };
-}
 
 const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[
     Allow(Target::Fn),
@@ -76,8 +66,8 @@ impl AttributeParser for StabilityParser {
         (
             &[sym::stable],
             template!(List: &[r#"feature = "name", since = "version""#]),
+            unstable!(staged_api),
             |this, cx, args| {
-                reject_outside_std!(cx);
                 if !this.check_duplicate(cx)
                     && let Some((feature, level)) = parse_stability(cx, args)
                 {
@@ -88,8 +78,8 @@ impl AttributeParser for StabilityParser {
         (
             &[sym::unstable],
             template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
+            unstable!(staged_api),
             |this, cx, args| {
-                reject_outside_std!(cx);
                 if !this.check_duplicate(cx)
                     && let Some((feature, level)) = parse_unstability(cx, args)
                 {
@@ -100,8 +90,8 @@ impl AttributeParser for StabilityParser {
         (
             &[sym::rustc_allowed_through_unstable_modules],
             template!(NameValueStr: "deprecation message"),
+            unstable!(staged_api),
             |this, cx, args| {
-                reject_outside_std!(cx);
                 let Some(nv) = cx.expect_name_value(args, cx.attr_span, None) else {
                     return;
                 };
@@ -158,8 +148,8 @@ impl AttributeParser for BodyStabilityParser {
     const ATTRIBUTES: AcceptMapping<Self> = &[(
         &[sym::rustc_default_body_unstable],
         template!(List: &[r#"feature = "name", reason = "...", issue = "N""#]),
+        unstable!(staged_api),
         |this, cx, args| {
-            reject_outside_std!(cx);
             if this.stability.is_some() {
                 cx.dcx()
                     .emit_err(session_diagnostics::MultipleStabilityLevels { span: cx.attr_span });
@@ -185,6 +175,7 @@ impl NoArgsAttributeParser for RustcConstStableIndirectParser {
         Allow(Target::Fn),
         Allow(Target::Method(MethodKind::Inherent)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcConstStableIndirect;
 }
 
@@ -211,9 +202,8 @@ impl AttributeParser for ConstStabilityParser {
         (
             &[sym::rustc_const_stable],
             template!(List: &[r#"feature = "name""#]),
+            unstable!(staged_api),
             |this, cx, args| {
-                reject_outside_std!(cx);
-
                 if !this.check_duplicate(cx)
                     && let Some((feature, level)) = parse_stability(cx, args)
                 {
@@ -227,8 +217,8 @@ impl AttributeParser for ConstStabilityParser {
         (
             &[sym::rustc_const_unstable],
             template!(List: &[r#"feature = "name""#]),
+            unstable!(staged_api),
             |this, cx, args| {
-                reject_outside_std!(cx);
                 if !this.check_duplicate(cx)
                     && let Some((feature, level)) = parse_unstability(cx, args)
                 {
@@ -239,8 +229,7 @@ impl AttributeParser for ConstStabilityParser {
                 }
             },
         ),
-        (&[sym::rustc_promotable], template!(Word), |this, cx, _| {
-            reject_outside_std!(cx);
+        (&[sym::rustc_promotable], template!(Word), unstable!(staged_api), |this, _cx, _| {
             this.promotable = true;
         }),
     ];
@@ -474,6 +463,7 @@ impl CombineAttributeParser for UnstableRemovedParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate =
         template!(List: &[r#"feature = "name", reason = "...", link = "...", since = "version""#]);
+    const STABILITY: AttributeStability = unstable!(staged_api);
 
     const CONVERT: ConvertFn<Self::Item> = |items, _| AttributeKind::UnstableRemoved(items);
 
@@ -485,11 +475,6 @@ impl CombineAttributeParser for UnstableRemovedParser {
         let mut reason = None;
         let mut link = None;
         let mut since = None;
-
-        if !cx.features().staged_api() {
-            cx.emit_err(session_diagnostics::StabilityOutsideStd { span: cx.attr_span });
-            return None;
-        }
 
         let list = cx.expect_list(args, cx.attr_span)?;
 

--- a/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/test_attrs.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_hir::attrs::RustcAbiAttrKind;
 use rustc_session::lint::builtin::ILL_FORMED_ATTRIBUTE_INPUT;
 
@@ -14,6 +15,7 @@ impl SingleAttributeParser for IgnoreParser {
         Word, NameValueStr: "reason",
         "https://doc.rust-lang.org/reference/attributes/testing.html#the-ignore-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::Ignore {
@@ -55,6 +57,7 @@ impl SingleAttributeParser for ShouldPanicParser {
         Word, List: &[r#"expected = "reason""#], NameValueStr: "reason",
         "https://doc.rust-lang.org/reference/attributes/testing.html#the-should_panic-attribute"
     );
+    const STABILITY: AttributeStability = AttributeStability::Stable;
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         Some(AttributeKind::ShouldPanic {
@@ -82,6 +85,7 @@ impl SingleAttributeParser for ReexportTestHarnessMainParser {
     const PATH: &[Symbol] = &[sym::reexport_test_harness_main];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "name");
+    const STABILITY: AttributeStability = unstable!(custom_test_frameworks);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let nv = cx.expect_name_value(
@@ -110,6 +114,7 @@ impl SingleAttributeParser for RustcAbiParser {
         Allow(Target::Method(MethodKind::Trait { body: false })),
         Allow(Target::Method(MethodKind::TraitImpl)),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let Some(args) = args.as_list() else {
@@ -146,6 +151,7 @@ pub(crate) struct RustcDelayedBugFromInsideQueryParser;
 impl NoArgsAttributeParser for RustcDelayedBugFromInsideQueryParser {
     const PATH: &[Symbol] = &[sym::rustc_delayed_bug_from_inside_query];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Fn)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDelayedBugFromInsideQuery;
 }
 
@@ -160,6 +166,7 @@ impl NoArgsAttributeParser for RustcEvaluateWhereClausesParser {
         Allow(Target::Method(MethodKind::TraitImpl)),
         Allow(Target::Method(MethodKind::Trait { body: false })),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcEvaluateWhereClauses;
 }
 
@@ -169,6 +176,7 @@ impl SingleAttributeParser for TestRunnerParser {
     const PATH: &[Symbol] = &[sym::test_runner];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["path"]);
+    const STABILITY: AttributeStability = unstable!(custom_test_frameworks);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let single = cx.expect_single_element_list(args, cx.attr_span)?;
@@ -191,6 +199,7 @@ impl SingleAttributeParser for RustcTestMarkerParser {
         Allow(Target::Fn),
         Allow(Target::Static),
     ]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const TEMPLATE: AttributeTemplate = template!(NameValueStr: "test_path");
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {

--- a/compiler/rustc_attr_parsing/src/attributes/traits.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/traits.rs
@@ -1,5 +1,7 @@
 use std::mem;
 
+use rustc_feature::AttributeStability;
+
 use super::prelude::*;
 use crate::attributes::{NoArgsAttributeParser, SingleAttributeParser};
 use crate::context::AcceptContext;
@@ -13,6 +15,7 @@ impl SingleAttributeParser for RustcSkipDuringMethodDispatchParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
 
     const TEMPLATE: AttributeTemplate = template!(List: &["array, boxed_slice"]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
 
     fn convert(cx: &mut AcceptContext<'_, '_>, args: &ArgParser) -> Option<AttributeKind> {
         let mut array = false;
@@ -50,6 +53,7 @@ pub(crate) struct RustcParenSugarParser;
 impl NoArgsAttributeParser for RustcParenSugarParser {
     const PATH: &[Symbol] = &[sym::rustc_paren_sugar];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcParenSugar;
 }
 
@@ -64,6 +68,7 @@ impl NoArgsAttributeParser for MarkerParser {
         Warn(Target::Arm),
         Warn(Target::MacroDef),
     ]);
+    const STABILITY: AttributeStability = unstable!(marker_trait_attr);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Marker;
 }
 
@@ -71,6 +76,7 @@ pub(crate) struct RustcDenyExplicitImplParser;
 impl NoArgsAttributeParser for RustcDenyExplicitImplParser {
     const PATH: &[Symbol] = &[sym::rustc_deny_explicit_impl];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcDenyExplicitImpl;
 }
 
@@ -78,6 +84,7 @@ pub(crate) struct RustcDynIncompatibleTraitParser;
 impl NoArgsAttributeParser for RustcDynIncompatibleTraitParser {
     const PATH: &[Symbol] = &[sym::rustc_dyn_incompatible_trait];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcDynIncompatibleTrait;
 }
 
@@ -87,6 +94,7 @@ pub(crate) struct RustcSpecializationTraitParser;
 impl NoArgsAttributeParser for RustcSpecializationTraitParser {
     const PATH: &[Symbol] = &[sym::rustc_specialization_trait];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcSpecializationTrait;
 }
 
@@ -94,6 +102,7 @@ pub(crate) struct RustcUnsafeSpecializationMarkerParser;
 impl NoArgsAttributeParser for RustcUnsafeSpecializationMarkerParser {
     const PATH: &[Symbol] = &[sym::rustc_unsafe_specialization_marker];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcUnsafeSpecializationMarker;
 }
 
@@ -103,6 +112,7 @@ pub(crate) struct RustcCoinductiveParser;
 impl NoArgsAttributeParser for RustcCoinductiveParser {
     const PATH: &[Symbol] = &[sym::rustc_coinductive];
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::RustcCoinductive;
 }
 
@@ -111,6 +121,7 @@ impl NoArgsAttributeParser for RustcAllowIncoherentImplParser {
     const PATH: &[Symbol] = &[sym::rustc_allow_incoherent_impl];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Method(MethodKind::Inherent))]);
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::RustcAllowIncoherentImpl;
 }
 
@@ -119,5 +130,6 @@ impl NoArgsAttributeParser for FundamentalParser {
     const PATH: &[Symbol] = &[sym::fundamental];
     const ALLOWED_TARGETS: AllowedTargets =
         AllowedTargets::AllowList(&[Allow(Target::Struct), Allow(Target::Trait)]);
+    const STABILITY: AttributeStability = unstable!(fundamental);
     const CREATE: fn(Span) -> AttributeKind = |_| AttributeKind::Fundamental;
 }

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -1,3 +1,4 @@
+use rustc_feature::AttributeStability;
 use rustc_span::hygiene::Transparency;
 
 use super::prelude::*;
@@ -9,6 +10,7 @@ impl SingleAttributeParser for RustcMacroTransparencyParser {
     const ON_DUPLICATE: OnDuplicate = OnDuplicate::Custom(|cx, used, unused| {
         cx.dcx().span_err(vec![used, unused], "multiple macro transparency attributes");
     });
+    const STABILITY: AttributeStability = unstable!(rustc_attrs);
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::MacroDef)]);
     const TEMPLATE: AttributeTemplate =
         template!(NameValueStr: ["transparent", "semiopaque", "opaque"]);

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 use rustc_ast::{AttrStyle, MetaItemLit, Safety};
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, Level, MultiSpan};
-use rustc_feature::{AttrSuggestionStyle, AttributeTemplate};
+use rustc_feature::{AttrSuggestionStyle, AttributeStability, AttributeTemplate};
 use rustc_hir::AttrPath;
 use rustc_hir::attrs::AttributeKind;
 use rustc_parse::parser::Recovery;
@@ -81,6 +81,7 @@ pub(super) struct GroupTypeInnerAccept {
     pub(super) accept_fn: AcceptFn,
     pub(super) allowed_targets: AllowedTargets,
     pub(super) safety: AttributeSafety,
+    pub(super) stability: AttributeStability,
     pub(super) finalizer: FinalizeFn,
 }
 
@@ -100,7 +101,7 @@ macro_rules! attribute_parsers {
                         static STATE_OBJECT: RefCell<$names> = RefCell::new(<$names>::default());
                     };
 
-                    for (path, template, accept_fn) in <$names>::ATTRIBUTES {
+                    for (path, template, stability, accept_fn) in <$names>::ATTRIBUTES {
                         match accepters.entry(*path) {
                             Entry::Vacant(e) => {
                                 e.insert(GroupTypeInnerAccept {
@@ -111,6 +112,7 @@ macro_rules! attribute_parsers {
                                         })
                                     }),
                                     safety: <$names as crate::attributes::AttributeParser>::SAFETY,
+                                    stability: *stability,
                                     allowed_targets: <$names as crate::attributes::AttributeParser>::ALLOWED_TARGETS,
                                     finalizer: |cx| {
                                         let state = STATE_OBJECT.take();

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -154,7 +154,7 @@ attribute_parsers!(
         // tidy-alphabetical-start
         Combine<AllowInternalUnstableParser>,
         Combine<CrateTypeParser>,
-        Combine<DebuggerViualizerParser>,
+        Combine<DebuggerVisualizerParser>,
         Combine<FeatureParser>,
         Combine<ForceTargetFeatureParser>,
         Combine<LinkParser>,

--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -346,6 +346,7 @@ impl<'sess> AttributeParser<'sess> {
                             accept.safety,
                             &mut emit_lint,
                         );
+                        self.check_attribute_stability(&attr_path, attr_span, accept.stability);
 
                         let Some(args) = ArgParser::from_attr_args(
                             args,

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -111,6 +111,7 @@ mod early_parsed;
 mod errors;
 mod safety;
 mod session_diagnostics;
+mod stability;
 mod target_checking;
 pub mod validate_attr;
 

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -324,13 +324,6 @@ pub(crate) struct ObjcSelectorExpectedStringLiteral {
 }
 
 #[derive(Diagnostic)]
-#[diag("stability attributes may not be used outside of the standard library", code = E0734)]
-pub(crate) struct StabilityOutsideStd {
-    #[primary_span]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag("expected at least one confusable name")]
 pub(crate) struct EmptyConfusables {
     #[primary_span]

--- a/compiler/rustc_attr_parsing/src/stability.rs
+++ b/compiler/rustc_attr_parsing/src/stability.rs
@@ -1,0 +1,70 @@
+use rustc_feature::AttributeStability;
+use rustc_hir::AttrPath;
+use rustc_session::errors::feature_err;
+use rustc_span::{Span, sym};
+
+use crate::{AttributeParser, ShouldEmit};
+
+#[macro_export]
+macro_rules! unstable {
+    ($feat: ident $(, $notes:expr)*) => {
+        AttributeStability::Unstable {
+            gate_name: rustc_span::sym::$feat,
+            gate_check: rustc_feature::Features::$feat,
+            notes: &[$($notes),*],
+        }
+    };
+}
+
+impl<'sess> AttributeParser<'sess> {
+    pub fn check_attribute_stability(
+        &mut self,
+        attr_path: &AttrPath,
+        attr_span: Span,
+        expected_stability: AttributeStability,
+    ) {
+        if matches!(self.should_emit, ShouldEmit::Nothing) {
+            return;
+        }
+
+        let AttributeStability::Unstable { gate_check, gate_name, notes } = expected_stability
+        else {
+            return;
+        };
+
+        if gate_check(self.features()) || attr_span.allows_unstable(gate_name) {
+            return;
+        }
+
+        let (explain, default_notes): (String, &[String]) = match gate_name {
+            sym::rustc_attrs => ("use of an internal attribute".to_string(), &[
+                format!("the `#[{attr_path}]` attribute is an internal implementation detail that will never be stable"
+            )]),
+            sym::staged_api => ("stability attributes may not be used outside of the standard library".to_string(), &[]),
+            sym::custom_mir => ("the `#[custom_mir]` attribute is just used for the Rust test suite".to_string(), &[]),
+            sym::allow_internal_unsafe => ("allow_internal_unsafe side-steps the unsafe_code lint".to_string(), &[]),
+            sym::allow_internal_unstable => ("allow_internal_unstable side-steps feature gating and stability checks".to_string(), &[]),
+            sym::compiler_builtins => ("the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate which contains compiler-rt intrinsics and will never be stable".to_string(), &[]),
+            sym::custom_test_frameworks => ("custom test frameworks are an unstable feature".to_string(), &[]),
+            sym::linkage => ("the `linkage` attribute is experimental and not portable across platforms".to_string(), &[]),
+            sym::dropck_eyepatch => ("`may_dangle` has unstable semantics and may be removed in the future".to_string(), &[]),
+            sym::intrinsics => ("the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items".to_string(), &[]),
+            sym::lang_items => ("lang items are subject to change".to_string(), &[]),
+            sym::prelude_import => ("`#[prelude_import]` is for use by rustc only".to_string(), &[]),
+            sym::profiler_runtime => ("the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate which contains the profiler runtime and will never be stable".to_string(), &[]),
+            sym::thread_local => ("`#[thread_local]` is an experimental feature, and does not currently handle destructors".to_string(), &[]),
+            _ => (format!("the `#[{attr_path}]` attribute is an experimental feature"), &[]),
+        };
+
+        let mut diag = feature_err(self.sess, gate_name, attr_span, explain);
+
+        for note in default_notes {
+            diag.note(note.clone());
+        }
+        for note in notes {
+            diag.note(*note);
+        }
+
+        diag.emit();
+    }
+}

--- a/compiler/rustc_attr_parsing/src/stability.rs
+++ b/compiler/rustc_attr_parsing/src/stability.rs
@@ -58,6 +58,13 @@ impl<'sess> AttributeParser<'sess> {
 
         let mut diag = feature_err(self.sess, gate_name, attr_span, explain);
 
+        // Remove the suggestion for `#![feature(staged_api)]` as these attributes are currently
+        // not usable outside std. If we do ever expose `#[stable]` etc under a different feature
+        // name then it would be unfortunate to have nightlies out there suggesting `staged_api`.
+        if gate_name == sym::staged_api {
+            diag.children.clear();
+        }
+
         for note in default_notes {
             diag.note(note.clone());
         }

--- a/compiler/rustc_attr_parsing/src/validate_attr.rs
+++ b/compiler/rustc_attr_parsing/src/validate_attr.rs
@@ -9,7 +9,7 @@ use rustc_ast::{
     self as ast, AttrArgs, Attribute, DelimArgs, MetaItem, MetaItemInner, MetaItemKind, Safety,
 };
 use rustc_errors::{Applicability, Diagnostic, PResult};
-use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP, BuiltinAttribute, template};
+use rustc_feature::{AttributeTemplate, BUILTIN_ATTRIBUTE_MAP, template};
 use rustc_hir::AttrPath;
 use rustc_parse::parse_in;
 use rustc_session::errors::report_lit_error;
@@ -29,7 +29,7 @@ pub fn check_attr(psess: &ParseSess, attr: &Attribute) {
 
     // Check input tokens for built-in and key-value attributes.
     match builtin_attr_info {
-        Some(BuiltinAttribute { name, .. }) => {
+        Some(name) => {
             if AttributeParser::is_parsed_attribute(slice::from_ref(&name)) {
                 return;
             }

--- a/compiler/rustc_error_codes/src/error_codes/E0734.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0734.md
@@ -1,8 +1,12 @@
+#### Note: this error code is no longer emitted by the compiler.
+
+This error code was replaced by the more generic E0658.
+
 A stability attribute has been used outside of the standard library.
 
 Erroneous code example:
 
-```compile_fail,E0734
+```compile_fail,E0658
 #[stable(feature = "a", since = "b")] // invalid
 #[unstable(feature = "b", issue = "none")] // invalid
 fn foo(){}

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -2,9 +2,8 @@
 
 use std::sync::LazyLock;
 
-use AttributeGate::*;
 use rustc_ast::ast::Safety;
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::AttrStyle;
 use rustc_span::{Symbol, sym};
 
@@ -60,23 +59,6 @@ const GATED_CFGS: &[GatedCfg] = &[
 /// Find a gated cfg determined by the `pred`icate which is given the cfg's name.
 pub fn find_gated_cfg(pred: impl Fn(Symbol) -> bool) -> Option<&'static GatedCfg> {
     GATED_CFGS.iter().find(|(cfg_sym, ..)| pred(*cfg_sym))
-}
-
-#[derive(Clone, Debug, Copy)]
-pub enum AttributeGate {
-    /// A gated attribute which requires a feature gate to be enabled.
-    Gated {
-        /// The feature gate, for example `#![feature(rustc_attrs)]` for rustc_* attributes.
-        feature: Symbol,
-        /// The error message displayed when an attempt is made to use the attribute without its feature gate.
-        message: &'static str,
-        /// Check function to be called during the `PostExpansionVisitor` pass.
-        check: fn(&Features) -> bool,
-        /// Notes to be displayed when an attempt is made to use the attribute without its feature gate.
-        notes: &'static [&'static str],
-    },
-    /// Ungated attribute, can be used on all release channels
-    Ungated,
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -210,608 +192,341 @@ macro_rules! template {
     } };
 }
 
-macro_rules! ungated {
-    ($attr:ident $(,)?) => {
-        BuiltinAttribute { name: sym::$attr, gate: Ungated }
-    };
-}
-
-macro_rules! gated {
-    ($attr:ident, $gate:ident, $message:expr $(,)?) => {
-        BuiltinAttribute {
-            name: sym::$attr,
-            gate: Gated {
-                feature: sym::$gate,
-                message: $message,
-                check: Features::$gate,
-                notes: &[],
-            },
-        }
-    };
-    ($attr:ident, $message:expr $(,)?) => {
-        BuiltinAttribute {
-            name: sym::$attr,
-            gate: Gated {
-                feature: sym::$attr,
-                message: $message,
-                check: Features::$attr,
-                notes: &[],
-            },
-        }
-    };
-}
-
-macro_rules! rustc_attr {
-    (TEST, $attr:ident $(,)?) => {
-        rustc_attr!(
-            $attr,
-            concat!(
-                "the `#[",
-                stringify!($attr),
-                "]` attribute is used for rustc unit tests"
-            ),
-        )
-    };
-    ($attr:ident $(, $notes:expr)* $(,)?) => {
-        BuiltinAttribute {
-            name: sym::$attr,
-            gate: Gated {
-                feature: sym::rustc_attrs,
-                message: "use of an internal attribute",
-                check: Features::rustc_attrs,
-                notes: &[
-                    concat!("the `#[",
-                    stringify!($attr),
-                    "]` attribute is an internal implementation detail that will never be stable"),
-                    $($notes),*
-                ]
-            },
-        }
-    };
-}
-
-macro_rules! experimental {
-    ($attr:ident) => {
-        concat!("the `#[", stringify!($attr), "]` attribute is an experimental feature")
-    };
-}
-
-pub struct BuiltinAttribute {
-    pub name: Symbol,
-    pub gate: AttributeGate,
-}
-
 /// Attributes that have a special meaning to rustc or rustdoc.
 #[rustfmt::skip]
-pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
+pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     // ==========================================================================
     // Stable attributes:
     // ==========================================================================
 
     // Conditional compilation:
-    ungated!(cfg),
-    ungated!(cfg_attr),
+    sym::cfg,
+    sym::cfg_attr,
 
     // Testing:
-    ungated!(ignore),
-    ungated!(should_panic),
+    sym::ignore,
+    sym::should_panic,
 
     // Macros:
-    ungated!(automatically_derived),
-    ungated!(macro_use),
-    ungated!(macro_escape), // Deprecated synonym for `macro_use`.
-    ungated!(macro_export),
-    ungated!(proc_macro),
-    ungated!(proc_macro_derive),
-    ungated!(proc_macro_attribute),
+    sym::automatically_derived,
+    sym::macro_use,
+    sym::macro_escape, // Deprecated synonym for `macro_use`.
+    sym::macro_export,
+    sym::proc_macro,
+    sym::proc_macro_derive,
+    sym::proc_macro_attribute,
 
     // Lints:
-    ungated!(warn),
-    ungated!(allow),
-    ungated!(expect),
-    ungated!(forbid),
-    ungated!(deny),
-    ungated!(must_use),
-    gated!(must_not_suspend, experimental!(must_not_suspend)),
-    ungated!(deprecated),
+    sym::warn,
+    sym::allow,
+    sym::expect,
+    sym::forbid,
+    sym::deny,
+    sym::must_use,
+    sym::must_not_suspend,
+    sym::deprecated,
 
     // Crate properties:
-    ungated!(crate_name),
-    ungated!(crate_type),
+    sym::crate_name,
+    sym::crate_type,
 
     // ABI, linking, symbols, and FFI
-    ungated!(link),
-    ungated!(link_name),
-    ungated!(no_link),
-    ungated!(repr),
+    sym::link,
+    sym::link_name,
+    sym::no_link,
+    sym::repr,
     // FIXME(#82232, #143834): temporarily renamed to mitigate `#[align]` nameres ambiguity
-    gated!(rustc_align, fn_align, experimental!(rustc_align)),
-    gated!(rustc_align_static, static_align, experimental!(rustc_align_static)),
-    ungated!(export_name),
-    ungated!(link_section),
-    ungated!(no_mangle),
-    ungated!(used),
-    ungated!(link_ordinal),
-    ungated!(naked),
+    sym::rustc_align,
+    sym::rustc_align_static,
+    sym::export_name,
+    sym::link_section,
+    sym::no_mangle,
+    sym::used,
+    sym::link_ordinal,
+    sym::naked,
     // See `TyAndLayout::pass_indirectly_in_non_rustic_abis` for details.
-    rustc_attr!(rustc_pass_indirectly_in_non_rustic_abis, "types marked with `#[rustc_pass_indirectly_in_non_rustic_abis]` are always passed indirectly by non-Rustic ABIs"),
+    sym::rustc_pass_indirectly_in_non_rustic_abis,
 
     // Limits:
-    ungated!(recursion_limit),
-    ungated!(type_length_limit),
-    gated!(move_size_limit, large_assignments, experimental!(move_size_limit)),
+    sym::recursion_limit,
+    sym::type_length_limit,
+    sym::move_size_limit,
 
     // Entry point:
-    ungated!(no_main),
+    sym::no_main,
 
     // Modules, prelude, and resolution:
-    ungated!(path),
-    ungated!(no_std),
-    ungated!(no_implicit_prelude),
-    ungated!(non_exhaustive),
+    sym::path,
+    sym::no_std,
+    sym::no_implicit_prelude,
+    sym::non_exhaustive,
 
     // Runtime
-    ungated!(windows_subsystem),
-    ungated!(panic_handler), // RFC 2070
+    sym::windows_subsystem,
+    sym::panic_handler, // RFC 2070
 
     // Code generation:
-    ungated!(inline),
-    ungated!(cold),
-    ungated!(no_builtins),
-    ungated!(target_feature),
-    ungated!(track_caller),
-    ungated!(instruction_set),
-    gated!(force_target_feature, effective_target_features, experimental!(force_target_feature)),
-    gated!(sanitize, sanitize, experimental!(sanitize)),
-    gated!(coverage, coverage_attribute, experimental!(coverage)),
+    sym::inline,
+    sym::cold,
+    sym::no_builtins,
+    sym::target_feature,
+    sym::track_caller,
+    sym::instruction_set,
+    sym::force_target_feature,
+    sym::sanitize,
+    sym::coverage,
 
-    ungated!(doc),
+    sym::doc,
 
     // Debugging
-    ungated!(debugger_visualizer),
-    ungated!(collapse_debuginfo),
+    sym::debugger_visualizer,
+    sym::collapse_debuginfo,
 
     // ==========================================================================
     // Unstable attributes:
     // ==========================================================================
 
     // Linking:
-    gated!(export_stable, experimental!(export_stable)),
+    sym::export_stable,
 
     // Testing:
-    gated!(test_runner, custom_test_frameworks, "custom test frameworks are an unstable feature"),
+    sym::test_runner,
 
-    gated!(reexport_test_harness_main, custom_test_frameworks, "custom test frameworks are an unstable feature"),
+    sym::reexport_test_harness_main,
 
     // RFC #1268
-    gated!(marker, marker_trait_attr, experimental!(marker)),
-    gated!(thread_local, "`#[thread_local]` is an experimental feature, and does not currently handle destructors"),
-    gated!(no_core, experimental!(no_core)),
+    sym::marker,
+    sym::thread_local,
+    sym::no_core,
     // RFC 2412
-    gated!(optimize, optimize_attribute, experimental!(optimize)),
+    sym::optimize,
 
-    gated!(ffi_pure, experimental!(ffi_pure)),
-    gated!(ffi_const, experimental!(ffi_const)),
-    gated!(register_tool, experimental!(register_tool)),
+    sym::ffi_pure,
+    sym::ffi_const,
+    sym::register_tool,
     // `#[cfi_encoding = ""]`
-    gated!(cfi_encoding, experimental!(cfi_encoding)),
+    sym::cfi_encoding,
 
     // `#[coroutine]` attribute to be applied to closures to make them coroutines instead
-    gated!(coroutine, coroutines, experimental!(coroutine)),
+    sym::coroutine,
 
     // RFC 3543
     // `#[patchable_function_entry(prefix_nops = m, entry_nops = n)]`
-    gated!(patchable_function_entry, experimental!(patchable_function_entry)),
+    sym::patchable_function_entry,
 
     // The `#[loop_match]` and `#[const_continue]` attributes are part of the
     // lang experiment for RFC 3720 tracked in:
     //
     // - https://github.com/rust-lang/rust/issues/132306
-    gated!(const_continue, loop_match, experimental!(const_continue)),
-    gated!(loop_match, loop_match, experimental!(loop_match)),
+    sym::const_continue,
+    sym::loop_match,
 
     // The `#[pin_v2]` attribute is part of the `pin_ergonomics` experiment
     // that allows structurally pinning, tracked in:
     //
     // - https://github.com/rust-lang/rust/issues/130494
-    gated!(pin_v2, pin_ergonomics, experimental!(pin_v2)),
+    sym::pin_v2,
 
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================
 
-    ungated!(feature),
+    sym::feature,
     // DuplicatesOk since it has its own validation
-    ungated!(stable),
-    ungated!(unstable),
-    ungated!(unstable_feature_bound),
-    ungated!(unstable_removed),
-    ungated!(rustc_const_unstable),
-    ungated!(rustc_const_stable),
-    ungated!(rustc_default_body_unstable),
-    gated!(
-        allow_internal_unstable,
-        "allow_internal_unstable side-steps feature gating and stability checks",
-    ),
-    gated!(
-        allow_internal_unsafe,
-        "allow_internal_unsafe side-steps the unsafe_code lint",
-    ),
-    gated!(
-        rustc_eii_foreign_item,
-        eii_internals,
-        "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
-    ),
-    rustc_attr!(
-        rustc_allowed_through_unstable_modules,
-        "rustc_allowed_through_unstable_modules special cases accidental stabilizations of stable items \
-        through unstable paths"
-    ),
-    rustc_attr!(
-        rustc_deprecated_safe_2024,
-        "`#[rustc_deprecated_safe_2024]` is used to declare functions unsafe across the edition 2024 boundary",
-    ),
-    rustc_attr!(
-        rustc_pub_transparent,
-        "used internally to mark types with a `transparent` representation when it is guaranteed by the documentation",
-    ),
+    sym::stable,
+    sym::unstable,
+    sym::unstable_feature_bound,
+    sym::unstable_removed,
+    sym::rustc_const_unstable,
+    sym::rustc_const_stable,
+    sym::rustc_default_body_unstable,
+    sym::allow_internal_unstable,
+    sym::allow_internal_unsafe,
+    sym::rustc_eii_foreign_item,
+    sym::rustc_allowed_through_unstable_modules,
+    sym::rustc_deprecated_safe_2024,
+    sym::rustc_pub_transparent,
 
 
     // ==========================================================================
     // Internal attributes: Type system related:
     // ==========================================================================
 
-    gated!(fundamental, experimental!(fundamental)),
-    gated!(
-        may_dangle,
-        dropck_eyepatch,
-        "`may_dangle` has unstable semantics and may be removed in the future",
-    ),
+    sym::fundamental,
+    sym::may_dangle,
 
-    rustc_attr!(
-        rustc_never_type_options,
-        "`rustc_never_type_options` is used to experiment with never type fallback and work on \
-         never type stabilization"
-    ),
+    sym::rustc_never_type_options,
 
     // ==========================================================================
     // Internal attributes: Runtime related:
     // ==========================================================================
 
-    rustc_attr!(rustc_allocator),
-    rustc_attr!(rustc_nounwind),
-    rustc_attr!(rustc_reallocator),
-    rustc_attr!(rustc_deallocator),
-    rustc_attr!(rustc_allocator_zeroed),
-    rustc_attr!(rustc_allocator_zeroed_variant),
-    gated!(
-        default_lib_allocator,
-        allocator_internals, experimental!(default_lib_allocator),
-    ),
-    gated!(
-        needs_allocator,
-        allocator_internals, experimental!(needs_allocator),
-    ),
-    gated!(
-        panic_runtime,
-        experimental!(panic_runtime)
-    ),
-    gated!(
-        needs_panic_runtime,
-        experimental!(needs_panic_runtime)
-    ),
-    gated!(
-        compiler_builtins,
-        "the `#[compiler_builtins]` attribute is used to identify the `compiler_builtins` crate \
-        which contains compiler-rt intrinsics and will never be stable",
-    ),
-    gated!(
-        profiler_runtime,
-        "the `#[profiler_runtime]` attribute is used to identify the `profiler_builtins` crate \
-        which contains the profiler runtime and will never be stable",
-    ),
+    sym::rustc_allocator,
+    sym::rustc_nounwind,
+    sym::rustc_reallocator,
+    sym::rustc_deallocator,
+    sym::rustc_allocator_zeroed,
+    sym::rustc_allocator_zeroed_variant,
+    sym::default_lib_allocator,
+    sym::needs_allocator,
+    sym::panic_runtime,
+    sym::needs_panic_runtime,
+    sym::compiler_builtins,
+    sym::profiler_runtime,
 
     // ==========================================================================
     // Internal attributes, Linkage:
     // ==========================================================================
 
-    gated!(
-        linkage,
-        "the `linkage` attribute is experimental and not portable across platforms",
-    ),
-    rustc_attr!(rustc_std_internal_symbol),
-    rustc_attr!(rustc_objc_class),
-    rustc_attr!(rustc_objc_selector),
+    sym::linkage,
+    sym::rustc_std_internal_symbol,
+    sym::rustc_objc_class,
+    sym::rustc_objc_selector,
 
     // ==========================================================================
     // Internal attributes, Macro related:
     // ==========================================================================
 
-    rustc_attr!(rustc_builtin_macro),
-    rustc_attr!(rustc_proc_macro_decls),
-    rustc_attr!(
-        rustc_macro_transparency,
-        "used internally for testing macro hygiene",
-    ),
-    rustc_attr!(rustc_autodiff),
-    rustc_attr!(rustc_offload_kernel),
+    sym::rustc_builtin_macro,
+    sym::rustc_proc_macro_decls,
+    sym::rustc_macro_transparency,
+    sym::rustc_autodiff,
+    sym::rustc_offload_kernel,
     // Traces that are left when `cfg` and `cfg_attr` attributes are expanded.
     // The attributes are not gated, to avoid stability errors, but they cannot be used in stable
     // or unstable code directly because `sym::cfg_(attr_)trace` are not valid identifiers, they
     // can only be generated by the compiler.
-    ungated!(cfg_trace),
-    ungated!(cfg_attr_trace),
+    sym::cfg_trace,
+    sym::cfg_attr_trace,
 
     // ==========================================================================
     // Internal attributes, Diagnostics related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_on_unimplemented,
-        "see `#[diagnostic::on_unimplemented]` for the stable equivalent of this attribute"
-    ),
-    rustc_attr!(rustc_confusables),
+    sym::rustc_on_unimplemented,
+    sym::rustc_confusables,
     // Enumerates "identity-like" conversion methods to suggest on type mismatch.
-    rustc_attr!(rustc_conversion_suggestion),
+    sym::rustc_conversion_suggestion,
     // Prevents field reads in the marked trait or method to be considered
     // during dead code analysis.
-    rustc_attr!(rustc_trivial_field_reads),
+    sym::rustc_trivial_field_reads,
     // Used by the `rustc::potential_query_instability` lint to warn methods which
     // might not be stable during incremental compilation.
-    rustc_attr!(rustc_lint_query_instability),
+    sym::rustc_lint_query_instability,
     // Used by the `rustc::untracked_query_information` lint to warn methods which
     // might not be stable during incremental compilation.
-    rustc_attr!(rustc_lint_untracked_query_information),
+    sym::rustc_lint_untracked_query_information,
     // Used by the `rustc::bad_opt_access` lint to identify `DebuggingOptions` and `CodegenOptions`
     // types (as well as any others in future).
-    rustc_attr!(rustc_lint_opt_ty),
+    sym::rustc_lint_opt_ty,
     // Used by the `rustc::bad_opt_access` lint on fields
     // types (as well as any others in future).
-    rustc_attr!(rustc_lint_opt_deny_field_access),
+    sym::rustc_lint_opt_deny_field_access,
 
     // ==========================================================================
     // Internal attributes, Const related:
     // ==========================================================================
 
-    rustc_attr!(rustc_promotable),
-    rustc_attr!(rustc_legacy_const_generics),
+    sym::rustc_promotable,
+    sym::rustc_legacy_const_generics,
     // Do not const-check this function's body. It will always get replaced during CTFE via `hook_special_const_fn`.
-    rustc_attr!(
-        rustc_do_not_const_check,
-        "`#[rustc_do_not_const_check]` skips const-check for this function's body",
-    ),
-    rustc_attr!(
-        rustc_const_stable_indirect,
-        "this is an internal implementation detail",
-    ),
-    rustc_attr!(
-        rustc_intrinsic_const_stable_indirect,
-         "this is an internal implementation detail",
-    ),
-    rustc_attr!(
-        rustc_allow_const_fn_unstable,
-        "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
-    ),
+    sym::rustc_do_not_const_check,
+    sym::rustc_const_stable_indirect,
+    sym::rustc_intrinsic_const_stable_indirect,
+    sym::rustc_allow_const_fn_unstable,
 
     // ==========================================================================
     // Internal attributes, Layout related:
     // ==========================================================================
 
-    rustc_attr!(
-        rustc_simd_monomorphize_lane_limit,
-        "the `#[rustc_simd_monomorphize_lane_limit]` attribute is just used by std::simd \
-        for better error messages",
-    ),
-    rustc_attr!(
-        rustc_nonnull_optimization_guaranteed,
-        "the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to document \
-        guaranteed niche optimizations in the standard library",
-        "the compiler does not even check whether the type indeed is being non-null-optimized; \
-        it is your responsibility to ensure that the attribute is only used on types that are optimized",
-    ),
+    sym::rustc_simd_monomorphize_lane_limit,
+    sym::rustc_nonnull_optimization_guaranteed,
 
     // ==========================================================================
     // Internal attributes, Misc:
     // ==========================================================================
-    gated!(
-        lang, lang_items,
-        "lang items are subject to change",
-    ),
-    rustc_attr!(
-        rustc_as_ptr,
-        "`#[rustc_as_ptr]` is used to mark functions returning pointers to their inner allocations"
-    ),
-    rustc_attr!(
-        rustc_should_not_be_called_on_const_items,
-        "`#[rustc_should_not_be_called_on_const_items]` is used to mark methods that don't make sense to be called on interior mutable consts"
-    ),
-    rustc_attr!(
-        rustc_pass_by_value,
-        "`#[rustc_pass_by_value]` is used to mark types that must be passed by value instead of reference"
-    ),
-    rustc_attr!(
-        rustc_never_returns_null_ptr,
-        "`#[rustc_never_returns_null_ptr]` is used to mark functions returning non-null pointers"
-    ),
-    rustc_attr!(
-        rustc_no_implicit_autorefs,
-        "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument"
-    ),
-    rustc_attr!(
-        rustc_coherence_is_core,
-        "`#![rustc_coherence_is_core]` allows inherent methods on builtin types, only intended to be used in `core`"
-    ),
-    rustc_attr!(
-        rustc_coinductive,
-        "`#[rustc_coinductive]` changes a trait to be coinductive, allowing cycles in the trait solver"
-    ),
-    rustc_attr!(
-        rustc_allow_incoherent_impl,
-        "`#[rustc_allow_incoherent_impl]` has to be added to all impl items of an incoherent inherent impl"
-    ),
-    rustc_attr!(
-        rustc_preserve_ub_checks,
-        "`#![rustc_preserve_ub_checks]` prevents the designated crate from evaluating whether UB checks are enabled when optimizing MIR",
-    ),
-    rustc_attr!(
-        rustc_deny_explicit_impl,
-        "`#[rustc_deny_explicit_impl]` enforces that a trait can have no user-provided impls"
-    ),
-    rustc_attr!(
-        rustc_dyn_incompatible_trait,
-        "`#[rustc_dyn_incompatible_trait]` marks a trait as dyn-incompatible, \
-        even if it otherwise satisfies the requirements to be dyn-compatible."
-    ),
-    rustc_attr!(
-        rustc_has_incoherent_inherent_impls,
-        "`#[rustc_has_incoherent_inherent_impls]` allows the addition of incoherent inherent impls for \
-         the given type by annotating all impl items with `#[rustc_allow_incoherent_impl]`"
-    ),
-    rustc_attr!(
-        rustc_non_const_trait_method,
-        "`#[rustc_non_const_trait_method]` should only used by the standard library to mark trait methods \
-        as non-const to allow large traits an easier transition to const"
-    ),
+    sym::lang,
+    sym::rustc_as_ptr,
+    sym::rustc_should_not_be_called_on_const_items,
+    sym::rustc_pass_by_value,
+    sym::rustc_never_returns_null_ptr,
+    sym::rustc_no_implicit_autorefs,
+    sym::rustc_coherence_is_core,
+    sym::rustc_coinductive,
+    sym::rustc_allow_incoherent_impl,
+    sym::rustc_preserve_ub_checks,
+    sym::rustc_deny_explicit_impl,
+    sym::rustc_dyn_incompatible_trait,
+    sym::rustc_has_incoherent_inherent_impls,
+    sym::rustc_non_const_trait_method,
 
-    BuiltinAttribute {
-        name: sym::rustc_diagnostic_item,
-        gate: Gated {
-            feature: sym::rustc_attrs,
-            message: "use of an internal attribute",
-            check: Features::rustc_attrs,
-            notes: &["the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types \
-            from the standard library for diagnostic purposes"],
-        },
-    },
-    gated!(
-        // Used in resolve:
-        prelude_import,
-        "`#[prelude_import]` is for use by rustc only",
-    ),
-    gated!(
-        rustc_paren_sugar,
-        unboxed_closures, "unboxed_closures are still evolving",
-    ),
-    rustc_attr!(
-        rustc_inherit_overflow_checks,
-        "the `#[rustc_inherit_overflow_checks]` attribute is just used to control \
-        overflow checking behavior of several functions in the standard library that are inlined \
-        across crates",
-    ),
-    rustc_attr!(
-        rustc_reservation_impl,
-        "the `#[rustc_reservation_impl]` attribute is internally used \
-        for reserving `impl<T> From<!> for T` as part of the effort to stabilize `!`"
-    ),
-    rustc_attr!(
-        rustc_test_marker,
-        "the `#[rustc_test_marker]` attribute is used internally to track tests",
-    ),
-    rustc_attr!(
-        rustc_unsafe_specialization_marker,
-        "the `#[rustc_unsafe_specialization_marker]` attribute is used to check specializations"
-    ),
-    rustc_attr!(
-        rustc_specialization_trait,
-        "the `#[rustc_specialization_trait]` attribute is used to check specializations"
-    ),
-    rustc_attr!(
-        rustc_main,
-        "the `#[rustc_main]` attribute is used internally to specify test entry point function",
-    ),
-    rustc_attr!(
-        rustc_skip_during_method_dispatch,
-        "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
-        from method dispatch when the receiver is of the following type, for compatibility in \
-        editions < 2021 (array) or editions < 2024 (boxed_slice)"
-    ),
-    rustc_attr!(
-        rustc_must_implement_one_of,
-        "the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete \
-        definition of a trait. Its syntax and semantics are highly experimental and will be \
-        subject to change before stabilization",
-    ),
-    rustc_attr!(
-        rustc_doc_primitive,
-        "the `#[rustc_doc_primitive]` attribute is used by the standard library \
-        to provide a way to generate documentation for primitive types",
-    ),
-    gated!(
-        rustc_intrinsic, intrinsics,
-        "the `#[rustc_intrinsic]` attribute is used to declare intrinsics as function items",
-    ),
-    rustc_attr!(
-        rustc_no_mir_inline,
-        "`#[rustc_no_mir_inline]` prevents the MIR inliner from inlining a function while not affecting codegen"
-    ),
-    rustc_attr!(
-        rustc_force_inline,
-        "`#[rustc_force_inline]` forces a free function to be inlined"
-    ),
-    rustc_attr!(
-        rustc_scalable_vector,
-        "`#[rustc_scalable_vector]` defines a scalable vector type"
-    ),
-    rustc_attr!(
-        rustc_must_match_exhaustively,
-        "enums with `#[rustc_must_match_exhaustively]` must be matched on with a match block that mentions all variants explicitly"
-    ),
-    rustc_attr!(
-        rustc_no_writable,
-        "`#[rustc_no_writable]` stops the compiler from considering mutable reference arguments of this function as implicitly writable"
-    ),
+    sym::rustc_diagnostic_item,
+    sym::prelude_import,
+    sym::rustc_paren_sugar,
+    sym::rustc_inherit_overflow_checks,
+    sym::rustc_reservation_impl,
+    sym::rustc_test_marker,
+    sym::rustc_unsafe_specialization_marker,
+    sym::rustc_specialization_trait,
+    sym::rustc_main,
+    sym::rustc_skip_during_method_dispatch,
+    sym::rustc_must_implement_one_of,
+    sym::rustc_doc_primitive,
+    sym::rustc_intrinsic,
+    sym::rustc_no_mir_inline,
+    sym::rustc_force_inline,
+    sym::rustc_scalable_vector,
+    sym::rustc_must_match_exhaustively,
+    sym::rustc_no_writable,
 
     // ==========================================================================
     // Internal attributes, Testing:
     // ==========================================================================
 
-    rustc_attr!(TEST, rustc_effective_visibility),
-    rustc_attr!(TEST, rustc_dump_inferred_outlives),
-    rustc_attr!(TEST, rustc_capture_analysis,),
-    rustc_attr!(TEST, rustc_insignificant_dtor),
-    rustc_attr!(TEST, rustc_no_implicit_bounds),
-    rustc_attr!(TEST, rustc_strict_coherence),
-    rustc_attr!(TEST, rustc_dump_variances),
-    rustc_attr!(TEST, rustc_dump_variances_of_opaques),
-    rustc_attr!(TEST, rustc_dump_hidden_type_of_opaques),
-    rustc_attr!(TEST, rustc_dump_layout),
-    rustc_attr!(TEST, rustc_abi),
-    rustc_attr!(TEST, rustc_regions),
-    rustc_attr!(TEST, rustc_delayed_bug_from_inside_query),
-    rustc_attr!(TEST, rustc_dump_user_args),
-    rustc_attr!(TEST, rustc_evaluate_where_clauses),
-    rustc_attr!(TEST, rustc_if_this_changed),
-    rustc_attr!(TEST, rustc_then_this_would_need),
-    rustc_attr!(TEST, rustc_clean),
-    rustc_attr!(TEST, rustc_partition_reused),
-    rustc_attr!(TEST, rustc_partition_codegened),
-    rustc_attr!(TEST, rustc_expected_cgu_reuse),
-    rustc_attr!(TEST, rustc_dump_symbol_name),
-    rustc_attr!(TEST, rustc_dump_def_path),
-    rustc_attr!(TEST, rustc_mir),
-    gated!(
-        custom_mir, "the `#[custom_mir]` attribute is just used for the Rust test suite",
-    ),
-    rustc_attr!(TEST, rustc_dump_item_bounds),
-    rustc_attr!(TEST, rustc_dump_predicates),
-    rustc_attr!(TEST, rustc_dump_def_parents),
-    rustc_attr!(TEST, rustc_dump_object_lifetime_defaults),
-    rustc_attr!(TEST, rustc_dump_vtable),
-    rustc_attr!(TEST, rustc_dummy),
-    rustc_attr!(TEST, pattern_complexity_limit),
+    sym::rustc_effective_visibility,
+    sym::rustc_dump_inferred_outlives,
+    sym::rustc_capture_analysis,
+    sym::rustc_insignificant_dtor,
+    sym::rustc_no_implicit_bounds,
+    sym::rustc_strict_coherence,
+    sym::rustc_dump_variances,
+    sym::rustc_dump_variances_of_opaques,
+    sym::rustc_dump_hidden_type_of_opaques,
+    sym::rustc_dump_layout,
+    sym::rustc_abi,
+    sym::rustc_regions,
+    sym::rustc_delayed_bug_from_inside_query,
+    sym::rustc_dump_user_args,
+    sym::rustc_evaluate_where_clauses,
+    sym::rustc_if_this_changed,
+    sym::rustc_then_this_would_need,
+    sym::rustc_clean,
+    sym::rustc_partition_reused,
+    sym::rustc_partition_codegened,
+    sym::rustc_expected_cgu_reuse,
+    sym::rustc_dump_symbol_name,
+    sym::rustc_dump_def_path,
+    sym::rustc_mir,
+    sym::custom_mir,
+    sym::rustc_dump_item_bounds,
+    sym::rustc_dump_predicates,
+    sym::rustc_dump_def_parents,
+    sym::rustc_dump_object_lifetime_defaults,
+    sym::rustc_dump_vtable,
+    sym::rustc_dummy,
+    sym::pattern_complexity_limit,
 ];
 
 pub fn is_builtin_attr_name(name: Symbol) -> bool {
     BUILTIN_ATTRIBUTE_MAP.get(&name).is_some()
 }
 
-pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>> =
-    LazyLock::new(|| {
-        let mut map = FxHashMap::default();
-        for attr in BUILTIN_ATTRIBUTES.iter() {
-            if map.insert(attr.name, attr).is_some() {
-                panic!("duplicate builtin attribute `{}`", attr.name);
-            }
+pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashSet<Symbol>> = LazyLock::new(|| {
+    let mut map = FxHashSet::default();
+    for attr in BUILTIN_ATTRIBUTES.iter() {
+        if !map.insert(*attr) {
+            panic!("duplicate builtin attribute `{}`", attr);
         }
-        map
-    });
+    }
+    map
+});

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -79,6 +79,21 @@ pub enum AttributeGate {
     Ungated,
 }
 
+#[derive(Clone, Debug, Copy)]
+pub enum AttributeStability {
+    /// An attribute that is unstable behind a specified feature fagte
+    Unstable {
+        /// The feature gate, for example `rustc_attrs` for rustc_* attributes.
+        gate_name: Symbol,
+        /// Check function to be called during the `PostExpansionVisitor` pass, which will be one of the `Features::*` functions
+        gate_check: fn(&Features) -> bool,
+        /// Notes to be displayed when an attempt is made to use the attribute without its feature gate.
+        notes: &'static [&'static str],
+    },
+    /// A stable attribute, can be used on all release channels
+    Stable,
+}
+
 // FIXME(jdonszelmann): move to rustc_hir::attrs
 /// A template that the attribute input must match.
 /// Only top-level shape (`#[attr]` vs `#[attr(...)]` vs `#[attr = ...]`) is considered now.

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -129,8 +129,9 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
-    AttrSuggestionStyle, AttributeGate, AttributeTemplate, BUILTIN_ATTRIBUTE_MAP,
-    BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg, is_builtin_attr_name,
+    AttrSuggestionStyle, AttributeGate, AttributeStability, AttributeTemplate,
+    BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg,
+    is_builtin_attr_name,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -129,9 +129,8 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
 
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
-    AttrSuggestionStyle, AttributeGate, AttributeStability, AttributeTemplate,
-    BUILTIN_ATTRIBUTE_MAP, BUILTIN_ATTRIBUTES, BuiltinAttribute, GatedCfg, find_gated_cfg,
-    is_builtin_attr_name,
+    AttrSuggestionStyle, AttributeStability, AttributeTemplate, BUILTIN_ATTRIBUTE_MAP,
+    BUILTIN_ATTRIBUTES, GatedCfg, find_gated_cfg, is_builtin_attr_name,
 };
 pub use removed::REMOVED_LANG_FEATURES;
 pub use unstable::{

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1282,9 +1282,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 // These trace attributes are compiler-generated and have
                                 // deliberately invalid names.
                                 .filter(|attr| {
-                                    !matches!(attr.name, sym::cfg_trace | sym::cfg_attr_trace)
+                                    !matches!(**attr, sym::cfg_trace | sym::cfg_attr_trace)
                                 })
-                                .map(|attr| TypoSuggestion::typo_from_name(attr.name, res)),
+                                .map(|attr| TypoSuggestion::typo_from_name(*attr, res)),
                         );
                     }
                 }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1838,9 +1838,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             builtin_attr_decls: BUILTIN_ATTRIBUTES
                 .iter()
                 .map(|builtin_attr| {
-                    let res = Res::NonMacroAttr(NonMacroAttrKind::Builtin(builtin_attr.name));
+                    let res = Res::NonMacroAttr(NonMacroAttrKind::Builtin(*builtin_attr));
                     let decl = arenas.new_pub_def_decl(res, DUMMY_SP, LocalExpnId::ROOT);
-                    (builtin_attr.name, decl)
+                    (*builtin_attr, decl)
                 })
                 .collect(),
             registered_tool_decls: registered_tools

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -126,15 +126,6 @@ error: the `#[proc_macro_derive]` attribute is only usable with crates of the `p
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/malformed-attrs.rs:215:1
-   |
-LL | #[allow_internal_unsafe = 1]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0539]: malformed `windows_subsystem` attribute input
   --> $DIR/malformed-attrs.rs:26:1
    |
@@ -787,6 +778,15 @@ LL + #[macro_export(local_inner_macros)]
 LL - #[macro_export = 18]
 LL + #[macro_export]
    |
+
+error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
+  --> $DIR/malformed-attrs.rs:215:1
+   |
+LL | #[allow_internal_unsafe = 1]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
   --> $DIR/malformed-attrs.rs:215:1

--- a/tests/ui/attributes/unstable_removed.stderr
+++ b/tests/ui/attributes/unstable_removed.stderr
@@ -9,9 +9,6 @@ LL | |     link = "https://github.com/rust-lang/rust/issues/141617",
 LL | |     since="1.92.0"
 LL | | )]
    | |__^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0557]: feature `old_feature` has been removed
   --> $DIR/unstable_removed.rs:3:12

--- a/tests/ui/attributes/unstable_removed.stderr
+++ b/tests/ui/attributes/unstable_removed.stderr
@@ -1,4 +1,4 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/unstable_removed.rs:9:1
    |
 LL | / #![unstable_removed(
@@ -9,6 +9,9 @@ LL | |     link = "https://github.com/rust-lang/rust/issues/141617",
 LL | |     since="1.92.0"
 LL | | )]
    | |__^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0557]: feature `old_feature` has been removed
   --> $DIR/unstable_removed.rs:3:12
@@ -30,5 +33,5 @@ LL | #![feature(concat_idents)]
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0557, E0734.
+Some errors have detailed explanations: E0557, E0658.
 For more information about an error, try `rustc --explain E0557`.

--- a/tests/ui/coroutine/gen_block.e2024.stderr
+++ b/tests/ui/coroutine/gen_block.e2024.stderr
@@ -1,3 +1,14 @@
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+  --> $DIR/gen_block.rs:16:16
+   |
+LL |     let _ = || yield true;
+   |                ^^^^^^^^^^
+   |
+help: use `#[coroutine]` to make this closure a coroutine
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ++++++++++++
+
 error[E0658]: the `#[coroutine]` attribute is an experimental feature
   --> $DIR/gen_block.rs:20:13
    |
@@ -17,17 +28,6 @@ LL |     let _ = #[coroutine] || {};
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(coroutines)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
-  --> $DIR/gen_block.rs:16:16
-   |
-LL |     let _ = || yield true;
-   |                ^^^^^^^^^^
-   |
-help: use `#[coroutine]` to make this closure a coroutine
-   |
-LL |     let _ = #[coroutine] || yield true;
-   |             ++++++++++++
 
 error[E0282]: type annotations needed
   --> $DIR/gen_block.rs:7:13

--- a/tests/ui/coroutine/gen_block.none.stderr
+++ b/tests/ui/coroutine/gen_block.none.stderr
@@ -44,26 +44,6 @@ LL |     let _ = #[coroutine] || yield true;
    = help: add `#![feature(yield_expr)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: the `#[coroutine]` attribute is an experimental feature
-  --> $DIR/gen_block.rs:20:13
-   |
-LL |     let _ = #[coroutine] || yield true;
-   |             ^^^^^^^^^^^^
-   |
-   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
-   = help: add `#![feature(coroutines)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: the `#[coroutine]` attribute is an experimental feature
-  --> $DIR/gen_block.rs:24:13
-   |
-LL |     let _ = #[coroutine] || {};
-   |             ^^^^^^^^^^^^
-   |
-   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
-   = help: add `#![feature(coroutines)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0658]: yield syntax is experimental
   --> $DIR/gen_block.rs:16:16
    |
@@ -85,6 +65,16 @@ help: use `#[coroutine]` to make this closure a coroutine
 LL |     let _ = #[coroutine] || yield true;
    |             ++++++++++++
 
+error[E0658]: the `#[coroutine]` attribute is an experimental feature
+  --> $DIR/gen_block.rs:20:13
+   |
+LL |     let _ = #[coroutine] || yield true;
+   |             ^^^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: yield syntax is experimental
   --> $DIR/gen_block.rs:20:29
    |
@@ -93,6 +83,16 @@ LL |     let _ = #[coroutine] || yield true;
    |
    = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
    = help: add `#![feature(yield_expr)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[coroutine]` attribute is an experimental feature
+  --> $DIR/gen_block.rs:24:13
+   |
+LL |     let _ = #[coroutine] || {};
+   |             ^^^^^^^^^^^^
+   |
+   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
+   = help: add `#![feature(coroutines)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 11 previous errors

--- a/tests/ui/feature-gates/feature-gate-rustc_const_unstable.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc_const_unstable.rs
@@ -1,6 +1,8 @@
 // Test internal const fn feature gate.
 
-#[rustc_const_unstable(feature="fzzzzzt")] //~ ERROR stability attributes may not be used outside
+#[rustc_const_unstable(feature="fzzzzzt")]
+//~^ ERROR stability attributes may not be used outside
+//~| ERROR missing 'issue'
 pub const fn bazinga() {}
 
 fn main() {

--- a/tests/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
@@ -3,9 +3,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[rustc_const_unstable(feature="fzzzzzt")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0547]: missing 'issue'
   --> $DIR/feature-gate-rustc_const_unstable.rs:3:1

--- a/tests/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
@@ -1,9 +1,19 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/feature-gate-rustc_const_unstable.rs:3:1
+   |
+LL | #[rustc_const_unstable(feature="fzzzzzt")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0547]: missing 'issue'
   --> $DIR/feature-gate-rustc_const_unstable.rs:3:1
    |
 LL | #[rustc_const_unstable(feature="fzzzzzt")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0734`.
+Some errors have detailed explanations: E0547, E0658.
+For more information about an error, try `rustc --explain E0547`.

--- a/tests/ui/feature-gates/feature-gate-staged_api.stderr
+++ b/tests/ui/feature-gates/feature-gate-staged_api.stderr
@@ -3,18 +3,12 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #![stable(feature = "a", since = "3.3.3")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/feature-gate-staged_api.rs:8:1
    |
 LL | #[stable(feature = "a", since = "3.3.3")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-staged_api.stderr
+++ b/tests/ui/feature-gates/feature-gate-staged_api.stderr
@@ -1,15 +1,21 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/feature-gate-staged_api.rs:1:1
    |
 LL | #![stable(feature = "a", since = "3.3.3")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/feature-gate-staged_api.rs:8:1
    |
 LL | #[stable(feature = "a", since = "3.3.3")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0734`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs-error.stderr
@@ -1,3 +1,11 @@
+error: `#[macro_export]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:9:1
+   |
+LL | #![macro_export]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: `#[macro_export]` can only be applied to macro defs
+
 error[E0658]: use of an internal attribute
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:1
    |
@@ -7,14 +15,6 @@ LL | #![rustc_main]
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: the `#[rustc_main]` attribute is an internal implementation detail that will never be stable
    = note: the `#[rustc_main]` attribute is used internally to specify test entry point function
-
-error: `#[macro_export]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:9:1
-   |
-LL | #![macro_export]
-   | ^^^^^^^^^^^^^^^^
-   |
-   = help: `#[macro_export]` can only be applied to macro defs
 
 error: `#[rustc_main]` attribute cannot be used on crates
   --> $DIR/issue-43106-gating-of-builtin-attrs-error.rs:11:1

--- a/tests/ui/feature-gates/issue-43106-gating-of-stable.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-stable.rs
@@ -6,29 +6,43 @@
 
 #![stable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'since'
+//~| ERROR missing 'feature'
 
 #[stable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'since'
+//~| ERROR missing 'feature'
 mod stable {
     mod inner {
         #![stable()]
         //~^ ERROR stability attributes may not be used outside of the standard library
+        //~| ERROR missing 'since'
+        //~| ERROR missing 'feature'
     }
 
     #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since'
+    //~| ERROR missing 'feature'
     fn f() {}
 
     #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since'
+    //~| ERROR missing 'feature'
     struct S;
 
     #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since'
+    //~| ERROR missing 'feature'
     type T = S;
 
     #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since'
+    //~| ERROR missing 'feature'
     impl S {}
 }
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-stable.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-stable.stderr
@@ -3,9 +3,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #![stable()]
    | ^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:7:1
@@ -24,9 +21,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:12:1
@@ -45,9 +39,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |         #![stable()]
    |         ^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:18:9
@@ -66,9 +57,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:24:5
@@ -87,9 +75,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:30:5
@@ -108,9 +93,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:36:5
@@ -129,9 +111,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:42:5

--- a/tests/ui/feature-gates/issue-43106-gating-of-stable.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-stable.stderr
@@ -1,45 +1,151 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:7:1
+   |
+LL | #![stable()]
+   | ^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:7:1
    |
 LL | #![stable()]
    | ^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:10:1
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:7:1
+   |
+LL | #![stable()]
+   | ^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:12:1
+   |
+LL | #[stable()]
+   | ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-stable.rs:12:1
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:14:9
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:12:1
+   |
+LL | #[stable()]
+   | ^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:18:9
+   |
+LL |         #![stable()]
+   |         ^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-stable.rs:18:9
    |
 LL |         #![stable()]
    |         ^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:18:5
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:18:9
+   |
+LL |         #![stable()]
+   |         ^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:24:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-stable.rs:24:5
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:22:5
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:24:5
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:26:5
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:30:5
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-stable.rs:30:5
    |
 LL |     #[stable()]
    |     ^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:30:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:36:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-stable.rs:36:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:36:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:42:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-stable.rs:42:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-stable.rs:42:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error: aborting due to 21 previous errors
+
+Some errors have detailed explanations: E0542, E0546, E0658.
+For more information about an error, try `rustc --explain E0542`.

--- a/tests/ui/feature-gates/issue-43106-gating-of-unstable.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-unstable.rs
@@ -6,29 +6,43 @@
 
 #![unstable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'issue'
+//~| ERROR missing 'feature'
 
 #[unstable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'issue'
+//~| ERROR missing 'feature'
 mod unstable {
     mod inner {
         #![unstable()]
         //~^ ERROR stability attributes may not be used outside of the standard library
+        //~| ERROR missing 'issue'
+        //~| ERROR missing 'feature'
     }
 
     #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'issue'
+    //~| ERROR missing 'feature'
     fn f() {}
 
     #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'issue'
+    //~| ERROR missing 'feature'
     struct S;
 
     #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'issue'
+    //~| ERROR missing 'feature'
     type T = S;
 
     #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'issue'
+    //~| ERROR missing 'feature'
     impl S {}
 }
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-unstable.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-unstable.stderr
@@ -3,9 +3,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #![unstable()]
    | ^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:7:1
@@ -24,9 +21,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:12:1
@@ -45,9 +39,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |         #![unstable()]
    |         ^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:18:9
@@ -66,9 +57,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:24:5
@@ -87,9 +75,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:30:5
@@ -108,9 +93,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:36:5
@@ -129,9 +111,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:42:5

--- a/tests/ui/feature-gates/issue-43106-gating-of-unstable.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-unstable.stderr
@@ -1,45 +1,151 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
+   |
+LL | #![unstable()]
+   | ^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:7:1
    |
 LL | #![unstable()]
    | ^^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:10:1
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
+   |
+LL | #![unstable()]
+   | ^^^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:12:1
+   |
+LL | #[unstable()]
+   | ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-unstable.rs:12:1
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:14:9
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:12:1
+   |
+LL | #[unstable()]
+   | ^^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:18:9
+   |
+LL |         #![unstable()]
+   |         ^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-unstable.rs:18:9
    |
 LL |         #![unstable()]
    |         ^^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:18:5
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:18:9
+   |
+LL |         #![unstable()]
+   |         ^^^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:24:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-unstable.rs:24:5
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:22:5
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:24:5
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:26:5
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:30:5
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0546]: missing 'feature'
   --> $DIR/issue-43106-gating-of-unstable.rs:30:5
    |
 LL |     #[unstable()]
    |     ^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:30:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:36:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-unstable.rs:36:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:36:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:42:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/issue-43106-gating-of-unstable.rs:42:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0547]: missing 'issue'
+  --> $DIR/issue-43106-gating-of-unstable.rs:42:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 21 previous errors
+
+Some errors have detailed explanations: E0546, E0547, E0658.
+For more information about an error, try `rustc --explain E0546`.

--- a/tests/ui/lang-items/issue-83471.stderr
+++ b/tests/ui/lang-items/issue-83471.stderr
@@ -4,6 +4,25 @@ error[E0573]: expected type, found built-in attribute `export_name`
 LL |     fn call(export_name);
    |             ^^^^^^^^^^^ not a type
 
+warning: anonymous parameters are deprecated and will be removed in the next edition
+  --> $DIR/issue-83471.rs:24:13
+   |
+LL |     fn call(export_name);
+   |             ^^^^^^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: export_name`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2018/trait-fn-parameters.html>
+   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
+
+error[E0718]: `fn` lang item must be applied to a trait with 1 generic argument
+  --> $DIR/issue-83471.rs:20:1
+   |
+LL | #[lang = "fn"]
+   | ^^^^^^^^^^^^^^
+...
+LL | trait Fn {
+   |         - this trait has 0 generic arguments
+
 error[E0658]: lang items are subject to change
   --> $DIR/issue-83471.rs:8:1
    |
@@ -39,25 +58,6 @@ LL | #[lang = "fn"]
    |
    = help: add `#![feature(lang_items)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-warning: anonymous parameters are deprecated and will be removed in the next edition
-  --> $DIR/issue-83471.rs:24:13
-   |
-LL |     fn call(export_name);
-   |             ^^^^^^^^^^^ help: try naming the parameter or explicitly ignoring it: `_: export_name`
-   |
-   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2018/trait-fn-parameters.html>
-   = note: `#[warn(anonymous_parameters)]` (part of `#[warn(rust_2018_compatibility)]`) on by default
-
-error[E0718]: `fn` lang item must be applied to a trait with 1 generic argument
-  --> $DIR/issue-83471.rs:20:1
-   |
-LL | #[lang = "fn"]
-   | ^^^^^^^^^^^^^^
-...
-LL | trait Fn {
-   |         - this trait has 0 generic arguments
 
 error[E0425]: cannot find function `a` in this scope
   --> $DIR/issue-83471.rs:30:5

--- a/tests/ui/stability-attribute/issue-106589.stderr
+++ b/tests/ui/stability-attribute/issue-106589.stderr
@@ -1,15 +1,21 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-106589.rs:3:1
    |
 LL | #![stable(feature = "foo", since = "1.0.0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-106589.rs:6:1
    |
 LL | #[unstable(feature = "foo", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0734`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/stability-attribute/issue-106589.stderr
+++ b/tests/ui/stability-attribute/issue-106589.stderr
@@ -3,18 +3,12 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #![stable(feature = "foo", since = "1.0.0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-106589.rs:6:1
    |
 LL | #[unstable(feature = "foo", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.rs
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.rs
@@ -1,5 +1,11 @@
 //@ compile-flags:-Zforce-unstable-if-unmarked
 
-#[unstable()] //~ ERROR: stability attributes may not be used
-#[stable()] //~ ERROR: stability attributes may not be used
+#[unstable()]
+//~^ ERROR stability attributes may not be used
+//~| ERROR missing 'feature'
+//~| ERROR missing 'issue'
+#[stable()]
+//~^ ERROR stability attributes may not be used
+//~| ERROR missing 'feature'
+//~| ERROR missing 'since'
 fn main() {}

--- a/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
@@ -3,9 +3,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:1
@@ -24,9 +21,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:1

--- a/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
@@ -1,15 +1,46 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:1
+   |
+LL | #[unstable()]
+   | ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:1
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/stability-attribute-non-staged-force-unstable.rs:4:1
+error[E0547]: missing 'issue'
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:3:1
+   |
+LL | #[unstable()]
+   | ^^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:1
+   |
+LL | #[stable()]
+   | ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:1
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:7:1
+   |
+LL | #[stable()]
+   | ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0542, E0546, E0547, E0658.
+For more information about an error, try `rustc --explain E0542`.

--- a/tests/ui/stability-attribute/stability-attribute-non-staged.rs
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged.rs
@@ -1,3 +1,9 @@
-#[unstable()] //~ ERROR: stability attributes may not be used
-#[stable()] //~ ERROR: stability attributes may not be used
+#[unstable()]
+//~^ ERROR: stability attributes may not be used
+//~| ERROR missing 'feature'
+//~| ERROR missing 'issue'
+#[stable()]
+//~^ ERROR: stability attributes may not be used
+//~| ERROR missing 'feature'
+//~| ERROR missing 'since'
 fn main() {}

--- a/tests/ui/stability-attribute/stability-attribute-non-staged.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged.stderr
@@ -3,9 +3,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged.rs:1:1
@@ -24,9 +21,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged.rs:5:1

--- a/tests/ui/stability-attribute/stability-attribute-non-staged.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-non-staged.stderr
@@ -1,15 +1,46 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/stability-attribute-non-staged.rs:1:1
+   |
+LL | #[unstable()]
+   | ^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-non-staged.rs:1:1
    |
 LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/stability-attribute-non-staged.rs:2:1
+error[E0547]: missing 'issue'
+  --> $DIR/stability-attribute-non-staged.rs:1:1
+   |
+LL | #[unstable()]
+   | ^^^^^^^^^^^^^
+
+error[E0658]: stability attributes may not be used outside of the standard library
+  --> $DIR/stability-attribute-non-staged.rs:5:1
+   |
+LL | #[stable()]
+   | ^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0546]: missing 'feature'
+  --> $DIR/stability-attribute-non-staged.rs:5:1
    |
 LL | #[stable()]
    | ^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-non-staged.rs:5:1
+   |
+LL | #[stable()]
+   | ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0542, E0546, E0547, E0658.
+For more information about an error, try `rustc --explain E0542`.

--- a/tests/ui/tool-attributes/diagnostic_item.rs
+++ b/tests/ui/tool-attributes/diagnostic_item.rs
@@ -1,5 +1,6 @@
 #[rustc_diagnostic_item = "foomp"]
 //~^ ERROR use of an internal attribute [E0658]
+//~| NOTE the `#[rustc_diagnostic_item]` attribute is an internal implementation detail that will never be stable
 //~| NOTE the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types from the standard library for diagnostic purposes
 struct Foomp;
 fn main() {}

--- a/tests/ui/tool-attributes/diagnostic_item.stderr
+++ b/tests/ui/tool-attributes/diagnostic_item.stderr
@@ -5,6 +5,7 @@ LL | #[rustc_diagnostic_item = "foomp"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+   = note: the `#[rustc_diagnostic_item]` attribute is an internal implementation detail that will never be stable
    = note: the `#[rustc_diagnostic_item]` attribute allows the compiler to reference types from the standard library for diagnostic purposes
 
 error: aborting due to 1 previous error

--- a/tests/ui/unstable-feature-bound/unstable_feature_bound_staged_api.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_feature_bound_staged_api.stderr
@@ -1,9 +1,12 @@
-error[E0734]: stability attributes may not be used outside of the standard library
+error[E0658]: stability attributes may not be used outside of the standard library
   --> $DIR/unstable_feature_bound_staged_api.rs:8:1
    |
 LL | #[unstable_feature_bound(feat_bar)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(staged_api)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0734`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/unstable-feature-bound/unstable_feature_bound_staged_api.stderr
+++ b/tests/ui/unstable-feature-bound/unstable_feature_bound_staged_api.stderr
@@ -3,9 +3,6 @@ error[E0658]: stability attributes may not be used outside of the standard libra
    |
 LL | #[unstable_feature_bound(feat_bar)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: add `#![feature(staged_api)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157195)*
<!-- homu-ignore:end -->

Does the feature gate checking for attributes during attribute parsing, rather than during expansion.
This is one more step towards removing `BUILTIN_ATTRIBUTES`.

My goal was to keep the diagnostics mostly the same during this PR, and do some improvements and cleanups later, to reduce the diff. Some diagnostics still had minor changes to keep the implementation simpler.

This PR was fully manually written, I triple-checked that I didn't accidentally stabilize or change the gate of an attribute, but I'm terrified of a mistake still slipping through so please check this again.

r? @mejrs @jdonszelmann
cc @nnethercote @scrabsha @Bryntet 

