### PR TITLE
Add regression test for macro matcher dollar suggestion

### DIFF
--- a/tests/ui/macros/macro-missing-fragment.rs
+++ b/tests/ui/macros/macro-missing-fragment.rs
@@ -17,6 +17,10 @@ macro_rules! accidental_dollar_prefix {
     ( $test:$tt ) => {}; //~ ERROR missing fragment
 }
 
+macro_rules! accidental_dollar_prefix_in_repetition {
+    ( $($e:$expr),* ) => {}; //~ ERROR missing fragment
+}
+
 fn main() {
     used_arm!();
     used_macro_unused_arm!();

--- a/tests/ui/macros/macro-missing-fragment.stderr
+++ b/tests/ui/macros/macro-missing-fragment.stderr
@@ -51,5 +51,19 @@ LL -     ( $test:$tt ) => {};
 LL +     ( $test:tt ) => {};
    |
 
-error: aborting due to 4 previous errors
+error: missing fragment specifier
+  --> $DIR/macro-missing-fragment.rs:21:12
+   |
+LL |     ( $($e:$expr),* ) => {};
+   |            ^
+   |
+   = note: fragment specifiers must be provided
+   = help: valid fragment specifiers are `ident`, `block`, `stmt`, `expr`, `pat`, `ty`, `lifetime`, `literal`, `path`, `meta`, `tt`, `item` and `vis`, along with `expr_2021` and `pat_param` for edition compatibility
+help: fragment specifiers should not be prefixed with `$`
+   |
+LL -     ( $($e:$expr),* ) => {};
+LL +     ( $($e:expr),* ) => {};
+   |
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Fixes rust-lang/rust#157157.

Adds regression coverage for the nested matcher form with an extraneous `$` before a macro fragment specifier.

The expected diagnostic points at the extra `$` and suggests removing it, producing `$e:expr`.

Verification:
- `git diff --check`
- `rustc +nightly-2026-05-28 --emit=metadata tests\ui\macros\macro-missing-fragment.rs`