### PR TITLE
Add regression test for TransmuteFrom inference ICE

### DIFF
--- a/tests/ui/traits/next-solver/transmute-from-inference-var-issue-151314.rs
+++ b/tests/ui/traits/next-solver/transmute-from-inference-var-issue-151314.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: -Znext-solver=globally
+
+// Regression test for #151314.
+
+#![feature(transmutability)]
+
+fn assert_transmutable<T>()
+where
+    (): std::mem::TransmuteFrom<T>,
+{
+}
+
+fn main() {
+    assert_transmutable()
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/traits/next-solver/transmute-from-inference-var-issue-151314.stderr
+++ b/tests/ui/traits/next-solver/transmute-from-inference-var-issue-151314.stderr
@@ -1,0 +1,23 @@
+error[E0283]: type annotations needed
+  --> $DIR/transmute-from-inference-var-issue-151314.rs:14:5
+   |
+LL |     assert_transmutable()
+   |     ^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `assert_transmutable`
+   |
+   = note: cannot satisfy `(): TransmuteFrom<_, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>`
+note: required by a bound in `assert_transmutable`
+  --> $DIR/transmute-from-inference-var-issue-151314.rs:9:9
+   |
+LL | fn assert_transmutable<T>()
+   |    ------------------- required by a bound in this function
+LL | where
+LL |     (): std::mem::TransmuteFrom<T>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_transmutable`
+help: consider specifying a concrete type for the type parameter `T`
+   |
+LL |     assert_transmutable::</* Type */>()
+   |                        ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
Fixes rust-lang/rust#151314.

Adds a next-solver UI regression test for an unconstrained `TransmuteFrom<T>` obligation involving an inference variable.

The current compiler emits a normal E0283 type-annotations diagnostic; the test ensures this case does not regress to an ICE.

Verification:
- `git diff --check`
- `rustfmt +nightly-2026-05-28 --edition 2024 tests\ui\traits\next-solver\issue-151314-transmute-from-inference-var.rs`
- `rustc +nightly-2026-05-28 -Znext-solver=globally tests\ui\traits\next-solver\issue-151314-transmute-from-inference-var.rs`