### PR TITLE
add #[rustc_no_writable] to slice::get_unchecked_mut

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -596,6 +596,7 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     #[rustc_const_unstable(feature = "const_index", issue = "143775")]
+    #[rustc_no_writable]
     pub const fn get_mut<I>(&mut self, index: I) -> Option<&mut I::Output>
     where
         I: [const] SliceIndex<Self>,
@@ -681,6 +682,7 @@ impl<T> [T] {
     #[must_use]
     #[track_caller]
     #[rustc_const_unstable(feature = "const_index", issue = "143775")]
+    #[rustc_no_writable]
     pub const unsafe fn get_unchecked_mut<I>(&mut self, index: I) -> &mut I::Output
     where
         I: [const] SliceIndex<Self>,

--- a/src/tools/miri/tests/pass/tree_borrows/implicit_writes/unchecked_mut.rs
+++ b/src/tools/miri/tests/pass/tree_borrows/implicit_writes/unchecked_mut.rs
@@ -1,0 +1,28 @@
+// This test reproduces the pattern used by `BorrowedCursor::as_mut`, which appears in `Socket::recv_with_flags` and `std::fs::read`.
+// Many crates depend on similar patterns. Before https://github.com/rust-lang/rust/pull/157202 this failed under Tree
+// Borrows with Implicit Writes. With the attribute `#[rustc_no_writable]` added to
+// `slice::get_unchecked_mut`, both this test and the affected crates work.
+//@compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
+
+struct BorrowedBuf<'a> {
+    buf: &'a mut [u8],
+}
+
+impl<'a> BorrowedBuf<'a> {
+    fn capacity(&self) -> usize {
+        self.buf.len()
+    }
+
+    unsafe fn as_mut(&mut self) -> &mut [u8] {
+        unsafe { self.buf.get_unchecked_mut(..) }
+    }
+}
+
+fn main() {
+    let mut arr = [0u8; 4];
+    let mut buf = BorrowedBuf { buf: &mut arr };
+
+    let ptr = unsafe { buf.as_mut() }.as_mut_ptr();
+    let _ = buf.capacity();
+    unsafe { ptr.write(42); }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157202)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This PR adds the `#[rustc_no_writable]` attribute introduced in https://github.com/rust-lang/rust/pull/155207 to the `slice::get_unchecked_mut` function.

Two library functions already received this attribute, as they were known to cause problems with the llvm writable attribute and tree borrows. Since that PR, I ran Miri on the 30'000 most downloaded crates to see what kind of code is now UB under Tree Borrows + implicit writes, using the detection implemented in https://github.com/rust-lang/miri/pull/4947. Adding this attribute to ignore checking for this function reduced the new UB introduced by more than 75%, meaning that instead of 19000 tests in 1700 crates having a difference, now only 3500 in 350 crates show a difference (measurement still running).