### PR TITLE
Link LLVM dynamically on aarch64-apple-darwin

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -411,6 +411,16 @@ fn main() {
             continue;
         }
 
+        // On apple-darwin, llvm-config reports the versioned shared library name such as LLVM-22-..., but
+        // the distributed toolchain ships libLLVM.dylib. Normalize the link name here.
+        let name =
+            if target.contains("apple-darwin") && llvm_kind == "dylib" && name.starts_with("LLVM-")
+            {
+                "LLVM"
+            } else {
+                name
+            };
+
         let kind = if name.starts_with("LLVM") {
             llvm_kind
         } else if is_static {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -62,12 +62,15 @@ pub fn walk_native_lib_search_dirs<R>(
         f(&sess.target_tlib_path.dir.join("self-contained"), false)?;
     }
 
+    let has_shared_llvm_apple_darwin =
+        sess.target.is_like_darwin && sess.target_tlib_path.dir.join("libLLVM.dylib").exists();
+
     // Toolchains for some targets may ship `libunwind.a`, but place it into the main sysroot
     // library directory instead of the self-contained directories.
     // Sanitizer libraries have the same issue and are also linked by name on Apple targets.
     // The targets here should be in sync with `copy_third_party_objects` in bootstrap.
-    // Finally there is shared LLVM library, which unlike compiler libraries, is linked by the name,
-    // therefore requiring the search path for the linker.
+    // On Apple targets, shared LLVM is linked by name, so when `libLLVM.dylib` is
+    // present in the target libdir, add that directory to the linker search path.
     // FIXME: implement `-Clink-self-contained=+/-unwind,+/-sanitizers`, move the shipped libunwind
     // and sanitizers to self-contained directory, and stop adding this search path.
     // FIXME: On AIX this also has the side-effect of making the list of library search paths
@@ -77,7 +80,8 @@ pub fn walk_native_lib_search_dirs<R>(
         || sess.target.os == Os::Linux
         || sess.target.os == Os::Fuchsia
         || sess.target.is_like_aix
-        || sess.target.is_like_darwin && !sess.sanitizers().is_empty()
+        || sess.target.is_like_darwin
+            && (!sess.sanitizers().is_empty() || has_shared_llvm_apple_darwin)
         || sess.target.os == Os::Windows
             && sess.target.env == Env::Gnu
             && sess.target.cfg_abi == CfgAbi::Llvm

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/154485
+Last change is for: https://github.com/rust-lang/rust/pull/154839

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/154839
+Last change is for: https://github.com/rust-lang/rust/pull/157205

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -2513,6 +2513,25 @@ fn maybe_install_llvm(
         let llvm_dylib_path = src_libdir.join("libLLVM.dylib");
         if llvm_dylib_path.exists() {
             builder.install(&llvm_dylib_path, dst_libdir, FileType::NativeLibrary);
+
+            if install_symlink && let Some(llvm_config_path) = &builder.llvm_config(target) {
+                let major = llvm::get_llvm_version_major(builder, llvm_config_path);
+                let versioned_name = match &builder.config.llvm_version_suffix {
+                    Some(version_suffix) => format!("libLLVM-{major}{version_suffix}.dylib"),
+                    None => {
+                        // dev builds use `-rust-dev`, while release-channel builds include the Rust version.
+                        if builder.config.channel == "dev" {
+                            format!("libLLVM-{major}-rust-dev.dylib")
+                        } else {
+                            format!(
+                                "libLLVM-{major}-rust-{}-{}.dylib",
+                                builder.version, builder.config.channel
+                            )
+                        }
+                    }
+                };
+                t!(builder.symlink_file("libLLVM.dylib", dst_libdir.join(versioned_name)));
+            }
         }
         !builder.config.dry_run()
     } else if let llvm::LlvmBuildStatus::AlreadyBuilt(llvm::LlvmResult {

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -526,6 +526,7 @@ auto:
         --enable-sanitizers
         --enable-profiler
         --set rust.jemalloc
+        --set llvm.link-shared=true
         --set rust.lto=thin
         --set rust.codegen-units=1
       # Aarch64 tooling only needs to support macOS 11.0 and up as nothing else


### PR DESCRIPTION
--set llvm.link-shared=true on dist-aarch64-apple to link LLVM dynamically on MacOS. 
Also, I fixed some link problems, by normalizing the libLLVM.dylib name, and creating a symlink(On Linux, we use linker script, but we can not use it for MacOS. ld64 does not recognize linker scripts) from versioned dylib to unversioned libLLVM.dylib to build successfully.

## How I verified on my Mac

1. remove the old build dir

```shell
rm -rf build/
```

2. configure for rust-dev dist

```shell
./configure \
    --set llvm.download-ci-llvm=false \
    --set llvm.link-shared=true \
    --release-channel=nightly
```

3. dist

```shell
./x dist rust-dev --host=aarch64-apple-darwin --target=aarch64-apple-darwin
```

4. move tarball to /tmp(or, wherever else except for inside build/) and delete the current build dir

We create build/ for both rust-dev dist, and local build tests. Once dist finished, we have to clear the directory so we can use it for build tests

```shell
cp build/dist/rust-dev-nightly-aarch64-apple-darwin.tar.xz /tmp/

rm -rf build
```

I saw a symlink created as expected

<img width="652" height="406" alt="rust-dev artifacts" src="https://github.com/user-attachments/assets/dc49a637-8a1f-45c8-84f2-2ef101faae51" />


6. modify download.rs temporary so it gets the locally built tarball at step3

```rust
    #[cfg(not(test))]
    fn download_ci_llvm(&self, _llvm_sha: &str) {
        let tarball = PathBuf::from("/tmp/rust-dev-nightly-aarch64-apple-darwin.tar.xz");
        let llvm_root = self.ci_llvm_root();
        self.unpack(&tarball, &llvm_root, "rust-dev");
    //     let llvm_assertions = self.llvm_assertions;

    //     let cache_prefix = format!("llvm-{llvm_sha}-{llvm_assertions}");
    //     let cache_dst =
    //         self.bootstrap_cache_path.as_ref().cloned().unwrap_or_else(|| self.out.join("cache"));

    //     let rustc_cache = cache_dst.join(cache_prefix);
    //     if !rustc_cache.exists() {
    //         t!(fs::create_dir_all(&rustc_cache));
    //     }
    //     let base = if llvm_assertions {
    //         &self.stage0_metadata.config.artifacts_with_llvm_assertions_server
    //     } else {
    //         &self.stage0_metadata.config.artifacts_server
    //     };
    //     let version = self.artifact_version_part(llvm_sha);
    //     let filename = format!("rust-dev-{}-{}.tar.xz", version, self.host_target.triple);
    //     let tarball = rustc_cache.join(&filename);
    //     if !tarball.exists() {
    //         let help_on_error = "ERROR: failed to download llvm from ci

    // HELP: There could be two reasons behind this:
    //     1) The host triple is not supported for `download-ci-llvm`.
    //     2) Old builds get deleted after a certain time.
    // HELP: In either case, disable `download-ci-llvm` in your bootstrap.toml:

    // [llvm]
    // download-ci-llvm = false
    // ";
    //         self.download_file(&format!("{base}/{llvm_sha}/{filename}"), &tarball, help_on_error);
    //     }
    //     let llvm_root = self.ci_llvm_root();
    //     self.unpack(&tarball, &llvm_root, "rust-dev");
    }
```

7. configure for ./x build

```shell
rm -rf bootstrap.toml // delete existing config of rust-dev dist

// maybe we don't need to specify llvm.download-ci-llvm=true, since I bumped download-ci-llvm-stamp.
// but anyway, I explicitly specified it when I tested it

./configure \
    --set llvm.download-ci-llvm=true \
    --set llvm.link-shared=true \
    --release-channel=nightly
```

8. ./x build

```shell
./x build (library)
```

Result: build completed successfully

<img width="861" height="763" alt="スクリーンショット 2026-06-01 0 38 21" src="https://github.com/user-attachments/assets/9660ac43-c275-4174-b80a-3483b4acfd40" />

r? @Kobzol 

cc: @ZuseZ4 
