### PR TITLE
Clarify documentation of `Option::{zip, zip_with}()`.

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1960,7 +1960,7 @@ impl<T> Option<T> {
         mem::replace(self, Some(value))
     }
 
-    /// Zips `self` with another `Option`.
+    /// Makes a tuple of the value in `self` and the value in another `Option`.
     ///
     /// If `self` is `Some(s)` and `other` is `Some(o)`, this method returns `Some((s, o))`.
     /// Otherwise, `None` is returned.
@@ -1988,7 +1988,7 @@ impl<T> Option<T> {
         }
     }
 
-    /// Zips `self` and another `Option` with function `f`.
+    /// Combines the value in `self` with the value in another `Option`, using the function `f`.
     ///
     /// If `self` is `Some(s)` and `other` is `Some(o)`, this method returns `Some(f(s, o))`.
     /// Otherwise, `None` is returned.


### PR DESCRIPTION
Instead of saying that `zip()` zips (which is nearly useless because either people already understood the function name and don’t need the introduction, or they didn’t and reiterating it doesn’t help), we can explain what it does more explicitly, in only a few more words.

This brings the first paragraphs closer in meaning to the second paragraphs, but they are still distinct: the first paragraph explains the overall goal without individual cases, and the second paragraph explains the full behavior case-by-case.

@rustbot label +A-docs