### PR TITLE
Experimental: using `indirectbr` (i.e. computed goto in rust)

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/loop_match.rs
@@ -13,3 +13,10 @@ impl NoArgsAttributeParser for ConstContinueParser {
     const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Expression)]);
     const CREATE: fn(Span) -> AttributeKind = AttributeKind::ConstContinue;
 }
+
+pub(crate) struct IndirectBranchParser;
+impl NoArgsAttributeParser for IndirectBranchParser {
+    const PATH: &[Symbol] = &[sym::indirect_branch];
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Expression)]);
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::IndirectBranch;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -236,6 +236,7 @@ attribute_parsers!(
         Single<WithoutArgs<FfiConstParser>>,
         Single<WithoutArgs<FfiPureParser>>,
         Single<WithoutArgs<FundamentalParser>>,
+        Single<WithoutArgs<IndirectBranchParser>>,
         Single<WithoutArgs<LoopMatchParser>>,
         Single<WithoutArgs<MacroEscapeParser>>,
         Single<WithoutArgs<MarkerParser>>,

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -878,7 +878,7 @@ impl<'a, 'tcx> ResultsVisitor<'tcx, Borrowck<'a, 'tcx>> for MirBorrowckCtxt<'a, 
         self.check_activations(loc, span, state);
 
         match &term.kind {
-            TerminatorKind::SwitchInt { discr, targets: _ } => {
+            TerminatorKind::SwitchInt { discr, targets: _, indirect_br: _ } => {
                 self.consume_operand(loc, (discr, span), state);
             }
             TerminatorKind::Drop {

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -94,7 +94,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'a, 'tcx> {
         self.check_activations(location);
 
         match &terminator.kind {
-            TerminatorKind::SwitchInt { discr, targets: _ } => {
+            TerminatorKind::SwitchInt { discr, targets: _, indirect_br: _ } => {
                 self.consume_operand(location, discr);
             }
             TerminatorKind::Drop {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -347,6 +347,56 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         }
     }
 
+    fn indirect_br(
+        &mut self,
+        v: &'ll Value,
+        else_llbb: &'ll BasicBlock,
+        cases: impl ExactSizeIterator<Item = (u128, &'ll BasicBlock)>,
+    ) {
+        let len = cases.len() + 1;
+
+        let mut basic_blocks = Vec::with_capacity(cases.len());
+        let mut block_addresses = Vec::with_capacity(cases.len());
+
+        // Use the else_llbb as the default for each index. We don't know the exact index that
+        // corresponds to the else branch (it might correspond to many values).
+        let else_address = unsafe { llvm::LLVMBlockAddress(self.llfn(), else_llbb) };
+
+        // FIXME: this is a hack, ensuring that the jump table is big enough for all u8 values. For
+        // a scrutinee type that is bigger than a u8, the jump table might not contain all indices
+        // that else_llbb corresponds to.
+        block_addresses.resize(256, else_address);
+
+        for (index, bb) in cases {
+            let index = index as usize;
+            block_addresses.resize(Ord::max(block_addresses.len(), index + 1), else_address);
+            block_addresses[index as usize] = unsafe { llvm::LLVMBlockAddress(self.llfn(), bb) };
+            basic_blocks.push(bb);
+        }
+
+        // Create the lookup table.
+        let table_ty = self.type_array(self.type_ptr(), block_addresses.len() as u64);
+        let table = self.const_array(self.type_ptr(), &block_addresses);
+        let jump_table = gpu_offload::add_unnamed_global(
+            self.cx,
+            "jump_table",
+            table,
+            llvm::Linkage::PrivateLinkage,
+        );
+
+        let index = self.zext(v, self.cx.type_i64());
+        let ptr = self.inbounds_gep(table_ty, jump_table, &[self.const_usize(0), index]);
+        let addr = self.load(self.type_ptr(), ptr, Align::EIGHT); // fixme should be align of ptr
+
+        let indirect_br = unsafe { llvm::LLVMBuildIndirectBr(self.llbuilder, addr, len as c_uint) };
+
+        for llbb in basic_blocks {
+            unsafe { llvm::LLVMAddDestination(indirect_br, llbb) };
+        }
+
+        unsafe { llvm::LLVMAddDestination(indirect_br, else_llbb) };
+    }
+
     fn switch(
         &mut self,
         v: &'ll Value,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1236,7 +1236,7 @@ unsafe extern "C" {
     // Add a case to the switch instruction
     pub(crate) fn LLVMAddCase<'a>(Switch: &'a Value, OnVal: &'a Value, Dest: &'a BasicBlock);
 
-    // Add a destintation to the indirectbr instruction
+    // Add a destination to the indirectbr instruction
     pub(crate) fn LLVMAddDestination<'a>(IndirectBr: &'a Value, Dest: &'a BasicBlock);
 
     // Get the block address of the given block in the given function

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1178,6 +1178,11 @@ unsafe extern "C" {
         Then: &'a BasicBlock,
         Else: &'a BasicBlock,
     ) -> &'a Value;
+    pub(crate) fn LLVMBuildIndirectBr<'a>(
+        B: &Builder<'a>,
+        Addr: &'a Value,
+        NumDests: c_uint,
+    ) -> &'a Value;
     pub(crate) fn LLVMBuildSwitch<'a>(
         B: &Builder<'a>,
         V: &'a Value,
@@ -1230,6 +1235,12 @@ unsafe extern "C" {
 
     // Add a case to the switch instruction
     pub(crate) fn LLVMAddCase<'a>(Switch: &'a Value, OnVal: &'a Value, Dest: &'a BasicBlock);
+
+    // Add a destintation to the indirectbr instruction
+    pub(crate) fn LLVMAddDestination<'a>(IndirectBr: &'a Value, Dest: &'a BasicBlock);
+
+    // Get the block address of the given block in the given function
+    pub(crate) fn LLVMBlockAddress<'a>(Func: &'a Value, Block: &'a BasicBlock) -> &'a Value;
 
     // Add a clause to the landing pad instruction
     pub(crate) fn LLVMAddClause<'a>(LandingPad: &'a Value, ClauseVal: &'a Value);

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -386,7 +386,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         bx: &mut Bx,
         discr: &mir::Operand<'tcx>,
         targets: &SwitchTargets,
-        _indirect_br: bool,
+        indirect_br: bool,
     ) {
         let discr = self.codegen_operand(bx, discr);
         let discr_value = discr.immediate();
@@ -499,12 +499,21 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             {
                 // All targets have the same weight,
                 // or `otherwise` is unreachable and it's the only target with a different weight.
-                bx.switch(
-                    discr_value,
-                    helper.llbb_with_cleanup(self, targets.otherwise()),
-                    target_iter
-                        .map(|(value, target)| (value, helper.llbb_with_cleanup(self, target))),
-                );
+                if indirect_br {
+                    bx.indirect_br(
+                        discr_value,
+                        helper.llbb_with_cleanup(self, targets.otherwise()),
+                        target_iter
+                            .map(|(value, target)| (value, helper.llbb_with_cleanup(self, target))),
+                    );
+                } else {
+                    bx.switch(
+                        discr_value,
+                        helper.llbb_with_cleanup(self, targets.otherwise()),
+                        target_iter
+                            .map(|(value, target)| (value, helper.llbb_with_cleanup(self, target))),
+                    );
+                }
             } else {
                 // Targets have different weights
                 bx.switch_with_weights(

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -386,6 +386,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         bx: &mut Bx,
         discr: &mir::Operand<'tcx>,
         targets: &SwitchTargets,
+        _indirect_br: bool,
     ) {
         let discr = self.codegen_operand(bx, discr);
         let discr_value = discr.immediate();
@@ -1570,8 +1571,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 helper.funclet_br(self, bx, target, mergeable_succ())
             }
 
-            mir::TerminatorKind::SwitchInt { ref discr, ref targets } => {
-                self.codegen_switchint_terminator(helper, bx, discr, targets);
+            mir::TerminatorKind::SwitchInt { ref discr, ref targets, indirect_br } => {
+                self.codegen_switchint_terminator(helper, bx, discr, targets, indirect_br);
                 MergingSucc::False
             }
 

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -123,6 +123,18 @@ pub trait BuilderMethods<'a, 'tcx>:
         self.switch(v, else_llbb, cases.map(|(val, bb, _)| (val, bb)))
     }
 
+    // A switch that duplicates the branching logic. Used in C for computed-goto.
+    //
+    // Default implementation calls `switch()`
+    fn indirect_br(
+        &mut self,
+        v: Self::Value,
+        else_llbb: Self::BasicBlock,
+        cases: impl ExactSizeIterator<Item = (u128, Self::BasicBlock)>,
+    ) {
+        self.switch(v, else_llbb, cases)
+    }
+
     fn invoke(
         &mut self,
         llty: Self::FunctionSignature,

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -516,7 +516,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
             Goto { target } => self.go_to_block(target),
 
-            SwitchInt { ref discr, ref targets } => {
+            SwitchInt { ref discr, ref targets, indirect_br: _ } => {
                 let discr = self.read_immediate(&self.eval_operand(discr, None)?)?;
                 trace!("SwitchInt({:?})", *discr);
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -393,6 +393,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     //
     // - https://github.com/rust-lang/rust/issues/132306
     gated!(const_continue, loop_match, experimental!(const_continue)),
+    gated!(indirect_branch, loop_match, experimental!(indirect_branch)),
     gated!(loop_match, loop_match, experimental!(loop_match)),
 
     // The `#[pin_v2]` attribute is part of the `pin_ergonomics` experiment

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1054,6 +1054,9 @@ pub enum AttributeKind {
         reason: Option<Symbol>,
     },
 
+    /// Represents `#[indirect_branch]`.
+    IndirectBranch(Span),
+
     /// Represents `#[inline]` and `#[rustc_force_inline]`.
     Inline(InlineAttr, Span),
 

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -48,6 +48,7 @@ impl AttributeKind {
             FfiPure(..) => No,
             Fundamental { .. } => Yes,
             Ignore { .. } => No,
+            IndirectBranch(..) => No,
             Inline(..) => No,
             InstructionSet(..) => No,
             Lang(..) => Yes,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -629,7 +629,7 @@ impl<'tcx> Body<'tcx> {
             mono_literal.try_eval_bits(tcx, typing_env)
         };
 
-        let TerminatorKind::SwitchInt { discr, targets } = &block.terminator().kind else {
+        let TerminatorKind::SwitchInt { discr, targets, .. } = &block.terminator().kind else {
             return None;
         };
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -705,6 +705,7 @@ pub enum TerminatorKind<'tcx> {
         /// The discriminant value being tested.
         discr: Operand<'tcx>,
         targets: SwitchTargets,
+        indirect_br: bool,
     },
 
     /// Indicates that the landing pad is finished and that the process should continue unwinding.

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -470,7 +470,11 @@ impl<'tcx> TerminatorKind<'tcx> {
 
     #[inline]
     pub fn if_(cond: Operand<'tcx>, t: BasicBlock, f: BasicBlock) -> TerminatorKind<'tcx> {
-        TerminatorKind::SwitchInt { discr: cond, targets: SwitchTargets::static_if(0, f, t) }
+        TerminatorKind::SwitchInt {
+            discr: cond,
+            targets: SwitchTargets::static_if(0, f, t),
+            indirect_br: false,
+        }
     }
 }
 
@@ -660,7 +664,7 @@ impl<'tcx> TerminatorKind<'tcx> {
     #[inline]
     pub fn as_switch(&self) -> Option<(&Operand<'tcx>, &SwitchTargets)> {
         match self {
-            TerminatorKind::SwitchInt { discr, targets } => Some((discr, targets)),
+            TerminatorKind::SwitchInt { discr, targets, .. } => Some((discr, targets)),
             _ => None,
         }
     }
@@ -785,7 +789,9 @@ impl<'tcx> TerminatorKind<'tcx> {
                 place: CallReturnPlaces::InlineAsm(operands),
             },
 
-            SwitchInt { ref targets, ref discr } => TerminatorEdges::SwitchInt { targets, discr },
+            SwitchInt { ref targets, ref discr, .. } => {
+                TerminatorEdges::SwitchInt { targets, discr }
+            }
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -545,7 +545,7 @@ macro_rules! make_mir_visitor {
                         );
                     }
 
-                    TerminatorKind::SwitchInt { discr, targets: _ } => {
+                    TerminatorKind::SwitchInt { discr, targets: _, indirect_br: _ } => {
                         self.visit_operand(discr, location);
                     }
 

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -382,6 +382,7 @@ pub enum ExprKind<'tcx> {
         scrutinee: ExprId,
         arms: Box<[ArmId]>,
         match_source: MatchSource,
+        indirect_br: bool,
     },
     /// A block.
     Block {

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             },
             ExprKind::Match { scrutinee, arms, .. } => {
                 let discr = self.parse_operand(*scrutinee)?;
-                self.parse_match(arms, expr.span).map(|t| TerminatorKind::SwitchInt { discr, targets: t })
+                self.parse_match(arms, expr.span).map(|t| TerminatorKind::SwitchInt { discr, targets: t, indirect_br: false })
             },
         )
     }

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -72,9 +72,13 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             @call(mir_tail_call, args) => {
                 self.parse_tail_call(args)
             },
-            ExprKind::Match { scrutinee, arms, .. } => {
+            ExprKind::Match { scrutinee, arms, indirect_br, .. } => {
                 let discr = self.parse_operand(*scrutinee)?;
-                self.parse_match(arms, expr.span).map(|t| TerminatorKind::SwitchInt { discr, targets: t, indirect_br: false })
+                self.parse_match(arms, expr.span).map(|t| TerminatorKind::SwitchInt {
+                    discr,
+                    targets: t,
+                    indirect_br: *indirect_br,
+                })
             },
         )
     }

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -57,13 +57,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Block { block: ast_block } => {
                 this.ast_block(destination, block, ast_block, source_info)
             }
-            ExprKind::Match { scrutinee, ref arms, .. } => this.match_expr(
+            ExprKind::Match { scrutinee, ref arms, indirect_br, .. } => this.match_expr(
                 destination,
                 block,
                 scrutinee,
                 arms,
                 expr_span,
                 this.thir[scrutinee].span,
+                indirect_br,
             ),
             ExprKind::If { cond, then, else_opt, if_then_scope } => {
                 let then_span = this.thir[then].span;
@@ -323,6 +324,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         match_start_span,
                         patterns,
                         false,
+                        false, // FIXME we can probably indirect_branch work?
                     );
 
                     let state_place = scrutinee_place_builder.to_place(this);

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -356,6 +356,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         arms: &[ArmId],
         span: Span,
         scrutinee_span: Span,
+        indirect_br: bool,
     ) -> BlockAnd<()> {
         let scrutinee_place =
             unpack!(block = self.lower_scrutinee(block, scrutinee_id, scrutinee_span));
@@ -370,13 +371,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 (&*arm.pattern, has_match_guard)
             })
             .collect();
+        let refutable = false;
         let built_tree = self.lower_match_tree(
             block,
             scrutinee_span,
             &scrutinee_place,
             match_start_span,
             patterns,
-            false,
+            refutable,
+            indirect_br,
         );
 
         self.lower_match_arms(
@@ -650,6 +653,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             irrefutable_pat.span,
             vec![(irrefutable_pat, HasMatchGuard::No)],
             false,
+            false, // this match is derived from a let
         );
         let [branch] = built_tree.branches.try_into().unwrap();
 
@@ -1583,6 +1587,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         match_start_span: Span,
         patterns: Vec<(&Pat<'tcx>, HasMatchGuard)>,
         refutable: bool,
+        indirect_br: bool,
     ) -> BuiltMatchTree<'tcx> {
         // Assemble the initial list of candidates. These top-level candidates are 1:1 with the
         // input patterns, but other parts of match lowering also introduce subcandidates (for
@@ -1606,8 +1611,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // If none of the arms match, we branch to `otherwise_block`. When lowering a `match`
         // expression, exhaustiveness checking ensures that this block is unreachable.
         let mut candidate_refs = candidates.iter_mut().collect::<Vec<_>>();
-        let otherwise_block =
-            self.match_candidates(match_start_span, scrutinee_span, block, &mut candidate_refs);
+        let otherwise_block = self.match_candidates(
+            match_start_span,
+            scrutinee_span,
+            block,
+            &mut candidate_refs,
+            indirect_br,
+        );
 
         // Set up false edges so that the borrow-checker cannot make use of the specific CFG we
         // generated. We falsely branch from each candidate to the one below it to make it as if we
@@ -1752,9 +1762,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scrutinee_span: Span,
         start_block: BasicBlock,
         candidates: &mut [&mut Candidate<'tcx>],
+        indirect_br: bool,
     ) -> BasicBlock {
         ensure_sufficient_stack(|| {
-            self.match_candidates_inner(span, scrutinee_span, start_block, candidates)
+            self.match_candidates_inner(span, scrutinee_span, start_block, candidates, indirect_br)
         })
     }
 
@@ -1766,6 +1777,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scrutinee_span: Span,
         mut start_block: BasicBlock,
         candidates: &mut [&mut Candidate<'tcx>],
+        indirect_br: bool,
     ) -> BasicBlock {
         if let [first, ..] = candidates {
             if first.false_edge_start_block.is_none() {
@@ -1794,17 +1806,23 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // But by expanding other candidates as early as possible, we unlock more
                 // opportunities to include them in test outcomes, making the match tree
                 // smaller and simpler.
-                self.expand_and_match_or_candidates(span, scrutinee_span, start_block, candidates)
+                self.expand_and_match_or_candidates(
+                    span,
+                    scrutinee_span,
+                    start_block,
+                    candidates,
+                    indirect_br,
+                )
             }
             candidates => {
                 // The first candidate has some unsatisfied match pairs; we proceed to do more tests.
-                self.test_candidates(span, scrutinee_span, candidates, start_block)
+                self.test_candidates(span, scrutinee_span, candidates, start_block, indirect_br)
             }
         };
 
         // Process any candidates that remain.
         let remaining_candidates = unpack!(start_block = rest);
-        self.match_candidates(span, scrutinee_span, start_block, remaining_candidates)
+        self.match_candidates(span, scrutinee_span, start_block, remaining_candidates, indirect_br)
     }
 
     /// Link up matched candidates.
@@ -1858,6 +1876,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scrutinee_span: Span,
         start_block: BasicBlock,
         candidates: &'b mut [&'c mut Candidate<'tcx>],
+        indirect_br: bool,
     ) -> BlockAnd<&'b mut [&'c mut Candidate<'tcx>]> {
         // We can't expand or-patterns freely. The rule is:
         // - If a candidate doesn't start with an or-pattern, we include it in
@@ -1925,6 +1944,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             scrutinee_span,
             start_block,
             expanded_candidates.as_mut_slice(),
+            indirect_br,
         );
 
         // Postprocess subcandidates, and process any leftover match pairs.
@@ -1943,7 +1963,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // with remaining match pairs, to avoid exponential blowup if possible
         // (for trivial or-patterns), and avoid useless work (for never patterns).
         if let Some(last_candidate) = candidates_to_expand.last_mut() {
-            self.test_remaining_match_pairs_after_or(span, scrutinee_span, last_candidate);
+            self.test_remaining_match_pairs_after_or(
+                span,
+                scrutinee_span,
+                last_candidate,
+                indirect_br,
+            );
         }
 
         remainder_start.and(remaining_candidates)
@@ -2107,6 +2132,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         span: Span,
         scrutinee_span: Span,
         candidate: &mut Candidate<'tcx>,
+        indirect_br: bool,
     ) {
         if candidate.match_pairs.is_empty() {
             return;
@@ -2139,8 +2165,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             leaf_candidate.match_pairs.extend(remaining_match_pairs.iter().cloned());
 
             let or_start = leaf_candidate.pre_binding_block.unwrap();
-            let otherwise =
-                self.match_candidates(span, scrutinee_span, or_start, &mut [leaf_candidate]);
+            let otherwise = self.match_candidates(
+                span,
+                scrutinee_span,
+                or_start,
+                &mut [leaf_candidate],
+                indirect_br,
+            );
             // In a case like `(P | Q, R | S)`, if `P` succeeds and `R | S` fails, we know `(Q,
             // R | S)` will fail too. If there is no guard, we skip testing of `Q` by branching
             // directly to `last_otherwise`. If there is a guard,
@@ -2286,6 +2317,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         scrutinee_span: Span,
         candidates: &'b mut [&'c mut Candidate<'tcx>],
         start_block: BasicBlock,
+        indirect_br: bool,
     ) -> BlockAnd<&'b mut [&'c mut Candidate<'tcx>]> {
         // Choose a match pair from the first candidate, and use it to determine a
         // test to perform that will confirm or refute that match pair.
@@ -2307,8 +2339,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .map(|(branch, mut candidates)| {
                 let branch_start = self.cfg.start_new_block();
                 // Recursively lower the rest of the match tree after the relevant outcome.
-                let branch_otherwise =
-                    self.match_candidates(span, scrutinee_span, branch_start, &mut *candidates);
+                let branch_otherwise = self.match_candidates(
+                    span,
+                    scrutinee_span,
+                    branch_start,
+                    &mut *candidates,
+                    indirect_br,
+                );
 
                 // Link up the `otherwise` block of the subtree to `remainder_start`.
                 let source_info = self.source_info(span);
@@ -2327,6 +2364,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             match_place,
             &test,
             target_blocks,
+            indirect_br,
         );
 
         remainder_start.and(remaining_candidates)
@@ -2363,6 +2401,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             pat.span,
             vec![(pat, HasMatchGuard::No)],
             true,
+            false,
         );
         let [branch] = built_tree.branches.try_into().unwrap();
 

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -70,6 +70,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         place: Place<'tcx>,
         test: &Test<'tcx>,
         target_blocks: FxIndexMap<TestBranch<'tcx>, BasicBlock>,
+        indirect_br: bool,
     ) {
         let place_ty = place.ty(&self.local_decls, self.tcx);
         debug!(?place, ?place_ty);
@@ -104,7 +105,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     TerminatorKind::SwitchInt {
                         discr: Operand::Move(discr),
                         targets: switch_targets,
-                        indirect_br: false,
+                        indirect_br,
                     },
                 );
             }
@@ -126,7 +127,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let terminator = TerminatorKind::SwitchInt {
                     discr: Operand::Copy(place),
                     targets: switch_targets,
-                    indirect_br: false,
+                    indirect_br,
                 };
                 self.cfg.terminate(block, self.source_info(match_start_span), terminator);
             }

--- a/compiler/rustc_mir_build/src/builder/matches/test.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/test.rs
@@ -104,6 +104,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     TerminatorKind::SwitchInt {
                         discr: Operand::Move(discr),
                         targets: switch_targets,
+                        indirect_br: false,
                     },
                 );
             }
@@ -125,6 +126,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let terminator = TerminatorKind::SwitchInt {
                     discr: Operand::Copy(place),
                     targets: switch_targets,
+                    indirect_br: false,
                 };
                 self.cfg.terminate(block, self.source_info(match_start_span), terminator);
             }

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -925,6 +925,7 @@ impl<'tcx> ThirBuildCx<'tcx> {
                 scrutinee: self.mirror_expr(discr),
                 arms: arms.iter().map(|a| self.convert_arm(a)).collect(),
                 match_source,
+                indirect_br: find_attr!(self.tcx, expr.hir_id, IndirectBranch(_)),
             },
             hir::ExprKind::Loop(body, ..) => {
                 if find_attr!(self.tcx, expr.hir_id, LoopMatch(_)) {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -148,7 +148,7 @@ impl<'p, 'tcx> Visitor<'p, 'tcx> for MatchVisitor<'p, 'tcx> {
                 }
                 return;
             }
-            ExprKind::Match { scrutinee, ref arms, match_source } => {
+            ExprKind::Match { scrutinee, ref arms, match_source, indirect_br: _ } => {
                 self.check_match(scrutinee, arms, match_source, ex.span);
             }
             ExprKind::LoopMatch {

--- a/compiler/rustc_mir_dataflow/src/framework/direction.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/direction.rs
@@ -113,7 +113,7 @@ impl Direction for Backward {
                     propagate(pred, &tmp);
                 }
 
-                mir::TerminatorKind::SwitchInt { ref targets, ref discr } => {
+                mir::TerminatorKind::SwitchInt { ref targets, ref discr, indirect_br: _ } => {
                     if let Some(_data) = analysis.get_switch_int_data(pred, targets, discr) {
                         bug!(
                             "SwitchInt edge effects are unsupported in backward dataflow analyses"

--- a/compiler/rustc_mir_transform/src/check_enums.rs
+++ b/compiler/rustc_mir_transform/src/check_enums.rs
@@ -394,6 +394,7 @@ fn insert_direct_enum_check<'tcx>(
                     .map(|discr_val| (discr.size.truncate(discr_val), new_block)),
                 invalid_discr_block,
             ),
+            indirect_br: false,
         },
     });
 

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1110,7 +1110,11 @@ fn insert_switch<'tcx>(
         }
     }
 
-    let switch = TerminatorKind::SwitchInt { discr: Operand::Move(discr), targets: switch_targets };
+    let switch = TerminatorKind::SwitchInt {
+        discr: Operand::Move(discr),
+        targets: switch_targets,
+        indirect_br: false,
+    };
     body.basic_blocks_mut()[START_BLOCK].terminator =
         Some(Terminator { source_info: SourceInfo::outermost(body.span), kind: switch });
 }

--- a/compiler/rustc_mir_transform/src/coroutine/drop.rs
+++ b/compiler/rustc_mir_transform/src/coroutine/drop.rs
@@ -173,6 +173,7 @@ fn build_poll_switch<'tcx>(
                         .into_iter(),
                     unreachable_block,
                 ),
+                indirect_br: false,
             },
         }),
         false,

--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -123,7 +123,7 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
             TerminatorKind::TailCall { .. } => {
                 self.penalty += CALL_PENALTY;
             }
-            TerminatorKind::SwitchInt { discr, targets } => {
+            TerminatorKind::SwitchInt { discr, targets, indirect_br: _ } => {
                 if matches!(discr, Operand::Constant(_) | Operand::RuntimeChecks(_)) {
                     // Not only will this become a `Goto`, but likely other
                     // things will be removable as unreachable.

--- a/compiler/rustc_mir_transform/src/coverage/tests.rs
+++ b/compiler/rustc_mir_transform/src/coverage/tests.rs
@@ -150,6 +150,7 @@ impl<'tcx> MockBlocks<'tcx> {
         let switchint_kind = TerminatorKind::SwitchInt {
             discr: Operand::Move(Place::from(self.new_temp())),
             targets: SwitchTargets::static_if(0, TEMP_BLOCK, TEMP_BLOCK),
+            indirect_br: false,
         };
         self.add_block_from(some_from_block, switchint_kind)
     }

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -243,7 +243,7 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
                 // They would have an effect, but are not allowed in this phase.
                 bug!("encountered disallowed terminator");
             }
-            TerminatorKind::SwitchInt { discr, targets } => {
+            TerminatorKind::SwitchInt { discr, targets, indirect_br: _ } => {
                 return self.handle_switch_int(discr, targets, state);
             }
             TerminatorKind::TailCall { .. } => {

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -111,7 +111,7 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
 
             should_cleanup = true;
 
-            let TerminatorKind::SwitchInt { discr: parent_op, targets: parent_targets } =
+            let TerminatorKind::SwitchInt { discr: parent_op, targets: parent_targets, .. } =
                 &bbs[parent].terminator().kind
             else {
                 unreachable!()
@@ -172,6 +172,7 @@ impl<'tcx> crate::MirPass<'tcx> for EarlyOtherwiseBranch {
                         // switch on the first discriminant, so we can mark the second one as dead
                         discr: parent_op,
                         targets: eq_targets,
+                        indirect_br: false,
                     },
                 }),
                 bbs[parent].is_cleanup,
@@ -221,7 +222,8 @@ fn evaluate_candidate<'tcx>(
     if bbs[parent].is_cleanup {
         return None;
     }
-    let TerminatorKind::SwitchInt { targets, discr: parent_discr } = &bbs[parent].terminator().kind
+    let TerminatorKind::SwitchInt { targets, discr: parent_discr, .. } =
+        &bbs[parent].terminator().kind
     else {
         return None;
     };
@@ -229,7 +231,7 @@ fn evaluate_candidate<'tcx>(
     let (_, child) = targets.iter().next()?;
 
     let Terminator {
-        kind: TerminatorKind::SwitchInt { targets: child_targets, discr: child_discr },
+        kind: TerminatorKind::SwitchInt { targets: child_targets, discr: child_discr, .. },
         source_info,
     } = bbs[child].terminator()
     else {
@@ -358,7 +360,8 @@ fn verify_candidate_branch<'tcx>(
     need_hoist_discriminant: bool,
 ) -> bool {
     // In order for the optimization to be correct, the terminator must be a `SwitchInt`.
-    let TerminatorKind::SwitchInt { discr: switch_op, targets } = &branch.terminator().kind else {
+    let TerminatorKind::SwitchInt { discr: switch_op, targets, .. } = &branch.terminator().kind
+    else {
         return false;
     };
     if need_hoist_discriminant {

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -957,6 +957,7 @@ where
                     values.iter().copied().zip(blocks.iter().copied()),
                     *blocks.last().unwrap(),
                 ),
+                indirect_br: false,
             },
         );
         self.drop_flag_test_block(switch_block, succ, unwind)

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -659,7 +659,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
                 return;
             }
             // `SwitchInt` is handled specially.
-            TerminatorKind::SwitchInt { ref discr, ref targets } => {
+            TerminatorKind::SwitchInt { ref discr, ref targets, indirect_br: _ } => {
                 return self.process_switch_int(discr, targets, state);
             }
             // These do not modify memory.

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -755,7 +755,7 @@ impl<'tcx> Visitor<'tcx> for ConstPropagator<'_, 'tcx> {
             TerminatorKind::Assert { expected, msg, cond, .. } => {
                 self.check_assertion(*expected, msg, cond, location);
             }
-            TerminatorKind::SwitchInt { discr, targets } => {
+            TerminatorKind::SwitchInt { discr, targets, indirect_br: _ } => {
                 if let Some(ref value) = self.eval_operand(discr)
                     && let Some(value_const) = self.use_ecx(|this| this.ecx.read_scalar(value))
                     && let Some(constant) = value_const.to_bits(value_const.size()).discard_err()

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -790,6 +790,7 @@ impl<'tcx> CloneShimBuilder<'tcx> {
                 *kind = TerminatorKind::SwitchInt {
                     discr: Operand::Move(temp),
                     targets: SwitchTargets::new(cases.into_iter(), unreachable),
+                    indirect_br: false,
                 };
             }
             BasicBlockData { terminator: None, .. } => unreachable!(),

--- a/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir_transform/src/simplify_comparison_integral.rs
@@ -134,8 +134,11 @@ impl<'tcx> crate::MirPass<'tcx> for SimplifyComparisonIntegral {
             let targets = SwitchTargets::new(iter::once((new_value, bb_cond)), bb_otherwise);
 
             let terminator = bb.terminator_mut();
-            terminator.kind =
-                TerminatorKind::SwitchInt { discr: Operand::Copy(opt.to_switch_on), targets };
+            terminator.kind = TerminatorKind::SwitchInt {
+                discr: Operand::Copy(opt.to_switch_on),
+                targets,
+                indirect_br: false,
+            };
         }
 
         for (idx, bb_idx) in storage_deads_to_remove {

--- a/compiler/rustc_mir_transform/src/ssa_range_prop.rs
+++ b/compiler/rustc_mir_transform/src/ssa_range_prop.rs
@@ -169,7 +169,7 @@ impl<'tcx> MutVisitor<'tcx> for RangeSet<'tcx, '_, '_> {
                     self.insert_range(place, successor, range);
                 }
             }
-            TerminatorKind::SwitchInt { discr, targets }
+            TerminatorKind::SwitchInt { discr, targets, indirect_br: _ }
                 if let Some(place) = discr.place()
                     && self.is_ssa(place)
                     // Reduce the potential compile-time overhead.

--- a/compiler/rustc_mir_transform/src/unreachable_enum_branching.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_enum_branching.rs
@@ -115,7 +115,8 @@ impl<'tcx> crate::MirPass<'tcx> for UnreachableEnumBranching {
             trace!("allowed_variants = {:?}", allowed_variants);
 
             unreachable_targets.clear();
-            let TerminatorKind::SwitchInt { targets, discr } = &bb_data.terminator().kind else {
+            let TerminatorKind::SwitchInt { targets, discr, .. } = &bb_data.terminator().kind
+            else {
                 bug!()
             };
 
@@ -164,7 +165,10 @@ impl<'tcx> crate::MirPass<'tcx> for UnreachableEnumBranching {
             for index in unreachable_targets.iter() {
                 targets.all_targets_mut()[*index] = unreachable_block;
             }
-            patch.patch_terminator(bb, TerminatorKind::SwitchInt { targets, discr: discr.clone() });
+            patch.patch_terminator(
+                bb,
+                TerminatorKind::SwitchInt { targets, discr: discr.clone(), indirect_br: false },
+            );
         }
 
         patch.apply(body);

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -70,7 +70,7 @@ pub(crate) fn remove_successors_from_switch<'tcx>(
     is_unreachable_block: impl Fn(BasicBlock) -> bool,
 ) -> bool {
     let terminator = body.basic_blocks[bb].terminator();
-    let TerminatorKind::SwitchInt { discr, targets } = &terminator.kind else { bug!() };
+    let TerminatorKind::SwitchInt { discr, targets, .. } = &terminator.kind else { bug!() };
     let source_info = terminator.source_info;
     let location = body.terminator_loc(bb);
 
@@ -146,7 +146,11 @@ pub(crate) fn remove_successors_from_switch<'tcx>(
             // Nothing has changed.
             return false;
         }
-        _ => TerminatorKind::SwitchInt { discr: discr.clone(), targets: new_targets },
+        _ => TerminatorKind::SwitchInt {
+            discr: discr.clone(),
+            targets: new_targets,
+            indirect_br: false,
+        },
     };
 
     patch.patch_terminator(bb, terminator);

--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -343,7 +343,7 @@ impl<'a, 'tcx> Visitor<'tcx> for CfgChecker<'a, 'tcx> {
             TerminatorKind::Goto { target } => {
                 self.check_edge(location, *target, EdgeKind::Normal);
             }
-            TerminatorKind::SwitchInt { targets, discr: _ } => {
+            TerminatorKind::SwitchInt { targets, discr: _, indirect_br: _ } => {
                 for (_, target) in targets.iter() {
                     self.check_edge(location, target, EdgeKind::Normal);
                 }
@@ -1569,7 +1569,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
 
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         match &terminator.kind {
-            TerminatorKind::SwitchInt { targets, discr } => {
+            TerminatorKind::SwitchInt { targets, discr, indirect_br: _ } => {
                 let switch_ty = discr.ty(&self.body.local_decls, self.tcx);
 
                 let target_width = self.tcx.sess.target.pointer_width;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -198,6 +198,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::ConstContinue(attr_span) => {
                 self.check_const_continue(hir_id, *attr_span, target)
             }
+            AttributeKind::IndirectBranch(attr_span) => {
+                self.check_indirect_branch(hir_id, *attr_span, target)
+            }
             AttributeKind::AllowInternalUnsafe(attr_span)
             | AttributeKind::AllowInternalUnstable(.., attr_span) => {
                 self.check_macro_only_attr(*attr_span, span, target, attrs)
@@ -1748,6 +1751,18 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
 
         if !matches!(self.tcx.hir_expect_expr(hir_id).kind, hir::ExprKind::Break(..)) {
             self.dcx().emit_err(errors::ConstContinueAttr { attr_span, node_span });
+        };
+    }
+
+    fn check_indirect_branch(&self, hir_id: HirId, _attr_span: Span, target: Target) {
+        let _node_span = self.tcx.hir_span(hir_id);
+
+        if !matches!(target, Target::Expression) {
+            return; // Handled in target checking during attr parse
+        }
+
+        if !matches!(self.tcx.hir_expect_expr(hir_id).kind, hir::ExprKind::Match(..)) {
+            todo!()
         };
     }
 }

--- a/compiler/rustc_public/src/unstable/convert/stable/mir.rs
+++ b/compiler/rustc_public/src/unstable/convert/stable/mir.rs
@@ -712,16 +712,18 @@ impl<'tcx> Stable<'tcx> for mir::TerminatorKind<'tcx> {
             mir::TerminatorKind::Goto { target } => {
                 TerminatorKind::Goto { target: target.as_usize() }
             }
-            mir::TerminatorKind::SwitchInt { discr, targets } => TerminatorKind::SwitchInt {
-                discr: discr.stable(tables, cx),
-                targets: {
-                    let branches = targets.iter().map(|(val, target)| (val, target.as_usize()));
-                    crate::mir::SwitchTargets::new(
-                        branches.collect(),
-                        targets.otherwise().as_usize(),
-                    )
-                },
-            },
+            mir::TerminatorKind::SwitchInt { discr, targets, indirect_br: _ } => {
+                TerminatorKind::SwitchInt {
+                    discr: discr.stable(tables, cx),
+                    targets: {
+                        let branches = targets.iter().map(|(val, target)| (val, target.as_usize()));
+                        crate::mir::SwitchTargets::new(
+                            branches.collect(),
+                            targets.otherwise().as_usize(),
+                        )
+                    },
+                }
+            }
             mir::TerminatorKind::UnwindResume => TerminatorKind::Resume,
             mir::TerminatorKind::UnwindTerminate(_) => TerminatorKind::Abort,
             mir::TerminatorKind::Return => TerminatorKind::Return,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1096,6 +1096,7 @@ symbols! {
         incomplete_features,
         index,
         index_mut,
+        indirect_branch,
         infer_outlives_requirements,
         infer_static_outlives_requirements,
         inherent_associated_types,

--- a/tests/codegen-llvm/indirectbr.rs
+++ b/tests/codegen-llvm/indirectbr.rs
@@ -1,0 +1,34 @@
+//@ add-minicore
+//@ compile-flags: -Copt-level=0
+#![feature(stmt_expr_attributes)]
+#![feature(loop_match)]
+#![crate_type = "lib"]
+
+// CHECK-LABEL: runner
+#[unsafe(no_mangle)]
+fn runner(opcodes: &[u8]) -> i32 {
+    let mut index = 0;
+    let mut accum = 0;
+
+    loop {
+        // CHECK: indirectbr ptr
+        #[indirect_branch]
+        match unsafe { *opcodes.get_unchecked(index) } {
+            b'+' => {
+                accum += 1;
+                index += 1;
+            }
+            b'-' => {
+                accum -= 1;
+                index += 1;
+            }
+            b'*' => {
+                accum *= 2;
+                index += 1;
+            }
+            0 => return accum,
+
+            _ => return -1,
+        }
+    }
+}

--- a/tests/ui/thir-print/str-patterns.stdout
+++ b/tests/ui/thir-print/str-patterns.stdout
@@ -216,6 +216,7 @@ Thir {
                     a2,
                 ],
                 match_source: Normal,
+                indirect_br: false,
             },
             ty: (),
             temp_scope_id: 4,


### PR DESCRIPTION
Part of the https://rust-lang.github.io/rust-project-goals/2026/tail-call-loop-match.html project goal.

This is extremely experimental. The implementation is _not good_, but I think it's sufficiently far along for some actual experiments. 

The aim here is to show that some construct that compiles down to `indirectbr` (what LLVM uses for C computed goto) is worthwhile. For now I've hijacked normal `match`es when annotated with the `#[indirect_branch]` attribute.

As an example of what this can do:

https://github.com/folkertdev/email-parser-benchmark/pull/1

```
Benchmark 2 (9 runs): ./target/release/indirect-branch
  measurement          mean ± σ            min … max           outliers         delta
  wall_time           577ms ± 2.57ms     574ms …  583ms          0 ( 0%)        ⚡- 31.4% ±  1.6%
  peak_rss           2.00MB ± 87.4KB    1.84MB … 2.10MB          0 ( 0%)          +  1.5% ±  4.0%
  cpu_cycles         2.64G  ± 1.99M     2.64G  … 2.65G           0 ( 0%)        ⚡- 31.6% ±  1.5%
  instructions       7.30G  ±  229      7.30G  … 7.30G           0 ( 0%)        ⚡- 23.1% ±  0.0%
  cache_references   60.7K  ± 13.1K     47.2K  … 86.2K           0 ( 0%)        ⚡- 34.2% ± 18.4%
  cache_misses       10.2K  ± 2.38K     7.75K  … 14.4K           0 ( 0%)          +  2.6% ± 32.8%
  branch_misses      11.1K  ± 1.02K     10.0K  … 13.5K           1 (11%)        ⚡-100.0% ±  8.1%
```

Now, caveats everywhere: this is a synthetic example, and also `loop_match` is actually even better on it. Nevertheless it shows that we're leaving performance on the table.

# Use 

For now this is under the `#![feature(loop_match)]` feature. Enable it, and just slap the attribute on a match:

```rust
#[indirect_branch]
match next_state { 
    // ...
}
```

I'm pretty sure the current implementation breaks on scrutinee valus that are not (in practice) restricted to `0..=u8::MAX as _`.

If you do want to play around with this, it's important that your match scrutinee is a basic value. So instead of 

```rust
match instructions[index] { 
    OpCode::Add => { 
        // ...
        index += 1;
    }

    // ...
}
```

Use 

```rust
let mut opcode = instructions[index];

match opcode { 
    OpCode::Add => { 
        // ...
        index += 1;
        opcode = instructions[index];
    }

    // ...
}
```

The `indirectbr` transformation only works in the `match opcode { /* ... */ }` case. 
