### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/interface.rs
+++ b/compiler/rustc_attr_parsing/src/interface.rs
@@ -337,11 +337,12 @@ impl<'sess> AttributeParser<'sess> {
 
                     let parts =
                         n.item.path.segments.iter().map(|seg| seg.ident.name).collect::<Vec<_>>();
+                    let inner_span = lower_span(n.item.span());
 
                     if let Some(accept) = ATTRIBUTE_PARSERS.accepters.get(parts.as_slice()) {
                         self.check_attribute_safety(
                             &attr_path,
-                            lower_span(n.item.span()),
+                            inner_span,
                             n.item.unsafety,
                             accept.safety,
                             &mut emit_lint,
@@ -396,7 +397,7 @@ impl<'sess> AttributeParser<'sess> {
                                 emit_lint: &mut emit_lint,
                             },
                             attr_span,
-                            inner_span: lower_span(n.item.span()),
+                            inner_span,
                             attr_style: attr.style,
                             parsed_description: ParsedDescription::Attribute,
                             template: &accept.template,
@@ -420,7 +421,7 @@ impl<'sess> AttributeParser<'sess> {
 
                         self.check_attribute_safety(
                             &attr_path,
-                            lower_span(n.item.span()),
+                            inner_span,
                             n.item.unsafety,
                             AttributeSafety::Normal,
                             &mut emit_lint,
@@ -429,7 +430,7 @@ impl<'sess> AttributeParser<'sess> {
                         if !matches!(self.should_emit, ShouldEmit::Nothing)
                             && target == Target::Crate
                         {
-                            self.check_invalid_crate_level_attr_item(&attr, n.item.span());
+                            self.check_invalid_crate_level_attr_item(&attr, inner_span);
                         }
 
                         attributes.push(Attribute::Unparsed(Box::new(attr)));

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1598,6 +1598,25 @@ impl Dir {
             .open_file(path.as_ref(), &OpenOptions::new().read(true).0)
             .map(|f| File { inner: f })
     }
+
+    /// Queries metadata about the underlying directory.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(dirfd)]
+    /// use std::fs::Dir;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let dir = Dir::open("foo")?;
+    ///     let metadata = dir.metadata()?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "dirfd", issue = "120426")]
+    pub fn metadata(&self) -> io::Result<Metadata> {
+        self.inner.metadata().map(Metadata)
+    }
 }
 
 impl AsInner<fs_imp::Dir> for Dir {
@@ -2144,6 +2163,12 @@ impl fmt::Debug for Metadata {
             debug.field("created", &created);
         }
         debug.finish_non_exhaustive()
+    }
+}
+
+impl IntoInner<fs_imp::FileAttr> for Metadata {
+    fn into_inner(self) -> fs_imp::FileAttr {
+        self.0
     }
 }
 

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -2545,3 +2545,11 @@ fn test_dir_read_file() {
     let buf = check!(io::read_to_string(f));
     assert_eq!("bar", &buf);
 }
+
+#[test]
+fn test_dir_metadata() {
+    let tmpdir = tmpdir();
+    let dir = check!(Dir::open(tmpdir.path()));
+    let metadata = check!(dir.metadata());
+    assert!(metadata.is_dir());
+}

--- a/library/std/src/sys/fs/common.rs
+++ b/library/std/src/sys/fs/common.rs
@@ -2,7 +2,8 @@
 
 use crate::io::{self, Error, ErrorKind};
 use crate::path::{Path, PathBuf};
-use crate::sys::fs::{File, OpenOptions};
+use crate::sys::IntoInner;
+use crate::sys::fs::{File, FileAttr, OpenOptions};
 use crate::sys::helpers::ignore_notfound;
 use crate::{fmt, fs};
 
@@ -71,6 +72,10 @@ impl Dir {
 
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
         File::open(&self.path.join(path), &opts)
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        self.path.metadata().map(|m| m.into_inner())
     }
 }
 

--- a/library/std/src/sys/fs/unix/dir.rs
+++ b/library/std/src/sys/fs/unix/dir.rs
@@ -25,7 +25,7 @@ use crate::os::wasi::io::{AsRawFd, FromRawFd};
 use crate::path::Path;
 use crate::sys::fd::FileDesc;
 use crate::sys::fs::OpenOptions;
-use crate::sys::fs::unix::{File, debug_path_fd};
+use crate::sys::fs::unix::{File, FileAttr, debug_path_fd};
 use crate::sys::helpers::run_path_with_cstr;
 use crate::sys::{AsInner, FromInner, IntoInner, cvt_r};
 use crate::{fmt, fs, io};
@@ -39,6 +39,16 @@ impl Dir {
 
     pub fn open_file(&self, path: &Path, opts: &OpenOptions) -> io::Result<File> {
         run_path_with_cstr(path.as_ref(), &|path| self.open_file_c(path, &opts))
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        // Reuse the implementation for files, which should work for all FDs.
+        let fd = self.0.as_raw_fd();
+        let f = core::mem::ManuallyDrop::new(File(
+            // SAFETY: we borrowed `self` so the FD will not be closed while this function runs.
+            unsafe { FileDesc::from_raw_fd(fd) },
+        ));
+        f.file_attr()
     }
 
     pub fn open_with_c(path: &CStr, opts: &OpenOptions) -> io::Result<Self> {

--- a/library/std/src/sys/fs/windows/dir.rs
+++ b/library/std/src/sys/fs/windows/dir.rs
@@ -5,7 +5,7 @@ use crate::os::windows::io::{
 use crate::path::Path;
 use crate::sys::api::{UnicodeStrRef, WinError};
 use crate::sys::fs::windows::debug_path_handle;
-use crate::sys::fs::{File, OpenOptions};
+use crate::sys::fs::{File, FileAttr, OpenOptions};
 use crate::sys::handle::Handle;
 use crate::sys::path::{WCStr, with_native_path};
 use crate::sys::{AsInner, FromInner, IntoInner, IoResult, c, to_u16s};
@@ -100,6 +100,16 @@ impl Dir {
             ..c::OBJECT_ATTRIBUTES::with_length()
         };
         unsafe { nt_create_file(opts, &object_attributes, c::FILE_NON_DIRECTORY_FILE) }
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        // Reuse the implementation for files, which should work for all handles.
+        let handle = self.handle.as_raw_handle();
+        let f = core::mem::ManuallyDrop::new(File {
+            // SAFETY: we borrowed `self` so the handle will not be closed while this function runs.
+            handle: unsafe { Handle::from_raw_handle(handle) },
+        });
+        f.file_attr()
     }
 }
 

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -71,7 +71,7 @@ fn synthesize_auto_trait_impl<'tcx>(
 ) -> Option<clean::Item> {
     let tcx = cx.tcx;
     let trait_ref = ty::Binder::dummy(ty::TraitRef::new(tcx, trait_def_id, [ty]));
-    if !cx.generated_synthetics.insert((ty, trait_def_id)) {
+    if !cx.synthetic_auto_trait_impls.insert((ty, trait_def_id)) {
         debug!("already generated, aborting");
         return None;
     }

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -25,7 +25,7 @@ pub(crate) fn synthesize_blanket_impls(
     let mut blanket_impls = Vec::new();
     for trait_def_id in tcx.visible_traits() {
         if !cx.cache.effective_visibilities.is_reachable(tcx, trait_def_id)
-            || cx.generated_synthetics.contains(&(ty.skip_binder(), trait_def_id))
+            || cx.synthetic_blanket_impls.contains(&(ty.skip_binder(), trait_def_id))
         {
             continue;
         }
@@ -81,7 +81,7 @@ pub(crate) fn synthesize_blanket_impls(
             }
             debug!("found applicable impl for trait ref {trait_ref:?}");
 
-            cx.generated_synthetics.insert((ty.skip_binder(), trait_def_id));
+            cx.synthetic_blanket_impls.insert((ty.skip_binder(), trait_def_id));
 
             blanket_impls.push(clean::Item {
                 inner: Box::new(clean::ItemInner {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -56,9 +56,18 @@ pub(crate) struct DocContext<'tcx> {
     pub(crate) current_type_aliases: DefIdMap<usize>,
     /// Table synthetic type parameter for `impl Trait` in argument position -> bounds
     pub(crate) impl_trait_bounds: FxHashMap<ImplTraitParam, Vec<clean::GenericBound>>,
-    /// Auto-trait or blanket impls processed so far, as `(self_ty, trait_def_id)`.
-    // FIXME(eddyb) make this a `ty::TraitRef<'tcx>` set.
-    pub(crate) generated_synthetics: FxHashSet<(Ty<'tcx>, DefId)>,
+
+    // FIXME: I'm pretty that the only reason we "need" these caches is because we also invoke
+    //        `synthesize_auto_trait_and_blanket_impls` on all impls(!) for primitive types
+    //        instead of calling it only once per primitive type (see also #97129).
+    //        Get rid of that jank and remove both caches!
+    //
+    /// The set of auto-trait impls generated so far; identified by `(self_ty, trait_def_id)`.
+    pub(crate) synthetic_auto_trait_impls: FxHashSet<(Ty<'tcx>, DefId)>,
+    /// The set of blanket impls generated so far; identified by `(self_ty, trait_def_id)`.
+    pub(crate) synthetic_blanket_impls: FxHashSet<(Ty<'tcx>, DefId)>,
+
+    /// All auto traits in the (visible) crate graph.
     pub(crate) auto_traits: Vec<DefId>,
     /// This same cache is used throughout rustdoc, including in [`crate::html::render`].
     pub(crate) cache: Cache,
@@ -369,7 +378,8 @@ pub(crate) fn run_global_ctxt(
         args: Default::default(),
         current_type_aliases: Default::default(),
         impl_trait_bounds: Default::default(),
-        generated_synthetics: Default::default(),
+        synthetic_auto_trait_impls: Default::default(),
+        synthetic_blanket_impls: Default::default(),
         auto_traits,
         cache: Cache::new(render_options.document_private, render_options.document_hidden),
         inlined: FxHashSet::default(),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1397,13 +1397,13 @@ fn render_all_impls(
     mut w: impl Write,
     cx: &Context<'_>,
     containing_item: &clean::Item,
-    concrete: &[&Impl],
-    synthetic: &[&Impl],
-    blanket_impl: &[&Impl],
+    concrete_impls: &[&Impl],
+    auto_trait_impls: &[&Impl],
+    blanket_impls: &[&Impl],
 ) -> fmt::Result {
     let impls = {
         let mut buf = String::new();
-        render_impls(cx, &mut buf, concrete, containing_item, true)?;
+        render_impls(cx, &mut buf, concrete_impls, containing_item, true)?;
         buf
     };
     if !impls.is_empty() {
@@ -1414,23 +1414,24 @@ fn render_all_impls(
         )?;
     }
 
-    if !synthetic.is_empty() {
+    if !auto_trait_impls.is_empty() {
+        // FIXME: Change the ID to `auto-trait-implementations-list`!
         write!(
             w,
             "{}<div id=\"synthetic-implementations-list\">",
             write_impl_section_heading("Auto Trait Implementations", "synthetic-implementations",)
         )?;
-        render_impls(cx, &mut w, synthetic, containing_item, false)?;
+        render_impls(cx, &mut w, auto_trait_impls, containing_item, false)?;
         w.write_str("</div>")?;
     }
 
-    if !blanket_impl.is_empty() {
+    if !blanket_impls.is_empty() {
         write!(
             w,
             "{}<div id=\"blanket-implementations-list\">",
             write_impl_section_heading("Blanket Implementations", "blanket-implementations")
         )?;
-        render_impls(cx, &mut w, blanket_impl, containing_item, false)?;
+        render_impls(cx, &mut w, blanket_impls, containing_item, false)?;
         w.write_str("</div>")?;
     }
     Ok(())
@@ -1459,10 +1460,10 @@ fn render_assoc_items_inner(
 ) -> fmt::Result {
     info!("Documenting associated items of {:?}", containing_item.name);
     let cache = &cx.shared.cache;
-    let Some(v) = cache.impls.get(&it) else { return Ok(()) };
-    let (mut non_trait, traits): (Vec<_>, _) =
-        v.iter().partition(|i| i.inner_impl().trait_.is_none());
-    if !non_trait.is_empty() {
+    let Some(impls) = cache.impls.get(&it) else { return Ok(()) };
+    let (mut inherent_impls, trait_impls): (Vec<_>, _) =
+        impls.iter().partition(|i| i.inner_impl().trait_.is_none());
+    if !inherent_impls.is_empty() {
         let render_mode = what.render_mode();
         let class_html = what
             .class()
@@ -1485,7 +1486,7 @@ fn render_assoc_items_inner(
                 // we should not show methods from `[MaybeUninit<u8>]`.
                 // this `retain` filters out any instances where
                 // the types do not line up perfectly.
-                non_trait.retain(|impl_| {
+                inherent_impls.retain(|impl_| {
                     type_.is_doc_subtype_of(&impl_.inner_impl().for_, &cx.shared.cache)
                 });
                 let derived_id = cx.derive_id(&id);
@@ -1512,8 +1513,8 @@ fn render_assoc_items_inner(
                 )
             }
         };
-        let impls_buf = fmt::from_fn(|f| {
-            non_trait
+        let inherent_impls_buf = fmt::from_fn(|f| {
+            inherent_impls
                 .iter()
                 .map(|i| {
                     render_impl(
@@ -1536,10 +1537,10 @@ fn render_assoc_items_inner(
         })
         .to_string();
 
-        if !impls_buf.is_empty() {
+        if !inherent_impls_buf.is_empty() {
             write!(
                 w,
-                "{section_heading}<div id=\"{id}\"{class_html}>{impls_buf}</div>{}",
+                "{section_heading}<div id=\"{id}\"{class_html}>{inherent_impls_buf}</div>{}",
                 matches!(what, AssocItemRender::DerefFor { .. })
                     .then_some("</details>")
                     .maybe_display(),
@@ -1547,13 +1548,14 @@ fn render_assoc_items_inner(
         }
     }
 
-    if !traits.is_empty() {
-        let deref_impl = traits.iter().find(|t| {
+    if !trait_impls.is_empty() {
+        let deref_impl = trait_impls.iter().find(|t| {
             t.trait_did() == cx.tcx().lang_items().deref_trait() && !t.is_negative_trait_impl()
         });
         if let Some(impl_) = deref_impl {
-            let has_deref_mut =
-                traits.iter().any(|t| t.trait_did() == cx.tcx().lang_items().deref_mut_trait());
+            let has_deref_mut = trait_impls
+                .iter()
+                .any(|t| t.trait_did() == cx.tcx().lang_items().deref_mut_trait());
             render_deref_methods(&mut w, cx, impl_, containing_item, has_deref_mut, derefs)?;
         }
 
@@ -1563,12 +1565,19 @@ fn render_assoc_items_inner(
             return Ok(());
         }
 
-        let (synthetic, concrete): (Vec<&Impl>, Vec<&Impl>) =
-            traits.into_iter().partition(|t| t.inner_impl().kind.is_auto());
-        let (blanket_impl, concrete): (Vec<&Impl>, _) =
-            concrete.into_iter().partition(|t| t.inner_impl().kind.is_blanket());
+        let (auto_trait_impls, trait_impls): (Vec<&Impl>, Vec<&Impl>) =
+            trait_impls.into_iter().partition(|t| t.inner_impl().kind.is_auto());
+        let (blanket_impls, concrete_impls): (Vec<&Impl>, _) =
+            trait_impls.into_iter().partition(|t| t.inner_impl().kind.is_blanket());
 
-        render_all_impls(w, cx, containing_item, &concrete, &synthetic, &blanket_impl)?;
+        render_all_impls(
+            w,
+            cx,
+            containing_item,
+            &concrete_impls,
+            &auto_trait_impls,
+            &blanket_impls,
+        )?;
     }
     Ok(())
 }

--- a/tests/rustdoc-html/impl/blanket-impl-trumps-auto-trait-impl.rs
+++ b/tests/rustdoc-html/impl/blanket-impl-trumps-auto-trait-impl.rs
@@ -1,0 +1,26 @@
+// The presence of built-in or user-written trait impls disqualifies potential built-in auto trait
+// impls for a type. Here we have a blanket impl of an auto trait which suppresses all hypothetical
+// auto trait impls.
+//
+// Check that we don't claim that there's an auto trait impl & ensure that we show the blanket impl.
+// Erroneously we once used to omit the blanket impl since auto trait impls & blanket impls used to
+// share the same cache and auto trait impls get generated first. Now, they have separate caches.
+//
+// issue: <https://github.com/rust-lang/rust/issues/148980>
+
+#![feature(auto_traits)]
+#![crate_name = "it"]
+
+pub auto trait Marker {}
+
+//@ has 'it/struct.Subject.html'
+#[derive(Clone, Copy)]
+pub struct Subject;
+
+// NOTE: `#synthetic-implementations-list` contains auto trait impls only despite its name.
+//@ !has - '//*[@id="synthetic-implementations-list"]//*[@class="impl"]' \
+//        'Marker for Subject'
+
+//@ has - '//*[@id="blanket-implementations-list"]//*[@class="impl"]' \
+//        'Marker for Twhere T: Copy'
+impl<T: Copy> Marker for T {}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157192 (directory handles: add Dir::metadata)
 - rust-lang/rust#157171 ( rustdoc: Separate the caches for synthetic auto trait & blanket impls)
 - rust-lang/rust#157185 (Don't lower `inner_span` multiple times)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157192,157171,157185)
<!-- homu-ignore:end -->

