### PR TITLE
[tiny] remove unecessary `.into()` calls

### DIFF
--- a/compiler/rustc_builtin_macros/src/format_foreign/shell/tests.rs
+++ b/compiler/rustc_builtin_macros/src/format_foreign/shell/tests.rs
@@ -22,7 +22,7 @@ fn test_escape() {
 fn test_parse() {
     macro_rules! assert_pns_eq_sub {
         ($in_:expr, $kind:ident($arg:expr, $pos:expr)) => {
-            assert_eq!(pns(concat!($in_, "!")), Some((S::$kind($arg.into(), $pos), "!")))
+            assert_eq!(pns(concat!($in_, "!")), Some((S::$kind($arg, $pos), "!")))
         };
     }
 

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -286,7 +286,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 (GenericArgKind::Lifetime(v_o), GenericArgKind::Lifetime(v_r)) => {
                     if v_o != v_r {
                         output_query_region_constraints.constraints.push((
-                            ty::RegionEqPredicate(v_o.into(), v_r).into(),
+                            ty::RegionEqPredicate(v_o, v_r).into(),
                             constraint_category,
                             ty::VisibleForLeakCheck::Yes,
                         ));

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -107,13 +107,12 @@ impl<'tcx> TyCtxt<'tcx> {
             Ok(Some(instance)) => GlobalId { instance, promoted: None },
             // For errors during resolution, we deliberately do not point at the usage site of the constant,
             // since for these errors the place the constant is used shouldn't matter.
-            Ok(None) => return Err(ErrorHandled::TooGeneric(DUMMY_SP).into()),
+            Ok(None) => return Err(ErrorHandled::TooGeneric(DUMMY_SP)),
             Err(err) => {
                 return Err(ErrorHandled::Reported(
                     ReportedErrorInfo::non_const_eval_error(err),
                     DUMMY_SP,
-                )
-                .into());
+                ));
             }
         };
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1098,7 +1098,7 @@ impl<'tcx> TypingEnv<'tcx> {
         def_id: impl IntoQueryKey<DefId>,
     ) -> TypingEnv<'tcx> {
         let def_id = def_id.into_query_key();
-        Self::new(tcx.param_env(def_id), TypingMode::non_body_analysis().into())
+        Self::new(tcx.param_env(def_id), TypingMode::non_body_analysis())
     }
 
     pub fn post_analysis(tcx: TyCtxt<'tcx>, def_id: impl IntoQueryKey<DefId>) -> TypingEnv<'tcx> {

--- a/compiler/rustc_mir_build/src/builder/expr/into.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/into.rs
@@ -914,7 +914,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     source_info,
                     destination,
-                    Rvalue::Reborrow(target, mutability, place.into()),
+                    Rvalue::Reborrow(target, mutability, place),
                 );
                 block.unit()
             }

--- a/compiler/rustc_mir_transform/src/check_null.rs
+++ b/compiler/rustc_mir_transform/src/check_null.rs
@@ -79,7 +79,7 @@ fn insert_null_check<'tcx>(
                 source_info,
                 StatementKind::Assign(Box::new((pointee_should_be_checked, rvalue))),
             ));
-            Operand::Copy(pointee_should_be_checked.into())
+            Operand::Copy(pointee_should_be_checked)
         }
     };
 

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -389,7 +389,7 @@ where
                 impl_def_id,
                 impl_args,
                 impl_trait_ref,
-                target_container_def_id.into(),
+                target_container_def_id,
             )?;
 
             if !cx.check_args_compatible(target_item_def_id.into(), target_args) {

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -252,7 +252,7 @@ impl ToJson for Target {
             };
             ($attr:ident, $json_name:expr) => {{
                 let name = $json_name;
-                d.insert(name.into(), target.$attr.to_json());
+                d.insert(name.to_string(), target.$attr.to_json());
             }};
         }
 
@@ -262,7 +262,7 @@ impl ToJson for Target {
                 let name = $json_name;
                 #[allow(rustc::bad_opt_access)]
                 if default.$attr != target.$attr {
-                    d.insert(name.into(), target.$attr.to_json());
+                    d.insert(name.to_string(), target.$attr.to_json());
                 }
             }};
             (link_args - $attr:ident, $json_name:expr) => {{
@@ -447,7 +447,6 @@ impl schemars::JsonSchema for EndianWrapper {
             "type": "string",
             "enum": ["big", "little"]
         })
-        .into()
     }
 }
 
@@ -473,7 +472,6 @@ impl schemars::JsonSchema for ExternAbiWrapper {
             "type": "string",
             "enum": all,
         })
-        .into()
     }
 }
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -522,7 +522,6 @@ impl schemars::JsonSchema for LinkerFlavorCli {
             "type": "string",
             "enum": all
         })
-        .into()
     }
 }
 
@@ -587,7 +586,6 @@ impl schemars::JsonSchema for LinkSelfContainedDefault {
             "type": "string",
             "enum": ["false", "true", "wasm", "musl", "mingw"]
         })
-        .into()
     }
 }
 
@@ -733,7 +731,6 @@ impl schemars::JsonSchema for LinkSelfContainedComponents {
             "type": "string",
             "enum": all,
         })
-        .into()
     }
 }
 
@@ -912,7 +909,6 @@ impl schemars::JsonSchema for SmallDataThresholdSupport {
             "type": "string",
             "pattern": r#"^none|default-for-arch|llvm-module-flag=.+|llvm-arg=.+$"#,
         })
-        .into()
     }
 }
 
@@ -1288,7 +1284,6 @@ impl schemars::JsonSchema for SanitizerSet {
             "type": "string",
             "enum": all,
         })
-        .into()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -562,12 +562,12 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
         // and therefore is treated as rigid.
         if let Some(ty::PredicateKind::AliasRelate(lhs, rhs, _)) = pred.kind().no_bound_vars() {
             goal.infcx().visit_proof_tree_at_depth(
-                goal.goal().with(tcx, ty::ClauseKind::WellFormed(lhs.into())),
+                goal.goal().with(tcx, ty::ClauseKind::WellFormed(lhs)),
                 goal.depth() + 1,
                 self,
             )?;
             goal.infcx().visit_proof_tree_at_depth(
-                goal.goal().with(tcx, ty::ClauseKind::WellFormed(rhs.into())),
+                goal.goal().with(tcx, ty::ClauseKind::WellFormed(rhs)),
                 goal.depth() + 1,
                 self,
             )?;

--- a/compiler/rustc_trait_selection/src/solve/normalize.rs
+++ b/compiler/rustc_trait_selection/src/solve/normalize.rs
@@ -48,8 +48,8 @@ where
             let delegate = <&SolverDelegate<'tcx>>::from(infcx);
             let infer_term = delegate.next_term_var_of_kind(alias_term, at.cause.span);
             let predicate = ty::PredicateKind::AliasRelate(
-                alias_term.into(),
-                infer_term.into(),
+                alias_term,
+                infer_term,
                 ty::AliasRelationDirection::Equate,
             );
             let goal = Goal::new(infcx.tcx, at.param_env, predicate);
@@ -92,8 +92,8 @@ impl<'me, 'tcx> ReplaceAliasWithInfer<'me, 'tcx> {
             self.at.cause.clone(),
             self.at.param_env,
             ty::PredicateKind::AliasRelate(
-                alias_term.into(),
-                infer_term.into(),
+                alias_term,
+                infer_term,
                 ty::AliasRelationDirection::Equate,
             ),
         );

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -295,7 +295,7 @@ impl<'a, 'b, 'tcx> AssocTypeNormalizer<'a, 'b, 'tcx> {
         let recursion_limit = self.cx().recursion_limit();
         if !recursion_limit.value_within_limit(self.depth) {
             self.selcx.infcx.err_ctxt().report_overflow_error(
-                OverflowCause::DeeplyNormalize(free.into()),
+                OverflowCause::DeeplyNormalize(free),
                 self.cause.span,
                 false,
                 |diag| {

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -275,10 +275,13 @@ pub fn normalize_projection_term<'a, 'b, 'tcx>(
             // and a deferred predicate to resolve this when more type
             // information is available.
 
-            selcx
-                .infcx
-                .projection_term_to_infer(param_env, alias_term, cause, depth + 1, obligations)
-                .into()
+            selcx.infcx.projection_term_to_infer(
+                param_env,
+                alias_term,
+                cause,
+                depth + 1,
+                obligations,
+            )
         })
 }
 

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -358,7 +358,7 @@ impl From<crate::net::TcpStream> for OwnedFd {
     /// Takes ownership of a [`TcpStream`](crate::net::TcpStream)'s socket file descriptor.
     #[inline]
     fn from(tcp_stream: crate::net::TcpStream) -> OwnedFd {
-        tcp_stream.into_inner().into_socket().into_inner().into_inner().into()
+        tcp_stream.into_inner().into_socket().into_inner().into_inner()
     }
 }
 
@@ -388,7 +388,7 @@ impl From<crate::net::TcpListener> for OwnedFd {
     /// Takes ownership of a [`TcpListener`](crate::net::TcpListener)'s socket file descriptor.
     #[inline]
     fn from(tcp_listener: crate::net::TcpListener) -> OwnedFd {
-        tcp_listener.into_inner().into_socket().into_inner().into_inner().into()
+        tcp_listener.into_inner().into_socket().into_inner().into_inner()
     }
 }
 
@@ -418,7 +418,7 @@ impl From<crate::net::UdpSocket> for OwnedFd {
     /// Takes ownership of a [`UdpSocket`](crate::net::UdpSocket)'s file descriptor.
     #[inline]
     fn from(udp_socket: crate::net::UdpSocket) -> OwnedFd {
-        udp_socket.into_inner().into_socket().into_inner().into_inner().into()
+        udp_socket.into_inner().into_socket().into_inner().into_inner()
     }
 }
 

--- a/library/std/src/sys/process/unix/unix.rs
+++ b/library/std/src/sys/process/unix/unix.rs
@@ -318,7 +318,7 @@ impl Command {
                         // An alternative would be to require CAP_SETGID (in
                         // addition to CAP_SETUID) for setting the UID.
                         if e.raw_os_error() != Some(libc::EPERM) {
-                            return Err(e.into());
+                            return Err(e);
                         }
                     }
                 }

--- a/src/librustdoc/build.rs
+++ b/src/librustdoc/build.rs
@@ -55,12 +55,9 @@ fn main() {
         let minified_path = std::path::PathBuf::from(format!("{out_dir}/{path}.min"));
         if path.ends_with(".js") || path.ends_with(".css") {
             let minified: String = if path.ends_with(".css") {
-                minifier::css::minify(str::from_utf8(&data_bytes).unwrap())
-                    .unwrap()
-                    .to_string()
-                    .into()
+                minifier::css::minify(str::from_utf8(&data_bytes).unwrap()).unwrap().to_string()
             } else {
-                minifier::js::minify(str::from_utf8(&data_bytes).unwrap()).to_string().into()
+                minifier::js::minify(str::from_utf8(&data_bytes).unwrap()).to_string()
             };
             std::fs::write(&minified_path, minified.as_bytes()).expect("write to out_dir");
         } else {

--- a/tests/ui/derives/coercepointee/auxiliary/another-proc-macro.rs
+++ b/tests/ui/derives/coercepointee/auxiliary/another-proc-macro.rs
@@ -11,7 +11,6 @@ pub fn derive(_input: TokenStream) -> TokenStream {
             const ANOTHER_MACRO_DERIVED: () = ();
         };
     }
-    .into()
 }
 
 #[proc_macro_attribute]
@@ -24,7 +23,6 @@ pub fn pointee(
             const POINTEE_MACRO_ATTR_DERIVED: () = ();
         };
     }
-    .into()
 }
 
 #[proc_macro_attribute]
@@ -37,5 +35,4 @@ pub fn default(
             const DEFAULT_MACRO_ATTR_DERIVED: () = ();
         };
     }
-    .into()
 }

--- a/tests/ui/process/process-panic-after-fork.rs
+++ b/tests/ui/process/process-panic-after-fork.rs
@@ -142,7 +142,7 @@ fn main() {
         let mut status: c_int = 0;
         let got = unsafe { libc::waitpid(child, &mut status, 0) };
         assert_eq!(got, child);
-        let status = ExitStatus::from_raw(status.into());
+        let status = ExitStatus::from_raw(status);
         status
     }
 


### PR DESCRIPTION
While working on rust-lang/rust#129249, encountered these cases in the codebase of calling `.into()` unecessarily. Splitting them out so that they can land independently of the lint.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
