### PR TITLE
Help people looking for random bytes find `DefaultRandomSource.fill_bytes`

### DIFF
--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -16,6 +16,8 @@ use crate::sys::random as sys;
 /// security is not a concern,  consider using an alternative random number
 /// generator (potentially seeded from this one).
 ///
+/// If you need to fill a buffer with random bytes, use `DefaultRandomSource.fill_bytes(&mut buf)`.
+///
 /// # Underlying sources
 ///
 /// Platform               | Source

--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -56,6 +56,7 @@ use crate::sys::random as sys;
 ///
 /// [`getrandom`]: https://www.man7.org/linux/man-pages/man2/getrandom.2.html
 /// [`/dev/urandom`]: https://www.man7.org/linux/man-pages/man4/random.4.html
+#[doc(alias = "getrandom", alias = "getentropy", alias = "arc4random")]
 #[derive(Default, Debug, Clone, Copy)]
 #[unstable(feature = "random", issue = "130703")]
 pub struct DefaultRandomSource;


### PR DESCRIPTION
Mention, in the `DefaultRandomSource` docs, how to fill a buffer with random bytes.

Add doc aliases for `DefaultRandomSource`, for people looking for various sources of randomness.

`getrandom` is both a crate for this and the name of the underlying syscall on various OSes. `getentropy` and `arc4random` are common library calls on various OSes.
