### PR TITLE
Manually unroll loop in `str::floor_char_boundary`

### DIFF
--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -2431,6 +2431,16 @@ fn floor_char_boundary() {
     check_many("🇯🇵", 0..4, 0);
     check_many("🇯🇵", 4..8, 4);
     check_many("🇯🇵", 8..10, 8);
+
+    // anticipate length- and index-based specializations
+    let s = "jpĵƥ日本🇯🇵jpĵƥ日本🇯🇵";
+    let expected = [
+        0, 1, 2, 2, 4, 4, 6, 6, 6, 9, 9, 9, 12, 12, 12, 12, 16, 16, 16, 16, 20, 21, 22, 22, 24, 24,
+        26, 26, 26, 29, 29, 29, 32, 32, 32, 32, 36, 36, 36, 36, 40, 40, 40, 40,
+    ];
+    for (idx, &ret) in expected.iter().enumerate() {
+        check_many(s, [idx], ret);
+    }
 }
 
 #[test]
@@ -2477,4 +2487,14 @@ fn ceil_char_boundary() {
 
     // above len
     check_many("hello", 5..=10, 5);
+
+    // anticipate length- and index-based specializations
+    let s = "jpĵƥ日本🇯🇵jpĵƥ日本🇯🇵";
+    let expected = [
+        0, 1, 2, 4, 4, 6, 6, 9, 9, 9, 12, 12, 12, 16, 16, 16, 16, 20, 20, 20, 20, 21, 22, 24, 24,
+        26, 26, 29, 29, 29, 32, 32, 32, 36, 36, 36, 36, 40, 40, 40, 40, 40, 40, 40,
+    ];
+    for (idx, &ret) in expected.iter().enumerate() {
+        check_many(s, [idx], ret);
+    }
 }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -15,6 +15,7 @@ mod validations;
 
 use self::pattern::{DoubleEndedSearcher, Pattern, ReverseSearcher, Searcher};
 use crate::char::{self, EscapeDebugExtArgs};
+use crate::hint::assert_unchecked;
 use crate::range::Range;
 use crate::slice::{self, SliceIndex};
 use crate::ub_checks::assert_unsafe_precondition;
@@ -421,21 +422,35 @@ impl str {
     #[inline]
     pub const fn floor_char_boundary(&self, index: usize) -> usize {
         if index >= self.len() {
-            self.len()
-        } else {
-            let mut i = index;
-            while i > 0 {
-                if self.as_bytes()[i].is_utf8_char_boundary() {
-                    break;
-                }
-                i -= 1;
-            }
-
-            //  The character boundary will be within four bytes of the index
-            debug_assert!(i >= index.saturating_sub(3));
-
-            i
+            return self.len();
         }
+        if self.as_bytes()[index].is_utf8_char_boundary() {
+            return index;
+        }
+        // Unlike `ceil_char_boundary`, the loop is unrolled manually to prevent the compiler from
+        // generating excessive unrolled loop bodies when `index` is statically known.
+
+        // The first byte of `&str` must always be a char boundary, so we can assume `i > 0` below
+        // for any `i` where `self.as_bytes()[i]` is not a char boundary.
+        debug_assert!(self.as_bytes()[0].is_utf8_char_boundary());
+
+        // SAFETY: `self.as_bytes()[0]` is always a char boundary with valid `&str`
+        unsafe { assert_unchecked(index >= 1) };
+        if self.as_bytes()[index - 1].is_utf8_char_boundary() {
+            return index - 1;
+        }
+
+        // SAFETY: `self.as_bytes()[0]` is always a char boundary with valid `&str`
+        unsafe { assert_unchecked(index >= 2) };
+        if self.as_bytes()[index - 2].is_utf8_char_boundary() {
+            return index - 2;
+        }
+
+        // `self.as_bytes()[0]` is always a char boundary with valid `&str`
+        debug_assert!(index >= 3);
+        // The character boundary will be within four bytes of the index
+        debug_assert!(self.as_bytes()[index - 3].is_utf8_char_boundary());
+        index - 3
     }
 
     /// Finds the closest `x` not below `index` where [`is_char_boundary(x)`] is `true`.
@@ -467,14 +482,14 @@ impl str {
             self.len()
         } else {
             let mut i = index;
-            while i < self.len() {
-                if self.as_bytes()[i].is_utf8_char_boundary() {
+            while !self.as_bytes()[i].is_utf8_char_boundary() {
+                i += 1;
+                if i >= self.len() {
                     break;
                 }
-                i += 1;
             }
 
-            //  The character boundary will be within four bytes of the index
+            // The character boundary will be within four bytes of the index
             debug_assert!(i <= index + 3);
 
             i


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157224)*
<!-- homu-ignore:end -->

This commit manually unrolls the while loops to at most three iterations, exploiting the UTF-8 invariant that a character is at most four bytes long.

Benefits:

- Prevents LLVM from generating unbounded unrolled code when `index` is statically known - e.g., `s.floor_char_boundary(20)` previously could emit up to 20 repeated loop bodies.
- Eliminates the check at `index - 3`: the UTF-8 invariant guarantees that if `index - 2` is not a character boundary, `index - 3` must be, so the third iteration needs no conditional.
- Allows out-of-order CPUs to issue all three byte loads in parallel, since their offsets are statically known.

This commit will close rust-lang/rust#149466 with simpler code. The optimizer appears to be able to eliminate bound checks and panic paths.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
