### PR TITLE
Partially stabilize `box_vec_non_null`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1347,16 +1347,12 @@ impl<T: ?Sized> Box<T> {
     /// Recreate a `Box` which was previously converted to a `NonNull`
     /// pointer using [`Box::into_non_null`]:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let x = Box::new(5);
     /// let non_null = Box::into_non_null(x);
     /// let x = unsafe { Box::from_non_null(non_null) };
     /// ```
     /// Manually create a `Box` from scratch by using the global allocator:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// use std::alloc::{alloc, Layout};
     /// use std::ptr::NonNull;
     ///
@@ -1372,7 +1368,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// [memory layout]: self#memory-layout
     /// [considerations for unsafe code]: self#considerations-for-unsafe-code
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     #[must_use = "call `drop(Box::from_non_null(ptr))` if you intend to drop the `Box`"]
     pub unsafe fn from_non_null(ptr: NonNull<T>) -> Self {
@@ -1461,8 +1457,6 @@ impl<T: ?Sized> Box<T> {
     /// Converting the `NonNull` pointer back into a `Box` with [`Box::from_non_null`]
     /// for automatic cleanup:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let x = Box::new(String::from("Hello"));
     /// let non_null = Box::into_non_null(x);
     /// let x = unsafe { Box::from_non_null(non_null) };
@@ -1470,8 +1464,6 @@ impl<T: ?Sized> Box<T> {
     /// Manual cleanup by explicitly running the destructor and deallocating
     /// the memory:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// use std::alloc::{dealloc, Layout};
     ///
     /// let x = Box::new(String::from("Hello"));
@@ -1483,8 +1475,6 @@ impl<T: ?Sized> Box<T> {
     /// ```
     /// Note: This is equivalent to the following:
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let x = Box::new(String::from("Hello"));
     /// let non_null = Box::into_non_null(x);
     /// unsafe {
@@ -1494,7 +1484,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// [memory layout]: self#memory-layout
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn into_non_null(b: Self) -> NonNull<T> {
         // SAFETY: `Box` is guaranteed to be non-null.
@@ -1611,7 +1601,6 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// [memory layout]: self#memory-layout
     /// [considerations for unsafe code]: self#considerations-for-unsafe-code
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub unsafe fn from_non_null_in(raw: NonNull<T>, alloc: A) -> Self {
         // SAFETY: guaranteed by the caller.
@@ -1726,7 +1715,6 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// [memory layout]: self#memory-layout
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[inline]
     pub fn into_non_null_with_allocator(b: Self) -> (NonNull<T>, A) {
         let (ptr, alloc) = Box::into_raw_with_allocator(b);

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2079,7 +2079,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_vec_non_null)]
+    /// #![feature(vec_as_non_null)]
     ///
     /// // Allocate vector big enough for 4 elements.
     /// let size = 4;
@@ -2099,7 +2099,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Due to the aliasing guarantee, the following code is legal:
     ///
     /// ```rust
-    /// #![feature(box_vec_non_null)]
+    /// #![feature(vec_as_non_null)]
     ///
     /// unsafe {
     ///     let mut v = vec![0];
@@ -2115,8 +2115,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// [`as_mut_ptr`]: Vec::as_mut_ptr
     /// [`as_ptr`]: Vec::as_ptr
     /// [`as_non_null`]: Vec::as_non_null
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[unstable(feature = "vec_as_non_null", issue = "157843")]
+    #[rustc_const_unstable(feature = "vec_as_non_null", issue = "157843")]
     #[rustc_as_ptr]
     #[inline]
     pub const fn as_non_null(&mut self) -> NonNull<T> {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2117,6 +2117,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// [`as_non_null`]: Vec::as_non_null
     #[unstable(feature = "box_vec_non_null", issue = "130364")]
     #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[rustc_as_ptr]
     #[inline]
     pub const fn as_non_null(&mut self) -> NonNull<T> {
         self.buf.non_null()

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -697,8 +697,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let v = vec![1, 2, 3];
     ///
     /// // Deconstruct the vector into parts.
@@ -719,8 +717,6 @@ impl<T> Vec<T> {
     /// Using memory that was allocated elsewhere:
     ///
     /// ```rust
-    /// #![feature(box_vec_non_null)]
-    ///
     /// use std::alloc::{alloc, Layout};
     /// use std::ptr::NonNull;
     ///
@@ -742,8 +738,8 @@ impl<T> Vec<T> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
     pub const unsafe fn from_parts(ptr: NonNull<T>, length: usize, capacity: usize) -> Self {
         unsafe { Self::from_parts_in(ptr, length, capacity, Global) }
     }
@@ -863,8 +859,6 @@ impl<T> Vec<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_vec_non_null)]
-    ///
     /// let v: Vec<i32> = vec![-1, 0, 1];
     ///
     /// let (ptr, len, cap) = v.into_parts();
@@ -879,8 +873,8 @@ impl<T> Vec<T> {
     /// assert_eq!(rebuilt, [4294967295, 0, 1]);
     /// ```
     #[must_use = "losing the pointer will leak memory"]
-    #[unstable(feature = "box_vec_non_null", issue = "130364")]
-    #[rustc_const_unstable(feature = "box_vec_non_null", issue = "130364")]
+    #[stable(feature = "box_vec_non_null", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
     pub const fn into_parts(self) -> (NonNull<T>, usize, usize) {
         let (ptr, len, capacity) = self.into_raw_parts();
         // SAFETY: A `Vec` always has a non-null pointer.
@@ -1305,7 +1299,6 @@ impl<T, A: Allocator> Vec<T, A> {
     #[inline]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[rustc_const_unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub const unsafe fn from_parts_in(
         ptr: NonNull<T>,
         length: usize,
@@ -1410,7 +1403,6 @@ impl<T, A: Allocator> Vec<T, A> {
     #[must_use = "losing the pointer will leak memory"]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[rustc_const_unstable(feature = "allocator_api", issue = "32838")]
-    // #[unstable(feature = "box_vec_non_null", issue = "130364")]
     pub const fn into_parts_with_alloc(self) -> (NonNull<T>, usize, usize, A) {
         let (ptr, len, capacity, alloc) = self.into_raw_parts_with_alloc();
         // SAFETY: A `Vec` always has a non-null pointer.

--- a/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
@@ -1,5 +1,5 @@
 #![deny(dangling_pointers_from_temporaries)]
-#![feature(box_vec_non_null)]
+#![feature(vec_as_non_null)]
 
 fn main() {
     vec![0u8].as_ptr();

--- a/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/methods.rs
@@ -1,8 +1,11 @@
 #![deny(dangling_pointers_from_temporaries)]
+#![feature(box_vec_non_null)]
 
 fn main() {
     vec![0u8].as_ptr();
     //~^ ERROR dangling pointer
     vec![0u8].as_mut_ptr();
+    //~^ ERROR dangling pointer
+    vec![0u8].as_non_null();
     //~^ ERROR dangling pointer
 }

--- a/tests/ui/lint/dangling-pointers-from-temporaries/methods.stderr
+++ b/tests/ui/lint/dangling-pointers-from-temporaries/methods.stderr
@@ -1,5 +1,5 @@
 error: this creates a dangling pointer because temporary `Vec<u8>` is dropped at end of statement
-  --> $DIR/methods.rs:4:15
+  --> $DIR/methods.rs:5:15
    |
 LL |     vec![0u8].as_ptr();
    |     --------- ^^^^^^ pointer created here
@@ -17,7 +17,7 @@ LL | #![deny(dangling_pointers_from_temporaries)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this creates a dangling pointer because temporary `Vec<u8>` is dropped at end of statement
-  --> $DIR/methods.rs:6:15
+  --> $DIR/methods.rs:7:15
    |
 LL |     vec![0u8].as_mut_ptr();
    |     --------- ^^^^^^^^^^ pointer created here
@@ -29,5 +29,18 @@ LL |     vec![0u8].as_mut_ptr();
    = note: returning a pointer to a local variable will always result in a dangling pointer
    = note: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
 
-error: aborting due to 2 previous errors
+error: this creates a dangling pointer because temporary `Vec<u8>` is dropped at end of statement
+  --> $DIR/methods.rs:9:15
+   |
+LL |     vec![0u8].as_non_null();
+   |     --------- ^^^^^^^^^^^ pointer created here
+   |     |
+   |     this `Vec<u8>` is dropped at end of statement
+   |
+   = help: bind the `Vec<u8>` to a variable such that it outlives the pointer returned by `as_non_null`
+   = note: a dangling pointer is safe, but dereferencing one is undefined behavior
+   = note: returning a pointer to a local variable will always result in a dangling pointer
+   = note: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
+
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157226)*
<!-- homu-ignore:end -->

Closes rust-lang/rust#130364

r? libs-api

### What's being stabilized

The following is being stabilized in this PR:

```rust
impl<T: ?Sized> Box<T> {
    pub unsafe fn from_non_null(ptr: NonNull<T>) -> Self { .... }
    pub fn into_non_null(b: Self) -> NonNull<T> { .... }
}
impl<T> Vec<T> {
    pub const unsafe fn from_parts(ptr: NonNull<T>, length: usize, capacity: usize) -> Self { .... }
    pub const fn into_parts(self) -> (NonNull<T>, usize, usize) { .... }
}
```

Note that `Vec::from_parts` and `Vec::into_parts` remain const-unstable behind the `const_heap` feature (like `Vec::from_raw_parts` and `Vec::into_raw_parts`).

The following APIs remain gated behind `allocator_api`
```rust
impl<T: ?Sized, A: Allocator> Box<T, A> {
    pub unsafe fn from_non_null_in(raw: NonNull<T>, alloc: A) -> Self { .... }
    pub fn into_non_null_with_allocator(b: Self) -> (NonNull<T>, A) { .... }
}
impl<T, A: Allocator> Vec<T, A> {
    pub const unsafe fn from_parts_in(ptr: NonNull<T>, length: usize, capacity: usize, alloc: A) -> Self { .... }
    pub const fn into_parts_with_alloc(self) -> (NonNull<T>, usize, usize, A) { .... }
}
```

The following API is split into a new unstable feature in rust-lang/rust#157843, and remains unstable:
```rust
impl<T, A: Allocator> Vec<T, A> {
    pub const fn as_non_null(&mut self) -> NonNull<T> { .... }
}
```

### Implementation History

Most of this feature was ACP'ed in https://github.com/rust-lang/libs-team/issues/418, and implemented in https://github.com/rust-lang/rust/pull/130061. `Vec::as_non_null` was ACP'ed separately in https://github.com/rust-lang/libs-team/issues/440, and implemented in https://github.com/rust-lang/rust/pull/130624.

### Potential issues

* Should `Vec::from_parts` and `Vec::into_parts` be the name used for this? Or should those names be used for functions that take/return `Box<[MaybeUninit<T>]>`? (Raised at https://github.com/rust-lang/rust/issues/130364#issuecomment-2357276951)
* Should these function names be named `non_null` or `nonnull`? (Raised at https://github.com/rust-lang/rust/issues/130364#issuecomment-4525680948. See https://github.com/rust-lang/rust/issues/154237#issuecomment-4120073976.)
* Will the methods on `Vec` collide with anything via autoderef?