### PR TITLE
borrowck: avoid ICE describing fields on generic params

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -525,7 +525,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 ty::Array(ty, _) | ty::Slice(ty) => {
                     self.describe_field_from_ty(ty, field, variant_index, including_tuple_field)
                 }
-                ty::Param(_) => Some(field.index().to_string()),
                 ty::Closure(def_id, _) | ty::Coroutine(def_id, _) => {
                     // We won't be borrowck'ing here if the closure came from another crate,
                     // so it's safe to call `expect_local`.
@@ -538,9 +537,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     Some(self.infcx.tcx.hir_name(var_id).to_string())
                 }
                 _ => {
-                    // Might need a revision when the fields in trait RFC is implemented
-                    // (https://github.com/rust-lang/rfcs/pull/1546)
-                    bug!("End-user description not implemented for field access on `{:?}`", ty);
+                    // This can happen for field accesses on `Box<T>`: the field is
+                    // described from the boxed type, which may have no named fields
+                    Some(field.index().to_string())
                 }
             }
         }

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -525,6 +525,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 ty::Array(ty, _) | ty::Slice(ty) => {
                     self.describe_field_from_ty(ty, field, variant_index, including_tuple_field)
                 }
+                ty::Param(_) => Some(field.index().to_string()),
                 ty::Closure(def_id, _) | ty::Coroutine(def_id, _) => {
                     // We won't be borrowck'ing here if the closure came from another crate,
                     // so it's safe to call `expect_local`.

--- a/tests/ui/borrowck/borrowck-describe-field-generic-param-owned-box.rs
+++ b/tests/ui/borrowck/borrowck-describe-field-generic-param-owned-box.rs
@@ -1,0 +1,56 @@
+// Regression test for #155344.
+// Borrowck diagnostics should not ICE when describing a field access on a generic parameter.
+
+//@ edition: 2024
+
+#![crate_type = "lib"]
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "pointee_sized"]
+pub trait PointeeSized {}
+
+#[lang = "meta_sized"]
+pub trait MetaSized: PointeeSized {}
+
+#[lang = "sized"]
+pub trait Sized: MetaSized {}
+
+#[lang = "legacy_receiver"]
+pub trait LegacyReceiver {}
+
+impl<T: PointeeSized> LegacyReceiver for &T {}
+impl<T: PointeeSized> LegacyReceiver for &mut T {}
+
+#[lang = "copy"]
+pub trait Copy {}
+
+impl Copy for *mut () {}
+
+#[lang = "drop"]
+pub trait Drop {
+    fn drop(&mut self);
+}
+
+unsafe extern "C" {
+    fn free(_: *mut ());
+}
+
+unsafe fn transmute<T, U>(_: T) -> U {
+    loop {}
+}
+
+#[repr(transparent)]
+pub struct NonNull<T: ?Sized>(pub *const T);
+
+#[lang = "owned_box"]
+pub struct Box<T: ?Sized, A = ()>(NonNull<T>, A);
+
+impl<T: ?Sized, A> Drop for Box<T, A> {
+    fn drop(&mut self) {
+        unsafe {
+            free(transmute::<NonNull<T>, *mut _>(self.0));
+            //~^ ERROR cannot move out of `self.0` which is behind a mutable reference
+        }
+    }
+}

--- a/tests/ui/borrowck/borrowck-describe-field-generic-param-owned-box.stderr
+++ b/tests/ui/borrowck/borrowck-describe-field-generic-param-owned-box.stderr
@@ -1,0 +1,9 @@
+error[E0507]: cannot move out of `self.0` which is behind a mutable reference
+  --> $DIR/borrowck-describe-field-generic-param-owned-box.rs:52:50
+   |
+LL |             free(transmute::<NonNull<T>, *mut _>(self.0));
+   |                                                  ^^^^^^ move occurs because `self.0` has type `NonNull<T>`, which does not implement the `Copy` trait
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
Fixes rust-lang/rust#155344.

`describe_field_from_ty` is used while building borrowck diagnostics. When the
base type is a generic parameter, there is no concrete ADT or tuple field name
to recover. So, fall back to the field index instead of ICEing

This avoids crashing while reporting the original borrowck error. Does not
change borrow-checking semantics.
