### PR TITLE
[EXPERIMENTAL] ci: use macos-26 for aarch64-apple job

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -26,6 +26,10 @@ runners:
     os: macos-15 # macOS 15 Arm64
     <<: *base-job
 
+  - &job-macos-26
+    os: macos-26 # macOS 26 Arm64
+    <<: *base-job
+
   - &job-windows
     os: windows-2025
     <<: *base-job
@@ -552,7 +556,7 @@ auto:
       # supports the hardware, so only need to test it there.
       MACOSX_DEPLOYMENT_TARGET: 11.0
       MACOSX_STD_DEPLOYMENT_TARGET: 11.0
-    <<: *job-macos
+    <<: *job-macos-26
 
   ######################
   #  Windows Builders  #


### PR DESCRIPTION
Trying https://github.com/rust-lang/rust/pull/152842 again.

The art of changing absolutely nothing but trying again later.

r? ghost

try-job: aarch64-apple