### PR TITLE
[EXPERIMENTAL] ci: use macos-26 for aarch64-apple job (`test library --stage=2` only)

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -545,8 +545,7 @@ auto:
   - name: aarch64-apple
     env:
       SCRIPT: >
-        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin &&
-        ./x.py --stage 2 test --host=aarch64-apple-darwin --target=aarch64-apple-darwin src/tools/cargo
+        ./x.py --stage 2 test library --host=aarch64-apple-darwin --target=aarch64-apple-darwin
       RUST_CONFIGURE_ARGS: >-
         --enable-sanitizers
         --enable-profiler

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -26,6 +26,10 @@ runners:
     os: macos-15 # macOS 15 Arm64
     <<: *base-job
 
+  - &job-macos-26
+    os: macos-26 # macOS 26 Arm64
+    <<: *base-job
+
   - &job-windows
     os: windows-2025
     <<: *base-job
@@ -552,7 +556,7 @@ auto:
       # supports the hardware, so only need to test it there.
       MACOSX_DEPLOYMENT_TARGET: 11.0
       MACOSX_STD_DEPLOYMENT_TARGET: 11.0
-    <<: *job-macos
+    <<: *job-macos-26
 
   ######################
   #  Windows Builders  #


### PR DESCRIPTION
`./x test library --stage=2` only version of https://github.com/rust-lang/rust/pull/157231.

r? ghost

try-job: aarch64-apple