### PR TITLE
Convert `lldb_batchmode` to a package

### DIFF
--- a/src/etc/lldb_batchmode/__init__.py
+++ b/src/etc/lldb_batchmode/__init__.py
@@ -1,0 +1,1 @@
+from .runner import main as main

--- a/src/etc/lldb_batchmode/runner.py
+++ b/src/etc/lldb_batchmode/runner.py
@@ -166,7 +166,7 @@ def start_watchdog():
     def watchdog():
         while clock() < watchdog_max_time:
             time.sleep(1)
-        print("TIMEOUT: lldb_batchmode.py has been running for too long. Aborting!")
+        print("TIMEOUT: lldb_batchmode has been running for too long. Aborting!")
         thread.interrupt_main()
 
     # Start the listener and let it run as a daemon
@@ -252,7 +252,3 @@ def main():
         sys.exit(1)
     finally:
         script_file.close()
-
-
-if __name__ == "__main__":
-    main()

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -705,7 +705,7 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
         "src/etc/gdb_load_rust_pretty_printers.py",
         "src/etc/gdb_lookup.py",
         "src/etc/gdb_providers.py",
-        "src/etc/lldb_batchmode.py",
+        "src/etc/lldb_batchmode",
         "src/etc/lldb_lookup.py",
         "src/etc/lldb_providers.py",
     ];

--- a/tests/debuginfo/basic-stepping.rs
+++ b/tests/debuginfo/basic-stepping.rs
@@ -58,10 +58,10 @@
 //@ lldb-command: settings set stop-line-count-after 0
 
 //@ lldb-command: run
-// In `breakpoint_callback()` in `./src/etc/lldb_batchmode.py` we do
+// In `breakpoint_callback()` in `./src/etc/lldb_batchmode/runner.py` we do
 // `SetSelectedFrame()`, which causes LLDB to show the current line and one line
 // before (since we changed `stop-line-count-before`). Note that
-// `normalize_whitespace()` in `lldb_batchmode.py` removes the newlines of the
+// `normalize_whitespace()` in `lldb_batchmode/runner.py` removes the newlines of the
 // output. So the current line and the line before actually ends up on the same
 // output line. That's fine.
 //@ lldb-check:   [...]let mut c = 27;[...]


### PR DESCRIPTION
The new testing logic for https://github.com/rust-lang/rust/issues/148483 will end up being a couple of python files, and it doesn't make sense to have them all as freefloating scripts in `src/etc`. 

I also made sure to update occurrences of `lldb_batchmode.py` in the code and documentation to point to the new package instead. 