### PR TITLE
additional changes for issue-144595

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -4642,7 +4642,7 @@ pub(crate) struct ReservedMultihashLint {
 
 #[derive(Subdiagnostic)]
 #[suggestion(
-    "if you meant to write a path, use a double colon:",
+    "if you meant to write a path, use a double colon",
     code = "::",
     applicability = "maybe-incorrect"
 )]
@@ -4653,13 +4653,13 @@ pub(crate) struct UseDoubleColonSuggestion {
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
-    "if you meant to create a regular struct, use curly braces:",
+    "if you meant to create a regular struct, use curly braces",
     applicability = "maybe-incorrect"
 )]
 pub(crate) struct UseRegularStructSuggestion {
-    #[suggestion_part(code = "{{")]
+    #[suggestion_part(code = " {{ ")]
     pub open: Span,
-    #[suggestion_part(code = "}}")]
+    #[suggestion_part(code = " }}")]
     pub close: Span,
     #[suggestion_part(code = "")]
     pub semicolon: Option<Span>,

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2163,8 +2163,10 @@ impl<'a> Parser<'a> {
         })
         .map(|(r, _)| r)
         .map_err(|mut error| {
-            if encountered_colon {
+            if self.token == token::Colon {
                 error.subdiagnostic(UseDoubleColonSuggestion { colon: self.token.span });
+            }
+            if encountered_colon {
                 self.eat_to_tokens(&[exp!(CloseParen)]);
                 self.bump();
                 error.subdiagnostic(UseRegularStructSuggestion {

--- a/tests/ui/parser/colon-in-tuple-struct.rs
+++ b/tests/ui/parser/colon-in-tuple-struct.rs
@@ -1,0 +1,5 @@
+// Suggest the user to use double colon when there's a colon in tuple struct
+
+struct Foo(std::string:String);
+//~^ ERROR expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
+//~| HELP if you meant to write a path, use a double colon

--- a/tests/ui/parser/colon-in-tuple-struct.stderr
+++ b/tests/ui/parser/colon-in-tuple-struct.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
+  --> $DIR/colon-in-tuple-struct.rs:3:23
+   |
+LL | struct Foo(std::string:String);
+   |                       ^ expected one of 7 possible tokens
+   |
+help: if you meant to write a path, use a double colon
+   |
+LL | struct Foo(std::string::String);
+   |                        +
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/field-name-in-tuple-struct.rs
+++ b/tests/ui/parser/field-name-in-tuple-struct.rs
@@ -2,5 +2,5 @@
 
 struct Foo(a:u8,b:u8);
 //~^ ERROR expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
-//~| HELP if you meant to write a path, use a double colon:
-//~| HELP if you meant to create a regular struct, use curly braces:
+//~| HELP if you meant to write a path, use a double colon
+//~| HELP if you meant to create a regular struct, use curly braces

--- a/tests/ui/parser/field-name-in-tuple-struct.stderr
+++ b/tests/ui/parser/field-name-in-tuple-struct.stderr
@@ -4,14 +4,14 @@ error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
 LL | struct Foo(a:u8,b:u8);
    |             ^ expected one of 7 possible tokens
    |
-help: if you meant to write a path, use a double colon:
+help: if you meant to write a path, use a double colon
    |
 LL | struct Foo(a::u8,b:u8);
    |              +
-help: if you meant to create a regular struct, use curly braces:
+help: if you meant to create a regular struct, use curly braces
    |
 LL - struct Foo(a:u8,b:u8);
-LL + struct Foo{a:u8,b:u8}
+LL + struct Foo { a:u8,b:u8 }
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

- add spaces between the braces @ada4a 
- remove `:` in the help message. 
I learn this from estebank ("In the text we don't include a trailing :, unless we have a very specific reason. These messages can render in the terminal, in different ways, or in IDEs. Having a : can look out of place in some cases, specifically in rust-analyzer in VSCode is one of them.")
- suggest to use `::` for any colon encountered in tuple struct. 
  So it now display help message for `std::string:String`. The same logic also appears in `parse_block_tail`, it suggest the user to use `::` when `parse_full_stmt` stops at a colon. So I think it's okay to make this change. 

r? mejrs