### PR TITLE
rustdoc: fix ICE when deprecated note with intra-doc link is on a private re-export of an external item

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -75,7 +75,28 @@ pub(crate) fn try_inline(
     debug!("attrs={attrs:?}");
 
     let attrs_without_docs = attrs.map(|(attrs, def_id)| {
-        (attrs.iter().filter(|a| a.doc_str().is_none()).cloned().collect::<Vec<_>>(), def_id)
+        (
+            attrs
+                .iter()
+                .filter(|a| {
+                    a.doc_str().is_none()
+                        // Don't propagate `#[deprecated]` from the import to inlined impl
+                        // blocks. The deprecation is on the re-export name, not on the
+                        // underlying type's implementations. Propagating it would cause
+                        // rustdoc to attempt to resolve any intra-doc links in the
+                        // deprecation note within the external crate's module context,
+                        // leading to an ICE.
+                        && !matches!(
+                            a,
+                            hir::Attribute::Parsed(
+                                hir::attrs::AttributeKind::Deprecated { .. }
+                            )
+                        )
+                })
+                .cloned()
+                .collect::<Vec<_>>(),
+            def_id,
+        )
     });
     let attrs_without_docs =
         attrs_without_docs.as_ref().map(|(attrs, def_id)| (&attrs[..], *def_id));

--- a/tests/rustdoc-ui/intra-doc/ice-deprecated-note-private-reexport-157210.rs
+++ b/tests/rustdoc-ui/intra-doc/ice-deprecated-note-private-reexport-157210.rs
@@ -1,0 +1,17 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/157210>.
+// Rustdoc used to ICE when a `pub use` inside a private module had a
+// `#[deprecated]` attribute with an intra-doc link in its note.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+
+// Private module: items are not exported so no link warning is expected,
+// but rustdoc must not ICE either.
+mod inner {
+    #[deprecated = "[A](TypeAlias::x)"]
+    pub use std::vec::Vec;
+}
+
+// Exported re-export: the broken intra-doc link should produce a warning.
+#[deprecated = "[A](TypeAlias::x)"]
+//~^ ERROR: unresolved link to `TypeAlias::x`
+pub use std::vec::Vec;

--- a/tests/rustdoc-ui/intra-doc/ice-deprecated-note-private-reexport-157210.stderr
+++ b/tests/rustdoc-ui/intra-doc/ice-deprecated-note-private-reexport-157210.stderr
@@ -1,0 +1,19 @@
+error: unresolved link to `TypeAlias::x`
+  --> $DIR/ice-deprecated-note-private-reexport-157210.rs:15:16
+   |
+LL | #[deprecated = "[A](TypeAlias::x)"]
+   |                ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           [A](TypeAlias::x)
+               ^^^^^^^^^^^^
+   = note: no item named `TypeAlias` in scope
+note: the lint level is defined here
+  --> $DIR/ice-deprecated-note-private-reexport-157210.rs:5:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When a `pub use` inside a private module re-exports an external type and carries a `#[deprecated]` note containing an intra-doc link, rustdoc ICEs:

```rust
  mod inner {
      #[deprecated = "[A](TypeAlias::x)"]
      pub use std::vec::Vec;
  }
```

The root cause is two-fold:

1. In `rustc_resolve` late resolution, non-exported items with doc links in attributes (e.g. deprecated notes) were skipped during doc-link pre-caching. Fix: also check `attr.may_have_doc_links()` before returning early, so deprecated notes with links get pre-cached even for non-exported items.

2. In `collect_intra_doc_links`, when `build_impl` inlines impl blocks of the re-exported type it propagates the `#[deprecated]` attr from the import to each impl block via `merge_attrs`. Those impl blocks have `inline_stmt_id = None` and a cross-crate DefId. The link resolver then looked up the link in the external crate's module (e.g. `alloc::vec`), where the locally-authored link text has no cached resolution, causing the ICE. Fix: when `inline_stmt_id` is None and the item is cross-crate, verify the deprecated attr is native to that item. If it isn't (i.e. it was inherited from a local import), skip resolution for that impl block — the link is already resolved correctly on the primary inlined item which has `inline_stmt_id` set.

Fixes rust-lang/rust#157210

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
