### PR TITLE
Enable Enzyme for aarch64-apple-darwin

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -517,7 +517,7 @@ auto:
   - name: dist-aarch64-apple
     env:
       SCRIPT: >-
-        ./x.py dist bootstrap
+        ./x.py dist bootstrap enzyme
         --include-default-paths
         --host=aarch64-apple-darwin
         --target=aarch64-apple-darwin


### PR DESCRIPTION
Enable Enzyme for aarch64-apple-darwin.

I linked LLVM dynamically on MacOS on the PR: https://github.com/rust-lang/rust/pull/157205
We can use Enzyme since the PR landed.

r? @ZuseZ4 