### PR TITLE
Trace `?id.local_def_index` instead of `id` in `def_path_hash`

### DIFF
--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -252,7 +252,9 @@ impl Definitions {
         self.def_id_to_key[id]
     }
 
-    #[instrument(level = "trace", skip(self), ret)]
+    // Log debug version of `local_def_index` (just a number), as tracing of this function
+    // is called too early and cause errors if `LocalDefId` is logged (#157238).
+    #[instrument(level = "trace", skip(self, id), fields(def_index=?id.local_def_index), ret)]
     #[inline(always)]
     pub fn def_path_hash(&self, id: LocalDefId) -> DefPathHash {
         DefPathHash::new(self.stable_crate_id, self.def_path_hashes[id])

--- a/tests/ui/rustc-env/def-path-hash-ice-157238.rs
+++ b/tests/ui/rustc-env/def-path-hash-ice-157238.rs
@@ -1,0 +1,9 @@
+//@ run-pass
+//
+// Ensure that `trace` level instrumentation in `def_path_hash` works,
+// see #157238.
+//
+//@ dont-check-compiler-stdout
+//@ dont-check-compiler-stderr
+//@ rustc-env:RUSTC_LOG=trace
+fn main() {}


### PR DESCRIPTION
Trace `local_def_index` instead of `LocalDefId` in `def_path_hash`, as latter causes errors (previous version of this function accepted `DefIndex`).

Fixes rust-lang/rust#157238.
r? @petrochenkov