### PR TITLE
Tune backport Zulip messages

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -776,6 +776,10 @@ message_on_add = [
 PR #{number} "{title}" fixes a regression and has been nominated for backport.
 {recipients}, what do you think about it?
 This topic will help T-compiler getting context about it.
+
+Tip: to approve or decline from this Zulip thread, use:
+@_**triagebot** backport approve beta #{number}
+@_**triagebot** backport decline beta #{number}
 """,
     """\
 /poll Should #{number} be beta backported?
@@ -801,6 +805,11 @@ message_on_add = [
     """\
 PR #{number} "{title}" fixes a regression and has been nominated for backport.
 {recipients}, what do you think about it?
+This topic will help T-compiler getting context about it.
+
+Tip: to approve or decline from this Zulip thread, use:
+@_**triagebot** backport approve stable #{number}
+@_**triagebot** backport decline stable #{number}
 """,
     """\
 /poll Approve stable backport of #{number}?


### PR DESCRIPTION
Asked in triagebot#2407

In the zulip message that opens a backport poll, adds a suggestion about the correct triagebot syntax to approve/decline a backport to avoid ambiguity and typos

Thanks for a review

r? @Urgau 