### PR TITLE
delegation: move statements out of the first arg

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -408,10 +408,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let block_id = self.lower_body(|this| {
             let mut parameters: Vec<hir::Param<'_>> = Vec::with_capacity(param_count);
             let mut args: Vec<hir::Expr<'_>> = Vec::with_capacity(param_count);
+            let mut stmts: &[hir::Stmt<'hir>] = &[];
 
             for idx in 0..param_count {
                 let (param, pat_node_id) = this.generate_param(is_method, idx, span);
                 parameters.push(param);
+
+                let generate_arg =
+                    |this: &mut Self| this.generate_arg(is_method, idx, param.pat.hir_id, span);
 
                 let arg = if let Some(block) = block
                     && idx == 0
@@ -424,10 +428,24 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     self_resolver.visit_block(block);
                     // Target expr needs to lower `self` path.
                     this.ident_and_label_to_local_id.insert(pat_node_id, param.pat.hir_id.local_id);
-                    this.lower_target_expr(&block)
+
+                    // Lower with `HirId::INVALID` as we will use only expr and stmts.
+                    // FIXME(fn_delegation): Alternatives for target expression lowering:
+                    // https://github.com/rust-lang/rfcs/pull/3530#issuecomment-2197170600.
+                    let block = this.lower_block_noalloc(HirId::INVALID, block, false);
+
+                    stmts = block.stmts;
+
+                    // The behavior of the delegation's target expression differs from the
+                    // behavior of the usual block, where if there is no final expression
+                    // the `()` is returned. In case of the similar situation in delegation
+                    // (no final expression) we propagate first argument instead of replacing
+                    // it with `()`.
+                    if let Some(&expr) = block.expr { expr } else { generate_arg(this) }
                 } else {
-                    this.generate_arg(is_method, idx, param.pat.hir_id, span)
+                    generate_arg(this)
                 };
+
                 args.push(arg);
             }
 
@@ -439,11 +457,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
             if param_count == 0
                 && let Some(block) = block
             {
-                args.push(this.lower_target_expr(&block));
+                args.push(this.lower_block_expr(&block));
             }
 
             let (final_expr, hir_id) =
-                this.finalize_body_lowering(delegation, args, generics, span);
+                this.finalize_body_lowering(delegation, stmts, args, generics, span);
 
             call_expr_id = hir_id;
 
@@ -455,22 +473,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         (block_id, call_expr_id)
     }
 
-    // FIXME(fn_delegation): Alternatives for target expression lowering:
-    // https://github.com/rust-lang/rfcs/pull/3530#issuecomment-2197170600.
-    fn lower_target_expr(&mut self, block: &Block) -> hir::Expr<'hir> {
-        if let [stmt] = block.stmts.as_slice()
-            && let StmtKind::Expr(expr) = &stmt.kind
-        {
-            return self.lower_expr_mut(expr);
-        }
-
-        let block = self.lower_block(block, false);
-        self.mk_expr(hir::ExprKind::Block(block, None), block.span)
-    }
-
     fn finalize_body_lowering(
         &mut self,
         delegation: &Delegation,
+        stmts: &'hir [hir::Stmt<'hir>],
         args: Vec<hir::Expr<'hir>>,
         generics: &mut GenericsGenerationResults<'hir>,
         span: Span,
@@ -522,7 +528,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let call = self.arena.alloc(self.mk_expr(hir::ExprKind::Call(callee_path, args), span));
 
         let block = self.arena.alloc(hir::Block {
-            stmts: &[],
+            stmts,
             expr: Some(call),
             hir_id: self.next_id(),
             rules: hir::BlockCheckMode::DefaultBlock,
@@ -587,7 +593,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
             let callee_path = this.arena.alloc(this.mk_expr(hir::ExprKind::Path(path), span));
             let args = if let Some(block) = delegation.body.as_ref() {
-                this.arena.alloc_slice(&[this.lower_target_expr(block)])
+                this.arena.alloc_slice(&[this.lower_block_expr(block)])
             } else {
                 &mut []
             };

--- a/tests/pretty/delegation-inline-attribute.pp
+++ b/tests/pretty/delegation-inline-attribute.pp
@@ -38,34 +38,32 @@ impl Trait for S {
     fn foo(self: _)
         ->
             _ {
-        Trait::foo(
-            // Check that #[inline(hint)] is added to foo0 reuse inside another reuse
+        // Check that #[inline(hint)] is added to foo0 reuse inside another reuse
+        #[attr = Inline(Hint)]
+        fn foo0(arg0: _) -> _ { to_reuse::foo(self + 1) }
 
-            // Check that #[inline(hint)] is added when other attributes present in inner reuse
+        // Check that #[inline(hint)] is added when other attributes present in inner reuse
+        #[attr = Cold]
+        #[attr = MustUse]
+        #[attr = Deprecated {deprecation: Deprecation {since: Unspecified}}]
+        #[attr = Inline(Hint)]
+        fn foo1(arg0: _) -> _ { to_reuse::foo(self / 2) }
 
-            // Check that #[inline(never)] is preserved in inner reuse
+        // Check that #[inline(never)] is preserved in inner reuse
+        #[attr = Inline(Never)]
+        fn foo2(arg0: _) -> _ { to_reuse::foo(self / 2) }
 
-            // Check that #[inline(always)] is preserved in inner reuse
+        // Check that #[inline(always)] is preserved in inner reuse
+        #[attr = Inline(Always)]
+        fn foo3(arg0: _) -> _ { to_reuse::foo(self / 2) }
 
-            // Check that #[inline(never)] is preserved when there are other attributes in inner reuse
-            {
-                #[attr = Inline(Hint)]
-                fn foo0(arg0: _) -> _ { to_reuse::foo(self + 1) }
-                #[attr = Cold]
-                #[attr = MustUse]
-                #[attr = Deprecated {deprecation: Deprecation {since: Unspecified}}]
-                #[attr = Inline(Hint)]
-                fn foo1(arg0: _) -> _ { to_reuse::foo(self / 2) }
-                #[attr = Inline(Never)]
-                fn foo2(arg0: _) -> _ { to_reuse::foo(self / 2) }
-                #[attr = Inline(Always)]
-                fn foo3(arg0: _) -> _ { to_reuse::foo(self / 2) }
-                #[attr = Cold]
-                #[attr = MustUse]
-                #[attr = Inline(Never)]
-                #[attr = Deprecated {deprecation: Deprecation {since: Unspecified}}]
-                fn foo4(arg0: _) -> _ { to_reuse::foo(self / 2) }
-            })
+        // Check that #[inline(never)] is preserved when there are other attributes in inner reuse
+        #[attr = Cold]
+        #[attr = MustUse]
+        #[attr = Inline(Never)]
+        #[attr = Deprecated {deprecation: Deprecation {since: Unspecified}}]
+        fn foo4(arg0: _) -> _ { to_reuse::foo(self / 2) }
+        Trait::foo(self)
     }
 
     // Check that #[inline(hint)] is added when there are other attributes present in trait reuse

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -12,7 +12,7 @@ fn b<C>(e: C) { }
 
 trait G {
     #[attr = Inline(Hint)]
-    fn b<C>(arg0: _) -> _ { b::<C>({ }) }
+    fn b<C>(arg0: _) -> _ { b::<C>(arg0) }
 }
 
 mod m {

--- a/tests/ui/delegation/ice-issue-124347.stderr
+++ b/tests/ui/delegation/ice-issue-124347.stderr
@@ -14,7 +14,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/ice-issue-124347.rs:4:18
    |
 LL |     reuse Trait::foo { &self.0 }
-   |                  ^^^   ------- unexpected argument
+   |                  ^^^ ----------- unexpected argument
    |
 note: associated function defined here
   --> $DIR/ice-issue-124347.rs:4:18
@@ -24,7 +24,7 @@ LL |     reuse Trait::foo { &self.0 }
 help: remove the extra argument
    |
 LL -     reuse Trait::foo { &self.0 }
-LL +     reuse Trait::fo&self.0 }
+LL +     reuse Trait::fo{ &self.0 }
    |
 
 warning: function cannot return without recursing

--- a/tests/ui/delegation/inner-attr.stderr
+++ b/tests/ui/delegation/inner-attr.stderr
@@ -13,7 +13,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/inner-attr.rs:5:7
    |
 LL | reuse a as b { #![rustc_dummy] self }
-   |       ^                        ---- unexpected argument
+   |       ^      ------------------------ unexpected argument
    |
 note: function defined here
   --> $DIR/inner-attr.rs:3:4
@@ -23,7 +23,7 @@ LL | fn a() {}
 help: remove the extra argument
    |
 LL - reuse a as b { #![rustc_dummy] self }
-LL + reuse self }
+LL + reuse { #![rustc_dummy] self }
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/delegation/self-coercion-block-errors.rs
+++ b/tests/ui/delegation/self-coercion-block-errors.rs
@@ -1,0 +1,58 @@
+// Test different scenarios with impossible adjustments due to blocks
+// or no-op target expressions.
+
+#![feature(fn_delegation)]
+
+trait Trait: Sized {
+    fn by_value(self) -> i32 { 1 }
+    fn by_mut_ref(&mut self) -> i32 { 2 }
+    fn by_ref(&self) -> i32 { 3 }
+}
+
+struct F;
+impl Trait for F {}
+
+struct Struct(F);
+reuse impl Trait for Struct { self.0 }
+
+struct S(F);
+reuse impl Trait for S { { self.0 } }
+//~^ ERROR: cannot move out of `self` which is behind a shared reference
+//~| ERROR: cannot move out of `self` which is behind a mutable reference
+
+struct S1(F);
+reuse impl Trait for S1 { { { { { { self.0 } } } } } }
+//~^ ERROR: cannot move out of `self` which is behind a shared reference
+//~| ERROR: cannot move out of `self` which is behind a mutable reference
+
+struct S2(F);
+reuse impl Trait for S2 { }
+//~^ WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+
+struct S3(F);
+reuse impl Trait for S3 { (); }
+//~^ WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+
+struct S4(F);
+reuse impl Trait for S4 { println!(); }
+//~^ WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+
+struct S5(F);
+reuse impl Trait for S5 { fn foo() {} }
+//~^ WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+
+struct S6(F);
+reuse impl Trait for S6;
+//~^ WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+//~| WARN: function cannot return without recursing [unconditional_recursion]
+
+fn main() {}

--- a/tests/ui/delegation/self-coercion-block-errors.stderr
+++ b/tests/ui/delegation/self-coercion-block-errors.stderr
@@ -1,0 +1,239 @@
+error[E0507]: cannot move out of `self` which is behind a mutable reference
+  --> $DIR/self-coercion-block-errors.rs:19:28
+   |
+LL | reuse impl Trait for S { { self.0 } }
+   |                            ^^^^^^ move occurs because `self.0` has type `F`, which does not implement the `Copy` trait
+   |
+note: if `F` implemented `Clone`, you could clone the value
+  --> $DIR/self-coercion-block-errors.rs:12:1
+   |
+LL | struct F;
+   | ^^^^^^^^ consider implementing `Clone` for this type
+...
+LL | reuse impl Trait for S { { self.0 } }
+   |                            ------ you could clone this value
+
+error[E0507]: cannot move out of `self` which is behind a shared reference
+  --> $DIR/self-coercion-block-errors.rs:19:28
+   |
+LL | reuse impl Trait for S { { self.0 } }
+   |                            ^^^^^^ move occurs because `self.0` has type `F`, which does not implement the `Copy` trait
+   |
+note: if `F` implemented `Clone`, you could clone the value
+  --> $DIR/self-coercion-block-errors.rs:12:1
+   |
+LL | struct F;
+   | ^^^^^^^^ consider implementing `Clone` for this type
+...
+LL | reuse impl Trait for S { { self.0 } }
+   |                            ------ you could clone this value
+
+error[E0507]: cannot move out of `self` which is behind a mutable reference
+  --> $DIR/self-coercion-block-errors.rs:24:37
+   |
+LL | reuse impl Trait for S1 { { { { { { self.0 } } } } } }
+   |                                     ^^^^^^ move occurs because `self.0` has type `F`, which does not implement the `Copy` trait
+   |
+note: if `F` implemented `Clone`, you could clone the value
+  --> $DIR/self-coercion-block-errors.rs:12:1
+   |
+LL | struct F;
+   | ^^^^^^^^ consider implementing `Clone` for this type
+...
+LL | reuse impl Trait for S1 { { { { { { self.0 } } } } } }
+   |                                     ------ you could clone this value
+
+error[E0507]: cannot move out of `self` which is behind a shared reference
+  --> $DIR/self-coercion-block-errors.rs:24:37
+   |
+LL | reuse impl Trait for S1 { { { { { { self.0 } } } } } }
+   |                                     ^^^^^^ move occurs because `self.0` has type `F`, which does not implement the `Copy` trait
+   |
+note: if `F` implemented `Clone`, you could clone the value
+  --> $DIR/self-coercion-block-errors.rs:12:1
+   |
+LL | struct F;
+   | ^^^^^^^^ consider implementing `Clone` for this type
+...
+LL | reuse impl Trait for S1 { { { { { { self.0 } } } } } }
+   |                                     ------ you could clone this value
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:29:1
+   |
+LL | reuse impl Trait for S2 { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:29:1
+   |
+LL | reuse impl Trait for S2 { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:29:1
+   |
+LL | reuse impl Trait for S2 { }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:35:1
+   |
+LL | reuse impl Trait for S3 { (); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:35:1
+   |
+LL | reuse impl Trait for S3 { (); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:35:1
+   |
+LL | reuse impl Trait for S3 { (); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:41:1
+   |
+LL | reuse impl Trait for S4 { println!(); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:41:1
+   |
+LL | reuse impl Trait for S4 { println!(); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:41:1
+   |
+LL | reuse impl Trait for S4 { println!(); }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:47:1
+   |
+LL | reuse impl Trait for S5 { fn foo() {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:47:1
+   |
+LL | reuse impl Trait for S5 { fn foo() {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:47:1
+   |
+LL | reuse impl Trait for S5 { fn foo() {} }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:53:1
+   |
+LL | reuse impl Trait for S6;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:53:1
+   |
+LL | reuse impl Trait for S6;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: function cannot return without recursing
+  --> $DIR/self-coercion-block-errors.rs:53:1
+   |
+LL | reuse impl Trait for S6;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | cannot return without recursing
+   | recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors; 15 warnings emitted
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/delegation/self-coercion-errors.rs
+++ b/tests/ui/delegation/self-coercion-errors.rs
@@ -41,12 +41,12 @@ struct S1(F);
 
 impl S1 {
     reuse Trait::{by_value, by_mut_ref, by_ref} {
-        //~^ ERROR: mismatched types
-        //~| ERROR: mismatched types
-        //~| ERROR: the trait bound `fn() -> F {foo}: Trait` is not satisfied
         println!("123");
         let x = &self.0;
         foo
+        //~^ ERROR: mismatched types
+        //~| ERROR: mismatched types
+        //~| ERROR: the trait bound `fn() -> F {foo}: Trait` is not satisfied
     }
 }
 
@@ -59,6 +59,7 @@ impl S2 {
         let x = foo();
 
         x
+        //~^ ERROR: cannot borrow `x` as mutable, as it is not declared as mutable
     }
 }
 

--- a/tests/ui/delegation/self-coercion-errors.stderr
+++ b/tests/ui/delegation/self-coercion-errors.stderr
@@ -1,32 +1,25 @@
 error[E0277]: the trait bound `fn() -> F {foo}: Trait` is not satisfied
-  --> $DIR/self-coercion-errors.rs:43:49
+  --> $DIR/self-coercion-errors.rs:46:9
    |
-LL |       reuse Trait::{by_value, by_mut_ref, by_ref} {
-   |  ___________________--------______________________^
-   | |                   |
-   | |                   required by a bound introduced by this call
-...  |
-LL | |         foo
-   | |         --- this tail expression is of type `fn() -> F {foo}`
-LL | |     }
-   | |_____^ the trait `Trait` is not implemented for fn item `fn() -> F {foo}`
+LL |     reuse Trait::{by_value, by_mut_ref, by_ref} {
+   |                   -------- required by a bound introduced by this call
+...
+LL |         foo
+   |         ^^^ the trait `Trait` is not implemented for fn item `fn() -> F {foo}`
    |
 help: use parentheses to call this function
    |
-LL |     }()
-   |      ++
+LL |         foo()
+   |            ++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:43:49
+  --> $DIR/self-coercion-errors.rs:46:9
    |
-LL |       reuse Trait::{by_value, by_mut_ref, by_ref} {
-   |  _____________________________----------__________^
-   | |                             |
-   | |                             arguments to this function are incorrect
-...  |
-LL | |         foo
-LL | |     }
-   | |_____^ expected `&mut _`, found fn item
+LL |     reuse Trait::{by_value, by_mut_ref, by_ref} {
+   |                             ---------- arguments to this function are incorrect
+...
+LL |         foo
+   |         ^^^ expected `&mut _`, found fn item
    |
    = note: expected mutable reference `&mut _`
                         found fn item `fn() -> F {foo}`
@@ -41,16 +34,13 @@ LL |         &mut foo
    |         ++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:43:49
+  --> $DIR/self-coercion-errors.rs:46:9
    |
-LL |       reuse Trait::{by_value, by_mut_ref, by_ref} {
-   |  _________________________________________------__^
-   | |                                         |
-   | |                                         arguments to this function are incorrect
-...  |
-LL | |         foo
-LL | |     }
-   | |_____^ expected `&_`, found fn item
+LL |     reuse Trait::{by_value, by_mut_ref, by_ref} {
+   |                                         ------ arguments to this function are incorrect
+...
+LL |         foo
+   |         ^^^ expected `&_`, found fn item
    |
    = note: expected reference `&_`
                 found fn item `fn() -> F {foo}`
@@ -65,7 +55,7 @@ LL |         &foo
    |         +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Box<_>`, found `&mut F`
@@ -86,7 +76,7 @@ LL |     reuse Trait::* { Box::new(&mut self.0) }
    |                      +++++++++           +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Arc<_>`, found `&mut F`
@@ -106,7 +96,7 @@ LL |     reuse Trait::* { (&mut self.0).into() }
    |                      +           ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Rc<_>`, found `&mut F`
@@ -126,7 +116,7 @@ LL |     reuse Trait::* { (&mut self.0).into() }
    |                      +           ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Pin<Box<_>>`, found `&mut F`
@@ -146,7 +136,7 @@ LL |     reuse Trait::* { Box::pin(&mut self.0) }
    |                      +++++++++           +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Pin<Rc<_>>`, found `&mut F`
@@ -162,7 +152,7 @@ LL |     fn pin_rc(self: Pin<Rc<Self>>) -> i32 { 8 }
    |        ^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Pin<Arc<_>>`, found `&mut F`
@@ -178,7 +168,7 @@ LL |     fn pin_arc(self: Pin<Arc<Self>>) -> i32 { 9 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ expected `Box<Box<_>>`, found `&mut F`
@@ -194,7 +184,7 @@ LL |     fn box_box(self: Box<Box<Self>>) -> i32 { 10 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Box<_>`, found `&F`
@@ -215,7 +205,7 @@ LL |     reuse Trait::* { Box::new(&self.0) }
    |                      +++++++++       +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Arc<_>`, found `&F`
@@ -235,7 +225,7 @@ LL |     reuse Trait::* { (&self.0).into() }
    |                      +       ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Rc<_>`, found `&F`
@@ -255,7 +245,7 @@ LL |     reuse Trait::* { (&self.0).into() }
    |                      +       ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Pin<Box<_>>`, found `&F`
@@ -275,7 +265,7 @@ LL |     reuse Trait::* { Box::pin(&self.0) }
    |                      +++++++++       +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Pin<Rc<_>>`, found `&F`
@@ -291,7 +281,7 @@ LL |     fn pin_rc(self: Pin<Rc<Self>>) -> i32 { 8 }
    |        ^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Pin<Arc<_>>`, found `&F`
@@ -307,7 +297,7 @@ LL |     fn pin_arc(self: Pin<Arc<Self>>) -> i32 { 9 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ expected `Box<Box<_>>`, found `&F`
@@ -323,7 +313,7 @@ LL |     fn box_box(self: Box<Box<Self>>) -> i32 { 10 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Box<_>`, found `&&&&F`
@@ -344,7 +334,7 @@ LL |     reuse Trait::* { Box::new(&&&&self.0) }
    |                      +++++++++          +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Arc<_>`, found `&&&&F`
@@ -364,7 +354,7 @@ LL |     reuse Trait::* { (&&&&self.0).into() }
    |                      +          ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Rc<_>`, found `&&&&F`
@@ -384,7 +374,7 @@ LL |     reuse Trait::* { (&&&&self.0).into() }
    |                      +          ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Pin<Box<_>>`, found `&&&&F`
@@ -404,7 +394,7 @@ LL |     reuse Trait::* { Box::pin(&&&&self.0) }
    |                      +++++++++          +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Pin<Rc<_>>`, found `&&&&F`
@@ -420,7 +410,7 @@ LL |     fn pin_rc(self: Pin<Rc<Self>>) -> i32 { 8 }
    |        ^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Pin<Arc<_>>`, found `&&&&F`
@@ -436,7 +426,7 @@ LL |     fn pin_arc(self: Pin<Arc<Self>>) -> i32 { 9 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ expected `Box<Box<_>>`, found `&&&&F`
@@ -452,7 +442,7 @@ LL |     fn box_box(self: Box<Box<Self>>) -> i32 { 10 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Box<_>`, found `&F`
@@ -473,7 +463,7 @@ LL +     reuse Trait::* { self.0 }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Arc<_>`, found `&F`
@@ -493,7 +483,7 @@ LL |     reuse Trait::* { self.0.as_ref().into() }
    |                                     +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Rc<_>`, found `&F`
@@ -513,7 +503,7 @@ LL |     reuse Trait::* { self.0.as_ref().into() }
    |                                     +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Pin<Box<_>>`, found `&F`
@@ -533,7 +523,7 @@ LL |     reuse Trait::* { Box::pin(self.0.as_ref()) }
    |                      +++++++++               +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Pin<Rc<_>>`, found `&F`
@@ -549,7 +539,7 @@ LL |     fn pin_rc(self: Pin<Rc<Self>>) -> i32 { 8 }
    |        ^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Pin<Arc<_>>`, found `&F`
@@ -565,7 +555,7 @@ LL |     fn pin_arc(self: Pin<Arc<Self>>) -> i32 { 9 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ expected `Box<Box<_>>`, found `&F`
@@ -581,7 +571,7 @@ LL |     fn box_box(self: Box<Box<Self>>) -> i32 { 10 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Box<_>`, found `&mut &mut &mut F`
@@ -602,7 +592,7 @@ LL |     reuse Trait::* { Box::new(&mut &mut &mut self.0) }
    |                      +++++++++                     +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Arc<_>`, found `&mut &mut &mut F`
@@ -622,7 +612,7 @@ LL |     reuse Trait::* { (&mut &mut &mut self.0).into() }
    |                      +                     ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Rc<_>`, found `&mut &mut &mut F`
@@ -642,7 +632,7 @@ LL |     reuse Trait::* { (&mut &mut &mut self.0).into() }
    |                      +                     ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Pin<Box<_>>`, found `&mut &mut &mut F`
@@ -662,7 +652,7 @@ LL |     reuse Trait::* { Box::pin(&mut &mut &mut self.0) }
    |                      +++++++++                     +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Pin<Rc<_>>`, found `&mut &mut &mut F`
@@ -678,7 +668,7 @@ LL |     fn pin_rc(self: Pin<Rc<Self>>) -> i32 { 8 }
    |        ^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Pin<Arc<_>>`, found `&mut &mut &mut F`
@@ -694,7 +684,7 @@ LL |     fn pin_arc(self: Pin<Arc<Self>>) -> i32 { 9 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ expected `Box<Box<_>>`, found `&mut &mut &mut F`
@@ -710,7 +700,7 @@ LL |     fn box_box(self: Box<Box<Self>>) -> i32 { 10 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Box<_>`, found `&&mut F`
@@ -731,7 +721,7 @@ LL |     reuse Trait::* { Box::new(&&mut self.0) }
    |                      +++++++++            +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Arc<_>`, found `&&mut F`
@@ -751,7 +741,7 @@ LL |     reuse Trait::* { (&&mut self.0).into() }
    |                      +            ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Rc<_>`, found `&&mut F`
@@ -771,7 +761,7 @@ LL |     reuse Trait::* { (&&mut self.0).into() }
    |                      +            ++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Pin<Box<_>>`, found `&&mut F`
@@ -791,7 +781,7 @@ LL |     reuse Trait::* { Box::pin(&&mut self.0) }
    |                      +++++++++            +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Pin<Rc<_>>`, found `&&mut F`
@@ -807,7 +797,7 @@ LL |     fn pin_rc(self: Pin<Rc<Self>>) -> i32 { 8 }
    |        ^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Pin<Arc<_>>`, found `&&mut F`
@@ -823,7 +813,7 @@ LL |     fn pin_arc(self: Pin<Arc<Self>>) -> i32 { 9 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ expected `Box<Box<_>>`, found `&&mut F`
@@ -839,7 +829,7 @@ LL |     fn box_box(self: Box<Box<Self>>) -> i32 { 10 }
    |        ^^^^^^^ ----
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:178:22
+  --> $DIR/self-coercion-errors.rs:179:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Arc<_>`, found `Box<F>`
@@ -860,7 +850,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:178:22
+  --> $DIR/self-coercion-errors.rs:179:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Rc<_>`, found `Box<F>`
@@ -881,7 +871,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:178:22
+  --> $DIR/self-coercion-errors.rs:179:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Box<_>>`, found `Box<F>`
@@ -902,7 +892,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:178:22
+  --> $DIR/self-coercion-errors.rs:179:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Rc<_>>`, found `Box<F>`
@@ -923,7 +913,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:178:22
+  --> $DIR/self-coercion-errors.rs:179:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Arc<_>>`, found `Box<F>`
@@ -944,7 +934,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:178:22
+  --> $DIR/self-coercion-errors.rs:179:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Box<Box<_>>`, found `Box<F>`
@@ -959,7 +949,7 @@ note: there is a field `0` on `Box<Box<X6>>` with type `std::ptr::Unique<Box<X6>
    |
    = note: if this field wasn't private, it would be accessible
    |
-  ::: $DIR/self-coercion-errors.rs:175:8
+  ::: $DIR/self-coercion-errors.rs:176:8
    |
 LL | struct X6(Box<F>);
    |        -- ------ this is the field that was accessed
@@ -979,7 +969,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Arc<_>`, found `Box<Arc<Box<F>>>`
@@ -999,7 +989,7 @@ LL |     reuse Trait::* { *self.0 }
    |                      +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Rc<_>`, found `Box<Arc<Box<F>>>`
@@ -1020,7 +1010,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Box<_>>`, found `Box<Arc<Box<F>>>`
@@ -1041,7 +1031,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Rc<_>>`, found `Box<Arc<Box<F>>>`
@@ -1062,7 +1052,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Arc<_>>`, found `Box<Arc<Box<F>>>`
@@ -1083,7 +1073,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Box<Box<_>>`, found `Box<Arc<Box<F>>>`
@@ -1098,7 +1088,7 @@ note: there is a field `0` on `Box<Box<X7>>` with type `std::ptr::Unique<Box<X7>
    |
    = note: if this field wasn't private, it would be accessible
    |
-  ::: $DIR/self-coercion-errors.rs:187:8
+  ::: $DIR/self-coercion-errors.rs:188:8
    |
 LL | struct X7(Box<Arc<Box<F>>>);
    |        -- ---------------- this is the field that was accessed
@@ -1118,7 +1108,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Box<_>`, found `Pin<Box<F>>`
@@ -1133,7 +1123,7 @@ note: there is a field `0` on `Box<X8>` with type `std::ptr::Unique<X8>` but it 
    |
    = note: if this field wasn't private, it would be accessible
    |
-  ::: $DIR/self-coercion-errors.rs:202:8
+  ::: $DIR/self-coercion-errors.rs:203:8
    |
 LL | struct X8(Pin<Box<F>>);
    |        -- ----------- this is the field that was accessed
@@ -1153,7 +1143,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Arc<_>`, found `Pin<Box<F>>`
@@ -1174,7 +1164,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Rc<_>`, found `Pin<Box<F>>`
@@ -1195,7 +1185,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Rc<_>>`, found `Pin<Box<F>>`
@@ -1216,7 +1206,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Arc<_>>`, found `Pin<Box<F>>`
@@ -1237,7 +1227,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Box<Box<_>>`, found `Pin<Box<F>>`
@@ -1252,7 +1242,7 @@ note: there is a field `0` on `Box<Box<X8>>` with type `std::ptr::Unique<Box<X8>
    |
    = note: if this field wasn't private, it would be accessible
    |
-  ::: $DIR/self-coercion-errors.rs:202:8
+  ::: $DIR/self-coercion-errors.rs:203:8
    |
 LL | struct X8(Pin<Box<F>>);
    |        -- ----------- this is the field that was accessed
@@ -1272,7 +1262,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0277]: the trait bound `OtherStruct: Trait` is not satisfied
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ unsatisfied trait bound
@@ -1280,7 +1270,7 @@ LL |     reuse Trait::* { self.0 }
    |                  required by a bound introduced by this call
    |
 help: the trait `Trait` is not implemented for `OtherStruct`
-  --> $DIR/self-coercion-errors.rs:217:1
+  --> $DIR/self-coercion-errors.rs:218:1
    |
 LL | struct OtherStruct;
    | ^^^^^^^^^^^^^^^^^^
@@ -1291,7 +1281,7 @@ LL | impl Trait for F {}
    | ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `&mut _`, found `OtherStruct`
@@ -1311,7 +1301,7 @@ LL |     reuse Trait::* { &mut self.0 }
    |                      ++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `&_`, found `OtherStruct`
@@ -1331,7 +1321,7 @@ LL |     reuse Trait::* { &self.0 }
    |                      +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Box<_>`, found `OtherStruct`
@@ -1346,7 +1336,7 @@ note: there is a field `0` on `Box<X9>` with type `std::ptr::Unique<X9>` but it 
    |
    = note: if this field wasn't private, it would be accessible
    |
-  ::: $DIR/self-coercion-errors.rs:218:8
+  ::: $DIR/self-coercion-errors.rs:219:8
    |
 LL | struct X9(OtherStruct);
    |        -- ----------- this is the field that was accessed
@@ -1366,7 +1356,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Arc<_>`, found `OtherStruct`
@@ -1387,7 +1377,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Rc<_>`, found `OtherStruct`
@@ -1408,7 +1398,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Box<_>>`, found `OtherStruct`
@@ -1429,7 +1419,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Rc<_>>`, found `OtherStruct`
@@ -1450,7 +1440,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Pin<Arc<_>>`, found `OtherStruct`
@@ -1471,7 +1461,7 @@ LL +     reuse Trait::* { self }
    |
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-errors.rs:221:22
+  --> $DIR/self-coercion-errors.rs:222:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ expected `Box<Box<_>>`, found `OtherStruct`
@@ -1486,7 +1476,7 @@ note: there is a field `0` on `Box<Box<X9>>` with type `std::ptr::Unique<Box<X9>
    |
    = note: if this field wasn't private, it would be accessible
    |
-  ::: $DIR/self-coercion-errors.rs:218:8
+  ::: $DIR/self-coercion-errors.rs:219:8
    |
 LL | struct X9(OtherStruct);
    |        -- ----------- this is the field that was accessed
@@ -1505,8 +1495,19 @@ LL -     reuse Trait::* { self.0 }
 LL +     reuse Trait::* { self }
    |
 
+error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/self-coercion-errors.rs:61:9
+   |
+LL |         x
+   |         ^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |         let mut x = foo();
+   |             +++
+
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/self-coercion-errors.rs:73:9
+  --> $DIR/self-coercion-errors.rs:74:9
    |
 LL |     reuse Trait::{by_value, by_mut_ref, by_ref} {
    |                   -------- value moved due to this method call
@@ -1529,7 +1530,7 @@ LL |         &mut x
    |         ------ you could clone this value
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/self-coercion-errors.rs:73:9
+  --> $DIR/self-coercion-errors.rs:74:9
    |
 LL |         &mut x
    |         ^^^^^^ cannot borrow as mutable
@@ -1540,7 +1541,7 @@ LL |         let mut x = foo();
    |             +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/self-coercion-errors.rs:73:9
+  --> $DIR/self-coercion-errors.rs:74:9
    |
 LL |         &mut x
    |         ^^^^^^ cannot borrow as mutable
@@ -1552,7 +1553,7 @@ LL |         let mut x = foo();
    |             +++
 
 error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/self-coercion-errors.rs:73:9
+  --> $DIR/self-coercion-errors.rs:74:9
    |
 LL |         &mut x
    |         ^^^^^^ cannot borrow as mutable
@@ -1564,7 +1565,7 @@ LL |         let mut x = foo();
    |             +++
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                  -   ^^^^^^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1586,7 +1587,7 @@ LL |     reuse Trait::* { &mut self.0 }
    |                      ----------- you could clone this value
 
 error[E0596]: cannot borrow `self.0` as mutable, as `self` is not declared as mutable
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                      ^^^^^^^^^^^ cannot borrow as mutable
@@ -1597,7 +1598,7 @@ LL |     reuse Trait::mut * { &mut self.0 }
    |                  +++
 
 error[E0596]: cannot borrow `self.0` as mutable, as it is behind a `&` reference
-  --> $DIR/self-coercion-errors.rs:84:22
+  --> $DIR/self-coercion-errors.rs:85:22
    |
 LL |     reuse Trait::* { &mut self.0 }
    |                      ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
@@ -1609,7 +1610,7 @@ LL +     reuse Trait::&mut self { &mut self.0 }
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                  -   ^^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1631,13 +1632,13 @@ LL |     reuse Trait::* { &self.0 }
    |                      ------- you could clone this value
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/self-coercion-errors.rs:100:22
+  --> $DIR/self-coercion-errors.rs:101:22
    |
 LL |     reuse Trait::* { &self.0 }
    |                      ^^^^^^^ cannot borrow as mutable
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                  -   ^^^^^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1659,13 +1660,13 @@ LL |     reuse Trait::* { &&&&self.0 }
    |                      ---------- you could clone this value
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/self-coercion-errors.rs:115:22
+  --> $DIR/self-coercion-errors.rs:116:22
    |
 LL |     reuse Trait::* { &&&&self.0 }
    |                      ^^^^^^^^^^ cannot borrow as mutable
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                  -   ^^^^^^^^^^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1687,13 +1688,13 @@ LL |     reuse Trait::* { self.0.as_ref() }
    |                      --------------- you could clone this value
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/self-coercion-errors.rs:130:22
+  --> $DIR/self-coercion-errors.rs:131:22
    |
 LL |     reuse Trait::* { self.0.as_ref() }
    |                      ^^^^^^^^^^^^^^^ cannot borrow as mutable
 
 error[E0507]: cannot move out of a mutable reference
-  --> $DIR/self-coercion-errors.rs:145:22
+  --> $DIR/self-coercion-errors.rs:146:22
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                  -   ^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1715,7 +1716,7 @@ LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                      --------------------- you could clone this value
 
 error[E0596]: cannot borrow `self.0` as mutable, as `self` is not declared as mutable
-  --> $DIR/self-coercion-errors.rs:145:32
+  --> $DIR/self-coercion-errors.rs:146:32
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                                ^^^^^^^^^^^ cannot borrow as mutable
@@ -1726,7 +1727,7 @@ LL |     reuse Trait::mut * { &mut &mut &mut self.0 }
    |                  +++
 
 error[E0596]: cannot borrow `self.0` as mutable, as it is behind a `&` reference
-  --> $DIR/self-coercion-errors.rs:145:32
+  --> $DIR/self-coercion-errors.rs:146:32
    |
 LL |     reuse Trait::* { &mut &mut &mut self.0 }
    |                                ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
@@ -1738,7 +1739,7 @@ LL +     reuse Trait::&mut self { &mut &mut &mut self.0 }
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                  -   ^^^^^^^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1760,7 +1761,7 @@ LL |     reuse Trait::* { &&mut self.0 }
    |                      ------------ you could clone this value
 
 error[E0596]: cannot borrow `self.0` as mutable, as `self` is not declared as mutable
-  --> $DIR/self-coercion-errors.rs:161:23
+  --> $DIR/self-coercion-errors.rs:162:23
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                       ^^^^^^^^^^^ cannot borrow as mutable
@@ -1771,13 +1772,13 @@ LL |     reuse Trait::mut * { &&mut self.0 }
    |                  +++
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/self-coercion-errors.rs:161:22
+  --> $DIR/self-coercion-errors.rs:162:22
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                      ^^^^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow `self.0` as mutable, as it is behind a `&` reference
-  --> $DIR/self-coercion-errors.rs:161:23
+  --> $DIR/self-coercion-errors.rs:162:23
    |
 LL |     reuse Trait::* { &&mut self.0 }
    |                       ^^^^^^^^^^^ `self` is a `&` reference, so it cannot be borrowed as mutable
@@ -1789,7 +1790,7 @@ LL +     reuse Trait::&mut self { &&mut self.0 }
    |
 
 error[E0507]: cannot move out of an `Arc`
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1811,7 +1812,7 @@ LL |     reuse Trait::* { self.0 }
    |                      ------ you could clone this value
 
 error[E0596]: cannot borrow data in an `Arc` as mutable
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                      ^^^^^^ cannot borrow as mutable
@@ -1819,7 +1820,7 @@ LL |     reuse Trait::* { self.0 }
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Arc<Box<F>>`
 
 error[E0507]: cannot move out of an `Arc`
-  --> $DIR/self-coercion-errors.rs:190:22
+  --> $DIR/self-coercion-errors.rs:191:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ move occurs because value has type `Box<F>`, which does not implement the `Copy` trait
@@ -1850,7 +1851,7 @@ LL | struct F;
    |
 
 error[E0507]: cannot move out of dereference of `Pin<Box<F>>`
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ move occurs because value has type `F`, which does not implement the `Copy` trait
@@ -1872,7 +1873,7 @@ LL |     reuse Trait::* { self.0 }
    |                      ------ you could clone this value
 
 error[E0596]: cannot borrow data in dereference of `Pin<Box<F>>` as mutable
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                      ^^^^^^ cannot borrow as mutable
@@ -1880,7 +1881,7 @@ LL |     reuse Trait::* { self.0 }
    = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Pin<Box<F>>`
 
 error[E0507]: cannot move out of dereference of `Pin<Box<X8>>`
-  --> $DIR/self-coercion-errors.rs:205:22
+  --> $DIR/self-coercion-errors.rs:206:22
    |
 LL |     reuse Trait::* { self.0 }
    |                  -   ^^^^^^ move occurs because value has type `Pin<Box<F>>`, which does not implement the `Copy` trait
@@ -1910,7 +1911,7 @@ LL + #[derive(Clone)]
 LL | struct F;
    |
 
-error: aborting due to 99 previous errors
+error: aborting due to 100 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0507, E0596.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/delegation/self-coercion-static-free.stderr
+++ b/tests/ui/delegation/self-coercion-static-free.stderr
@@ -1,9 +1,17 @@
 error[E0308]: mismatched types
   --> $DIR/self-coercion-static-free.rs:24:9
    |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                                        -------------- arguments to this function are incorrect
+LL |         let _ = self;
 LL |         S::static_self()
    |         ^^^^^^^^^^^^^^^^ expected `&mut F`, found `F`
    |
+note: associated function defined here
+  --> $DIR/self-coercion-static-free.rs:11:8
+   |
+LL |     fn static_mut_ref(_: &mut Self) -> i32 { 2 }
+   |        ^^^^^^^^^^^^^^ ------------
 help: consider mutably borrowing here
    |
 LL |         &mut S::static_self()
@@ -12,9 +20,17 @@ LL |         &mut S::static_self()
 error[E0308]: mismatched types
   --> $DIR/self-coercion-static-free.rs:24:9
    |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                                                        ---------- arguments to this function are incorrect
+LL |         let _ = self;
 LL |         S::static_self()
    |         ^^^^^^^^^^^^^^^^ expected `&F`, found `F`
    |
+note: associated function defined here
+  --> $DIR/self-coercion-static-free.rs:12:8
+   |
+LL |     fn static_ref(_: &Self) -> i32 { 3 }
+   |        ^^^^^^^^^^ --------
 help: consider borrowing here
    |
 LL |         &S::static_self()
@@ -23,9 +39,17 @@ LL |         &S::static_self()
 error[E0308]: mismatched types
   --> $DIR/self-coercion-static-free.rs:35:9
    |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                                        -------------- arguments to this function are incorrect
+LL |         let _ = self;
 LL |         S1::static_self()
    |         ^^^^^^^^^^^^^^^^^ expected `&mut F`, found `F`
    |
+note: associated function defined here
+  --> $DIR/self-coercion-static-free.rs:11:8
+   |
+LL |     fn static_mut_ref(_: &mut Self) -> i32 { 2 }
+   |        ^^^^^^^^^^^^^^ ------------
 help: consider mutably borrowing here
    |
 LL |         &mut S1::static_self()
@@ -34,9 +58,17 @@ LL |         &mut S1::static_self()
 error[E0308]: mismatched types
   --> $DIR/self-coercion-static-free.rs:35:9
    |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                                                        ---------- arguments to this function are incorrect
+LL |         let _ = self;
 LL |         S1::static_self()
    |         ^^^^^^^^^^^^^^^^^ expected `&F`, found `F`
    |
+note: associated function defined here
+  --> $DIR/self-coercion-static-free.rs:12:8
+   |
+LL |     fn static_ref(_: &Self) -> i32 { 3 }
+   |        ^^^^^^^^^^ --------
 help: consider borrowing here
    |
 LL |         &S1::static_self()

--- a/tests/ui/delegation/target-expr-pass.rs
+++ b/tests/ui/delegation/target-expr-pass.rs
@@ -13,8 +13,10 @@ reuse to_reuse::foo {{
     x + self
 }}
 
-trait Trait { //~ WARN trait `Trait` is never used
-    fn bar(&self, x: i32) -> i32 { x }
+trait Trait: Sized { //~ WARN trait `Trait` is never used
+    fn by_value(self, x: i32) -> i32 { x }
+    fn by_ref(&self, x: i32) -> i32 { x }
+    fn by_mut_ref(&mut self, x: i32) -> i32 { x }
 }
 
 struct F; //~ WARN struct `F` is never constructed
@@ -22,12 +24,12 @@ impl Trait for F {}
 
 struct S(F); //~ WARN struct `S` is never constructed
 impl Trait for S {
-    reuse <F as Trait>::bar {
+    reuse <F as Trait>::* {
         #[allow(unused_imports)]
         use self::to_reuse::{foo, inner::{self}};
         let x = foo(12);
         assert_eq!(x, 12);
-        &self.0
+        self.0
     }
 }
 

--- a/tests/ui/delegation/target-expr-pass.stderr
+++ b/tests/ui/delegation/target-expr-pass.stderr
@@ -1,19 +1,19 @@
 warning: trait `Trait` is never used
   --> $DIR/target-expr-pass.rs:16:7
    |
-LL | trait Trait {
+LL | trait Trait: Sized {
    |       ^^^^^
    |
    = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 
 warning: struct `F` is never constructed
-  --> $DIR/target-expr-pass.rs:20:8
+  --> $DIR/target-expr-pass.rs:22:8
    |
 LL | struct F;
    |        ^
 
 warning: struct `S` is never constructed
-  --> $DIR/target-expr-pass.rs:23:8
+  --> $DIR/target-expr-pass.rs:25:8
    |
 LL | struct S(F);
    |        ^

--- a/tests/ui/delegation/target-expr.rs
+++ b/tests/ui/delegation/target-expr.rs
@@ -15,8 +15,7 @@ fn foo(x: i32) -> i32 { x }
 
 fn bar<T: Default>(_: T) {
     reuse Trait::static_method {
-    //~^ ERROR mismatched types
-    //~| ERROR: delegation self type is not specified
+    //~^ ERROR: delegation self type is not specified
         let _ = T::Default();
         //~^ ERROR can't use generic parameters from outer item
     }

--- a/tests/ui/delegation/target-expr.stderr
+++ b/tests/ui/delegation/target-expr.stderr
@@ -1,18 +1,18 @@
 error[E0401]: can't use generic parameters from outer item
-  --> $DIR/target-expr.rs:20:17
+  --> $DIR/target-expr.rs:19:17
    |
 LL | fn bar<T: Default>(_: T) {
    |        - type parameter from outer item
 LL |     reuse Trait::static_method {
    |                  ------------- generic parameter used in this inner delegated function
-...
+LL |
 LL |         let _ = T::Default();
    |                 ^ use of generic parameter from outer item
    |
    = note: nested items are independent from their parent item for everything except for privacy and name resolution
 
 error[E0434]: can't capture dynamic environment in a fn item
-  --> $DIR/target-expr.rs:28:17
+  --> $DIR/target-expr.rs:27:17
    |
 LL |         let x = y;
    |                 ^
@@ -20,7 +20,7 @@ LL |         let x = y;
    = help: use the `|| { ... }` closure form instead
 
 error[E0424]: expected value, found module `self`
-  --> $DIR/target-expr.rs:35:5
+  --> $DIR/target-expr.rs:34:5
    |
 LL | fn main() {
    |    ---- this function can't have a `self` parameter
@@ -29,13 +29,13 @@ LL |     self.0;
    |     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
 
 error[E0425]: cannot find value `x` in this scope
-  --> $DIR/target-expr.rs:37:13
+  --> $DIR/target-expr.rs:36:13
    |
 LL |     let z = x;
    |             ^
    |
 help: the binding `x` is available in a different scope in the same function
-  --> $DIR/target-expr.rs:28:13
+  --> $DIR/target-expr.rs:27:13
    |
 LL |         let x = y;
    |             ^
@@ -48,19 +48,7 @@ LL |     reuse Trait::static_method {
    |
    = help: consider explicitly specifying self type: `reuse </* Type */ as Trait>::function`
 
-error[E0308]: mismatched types
-  --> $DIR/target-expr.rs:17:32
-   |
-LL |       reuse Trait::static_method {
-   |  ________________________________^
-LL | |
-LL | |
-LL | |         let _ = T::Default();
-LL | |
-LL | |     }
-   | |_____^ expected `i32`, found `()`
+error: aborting due to 5 previous errors
 
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0308, E0401, E0424, E0425, E0434.
-For more information about an error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0401, E0424, E0425, E0434.
+For more information about an error, try `rustc --explain E0401`.

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
@@ -25,7 +25,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/zero-args-delegations-ice-154332.rs:25:21
    |
 LL |     reuse to_reuse::zero_args { self }
-   |                     ^^^^^^^^^   ---- unexpected argument
+   |                     ^^^^^^^^^ -------- unexpected argument
    |
 note: function defined here
   --> $DIR/zero-args-delegations-ice-154332.rs:20:16
@@ -35,7 +35,7 @@ LL |         pub fn zero_args() -> i32 {
 help: remove the extra argument
    |
 LL -     reuse to_reuse::zero_args { self }
-LL +     reuse to_reuse::zero_argself }
+LL +     reuse to_reuse::zero_arg{ self }
    |
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
This PR moves statements that precede final block expression out of the first argument, so we can apply adjustments to final block expression in more cases.

This changes behavior a bit, for example if we specify an empty block:
```rust
fn b<C>(e: C) {}
reuse b {}

// Desugaring:
fn b<C>(arg0: _) -> _ { b::<C>(arg0) }
```

So we generated the first arg and block is no-op.

In general scenario:
```rust
trait Trait: Sized { //~ WARN trait `Trait` is never used
    fn by_value(self, x: i32) -> i32 { x }
    fn by_ref(&self, x: i32) -> i32 { x }
    fn by_mut_ref(&mut self, x: i32) -> i32 { x }
}

struct F; //~ WARN struct `F` is never constructed
impl Trait for F {}

struct S(F); //~ WARN struct `S` is never constructed
impl Trait for S {
    reuse <F as Trait>::* {
        println!();
        // Final expression is adjusted even if it is in a block.
        self.0
    }
}

// Desugaring:
#[attr = Inline(Hint)]
fn by_value(self: _, arg1: _)
    ->
        _ {
    // Final expression is adjusted even if it is in a block.

    { ::std::io::_print(format_arguments::from_str("\n")); };
    <F as Trait>::by_value(self.0, arg1)
}
#[attr = Inline(Hint)]
fn by_ref(self: _, arg1: _)
    ->
        _ {
    { ::std::io::_print(format_arguments::from_str("\n")); };
    <F as Trait>::by_ref(self.0, arg1)
}
#[attr = Inline(Hint)]
fn by_mut_ref(self: _, arg1: _)
    ->
        _ {
    { ::std::io::_print(format_arguments::from_str("\n")); };
    <F as Trait>::by_mut_ref(self.0, arg1)
}
```

If we change target expression to
```rust
reuse <F as Trait>::* {
    println!();
    let x = 1;
}

// Desugaring:
#[attr = Inline(Hint)]
fn by_value(self: _, arg1: _)
    ->
        _ {

    { ::std::io::_print(format_arguments::from_str("\n")); };
    let x = 1;
    <F as Trait>::by_value(self, arg1)
}
```

Once again we generated default arguments for function and block is no-op now (meaning it does not affect callee arguments).

Part of rust-lang/rust#118212.
r? @petrochenkov 