### PR TITLE
tests: codegen-llvm: Update bpf-alu32 with the new LLVM attributes

### DIFF
--- a/tests/codegen-llvm/bpf-alu32.rs
+++ b/tests/codegen-llvm/bpf-alu32.rs
@@ -5,7 +5,7 @@
 
 #[no_mangle]
 #[target_feature(enable = "alu32")]
-// CHECK: define i8 @foo(i8 returned %arg) unnamed_addr #0
+// CHECK: define {{.*}}i8 @foo(i8 {{.*}}%arg) unnamed_addr #0
 pub unsafe fn foo(arg: u8) -> u8 {
     arg
 }

--- a/tests/codegen-llvm/bpf-alu32.rs
+++ b/tests/codegen-llvm/bpf-alu32.rs
@@ -12,6 +12,7 @@ use minicore::*;
 #[no_mangle]
 #[target_feature(enable = "alu32")]
 // CHECK: define {{.*}}i8 @foo(i8 {{.*}}%arg) unnamed_addr #0
+// CHECK: attributes #0 = { {{.*}}"target-features"="{{[^"]*}}+alu32{{.*}} }
 pub unsafe fn foo(arg: u8) -> u8 {
     arg
 }

--- a/tests/codegen-llvm/bpf-alu32.rs
+++ b/tests/codegen-llvm/bpf-alu32.rs
@@ -1,5 +1,5 @@
 //@ add-minicore
-//@ compile-flags: --target=bpfel-unknown-none
+//@ compile-flags: --target=bpfel-unknown-none -C opt-level=0
 //@ needs-llvm-components: bpf
 #![crate_type = "lib"]
 #![feature(bpf_target_feature, no_core)]

--- a/tests/codegen-llvm/bpf-alu32.rs
+++ b/tests/codegen-llvm/bpf-alu32.rs
@@ -1,7 +1,13 @@
-//@ only-bpf
+//@ add-minicore
+//@ compile-flags: --target=bpfel-unknown-none
+//@ needs-llvm-components: bpf
 #![crate_type = "lib"]
-#![feature(bpf_target_feature)]
+#![feature(bpf_target_feature, no_core)]
+#![no_core]
 #![no_std]
+
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 #[target_feature(enable = "alu32")]


### PR DESCRIPTION
The LLVM backend now emits `noundef zeroext` on `i8` return values and `noundef` on `i8` parameters. Update the FileCheck pattern to match.

r? @nagisa

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
