### PR TITLE
Correct description of panic.rs

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -1,4 +1,4 @@
-//! Panic support in the standard library.
+//! Panic support in core.
 
 #![stable(feature = "core_panic_info", since = "1.41.0")]
 


### PR DESCRIPTION
I was perusing the module documentation and stumbled upon the existing description, which confused me for a minute.

## Summary:

The foremost description of this module was:
> Panic support in the standard library.

This commit changes that to:
> Panic support in core.


