### PR TITLE
Implement `ManuallyDrop<T>::pinned_*` methods

### DIFF
--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -3,6 +3,7 @@ use crate::hash::{Hash, Hasher};
 use crate::marker::{Destruct, StructuralPartialEq};
 use crate::mem::MaybeDangling;
 use crate::ops::{Deref, DerefMut, DerefPure};
+use crate::pin::Pin;
 use crate::ptr;
 
 /// A wrapper to inhibit the compiler from automatically calling `T`’s
@@ -205,6 +206,42 @@ impl<T> ManuallyDrop<T> {
         unsafe { (&raw const slot).cast::<T>().read() }
     }
 
+    /// Constructs a new pin by mapping and dereferencing the interior
+    /// `&ManuallyDrop<T>` container.
+    ///
+    /// For example, if you wanted to get a `Pin` of a field of something,
+    /// you could use this to get immutable access to that field in one line of code.
+    /// However, there are several gotchas with these "pinning projections";
+    /// see the [`pin` module] documentation for further details on that topic.
+    ///
+    /// [`pin` module]: crate::pin#projections-and-structural-pinning
+    #[unstable(feature = "manually_drop_pinned", issue = "157268")]
+    #[inline(always)]
+    pub fn pinned_deref(pinned: Pin<&ManuallyDrop<T>>) -> Pin<&T> {
+        // SAFETY: Since we are immutably borrowing `ManuallyDrop<T>`, the T
+        // should not be dropped, hence we can construct a new `Pin` that has
+        // an immutable borrow to T as well.
+        unsafe { pinned.map_unchecked(|manually_drop| manually_drop.deref()) }
+    }
+
+    /// Constructs a new pin by mapping and dereferencing the interior
+    /// `&mut ManuallyDrop<T>` container.
+    ///
+    /// For example, if you wanted to get a `Pin` of a field of something,
+    /// you could use this to get mutable access to that field in one line of code.
+    /// However, there are several gotchas with these "pinning projections";
+    /// see the [`pin` module] documentation for further details on that topic.
+    ///
+    /// [`pin` module]: crate::pin#projections-and-structural-pinning
+    #[unstable(feature = "manually_drop_pinned", issue = "157268")]
+    #[inline(always)]
+    pub fn pinned_deref_mut(pinned: Pin<&mut ManuallyDrop<T>>) -> Pin<&mut T> {
+        // SAFETY: Since we are mutably borrowing `ManuallyDrop<T>`, the T
+        // should not be dropped, hence we can construct a new `Pin` that has
+        // a mutable borrow to T as well.
+        unsafe { pinned.map_unchecked_mut(|manually_drop| manually_drop.deref_mut()) }
+    }
+
     /// Takes the value from the `ManuallyDrop<T>` container out.
     ///
     /// This method is primarily intended for moving out values in drop.
@@ -265,6 +302,44 @@ impl<T: ?Sized> ManuallyDrop<T> {
         // which is guaranteed to be valid for writes.
         // It is up to the caller to make sure that `slot` isn't dropped again.
         unsafe { ptr::drop_in_place(slot.value.as_mut()) }
+    }
+
+    /// Manually drops the pinned contained value.
+    ///
+    /// This is exactly equivalent to calling [`ptr::drop_in_place`] with a
+    /// pinned pointer to the contained value. As such, unless the contained value is a
+    /// packed struct, the destructor will be called in-place without moving the
+    /// value, and thus can be used to safely drop [pinned] data.
+    ///
+    /// If you have ownership of the pinned contained value, you can use [`Pin::into_inner`]
+    /// and then [`ManuallyDrop::into_inner`] instead.
+    ///
+    /// # Safety
+    ///
+    /// This function runs the destructor of the contained value. Other than changes made by
+    /// the destructor itself, the memory is left unchanged, and so as far as the compiler is
+    /// concerned still holds a bit-pattern which is valid for the type `T`.
+    ///
+    /// However, this "zombie" value should not be exposed to safe code, and this function
+    /// should not be called more than once, nor with drop being called on the internal
+    /// `&mut ManuallyDrop<T>` container beforehand. To use a value after it's been dropped,
+    /// or drop a value multiple times, can cause Undefined Behavior (depending on what `drop` does).
+    /// This is normally prevented by the type system, but users of `ManuallyDrop` must
+    /// uphold those guarantees without assistance from the compiler.
+    ///
+    /// [pinned]: crate::pin
+    #[unstable(feature = "manually_drop_pinned", issue = "157268")]
+    #[inline]
+    #[rustc_const_unstable(feature = "const_drop_in_place", issue = "109342")]
+    pub const unsafe fn pinned_drop(pinned: Pin<&mut ManuallyDrop<T>>)
+    where
+        T: [const] Destruct,
+    {
+        // SAFETY: we are dropping the pinned value pointed to by a mutable reference
+        // which is guaranteed to be valid for writes.
+        // It is up to the caller to make sure that the `ManuallyDrop<T>` isn't dropped
+        // again.
+        unsafe { Self::drop(pinned.get_unchecked_mut()) }
     }
 }
 

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -82,6 +82,7 @@
 #![feature(iterator_try_collect)]
 #![feature(iterator_try_reduce)]
 #![feature(layout_for_ptr)]
+#![feature(manually_drop_pinned)]
 #![feature(maybe_uninit_fill)]
 #![feature(maybe_uninit_uninit_array_transpose)]
 #![feature(min_specialization)]

--- a/library/coretests/tests/manually_drop.rs
+++ b/library/coretests/tests/manually_drop.rs
@@ -1,6 +1,7 @@
 #![allow(undropped_manually_drops)]
 
 use core::mem::ManuallyDrop;
+use core::pin::Pin;
 
 #[test]
 fn smoke() {
@@ -64,4 +65,112 @@ fn const_drop_in_place() {
         counter.get()
     };
     assert_eq!(COUNTER, 3);
+}
+
+#[test]
+fn const_pinned_drop_in_place() {
+    const COUNTER: usize = {
+        use core::cell::Cell;
+
+        let counter = Cell::new(0);
+
+        // only exists to make `Drop` indirect impl
+        #[allow(dead_code)]
+        struct Test<'a>(Dropped<'a>);
+
+        struct Dropped<'a>(&'a Cell<usize>);
+        const impl Drop for Dropped<'_> {
+            fn drop(&mut self) {
+                self.0.set(self.0.get() + 1);
+            }
+        }
+
+        let mut one = ManuallyDrop::new(Test(Dropped(&counter)));
+        let mut two = ManuallyDrop::new(Test(Dropped(&counter)));
+        let mut three = ManuallyDrop::new(Test(Dropped(&counter)));
+
+        let mut pinned_one = Pin::new(&mut one);
+        let mut pinned_two = Pin::new(&mut two);
+        let mut pinned_three = Pin::new(&mut three);
+        assert!(counter.get() == 0);
+        unsafe {
+            ManuallyDrop::pinned_drop(pinned_one.as_mut());
+        }
+        assert!(counter.get() == 1);
+        unsafe {
+            ManuallyDrop::pinned_drop(pinned_two.as_mut());
+        }
+        assert!(counter.get() == 2);
+        unsafe {
+            ManuallyDrop::pinned_drop(pinned_three.as_mut());
+        }
+        counter.get()
+    };
+    assert_eq!(COUNTER, 3);
+}
+
+#[test]
+fn pinned_deref_in_place() {
+    use core::cell::Cell;
+
+    let counter = Cell::new(0);
+
+    #[allow(dead_code)]
+    // only exists to make `Drop` indirect impl
+    struct Dropped<'a>(&'a Cell<usize>);
+    impl Drop for Dropped<'_> {
+        fn drop(&mut self) {
+            unreachable!("Should not get dropped");
+        }
+    }
+
+    let one = ManuallyDrop::new(Dropped(&counter));
+    let two = ManuallyDrop::new(Dropped(&counter));
+    let three = ManuallyDrop::new(Dropped(&counter));
+
+    let pinned_one = Pin::new(&one);
+    let pinned_two = Pin::new(&two);
+    let pinned_three = Pin::new(&three);
+
+    let manually_pinned_one = ManuallyDrop::pinned_deref(pinned_one.as_ref());
+    assert_eq!(manually_pinned_one.as_ref().0.get(), 0);
+
+    let manually_pinned_two = ManuallyDrop::pinned_deref(pinned_two.as_ref());
+    assert_eq!(manually_pinned_two.as_ref().0.get(), 0);
+
+    let manually_pinned_three = ManuallyDrop::pinned_deref(pinned_three.as_ref());
+    assert_eq!(manually_pinned_three.as_ref().0.get(), 0);
+}
+
+#[test]
+fn pinned_deref_mut_in_place() {
+    use core::cell::Cell;
+
+    let counter = Cell::new(0);
+
+    #[allow(dead_code)]
+    // only exists to make `Drop` indirect impl
+    struct Dropped<'a>(&'a Cell<usize>);
+    impl Drop for Dropped<'_> {
+        fn drop(&mut self) {
+            unreachable!("Should not get dropped");
+        }
+    }
+
+    let mut one = ManuallyDrop::new(Dropped(&counter));
+    let mut two = ManuallyDrop::new(Dropped(&counter));
+    let mut three = ManuallyDrop::new(Dropped(&counter));
+
+    let mut pinned_one = Pin::new(&mut one);
+    let mut pinned_two = Pin::new(&mut two);
+    let mut pinned_three = Pin::new(&mut three);
+
+    let mut manually_pinned_one = ManuallyDrop::pinned_deref_mut(pinned_one.as_mut());
+    assert_eq!(manually_pinned_one.as_mut().0.get(), 0);
+
+    let mut manually_pinned_two = ManuallyDrop::pinned_deref_mut(pinned_two.as_mut());
+    assert_eq!(manually_pinned_two.as_mut().0.get(), 0);
+
+    let mut manually_pinned_three = ManuallyDrop::pinned_deref_mut(pinned_three.as_mut());
+    assert_eq!(manually_pinned_three.as_mut().0.get(), 0);
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR implements the `ManuallyDrop<T>::pinned_*` as accepted in this [ACP](https://github.com/rust-lang/libs-team/issues/580) that was made a while ago.

The tracking issue for this is [here](https://github.com/rust-lang/rust/issues/157268).