### PR TITLE
Add experimental `unnamed_enum_variants` feature gate

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -857,6 +857,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
     }
 
     fn lower_variant(&mut self, item_kind: &ItemKind, v: &Variant) -> hir::Variant<'hir> {
+        if v.ident.name == kw::Underscore && self.tcx.features().unnamed_enum_variants() {
+            // FIXME(#156628): lower unnamed enum variants to HIR.
+            self.dcx()
+                .struct_span_fatal(v.span, "unnamed enum variants are not yet implemented")
+                .emit()
+        }
         let hir_id = self.lower_node_id(v.id);
         self.lower_attrs(hir_id, &v.attrs, v.span, Target::Variant);
         hir::Variant {

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -511,6 +511,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(return_type_notation, "return type notation is experimental");
     gate_all!(super_let, "`super let` is experimental");
     gate_all!(try_blocks_heterogeneous, "`try bikeshed` expression is experimental");
+    gate_all!(unnamed_enum_variants, "unnamed enum variants are experimental");
     gate_all!(unsafe_binders, "unsafe binder types are experimental");
     gate_all!(unsafe_fields, "`unsafe` fields are experimental");
     gate_all!(view_types, "view types are experimental");

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -750,6 +750,8 @@ declare_features! (
     /// Allows creation of instances of a struct by moving fields that have
     /// not changed from prior instances of the same struct (RFC #2528)
     (unstable, type_changing_struct_update, "1.58.0", Some(86555)),
+    /// Allows using `_ = <range-or-int>` enum variants.
+    (incomplete, unnamed_enum_variants, "CURRENT_RUSTC_VERSION", Some(156628)),
     /// Allows using `unsafe<'a> &'a T` unsafe binder types.
     (incomplete, unsafe_binders, "1.85.0", Some(130516)),
     /// Allows declaring fields `unsafe`.

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1915,6 +1915,10 @@ impl<'a> Parser<'a> {
                 None
             };
 
+            let span = vlo.to(this.prev_token.span);
+            if ident.name == kw::Underscore {
+                this.psess.gated_spans.gate(sym::unnamed_enum_variants, span);
+            }
             let vr = ast::Variant {
                 ident,
                 vis,
@@ -1922,7 +1926,7 @@ impl<'a> Parser<'a> {
                 attrs: variant_attrs,
                 data: struct_def,
                 disr_expr,
-                span: vlo.to(this.prev_token.span),
+                span,
                 is_placeholder: false,
             };
 
@@ -2382,7 +2386,10 @@ impl<'a> Parser<'a> {
     /// for better diagnostics and suggestions.
     fn parse_field_ident(&mut self, adt_ty: &str, lo: Span) -> PResult<'a, Ident> {
         let (ident, is_raw) = self.ident_or_err(true)?;
-        if is_raw == IdentIsRaw::No && ident.is_reserved() {
+        if is_raw == IdentIsRaw::No
+            && ident.is_reserved()
+            && !(ident.name == kw::Underscore && adt_ty == "enum")
+        {
             let snapshot = self.create_snapshot_for_diagnostic();
             let err = if self.check_fn_front_matter(false, Case::Sensitive) {
                 let inherited_vis =

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2171,6 +2171,7 @@ symbols! {
         unix,
         unlikely,
         unmarked_api,
+        unnamed_enum_variants,
         unnamed_fields,
         unpin,
         unqualified_local_imports,

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -1501,6 +1501,10 @@ See [Uninhabited | Reference](https://doc.rust-lang.org/reference/glossary.html?
 
 See [Unions | Reference](https://doc.rust-lang.org/reference/items/unions.html).
 
+## `tests/ui/unnamed-enum-variants`: `_ = <range-or-int>` in an `enum`
+
+See [Tracking Issue for Unnamed Enum Variants (Open Enums) #156628](https://github.com/rust-lang/rust/issues/156628)
+
 ## `tests/ui/unop/`: Unary operators `-`, `*` and `!`
 
 Tests the three unary operators for negating, dereferencing and inverting, across different contexts.

--- a/tests/ui/feature-gates/feature-gate-unnamed-enum-variants.rs
+++ b/tests/ui/feature-gates/feature-gate-unnamed-enum-variants.rs
@@ -1,0 +1,13 @@
+#[repr(u8)]
+enum Foo {
+    X = 0,
+    _ = 1, //~ ERROR unnamed enum variants are experimental
+}
+
+// This should not parse as an unnamed enum variant.
+#[cfg(false)]
+struct Foo {
+    _: i32, //~ ERROR expected identifier, found reserved identifier `_`
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-unnamed-enum-variants.stderr
+++ b/tests/ui/feature-gates/feature-gate-unnamed-enum-variants.stderr
@@ -1,0 +1,21 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/feature-gate-unnamed-enum-variants.rs:10:5
+   |
+LL | struct Foo {
+   |        --- while parsing this struct
+LL |     _: i32,
+   |     ^ expected identifier, found reserved identifier
+
+error[E0658]: unnamed enum variants are experimental
+  --> $DIR/feature-gate-unnamed-enum-variants.rs:4:5
+   |
+LL |     _ = 1,
+   |     ^^^^^
+   |
+   = note: see issue #156628 <https://github.com/rust-lang/rust/issues/156628> for more information
+   = help: add `#![feature(unnamed_enum_variants)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/unnamed-enum-variants/unimplemented.rs
+++ b/tests/ui/unnamed-enum-variants/unimplemented.rs
@@ -1,0 +1,8 @@
+//@ compile-flags: --crate-type=lib
+#![allow(incomplete_features)]
+#![feature(unnamed_enum_variants)]
+
+#[repr(u8)]
+enum Foo {
+    _ = 1, //~ ERROR unnamed enum variants are not yet implemented
+}

--- a/tests/ui/unnamed-enum-variants/unimplemented.stderr
+++ b/tests/ui/unnamed-enum-variants/unimplemented.stderr
@@ -1,0 +1,8 @@
+error: unnamed enum variants are not yet implemented
+  --> $DIR/unimplemented.rs:7:5
+   |
+LL |     _ = 1,
+   |     ^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This parses the basic syntax and defines a feature gate for the unnamed enum variants lang experiment, tracking issue rust-lang/rust#156628.

cc @joshtriplett, @scottmcm, @tmandry
