### PR TITLE
triagebot.toml: add LawnGnome to libs reviewers

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1487,6 +1487,7 @@ libs = [
     "@thomcc",
     "@joboet",
     "@nia-e",
+    "@LawnGnome",
 ]
 infra-ci = [
     "@Mark-Simulacrum",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? me