### PR TITLE
Add (in)stability disclaimer to rustdoc JSON files.

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -249,6 +249,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
 
         debug!("Constructing Output");
         let output_crate = types::Crate {
+            format_disclaimer: types::FORMAT_DISCLAIMER.to_owned(),
             root: self.id_from_item_default(e.def_id().into()),
             crate_version: self.cache.crate_version.clone(),
             includes_private: self.cache.document_private,
@@ -345,7 +346,7 @@ mod size_asserts {
     use super::types::*;
     // tidy-alphabetical-start
     static_assert_size!(AssocItemConstraint, 112);
-    static_assert_size!(Crate, 184);
+    static_assert_size!(Crate, 208);
     static_assert_size!(FunctionPointer, 168);
     static_assert_size!(GenericArg, 80);
     static_assert_size!(GenericArgs, 104);

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -114,8 +114,11 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 // will instead cause conflicts. See #94591 for more. (This paragraph and the "Latest feature" line
 // are deliberately not in a doc comment, because they need not be in public docs.)
 //
-// Latest feature: Add `ExternCrate::path`.
-pub const FORMAT_VERSION: u32 = 57;
+// Latest feature: Add `Crate::format_disclaimer` serialized as `$comment`.
+pub const FORMAT_VERSION: u32 = 58;
+
+pub const FORMAT_DISCLAIMER: &str = "The format of this file is unstable and subject to change \
+without notice. Please always follow `format_version`.";
 
 /// The root of the emitted JSON blob.
 ///
@@ -126,6 +129,9 @@ pub const FORMAT_VERSION: u32 = 57;
 #[cfg_attr(feature = "rkyv_0_8", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
 #[cfg_attr(feature = "rkyv_0_8", rkyv(derive(Debug)))]
 pub struct Crate {
+    /// A warning that the JSON format is unstable.
+    #[serde(rename = "$comment")]
+    pub format_disclaimer: String,
     /// The id of the root [`Module`] item of the local crate.
     pub root: Id,
     /// The version string given to `--crate-version`, if any.

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -1,5 +1,7 @@
 use rustc_hash::FxHashMap;
-use rustdoc_json_types::{Abi, FORMAT_VERSION, FunctionHeader, Item, ItemKind, Visibility};
+use rustdoc_json_types::{
+    Abi, FORMAT_DISCLAIMER, FORMAT_VERSION, FunctionHeader, Item, ItemKind, Visibility,
+};
 
 use super::*;
 use crate::json_find::SelectorPart;
@@ -18,6 +20,7 @@ fn check(krate: &Crate, errs: &[Error]) {
 #[test]
 fn errors_on_missing_links() {
     let k = Crate {
+        format_disclaimer: FORMAT_DISCLAIMER.to_owned(),
         root: Id(0),
         crate_version: None,
         includes_private: false,
@@ -65,6 +68,7 @@ fn errors_on_missing_links() {
 #[test]
 fn errors_on_local_in_paths_and_not_index() {
     let krate = Crate {
+        format_disclaimer: FORMAT_DISCLAIMER.to_owned(),
         root: Id(0),
         crate_version: None,
         includes_private: false,
@@ -137,6 +141,7 @@ fn errors_on_missing_path() {
     let generics = Generics { params: vec![], where_predicates: vec![] };
 
     let krate = Crate {
+        format_disclaimer: FORMAT_DISCLAIMER.to_owned(),
         root: Id(0),
         crate_version: None,
         includes_private: false,
@@ -238,6 +243,7 @@ fn errors_on_missing_path() {
 #[should_panic = "LOCAL_CRATE_ID is wrong"]
 fn checks_local_crate_id_is_correct() {
     let krate = Crate {
+        format_disclaimer: FORMAT_DISCLAIMER.to_owned(),
         root: Id(0),
         crate_version: None,
         includes_private: false,


### PR DESCRIPTION
Add a note to generated rustdoc JSON files to remind users that the file format is not stable, and may change without notice. Following the suggestion in https://github.com/rust-lang/rust/pull/156926#issuecomment-4577751005

r? @Urgau 

LLM disclosure: I wrote this code by hand, after using an LLM to generate a separate local prototype to identify code locations that needed to be changed to satisfy the test suite.