### PR TITLE
traits: Allow escaping self types in ExistentialTraitRef::with_self_ty

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -974,7 +974,22 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                     // go through an anon const still have their types checked.
                     //
                     // See also: https://rustc-dev-guide.rust-lang.org/const-generics.html
-                    let args = principal.skip_binder().with_self_ty(self.tcx(), t).args;
+                    //
+                    // We only use this trait ref to read off its `ConstArgHasType` clauses,
+                    // which constrain the trait's own const arguments and never mention the
+                    // `Self` type. The `with_self_ty` assertion forbids an escaping self type
+                    // (those vars would be captured by the trait-ref binder), and `t` can carry
+                    // escaping bound vars here because WF-checking walks through higher-ranked
+                    // binders without instantiating them (e.g. a `dyn Trait` nested in a
+                    // `for<'a>` bound). Since the self type is irrelevant to the clauses we
+                    // keep, fall back to the dummy self type in that case rather than skipping
+                    // the check entirely.
+                    let self_ty = if t.has_escaping_bound_vars() {
+                        tcx.types.trait_object_dummy_self
+                    } else {
+                        t
+                    };
+                    let args = principal.skip_binder().with_self_ty(tcx, self_ty).args;
                     let obligations =
                         self.nominal_obligations(principal_def_id, args).into_iter().filter(|o| {
                             let kind = o.predicate.kind().skip_binder();

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -974,22 +974,7 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                     // go through an anon const still have their types checked.
                     //
                     // See also: https://rustc-dev-guide.rust-lang.org/const-generics.html
-                    //
-                    // We only use this trait ref to read off its `ConstArgHasType` clauses,
-                    // which constrain the trait's own const arguments and never mention the
-                    // `Self` type. The `with_self_ty` assertion forbids an escaping self type
-                    // (those vars would be captured by the trait-ref binder), and `t` can carry
-                    // escaping bound vars here because WF-checking walks through higher-ranked
-                    // binders without instantiating them (e.g. a `dyn Trait` nested in a
-                    // `for<'a>` bound). Since the self type is irrelevant to the clauses we
-                    // keep, fall back to the dummy self type in that case rather than skipping
-                    // the check entirely.
-                    let self_ty = if t.has_escaping_bound_vars() {
-                        tcx.types.trait_object_dummy_self
-                    } else {
-                        t
-                    };
-                    let args = principal.skip_binder().with_self_ty(tcx, self_ty).args;
+                    let args = principal.skip_binder().with_self_ty(self.tcx(), t).args;
                     let obligations =
                         self.nominal_obligations(principal_def_id, args).into_iter().filter(|o| {
                             let kind = o.predicate.kind().skip_binder();

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -443,12 +443,8 @@ impl<I: Interner> ExistentialTraitRef<I> {
     /// Therefore, you must specify *some* self type to perform the conversion.
     /// A common choice is the trait object type itself or some kind of dummy type.
     pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> TraitRef<I> {
-        // FIXME(#157122): This assertion was accidentally commented out in refactoring PR #53816
-        //                 back in 2018 but nowadays it can actually trigger. Either remove this
-        //                 comment entirely if the assertion is incorrect or uncomment it and fix
-        //                 the fallout!
         // otherwise the escaping vars would be captured by the binder
-        //debug_assert!(!self_ty.has_escaping_bound_vars());
+        debug_assert!(!self_ty.has_escaping_bound_vars());
 
         TraitRef::new(interner, self.def_id, [self_ty.into()].into_iter().chain(self.args.iter()))
     }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -443,9 +443,6 @@ impl<I: Interner> ExistentialTraitRef<I> {
     /// Therefore, you must specify *some* self type to perform the conversion.
     /// A common choice is the trait object type itself or some kind of dummy type.
     pub fn with_self_ty(self, interner: I, self_ty: I::Ty) -> TraitRef<I> {
-        // otherwise the escaping vars would be captured by the binder
-        debug_assert!(!self_ty.has_escaping_bound_vars());
-
         TraitRef::new(interner, self.def_id, [self_ty.into()].into_iter().chain(self.args.iter()))
     }
 }

--- a/tests/ui/wf/wf-dyn-in-hrtb-bound-const-mismatch.rs
+++ b/tests/ui/wf/wf-dyn-in-hrtb-bound-const-mismatch.rs
@@ -1,11 +1,11 @@
 // Companion to #157122 / `wf-dyn-in-hrtb-bound-issue-157122.rs`.
 //
-// That test fixes an ICE in `WfPredicates::visit_ty` where a `dyn Trait` nested
+// That test covers an ICE in `WfPredicates::visit_ty` where a `dyn Trait` nested
 // inside a `for<'a>` binder reached `ExistentialTraitRef::with_self_ty` with an
-// escaping self type. The fix substitutes a placeholder self type for that case
-// instead of skipping the block. Skipping would have been a silent regression:
-// the block emits the `ConstArgHasType` obligation that type-checks a `dyn`'s
-// const argument, so dropping it makes an ill-typed const argument compile.
+// escaping self type. The fix removes the offending `debug_assert!` rather than
+// skipping the block. Skipping would have been a silent regression: the block
+// emits the `ConstArgHasType` obligation that type-checks a `dyn`'s const
+// argument, so dropping it makes an ill-typed const argument compile.
 //
 // Here `B` has type `bool` but `HasConst` expects `const N: usize`, and the
 // `dyn HasConst<'a, B>` carries the escaping late-bound `'a`. This must still be

--- a/tests/ui/wf/wf-dyn-in-hrtb-bound-const-mismatch.rs
+++ b/tests/ui/wf/wf-dyn-in-hrtb-bound-const-mismatch.rs
@@ -1,0 +1,19 @@
+// Companion to #157122 / `wf-dyn-in-hrtb-bound-issue-157122.rs`.
+//
+// That test fixes an ICE in `WfPredicates::visit_ty` where a `dyn Trait` nested
+// inside a `for<'a>` binder reached `ExistentialTraitRef::with_self_ty` with an
+// escaping self type. The fix substitutes a placeholder self type for that case
+// instead of skipping the block. Skipping would have been a silent regression:
+// the block emits the `ConstArgHasType` obligation that type-checks a `dyn`'s
+// const argument, so dropping it makes an ill-typed const argument compile.
+//
+// Here `B` has type `bool` but `HasConst` expects `const N: usize`, and the
+// `dyn HasConst<'a, B>` carries the escaping late-bound `'a`. This must still be
+// rejected, exactly as it is without the surrounding `for<'a>` binder.
+
+trait HasConst<'a, const N: usize> {}
+
+fn nested<const B: bool>(_f: &dyn for<'a> Fn(&'a (), &'a dyn HasConst<'a, B>)) {}
+//~^ ERROR the constant `B` is not of type `usize`
+
+fn main() {}

--- a/tests/ui/wf/wf-dyn-in-hrtb-bound-const-mismatch.stderr
+++ b/tests/ui/wf/wf-dyn-in-hrtb-bound-const-mismatch.stderr
@@ -1,0 +1,14 @@
+error: the constant `B` is not of type `usize`
+  --> $DIR/wf-dyn-in-hrtb-bound-const-mismatch.rs:16:30
+   |
+LL | fn nested<const B: bool>(_f: &dyn for<'a> Fn(&'a (), &'a dyn HasConst<'a, B>)) {}
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
+   |
+note: required by a const generic parameter in `HasConst`
+  --> $DIR/wf-dyn-in-hrtb-bound-const-mismatch.rs:14:20
+   |
+LL | trait HasConst<'a, const N: usize> {}
+   |                    ^^^^^^^^^^^^^^ required by this const generic parameter in `HasConst`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/wf/wf-dyn-in-hrtb-bound-issue-157122.rs
+++ b/tests/ui/wf/wf-dyn-in-hrtb-bound-issue-157122.rs
@@ -1,0 +1,28 @@
+//@ check-pass
+
+// Regression test for #157122.
+//
+// When WF-checking a type, the visitor recurses through higher-ranked binders
+// without instantiating them, so a `dyn Trait` nested inside a `for<'a>` binder
+// reaches the `ty::Dynamic` arm of `WfPredicates::visit_ty` while still carrying
+// escaping bound vars. Building the principal trait ref there via
+// `ExistentialTraitRef::with_self_ty` fed that escaping self type straight into
+// `debug_assert!(!self_ty.has_escaping_bound_vars())`, causing an ICE. We now
+// substitute a placeholder self type for the escaping case (the self type is
+// irrelevant to the `ConstArgHasType` clauses this code reads off), so the
+// assertion holds and the const-argument check is still performed -- see
+// `wf-dyn-in-hrtb-bound-const-mismatch.rs` for the latter. Distilled from
+// `itertools`'s `FormatWith` `Display` impl.
+
+use std::fmt;
+
+fn call<F>(mut f: F)
+where
+    F: FnMut(&mut dyn FnMut(&dyn fmt::Display) -> fmt::Result) -> fmt::Result,
+{
+    let _ = f(&mut |_disp: &dyn fmt::Display| Ok(()));
+}
+
+fn main() {
+    call(|cb| cb(&0i32));
+}

--- a/tests/ui/wf/wf-dyn-in-hrtb-bound-issue-157122.rs
+++ b/tests/ui/wf/wf-dyn-in-hrtb-bound-issue-157122.rs
@@ -6,13 +6,13 @@
 // without instantiating them, so a `dyn Trait` nested inside a `for<'a>` binder
 // reaches the `ty::Dynamic` arm of `WfPredicates::visit_ty` while still carrying
 // escaping bound vars. Building the principal trait ref there via
-// `ExistentialTraitRef::with_self_ty` fed that escaping self type straight into
-// `debug_assert!(!self_ty.has_escaping_bound_vars())`, causing an ICE. We now
-// substitute a placeholder self type for the escaping case (the self type is
-// irrelevant to the `ConstArgHasType` clauses this code reads off), so the
-// assertion holds and the const-argument check is still performed -- see
-// `wf-dyn-in-hrtb-bound-const-mismatch.rs` for the latter. Distilled from
-// `itertools`'s `FormatWith` `Display` impl.
+// `ExistentialTraitRef::with_self_ty` passed that escaping self type to a
+// `debug_assert!(!self_ty.has_escaping_bound_vars())`, which ICEs once the
+// assertion is enabled. Creating a trait ref with an escaping self type is fine
+// -- escaping bound vars are caught where they are actually used -- so the
+// assertion was removed rather than worked around. The `ConstArgHasType` check
+// this arm reads off still runs; see `wf-dyn-in-hrtb-bound-const-mismatch.rs`.
+// Distilled from `itertools`'s `FormatWith` `Display` impl.
 
 use std::fmt;
 


### PR DESCRIPTION
Fixes rust-lang/rust#157122

WF-checking recurses through higher-ranked binders without instantiating them, so a `dyn Trait` nested inside a `for<'a>` binder reaches the `ty::Dynamic` arm of `WfPredicates::visit_ty` while still carrying escaping bound vars. Building the principal trait ref there via `ExistentialTraitRef::with_self_ty` hands that escaping self type to a `debug_assert!(!self_ty.has_escaping_bound_vars())`, which ICEs once the assertion is enabled. The assert was accidentally disabled in 2018 refactor rust-lang/rust#53816, and the `// FIXME(#157122)` left in its place asks whether to remove it or fix the fallout.

An escaping bound var is expected for trait objects, and we already catch trait refs with escaping bound vars at the places that actually use them — so creating one here is fine. Rather than work around the assert in WF, this removes the assert and its stale FIXME from `with_self_ty`.

Two regression tests pin the behavior:
- `wf-dyn-in-hrtb-bound-issue-157122.rs` reproduces the original ICE (`dyn` nested in an HRTB bound).
- `wf-dyn-in-hrtb-bound-const-mismatch.rs` checks that the `ConstArgHasType` obligation this arm reads off still fires, so an ill-typed const argument on such a `dyn` keeps erroring instead of compiling clean.
