### PR TITLE
perf: skip irrelevant foreign impls when building the specialization graph

### DIFF
--- a/compiler/rustc_middle/src/traits/specialization_graph.rs
+++ b/compiler/rustc_middle/src/traits/specialization_graph.rs
@@ -144,6 +144,7 @@ impl Node {
 
 #[derive(Copy, Clone)]
 pub struct Ancestors<'tcx> {
+    tcx: TyCtxt<'tcx>,
     trait_def_id: DefId,
     specialization_graph: &'tcx Graph,
     current_source: Option<Node>,
@@ -154,7 +155,14 @@ impl Iterator for Ancestors<'_> {
     fn next(&mut self) -> Option<Node> {
         let cur = self.current_source.take();
         if let Some(Node::Impl(cur_impl)) = cur {
-            let parent = self.specialization_graph.parent(cur_impl);
+            // Graph construction may skip foreign impls, so resolve a foreign impl's
+            // parent from crate metadata instead; recorded foreign impls use the same
+            // value (see `record_impl_from_cstore`).
+            let parent = if cur_impl.is_local() {
+                self.specialization_graph.parent(cur_impl)
+            } else {
+                self.tcx.impl_parent(cur_impl).unwrap_or(self.trait_def_id)
+            };
 
             self.current_source = if parent == self.trait_def_id {
                 Some(Node::Trait(parent))
@@ -254,6 +262,7 @@ pub fn ancestors(
         Err(reported)
     } else {
         Ok(Ancestors {
+            tcx,
             trait_def_id,
             specialization_graph,
             current_source: Some(Node::Impl(start_from_impl)),

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -19,6 +19,7 @@ use rustc_infer::traits::Obligation;
 use rustc_middle::bug;
 use rustc_middle::query::LocalCrate;
 use rustc_middle::traits::query::NoSolution;
+use rustc_middle::ty::fast_reject::{self, TreatParams};
 use rustc_middle::ty::print::PrintTraitRefExt as _;
 use rustc_middle::ty::{
     self, GenericArgsRef, Ty, TyCtxt, TypeVisitableExt, TypingMode, Unnormalized,
@@ -395,7 +396,38 @@ pub(super) fn specialization_graph_provider(
     let mut sg = specialization_graph::Graph::new();
     let overlap_mode = specialization_graph::OverlapMode::get(tcx, trait_id);
 
-    let mut trait_impls: Vec<_> = tcx.all_impls(trait_id).collect();
+    // Skip foreign non-blanket impls whose simplified-self bucket holds no
+    // local impl. This is sound because:
+    // - foreign impls are never overlap-checked, only recorded; `Ancestors`
+    //   reads their parent lazily from metadata instead (the same value).
+    // - a local non-blanket impl is only compared against blanket impls and
+    //   impls in its own bucket (see `filtered_children`), and instantiation
+    //   preserves the simplified type, so kept buckets are complete at every
+    //   level of the tree.
+    // - a local blanket impl, including alias self types which simplify to
+    //   `None`, is compared against every child, so then all buckets are kept;
+    //   pruning them would change error recovery (see impl-unpin.rs, `tait`
+    //   revision).
+    let all_impls = tcx.trait_impls_of(trait_id);
+    let mut trait_impls: Vec<DefId> = all_impls.blanket_impls().to_vec();
+    let has_local_blanket_impl =
+        all_impls.blanket_impls().iter().any(|impl_def_id| impl_def_id.is_local());
+    for (&simplified_self, bucket) in all_impls.non_blanket_impls() {
+        if has_local_blanket_impl || bucket.iter().any(|impl_def_id| impl_def_id.is_local()) {
+            trait_impls.extend(bucket.iter().copied());
+        } else if cfg!(debug_assertions) {
+            // Assert metadata-derived key matches what the overlap checker recomputes.
+            for &impl_def_id in bucket {
+                let self_ty = tcx.impl_trait_ref(impl_def_id).skip_binder().self_ty();
+                debug_assert_eq!(
+                    fast_reject::simplify_type(tcx, self_ty, TreatParams::InstantiateWithInfer),
+                    Some(simplified_self),
+                    "trait_impls_of bucket key disagrees with overlap-check \
+                     simplification for foreign impl {impl_def_id:?}",
+                );
+            }
+        }
+    }
 
     // The coherence checking implementation seems to rely on impls being
     // iterated over (roughly) in definition order, so we are sorting by


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157281)*
<!-- homu-ignore:end -->

Skip foreign non-blanket impls that can't overlap any local impl when building the specialization graph. The call site showed up when profiling and this PR leads to a mean -1.5% instructions perf improvement, see https://github.com/rust-lang/rust/pull/157281#issuecomment-4673863153