### PR TITLE
Enum Layout Optimization: Variant fields reordering around niche.

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -610,7 +610,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             let mut combined_seed = repr.field_shuffle_seed;
 
             let mut variants_info = IndexVec::<VariantIdx, _>::with_capacity(variants.len());
-            let mut variant_layouts = variants
+            let variant_layouts = variants
                 .iter()
                 .map(|v| {
                     let st = self.univariant(v, repr, StructKind::AlwaysSized).ok()?;
@@ -626,203 +626,27 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                 })
                 .collect::<Option<IndexVec<VariantIdx, _>>>()?;
 
-            let largest_variant_index = variant_layouts
-                .iter_enumerated()
-                .max_by_key(|(_i, layout)| layout.size.bytes())
-                .map(|(i, _layout)| i)?;
-
-            let all_indices = variants.indices();
-            let needs_disc =
-                |index: VariantIdx| index != largest_variant_index && !absent(&variants[index]);
-            let niche_variants = RangeInclusive {
-                start: all_indices.clone().find(|v| needs_disc(*v)).unwrap(),
-                last: all_indices.rev().find(|v| needs_disc(*v)).unwrap(),
-            };
-
-            let count =
-                (niche_variants.last.index() as u128 - niche_variants.start.index() as u128) + 1;
-
-            // Use the largest niche in the largest variant.
-            let niche = variant_layouts[largest_variant_index].largest_niche?;
-            let (niche_start, niche_scalar) = niche.reserve(dl, count)?;
-            let niche_offset = niche.offset;
-            let niche_size = niche.value.size(dl);
-            let size = variant_layouts[largest_variant_index].size.align_to(align);
-
-            let all_variants_fit = variant_layouts.iter_enumerated_mut().all(|(i, layout)| {
-                if i == largest_variant_index {
-                    return true;
-                }
-
-                layout.largest_niche = None;
-
-                if layout.size <= niche_offset {
-                    // This variant will fit before the niche.
-                    return true;
-                }
-
-                // Determine if it'll fit after the niche.
-                let this_align = variants_info[i].align_abi;
-                let this_offset = (niche_offset + niche_size).align_to(this_align);
-
-                if this_offset + layout.size > size {
-                    return false;
-                }
-
-                // It'll fit, but we need to make some adjustments.
-                for offset in layout.field_offsets.iter_mut() {
-                    *offset += this_offset;
-                }
-
-                // It can't be a Scalar or ScalarPair because the offset isn't 0.
-                if !layout.is_uninhabited() {
-                    layout.backend_repr = BackendRepr::Memory { sized: true };
-                }
-                layout.size += this_offset;
-
-                true
-            });
-
-            if !all_variants_fit {
-                return None;
-            }
-
-            let largest_niche = Niche::from_scalar(dl, niche_offset, niche_scalar);
-
-            let others_zst = variant_layouts
-                .iter_enumerated()
-                .all(|(i, layout)| i == largest_variant_index || layout.size == Size::ZERO);
-            let same_size = size == variant_layouts[largest_variant_index].size;
-            let same_align = align == variants_info[largest_variant_index].align_abi;
-
-            let uninhabited = variant_layouts.iter().all(|v| v.is_uninhabited());
-            let abi = if same_size && same_align && others_zst {
-                match variant_layouts[largest_variant_index].backend_repr {
-                    // When the total alignment and size match, we can use the
-                    // same ABI as the scalar variant with the reserved niche.
-                    BackendRepr::Scalar(_) => BackendRepr::Scalar(niche_scalar),
-                    BackendRepr::ScalarPair { a: first, b: second, b_offset } => {
-                        // Only the niche is guaranteed to be initialised,
-                        // so use union layouts for the other primitive.
-                        if niche_offset == Size::ZERO {
-                            BackendRepr::ScalarPair {
-                                a: niche_scalar,
-                                b: second.to_union(),
-                                b_offset,
-                            }
-                        } else {
-                            BackendRepr::ScalarPair {
-                                a: first.to_union(),
-                                b: niche_scalar,
-                                b_offset,
-                            }
-                        }
-                    }
-                    _ => BackendRepr::Memory { sized: true },
-                }
-            } else {
-                BackendRepr::Memory { sized: true }
-            };
-
-            let layout = LayoutData {
-                variants: Variants::Multiple {
-                    tag: niche_scalar,
-                    tag_encoding: TagEncoding::Niche {
-                        untagged_variant: largest_variant_index,
-                        niche_variants,
-                        niche_start,
-                    },
-                    tag_field: FieldIdx::new(0),
-                    variants: variant_layouts,
-                },
-                fields: FieldsShape::Arbitrary {
-                    offsets: [niche_offset].into(),
-                    in_memory_order: [FieldIdx::new(0)].into(),
-                },
-                backend_repr: abi,
-                largest_niche,
-                uninhabited,
-                size,
-                align: AbiAlign::new(align),
-                max_repr_align,
-                unadjusted_abi_align,
-                randomization_seed: combined_seed,
-            };
-
-            Some(layout)
-        };
-
-        let calculate_niche_filling_layout_repacked =
-            || -> Option<LayoutData<FieldIdx, VariantIdx>> {
-                struct VariantLayoutInfo {
-                    align_abi: Align,
-                }
-
-                if repr.inhibit_enum_layout_opt() {
-                    return None;
-                }
-
-                if variants.len() < 2 {
-                    return None;
-                }
-
-                let mut align = dl.aggregate_align;
-                let mut max_repr_align = repr.align;
-                let mut unadjusted_abi_align = align;
-                let mut combined_seed = repr.field_shuffle_seed;
-
-                let mut variants_info = IndexVec::<VariantIdx, _>::with_capacity(variants.len());
-                let variant_layouts = variants
-                    .iter()
-                    .map(|v| {
-                        let st = self.univariant(v, repr, StructKind::AlwaysSized).ok()?;
-
-                        variants_info.push(VariantLayoutInfo { align_abi: st.align.abi });
-
-                        align = align.max(st.align.abi);
-                        max_repr_align = max_repr_align.max(st.max_repr_align);
-                        unadjusted_abi_align = unadjusted_abi_align.max(st.unadjusted_abi_align);
-                        combined_seed = combined_seed.wrapping_add(st.randomization_seed);
-
-                        Some(VariantLayout::from_layout(st))
-                    })
-                    .collect::<Option<IndexVec<VariantIdx, _>>>()?;
-
-                let max_variant_size = variant_layouts.iter().map(|layout| layout.size).max()?;
-
-                // Chooses the first max-sized niche-providing variant whose layout succeeds.
-                for (largest_variant_index, _) in
-                    variant_layouts.iter_enumerated().filter(|&(_, layout)| {
-                        layout.size == max_variant_size && layout.largest_niche.is_some()
-                    })
-                {
+            let try_niche_variant =
+                |largest_variant_index: VariantIdx| -> Option<LayoutData<FieldIdx, VariantIdx>> {
+                    //so niche_variant candidates don't contaminate each other if one fails
                     let mut variant_layouts = variant_layouts.clone();
 
                     let all_indices = variants.indices();
                     let needs_disc = |index: VariantIdx| {
                         index != largest_variant_index && !absent(&variants[index])
                     };
-                    let Some(niche_variants_start) = all_indices.clone().find(|v| needs_disc(*v))
-                    else {
-                        continue;
+                    let niche_variants = RangeInclusive {
+                        start: all_indices.clone().find(|v| needs_disc(*v)).unwrap(),
+                        last: all_indices.rev().find(|v| needs_disc(*v)).unwrap(),
                     };
-                    let Some(niche_variants_end) = all_indices.rev().find(|v| needs_disc(*v))
-                    else {
-                        continue;
-                    };
-                    let niche_variants = niche_variants_start..=niche_variants_end;
 
-                    let count = (niche_variants.end().index() as u128
-                        - niche_variants.start().index() as u128)
+                    let count = (niche_variants.last.index() as u128
+                        - niche_variants.start.index() as u128)
                         + 1;
 
                     // Use the largest niche in the largest variant.
-                    let Some(niche) = variant_layouts[largest_variant_index].largest_niche else {
-                        continue;
-                    };
-                    let Some((niche_start, niche_scalar)) = niche.reserve(dl, count) else {
-                        continue;
-                    };
+                    let niche = variant_layouts[largest_variant_index].largest_niche?;
+                    let (niche_start, niche_scalar) = niche.reserve(dl, count)?;
                     let niche_offset = niche.offset;
                     let niche_size = niche.value.size(dl);
                     let size = variant_layouts[largest_variant_index].size.align_to(align);
@@ -844,41 +668,46 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                             let this_align = variants_info[i].align_abi;
                             let this_offset = (niche_offset + niche_size).align_to(this_align);
 
-                            if this_offset + layout.size > size {
-                                // The ordinary niche-filling path can only move a non-largest variant as a
-                                // whole before or after the chosen niche. If that fails, try placing the
-                                // variant's fields individually while treating the niche bytes as reserved.
-                                if let Some(repacked) = self.try_layout_variant_around_niche(
-                                    &variants[i],
-                                    repr,
-                                    i,
-                                    size,
-                                    align,
-                                    niche_offset,
-                                    niche_size,
-                                ) {
-                                    *layout = VariantLayout::from_layout(repacked);
-                                    return true;
+                            if this_offset + layout.size <= size {
+                                // It'll fit, but we need to make some adjustments.
+                                for offset in layout.field_offsets.iter_mut() {
+                                    *offset += this_offset;
                                 }
+
+                                // It can't be a Scalar or ScalarPair because the offset isn't 0.
+                                if !layout.is_uninhabited() {
+                                    layout.backend_repr = BackendRepr::Memory { sized: true };
+                                }
+                                layout.size += this_offset;
+
+                                return true;
+                            }
+                            // Repacking is currently only on future edition. For editions where it is disabled,
+                            // fall back to the original niche-filling behaviour.
+                            if !repr.can_repack_variant_around_niche() {
                                 return false;
                             }
-
-                            // It'll fit, but we need to make some adjustments.
-                            for offset in layout.field_offsets.iter_mut() {
-                                *offset += this_offset;
+                            // The ordinary niche-filling path can only move a non-largest variant as a
+                            // whole before or after the chosen niche. If that fails, try placing the
+                            // variant's fields individually while treating the niche bytes as reserved.
+                            if let Some(repacked) = self.try_layout_variant_around_niche(
+                                &variants[i],
+                                repr,
+                                i,
+                                size,
+                                align,
+                                niche_offset,
+                                niche_size,
+                            ) {
+                                *layout = VariantLayout::from_layout(repacked);
+                                return true;
                             }
 
-                            // It can't be a Scalar or ScalarPair because the offset isn't 0.
-                            if !layout.is_uninhabited() {
-                                layout.backend_repr = BackendRepr::Memory { sized: true };
-                            }
-                            layout.size += this_offset;
-
-                            true
+                            false
                         });
 
                     if !all_variants_fit {
-                        continue;
+                        return None;
                     }
 
                     let largest_niche = Niche::from_scalar(dl, niche_offset, niche_scalar);
@@ -895,13 +724,21 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                             // When the total alignment and size match, we can use the
                             // same ABI as the scalar variant with the reserved niche.
                             BackendRepr::Scalar(_) => BackendRepr::Scalar(niche_scalar),
-                            BackendRepr::ScalarPair(first, second) => {
+                            BackendRepr::ScalarPair { a: first, b: second, b_offset } => {
                                 // Only the niche is guaranteed to be initialised,
                                 // so use union layouts for the other primitive.
                                 if niche_offset == Size::ZERO {
-                                    BackendRepr::ScalarPair(niche_scalar, second.to_union())
+                                    BackendRepr::ScalarPair {
+                                        a: niche_scalar,
+                                        b: second.to_union(),
+                                        b_offset,
+                                    }
                                 } else {
-                                    BackendRepr::ScalarPair(first.to_union(), niche_scalar)
+                                    BackendRepr::ScalarPair {
+                                        a: first.to_union(),
+                                        b: niche_scalar,
+                                        b_offset,
+                                    }
                                 }
                             }
                             _ => BackendRepr::Memory { sized: true },
@@ -910,7 +747,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                         BackendRepr::Memory { sized: true }
                     };
 
-                    return Some(LayoutData {
+                    let layout = LayoutData {
                         variants: Variants::Multiple {
                             tag: niche_scalar,
                             tag_encoding: TagEncoding::Niche {
@@ -933,17 +770,34 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                         max_repr_align,
                         unadjusted_abi_align,
                         randomization_seed: combined_seed,
-                    });
+                    };
+
+                    Some(layout)
+                };
+            if repr.can_repack_variant_around_niche() {
+                let max_variant_size = variant_layouts.iter().map(|layout| layout.size).max()?;
+                // Chooses the first max-sized niche-providing variant whose layout succeeds.
+                for (largest_variant_index, _) in
+                    variant_layouts.iter_enumerated().filter(|&(_, layout)| {
+                        layout.size == max_variant_size && layout.largest_niche.is_some()
+                    })
+                {
+                    if let Some(layout) = try_niche_variant(largest_variant_index) {
+                        return Some(layout);
+                    }
                 }
 
                 None
-            };
-
-        let niche_filling_layout = if repr.can_repack_variant_around_niche() {
-            calculate_niche_filling_layout_repacked()
-        } else {
-            calculate_niche_filling_layout()
+            } else {
+                let largest_variant_index = variant_layouts
+                    .iter_enumerated()
+                    .max_by_key(|(_i, layout)| layout.size.bytes())
+                    .map(|(i, _layout)| i)?;
+                try_niche_variant(largest_variant_index)
+            }
         };
+
+        let niche_filling_layout = calculate_niche_filling_layout();
 
         let discr_type = repr.discr_type();
         let discr_size = Integer::from_attr(dl, discr_type).size();

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -682,11 +682,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
 
                                 return true;
                             }
-                            // Repacking is currently only on future edition. For editions where it is disabled,
-                            // fall back to the original niche-filling behaviour.
-                            if !repr.can_repack_variant_around_niche() {
-                                return false;
-                            }
+
                             // The ordinary niche-filling path can only move a non-largest variant as a
                             // whole before or after the chosen niche. If that fails, try placing the
                             // variant's fields individually while treating the niche bytes as reserved.
@@ -774,27 +770,20 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
 
                     Some(layout)
                 };
-            if repr.can_repack_variant_around_niche() {
-                let max_variant_size = variant_layouts.iter().map(|layout| layout.size).max()?;
-                // Chooses the first max-sized niche-providing variant whose layout succeeds.
-                for (largest_variant_index, _) in
-                    variant_layouts.iter_enumerated().filter(|&(_, layout)| {
-                        layout.size == max_variant_size && layout.largest_niche.is_some()
-                    })
-                {
-                    if let Some(layout) = try_niche_variant(largest_variant_index) {
-                        return Some(layout);
-                    }
-                }
 
-                None
-            } else {
-                let largest_variant_index = variant_layouts
-                    .iter_enumerated()
-                    .max_by_key(|(_i, layout)| layout.size.bytes())
-                    .map(|(i, _layout)| i)?;
-                try_niche_variant(largest_variant_index)
+            let max_variant_size = variant_layouts.iter().map(|layout| layout.size).max()?;
+            // Chooses the first max-sized niche-providing variant whose layout succeeds.
+            for (largest_variant_index, _) in
+                variant_layouts.iter_enumerated().filter(|&(_, layout)| {
+                    layout.size == max_variant_size && layout.largest_niche.is_some()
+                })
+            {
+                if let Some(layout) = try_niche_variant(largest_variant_index) {
+                    return Some(layout);
+                }
             }
+
+            None
         };
 
         let niche_filling_layout = calculate_niche_filling_layout();

--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -752,7 +752,198 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             Some(layout)
         };
 
-        let niche_filling_layout = calculate_niche_filling_layout();
+        let calculate_niche_filling_layout_repacked =
+            || -> Option<LayoutData<FieldIdx, VariantIdx>> {
+                struct VariantLayoutInfo {
+                    align_abi: Align,
+                }
+
+                if repr.inhibit_enum_layout_opt() {
+                    return None;
+                }
+
+                if variants.len() < 2 {
+                    return None;
+                }
+
+                let mut align = dl.aggregate_align;
+                let mut max_repr_align = repr.align;
+                let mut unadjusted_abi_align = align;
+                let mut combined_seed = repr.field_shuffle_seed;
+
+                let mut variants_info = IndexVec::<VariantIdx, _>::with_capacity(variants.len());
+                let variant_layouts = variants
+                    .iter()
+                    .map(|v| {
+                        let st = self.univariant(v, repr, StructKind::AlwaysSized).ok()?;
+
+                        variants_info.push(VariantLayoutInfo { align_abi: st.align.abi });
+
+                        align = align.max(st.align.abi);
+                        max_repr_align = max_repr_align.max(st.max_repr_align);
+                        unadjusted_abi_align = unadjusted_abi_align.max(st.unadjusted_abi_align);
+                        combined_seed = combined_seed.wrapping_add(st.randomization_seed);
+
+                        Some(VariantLayout::from_layout(st))
+                    })
+                    .collect::<Option<IndexVec<VariantIdx, _>>>()?;
+
+                let max_variant_size = variant_layouts.iter().map(|layout| layout.size).max()?;
+
+                // Chooses the first max-sized niche-providing variant whose layout succeeds.
+                for (largest_variant_index, _) in
+                    variant_layouts.iter_enumerated().filter(|&(_, layout)| {
+                        layout.size == max_variant_size && layout.largest_niche.is_some()
+                    })
+                {
+                    let mut variant_layouts = variant_layouts.clone();
+
+                    let all_indices = variants.indices();
+                    let needs_disc = |index: VariantIdx| {
+                        index != largest_variant_index && !absent(&variants[index])
+                    };
+                    let Some(niche_variants_start) = all_indices.clone().find(|v| needs_disc(*v))
+                    else {
+                        continue;
+                    };
+                    let Some(niche_variants_end) = all_indices.rev().find(|v| needs_disc(*v))
+                    else {
+                        continue;
+                    };
+                    let niche_variants = niche_variants_start..=niche_variants_end;
+
+                    let count = (niche_variants.end().index() as u128
+                        - niche_variants.start().index() as u128)
+                        + 1;
+
+                    // Use the largest niche in the largest variant.
+                    let Some(niche) = variant_layouts[largest_variant_index].largest_niche else {
+                        continue;
+                    };
+                    let Some((niche_start, niche_scalar)) = niche.reserve(dl, count) else {
+                        continue;
+                    };
+                    let niche_offset = niche.offset;
+                    let niche_size = niche.value.size(dl);
+                    let size = variant_layouts[largest_variant_index].size.align_to(align);
+
+                    let all_variants_fit =
+                        variant_layouts.iter_enumerated_mut().all(|(i, layout)| {
+                            if i == largest_variant_index {
+                                return true;
+                            }
+
+                            layout.largest_niche = None;
+
+                            if layout.size <= niche_offset {
+                                // This variant will fit before the niche.
+                                return true;
+                            }
+
+                            // Determine if it'll fit after the niche.
+                            let this_align = variants_info[i].align_abi;
+                            let this_offset = (niche_offset + niche_size).align_to(this_align);
+
+                            if this_offset + layout.size > size {
+                                // The ordinary niche-filling path can only move a non-largest variant as a
+                                // whole before or after the chosen niche. If that fails, try placing the
+                                // variant's fields individually while treating the niche bytes as reserved.
+                                if let Some(repacked) = self.try_layout_variant_around_niche(
+                                    &variants[i],
+                                    repr,
+                                    i,
+                                    size,
+                                    align,
+                                    niche_offset,
+                                    niche_size,
+                                ) {
+                                    *layout = VariantLayout::from_layout(repacked);
+                                    return true;
+                                }
+                                return false;
+                            }
+
+                            // It'll fit, but we need to make some adjustments.
+                            for offset in layout.field_offsets.iter_mut() {
+                                *offset += this_offset;
+                            }
+
+                            // It can't be a Scalar or ScalarPair because the offset isn't 0.
+                            if !layout.is_uninhabited() {
+                                layout.backend_repr = BackendRepr::Memory { sized: true };
+                            }
+                            layout.size += this_offset;
+
+                            true
+                        });
+
+                    if !all_variants_fit {
+                        continue;
+                    }
+
+                    let largest_niche = Niche::from_scalar(dl, niche_offset, niche_scalar);
+
+                    let others_zst = variant_layouts
+                        .iter_enumerated()
+                        .all(|(i, layout)| i == largest_variant_index || layout.size == Size::ZERO);
+                    let same_size = size == variant_layouts[largest_variant_index].size;
+                    let same_align = align == variants_info[largest_variant_index].align_abi;
+
+                    let uninhabited = variant_layouts.iter().all(|v| v.is_uninhabited());
+                    let abi = if same_size && same_align && others_zst {
+                        match variant_layouts[largest_variant_index].backend_repr {
+                            // When the total alignment and size match, we can use the
+                            // same ABI as the scalar variant with the reserved niche.
+                            BackendRepr::Scalar(_) => BackendRepr::Scalar(niche_scalar),
+                            BackendRepr::ScalarPair(first, second) => {
+                                // Only the niche is guaranteed to be initialised,
+                                // so use union layouts for the other primitive.
+                                if niche_offset == Size::ZERO {
+                                    BackendRepr::ScalarPair(niche_scalar, second.to_union())
+                                } else {
+                                    BackendRepr::ScalarPair(first.to_union(), niche_scalar)
+                                }
+                            }
+                            _ => BackendRepr::Memory { sized: true },
+                        }
+                    } else {
+                        BackendRepr::Memory { sized: true }
+                    };
+
+                    return Some(LayoutData {
+                        variants: Variants::Multiple {
+                            tag: niche_scalar,
+                            tag_encoding: TagEncoding::Niche {
+                                untagged_variant: largest_variant_index,
+                                niche_variants,
+                                niche_start,
+                            },
+                            tag_field: FieldIdx::new(0),
+                            variants: variant_layouts,
+                        },
+                        fields: FieldsShape::Arbitrary {
+                            offsets: [niche_offset].into(),
+                            in_memory_order: [FieldIdx::new(0)].into(),
+                        },
+                        backend_repr: abi,
+                        largest_niche,
+                        uninhabited,
+                        size,
+                        align: AbiAlign::new(align),
+                        max_repr_align,
+                        unadjusted_abi_align,
+                        randomization_seed: combined_seed,
+                    });
+                }
+
+                None
+            };
+
+        let niche_filling_layout = if repr.can_repack_variant_around_niche() {
+            calculate_niche_filling_layout_repacked()
+        } else {
+            calculate_niche_filling_layout()
+        };
 
         let discr_type = repr.discr_type();
         let discr_size = Integer::from_attr(dl, discr_type).size();
@@ -1076,6 +1267,121 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
         };
 
         Ok(best_layout)
+    }
+
+    fn try_layout_variant_around_niche<
+        'a,
+        FieldIdx: Idx,
+        VariantIdx: Idx,
+        F: Deref<Target = &'a LayoutData<FieldIdx, VariantIdx>> + fmt::Debug + Copy,
+    >(
+        &self,
+        fields: &IndexSlice<FieldIdx, F>,
+        repr: &ReprOptions,
+        variant_index: VariantIdx,
+        total_size: Size,
+        total_align: Align,
+        niche_offset: Size,
+        niche_size: Size,
+    ) -> Option<LayoutData<FieldIdx, VariantIdx>> {
+        let dl = self.cx.data_layout();
+
+        if repr.inhibit_struct_field_reordering() {
+            return None;
+        }
+        if fields.iter().any(|f| f.is_unsized()) {
+            return None;
+        }
+
+        // This is only a necessary condition: alignment can still make placement fail below.
+        let min_used_size = fields.iter().try_fold(niche_size, |size, field| {
+            if field.is_zst() { Some(size) } else { size.checked_add(field.size, dl) }
+        })?;
+        if min_used_size > total_size {
+            return None;
+        }
+
+        let mut offsets = IndexVec::from_elem(Size::ZERO, fields);
+        let mut in_memory_order: IndexVec<u32, FieldIdx> = fields.indices().collect();
+
+        in_memory_order.raw.sort_by_key(|&i| {
+            let field = &fields[i];
+
+            let field_align = if let Some(pack) = repr.pack {
+                field.align.min(AbiAlign::new(pack))
+            } else {
+                field.align
+            };
+
+            (cmp::Reverse(field_align.abi.bytes()), cmp::Reverse(field.size.bytes()))
+        });
+
+        let niche_end = niche_offset.checked_add(niche_size, dl)?;
+        let mut occupied = vec![(niche_offset, niche_end)];
+
+        let mut max_repr_align = repr.align;
+        let mut unadjusted_abi_align =
+            if repr.pack.is_some() { dl.i8_align } else { dl.aggregate_align };
+
+        for &i in &in_memory_order {
+            let field = &fields[i];
+
+            let field_align = if let Some(pack) = repr.pack {
+                field.align.min(AbiAlign::new(pack))
+            } else {
+                field.align
+            };
+
+            max_repr_align = max_repr_align.max(field.max_repr_align);
+            unadjusted_abi_align = unadjusted_abi_align.max(field_align.abi);
+
+            let mut candidate = Size::ZERO;
+            'search: loop {
+                candidate = candidate.align_to(field_align.abi);
+
+                let end = candidate.checked_add(field.size, dl)?;
+                if end > total_size {
+                    return None;
+                }
+
+                for &(occupied_start, occupied_end) in &occupied {
+                    if end <= occupied_start {
+                        break;
+                    }
+                    if candidate < occupied_end {
+                        candidate = occupied_end;
+                        continue 'search;
+                    }
+                }
+
+                offsets[i] = candidate;
+
+                if !field.is_zst() {
+                    occupied.push((candidate, end));
+                    occupied.sort_by_key(|&(start, _end)| start);
+                }
+
+                break;
+            }
+        }
+
+        in_memory_order.raw.sort_by_key(|&i| offsets[i]);
+
+        Some(LayoutData {
+            variants: Variants::Single { index: variant_index },
+            fields: FieldsShape::Arbitrary { offsets, in_memory_order },
+            backend_repr: BackendRepr::Memory { sized: true },
+            largest_niche: None,
+            uninhabited: fields.iter().any(|f| f.is_uninhabited()),
+            align: AbiAlign::new(total_align),
+            size: total_size,
+            max_repr_align,
+            unadjusted_abi_align,
+            randomization_seed: fields
+                .iter()
+                .fold(Hash64::ZERO, |acc, f| acc.wrapping_add(f.randomization_seed))
+                .wrapping_add(repr.field_shuffle_seed),
+        })
     }
 
     fn univariant_biased<

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -101,9 +101,6 @@ bitflags! {
         /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
         const PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS = 1 << 5;
         const IS_SCALABLE        = 1 << 6;
-        /// If true, enum niche-filling may repack variant fields around the reserved niche.
-        const CAN_REPACK_VARIANT_AROUND_NICHE = 1 << 7;
-        // Any of these flags being set prevent field reordering optimisation.
         const FIELD_ORDER_UNOPTIMIZABLE = ReprFlags::IS_C.bits()
                                  | ReprFlags::IS_SIMD.bits()
                                  | ReprFlags::IS_SCALABLE.bits()
@@ -233,12 +230,6 @@ impl ReprOptions {
     /// was enabled for its declaration crate.
     pub fn can_randomize_type_layout(&self) -> bool {
         !self.inhibit_struct_field_reordering() && self.flags.contains(ReprFlags::RANDOMIZE_LAYOUT)
-    }
-
-    /// Returns `true` if enum niche-filling can try to pack variant fields around
-    /// the reserved niche when whole-variant placement fails.
-    pub fn can_repack_variant_around_niche(&self) -> bool {
-        self.flags.contains(ReprFlags::CAN_REPACK_VARIANT_AROUND_NICHE)
     }
 
     /// Returns `true` if this `#[repr()]` should inhibit union ABI optimisations.

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -101,7 +101,9 @@ bitflags! {
         /// See [`TyAndLayout::pass_indirectly_in_non_rustic_abis`] for details.
         const PASS_INDIRECTLY_IN_NON_RUSTIC_ABIS = 1 << 5;
         const IS_SCALABLE        = 1 << 6;
-         // Any of these flags being set prevent field reordering optimisation.
+        /// If true, enum niche-filling may repack variant fields around the reserved niche.
+        const CAN_REPACK_VARIANT_AROUND_NICHE = 1 << 7;
+        // Any of these flags being set prevent field reordering optimisation.
         const FIELD_ORDER_UNOPTIMIZABLE = ReprFlags::IS_C.bits()
                                  | ReprFlags::IS_SIMD.bits()
                                  | ReprFlags::IS_SCALABLE.bits()
@@ -231,6 +233,12 @@ impl ReprOptions {
     /// was enabled for its declaration crate.
     pub fn can_randomize_type_layout(&self) -> bool {
         !self.inhibit_struct_field_reordering() && self.flags.contains(ReprFlags::RANDOMIZE_LAYOUT)
+    }
+
+    /// Returns `true` if enum niche-filling can try to pack variant fields around
+    /// the reserved niche when whole-variant placement fails.
+    pub fn can_repack_variant_around_niche(&self) -> bool {
+        self.flags.contains(ReprFlags::CAN_REPACK_VARIANT_AROUND_NICHE)
     }
 
     /// Returns `true` if this `#[repr()]` should inhibit union ABI optimisations.

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -4468,7 +4468,13 @@ mod size_asserts {
     static_assert_size!(GenericParam, 80);
     static_assert_size!(Generics, 40);
     static_assert_size!(Impl, 80);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(Item, 136);
+    #[cfg(bootstrap)]
     static_assert_size!(Item, 144);
+    #[cfg(not(bootstrap))]
+    static_assert_size!(ItemKind, 80);
+    #[cfg(bootstrap)]
     static_assert_size!(ItemKind, 88);
     static_assert_size!(Lifetime, 16);
     static_assert_size!(LitKind, 24);

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1770,10 +1770,6 @@ impl<'tcx> TyCtxt<'tcx> {
             flags.insert(ReprFlags::RANDOMIZE_LAYOUT);
         }
 
-        if self.def_span(did).edition().at_least_edition_future() {
-            flags.insert(ReprFlags::CAN_REPACK_VARIANT_AROUND_NICHE);
-        }
-
         // box is special, on the one hand the compiler assumes an ordered layout, with the pointer
         // always at offset zero. On the other hand we want scalar abi optimizations.
         let is_box = self.is_lang_item(did.to_def_id(), LangItem::OwnedBox);

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1770,6 +1770,10 @@ impl<'tcx> TyCtxt<'tcx> {
             flags.insert(ReprFlags::RANDOMIZE_LAYOUT);
         }
 
+        if self.def_span(did).edition().at_least_edition_future() {
+            flags.insert(ReprFlags::CAN_REPACK_VARIANT_AROUND_NICHE);
+        }
+
         // box is special, on the one hand the compiler assumes an ordered layout, with the pointer
         // always at offset zero. On the other hand we want scalar abi optimizations.
         let is_box = self.is_lang_item(did.to_def_id(), LangItem::OwnedBox);

--- a/tests/ui/print_type_sizes/padding.stdout
+++ b/tests/ui/print_type_sizes/padding.stdout
@@ -1,21 +1,15 @@
-print-type-size type: `E1`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
-print-type-size     variant `B`: 11 bytes
-print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size     variant `A`: 7 bytes
+print-type-size type: `E1`: 8 bytes, alignment: 4 bytes
+print-type-size     variant `B`: 8 bytes
+print-type-size         field `.0`: 8 bytes
+print-type-size     variant `A`: 5 bytes
+print-type-size         field `.0`: 4 bytes
 print-type-size         field `.1`: 1 bytes
-print-type-size         padding: 2 bytes
-print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
-print-type-size type: `E2`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
-print-type-size     variant `B`: 11 bytes
-print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size     variant `A`: 7 bytes
+print-type-size type: `E2`: 8 bytes, alignment: 4 bytes
+print-type-size     variant `B`: 8 bytes
+print-type-size         field `.0`: 8 bytes
+print-type-size     variant `A`: 5 bytes
+print-type-size         field `.1`: 4 bytes
 print-type-size         field `.0`: 1 bytes
-print-type-size         padding: 2 bytes
-print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
 print-type-size type: `S`: 8 bytes, alignment: 4 bytes
 print-type-size     field `.g`: 4 bytes
 print-type-size     field `.a`: 1 bytes

--- a/tests/ui/stats/input-stats.rs
+++ b/tests/ui/stats/input-stats.rs
@@ -15,6 +15,7 @@
 // stage1 and stage2 will give different outputs for this test.
 // Add an `ignore-stage1` comment marker to work around that problem during
 // that time.
+//@ ignore-stage1
 
 
 // The aim here is to include at least one of every different type of top-level

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -2,14 +2,14 @@ ast-stats ================================================================
 ast-stats POST EXPANSION AST STATS: input_stats
 ast-stats Name                Accumulated Size         Count     Item Size
 ast-stats ----------------------------------------------------------------
-ast-stats Item                   1_584 (NN.N%)            11           144
-ast-stats - Enum                     144 (NN.N%)             1
-ast-stats - ExternCrate              144 (NN.N%)             1
-ast-stats - ForeignMod               144 (NN.N%)             1
-ast-stats - Impl                     144 (NN.N%)             1
-ast-stats - Trait                    144 (NN.N%)             1
-ast-stats - Fn                       288 (NN.N%)             2
-ast-stats - Use                      576 (NN.N%)             4
+ast-stats Item                   1_496 (NN.N%)            11           136
+ast-stats - Enum                     136 (NN.N%)             1
+ast-stats - ExternCrate              136 (NN.N%)             1
+ast-stats - ForeignMod               136 (NN.N%)             1
+ast-stats - Impl                     136 (NN.N%)             1
+ast-stats - Trait                    136 (NN.N%)             1
+ast-stats - Fn                       272 (NN.N%)             2
+ast-stats - Use                      544 (NN.N%)             4
 ast-stats PathSegment              840 (NN.N%)            35            24
 ast-stats Ty                       784 (NN.N%)            14            56
 ast-stats - Ptr                       56 (NN.N%)             1
@@ -58,7 +58,7 @@ ast-stats GenericArgs               40 (NN.N%)             1            40
 ast-stats - AngleBracketed            40 (NN.N%)             1
 ast-stats Crate                     40 (NN.N%)             1            40
 ast-stats ----------------------------------------------------------------
-ast-stats Total                  6_872                   126
+ast-stats Total                  6_784                   126
 ast-stats ================================================================
 hir-stats ================================================================
 hir-stats HIR STATS: input_stats

--- a/tests/ui/structs-enums/enum-niche-fill-around-tag.rs
+++ b/tests/ui/structs-enums/enum-niche-fill-around-tag.rs
@@ -1,0 +1,140 @@
+//@ revisions: old future
+//@ run-pass
+//@ [old] edition:2024
+//@ [future] edition:future
+//@ [future] compile-flags: -Z unstable-options
+
+#![allow(dead_code)]
+#![cfg_attr(future, feature(offset_of_enum))]
+
+#[cfg(future)]
+use std::mem::{align_of, offset_of};
+use std::mem::size_of;
+use std::num::NonZero;
+
+enum Inner {
+    A(u8, u32),
+    B(u32),
+}
+
+enum Outer {
+    A(Inner),
+    B(u32, u8),
+}
+
+struct WithPadding {
+    a: bool,
+    b: bool,
+    c: u32,
+}
+
+enum RepackPadding {
+    A(u32, u8),
+    B(WithPadding),
+}
+
+struct RepackedBase {
+    int32: u32,
+    boolean: bool,
+}
+
+enum RepackedAroundNiche {
+    A(RepackedBase),
+    B(u16, u32, u8),
+}
+
+enum NestedRepackedAroundNiche {
+    A(RepackedAroundNiche),
+    B(u16, u32, u8),
+}
+
+struct RepackedPair {
+    field2: u16,
+    field3: u8,
+}
+
+enum RepackedNestedAggregate {
+    A(u16, RepackedPair),
+    B(NestedRepackedAroundNiche),
+}
+
+struct FittingNichePayload {
+    word: u32,
+    flag: bool,
+}
+
+// The first and last max-sized niche candidates cannot encode all variants.
+// The middle candidate can, so the enum layout has to keep looking.
+enum ChooseFittingNiche {
+    SmallNicheFront(u16, u32, NonZero<u8>),
+    WideNiche(FittingNichePayload),
+    SmallNicheBack(u16, u32, NonZero<u8>),
+    V0,
+    V1,
+    V2,
+}
+
+fn main() {
+    assert_eq!(size_of::<Inner>(), 8);
+
+    #[cfg(old)]
+    {
+        assert_eq!(size_of::<Outer>(), 12);
+        assert_eq!(size_of::<RepackPadding>(), 12);
+    }
+
+    #[cfg(future)]
+    {
+        assert_eq!(size_of::<Outer>(), 8);
+        assert_eq!(size_of::<RepackPadding>(), 8);
+
+        assert_eq!(size_of::<RepackedBase>(), 8);
+        assert_eq!(align_of::<RepackedBase>(), 4);
+        assert_eq!(offset_of!(RepackedBase, int32), 0);
+        assert_eq!(offset_of!(RepackedBase, boolean), 4);
+
+        assert_eq!(size_of::<RepackedAroundNiche>(), 8);
+        assert_eq!(align_of::<RepackedAroundNiche>(), 4);
+        assert_eq!(size_of::<Option<RepackedAroundNiche>>(), 8);
+        assert_eq!(offset_of!(RepackedAroundNiche, A.0), 0);
+        assert_eq!(offset_of!(RepackedAroundNiche, B.1), 0);
+        assert_eq!(offset_of!(RepackedAroundNiche, B.2), 5);
+        assert_eq!(offset_of!(RepackedAroundNiche, B.0), 6);
+
+        assert_eq!(size_of::<NestedRepackedAroundNiche>(), 8);
+        assert_eq!(align_of::<NestedRepackedAroundNiche>(), 4);
+        assert_eq!(size_of::<Option<NestedRepackedAroundNiche>>(), 8);
+        assert_eq!(offset_of!(NestedRepackedAroundNiche, A.0), 0);
+        assert_eq!(offset_of!(NestedRepackedAroundNiche, B.1), 0);
+        assert_eq!(offset_of!(NestedRepackedAroundNiche, B.2), 5);
+        assert_eq!(offset_of!(NestedRepackedAroundNiche, B.0), 6);
+
+        assert_eq!(size_of::<RepackedPair>(), 4);
+        assert_eq!(align_of::<RepackedPair>(), 2);
+        assert_eq!(offset_of!(RepackedPair, field2), 0);
+        assert_eq!(offset_of!(RepackedPair, field3), 2);
+
+        assert_eq!(size_of::<RepackedNestedAggregate>(), 8);
+        assert_eq!(align_of::<RepackedNestedAggregate>(), 4);
+        assert_eq!(size_of::<Option<RepackedNestedAggregate>>(), 8);
+        assert_eq!(offset_of!(RepackedNestedAggregate, B.0), 0);
+        assert_eq!(offset_of!(RepackedNestedAggregate, A.1), 0);
+        assert_eq!(offset_of!(RepackedNestedAggregate, A.0), 6);
+
+        assert_eq!(size_of::<FittingNichePayload>(), 8);
+        assert_eq!(align_of::<FittingNichePayload>(), 4);
+        assert_eq!(offset_of!(FittingNichePayload, word), 0);
+        assert_eq!(offset_of!(FittingNichePayload, flag), 4);
+
+        assert_eq!(size_of::<ChooseFittingNiche>(), 8);
+        assert_eq!(align_of::<ChooseFittingNiche>(), 4);
+        assert_eq!(size_of::<Option<ChooseFittingNiche>>(), 8);
+        assert_eq!(offset_of!(ChooseFittingNiche, WideNiche.0), 0);
+        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.1), 0);
+        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.2), 5);
+        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.0), 6);
+        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.1), 0);
+        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.2), 5);
+        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.0), 6);
+    }
+}

--- a/tests/ui/structs-enums/enum-niche-fill-around-tag.rs
+++ b/tests/ui/structs-enums/enum-niche-fill-around-tag.rs
@@ -1,13 +1,8 @@
-//@ revisions: old future
 //@ run-pass
-//@ [old] edition:2024
-//@ [future] edition:future
-//@ [future] compile-flags: -Z unstable-options
 
 #![allow(dead_code)]
-#![cfg_attr(future, feature(offset_of_enum))]
+#![feature(offset_of_enum)]
 
-#[cfg(future)]
 use std::mem::{align_of, offset_of};
 use std::mem::size_of;
 use std::num::NonZero;
@@ -77,64 +72,55 @@ enum ChooseFittingNiche {
 fn main() {
     assert_eq!(size_of::<Inner>(), 8);
 
-    #[cfg(old)]
-    {
-        assert_eq!(size_of::<Outer>(), 12);
-        assert_eq!(size_of::<RepackPadding>(), 12);
-    }
+    assert_eq!(size_of::<Outer>(), 8);
+    assert_eq!(size_of::<RepackPadding>(), 8);
 
-    #[cfg(future)]
-    {
-        assert_eq!(size_of::<Outer>(), 8);
-        assert_eq!(size_of::<RepackPadding>(), 8);
+    assert_eq!(size_of::<RepackedBase>(), 8);
+    assert_eq!(align_of::<RepackedBase>(), 4);
+    assert_eq!(offset_of!(RepackedBase, int32), 0);
+    assert_eq!(offset_of!(RepackedBase, boolean), 4);
 
-        assert_eq!(size_of::<RepackedBase>(), 8);
-        assert_eq!(align_of::<RepackedBase>(), 4);
-        assert_eq!(offset_of!(RepackedBase, int32), 0);
-        assert_eq!(offset_of!(RepackedBase, boolean), 4);
+    assert_eq!(size_of::<RepackedAroundNiche>(), 8);
+    assert_eq!(align_of::<RepackedAroundNiche>(), 4);
+    assert_eq!(size_of::<Option<RepackedAroundNiche>>(), 8);
+    assert_eq!(offset_of!(RepackedAroundNiche, A.0), 0);
+    assert_eq!(offset_of!(RepackedAroundNiche, B.1), 0);
+    assert_eq!(offset_of!(RepackedAroundNiche, B.2), 5);
+    assert_eq!(offset_of!(RepackedAroundNiche, B.0), 6);
 
-        assert_eq!(size_of::<RepackedAroundNiche>(), 8);
-        assert_eq!(align_of::<RepackedAroundNiche>(), 4);
-        assert_eq!(size_of::<Option<RepackedAroundNiche>>(), 8);
-        assert_eq!(offset_of!(RepackedAroundNiche, A.0), 0);
-        assert_eq!(offset_of!(RepackedAroundNiche, B.1), 0);
-        assert_eq!(offset_of!(RepackedAroundNiche, B.2), 5);
-        assert_eq!(offset_of!(RepackedAroundNiche, B.0), 6);
+    assert_eq!(size_of::<NestedRepackedAroundNiche>(), 8);
+    assert_eq!(align_of::<NestedRepackedAroundNiche>(), 4);
+    assert_eq!(size_of::<Option<NestedRepackedAroundNiche>>(), 8);
+    assert_eq!(offset_of!(NestedRepackedAroundNiche, A.0), 0);
+    assert_eq!(offset_of!(NestedRepackedAroundNiche, B.1), 0);
+    assert_eq!(offset_of!(NestedRepackedAroundNiche, B.2), 5);
+    assert_eq!(offset_of!(NestedRepackedAroundNiche, B.0), 6);
 
-        assert_eq!(size_of::<NestedRepackedAroundNiche>(), 8);
-        assert_eq!(align_of::<NestedRepackedAroundNiche>(), 4);
-        assert_eq!(size_of::<Option<NestedRepackedAroundNiche>>(), 8);
-        assert_eq!(offset_of!(NestedRepackedAroundNiche, A.0), 0);
-        assert_eq!(offset_of!(NestedRepackedAroundNiche, B.1), 0);
-        assert_eq!(offset_of!(NestedRepackedAroundNiche, B.2), 5);
-        assert_eq!(offset_of!(NestedRepackedAroundNiche, B.0), 6);
+    assert_eq!(size_of::<RepackedPair>(), 4);
+    assert_eq!(align_of::<RepackedPair>(), 2);
+    assert_eq!(offset_of!(RepackedPair, field2), 0);
+    assert_eq!(offset_of!(RepackedPair, field3), 2);
 
-        assert_eq!(size_of::<RepackedPair>(), 4);
-        assert_eq!(align_of::<RepackedPair>(), 2);
-        assert_eq!(offset_of!(RepackedPair, field2), 0);
-        assert_eq!(offset_of!(RepackedPair, field3), 2);
+    assert_eq!(size_of::<RepackedNestedAggregate>(), 8);
+    assert_eq!(align_of::<RepackedNestedAggregate>(), 4);
+    assert_eq!(size_of::<Option<RepackedNestedAggregate>>(), 8);
+    assert_eq!(offset_of!(RepackedNestedAggregate, B.0), 0);
+    assert_eq!(offset_of!(RepackedNestedAggregate, A.1), 0);
+    assert_eq!(offset_of!(RepackedNestedAggregate, A.0), 6);
 
-        assert_eq!(size_of::<RepackedNestedAggregate>(), 8);
-        assert_eq!(align_of::<RepackedNestedAggregate>(), 4);
-        assert_eq!(size_of::<Option<RepackedNestedAggregate>>(), 8);
-        assert_eq!(offset_of!(RepackedNestedAggregate, B.0), 0);
-        assert_eq!(offset_of!(RepackedNestedAggregate, A.1), 0);
-        assert_eq!(offset_of!(RepackedNestedAggregate, A.0), 6);
+    assert_eq!(size_of::<FittingNichePayload>(), 8);
+    assert_eq!(align_of::<FittingNichePayload>(), 4);
+    assert_eq!(offset_of!(FittingNichePayload, word), 0);
+    assert_eq!(offset_of!(FittingNichePayload, flag), 4);
 
-        assert_eq!(size_of::<FittingNichePayload>(), 8);
-        assert_eq!(align_of::<FittingNichePayload>(), 4);
-        assert_eq!(offset_of!(FittingNichePayload, word), 0);
-        assert_eq!(offset_of!(FittingNichePayload, flag), 4);
-
-        assert_eq!(size_of::<ChooseFittingNiche>(), 8);
-        assert_eq!(align_of::<ChooseFittingNiche>(), 4);
-        assert_eq!(size_of::<Option<ChooseFittingNiche>>(), 8);
-        assert_eq!(offset_of!(ChooseFittingNiche, WideNiche.0), 0);
-        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.1), 0);
-        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.2), 5);
-        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.0), 6);
-        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.1), 0);
-        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.2), 5);
-        assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.0), 6);
-    }
+    assert_eq!(size_of::<ChooseFittingNiche>(), 8);
+    assert_eq!(align_of::<ChooseFittingNiche>(), 4);
+    assert_eq!(size_of::<Option<ChooseFittingNiche>>(), 8);
+    assert_eq!(offset_of!(ChooseFittingNiche, WideNiche.0), 0);
+    assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.1), 0);
+    assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.2), 5);
+    assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheFront.0), 6);
+    assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.1), 0);
+    assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.2), 5);
+    assert_eq!(offset_of!(ChooseFittingNiche, SmallNicheBack.0), 6);
 }


### PR DESCRIPTION
## Discussion
Following the discussion in this issue, we looked into the matter and tried to implement it. 

First, as @zachs18 said: for this example to work we would need to change the enum tag attribution strategy to create the lowest tag possible (instead of the biggest that does not increase the final size). Because currently this Inner tag is being created with 4bytes.
```
pub enum Inner {
    A(u32),
    B(u32),
}

pub enum Outer {
    A(Inner),
    B(u32, u8),
}
```
<https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=519748d9a2c1b53ee38c46bff89bf375>

The thing is, that looks to be done for optimizations in the LLVM :
<https://github.com/rust-lang/rust/blob/99b9a8850349e56247acb6ce19910c7f96db8439/compiler/rustc_abi/src/layout.rs#L894-L901>

Removing this optimization looks more like a regression, so instead let's use another example were the tag does not use all all space in alignment.

```
enum Inner {
    A(u32, u8),
    B(u32),
}

enum Outer {
    A(Inner),
    B(u32, u8),    
}
```
<https://play.rust-lang.org/?version=nightly&mode=debug&edition=2024&gist=e8f7bc1e568a63cc698d2b26036d817f>
In this example because of u8 in the Inner, the tag will only be 1 byte.
[tag(1byte)] [u8] [padding(2bytes)] [u32]
(8bytes in total)

Now in this example we could try to reorder fields. Outer::B could fit like this:
[tag(1b)] [u8(1b)] [pad(2b)] [u32(4b)], which as we can see fits in 8bytes.

## Implementation
Our solution is basically to place the variant fields all around the niche of the "biggest variant" instead of just trying to place the whole struct on the left or right, **when** the normal method does not work.

We are not sure of this, but since this changes the layout of a basic structure of Rust, we implemented this in a way that it only runs if compiled with the flag "-Zunstable-options --edition future".
Considering this, and that we needed to change the logic of selecting the biggest variant, and as to not complicate **calculate_niche_filling_layout** we added a closure **calculate_niche_filling_layout_repacked** that is based on **calculate_niche_filling_layout** with some changes in the biggest variant choice and the calling of the new function that tries repack fields around niche. 
<https://github.com/Pinguimmar/rust/blob/c34d41888b2f9167bac60167afe1e616e130a0d3/compiler/rustc_abi/src/layout.rs#L742-L752>
Thinking about it now, it is repeating quite some code so we should probably change it, but for now we will create this PR with the current version.

### Choice of Variant to serve as niche-tag
Before, choosing one of the max-size variants was good enough (because we use the whole struct as a unit), but now since we will be reordering the fields, it is not sufficient. The size of a variant includes alignments, but since we will be placing the fields individually, that padding space may disappear, which would mean that the variant size is not correct. With this in mind we substituted it by a for loop that runs through the the variants that have the biggest size and contain niche.
<https://github.com/Pinguimmar/rust/blob/c34d41888b2f9167bac60167afe1e616e130a0d3/compiler/rustc_abi/src/layout.rs#L778-L785>

We accept the first max-size variant that works, as trying all max-size variants as niche-tag candidates would not optimize the final enum size and we deem not worth it, but this is debatable.

### Repacking fields Function
We created a function that tries to fit the fields around the niche. Instead of handling the variant as a whole struct we treat each field individually. We consider the niche as a fixed offset and occupied, and then for each field we try to put it in the first possible position. The fields are placed by decreasing order, so as to avoid paddings.

Note that this function is only called if any of the variants cannot fit as a whole **before and after** the niche, (in a give up case). We implemented it in this way so as to not increase complexity for the cases that currently work.
<https://github.com/Pinguimmar/rust/blob/c34d41888b2f9167bac60167afe1e616e130a0d3/compiler/rustc_abi/src/layout.rs#L824-L852>

Closes rust-lang/rust#147341 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
