### PR TITLE
Stabilize `dyn` subset of `Allocator` as `core::alloc::Alloc`

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -202,14 +202,14 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 impl Global {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    fn alloc_impl_runtime(layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+    fn alloc_impl_runtime(layout: Layout, zeroed: bool) -> Result<NonNull<u8>, AllocError> {
         match layout.size() {
-            0 => Ok(layout.dangling_ptr().cast_slice(0)),
+            0 => Ok(layout.dangling_ptr()),
             // SAFETY: `layout` is non-zero in size,
-            size => unsafe {
+            _ => unsafe {
                 let raw_ptr = if zeroed { alloc_zeroed(layout) } else { alloc(layout) };
                 let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
-                Ok(ptr.cast_slice(size))
+                Ok(ptr)
             },
         }
     }
@@ -224,13 +224,13 @@ impl Global {
             //   "fit" always means a layout that is equal to the original, because our
             //   `allocate()`, `grow()`, and `shrink()` implementations never returns a larger
             //   allocation than requested.
-            // * Other conditions must be upheld by the caller, as per `Allocator::deallocate()`'s
+            // * Other conditions must be upheld by the caller, as per `Alloc::deallocate()`'s
             //   safety documentation.
             unsafe { dealloc_nonnull(ptr, layout) }
         }
     }
 
-    // SAFETY: Same as `Allocator::grow`
+    // SAFETY: Same as `Alloc::grow`
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     fn grow_impl_runtime(
@@ -239,7 +239,7 @@ impl Global {
         old_layout: Layout,
         new_layout: Layout,
         zeroed: bool,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
@@ -261,7 +261,7 @@ impl Global {
                 if zeroed {
                     raw_ptr.add(old_size).write_bytes(0, new_size - old_size);
                 }
-                Ok(ptr.cast_slice(new_size))
+                Ok(ptr)
             },
 
             // SAFETY: because `new_layout.size()` must be greater than or equal to `old_size`,
@@ -271,14 +271,14 @@ impl Global {
             // for `dealloc` must be upheld by the caller.
             old_size => unsafe {
                 let new_ptr = self.alloc_impl(new_layout, zeroed)?;
-                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), old_size);
-                self.deallocate(ptr, old_layout);
+                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_size);
+                self.alloc_ref().deallocate(ptr, old_layout);
                 Ok(new_ptr)
             },
         }
     }
 
-    // SAFETY: Same as `Allocator::grow`
+    // SAFETY: Same as `Alloc::grow`
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     fn shrink_impl_runtime(
@@ -287,7 +287,7 @@ impl Global {
         old_layout: Layout,
         new_layout: Layout,
         _zeroed: bool,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
@@ -296,8 +296,8 @@ impl Global {
         match new_layout.size() {
             // SAFETY: conditions must be upheld by the caller
             0 => unsafe {
-                self.deallocate(ptr, old_layout);
-                Ok(new_layout.dangling_ptr().cast_slice(0))
+                self.alloc_ref().deallocate(ptr, old_layout);
+                Ok(new_layout.dangling_ptr())
             },
 
             // SAFETY: `new_size` is non-zero. Other conditions must be upheld by the caller
@@ -307,7 +307,7 @@ impl Global {
 
                 let raw_ptr = realloc_nonnull(ptr, old_layout, new_size);
                 let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
-                Ok(ptr.cast_slice(new_size))
+                Ok(ptr)
             },
 
             // SAFETY: because `new_size` must be smaller than or equal to `old_layout.size()`,
@@ -316,19 +316,19 @@ impl Global {
             // `new_ptr`. Thus, the call to `copy_nonoverlapping` is safe. The safety contract
             // for `dealloc` must be upheld by the caller.
             new_size => unsafe {
-                let new_ptr = self.allocate(new_layout)?;
-                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), new_size);
-                self.deallocate(ptr, old_layout);
+                let new_ptr = self.alloc_ref().allocate(new_layout)?;
+                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
+                self.alloc_ref().deallocate(ptr, old_layout);
                 Ok(new_ptr)
             },
         }
     }
 
-    // SAFETY: Same as `Allocator::allocate`
+    // SAFETY: Same as `Alloc::allocate`
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
-    const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+    const fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<u8>, AllocError> {
         core::intrinsics::const_eval_select(
             (layout, zeroed),
             Global::alloc_impl_const,
@@ -336,7 +336,7 @@ impl Global {
         )
     }
 
-    // SAFETY: Same as `Allocator::deallocate`
+    // SAFETY: Same as `Alloc::deallocate`
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
@@ -348,7 +348,7 @@ impl Global {
         )
     }
 
-    // SAFETY: Same as `Allocator::grow`
+    // SAFETY: Same as `Alloc::grow`
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
@@ -358,7 +358,7 @@ impl Global {
         old_layout: Layout,
         new_layout: Layout,
         zeroed: bool,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         core::intrinsics::const_eval_select(
             (self, ptr, old_layout, new_layout, zeroed),
             Global::grow_shrink_impl_const,
@@ -366,7 +366,7 @@ impl Global {
         )
     }
 
-    // SAFETY: Same as `Allocator::shrink`
+    // SAFETY: Same as `Alloc::shrink`
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
@@ -375,7 +375,7 @@ impl Global {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         core::intrinsics::const_eval_select(
             (self, ptr, old_layout, new_layout, false),
             Global::grow_shrink_impl_const,
@@ -386,9 +386,9 @@ impl Global {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
-    const fn alloc_impl_const(layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+    const fn alloc_impl_const(layout: Layout, zeroed: bool) -> Result<NonNull<u8>, AllocError> {
         match layout.size() {
-            0 => Ok(layout.dangling_ptr().cast_slice(0)),
+            0 => Ok(layout.dangling_ptr()),
             // SAFETY: `layout` is non-zero in size,
             size => unsafe {
                 let raw_ptr = core::intrinsics::const_allocate(layout.size(), layout.align());
@@ -397,7 +397,7 @@ impl Global {
                     // SAFETY: the pointer returned by `const_allocate` is valid to write to.
                     ptr.write_bytes(0, size);
                 }
-                Ok(ptr.cast_slice(size))
+                Ok(ptr)
             },
         }
     }
@@ -423,13 +423,13 @@ impl Global {
         old_layout: Layout,
         new_layout: Layout,
         zeroed: bool,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         let new_ptr = self.alloc_impl(new_layout, zeroed)?;
         // SAFETY: both pointers are valid and this operations is in bounds.
         unsafe {
             ptr::copy_nonoverlapping(
                 ptr.as_ptr(),
-                new_ptr.as_mut_ptr(),
+                new_ptr.as_ptr(),
                 cmp::min(old_layout.size(), new_layout.size()),
             );
         }
@@ -440,26 +440,33 @@ impl Global {
     }
 }
 
+// Only needed while `Alloc::allocate` and `Allocator::allocate`
+// coexist for `hashbrown` compatibility.
+#[unstable(feature = "allocator_api", issue = "32838")]
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct __GlobalButOnlyAlloc(Global);
+
 #[unstable(feature = "allocator_api", issue = "32838")]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
-const unsafe impl Allocator for Global {
+const unsafe impl Alloc for __GlobalButOnlyAlloc {
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.alloc_impl(layout, false)
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        self.0.alloc_impl(layout, false)
     }
 
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.alloc_impl(layout, true)
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        self.0.alloc_impl(layout, true)
     }
 
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.deallocate_impl(ptr, layout) }
+        unsafe { self.0.deallocate_impl(ptr, layout) }
     }
 
     #[inline]
@@ -469,9 +476,9 @@ const unsafe impl Allocator for Global {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.grow_impl(ptr, old_layout, new_layout, false) }
+        unsafe { self.0.grow_impl(ptr, old_layout, new_layout, false) }
     }
 
     #[inline]
@@ -481,9 +488,9 @@ const unsafe impl Allocator for Global {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.grow_impl(ptr, old_layout, new_layout, true) }
+        unsafe { self.0.grow_impl(ptr, old_layout, new_layout, true) }
     }
 
     #[inline]
@@ -493,9 +500,19 @@ const unsafe impl Allocator for Global {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.shrink_impl(ptr, old_layout, new_layout) }
+        unsafe { self.0.shrink_impl(ptr, old_layout, new_layout) }
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+#[rustc_const_unstable(feature = "const_heap", issue = "79597")]
+const unsafe impl Allocator for Global {
+    type Alloc = __GlobalButOnlyAlloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        &__GlobalButOnlyAlloc(Global)
     }
 }
 

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -206,7 +206,7 @@ use core::task::{Context, Poll};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{Alloc, AllocError, Allocator, Global, Layout};
 use crate::raw_vec::RawVec;
 #[cfg(not(no_global_oom_handling))]
 use crate::str::from_boxed_utf8_unchecked;
@@ -245,8 +245,8 @@ pub struct Box<
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 #[cfg(not(no_global_oom_handling))]
 fn box_new_uninit(layout: Layout) -> *mut u8 {
-    match Global.allocate(layout) {
-        Ok(ptr) => ptr.as_mut_ptr(),
+    match Global.alloc_ref().allocate(layout) {
+        Ok(ptr) => ptr.as_ptr(),
         Err(_) => handle_alloc_error(layout),
     }
 }
@@ -611,7 +611,7 @@ impl<T, A: Allocator> Box<T, A> {
             NonNull::dangling()
         } else {
             let layout = Layout::new::<mem::MaybeUninit<T>>();
-            alloc.allocate(layout)?.cast()
+            alloc.alloc_ref().allocate(layout)?.cast()
         };
         unsafe { Ok(Box::from_raw_in(ptr.as_ptr(), alloc)) }
     }
@@ -683,7 +683,7 @@ impl<T, A: Allocator> Box<T, A> {
             NonNull::dangling()
         } else {
             let layout = Layout::new::<mem::MaybeUninit<T>>();
-            alloc.allocate_zeroed(layout)?.cast()
+            alloc.alloc_ref().allocate_zeroed(layout)?.cast()
         };
         unsafe { Ok(Box::from_raw_in(ptr.as_ptr(), alloc)) }
     }
@@ -801,7 +801,6 @@ impl<T: ?Sized + CloneToUninit> Box<T> {
     ///
     /// ```
     /// #![feature(clone_from_ref)]
-    /// #![feature(allocator_api)]
     ///
     /// let hello: Box<str> = Box::try_clone_from_ref("hello")?;
     /// # Ok::<(), std::alloc::AllocError>(())
@@ -869,7 +868,7 @@ impl<T: ?Sized + CloneToUninit, A: Allocator> Box<T, A> {
                 let &mut DeallocDropGuard(layout, alloc, ptr) = self;
                 // Safety: `ptr` was allocated by `*alloc` with layout `layout`
                 unsafe {
-                    alloc.deallocate(ptr, layout);
+                    alloc.alloc_ref().deallocate(ptr, layout);
                 }
             }
         }
@@ -878,7 +877,7 @@ impl<T: ?Sized + CloneToUninit, A: Allocator> Box<T, A> {
             (layout.dangling_ptr(), None)
         } else {
             // Safety: layout is non-zero-sized
-            let ptr = alloc.allocate(layout)?.cast();
+            let ptr = alloc.alloc_ref().allocate(layout)?.cast();
             (ptr, Some(DeallocDropGuard(layout, &alloc, ptr)))
         };
         let ptr = ptr.as_ptr();
@@ -968,7 +967,7 @@ impl<T> Box<[T]> {
                 Ok(l) => l,
                 Err(_) => return Err(AllocError),
             };
-            Global.allocate(layout)?.cast()
+            Global.alloc_ref().allocate(layout)?.cast()
         };
         unsafe { Ok(RawVec::from_raw_parts_in(ptr.as_ptr(), len, Global).into_box(len)) }
     }
@@ -1002,7 +1001,7 @@ impl<T> Box<[T]> {
                 Ok(l) => l,
                 Err(_) => return Err(AllocError),
             };
-            Global.allocate_zeroed(layout)?.cast()
+            Global.alloc_ref().allocate_zeroed(layout)?.cast()
         };
         unsafe { Ok(RawVec::from_raw_parts_in(ptr.as_ptr(), len, Global).into_box(len)) }
     }
@@ -1094,7 +1093,7 @@ impl<T, A: Allocator> Box<[T], A> {
                 Ok(l) => l,
                 Err(_) => return Err(AllocError),
             };
-            alloc.allocate(layout)?.cast()
+            alloc.alloc_ref().allocate(layout)?.cast()
         };
         unsafe { Ok(RawVec::from_raw_parts_in(ptr.as_ptr(), len, alloc).into_box(len)) }
     }
@@ -1133,7 +1132,7 @@ impl<T, A: Allocator> Box<[T], A> {
                 Ok(l) => l,
                 Err(_) => return Err(AllocError),
             };
-            alloc.allocate_zeroed(layout)?.cast()
+            alloc.alloc_ref().allocate_zeroed(layout)?.cast()
         };
         unsafe { Ok(RawVec::from_raw_parts_in(ptr.as_ptr(), len, alloc).into_box(len)) }
     }
@@ -1537,12 +1536,12 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// ```
     /// Manually create a `Box` from scratch by using the system allocator:
     /// ```
-    /// #![feature(allocator_api, slice_ptr_get)]
+    /// #![feature(allocator_api)]
     ///
-    /// use std::alloc::{Allocator, Layout, System};
+    /// use std::alloc::{Alloc, Allocator, Layout, System};
     ///
     /// unsafe {
-    ///     let ptr = System.allocate(Layout::new::<i32>())?.as_mut_ptr() as *mut i32;
+    ///     let ptr = System.alloc_ref().allocate(Layout::new::<i32>())?.as_ptr() as *mut i32;
     ///     // In general .write is required to avoid attempting to destruct
     ///     // the (uninitialized) previous contents of `ptr`, though for this
     ///     // simple example `*ptr = 5` would have worked as well.
@@ -1596,10 +1595,10 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// ```
     /// #![feature(allocator_api)]
     ///
-    /// use std::alloc::{Allocator, Layout, System};
+    /// use std::alloc::{Alloc, Allocator, Layout, System};
     ///
     /// unsafe {
-    ///     let non_null = System.allocate(Layout::new::<i32>())?.cast::<i32>();
+    ///     let non_null = System.alloc_ref().allocate(Layout::new::<i32>())?.cast::<i32>();
     ///     // In general .write is required to avoid attempting to destruct
     ///     // the (uninitialized) previous contents of `non_null`.
     ///     non_null.write(5);
@@ -1651,7 +1650,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// ```
     /// #![feature(allocator_api)]
     ///
-    /// use std::alloc::{Allocator, Layout, System};
+    /// use std::alloc::{Alloc, Allocator, Layout, System};
     /// use std::ptr::{self, NonNull};
     ///
     /// let x = Box::new_in(String::from("Hello"), System);
@@ -1659,7 +1658,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// unsafe {
     ///     ptr::drop_in_place(ptr);
     ///     let non_null = NonNull::new_unchecked(ptr);
-    ///     alloc.deallocate(non_null.cast(), Layout::new::<String>());
+    ///     alloc.alloc_ref().deallocate(non_null.cast(), Layout::new::<String>());
     /// }
     /// ```
     ///
@@ -1713,13 +1712,13 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// ```
     /// #![feature(allocator_api)]
     ///
-    /// use std::alloc::{Allocator, Layout, System};
+    /// use std::alloc::{Alloc, Allocator, Layout, System};
     ///
     /// let x = Box::new_in(String::from("Hello"), System);
     /// let (non_null, alloc) = Box::into_non_null_with_allocator(x);
     /// unsafe {
     ///     non_null.drop_in_place();
-    ///     alloc.deallocate(non_null.cast::<u8>(), Layout::new::<String>());
+    ///     alloc.alloc_ref().deallocate(non_null.cast::<u8>(), Layout::new::<String>());
     /// }
     /// ```
     ///
@@ -1955,7 +1954,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Box<T, A> {
         unsafe {
             let layout = Layout::for_value_raw(ptr.as_ptr());
             if layout.size() != 0 {
-                self.1.deallocate(From::from(ptr.cast()), layout);
+                self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
             }
         }
     }
@@ -2434,15 +2433,15 @@ impl<E: Error> Error for Box<E> {
     }
 }
 
-#[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Box<T, A> {
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+unsafe impl<T: ?Sized + Alloc, A: Allocator> Alloc for Box<T, A> {
     #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         (**self).allocate(layout)
     }
 
     #[inline]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         (**self).allocate_zeroed(layout)
     }
 
@@ -2458,7 +2457,7 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Box<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).grow(ptr, old_layout, new_layout) }
     }
@@ -2469,7 +2468,7 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Box<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
     }
@@ -2480,8 +2479,17 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Box<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator, A: Allocator> Allocator for Box<T, A> {
+    type Alloc = T::Alloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        (**self).alloc_ref()
     }
 }

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -78,7 +78,6 @@ impl<T> ThinBox<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(allocator_api)]
     /// #![feature(thin_box)]
     /// use std::boxed::ThinBox;
     ///

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -37,7 +37,7 @@ use core::num::NonZero;
 use core::ptr::{self, NonNull};
 use core::slice::SliceIndex;
 
-use crate::alloc::{Allocator, Layout};
+use crate::alloc::{Alloc, Allocator, Layout};
 use crate::boxed::Box;
 
 const B: usize = 6;
@@ -409,7 +409,7 @@ impl<K, V> NodeRef<marker::Dying, K, V, marker::LeafOrInternal> {
         let node = self.node;
         let ret = self.ascend().ok();
         unsafe {
-            alloc.deallocate(
+            alloc.alloc_ref().deallocate(
                 node.cast(),
                 if height > 0 {
                     Layout::new::<InternalNode<K, V>>()
@@ -628,7 +628,7 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::LeafOrInternal> {
         self.clear_parent_link();
 
         unsafe {
-            alloc.deallocate(top.cast(), Layout::new::<InternalNode<K, V>>());
+            alloc.alloc_ref().deallocate(top.cast(), Layout::new::<InternalNode<K, V>>());
         }
     }
 }
@@ -1446,9 +1446,13 @@ impl<'a, K: 'a, V: 'a> BalancingContext<'a, K, V> {
 
                 left_node.correct_childrens_parent_links(old_left_len + 1..new_left_len + 1);
 
-                alloc.deallocate(right_node.node.cast(), Layout::new::<InternalNode<K, V>>());
+                alloc
+                    .alloc_ref()
+                    .deallocate(right_node.node.cast(), Layout::new::<InternalNode<K, V>>());
             } else {
-                alloc.deallocate(right_node.node.cast(), Layout::new::<LeafNode<K, V>>());
+                alloc
+                    .alloc_ref()
+                    .deallocate(right_node.node.cast(), Layout::new::<LeafNode<K, V>>());
             }
         }
         result(parent_node, left_node)

--- a/library/alloc/src/collections/linked_list/tests.rs
+++ b/library/alloc/src/collections/linked_list/tests.rs
@@ -1157,7 +1157,7 @@ fn test_drop_panic() {
 
 #[test]
 fn test_allocator() {
-    use core::alloc::{AllocError, Allocator, Layout};
+    use core::alloc::{Alloc, AllocError, Allocator, Layout};
     use core::cell::Cell;
 
     struct A {
@@ -1165,19 +1165,25 @@ fn test_allocator() {
         has_deallocated: Cell<bool>,
     }
 
-    unsafe impl Allocator for A {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for A {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             assert!(!self.has_allocated.get());
             self.has_allocated.set(true);
 
-            Global.allocate(layout)
+            Global.alloc_ref().allocate(layout)
         }
 
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             assert!(!self.has_deallocated.get());
             self.has_deallocated.set(true);
 
-            unsafe { Global.deallocate(ptr, layout) }
+            unsafe { Global.alloc_ref().deallocate(ptr, layout) }
+        }
+    }
+    unsafe impl Allocator for A {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 

--- a/library/alloc/src/raw_vec/mod.rs
+++ b/library/alloc/src/raw_vec/mod.rs
@@ -11,7 +11,7 @@ use core::{cmp, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{Allocator, Global, Layout};
+use crate::alloc::{Alloc, Allocator, Global, Layout};
 use crate::boxed::Box;
 use crate::collections::TryReserveError;
 use crate::collections::TryReserveErrorKind::*;
@@ -462,18 +462,15 @@ const impl<A: [const] Allocator + [const] Destruct> RawVecInner<A> {
         }
 
         let result = match init {
-            AllocInit::Uninitialized => alloc.allocate(layout),
+            AllocInit::Uninitialized => alloc.alloc_ref().allocate(layout),
             #[cfg(not(no_global_oom_handling))]
-            AllocInit::Zeroed => alloc.allocate_zeroed(layout),
+            AllocInit::Zeroed => alloc.alloc_ref().allocate_zeroed(layout),
         };
         let ptr = match result {
-            Ok(ptr) => ptr,
+            Ok(ptr) => ptr.cast_slice(layout.size()),
             Err(_) => return Err(AllocError { layout, non_exhaustive: () }.into()),
         };
 
-        // Allocators currently return a `NonNull<[u8]>` whose length
-        // matches the size requested. If that ever changes, the capacity
-        // here should change to `ptr.len() / size_of::<T>()`.
         Ok(Self {
             ptr: Unique::from(ptr.cast()),
             cap: unsafe { Cap::new_unchecked(capacity) },
@@ -553,15 +550,15 @@ const impl<A: [const] Allocator + [const] Destruct> RawVecInner<A> {
             unsafe {
                 // The allocator checks for alignment equality
                 hint::assert_unchecked(old_layout.align() == new_layout.align());
-                self.alloc.grow(ptr, old_layout, new_layout)
+                self.alloc.alloc_ref().grow(ptr, old_layout, new_layout)
             }
         } else {
-            self.alloc.allocate(new_layout)
+            self.alloc.alloc_ref().allocate(new_layout)
         };
 
         // FIXME(const-hack): switch back to `map_err`
         match memory {
-            Ok(memory) => Ok(memory),
+            Ok(memory) => Ok(memory.cast_slice(new_layout.size())),
             Err(_) => Err(AllocError { layout: new_layout, non_exhaustive: () }.into()),
         }
     }
@@ -770,9 +767,6 @@ impl<A: Allocator> RawVecInner<A> {
     #[inline]
     #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
     const unsafe fn set_ptr_and_cap(&mut self, ptr: NonNull<[u8]>, cap: usize) {
-        // Allocators currently return a `NonNull<[u8]>` whose length matches
-        // the size requested. If that ever changes, the capacity here should
-        // change to `ptr.len() / size_of::<T>()`.
         self.ptr = Unique::from(ptr.cast());
         self.cap = unsafe { Cap::new_unchecked(cap) };
     }
@@ -840,7 +834,7 @@ impl<A: Allocator> RawVecInner<A> {
         // for the T::IS_ZST case since current_memory() will have returned
         // None.
         if cap == 0 {
-            unsafe { self.alloc.deallocate(ptr, layout) };
+            unsafe { self.alloc.alloc_ref().deallocate(ptr, layout) };
             self.ptr =
                 unsafe { Unique::new_unchecked(ptr::without_provenance_mut(elem_layout.align())) };
             self.cap = ZERO_CAP;
@@ -851,12 +845,13 @@ impl<A: Allocator> RawVecInner<A> {
                 let new_size = elem_layout.size().unchecked_mul(cap);
                 let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
                 self.alloc
+                    .alloc_ref()
                     .shrink(ptr, layout, new_layout)
                     .map_err(|_| AllocError { layout: new_layout, non_exhaustive: () })?
             };
             // SAFETY: if the allocation is valid, then the capacity is too
             unsafe {
-                self.set_ptr_and_cap(ptr, cap);
+                self.set_ptr_and_cap(ptr.cast_slice(layout.size()), cap);
             }
         }
         Ok(())
@@ -873,7 +868,7 @@ impl<A: Allocator> RawVecInner<A> {
         // SAFETY: Precondition passed to caller
         if let Some((ptr, layout)) = unsafe { self.current_memory(elem_layout) } {
             unsafe {
-                self.alloc.deallocate(ptr, layout);
+                self.alloc.alloc_ref().deallocate(ptr, layout);
             }
         }
     }

--- a/library/alloc/src/raw_vec/tests.rs
+++ b/library/alloc/src/raw_vec/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 
 #[test]
 fn allocator_param() {
-    use crate::alloc::AllocError;
+    use crate::alloc::{Alloc, AllocError};
 
     // Writing a test of integration between third-party
     // allocators and `RawVec` is a little tricky because the `RawVec`
@@ -21,13 +21,13 @@ fn allocator_param() {
     struct BoundedAlloc {
         fuel: Cell<usize>,
     }
-    unsafe impl Allocator for BoundedAlloc {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for BoundedAlloc {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             let size = layout.size();
             if size > self.fuel.get() {
                 return Err(AllocError);
             }
-            match Global.allocate(layout) {
+            match Global.alloc_ref().allocate(layout) {
                 ok @ Ok(_) => {
                     self.fuel.set(self.fuel.get() - size);
                     ok
@@ -36,7 +36,13 @@ fn allocator_param() {
             }
         }
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            unsafe { Global.deallocate(ptr, layout) }
+            unsafe { Global.alloc_ref().deallocate(ptr, layout) }
+        }
+    }
+    unsafe impl Allocator for BoundedAlloc {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -268,7 +268,7 @@ use core::{borrow, fmt, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{Alloc, AllocError, Allocator, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 #[cfg(not(no_global_oom_handling))]
@@ -512,7 +512,7 @@ impl<T> Rc<T> {
         unsafe {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate(layout),
+                |layout| Global.alloc_ref().allocate(layout),
                 <*mut u8>::cast,
             ))
         }
@@ -543,7 +543,7 @@ impl<T> Rc<T> {
         unsafe {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
+                |layout| Global.alloc_ref().allocate_zeroed(layout),
                 <*mut u8>::cast,
             ))
         }
@@ -602,7 +602,7 @@ impl<T> Rc<T> {
         unsafe {
             Ok(Rc::from_ptr(Rc::try_allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate(layout),
+                |layout| Global.alloc_ref().allocate(layout),
                 <*mut u8>::cast,
             )?))
         }
@@ -634,7 +634,7 @@ impl<T> Rc<T> {
         unsafe {
             Ok(Rc::from_ptr(Rc::try_allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
+                |layout| Global.alloc_ref().allocate_zeroed(layout),
                 <*mut u8>::cast,
             )?))
         }
@@ -791,7 +791,7 @@ impl<T, A: Allocator> Rc<T, A> {
             Rc::from_ptr_in(
                 Rc::allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate(layout),
+                    |layout| alloc.alloc_ref().allocate(layout),
                     <*mut u8>::cast,
                 ),
                 alloc,
@@ -828,7 +828,7 @@ impl<T, A: Allocator> Rc<T, A> {
             Rc::from_ptr_in(
                 Rc::allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate_zeroed(layout),
+                    |layout| alloc.alloc_ref().allocate_zeroed(layout),
                     <*mut u8>::cast,
                 ),
                 alloc,
@@ -972,7 +972,7 @@ impl<T, A: Allocator> Rc<T, A> {
             Ok(Rc::from_ptr_in(
                 Rc::try_allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate(layout),
+                    |layout| alloc.alloc_ref().allocate(layout),
                     <*mut u8>::cast,
                 )?,
                 alloc,
@@ -1010,7 +1010,7 @@ impl<T, A: Allocator> Rc<T, A> {
             Ok(Rc::from_ptr_in(
                 Rc::try_allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate_zeroed(layout),
+                    |layout| alloc.alloc_ref().allocate_zeroed(layout),
                     <*mut u8>::cast,
                 )?,
                 alloc,
@@ -1159,7 +1159,7 @@ impl<T> Rc<[T]> {
         unsafe {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| Global.allocate_zeroed(layout),
+                |layout| Global.alloc_ref().allocate_zeroed(layout),
                 |mem| mem.cast::<T>().cast_slice(len) as *mut RcInner<[mem::MaybeUninit<T>]>,
             ))
         }
@@ -1227,7 +1227,7 @@ impl<T, A: Allocator> Rc<[T], A> {
             Rc::from_ptr_in(
                 Rc::allocate_for_layout(
                     Layout::array::<T>(len).unwrap(),
-                    |layout| alloc.allocate_zeroed(layout),
+                    |layout| alloc.alloc_ref().allocate_zeroed(layout),
                     |mem| mem.cast::<T>().cast_slice(len) as *mut RcInner<[mem::MaybeUninit<T>]>,
                 ),
                 alloc,
@@ -1328,7 +1328,6 @@ impl<T: ?Sized + CloneToUninit> Rc<T> {
     ///
     /// ```
     /// #![feature(clone_from_ref)]
-    /// #![feature(allocator_api)]
     /// use std::rc::Rc;
     ///
     /// let hello: Rc<str> = Rc::try_clone_from_ref("hello")?;
@@ -2236,7 +2235,7 @@ impl<T: ?Sized> Rc<T> {
     #[cfg(not(no_global_oom_handling))]
     unsafe fn allocate_for_layout(
         value_layout: Layout,
-        allocate: impl FnOnce(Layout) -> Result<NonNull<[u8]>, AllocError>,
+        allocate: impl FnOnce(Layout) -> Result<NonNull<u8>, AllocError>,
         mem_to_rc_inner: impl FnOnce(*mut u8) -> *mut RcInner<T>,
     ) -> *mut RcInner<T> {
         let layout = rc_inner_layout_for_value_layout(value_layout);
@@ -2255,7 +2254,7 @@ impl<T: ?Sized> Rc<T> {
     #[inline]
     unsafe fn try_allocate_for_layout(
         value_layout: Layout,
-        allocate: impl FnOnce(Layout) -> Result<NonNull<[u8]>, AllocError>,
+        allocate: impl FnOnce(Layout) -> Result<NonNull<u8>, AllocError>,
         mem_to_rc_inner: impl FnOnce(*mut u8) -> *mut RcInner<T>,
     ) -> Result<*mut RcInner<T>, AllocError> {
         let layout = rc_inner_layout_for_value_layout(value_layout);
@@ -2264,7 +2263,7 @@ impl<T: ?Sized> Rc<T> {
         let ptr = allocate(layout)?;
 
         // Initialize the RcInner
-        let inner = mem_to_rc_inner(ptr.as_non_null_ptr().as_ptr());
+        let inner = mem_to_rc_inner(ptr.as_ptr());
         unsafe {
             debug_assert_eq!(Layout::for_value_raw(inner), layout);
 
@@ -2284,7 +2283,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
         unsafe {
             Rc::<T>::allocate_for_layout(
                 Layout::for_value_raw(ptr),
-                |layout| alloc.allocate(layout),
+                |layout| alloc.alloc_ref().allocate(layout),
                 |mem| mem.with_metadata_of(ptr as *const RcInner<T>),
             )
         }
@@ -2320,7 +2319,7 @@ impl<T> Rc<[T]> {
         unsafe {
             Self::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| Global.allocate(layout),
+                |layout| Global.alloc_ref().allocate(layout),
                 |mem| mem.cast::<T>().cast_slice(len) as *mut RcInner<[T]>,
             )
         }
@@ -2360,7 +2359,7 @@ impl<T> Rc<[T]> {
                     let slice = from_raw_parts_mut(self.elems, self.n_elems);
                     ptr::drop_in_place(slice);
 
-                    Global.deallocate(self.mem, self.layout);
+                    Global.alloc_ref().deallocate(self.mem, self.layout);
                 }
             }
         }
@@ -2397,7 +2396,7 @@ impl<T, A: Allocator> Rc<[T], A> {
         unsafe {
             Rc::<[T]>::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| alloc.allocate(layout),
+                |layout| alloc.alloc_ref().allocate(layout),
                 |mem| mem.cast::<T>().cast_slice(len) as *mut RcInner<[T]>,
             )
         }
@@ -3681,7 +3680,9 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Weak<T, A> {
         // the strong pointers have disappeared.
         if inner.weak() == 0 {
             unsafe {
-                self.alloc.deallocate(self.ptr.cast(), Layout::for_value_raw(self.ptr.as_ptr()));
+                self.alloc
+                    .alloc_ref()
+                    .deallocate(self.ptr.cast(), Layout::for_value_raw(self.ptr.as_ptr()));
             }
         }
     }
@@ -4465,7 +4466,9 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for UniqueRc<T, A> {
             self.ptr.as_ref().dec_weak();
 
             if self.ptr.as_ref().weak() == 0 {
-                self.alloc.deallocate(self.ptr.cast(), Layout::for_value_raw(self.ptr.as_ptr()));
+                self.alloc
+                    .alloc_ref()
+                    .deallocate(self.ptr.cast(), Layout::for_value_raw(self.ptr.as_ptr()));
             }
         }
     }
@@ -4491,7 +4494,7 @@ impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
         let ptr = unsafe {
             Rc::allocate_for_layout(
                 layout,
-                |layout_for_rc_inner| alloc.allocate(layout_for_rc_inner),
+                |layout_for_rc_inner| alloc.alloc_ref().allocate(layout_for_rc_inner),
                 |mem| mem.with_metadata_of(ptr::from_ref(for_value) as *const RcInner<T>),
             )
         };
@@ -4505,7 +4508,7 @@ impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
         let ptr = unsafe {
             Rc::try_allocate_for_layout(
                 layout,
-                |layout_for_rc_inner| alloc.allocate(layout_for_rc_inner),
+                |layout_for_rc_inner| alloc.alloc_ref().allocate(layout_for_rc_inner),
                 |mem| mem.with_metadata_of(ptr::from_ref(for_value) as *const RcInner<T>),
             )?
         };
@@ -4540,7 +4543,7 @@ impl<T: ?Sized, A: Allocator> Drop for UniqueRcUninit<T, A> {
         // * new() produced a pointer safe to deallocate.
         // * We own the pointer unless into_rc() was called, which forgets us.
         unsafe {
-            self.alloc.take().unwrap().deallocate(
+            self.alloc.take().unwrap().alloc_ref().deallocate(
                 self.ptr.cast(),
                 rc_inner_layout_for_value_layout(self.layout_for_value),
             );
@@ -4548,15 +4551,15 @@ impl<T: ?Sized, A: Allocator> Drop for UniqueRcUninit<T, A> {
     }
 }
 
-#[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Rc<T, A> {
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+unsafe impl<T: ?Sized + Alloc, A: Allocator> Alloc for Rc<T, A> {
     #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         (**self).allocate(layout)
     }
 
     #[inline]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         (**self).allocate_zeroed(layout)
     }
 
@@ -4572,7 +4575,7 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Rc<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).grow(ptr, old_layout, new_layout) }
     }
@@ -4583,7 +4586,7 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Rc<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
     }
@@ -4594,8 +4597,26 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Rc<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<A: Allocator> Allocator for Rc<dyn Alloc, A> {
+    type Alloc = dyn Alloc + 'static;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        &**self
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator, A: Allocator> Allocator for Rc<T, A> {
+    type Alloc = T::Alloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        (**self).alloc_ref()
     }
 }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -35,7 +35,7 @@ use core::{borrow, fmt, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{Alloc, AllocError, Allocator, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::rc::is_dangling;
@@ -517,7 +517,7 @@ impl<T> Arc<T> {
         unsafe {
             Arc::from_ptr(Arc::allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate(layout),
+                |layout| Global.alloc_ref().allocate(layout),
                 <*mut u8>::cast,
             ))
         }
@@ -549,7 +549,7 @@ impl<T> Arc<T> {
         unsafe {
             Arc::from_ptr(Arc::allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
+                |layout| Global.alloc_ref().allocate_zeroed(layout),
                 <*mut u8>::cast,
             ))
         }
@@ -620,7 +620,7 @@ impl<T> Arc<T> {
         unsafe {
             Ok(Arc::from_ptr(Arc::try_allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate(layout),
+                |layout| Global.alloc_ref().allocate(layout),
                 <*mut u8>::cast,
             )?))
         }
@@ -652,7 +652,7 @@ impl<T> Arc<T> {
         unsafe {
             Ok(Arc::from_ptr(Arc::try_allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
+                |layout| Global.alloc_ref().allocate_zeroed(layout),
                 <*mut u8>::cast,
             )?))
         }
@@ -807,7 +807,7 @@ impl<T, A: Allocator> Arc<T, A> {
             Arc::from_ptr_in(
                 Arc::allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate(layout),
+                    |layout| alloc.alloc_ref().allocate(layout),
                     <*mut u8>::cast,
                 ),
                 alloc,
@@ -844,7 +844,7 @@ impl<T, A: Allocator> Arc<T, A> {
             Arc::from_ptr_in(
                 Arc::allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate_zeroed(layout),
+                    |layout| alloc.alloc_ref().allocate_zeroed(layout),
                     <*mut u8>::cast,
                 ),
                 alloc,
@@ -1028,7 +1028,7 @@ impl<T, A: Allocator> Arc<T, A> {
             Ok(Arc::from_ptr_in(
                 Arc::try_allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate(layout),
+                    |layout| alloc.alloc_ref().allocate(layout),
                     <*mut u8>::cast,
                 )?,
                 alloc,
@@ -1066,7 +1066,7 @@ impl<T, A: Allocator> Arc<T, A> {
             Ok(Arc::from_ptr_in(
                 Arc::try_allocate_for_layout(
                     Layout::new::<T>(),
-                    |layout| alloc.allocate_zeroed(layout),
+                    |layout| alloc.alloc_ref().allocate_zeroed(layout),
                     <*mut u8>::cast,
                 )?,
                 alloc,
@@ -1305,7 +1305,7 @@ impl<T> Arc<[T]> {
         unsafe {
             Arc::from_ptr(Arc::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| Global.allocate_zeroed(layout),
+                |layout| Global.alloc_ref().allocate_zeroed(layout),
                 |mem| mem.cast::<T>().cast_slice(len) as *mut ArcInner<[mem::MaybeUninit<T>]>,
             ))
         }
@@ -1374,7 +1374,7 @@ impl<T, A: Allocator> Arc<[T], A> {
             Arc::from_ptr_in(
                 Arc::allocate_for_layout(
                     Layout::array::<T>(len).unwrap(),
-                    |layout| alloc.allocate_zeroed(layout),
+                    |layout| alloc.alloc_ref().allocate_zeroed(layout),
                     |mem| mem.cast::<T>().cast_slice(len) as *mut ArcInner<[mem::MaybeUninit<T>]>,
                 ),
                 alloc,
@@ -1476,7 +1476,6 @@ impl<T: ?Sized + CloneToUninit> Arc<T> {
     ///
     /// ```
     /// #![feature(clone_from_ref)]
-    /// #![feature(allocator_api)]
     /// use std::sync::Arc;
     ///
     /// let hello: Arc<str> = Arc::try_clone_from_ref("hello")?;
@@ -2173,7 +2172,7 @@ impl<T: ?Sized> Arc<T> {
     #[cfg(not(no_global_oom_handling))]
     unsafe fn allocate_for_layout(
         value_layout: Layout,
-        allocate: impl FnOnce(Layout) -> Result<NonNull<[u8]>, AllocError>,
+        allocate: impl FnOnce(Layout) -> Result<NonNull<u8>, AllocError>,
         mem_to_arcinner: impl FnOnce(*mut u8) -> *mut ArcInner<T>,
     ) -> *mut ArcInner<T> {
         let layout = arcinner_layout_for_value_layout(value_layout);
@@ -2191,7 +2190,7 @@ impl<T: ?Sized> Arc<T> {
     /// and must return back a (potentially fat)-pointer for the `ArcInner<T>`.
     unsafe fn try_allocate_for_layout(
         value_layout: Layout,
-        allocate: impl FnOnce(Layout) -> Result<NonNull<[u8]>, AllocError>,
+        allocate: impl FnOnce(Layout) -> Result<NonNull<u8>, AllocError>,
         mem_to_arcinner: impl FnOnce(*mut u8) -> *mut ArcInner<T>,
     ) -> Result<*mut ArcInner<T>, AllocError> {
         let layout = arcinner_layout_for_value_layout(value_layout);
@@ -2204,11 +2203,11 @@ impl<T: ?Sized> Arc<T> {
     }
 
     unsafe fn initialize_arcinner(
-        ptr: NonNull<[u8]>,
+        ptr: NonNull<u8>,
         layout: Layout,
         mem_to_arcinner: impl FnOnce(*mut u8) -> *mut ArcInner<T>,
     ) -> *mut ArcInner<T> {
-        let inner = mem_to_arcinner(ptr.as_non_null_ptr().as_ptr());
+        let inner = mem_to_arcinner(ptr.as_ptr());
         debug_assert_eq!(unsafe { Layout::for_value_raw(inner) }, layout);
 
         unsafe {
@@ -2229,7 +2228,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
         unsafe {
             Arc::allocate_for_layout(
                 Layout::for_value_raw(ptr),
-                |layout| alloc.allocate(layout),
+                |layout| alloc.alloc_ref().allocate(layout),
                 |mem| mem.with_metadata_of(ptr as *const ArcInner<T>),
             )
         }
@@ -2265,7 +2264,7 @@ impl<T> Arc<[T]> {
         unsafe {
             Self::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| Global.allocate(layout),
+                |layout| Global.alloc_ref().allocate(layout),
                 |mem| mem.cast::<T>().cast_slice(len) as *mut ArcInner<[T]>,
             )
         }
@@ -2307,7 +2306,7 @@ impl<T> Arc<[T]> {
                     let slice = from_raw_parts_mut(self.elems, self.n_elems);
                     ptr::drop_in_place(slice);
 
-                    Global.deallocate(self.mem, self.layout);
+                    Global.alloc_ref().deallocate(self.mem, self.layout);
                 }
             }
         }
@@ -2344,7 +2343,7 @@ impl<T, A: Allocator> Arc<[T], A> {
         unsafe {
             Arc::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| alloc.allocate(layout),
+                |layout| alloc.alloc_ref().allocate(layout),
                 |mem| mem.cast::<T>().cast_slice(len) as *mut ArcInner<[T]>,
             )
         }
@@ -3513,7 +3512,9 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Weak<T, A> {
             );
 
             unsafe {
-                self.alloc.deallocate(self.ptr.cast(), Layout::for_value_raw(self.ptr.as_ptr()))
+                self.alloc
+                    .alloc_ref()
+                    .deallocate(self.ptr.cast(), Layout::for_value_raw(self.ptr.as_ptr()))
             }
         }
     }
@@ -4260,7 +4261,7 @@ impl<T: ?Sized, A: Allocator> UniqueArcUninit<T, A> {
         let ptr = unsafe {
             Arc::allocate_for_layout(
                 layout,
-                |layout_for_arcinner| alloc.allocate(layout_for_arcinner),
+                |layout_for_arcinner| alloc.alloc_ref().allocate(layout_for_arcinner),
                 |mem| mem.with_metadata_of(ptr::from_ref(for_value) as *const ArcInner<T>),
             )
         };
@@ -4274,7 +4275,7 @@ impl<T: ?Sized, A: Allocator> UniqueArcUninit<T, A> {
         let ptr = unsafe {
             Arc::try_allocate_for_layout(
                 layout,
-                |layout_for_arcinner| alloc.allocate(layout_for_arcinner),
+                |layout_for_arcinner| alloc.alloc_ref().allocate(layout_for_arcinner),
                 |mem| mem.with_metadata_of(ptr::from_ref(for_value) as *const ArcInner<T>),
             )?
         };
@@ -4310,7 +4311,7 @@ impl<T: ?Sized, A: Allocator> Drop for UniqueArcUninit<T, A> {
         // * new() produced a pointer safe to deallocate.
         // * We own the pointer unless into_arc() was called, which forgets us.
         unsafe {
-            self.alloc.take().unwrap().deallocate(
+            self.alloc.take().unwrap().alloc_ref().deallocate(
                 self.ptr.cast(),
                 arcinner_layout_for_value_layout(self.layout_for_value),
             );
@@ -4917,15 +4918,15 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for UniqueArc<T, A> {
     }
 }
 
-#[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Arc<T, A> {
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+unsafe impl<T: ?Sized + Alloc, A: Allocator> Alloc for Arc<T, A> {
     #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         (**self).allocate(layout)
     }
 
     #[inline]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         (**self).allocate_zeroed(layout)
     }
 
@@ -4941,7 +4942,7 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Arc<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).grow(ptr, old_layout, new_layout) }
     }
@@ -4952,7 +4953,7 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Arc<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
     }
@@ -4963,8 +4964,26 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Arc<T, A> {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: the safety contract must be upheld by the caller
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<A: Allocator> Allocator for Arc<dyn Alloc, A> {
+    type Alloc = dyn Alloc + 'static;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        &**self
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator, A: Allocator> Allocator for Arc<T, A> {
+    type Alloc = T::Alloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        (**self).alloc_ref()
     }
 }

--- a/library/alloc/src/vec/in_place_collect.rs
+++ b/library/alloc/src/vec/in_place_collect.rs
@@ -155,7 +155,7 @@
 //! vec.truncate(write_idx);
 //! ```
 
-use core::alloc::{Allocator, Layout};
+use core::alloc::{Alloc, Allocator, Layout};
 use core::iter::{InPlaceIterable, SourceIter, TrustedRandomAccessNoCoerce};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, SizedTypeProperties};
@@ -318,7 +318,7 @@ where
             let dst_size = size_of::<T>().unchecked_mul(dst_cap);
             let new_layout = Layout::from_size_align_unchecked(dst_size, dst_align);
 
-            let result = alloc.shrink(dst_buf.cast(), old_layout, new_layout);
+            let result = alloc.alloc_ref().shrink(dst_buf.cast(), old_layout, new_layout);
             let Ok(reallocated) = result else { handle_alloc_error(new_layout) };
             dst_buf = reallocated.cast::<T>();
         }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1130,8 +1130,8 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// [`String`]: crate::string::String
     /// [`dealloc`]: crate::alloc::GlobalAlloc::dealloc
-    /// [*currently allocated*]: crate::alloc::Allocator#currently-allocated-memory
-    /// [*fit*]: crate::alloc::Allocator#memory-fitting
+    /// [*currently allocated*]: crate::alloc::Alloc#currently-allocated-memory
+    /// [*fit*]: crate::alloc::Alloc#memory-fitting
     ///
     /// # Examples
     ///
@@ -1167,13 +1167,13 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```rust
     /// #![feature(allocator_api)]
     ///
-    /// use std::alloc::{AllocError, Allocator, Global, Layout};
+    /// use std::alloc::{Alloc, Allocator, AllocError, Global, Layout};
     ///
     /// fn main() {
     ///     let layout = Layout::array::<u32>(16).expect("overflow cannot happen");
     ///
     ///     let vec = unsafe {
-    ///         let mem = match Global.allocate(layout) {
+    ///         let mem = match Global.alloc_ref().allocate(layout) {
     ///             Ok(mem) => mem.cast::<u32>().as_ptr(),
     ///             Err(AllocError) => return,
     ///         };
@@ -1247,8 +1247,8 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// [`String`]: crate::string::String
     /// [`dealloc`]: crate::alloc::GlobalAlloc::dealloc
-    /// [*currently allocated*]: crate::alloc::Allocator#currently-allocated-memory
-    /// [*fit*]: crate::alloc::Allocator#memory-fitting
+    /// [*currently allocated*]: crate::alloc::Alloc#currently-allocated-memory
+    /// [*fit*]: crate::alloc::Alloc#memory-fitting
     ///
     /// # Examples
     ///
@@ -1282,13 +1282,13 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```rust
     /// #![feature(allocator_api)]
     ///
-    /// use std::alloc::{AllocError, Allocator, Global, Layout};
+    /// use std::alloc::{Alloc, Allocator, AllocError, Global, Layout};
     ///
     /// fn main() {
     ///     let layout = Layout::array::<u32>(16).expect("overflow cannot happen");
     ///
     ///     let vec = unsafe {
-    ///         let mem = match Global.allocate(layout) {
+    ///         let mem = match Global.alloc_ref().allocate(layout) {
     ///             Ok(mem) => mem.cast::<u32>(),
     ///             Err(AllocError) => return,
     ///         };
@@ -1585,9 +1585,10 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// The behavior of this method depends on the allocator, which may either shrink the vector
     /// in-place or reallocate. The resulting vector might still have some excess capacity, just as
-    /// is the case for [`with_capacity`]. See [`Allocator::shrink`] for more details.
+    /// is the case for [`with_capacity`]. See [`Alloc::shrink`] for more details.
     ///
     /// [`with_capacity`]: Vec::with_capacity
+    /// [`Alloc::shrink`]: crate::alloc::Alloc::shrink
     ///
     /// # Examples
     ///
@@ -1640,15 +1641,16 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// The behavior of this method depends on the allocator, which may either shrink the vector
     /// in-place or reallocate. The resulting vector might still have some excess capacity, just as
-    /// is the case for [`with_capacity`]. See [`Allocator::shrink`] for more details.
+    /// is the case for [`with_capacity`]. See [`Alloc::shrink`] for more details.
     ///
     /// [`with_capacity`]: Vec::with_capacity
+    /// [`Alloc::shrink`]: crate::alloc::Alloc::shrink
     ///
     /// # Errors
     ///
     /// This function returns an error if the allocator fails to shrink the allocation,
     /// the vector thereafter is still safe to use, the capacity remains unchanged
-    /// however. See [`Allocator::shrink`].
+    /// however. See [`Alloc::shrink`].
     ///
     /// # Examples
     ///
@@ -1678,7 +1680,9 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// This function returns an error if the allocator fails to shrink the allocation,
     /// the vector thereafter is still safe to use, the capacity remains unchanged
-    /// however. See [`Allocator::shrink`].
+    /// however. See [`Alloc::shrink`].
+    ///
+    /// [`Alloc::shrink`]: crate::alloc::Alloc::shrink
     ///
     /// # Examples
     ///

--- a/library/alloctests/tests/alloc_test.rs
+++ b/library/alloctests/tests/alloc_test.rs
@@ -8,16 +8,18 @@ use test::Bencher;
 fn allocate_zeroed() {
     unsafe {
         let layout = Layout::from_size_align(1024, 1).unwrap();
-        let ptr =
-            Global.allocate_zeroed(layout.clone()).unwrap_or_else(|_| handle_alloc_error(layout));
+        let ptr = Global
+            .alloc_ref()
+            .allocate_zeroed(layout.clone())
+            .unwrap_or_else(|_| handle_alloc_error(layout));
 
-        let mut i = ptr.as_non_null_ptr().as_ptr();
+        let mut i = ptr.as_ptr();
         let end = i.add(layout.size());
         while i < end {
             assert_eq!(*i, 0);
             i = i.add(1);
         }
-        Global.deallocate(ptr.as_non_null_ptr(), layout);
+        Global.alloc_ref().deallocate(ptr, layout);
     }
 }
 

--- a/library/alloctests/tests/arc.rs
+++ b/library/alloctests/tests/arc.rs
@@ -241,19 +241,25 @@ fn weak_may_dangle() {
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_no_leak() {
-    use std::alloc::{AllocError, Allocator, Global, Layout};
+    use std::alloc::{Alloc, AllocError, Allocator, Global, Layout};
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::ptr::NonNull;
 
     struct AllocCount(Cell<i32>);
-    unsafe impl Allocator for AllocCount {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for AllocCount {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             self.0.set(self.0.get() + 1);
-            Global.allocate(layout)
+            Global.alloc_ref().allocate(layout)
         }
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             self.0.set(self.0.get() - 1);
-            unsafe { Global.deallocate(ptr, layout) }
+            unsafe { Global.alloc_ref().deallocate(ptr, layout) }
+        }
+    }
+    unsafe impl Allocator for AllocCount {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 

--- a/library/alloctests/tests/boxed.rs
+++ b/library/alloctests/tests/boxed.rs
@@ -1,4 +1,4 @@
-use core::alloc::{AllocError, Allocator, Layout};
+use core::alloc::{Alloc, AllocError, Allocator, Layout};
 use core::cell::Cell;
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
@@ -64,19 +64,25 @@ fn box_deref_lval() {
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_no_leak() {
-    use std::alloc::{AllocError, Allocator, Global, Layout};
+    use std::alloc::{Alloc, AllocError, Allocator, Global, Layout};
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::ptr::NonNull;
 
     struct AllocCount(Cell<i32>);
-    unsafe impl Allocator for AllocCount {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for AllocCount {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             self.0.set(self.0.get() + 1);
-            Global.allocate(layout)
+            Global.alloc_ref().allocate(layout)
         }
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             self.0.set(self.0.get() - 1);
-            unsafe { Global.deallocate(ptr, layout) }
+            unsafe { Global.alloc_ref().deallocate(ptr, layout) }
+        }
+    }
+    unsafe impl Allocator for AllocCount {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 
@@ -101,13 +107,13 @@ fn panic_no_leak() {
 #[allow(unused)]
 pub struct ConstAllocator;
 
-unsafe impl Allocator for ConstAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl Alloc for ConstAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         match layout.size() {
-            0 => Ok(layout.dangling_ptr().cast_slice(0)),
+            0 => Ok(layout.dangling_ptr()),
             _ => unsafe {
                 let ptr = core::intrinsics::const_allocate(layout.size(), layout.align());
-                Ok(NonNull::new_unchecked(ptr as *mut [u8; 0] as *mut [u8]))
+                Ok(NonNull::new_unchecked(ptr))
             },
         }
     }
@@ -119,11 +125,11 @@ unsafe impl Allocator for ConstAllocator {
         }
     }
 
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let ptr = self.allocate(layout)?;
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        let ptr = Alloc::allocate(self, layout)?;
         if layout.size() > 0 {
             unsafe {
-                ptr.as_mut_ptr().write_bytes(0, layout.size());
+                ptr.write_bytes(0, layout.size());
             }
         }
         Ok(ptr)
@@ -134,25 +140,25 @@ unsafe impl Allocator for ConstAllocator {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
         );
 
-        let new_ptr = self.allocate(new_layout)?;
+        let new_ptr = Alloc::allocate(self, new_layout)?;
         if new_layout.size() > 0 {
             // Safety: `new_ptr` is valid for writes and `ptr` for reads of
             // `old_layout.size()`, because `new_layout.size() >=
             // old_layout.size()` (which is an invariant that must be upheld by
             // callers).
             unsafe {
-                new_ptr.as_mut_ptr().copy_from_nonoverlapping(ptr.as_ptr(), old_layout.size());
+                new_ptr.as_ptr().copy_from_nonoverlapping(ptr.as_ptr(), old_layout.size());
             }
             // Safety: `ptr` is never used again is also an invariant which must
             // be upheld by callers.
             unsafe {
-                self.deallocate(ptr, old_layout);
+                Alloc::deallocate(self, ptr, old_layout);
             }
         }
         Ok(new_ptr)
@@ -163,14 +169,14 @@ unsafe impl Allocator for ConstAllocator {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // Safety: Invariants of `grow_zeroed` and `grow` are the same, and must
         // be enforced by callers.
         let new_ptr = unsafe { self.grow(ptr, old_layout, new_layout)? };
         if new_layout.size() > 0 {
             let old_size = old_layout.size();
             let new_size = new_layout.size();
-            let raw_ptr = new_ptr.as_mut_ptr();
+            let raw_ptr = new_ptr.as_ptr();
             // Safety:
             // - `grow` returned Ok, so the returned pointer must be valid for
             //   `new_size` bytes
@@ -188,28 +194,35 @@ unsafe impl Allocator for ConstAllocator {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
         );
 
-        let new_ptr = self.allocate(new_layout)?;
+        let new_ptr = Alloc::allocate(self, new_layout)?;
         if new_layout.size() > 0 {
             // Safety: `new_ptr` and `ptr` are valid for reads/writes of
             // `new_layout.size()` because of the invariants of shrink, which
             // include `new_layout.size()` being smaller than (or equal to)
             // `old_layout.size()`.
             unsafe {
-                new_ptr.as_mut_ptr().copy_from_nonoverlapping(ptr.as_ptr(), new_layout.size());
+                new_ptr.as_ptr().copy_from_nonoverlapping(ptr.as_ptr(), new_layout.size());
             }
             // Safety: `ptr` is never used again is also an invariant which must
             // be upheld by callers.
             unsafe {
-                self.deallocate(ptr, old_layout);
+                Alloc::deallocate(self, ptr, old_layout);
             }
         }
         Ok(new_ptr)
+    }
+}
+
+unsafe impl Allocator for ConstAllocator {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 
     fn by_ref(&self) -> &Self

--- a/library/alloctests/tests/heap.rs
+++ b/library/alloctests/tests/heap.rs
@@ -1,4 +1,4 @@
-use std::alloc::{Allocator, Global, Layout, System};
+use std::alloc::{Alloc, Allocator, Global, Layout, System};
 
 /// Issue #45955 and #62251.
 #[test]
@@ -20,12 +20,15 @@ fn check_overalign_requests<T: Allocator>(allocator: T) {
             unsafe {
                 let pointers: Vec<_> = (0..iterations)
                     .map(|_| {
-                        allocator.allocate(Layout::from_size_align(size, align).unwrap()).unwrap()
+                        allocator
+                            .alloc_ref()
+                            .allocate(Layout::from_size_align(size, align).unwrap())
+                            .unwrap()
                     })
                     .collect();
                 for &ptr in &pointers {
                     assert_eq!(
-                        ptr.as_non_null_ptr().as_ptr().addr() % align,
+                        ptr.as_ptr().addr() % align,
                         0,
                         "Got a pointer less aligned than requested"
                     )
@@ -33,10 +36,9 @@ fn check_overalign_requests<T: Allocator>(allocator: T) {
 
                 // Clean up
                 for &ptr in &pointers {
-                    allocator.deallocate(
-                        ptr.as_non_null_ptr(),
-                        Layout::from_size_align(size, align).unwrap(),
-                    )
+                    allocator
+                        .alloc_ref()
+                        .deallocate(ptr, Layout::from_size_align(size, align).unwrap())
                 }
             }
         }

--- a/library/alloctests/tests/lib.rs
+++ b/library/alloctests/tests/lib.rs
@@ -18,7 +18,6 @@
 #![feature(unboxed_closures)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
-#![feature(slice_ptr_get)]
 #![feature(slice_range)]
 #![feature(slice_partial_sort_unstable)]
 #![feature(inplace_iteration)]

--- a/library/alloctests/tests/rc.rs
+++ b/library/alloctests/tests/rc.rs
@@ -238,19 +238,25 @@ fn weak_may_dangle() {
 #[test]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_no_leak() {
-    use std::alloc::{AllocError, Allocator, Global, Layout};
+    use std::alloc::{Alloc, AllocError, Allocator, Global, Layout};
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::ptr::NonNull;
 
     struct AllocCount(Cell<i32>);
-    unsafe impl Allocator for AllocCount {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for AllocCount {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             self.0.set(self.0.get() + 1);
-            Global.allocate(layout)
+            Global.alloc_ref().allocate(layout)
         }
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             self.0.set(self.0.get() - 1);
-            unsafe { Global.deallocate(ptr, layout) }
+            unsafe { Global.alloc_ref().deallocate(ptr, layout) }
+        }
+    }
+    unsafe impl Allocator for AllocCount {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 

--- a/library/alloctests/tests/sync.rs
+++ b/library/alloctests/tests/sync.rs
@@ -1,5 +1,5 @@
 use alloc::sync::*;
-use std::alloc::{AllocError, Allocator, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Layout};
 use std::any::Any;
 use std::clone::Clone;
 use std::mem::MaybeUninit;
@@ -34,13 +34,19 @@ impl<'a> AllocCanary<'a> {
     }
 }
 
-unsafe impl Allocator for AllocCanary<'_> {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        std::alloc::Global.allocate(layout)
+unsafe impl Alloc for AllocCanary<'_> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        std::alloc::Global.alloc_ref().allocate(layout)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        unsafe { std::alloc::Global.deallocate(ptr, layout) }
+        unsafe { std::alloc::Global.alloc_ref().deallocate(ptr, layout) }
+    }
+}
+unsafe impl Allocator for AllocCanary<'_> {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/library/alloctests/tests/vec.rs
+++ b/library/alloctests/tests/vec.rs
@@ -1,4 +1,4 @@
-use core::alloc::{Allocator, Layout};
+use core::alloc::{Alloc, Allocator, Layout};
 use core::num::NonZero;
 use core::ptr::NonNull;
 use core::{assert_eq, assert_ne};
@@ -1082,14 +1082,20 @@ fn test_into_iter_advance_by() {
 fn test_into_iter_drop_allocator() {
     struct ReferenceCountedAllocator<'a>(#[allow(dead_code)] DropCounter<'a>);
 
-    unsafe impl Allocator for ReferenceCountedAllocator<'_> {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
-            System.allocate(layout)
+    unsafe impl Alloc for ReferenceCountedAllocator<'_> {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, core::alloc::AllocError> {
+            System.alloc_ref().allocate(layout)
         }
 
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             // Safety: Invariants passed to caller.
-            unsafe { System.deallocate(ptr, layout) }
+            unsafe { System.alloc_ref().deallocate(ptr, layout) }
+        }
+    }
+    unsafe impl Allocator for ReferenceCountedAllocator<'_> {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 
@@ -2557,8 +2563,8 @@ fn test_box_zero_allocator() {
     struct ZstTracker {
         state: RefCell<(HashSet<usize>, usize)>,
     }
-    unsafe impl Allocator for ZstTracker {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for ZstTracker {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             let ptr = if layout.size() == 0 {
                 let mut state = self.state.borrow_mut();
                 let addr = state.1;
@@ -2569,7 +2575,7 @@ fn test_box_zero_allocator() {
             } else {
                 unsafe { std::alloc::alloc(layout) }
             };
-            Ok(NonNull::new(ptr).ok_or(AllocError)?.cast_slice(layout.size()))
+            Ok(NonNull::new(ptr).ok_or(AllocError)?)
         }
 
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
@@ -2581,6 +2587,12 @@ fn test_box_zero_allocator() {
             } else {
                 unsafe { std::alloc::dealloc(ptr.as_ptr(), layout) }
             }
+        }
+    }
+    unsafe impl Allocator for ZstTracker {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 

--- a/library/alloctests/tests/vec_deque_alloc_error.rs
+++ b/library/alloctests/tests/vec_deque_alloc_error.rs
@@ -1,6 +1,6 @@
 #![feature(alloc_error_hook, allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout, System, set_alloc_error_hook};
+use std::alloc::{Alloc, AllocError, Allocator, Layout, System, set_alloc_error_hook};
 use std::collections::VecDeque;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::ptr::NonNull;
@@ -14,16 +14,16 @@ fn test_shrink_to_unwind() {
 
     struct BadAlloc;
 
-    unsafe impl Allocator for BadAlloc {
-        fn allocate(&self, l: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Alloc for BadAlloc {
+        fn allocate(&self, l: Layout) -> Result<NonNull<u8>, AllocError> {
             // We allocate zeroed here so that the whole buffer of the deque
             // is always initialized. That way, even if the deque is left in
             // an inconsistent state, no uninitialized memory should be accessed.
-            System.allocate_zeroed(l)
+            System.alloc_ref().allocate_zeroed(l)
         }
 
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            unsafe { System.deallocate(ptr, layout) }
+            unsafe { System.alloc_ref().deallocate(ptr, layout) }
         }
 
         unsafe fn shrink(
@@ -31,8 +31,14 @@ fn test_shrink_to_unwind() {
             _ptr: NonNull<u8>,
             _old_layout: Layout,
             _new_layout: Layout,
-        ) -> Result<NonNull<[u8]>, AllocError> {
+        ) -> Result<NonNull<u8>, AllocError> {
             Err(AllocError)
+        }
+    }
+    unsafe impl Allocator for BadAlloc {
+        type Alloc = Self;
+        fn alloc_ref(&self) -> &Self::Alloc {
+            self
         }
     }
 

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -27,33 +27,28 @@ use crate::ptr::{self, NonNull};
 /// that may be due to resource exhaustion or to
 /// something wrong when combining the given input arguments with this
 /// allocator.
-#[unstable(feature = "allocator_api", issue = "32838")]
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct AllocError;
 
-#[unstable(
-    feature = "allocator_api",
-    reason = "the precise API and guarantees it provides may be tweaked.",
-    issue = "32838"
-)]
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
 impl Error for AllocError {}
 
-// (we need this for downstream impl of trait Error)
-#[unstable(feature = "allocator_api", issue = "32838")]
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
 impl fmt::Display for AllocError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("memory allocation failed")
     }
 }
 
-/// An implementation of `Allocator` can allocate, grow, shrink, and deallocate arbitrary blocks of
+/// An implementation of `Alloc` can allocate, grow, shrink, and deallocate arbitrary blocks of
 /// data described via [`Layout`][].
 ///
-/// `Allocator` is designed to be implemented on ZSTs, references, or smart pointers.
+/// `Alloc` is designed to be implemented on ZSTs, references, or smart pointers.
 /// An allocator for `MyAlloc([u8; N])` cannot be moved, without updating the pointers to the
 /// allocated memory.
 ///
-/// In contrast to [`GlobalAlloc`][], `Allocator` allows zero-sized allocations. If an underlying
+/// In contrast to [`GlobalAlloc`][], `Alloc` allows zero-sized allocations. If an underlying
 /// allocator does not support this (like jemalloc) or responds by returning a null pointer
 /// (such as `libc::malloc`), this must be caught by the implementation.
 ///
@@ -70,10 +65,10 @@ impl fmt::Display for AllocError {
 /// A call to `grow` or `shrink` that returns `Err`,
 /// does not deallocate the memory block passed to it.
 ///
-/// [`allocate`]: Allocator::allocate
-/// [`grow`]: Allocator::grow
-/// [`shrink`]: Allocator::shrink
-/// [`deallocate`]: Allocator::deallocate
+/// [`allocate`]: Alloc::allocate
+/// [`grow`]: Alloc::grow
+/// [`shrink`]: Alloc::shrink
+/// [`deallocate`]: Alloc::deallocate
 ///
 /// ### Memory fitting
 ///
@@ -89,13 +84,13 @@ impl fmt::Display for AllocError {
 ///
 /// # Safety
 ///
-/// Memory blocks that are [*currently allocated*] by an allocator,
+/// Memory blocks that are [*currently allocated*] by an `Alloc` instance
 /// must point to valid memory, and retain their validity until either:
 ///  - the memory block is deallocated, or
-///  - the allocator is dropped.
+///  - the `Alloc` instance is moved or dropped.
 ///
-/// Copying, cloning, or moving the allocator must not invalidate memory blocks returned from it.
-/// A copied or cloned allocator must behave like the original allocator.
+/// Copying or cloning an `Alloc` instance must not invalidate memory
+/// blocks returned from it.
 ///
 /// A memory block which is [*currently allocated*] may be passed to
 /// any method of the allocator that accepts such an argument.
@@ -108,19 +103,19 @@ impl fmt::Display for AllocError {
 /// This ensures that pointer arithmetic within the allocation
 /// (for example, `ptr.add(len)`) cannot overflow the address space.
 /// [*currently allocated*]: #currently-allocated-memory
-#[unstable(feature = "allocator_api", issue = "32838")]
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
-pub const unsafe trait Allocator {
+pub const unsafe trait Alloc {
     /// Attempts to allocate a block of memory.
     ///
-    /// On success, returns a [`NonNull<[u8]>`][NonNull] meeting the size and alignment guarantees of `layout`.
+    /// On success, returns a [`NonNull<u8>`][NonNull] meeting the size and alignment guarantees of `layout`.
     ///
     /// The returned block may have a larger size than specified by `layout.size()`, and may or may
     /// not have its contents initialized.
     ///
     /// The returned block of memory remains valid as long as it is [*currently allocated*] and the shorter of:
     ///   - the borrow-checker lifetime of the allocator type itself.
-    ///   - as long as the allocator and all its clones have not been dropped.
+    ///   - as long as the allocator has not been moved or dropped.
     ///
     /// [*currently allocated*]: #currently-allocated-memory
     ///
@@ -137,7 +132,8 @@ pub const unsafe trait Allocator {
     /// call the [`handle_alloc_error`] function, rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError>;
+    #[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError>;
 
     /// Behaves like `allocate`, but also ensures that the returned memory is zero-initialized.
     ///
@@ -154,10 +150,11 @@ pub const unsafe trait Allocator {
     /// call the [`handle_alloc_error`] function, rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    #[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         let ptr = self.allocate(layout)?;
         // SAFETY: `alloc` returns a valid memory block
-        unsafe { ptr.as_non_null_ptr().as_ptr().write_bytes(0, ptr.len()) }
+        unsafe { ptr.as_ptr().write_bytes(0, layout.size()) }
         Ok(ptr)
     }
 
@@ -170,12 +167,13 @@ pub const unsafe trait Allocator {
     ///
     /// [*currently allocated*]: #currently-allocated-memory
     /// [*fit*]: #memory-fitting
+    #[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
 
     /// Attempts to extend the memory block.
     ///
-    /// Returns a new [`NonNull<[u8]>`][NonNull] containing a pointer and the actual size of the allocated
-    /// memory. The pointer is suitable for holding data described by `new_layout`. To accomplish
+    /// Returns a new [`NonNull<u8>`][NonNull] containing a pointer to the allocated memory.
+    /// The pointer is suitable for holding data described by `new_layout`. To accomplish
     /// this, the allocator may extend the allocation referenced by `ptr` to fit the new layout.
     ///
     /// If this returns `Ok`, then ownership of the memory block referenced by `ptr` has been
@@ -210,12 +208,13 @@ pub const unsafe trait Allocator {
     /// call the [`handle_alloc_error`] function, rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
+    #[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
     unsafe fn grow(
         &self,
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
@@ -229,7 +228,7 @@ pub const unsafe trait Allocator {
         // deallocated, it cannot overlap `new_ptr`. Thus, the call to `copy_nonoverlapping` is
         // safe. The safety contract for `dealloc` must be upheld by the caller.
         unsafe {
-            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), old_layout.size());
+            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_layout.size());
             self.deallocate(ptr, old_layout);
         }
 
@@ -242,12 +241,7 @@ pub const unsafe trait Allocator {
     /// The memory block will contain the following contents after a successful call to
     /// `grow_zeroed`:
     ///   * Bytes `0..old_layout.size()` are preserved from the original allocation.
-    ///   * Bytes `old_layout.size()..old_size` will either be preserved or zeroed, depending on
-    ///     the allocator implementation. `old_size` refers to the size of the memory block prior
-    ///     to the `grow_zeroed` call, which may be larger than the size that was originally
-    ///     requested when it was allocated.
-    ///   * Bytes `old_size..new_size` are zeroed. `new_size` refers to the size of the memory
-    ///     block returned by the `grow_zeroed` call.
+    ///   * Bytes `old_layout.size()..new_layout.size()` are zeroed.
     ///
     /// # Safety
     ///
@@ -273,12 +267,13 @@ pub const unsafe trait Allocator {
     /// call the [`handle_alloc_error`] function, rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
+    #[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
     unsafe fn grow_zeroed(
         &self,
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
@@ -292,7 +287,7 @@ pub const unsafe trait Allocator {
         // deallocated, it cannot overlap `new_ptr`. Thus, the call to `copy_nonoverlapping` is
         // safe. The safety contract for `dealloc` must be upheld by the caller.
         unsafe {
-            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), old_layout.size());
+            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_layout.size());
             self.deallocate(ptr, old_layout);
         }
 
@@ -301,8 +296,8 @@ pub const unsafe trait Allocator {
 
     /// Attempts to shrink the memory block.
     ///
-    /// Returns a new [`NonNull<[u8]>`][NonNull] containing a pointer and the actual size of the allocated
-    /// memory. The pointer is suitable for holding data described by `new_layout`. To accomplish
+    /// Returns a new [`NonNull<u8>`][NonNull] containing a pointer to the allocated memory.
+    /// The pointer is suitable for holding data described by `new_layout`. To accomplish
     /// this, the allocator may shrink the allocation referenced by `ptr` to fit the new layout.
     ///
     /// If this returns `Ok`, then ownership of the memory block referenced by `ptr` has been
@@ -337,12 +332,13 @@ pub const unsafe trait Allocator {
     /// call the [`handle_alloc_error`] function, rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
+    #[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
     unsafe fn shrink(
         &self,
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
@@ -356,11 +352,180 @@ pub const unsafe trait Allocator {
         // deallocated, it cannot overlap `new_ptr`. Thus, the call to `copy_nonoverlapping` is
         // safe. The safety contract for `dealloc` must be upheld by the caller.
         unsafe {
-            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), new_layout.size());
+            ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_layout.size());
             self.deallocate(ptr, old_layout);
         }
 
         Ok(new_ptr)
+    }
+}
+
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_unstable(feature = "const_heap", issue = "79597")]
+const unsafe impl<A> Alloc for &A
+where
+    A: [const] Alloc + ?Sized,
+{
+    #[inline]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        (**self).allocate(layout)
+    }
+
+    #[inline]
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        (**self).allocate_zeroed(layout)
+    }
+
+    #[inline]
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).deallocate(ptr, layout) }
+    }
+
+    #[inline]
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<u8>, AllocError> {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).grow(ptr, old_layout, new_layout) }
+    }
+
+    #[inline]
+    unsafe fn grow_zeroed(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<u8>, AllocError> {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
+    }
+
+    #[inline]
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<u8>, AllocError> {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    }
+}
+
+#[stable(feature = "allocator_api_mvp", since = "CURRENT_RUSTC_VERSION")]
+unsafe impl<A> Alloc for &mut A
+where
+    A: Alloc + ?Sized,
+{
+    #[inline]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        (**self).allocate(layout)
+    }
+
+    #[inline]
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        (**self).allocate_zeroed(layout)
+    }
+
+    #[inline]
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).deallocate(ptr, layout) }
+    }
+
+    #[inline]
+    unsafe fn grow(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<u8>, AllocError> {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).grow(ptr, old_layout, new_layout) }
+    }
+
+    #[inline]
+    unsafe fn grow_zeroed(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<u8>, AllocError> {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
+    }
+
+    #[inline]
+    unsafe fn shrink(
+        &self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> Result<NonNull<u8>, AllocError> {
+        // SAFETY: the safety contract must be upheld by the caller
+        unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    }
+}
+
+/// An implementation of `Allocator` represents a single instance of `Alloc`, or a group of
+/// such instances that share the same underlying allocation state. Copies or clones of an
+/// `Allocator` must be able to operate on allocations from any other copy or clone of
+/// that `Allocator`.
+///
+/// # Safety
+///
+/// Memory blocks that are [*currently allocated*] by an allocator,
+/// must point to valid memory, and retain their validity until either:
+///  - the memory block is deallocated, or
+///  - the allocator is dropped.
+///
+/// Copying, cloning, or  moving the allocator must not invalidate memory
+/// blocks returned from it.
+///
+/// A copied or cloned allocator must behave like the original allocator.
+#[unstable(feature = "allocator_api", issue = "32838")]
+#[rustc_const_unstable(feature = "const_heap", issue = "79597")]
+pub const unsafe trait Allocator {
+    type Alloc: [const] Alloc + ?Sized;
+
+    /// Obtain a reference to this allocator's `Alloc` instance.
+    ///
+    /// The `Alloc` must be behaviorally equivalent to any other instance of
+    /// `Alloc` returned by copies or clones of this `Allocator`.
+    fn alloc_ref(&self) -> &Self::Alloc;
+
+    /// Attempts to allocate a block of memory.
+    ///
+    /// On success, returns a [`NonNull<[u8]>`][NonNull] meeting the size and alignment guarantees of `layout`.
+    ///
+    /// The returned slice may have a larger size than specified by `layout.size()`, and may or may
+    /// not have its contents initialized.
+    ///
+    /// See [`Alloc::allocate`] for details.
+    ///
+    /// FIXME: This function exists for compatibility with existing clients
+    /// of the unstable `allocator_api` feature, and should be reviewed before
+    /// stabilization.
+    #[inline(always)]
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Ok(self.alloc_ref().allocate(layout)?.cast_slice(layout.size()))
+    }
+
+    /// Deallocates the memory referenced by `ptr`.
+    ///
+    /// See [`Alloc::deallocate`] for details.
+    ///
+    /// FIXME: This function exists for compatibility with existing clients
+    /// of the unstable `allocator_api` feature, and should be reviewed before
+    /// stabilization.
+    #[inline(always)]
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        // SAFETY: all conditions must be upheld by the caller
+        unsafe { self.alloc_ref().deallocate(ptr, layout) }
     }
 
     /// Creates a "by reference" adapter for this instance of `Allocator`.
@@ -376,112 +541,44 @@ pub const unsafe trait Allocator {
 }
 
 #[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<'a> Allocator for &'a dyn Alloc {
+    type Alloc = dyn Alloc + 'a;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<'a> Allocator for &'a mut dyn Alloc {
+    type Alloc = dyn Alloc + 'a;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        &**self
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
 const unsafe impl<A> Allocator for &A
 where
-    A: [const] Allocator + ?Sized,
+    A: [const] Allocator,
 {
-    #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        (**self).allocate(layout)
-    }
-
-    #[inline]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        (**self).allocate_zeroed(layout)
-    }
-
-    #[inline]
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).deallocate(ptr, layout) }
-    }
-
-    #[inline]
-    unsafe fn grow(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).grow(ptr, old_layout, new_layout) }
-    }
-
-    #[inline]
-    unsafe fn grow_zeroed(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
-    }
-
-    #[inline]
-    unsafe fn shrink(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    type Alloc = A::Alloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        (**self).alloc_ref()
     }
 }
 
 #[unstable(feature = "allocator_api", issue = "32838")]
 unsafe impl<A> Allocator for &mut A
 where
-    A: Allocator + ?Sized,
+    A: Allocator,
 {
-    #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        (**self).allocate(layout)
-    }
-
-    #[inline]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        (**self).allocate_zeroed(layout)
-    }
-
-    #[inline]
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).deallocate(ptr, layout) }
-    }
-
-    #[inline]
-    unsafe fn grow(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).grow(ptr, old_layout, new_layout) }
-    }
-
-    #[inline]
-    unsafe fn grow_zeroed(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).grow_zeroed(ptr, old_layout, new_layout) }
-    }
-
-    #[inline]
-    unsafe fn shrink(
-        &self,
-        ptr: NonNull<u8>,
-        old_layout: Layout,
-        new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // SAFETY: the safety contract must be upheld by the caller
-        unsafe { (**self).shrink(ptr, old_layout, new_layout) }
+    type Alloc = A::Alloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        (**self).alloc_ref()
     }
 }

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1611,19 +1611,20 @@ impl<T> NonNull<[T]> {
     /// # Examples
     ///
     /// ```rust
-    /// #![feature(allocator_api, ptr_as_uninit)]
+    /// #![feature(allocator_api, ptr_as_uninit, ptr_cast_slice)]
     ///
-    /// use std::alloc::{Allocator, Layout, Global};
+    /// use std::alloc::{Alloc, Allocator, Layout, Global};
     /// use std::mem::MaybeUninit;
     /// use std::ptr::NonNull;
     ///
-    /// let memory: NonNull<[u8]> = Global.allocate(Layout::new::<[u8; 32]>())?;
+    /// let layout = Layout::new::<[u8; 32]>();
+    /// let memory: NonNull<[u8]> = Global.alloc_ref().allocate(layout)?.cast_slice(layout.size());
     /// // This is safe as `memory` is valid for reads and writes for `memory.len()` many bytes.
     /// // Note that calling `memory.as_mut()` is not allowed here as the content may be uninitialized.
     /// # #[allow(unused_variables)]
     /// let slice: &mut [MaybeUninit<u8>] = unsafe { memory.as_uninit_slice_mut() };
     /// # // Prevent leaks for Miri.
-    /// # unsafe { Global.deallocate(memory.cast(), Layout::new::<[u8; 32]>()); }
+    /// # unsafe { Global.alloc_ref().deallocate(memory.cast(), Layout::new::<[u8; 32]>()); }
     /// # Ok::<_, std::alloc::AllocError>(())
     /// ```
     #[inline]

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -140,23 +140,23 @@ pub struct System;
 
 impl System {
     #[inline]
-    fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
+    fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<u8>, AllocError> {
         match layout.size() {
-            0 => Ok(layout.dangling_ptr().cast_slice(0)),
+            0 => Ok(layout.dangling_ptr()),
             // SAFETY: `layout` is non-zero in size,
-            size => unsafe {
+            _ => unsafe {
                 let raw_ptr = if zeroed {
                     GlobalAlloc::alloc_zeroed(self, layout)
                 } else {
                     GlobalAlloc::alloc(self, layout)
                 };
                 let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
-                Ok(ptr.cast_slice(size))
+                Ok(ptr)
             },
         }
     }
 
-    // SAFETY: Same as `Allocator::grow`
+    // SAFETY: Same as `Alloc::grow`
     #[inline]
     unsafe fn grow_impl(
         &self,
@@ -164,7 +164,7 @@ impl System {
         old_layout: Layout,
         new_layout: Layout,
         zeroed: bool,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
@@ -187,7 +187,7 @@ impl System {
                 if zeroed {
                     raw_ptr.add(old_size).write_bytes(0, new_size - old_size);
                 }
-                Ok(ptr.cast_slice(new_size))
+                Ok(ptr)
             },
 
             // SAFETY: because `new_layout.size()` must be greater than or equal to `old_size`,
@@ -197,26 +197,33 @@ impl System {
             // for `dealloc` must be upheld by the caller.
             old_size => unsafe {
                 let new_ptr = self.alloc_impl(new_layout, zeroed)?;
-                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), old_size);
-                Allocator::deallocate(self, ptr, old_layout);
+                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), old_size);
+                self.alloc_ref().deallocate(ptr, old_layout);
                 Ok(new_ptr)
             },
         }
     }
 }
 
-// The Allocator impl checks the layout size to be non-zero and forwards to the GlobalAlloc impl,
+// Only needed while `Alloc::allocate` and `Allocator::allocate`
+// coexist for `hashbrown` compatibility.
+#[unstable(feature = "allocator_api", issue = "32838")]
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct __SystemButOnlyAlloc(System);
+
+// The Alloc impl checks the layout size to be non-zero and forwards to the GlobalAlloc impl,
 // which is in `std::sys::*::alloc`.
 #[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl Allocator for System {
+unsafe impl Alloc for __SystemButOnlyAlloc {
     #[inline]
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.alloc_impl(layout, false)
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        self.0.alloc_impl(layout, false)
     }
 
     #[inline]
-    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.alloc_impl(layout, true)
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        self.0.alloc_impl(layout, true)
     }
 
     #[inline]
@@ -224,7 +231,7 @@ unsafe impl Allocator for System {
         if layout.size() != 0 {
             // SAFETY: `layout` is non-zero in size,
             // other conditions must be upheld by the caller
-            unsafe { GlobalAlloc::dealloc(self, ptr.as_ptr(), layout) }
+            unsafe { GlobalAlloc::dealloc(&self.0, ptr.as_ptr(), layout) }
         }
     }
 
@@ -234,9 +241,9 @@ unsafe impl Allocator for System {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.grow_impl(ptr, old_layout, new_layout, false) }
+        unsafe { self.0.grow_impl(ptr, old_layout, new_layout, false) }
     }
 
     #[inline]
@@ -245,9 +252,9 @@ unsafe impl Allocator for System {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         // SAFETY: all conditions must be upheld by the caller
-        unsafe { self.grow_impl(ptr, old_layout, new_layout, true) }
+        unsafe { self.0.grow_impl(ptr, old_layout, new_layout, true) }
     }
 
     #[inline]
@@ -256,7 +263,7 @@ unsafe impl Allocator for System {
         ptr: NonNull<u8>,
         old_layout: Layout,
         new_layout: Layout,
-    ) -> Result<NonNull<[u8]>, AllocError> {
+    ) -> Result<NonNull<u8>, AllocError> {
         debug_assert!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
@@ -265,8 +272,8 @@ unsafe impl Allocator for System {
         match new_layout.size() {
             // SAFETY: conditions must be upheld by the caller
             0 => unsafe {
-                Allocator::deallocate(self, ptr, old_layout);
-                Ok(new_layout.dangling_ptr().cast_slice(0))
+                Alloc::deallocate(self, ptr, old_layout);
+                Ok(new_layout.dangling_ptr())
             },
 
             // SAFETY: `new_size` is non-zero. Other conditions must be upheld by the caller
@@ -274,9 +281,9 @@ unsafe impl Allocator for System {
                 // `realloc` probably checks for `new_size <= old_layout.size()` or something similar.
                 hint::assert_unchecked(new_size <= old_layout.size());
 
-                let raw_ptr = GlobalAlloc::realloc(self, ptr.as_ptr(), old_layout, new_size);
+                let raw_ptr = GlobalAlloc::realloc(&self.0, ptr.as_ptr(), old_layout, new_size);
                 let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
-                Ok(ptr.cast_slice(new_size))
+                Ok(ptr)
             },
 
             // SAFETY: because `new_size` must be smaller than or equal to `old_layout.size()`,
@@ -285,12 +292,21 @@ unsafe impl Allocator for System {
             // `new_ptr`. Thus, the call to `copy_nonoverlapping` is safe. The safety contract
             // for `dealloc` must be upheld by the caller.
             new_size => unsafe {
-                let new_ptr = Allocator::allocate(self, new_layout)?;
-                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), new_size);
-                Allocator::deallocate(self, ptr, old_layout);
+                let new_ptr = Alloc::allocate(self, new_layout)?;
+                ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_ptr(), new_size);
+                Alloc::deallocate(self, ptr, old_layout);
                 Ok(new_ptr)
             },
         }
+    }
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl Allocator for System {
+    type Alloc = __SystemButOnlyAlloc;
+    #[inline(always)]
+    fn alloc_ref(&self) -> &Self::Alloc {
+        &__SystemButOnlyAlloc(System)
     }
 }
 

--- a/src/tools/clippy/tests/ui/vec_box_sized.rs
+++ b/src/tools/clippy/tests/ui/vec_box_sized.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Layout};
 use std::ptr::NonNull;
 
 struct SizedStruct(i32);
@@ -11,12 +11,18 @@ struct UnsizedStruct([i32]);
 struct BigStruct([i32; 10000]);
 
 struct DummyAllocator;
-unsafe impl Allocator for DummyAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl Alloc for DummyAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         todo!()
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         todo!()
+    }
+}
+unsafe impl Allocator for DummyAllocator {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/src/tools/clippy/tests/ui/vec_box_sized.stderr
+++ b/src/tools/clippy/tests/ui/vec_box_sized.stderr
@@ -1,5 +1,5 @@
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:26:14
+  --> tests/ui/vec_box_sized.rs:32:14
    |
 LL |     const C: Vec<Box<i32>> = Vec::new();
    |              ^^^^^^^^^^^^^ help: try: `Vec<i32>`
@@ -8,49 +8,49 @@ LL |     const C: Vec<Box<i32>> = Vec::new();
    = help: to override `-D warnings` add `#[allow(clippy::vec_box)]`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:28:15
+  --> tests/ui/vec_box_sized.rs:34:15
    |
 LL |     static S: Vec<Box<i32>> = Vec::new();
    |               ^^^^^^^^^^^^^ help: try: `Vec<i32>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:32:21
+  --> tests/ui/vec_box_sized.rs:38:21
    |
 LL |         sized_type: Vec<Box<SizedStruct>>,
    |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<SizedStruct>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:36:14
+  --> tests/ui/vec_box_sized.rs:42:14
    |
 LL |     struct A(Vec<Box<SizedStruct>>);
    |              ^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<SizedStruct>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:38:18
+  --> tests/ui/vec_box_sized.rs:44:18
    |
 LL |     struct B(Vec<Vec<Box<(u32)>>>);
    |                  ^^^^^^^^^^^^^^^ help: try: `Vec<u32>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:41:42
+  --> tests/ui/vec_box_sized.rs:47:42
    |
 LL |     fn allocator_global_defined_vec() -> Vec<Box<i32>, std::alloc::Global> {
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<i32>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:45:42
+  --> tests/ui/vec_box_sized.rs:51:42
    |
 LL |     fn allocator_global_defined_box() -> Vec<Box<i32, std::alloc::Global>> {
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<i32>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:49:29
+  --> tests/ui/vec_box_sized.rs:55:29
    |
 LL |     fn allocator_match() -> Vec<Box<i32, DummyAllocator>, DummyAllocator> {
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Vec<i32>`
 
 error: `Vec<T>` is already on the heap, the boxing is unnecessary
-  --> tests/ui/vec_box_sized.rs:87:23
+  --> tests/ui/vec_box_sized.rs:93:23
    |
 LL |         pub fn f() -> Vec<Box<S>> {
    |                       ^^^^^^^^^^^ help: try: `Vec<S>`

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation of `pthread_mutex_t` is forbidden while the queue is non-empty
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/alloc/global_system_mixup.stderr
+++ b/src/tools/miri/tests/fail/alloc/global_system_mixup.stderr
@@ -9,9 +9,11 @@ LL |         FREE();
    = note: stack backtrace:
            0: std::sys::alloc::PLATFORM::<impl std::alloc::GlobalAlloc for std::alloc::System>::dealloc
                at RUSTLIB/std/src/sys/alloc/PLATFORM.rs:LL:CC
-           1: <std::alloc::System as std::alloc::Allocator>::deallocate
+           1: <std::alloc::__SystemButOnlyAlloc as std::alloc::Alloc>::deallocate
                at RUSTLIB/std/src/alloc.rs:LL:CC
-           2: main
+           2: <std::alloc::System as std::alloc::Allocator>::deallocate
+               at RUSTLIB/core/src/alloc/PLATFORM.rs:LL:CC
+           3: main
                at tests/fail/alloc/global_system_mixup.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/alloc/stack_free.stderr
+++ b/src/tools/miri/tests/fail/alloc/stack_free.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocating ALLOC, which is stack variable memory, using Rust heap deallocation operation
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.rs
+++ b/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.rs
@@ -6,7 +6,7 @@
 //@normalize-stderr-test: "\[0x[a-fx\d.]+\]" -> "[RANGE]"
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Layout};
 use std::cell::{Cell, UnsafeCell};
 use std::mem;
 use std::ptr::{self, NonNull, addr_of};
@@ -80,12 +80,12 @@ impl MyAllocator {
     }
 }
 
-unsafe impl Allocator for MyAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl Alloc for MyAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         // Expensive bin search.
         let bin = self.find_bin(layout).ok_or(AllocError)?;
         let ptr = bin.pop().ok_or(AllocError)?;
-        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+        Ok(ptr)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
@@ -105,6 +105,13 @@ unsafe impl Allocator for MyAllocator {
         }
         // Make sure we can also still access this via `self` after the rest is done.
         let _val = self.bins[0].top.get();
+    }
+}
+
+unsafe impl Allocator for MyAllocator {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
@@ -12,23 +12,21 @@ help: <TAG> was created by a Unique retag at offsets [RANGE]
 LL |     (Box::new_in([t], a) as Box<[T], A>).into_vec()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: stack backtrace:
-           0: <MyAllocator as std::alloc::Allocator>::deallocate
+           0: <MyAllocator as std::alloc::Alloc>::deallocate
                at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
-           1: <&MyAllocator as std::alloc::Allocator>::deallocate
-               at RUSTLIB/core/src/alloc/mod.rs:LL:CC
-           2: alloc::raw_vec::RawVecInner::<&MyAllocator>::deallocate
+           1: alloc::raw_vec::RawVecInner::<&MyAllocator>::deallocate
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           3: <alloc::raw_vec::RawVec<usize, &MyAllocator> as std::ops::Drop>::drop
+           2: <alloc::raw_vec::RawVec<usize, &MyAllocator> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           4: std::ptr::drop_glue::<alloc::raw_vec::RawVec<usize, &MyAllocator>> - shim(Some(alloc::raw_vec::RawVec<usize, &MyAllocator>))
+           3: std::ptr::drop_glue::<alloc::raw_vec::RawVec<usize, &MyAllocator>> - shim(Some(alloc::raw_vec::RawVec<usize, &MyAllocator>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           5: std::ptr::drop_glue::<std::vec::Vec<usize, &MyAllocator>> - shim(Some(std::vec::Vec<usize, &MyAllocator>))
+           4: std::ptr::drop_glue::<std::vec::Vec<usize, &MyAllocator>> - shim(Some(std::vec::Vec<usize, &MyAllocator>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           6: std::ptr::drop_glue::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)> - shim(Some((std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)))
+           5: std::ptr::drop_glue::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)> - shim(Some((std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           7: std::mem::drop::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)>
+           6: std::mem::drop::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
-           8: main
+           7: main
                at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/box-custom-alloc-aliasing.tree.stderr
@@ -27,23 +27,21 @@ LL |         self.top.set(top + 1);
    = note: stack backtrace:
            0: MyBin::push
                at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
-           1: <MyAllocator as std::alloc::Allocator>::deallocate
+           1: <MyAllocator as std::alloc::Alloc>::deallocate
                at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
-           2: <&MyAllocator as std::alloc::Allocator>::deallocate
-               at RUSTLIB/core/src/alloc/mod.rs:LL:CC
-           3: alloc::raw_vec::RawVecInner::<&MyAllocator>::deallocate
+           2: alloc::raw_vec::RawVecInner::<&MyAllocator>::deallocate
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           4: <alloc::raw_vec::RawVec<usize, &MyAllocator> as std::ops::Drop>::drop
+           3: <alloc::raw_vec::RawVec<usize, &MyAllocator> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           5: std::ptr::drop_glue::<alloc::raw_vec::RawVec<usize, &MyAllocator>> - shim(Some(alloc::raw_vec::RawVec<usize, &MyAllocator>))
+           4: std::ptr::drop_glue::<alloc::raw_vec::RawVec<usize, &MyAllocator>> - shim(Some(alloc::raw_vec::RawVec<usize, &MyAllocator>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           6: std::ptr::drop_glue::<std::vec::Vec<usize, &MyAllocator>> - shim(Some(std::vec::Vec<usize, &MyAllocator>))
+           5: std::ptr::drop_glue::<std::vec::Vec<usize, &MyAllocator>> - shim(Some(std::vec::Vec<usize, &MyAllocator>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           7: std::ptr::drop_glue::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)> - shim(Some((std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)))
+           6: std::ptr::drop_glue::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)> - shim(Some((std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           8: std::mem::drop::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)>
+           7: std::mem::drop::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
-           9: main
+           8: main
                at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information

--- a/src/tools/miri/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocating while item [Unique for <TAG>] is strongly protected
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/src/tools/miri/tests/fail/tree_borrows/strongly-protected.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/strongly-protected.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information

--- a/src/tools/miri/tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information

--- a/src/tools/miri/tests/fail/validity/box-custom-alloc-dangling-ptr.rs
+++ b/src/tools/miri/tests/fail/validity/box-custom-alloc-dangling-ptr.rs
@@ -8,13 +8,20 @@ use std::ptr::NonNull;
 #[allow(unused)]
 struct MyAlloc(usize, usize); // make sure `Box<T, MyAlloc>` is an `Aggregate`
 
-unsafe impl std::alloc::Allocator for MyAlloc {
-    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, std::alloc::AllocError> {
+unsafe impl std::alloc::Alloc for MyAlloc {
+    fn allocate(&self, _layout: Layout) -> Result<NonNull<u8>, std::alloc::AllocError> {
         unimplemented!()
     }
 
     unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
         unimplemented!()
+    }
+}
+
+unsafe impl std::alloc::Allocator for MyAlloc {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/src/tools/miri/tests/fail/validity/box-custom-alloc-invalid-alloc.rs
+++ b/src/tools/miri/tests/fail/validity/box-custom-alloc-invalid-alloc.rs
@@ -13,13 +13,20 @@ struct MyAlloc {
     my_alloc_field2: usize,
 }
 
-unsafe impl std::alloc::Allocator for MyAlloc {
-    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, std::alloc::AllocError> {
+unsafe impl std::alloc::Alloc for MyAlloc {
+    fn allocate(&self, _layout: Layout) -> Result<NonNull<u8>, std::alloc::AllocError> {
         unimplemented!()
     }
 
     unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
         unimplemented!()
+    }
+}
+
+unsafe impl std::alloc::Allocator for MyAlloc {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/src/tools/miri/tests/pass/alloc-access-tracking.stderr
+++ b/src/tools/miri/tests/pass/alloc-access-tracking.stderr
@@ -19,8 +19,8 @@ LL |         assert_eq!(*ptr, 42);
 note: freed allocation ALLOC
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ tracking was triggered here
+LL |                 self.1.alloc_ref().deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ tracking was triggered here
    |
    = note: stack backtrace:
            0: <std::boxed::Box<std::mem::MaybeUninit<[u8; 123]>> as std::ops::Drop>::drop

--- a/src/tools/miri/tests/pass/box-custom-alloc-aliasing.rs
+++ b/src/tools/miri/tests/pass/box-custom-alloc-aliasing.rs
@@ -7,7 +7,7 @@
 //@compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-relax-custom-allocator-uniqueness -Zmiri-tree-borrows-implicit-writes
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Layout};
 use std::cell::{Cell, UnsafeCell};
 use std::mem;
 use std::ptr::{self, NonNull, addr_of};
@@ -80,12 +80,12 @@ impl MyAllocator {
     }
 }
 
-unsafe impl Allocator for MyAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl Alloc for MyAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         // Expensive bin search.
         let bin = self.find_bin(layout).ok_or(AllocError)?;
         let ptr = bin.pop().ok_or(AllocError)?;
-        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+        Ok(ptr)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
@@ -104,6 +104,13 @@ unsafe impl Allocator for MyAllocator {
         }
         // Make sure we can also still access this via `self` after the rest is done.
         let _val = self.bins[0].top.get();
+    }
+}
+
+unsafe impl Allocator for MyAllocator {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/src/tools/miri/tests/pass/box-custom-alloc.rs
+++ b/src/tools/miri/tests/pass/box-custom-alloc.rs
@@ -3,17 +3,17 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Layout};
 use std::cell::Cell;
 use std::mem::MaybeUninit;
-use std::ptr::{self, NonNull};
+use std::ptr::{NonNull};
 
 struct OnceAlloc<'a> {
     space: Cell<&'a mut [MaybeUninit<u8>]>,
 }
 
-unsafe impl<'shared, 'a: 'shared> Allocator for &'shared OnceAlloc<'a> {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl<'shared, 'a: 'shared> Alloc for &'shared OnceAlloc<'a> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         let space = self.space.replace(&mut []);
 
         let (ptr, len) = (space.as_mut_ptr(), space.len());
@@ -22,11 +22,17 @@ unsafe impl<'shared, 'a: 'shared> Allocator for &'shared OnceAlloc<'a> {
             return Err(AllocError);
         }
 
-        let slice_ptr = ptr::slice_from_raw_parts_mut(ptr as *mut u8, len);
-        unsafe { Ok(NonNull::new_unchecked(slice_ptr)) }
+        unsafe { Ok(NonNull::new_unchecked(ptr as *mut u8)) }
     }
 
     unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+}
+
+unsafe impl<'shared, 'a: 'shared> Allocator for &'shared OnceAlloc<'a> {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
+    }
 }
 
 trait MyTrait {
@@ -59,13 +65,20 @@ fn test1() {
 // Make the allocator itself so big that the Box is not even a ScalarPair any more.
 struct OnceAllocRef<'s, 'a>(&'s OnceAlloc<'a>, #[allow(dead_code)] u64);
 
-unsafe impl<'shared, 'a: 'shared> Allocator for OnceAllocRef<'shared, 'a> {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.0.allocate(layout)
+unsafe impl<'shared, 'a: 'shared> Alloc for OnceAllocRef<'shared, 'a> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Alloc::allocate(self.0.alloc_ref(), layout)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        self.0.deallocate(ptr, layout)
+        Alloc::deallocate(self.0.alloc_ref(), ptr, layout)
+    }
+}
+
+unsafe impl<'shared, 'a: 'shared> Allocator for OnceAllocRef<'shared, 'a> {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/src/tools/miri/tests/pass/heap_allocator.rs
+++ b/src/tools/miri/tests/pass/heap_allocator.rs
@@ -1,6 +1,6 @@
 #![feature(allocator_api, slice_ptr_get)]
 
-use std::alloc::{Allocator, Global, Layout, System};
+use std::alloc::{Alloc, Allocator, Global, Layout, System};
 use std::ptr::NonNull;
 use std::slice;
 
@@ -12,16 +12,16 @@ fn check_alloc<T: Allocator>(allocator: T) {
             let layout_10 = Layout::from_size_align(10, align / 2).unwrap();
 
             for _ in 0..32 {
-                let a = allocator.allocate(layout_20).unwrap().as_non_null_ptr();
+                let a = allocator.alloc_ref().allocate(layout_20).unwrap();
                 assert_eq!(
                     a.as_ptr() as usize % layout_20.align(),
                     0,
                     "pointer is incorrectly aligned",
                 );
-                allocator.deallocate(a, layout_20);
+                allocator.alloc_ref().deallocate(a, layout_20);
             }
 
-            let p1 = allocator.allocate_zeroed(layout_20).unwrap().as_non_null_ptr();
+            let p1 = allocator.alloc_ref().allocate_zeroed(layout_20).unwrap();
             assert_eq!(
                 p1.as_ptr() as usize % layout_20.align(),
                 0,
@@ -30,7 +30,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(*p1.as_ptr(), 0);
 
             // old size < new size
-            let p2 = allocator.grow(p1, layout_20, layout_40).unwrap().as_non_null_ptr();
+            let p2 = allocator.alloc_ref().grow(p1, layout_20, layout_40).unwrap();
             assert_eq!(
                 p2.as_ptr() as usize % layout_40.align(),
                 0,
@@ -40,7 +40,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(&slice, &[0_u8; 20]);
 
             // old size == new size
-            let p3 = allocator.grow(p2, layout_40, layout_40).unwrap().as_non_null_ptr();
+            let p3 = allocator.alloc_ref().grow(p2, layout_40, layout_40).unwrap();
             assert_eq!(
                 p3.as_ptr() as usize % layout_40.align(),
                 0,
@@ -50,7 +50,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(&slice, &[0_u8; 20]);
 
             // old size > new size
-            let p4 = allocator.shrink(p3, layout_40, layout_10).unwrap().as_non_null_ptr();
+            let p4 = allocator.alloc_ref().shrink(p3, layout_40, layout_10).unwrap();
             assert_eq!(
                 p4.as_ptr() as usize % layout_10.align(),
                 0,
@@ -59,7 +59,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             let slice = slice::from_raw_parts(p4.as_ptr(), 10);
             assert_eq!(&slice, &[0_u8; 10]);
 
-            allocator.deallocate(p4, layout_10);
+            allocator.alloc_ref().deallocate(p4, layout_10);
         }
     }
 }
@@ -73,9 +73,9 @@ fn check_align_requests<T: Allocator>(allocator: T) {
                 let pointers: Vec<_> = (0..iterations)
                     .map(|_| {
                         allocator
+                            .alloc_ref()
                             .allocate(Layout::from_size_align(size, align).unwrap())
                             .unwrap()
-                            .as_non_null_ptr()
                     })
                     .collect();
                 for &ptr in &pointers {
@@ -88,7 +88,7 @@ fn check_align_requests<T: Allocator>(allocator: T) {
 
                 // Clean up.
                 for &ptr in &pointers {
-                    allocator.deallocate(ptr, Layout::from_size_align(size, align).unwrap())
+                    allocator.alloc_ref().deallocate(ptr, Layout::from_size_align(size, align).unwrap())
                 }
             }
         }
@@ -100,7 +100,7 @@ fn global_to_box() {
     let l = Layout::new::<T>();
     // allocate manually with global allocator, then turn into Box and free there
     unsafe {
-        let ptr = Global.allocate(l).unwrap().as_non_null_ptr().as_ptr() as *mut T;
+        let ptr = Global.alloc_ref().allocate(l).unwrap().as_ptr() as *mut T;
         let b = Box::from_raw(ptr);
         drop(b);
     }

--- a/tests/mir-opt/box_conditional_drop_allocator.rs
+++ b/tests/mir-opt/box_conditional_drop_allocator.rs
@@ -6,17 +6,23 @@
 // Regression test for #131082.
 // Testing that the allocator of a Box is dropped in conditional drops
 
-use std::alloc::{AllocError, Allocator, Global, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Global, Layout};
 use std::ptr::NonNull;
 
 struct DropAllocator;
 
-unsafe impl Allocator for DropAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        Global.allocate(layout)
+unsafe impl Alloc for DropAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Global.alloc_ref().allocate(layout)
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        Global.deallocate(ptr, layout);
+        Global.alloc_ref().deallocate(ptr, layout);
+    }
+}
+unsafe impl Allocator for DropAllocator {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 impl Drop for DropAllocator {

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.runtime-optimized.after.panic-abort.mir
@@ -23,15 +23,17 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.runtime-optimized.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_bytes.runtime-optimized.after.panic-unwind.mir
@@ -23,15 +23,17 @@ fn drop_bytes(_1: *mut Box<[u8; 1024]>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.runtime-optimized.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.runtime-optimized.after.panic-abort.mir
@@ -23,15 +23,17 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.runtime-optimized.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_box_of_sized.drop_generic.runtime-optimized.after.panic-unwind.mir
@@ -23,15 +23,17 @@ fn drop_generic(_1: *mut Box<T>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.32bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.32bit.panic-abort.mir
@@ -26,15 +26,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.32bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.32bit.panic-unwind.mir
@@ -26,15 +26,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.64bit.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.64bit.panic-abort.mir
@@ -26,15 +26,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.64bit.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/drop_boxed_slice.generic_in_place.runtime-optimized.after.64bit.panic-unwind.mir
@@ -26,15 +26,17 @@ fn generic_in_place(_1: *mut Box<[T]>) -> () {
                             scope 23 (inlined std::ptr::Unique::<u8>::as_non_null_ptr) {
                             }
                         }
-                        scope 24 (inlined <std::alloc::Global as Allocator>::deallocate) {
-                            scope 25 (inlined std::alloc::Global::deallocate_impl) {
-                                scope 26 (inlined std::alloc::Global::deallocate_impl_runtime) {
-                                    scope 27 (inlined Layout::size) {
+                        scope 24 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+                        }
+                        scope 25 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::deallocate) {
+                            scope 26 (inlined std::alloc::Global::deallocate_impl) {
+                                scope 27 (inlined std::alloc::Global::deallocate_impl_runtime) {
+                                    scope 28 (inlined Layout::size) {
                                     }
-                                    scope 28 (inlined alloc::alloc::dealloc_nonnull) {
-                                        scope 29 (inlined Layout::size) {
+                                    scope 29 (inlined alloc::alloc::dealloc_nonnull) {
+                                        scope 30 (inlined Layout::size) {
                                         }
-                                        scope 30 (inlined Layout::alignment) {
+                                        scope 31 (inlined Layout::alignment) {
                                         }
                                     }
                                 }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -5,37 +5,38 @@
       let mut _0: ();
       let _1: std::alloc::Layout;
       let mut _2: std::option::Option<std::alloc::Layout>;
-      let mut _3: *mut u8;
-      let mut _4: *mut [u8];
-      let mut _5: std::ptr::NonNull<[u8]>;
-      let mut _6: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
-      let mut _7: std::alloc::Layout;
+      let mut _4: std::ptr::NonNull<u8>;
+      let mut _5: std::result::Result<std::ptr::NonNull<u8>, std::alloc::AllocError>;
+      let mut _6: std::alloc::Layout;
       scope 1 {
           debug layout => _1;
+          let _3: *mut u8;
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
-              scope 6 (inlined std::alloc::Global::alloc_impl) {
+          scope 5 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+          }
+          scope 6 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::allocate) {
+              scope 7 (inlined std::alloc::Global::alloc_impl) {
               }
           }
-          scope 7 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
-              let mut _10: isize;
-              let _11: std::alloc::AllocError;
-              let mut _12: !;
-              let mut _13: &dyn std::fmt::Debug;
-              let _14: &std::alloc::AllocError;
-              scope 8 {
-              }
+          scope 8 (inlined #[track_caller] Result::<NonNull<u8>, std::alloc::AllocError>::unwrap) {
+              let mut _9: isize;
+              let _10: std::alloc::AllocError;
+              let mut _11: !;
+              let mut _12: &dyn std::fmt::Debug;
+              let _13: &std::alloc::AllocError;
               scope 9 {
               }
+              scope 10 {
+              }
           }
-          scope 10 (inlined NonNull::<[u8]>::as_ptr) {
+          scope 11 (inlined NonNull::<u8>::as_ptr) {
           }
       }
       scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
-          let mut _8: isize;
-          let mut _9: !;
+          let mut _7: isize;
+          let mut _8: !;
           scope 4 {
           }
       }
@@ -45,10 +46,10 @@
           StorageLive(_2);
 -         _2 = Option::<Layout>::None;
 +         _2 = const Option::<Layout>::None;
-          StorageLive(_8);
--         _8 = discriminant(_2);
--         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         _8 = const 0_isize;
+          StorageLive(_7);
+-         _7 = discriminant(_2);
+-         switchInt(move _7) -> [0: bb2, 1: bb3, otherwise: bb1];
++         _7 = const 0_isize;
 +         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
@@ -57,47 +58,44 @@
       }
   
       bb2: {
-          _9 = option::unwrap_failed() -> unwind unreachable;
+          _8 = option::unwrap_failed() -> unwind unreachable;
       }
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
-          StorageDead(_8);
+          StorageDead(_7);
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
-          StorageLive(_7);
--         _7 = copy _1;
--         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
+-         _6 = copy _1;
+-         _5 = std::alloc::Global::alloc_impl_runtime(move _6, const false) -> [return: bb4, unwind unreachable];
++         _6 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
++         _5 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
-          StorageDead(_7);
-          StorageLive(_10);
-          _10 = discriminant(_6);
-          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb1];
+          StorageDead(_6);
+          StorageLive(_9);
+          _9 = discriminant(_5);
+          switchInt(move _9) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {
+          StorageLive(_12);
           StorageLive(_13);
-          StorageLive(_14);
-          _14 = &_11;
-          _13 = copy _14 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
-          _12 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _13) -> unwind unreachable;
+          _13 = &_10;
+          _12 = copy _13 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
+          _11 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _12) -> unwind unreachable;
       }
   
       bb6: {
-          _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
-          StorageDead(_10);
-          StorageDead(_6);
-          _4 = copy _5 as *mut [u8] (Transmute);
+          _4 = move ((_5 as Ok).0: std::ptr::NonNull<u8>);
+          StorageDead(_9);
           StorageDead(_5);
-          _3 = copy _4 as *mut u8 (PtrToPtr);
+          _3 = copy _4 as *mut u8 (Transmute);
           StorageDead(_4);
           StorageDead(_3);
           StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -5,26 +5,27 @@
       let mut _0: ();
       let _1: std::alloc::Layout;
       let mut _2: std::option::Option<std::alloc::Layout>;
-      let mut _3: *mut u8;
-      let mut _4: *mut [u8];
-      let mut _5: std::ptr::NonNull<[u8]>;
-      let mut _6: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
-      let mut _7: std::alloc::Layout;
+      let mut _4: std::ptr::NonNull<u8>;
+      let mut _5: std::result::Result<std::ptr::NonNull<u8>, std::alloc::AllocError>;
+      let mut _6: std::alloc::Layout;
       scope 1 {
           debug layout => _1;
+          let _3: *mut u8;
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
-              scope 6 (inlined std::alloc::Global::alloc_impl) {
+          scope 5 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+          }
+          scope 6 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::allocate) {
+              scope 7 (inlined std::alloc::Global::alloc_impl) {
               }
           }
-          scope 7 (inlined NonNull::<[u8]>::as_ptr) {
+          scope 8 (inlined NonNull::<u8>::as_ptr) {
           }
       }
       scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
-          let mut _8: isize;
-          let mut _9: !;
+          let mut _7: isize;
+          let mut _8: !;
           scope 4 {
           }
       }
@@ -34,18 +35,16 @@
           StorageLive(_2);
 -         _2 = Option::<Layout>::None;
 +         _2 = const Option::<Layout>::None;
-          StorageLive(_8);
--         _8 = discriminant(_2);
--         switchInt(move _8) -> [0: bb3, 1: bb4, otherwise: bb2];
-+         _8 = const 0_isize;
+          StorageLive(_7);
+-         _7 = discriminant(_2);
+-         switchInt(move _7) -> [0: bb3, 1: bb4, otherwise: bb2];
++         _7 = const 0_isize;
 +         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
       }
   
       bb1: {
-          StorageDead(_6);
-          _4 = copy _5 as *mut [u8] (Transmute);
           StorageDead(_5);
-          _3 = copy _4 as *mut u8 (PtrToPtr);
+          _3 = copy _4 as *mut u8 (Transmute);
           StorageDead(_4);
           StorageDead(_3);
           StorageDead(_1);
@@ -57,28 +56,27 @@
       }
   
       bb3: {
-          _9 = option::unwrap_failed() -> unwind continue;
+          _8 = option::unwrap_failed() -> unwind continue;
       }
   
       bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
-          StorageDead(_8);
+          StorageDead(_7);
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
-          StorageLive(_7);
--         _7 = copy _1;
--         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb5, unwind continue];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
+-         _6 = copy _1;
+-         _5 = std::alloc::Global::alloc_impl_runtime(move _6, const false) -> [return: bb5, unwind continue];
++         _6 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }};
++         _5 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x00000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
       }
   
       bb5: {
-          StorageDead(_7);
-          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
+          StorageDead(_6);
+          _4 = Result::<NonNull<u8>, std::alloc::AllocError>::unwrap(move _5) -> [return: bb1, unwind continue];
       }
 + }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -5,37 +5,38 @@
       let mut _0: ();
       let _1: std::alloc::Layout;
       let mut _2: std::option::Option<std::alloc::Layout>;
-      let mut _3: *mut u8;
-      let mut _4: *mut [u8];
-      let mut _5: std::ptr::NonNull<[u8]>;
-      let mut _6: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
-      let mut _7: std::alloc::Layout;
+      let mut _4: std::ptr::NonNull<u8>;
+      let mut _5: std::result::Result<std::ptr::NonNull<u8>, std::alloc::AllocError>;
+      let mut _6: std::alloc::Layout;
       scope 1 {
           debug layout => _1;
+          let _3: *mut u8;
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
-              scope 6 (inlined std::alloc::Global::alloc_impl) {
+          scope 5 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+          }
+          scope 6 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::allocate) {
+              scope 7 (inlined std::alloc::Global::alloc_impl) {
               }
           }
-          scope 7 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
-              let mut _10: isize;
-              let _11: std::alloc::AllocError;
-              let mut _12: !;
-              let mut _13: &dyn std::fmt::Debug;
-              let _14: &std::alloc::AllocError;
-              scope 8 {
-              }
+          scope 8 (inlined #[track_caller] Result::<NonNull<u8>, std::alloc::AllocError>::unwrap) {
+              let mut _9: isize;
+              let _10: std::alloc::AllocError;
+              let mut _11: !;
+              let mut _12: &dyn std::fmt::Debug;
+              let _13: &std::alloc::AllocError;
               scope 9 {
               }
+              scope 10 {
+              }
           }
-          scope 10 (inlined NonNull::<[u8]>::as_ptr) {
+          scope 11 (inlined NonNull::<u8>::as_ptr) {
           }
       }
       scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
-          let mut _8: isize;
-          let mut _9: !;
+          let mut _7: isize;
+          let mut _8: !;
           scope 4 {
           }
       }
@@ -45,10 +46,10 @@
           StorageLive(_2);
 -         _2 = Option::<Layout>::None;
 +         _2 = const Option::<Layout>::None;
-          StorageLive(_8);
--         _8 = discriminant(_2);
--         switchInt(move _8) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         _8 = const 0_isize;
+          StorageLive(_7);
+-         _7 = discriminant(_2);
+-         switchInt(move _7) -> [0: bb2, 1: bb3, otherwise: bb1];
++         _7 = const 0_isize;
 +         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
   
@@ -57,47 +58,44 @@
       }
   
       bb2: {
-          _9 = option::unwrap_failed() -> unwind unreachable;
+          _8 = option::unwrap_failed() -> unwind unreachable;
       }
   
       bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
-          StorageDead(_8);
+          StorageDead(_7);
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
-          StorageLive(_7);
--         _7 = copy _1;
--         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb4, unwind unreachable];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
+-         _6 = copy _1;
+-         _5 = std::alloc::Global::alloc_impl_runtime(move _6, const false) -> [return: bb4, unwind unreachable];
++         _6 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
++         _5 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
-          StorageDead(_7);
-          StorageLive(_10);
-          _10 = discriminant(_6);
-          switchInt(move _10) -> [0: bb6, 1: bb5, otherwise: bb1];
+          StorageDead(_6);
+          StorageLive(_9);
+          _9 = discriminant(_5);
+          switchInt(move _9) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {
+          StorageLive(_12);
           StorageLive(_13);
-          StorageLive(_14);
-          _14 = &_11;
-          _13 = copy _14 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
-          _12 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _13) -> unwind unreachable;
+          _13 = &_10;
+          _12 = copy _13 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
+          _11 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _12) -> unwind unreachable;
       }
   
       bb6: {
-          _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
-          StorageDead(_10);
-          StorageDead(_6);
-          _4 = copy _5 as *mut [u8] (Transmute);
+          _4 = move ((_5 as Ok).0: std::ptr::NonNull<u8>);
+          StorageDead(_9);
           StorageDead(_5);
-          _3 = copy _4 as *mut u8 (PtrToPtr);
+          _3 = copy _4 as *mut u8 (Transmute);
           StorageDead(_4);
           StorageDead(_3);
           StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -5,26 +5,27 @@
       let mut _0: ();
       let _1: std::alloc::Layout;
       let mut _2: std::option::Option<std::alloc::Layout>;
-      let mut _3: *mut u8;
-      let mut _4: *mut [u8];
-      let mut _5: std::ptr::NonNull<[u8]>;
-      let mut _6: std::result::Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError>;
-      let mut _7: std::alloc::Layout;
+      let mut _4: std::ptr::NonNull<u8>;
+      let mut _5: std::result::Result<std::ptr::NonNull<u8>, std::alloc::AllocError>;
+      let mut _6: std::alloc::Layout;
       scope 1 {
           debug layout => _1;
+          let _3: *mut u8;
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
-              scope 6 (inlined std::alloc::Global::alloc_impl) {
+          scope 5 (inlined <std::alloc::Global as Allocator>::alloc_ref) {
+          }
+          scope 6 (inlined <std::alloc::__GlobalButOnlyAlloc as Alloc>::allocate) {
+              scope 7 (inlined std::alloc::Global::alloc_impl) {
               }
           }
-          scope 7 (inlined NonNull::<[u8]>::as_ptr) {
+          scope 8 (inlined NonNull::<u8>::as_ptr) {
           }
       }
       scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
-          let mut _8: isize;
-          let mut _9: !;
+          let mut _7: isize;
+          let mut _8: !;
           scope 4 {
           }
       }
@@ -34,18 +35,16 @@
           StorageLive(_2);
 -         _2 = Option::<Layout>::None;
 +         _2 = const Option::<Layout>::None;
-          StorageLive(_8);
--         _8 = discriminant(_2);
--         switchInt(move _8) -> [0: bb3, 1: bb4, otherwise: bb2];
-+         _8 = const 0_isize;
+          StorageLive(_7);
+-         _7 = discriminant(_2);
+-         switchInt(move _7) -> [0: bb3, 1: bb4, otherwise: bb2];
++         _7 = const 0_isize;
 +         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
       }
   
       bb1: {
-          StorageDead(_6);
-          _4 = copy _5 as *mut [u8] (Transmute);
           StorageDead(_5);
-          _3 = copy _4 as *mut u8 (PtrToPtr);
+          _3 = copy _4 as *mut u8 (Transmute);
           StorageDead(_4);
           StorageDead(_3);
           StorageDead(_1);
@@ -57,28 +56,27 @@
       }
   
       bb3: {
-          _9 = option::unwrap_failed() -> unwind continue;
+          _8 = option::unwrap_failed() -> unwind continue;
       }
   
       bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
-          StorageDead(_8);
+          StorageDead(_7);
           StorageDead(_2);
           StorageLive(_3);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
-          StorageLive(_7);
--         _7 = copy _1;
--         _6 = std::alloc::Global::alloc_impl_runtime(move _7, const false) -> [return: bb5, unwind continue];
-+         _7 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
-+         _6 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
+-         _6 = copy _1;
+-         _5 = std::alloc::Global::alloc_impl_runtime(move _6, const false) -> [return: bb5, unwind continue];
++         _6 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }};
++         _5 = std::alloc::Global::alloc_impl_runtime(const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::mem::Alignment {{ _inner_repr_trick: Scalar(0x0000000000000000): mem::alignment::AlignmentEnum }} }}, const false) -> [return: bb5, unwind continue];
       }
   
       bb5: {
-          StorageDead(_7);
-          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
+          StorageDead(_6);
+          _4 = Result::<NonNull<u8>, std::alloc::AllocError>::unwrap(move _5) -> [return: bb1, unwind continue];
       }
 + }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.rs
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.rs
@@ -5,12 +5,12 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{Allocator, Global, Layout};
+use std::alloc::{Alloc, Allocator, Global, Layout};
 
 // EMIT_MIR issue_117368_print_invalid_constant.main.GVN.diff
 fn main() {
     // CHECK-LABEL: fn main(
     // CHECK: debug layout => const Layout
     let layout: Layout = None.unwrap();
-    let ptr: *mut u8 = Global.allocate(layout).unwrap().as_ptr() as _;
+    let ptr: *mut u8 = Global.alloc_ref().allocate(layout).unwrap().as_ptr();
 }

--- a/tests/ui/allocator/alloc-shrink-oob-read.rs
+++ b/tests/ui/allocator/alloc-shrink-oob-read.rs
@@ -5,9 +5,8 @@
 //@ run-pass
 
 #![feature(allocator_api)]
-#![feature(slice_ptr_get)]
 
-use std::alloc::{Allocator, Global, Layout, handle_alloc_error};
+use std::alloc::{Alloc, Allocator, Global, Layout, handle_alloc_error};
 use std::ptr::{self, NonNull};
 
 fn main() {
@@ -42,13 +41,16 @@ unsafe fn test_triangle() -> bool {
             println!("allocate({:?})", layout);
         }
 
-        let ptr = Global.allocate(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+        let ptr = Global
+            .alloc_ref()
+            .allocate(layout)
+            .unwrap_or_else(|_| handle_alloc_error(layout));
 
         if PRINT {
             println!("allocate({:?}) = {:?}", layout, ptr);
         }
 
-        ptr.as_mut_ptr()
+        ptr.as_ptr()
     }
 
     unsafe fn deallocate(ptr: *mut u8, layout: Layout) {
@@ -56,7 +58,7 @@ unsafe fn test_triangle() -> bool {
             println!("deallocate({:?}, {:?}", ptr, layout);
         }
 
-        Global.deallocate(NonNull::new_unchecked(ptr), layout);
+        Global.alloc_ref().deallocate(NonNull::new_unchecked(ptr), layout);
     }
 
     unsafe fn reallocate(ptr: *mut u8, old: Layout, new: Layout) -> *mut u8 {
@@ -65,9 +67,9 @@ unsafe fn test_triangle() -> bool {
         }
 
         let memory = if new.size() > old.size() {
-            Global.grow(NonNull::new_unchecked(ptr), old, new)
+            Global.alloc_ref().grow(NonNull::new_unchecked(ptr), old, new)
         } else {
-            Global.shrink(NonNull::new_unchecked(ptr), old, new)
+            Global.alloc_ref().shrink(NonNull::new_unchecked(ptr), old, new)
         };
 
         let ptr = memory.unwrap_or_else(|_| handle_alloc_error(new));
@@ -75,7 +77,7 @@ unsafe fn test_triangle() -> bool {
         if PRINT {
             println!("reallocate({:?}, old={:?}, new={:?}) = {:?}", ptr, old, new, ptr);
         }
-        ptr.as_mut_ptr()
+        ptr.as_ptr()
     }
 
     fn idx_to_size(i: usize) -> usize {

--- a/tests/ui/allocator/custom.rs
+++ b/tests/ui/allocator/custom.rs
@@ -4,11 +4,10 @@
 //@ no-prefer-dynamic
 
 #![feature(allocator_api)]
-#![feature(slice_ptr_get)]
 
 extern crate helper;
 
-use std::alloc::{self, Allocator, Global, Layout, System};
+use std::alloc::{self, Alloc, Allocator, Global, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static HITS: AtomicUsize = AtomicUsize::new(0);
@@ -38,10 +37,10 @@ fn main() {
     unsafe {
         let layout = Layout::from_size_align(4, 2).unwrap();
 
-        let memory = Global.allocate(layout.clone()).unwrap();
+        let memory = Global.alloc_ref().allocate(layout.clone()).unwrap();
         helper::work_with(&memory);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 1);
-        Global.deallocate(memory.as_non_null_ptr(), layout);
+        Global.alloc_ref().deallocate(memory, layout);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 2);
 
         let s = String::with_capacity(10);
@@ -50,10 +49,10 @@ fn main() {
         drop(s);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
 
-        let memory = System.allocate(layout.clone()).unwrap();
+        let memory = System.alloc_ref().allocate(layout.clone()).unwrap();
         helper::work_with(&memory);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
-        System.deallocate(memory.as_non_null_ptr(), layout);
+        System.alloc_ref().deallocate(memory, layout);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
     }
 }

--- a/tests/ui/allocator/dyn-compatible.rs
+++ b/tests/ui/allocator/dyn-compatible.rs
@@ -1,13 +1,13 @@
 //@ run-pass
 
-// Check that `Allocator` is dyn-compatible, this allows for polymorphic allocators
+// Check that `Alloc` is dyn-compatible, this allows for polymorphic allocators
 
 #![feature(allocator_api)]
 
-use std::alloc::{Allocator, System};
+use std::alloc::{Alloc, Allocator, System};
 
-fn ensure_dyn_compatible(_: &dyn Allocator) {}
+fn ensure_dyn_compatible(_: &dyn Alloc) {}
 
 fn main() {
-    ensure_dyn_compatible(&System);
+    ensure_dyn_compatible(System.alloc_ref());
 }

--- a/tests/ui/allocator/xcrate-use.rs
+++ b/tests/ui/allocator/xcrate-use.rs
@@ -5,12 +5,11 @@
 //@ no-prefer-dynamic
 
 #![feature(allocator_api)]
-#![feature(slice_ptr_get)]
 
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{Allocator, Global, Layout, System};
+use std::alloc::{Alloc, Allocator, Global, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[global_allocator]
@@ -21,16 +20,16 @@ fn main() {
         let n = GLOBAL.0.load(Ordering::SeqCst);
         let layout = Layout::from_size_align(4, 2).unwrap();
 
-        let memory = Global.allocate(layout.clone()).unwrap();
+        let memory = Global.alloc_ref().allocate(layout.clone()).unwrap();
         helper::work_with(&memory);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 1);
-        Global.deallocate(memory.as_non_null_ptr(), layout);
+        Global.alloc_ref().deallocate(memory, layout);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
 
-        let memory = System.allocate(layout.clone()).unwrap();
+        let memory = System.alloc_ref().allocate(layout.clone()).unwrap();
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
         helper::work_with(&memory);
-        System.deallocate(memory.as_non_null_ptr(), layout);
+        System.alloc_ref().deallocate(memory, layout);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
     }
 }

--- a/tests/ui/async-await/async-drop/async-drop-box-allocator.rs
+++ b/tests/ui/async-await/async-drop/async-drop-box-allocator.rs
@@ -21,7 +21,7 @@ use std::{
     pin::{pin, Pin},
     sync::{mpsc, Arc},
     task::{Context, Poll, Wake, Waker},
-    alloc::{AllocError, Allocator, Global, Layout},
+    alloc::{Alloc, AllocError, Allocator, Global, Layout},
     ptr::NonNull,
 };
 
@@ -51,12 +51,19 @@ impl AsyncDrop for Foo {
     }
 }
 
-unsafe impl Allocator for Foo {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        Global.allocate(layout)
+unsafe impl Alloc for Foo {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Global.alloc_ref().allocate(layout)
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        Global.deallocate(ptr, layout);
+        Global.alloc_ref().deallocate(ptr, layout);
+    }
+}
+
+unsafe impl Allocator for Foo {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/tests/ui/box/large-allocator-ice.rs
+++ b/tests/ui/box/large-allocator-ice.rs
@@ -2,19 +2,26 @@
 #![feature(allocator_api)]
 #![allow(unused_must_use)]
 
-use std::alloc::Allocator;
+use std::alloc::{Alloc, Allocator};
 
 struct BigAllocator([usize; 2]);
 
-unsafe impl Allocator for BigAllocator {
+unsafe impl Alloc for BigAllocator {
     fn allocate(
         &self,
         _: std::alloc::Layout,
-    ) -> Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError> {
+    ) -> Result<std::ptr::NonNull<u8>, std::alloc::AllocError> {
         todo!()
     }
     unsafe fn deallocate(&self, _: std::ptr::NonNull<u8>, _: std::alloc::Layout) {
         todo!()
+    }
+}
+
+unsafe impl Allocator for BigAllocator {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/tests/ui/box/leak-alloc.rs
+++ b/tests/ui/box/leak-alloc.rs
@@ -1,26 +1,33 @@
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout, System};
+use std::alloc::{Alloc, AllocError, Allocator, Layout, System};
 use std::ptr::NonNull;
 
 use std::boxed::Box;
 
-struct Alloc {}
+struct LeakAlloc {}
 
-unsafe impl Allocator for Alloc {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        System.allocate(layout)
+unsafe impl Alloc for LeakAlloc {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        System.alloc_ref().allocate(layout)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        System.deallocate(ptr, layout)
+        System.alloc_ref().deallocate(ptr, layout)
+    }
+}
+
+unsafe impl Allocator for LeakAlloc {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 
 fn use_value(_: u32) {}
 
 fn main() {
-    let alloc = Alloc {};
+    let alloc = LeakAlloc {};
     let boxed = Box::new_in(10, alloc.by_ref());
     let theref = Box::leak(boxed);
     drop(alloc);

--- a/tests/ui/box/leak-alloc.stderr
+++ b/tests/ui/box/leak-alloc.stderr
@@ -1,7 +1,7 @@
 error[E0505]: cannot move out of `alloc` because it is borrowed
-  --> $DIR/leak-alloc.rs:26:10
+  --> $DIR/leak-alloc.rs:33:10
    |
-LL |     let alloc = Alloc {};
+LL |     let alloc = LeakAlloc {};
    |         ----- binding `alloc` declared here
 LL |     let boxed = Box::new_in(10, alloc.by_ref());
    |                                 ----- borrow of `alloc` occurs here
@@ -12,11 +12,11 @@ LL |
 LL |     use_value(*theref)
    |               ------- borrow later used here
    |
-note: if `Alloc` implemented `Clone`, you could clone the value
+note: if `LeakAlloc` implemented `Clone`, you could clone the value
   --> $DIR/leak-alloc.rs:8:1
    |
-LL | struct Alloc {}
-   | ^^^^^^^^^^^^ consider implementing `Clone` for this type
+LL | struct LeakAlloc {}
+   | ^^^^^^^^^^^^^^^^ consider implementing `Clone` for this type
 ...
 LL |     let boxed = Box::new_in(10, alloc.by_ref());
    |                                 ----- you could clone this value

--- a/tests/ui/debuginfo/debuginfo-box-with-large-allocator.rs
+++ b/tests/ui/debuginfo/debuginfo-box-with-large-allocator.rs
@@ -4,17 +4,24 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, Allocator, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Layout};
 use std::ptr::NonNull;
 
 struct ZST;
 
-unsafe impl Allocator for &ZST {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl Alloc for &ZST {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
         todo!()
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         todo!()
+    }
+}
+
+unsafe impl Allocator for &ZST {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/tests/ui/drop/box-conditional-drop-allocator.rs
+++ b/tests/ui/drop/box-conditional-drop-allocator.rs
@@ -4,18 +4,24 @@
 // Regression test for #131082.
 // Testing that the allocator of a Box is dropped in conditional drops
 
-use std::alloc::{AllocError, Allocator, Global, Layout};
+use std::alloc::{Alloc, AllocError, Allocator, Global, Layout};
 use std::cell::Cell;
 use std::ptr::NonNull;
 
 struct DropCheckingAllocator<'a>(&'a Cell<bool>);
 
-unsafe impl Allocator for DropCheckingAllocator<'_> {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        Global.allocate(layout)
+unsafe impl Alloc for DropCheckingAllocator<'_> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        Global.alloc_ref().allocate(layout)
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        Global.deallocate(ptr, layout);
+        Global.alloc_ref().deallocate(ptr, layout);
+    }
+}
+unsafe impl Allocator for DropCheckingAllocator<'_> {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 impl Drop for DropCheckingAllocator<'_> {

--- a/tests/ui/lint/must_not_suspend/allocator.rs
+++ b/tests/ui/lint/must_not_suspend/allocator.rs
@@ -9,12 +9,19 @@ use std::ptr::NonNull;
 #[must_not_suspend]
 struct MyAllocatorWhichMustNotSuspend;
 
-unsafe impl Allocator for MyAllocatorWhichMustNotSuspend {
-    fn allocate(&self, l: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        Global.allocate(l)
+unsafe impl Alloc for MyAllocatorWhichMustNotSuspend {
+    fn allocate(&self, l: Layout) -> Result<NonNull<u8>, AllocError> {
+        Global.alloc_ref().allocate(l)
     }
     unsafe fn deallocate(&self, p: NonNull<u8>, l: Layout) {
-        Global.deallocate(p, l)
+        Global.alloc_ref().deallocate(p, l)
+    }
+}
+
+unsafe impl Allocator for MyAllocatorWhichMustNotSuspend {
+    type Alloc = Self;
+    fn alloc_ref(&self) -> &Self::Alloc {
+        self
     }
 }
 

--- a/tests/ui/lint/must_not_suspend/allocator.stderr
+++ b/tests/ui/lint/must_not_suspend/allocator.stderr
@@ -1,5 +1,5 @@
 error: allocator `MyAllocatorWhichMustNotSuspend` held across a suspend point, but should not be
-  --> $DIR/allocator.rs:24:9
+  --> $DIR/allocator.rs:31:9
    |
 LL |     let x = Box::new_in(1i32, MyAllocatorWhichMustNotSuspend);
    |         ^
@@ -8,7 +8,7 @@ LL |     suspend().await;
    |               ----- the value is held across this suspend point
    |
 help: consider using a block (`{ ... }`) to shrink the value's scope, ending before the suspend point
-  --> $DIR/allocator.rs:24:9
+  --> $DIR/allocator.rs:31:9
    |
 LL |     let x = Box::new_in(1i32, MyAllocatorWhichMustNotSuspend);
    |         ^

--- a/tests/ui/regions/regions-mock-codegen.rs
+++ b/tests/ui/regions/regions-mock-codegen.rs
@@ -3,7 +3,7 @@
 #![allow(non_camel_case_types)]
 #![feature(allocator_api)]
 
-use std::alloc::{handle_alloc_error, Allocator, Global, Layout};
+use std::alloc::{handle_alloc_error, Alloc, Allocator, Global, Layout};
 use std::ptr::NonNull;
 
 struct arena(());
@@ -24,7 +24,10 @@ struct Ccx {
 fn allocate(_bcx: &arena) -> &mut Bcx<'_> {
     unsafe {
         let layout = Layout::new::<Bcx>();
-        let ptr = Global.allocate(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+        let ptr = Global
+            .alloc_ref()
+            .allocate(layout)
+            .unwrap_or_else(|_| handle_alloc_error(layout));
         &mut *ptr.as_ptr().cast()
     }
 }
@@ -37,7 +40,9 @@ fn g(fcx: &Fcx) {
     let bcx = Bcx { fcx };
     let bcx2 = h(&bcx);
     unsafe {
-        Global.deallocate(NonNull::new_unchecked(bcx2 as *mut _ as *mut _), Layout::new::<Bcx>());
+        Global
+            .alloc_ref()
+            .deallocate(NonNull::new_unchecked(bcx2 as *mut _ as *mut _), Layout::new::<Bcx>());
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157286)*
<!-- homu-ignore:end -->

Stabilize an MVP subset of the unstable `Allocator` trait as `core::alloc::Alloc`. This new trait provides memory allocation only (it can be considered a trait version of `alloc` / `realloc` / `dealloc`), and does not require the shared-identity `Copy` / `Clone` of `Allocator`.

The `Allocator` trait remains as a marker trait for the safety properties required by the standard container types, such as `Box`, and is not being stabilized in this commit. It is expected that future work on `allocator_api` will expand the `Allocator` trait with new safety properties or functionality (which may be `dyn`-incompatible).

As part of the split, functions of `Alloc` were adjusted to return `NonNull<u8>` instead of `NonNull<[u8]>`. This change is intended to better match the actual usage of allocation APIs, make the API more resistant to accidental unsoundness, and relax the expectation of slice length elision via inlining.

Stubs of `Allocator::allocate` and `Allocator::deallocate` are temporarily retained for compatibility with `hashbrown`, which depends on the existing unstable `allocator_api` signature when being built as part of the standard library. Those stubs will need to be removed before `Allocator` stabilizes.

cc @rust-lang/libs @rust-lang/libs-api @rust-lang/opsem

r? libs