### PR TITLE
Const generics: remove AliasTerm::kind(), and small fixes

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -636,7 +636,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     | PredicateFilter::SelfAndAssociatedTypeBounds
                     | PredicateFilter::ConstIfConst => {
                         let projection_ty = projection_term
-                            .map_bound(|projection_term| projection_term.expect_ty(self.tcx()));
+                            .map_bound(|projection_term| projection_term.expect_ty());
                         // Calling `skip_binder` is okay, because `lower_bounds` expects the `param_ty`
                         // parameter to have a skipped binder.
                         let param_ty = Ty::new_alias(tcx, projection_ty.skip_binder());

--- a/compiler/rustc_infer/src/infer/projection.rs
+++ b/compiler/rustc_infer/src/infer/projection.rs
@@ -23,7 +23,7 @@ impl<'tcx> InferCtxt<'tcx> {
         debug_assert!(!self.next_trait_solver());
 
         let span = self.tcx.def_span(alias_term.def_id());
-        let infer_var = if alias_term.kind(self.tcx).is_type() {
+        let infer_var = if alias_term.kind.is_type() {
             self.next_ty_var(span).into()
         } else {
             self.next_const_var(span).into()

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -187,7 +187,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 let Some(source_alias) = source_term.to_alias_term() else {
                     bug!("generalized `{source_term:?} to infer, not an alias");
                 };
-                match source_alias.kind(self.tcx) {
+                match source_alias.kind {
                     ty::AliasTermKind::ProjectionTy { .. }
                     | ty::AliasTermKind::ProjectionConst { .. } => {
                         // FIXME: This does not handle subtyping correctly, we could
@@ -426,7 +426,7 @@ impl<'tcx> Generalizer<'_, 'tcx> {
     /// Create a new type variable in the universe of the target when
     /// generalizing an alias.
     fn next_var_for_alias_of_kind(&self, alias: ty::AliasTerm<'tcx>) -> ty::Term<'tcx> {
-        if alias.kind(self.cx()).is_type() {
+        if alias.kind.is_type() {
             self.infcx.next_ty_var_in_universe(self.span, self.for_universe).into()
         } else {
             self.infcx.next_const_var_in_universe(self.span, self.for_universe).into()

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3156,7 +3156,7 @@ define_print! {
     }
 
     ty::AliasTerm<'tcx> {
-        match self.kind(p.tcx()) {
+        match self.kind {
             ty::AliasTermKind::InherentTy {..} | ty::AliasTermKind::InherentConst {..} => p.pretty_print_inherent_projection(*self)?,
             ty::AliasTermKind::ProjectionTy { def_id } => {
                 if !(p.should_print_verbose() || with_reduced_queries())

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/anon_const.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/anon_const.rs
@@ -16,7 +16,7 @@ where
         goal: Goal<I, ty::NormalizesTo<I>>,
         def_id: I::UnevaluatedConstId,
     ) -> QueryResultOrRerunNonErased<I> {
-        let uv = goal.predicate.alias.expect_ct(self.cx());
+        let uv = goal.predicate.alias.expect_ct();
         self.evaluate_const_and_instantiate_normalizes_to_term(goal, uv)
     }
 }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/free_alias.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/free_alias.rs
@@ -31,7 +31,7 @@ where
                 .map(|pred| goal.with(cx, pred)),
         );
 
-        let actual = match free_alias.kind(cx) {
+        let actual = match free_alias.kind {
             ty::AliasTermKind::FreeTy { def_id } => {
                 cx.type_of(def_id.into()).instantiate(cx, free_alias.args).skip_norm_wip().into()
             }
@@ -43,7 +43,7 @@ where
             ty::AliasTermKind::FreeConst { .. } => {
                 return self.evaluate_const_and_instantiate_normalizes_to_term(
                     goal,
-                    free_alias.expect_ct(cx),
+                    free_alias.expect_ct(),
                 );
             }
             kind => panic!("expected free alias, found {kind:?}"),

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/inherent.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/inherent.rs
@@ -54,7 +54,7 @@ where
                 .map(|pred| goal.with(cx, pred)),
         );
 
-        let normalized = match inherent.kind(cx) {
+        let normalized = match inherent.kind {
             ty::AliasTermKind::InherentTy { def_id } => {
                 cx.type_of(def_id.into()).instantiate(cx, inherent_args).skip_norm_wip().into()
             }

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -287,7 +287,7 @@ where
             );
 
             let error_response = |ecx: &mut EvalCtxt<'_, D>, guar| {
-                let error_term = match goal.predicate.alias.kind(cx) {
+                let error_term = match goal.predicate.alias.kind {
                     ty::AliasTermKind::ProjectionTy { .. } => Ty::new_error(cx, guar).into(),
                     ty::AliasTermKind::ProjectionConst { .. } => Const::new_error(cx, guar).into(),
                     kind => panic!("expected projection, found {kind:?}"),
@@ -400,7 +400,7 @@ where
             }
 
             // Finally we construct the actual value of the associated type.
-            let term = match goal.predicate.alias.kind(cx) {
+            let term = match goal.predicate.alias.kind {
                 ty::AliasTermKind::ProjectionTy { .. } => cx
                     .type_of(target_item_def_id.into())
                     .instantiate(cx, target_args)

--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -417,7 +417,9 @@ where
                 ty::AliasTermKind::ProjectionConst { .. } => {
                     let uv = ty::UnevaluatedConst::new(
                         cx,
-                        ty::UnevaluatedConstKind::new_from_def_id(cx, target_item_def_id.into()),
+                        ty::UnevaluatedConstKind::Projection {
+                            def_id: target_item_def_id.into().try_into().unwrap(),
+                        },
                         target_args,
                     );
                     return ecx.evaluate_const_and_instantiate_normalizes_to_term(goal, uv);
@@ -501,7 +503,7 @@ where
         let pred = ty::ProjectionPredicate {
             projection_term: ty::AliasTerm::new(
                 cx,
-                cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                goal.predicate.alias.kind,
                 [goal.predicate.self_ty(), inputs],
             ),
             term: output.into(),
@@ -558,7 +560,7 @@ where
             (
                 ty::AliasTerm::new(
                     cx,
-                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    goal.predicate.alias.kind,
                     [goal.predicate.self_ty(), tupled_inputs_ty],
                 ),
                 output_coroutine_ty.into(),
@@ -567,7 +569,7 @@ where
             (
                 ty::AliasTerm::new(
                     cx,
-                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    goal.predicate.alias.kind,
                     [
                         I::GenericArg::from(goal.predicate.self_ty()),
                         tupled_inputs_ty.into(),
@@ -580,7 +582,7 @@ where
             (
                 ty::AliasTerm::new(
                     cx,
-                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    goal.predicate.alias.kind,
                     [goal.predicate.self_ty(), tupled_inputs_ty],
                 ),
                 coroutine_return_ty.into(),
@@ -784,11 +786,7 @@ where
             CandidateSource::BuiltinImpl(BuiltinImplSource::Misc),
             goal,
             ty::ProjectionPredicate {
-                projection_term: ty::AliasTerm::new(
-                    ecx.cx(),
-                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
-                    [self_ty],
-                ),
+                projection_term: ty::AliasTerm::new(ecx.cx(), goal.predicate.alias.kind, [self_ty]),
                 term,
             }
             .upcast(cx),
@@ -820,11 +818,7 @@ where
             CandidateSource::BuiltinImpl(BuiltinImplSource::Misc),
             goal,
             ty::ProjectionPredicate {
-                projection_term: ty::AliasTerm::new(
-                    ecx.cx(),
-                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
-                    [self_ty],
-                ),
+                projection_term: ty::AliasTerm::new(ecx.cx(), goal.predicate.alias.kind, [self_ty]),
                 term,
             }
             .upcast(cx),
@@ -912,7 +906,7 @@ where
             ty::ProjectionPredicate {
                 projection_term: ty::AliasTerm::new(
                     ecx.cx(),
-                    cx.alias_term_kind_from_def_id(goal.predicate.def_id()),
+                    goal.predicate.alias.kind,
                     [self_ty, coroutine.resume_ty()],
                 ),
                 term,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1666,7 +1666,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
                     if let Some(lhs) = lhs.to_alias_term()
                         && let ty::AliasTermKind::ProjectionTy { .. }
-                        | ty::AliasTermKind::ProjectionConst { .. } = lhs.kind(self.tcx)
+                        | ty::AliasTermKind::ProjectionConst { .. } = lhs.kind
                         && let Some((better_type_err, expected_term)) =
                             derive_better_type_error(lhs, rhs)
                     {
@@ -1676,7 +1676,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         )
                     } else if let Some(rhs) = rhs.to_alias_term()
                         && let ty::AliasTermKind::ProjectionTy { .. }
-                        | ty::AliasTermKind::ProjectionConst { .. } = rhs.kind(self.tcx)
+                        | ty::AliasTermKind::ProjectionConst { .. } = rhs.kind
                         && let Some((better_type_err, expected_term)) =
                             derive_better_type_error(rhs, lhs)
                     {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut err = match cause {
             OverflowCause::DeeplyNormalize(alias_term) => {
                 let alias_term = self.resolve_vars_if_possible(alias_term);
-                let kind = alias_term.kind(self.tcx).descr();
+                let kind = alias_term.kind.descr();
                 let alias_str = with_short_path(self.tcx, alias_term);
                 struct_span_code_err!(
                     self.dcx(),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4876,7 +4876,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         expected: where_pred
                             .skip_binder()
                             .projection_term
-                            .expect_ty(self.tcx)
+                            .expect_ty()
                             .to_ty(self.tcx),
                         found,
                     })];

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -395,7 +395,6 @@ impl<'tcx> BestObligation<'tcx> {
         &mut self,
         goal: &inspect::InspectGoal<'_, 'tcx>,
     ) -> ControlFlow<PredicateObligation<'tcx>> {
-        let tcx = goal.infcx().tcx;
         let pred_kind = goal.goal().predicate.kind();
 
         match pred_kind.no_bound_vars() {
@@ -404,7 +403,7 @@ impl<'tcx> BestObligation<'tcx> {
             }
             Some(ty::PredicateKind::NormalizesTo(pred))
                 if let ty::AliasTermKind::ProjectionTy { .. }
-                | ty::AliasTermKind::ProjectionConst { .. } = pred.alias.kind(tcx) =>
+                | ty::AliasTermKind::ProjectionConst { .. } = pred.alias.kind =>
             {
                 self.detect_error_in_self_ty_normalization(goal, pred.alias.self_ty())?;
                 self.detect_non_well_formed_assoc_item(goal, pred.alias)?;
@@ -471,7 +470,7 @@ impl<'tcx> ProofTreeVisitor<'tcx> for BestObligation<'tcx> {
             }
             ty::PredicateKind::NormalizesTo(normalizes_to)
                 if matches!(
-                    normalizes_to.alias.kind(tcx),
+                    normalizes_to.alias.kind,
                     ty::AliasTermKind::ProjectionTy { .. }
                         | ty::AliasTermKind::ProjectionConst { .. }
                 ) =>

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -561,7 +561,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
 
     fn is_self_referential_projection(&self, p: ty::PolyProjectionPredicate<'tcx>) -> bool {
         if let Some(ty) = p.term().skip_binder().as_type() {
-            matches!(ty.kind(), ty::Alias(proj @ ty::AliasTy { kind: ty::Projection { .. }, .. }) if proj == &p.skip_binder().projection_term.expect_ty(self.tcx))
+            matches!(ty.kind(), ty::Alias(proj @ ty::AliasTy { kind: ty::Projection { .. }, .. }) if proj == &p.skip_binder().projection_term.expect_ty())
         } else {
             false
         }

--- a/compiler/rustc_trait_selection/src/traits/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/normalize.rs
@@ -339,7 +339,7 @@ impl<'a, 'b, 'tcx> AssocTypeNormalizer<'a, 'b, 'tcx> {
                 }),
         );
         self.depth += 1;
-        let res = if free.kind(infcx.tcx).is_type() {
+        let res = if free.kind.is_type() {
             infcx
                 .tcx
                 .type_of(free.def_id())

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -462,7 +462,7 @@ fn normalize_to_error<'a, 'tcx>(
     depth: usize,
 ) -> NormalizedTerm<'tcx> {
     let trait_ref = ty::Binder::dummy(projection_term.trait_ref(selcx.tcx()));
-    let new_value = match projection_term.kind(selcx.tcx()) {
+    let new_value = match projection_term.kind {
         ty::AliasTermKind::ProjectionTy { .. }
         | ty::AliasTermKind::InherentTy { .. }
         | ty::AliasTermKind::OpaqueTy { .. }
@@ -545,7 +545,7 @@ pub fn normalize_inherent_projection<'a, 'b, 'tcx>(
         ));
     }
 
-    let term: Term<'tcx> = if alias_term.kind(tcx).is_type() {
+    let term: Term<'tcx> = if alias_term.kind.is_type() {
         tcx.type_of(alias_term.def_id()).instantiate(tcx, args).skip_norm_wip().into()
     } else {
         tcx.const_of_item(alias_term.def_id()).instantiate(tcx, args).skip_norm_wip().into()
@@ -629,7 +629,7 @@ impl<'tcx> Progress<'tcx> {
         alias_term: ty::AliasTerm<'tcx>,
         guar: ErrorGuaranteed,
     ) -> Self {
-        let err_term = if alias_term.kind(tcx).is_type() {
+        let err_term = if alias_term.kind.is_type() {
             Ty::new_error(tcx, guar).into()
         } else {
             ty::Const::new_error(tcx, guar).into()
@@ -2010,7 +2010,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
             return Ok(Projected::NoProgress(obligation.predicate.to_term(tcx)));
         } else {
             return Ok(Projected::Progress(Progress {
-                term: if obligation.predicate.kind(tcx).is_type() {
+                term: if obligation.predicate.kind.is_type() {
                     Ty::new_misc_error(tcx).into()
                 } else {
                     ty::Const::new_misc_error(tcx).into()
@@ -2029,7 +2029,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     let args = obligation.predicate.args.rebase_onto(tcx, trait_def_id, args);
     let args = translate_args(selcx.infcx, param_env, impl_def_id, args, assoc_term.defining_node);
 
-    let term = if obligation.predicate.kind(tcx).is_type() {
+    let term = if obligation.predicate.kind.is_type() {
         tcx.type_of(assoc_term.item.def_id).map_bound(|ty| ty.into())
     } else {
         tcx.const_of_item(assoc_term.item.def_id).map_bound(|ct| ct.into())
@@ -2038,7 +2038,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     let progress = if !tcx.check_args_compatible(assoc_term.item.def_id, args) {
         let msg = "impl item and trait item have different parameters";
         let span = obligation.cause.span;
-        let err = if obligation.predicate.kind(tcx).is_type() {
+        let err = if obligation.predicate.kind.is_type() {
             Ty::new_error_with_message(tcx, span, msg).into()
         } else {
             ty::Const::new_error_with_message(tcx, span, msg).into()

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -327,7 +327,7 @@ impl<'a, 'tcx> QueryNormalizer<'a, 'tcx> {
         let c_term = infcx.canonicalize_query(self.param_env.and(term), &mut orig_values);
         debug!("QueryNormalizer: c_term = {:#?}", c_term);
         debug!("QueryNormalizer: orig_values = {:#?}", orig_values);
-        let result = match term.kind(tcx) {
+        let result = match term.kind {
             ty::AliasTermKind::ProjectionTy { .. } | ty::AliasTermKind::ProjectionConst { .. } => {
                 tcx.normalize_canonicalized_projection(c_term)
             }
@@ -380,7 +380,7 @@ impl<'a, 'tcx> QueryNormalizer<'a, 'tcx> {
         if res != term.to_term(tcx)
             && (res.has_type_flags(ty::TypeFlags::HAS_CT_PROJECTION)
                 || matches!(
-                    term.kind(tcx),
+                    term.kind,
                     ty::AliasTermKind::FreeTy { .. } | ty::AliasTermKind::FreeConst { .. }
                 ))
         {

--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -86,7 +86,7 @@ fn normalize_canonicalized_free_alias<'tcx>(
                 },
             );
             ocx.register_obligations(obligations);
-            let normalized_term = if goal.kind(tcx).is_type() {
+            let normalized_term = if goal.kind.is_type() {
                 tcx.type_of(goal.def_id()).instantiate(tcx, goal.args).skip_norm_wip().into()
             } else {
                 tcx.const_of_item(goal.def_id()).instantiate(tcx, goal.args).skip_norm_wip().into()

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -130,7 +130,6 @@ impl<I: Interner> UnevaluatedConstKind<I> {
             UnevaluatedConstKind::Inherent { def_id } => def_id.into(),
             UnevaluatedConstKind::Free { def_id } => def_id.into(),
             UnevaluatedConstKind::Anon { def_id } => def_id.into(),
-            //UnevaluatedConstKind::Expr { def_id } => def_id.into(),
         }
     }
 }

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -734,8 +734,8 @@ impl<I: Interner> AliasTerm<I> {
         Self::new_from_args(interner, kind, args)
     }
 
-    pub fn expect_ty(self, interner: I) -> ty::AliasTy<I> {
-        let kind = match self.kind(interner) {
+    pub fn expect_ty(self) -> ty::AliasTy<I> {
+        let kind = match self.kind {
             AliasTermKind::ProjectionTy { def_id } => AliasTyKind::Projection { def_id },
             AliasTermKind::InherentTy { def_id } => AliasTyKind::Inherent { def_id },
             AliasTermKind::OpaqueTy { def_id } => AliasTyKind::Opaque { def_id },
@@ -750,8 +750,8 @@ impl<I: Interner> AliasTerm<I> {
         ty::AliasTy { kind, args: self.args, _use_alias_ty_new_instead: () }
     }
 
-    pub fn expect_ct(self, interner: I) -> ty::UnevaluatedConst<I> {
-        let def = match self.kind(interner) {
+    pub fn expect_ct(self) -> ty::UnevaluatedConst<I> {
+        let kind = match self.kind {
             AliasTermKind::InherentConst { def_id } => UnevaluatedConstKind::Inherent { def_id },
             AliasTermKind::FreeConst { def_id } => UnevaluatedConstKind::Free { def_id },
             AliasTermKind::AnonConst { def_id } => UnevaluatedConstKind::Anon { def_id },
@@ -765,12 +765,7 @@ impl<I: Interner> AliasTerm<I> {
                 panic!("Cannot turn `{}` into `UnevaluatedConst`", kind.descr())
             }
         };
-        ty::UnevaluatedConst::new(interner, def, self.args)
-    }
-
-    // FIXME: remove this function (access the field instead)
-    pub fn kind(self, _interner: I) -> AliasTermKind<I> {
-        self.kind
+        ty::UnevaluatedConst { kind, args: self.args, _use_unevaluated_const_new_instead: () }
     }
 
     // FIXME: replace with explicit matches
@@ -789,7 +784,7 @@ impl<I: Interner> AliasTerm<I> {
             )
             .into()
         };
-        match self.kind(interner) {
+        match self.kind {
             AliasTermKind::FreeConst { def_id } => {
                 unevaluated_const(UnevaluatedConstKind::Free { def_id })
             }
@@ -894,7 +889,7 @@ impl<I: Interner> AliasTerm<I> {
         interner: I,
     ) -> I::GenericArgs {
         debug_assert!(matches!(
-            self.kind(interner),
+            self.kind,
             AliasTermKind::InherentTy { .. } | AliasTermKind::InherentConst { .. }
         ));
         interner.mk_args_from_iter(impl_args.iter().chain(self.args.iter().skip(1)))

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -239,7 +239,7 @@ impl<I: Interner> Relate<I> for ty::AliasTerm<I> {
         if a.def_id() != b.def_id() {
             Err(TypeError::ProjectionMismatched(ExpectedFound::new(a.def_id(), b.def_id())))
         } else {
-            let args = match a.kind(relation.cx()) {
+            let args = match a.kind {
                 ty::AliasTermKind::OpaqueTy { .. } => relate_args_with_variances(
                     relation,
                     relation.cx().variances_of(a.def_id()),

--- a/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_borrows_for_generic_args.rs
@@ -433,7 +433,7 @@ fn replace_types<'tcx>(
                     let projection = projection_predicate
                         .projection_term
                         .with_replaced_self_ty(cx.tcx, new_ty)
-                        .expect_ty(cx.tcx)
+                        .expect_ty()
                         .to_ty(cx.tcx);
 
                     if let Ok(projected_ty) = cx


### PR DESCRIPTION
When implementing https://github.com/rust-lang/rust/pull/157094 there were a few things I stumbled upon that I fixed, that were technically unrelated, and because that PR was already getting so big, I split the silly nitpick fixups into another PR (this PR).

- first commit: `cx.alias_term_kind_from_def_id(goal.predicate.def_id())` can be written as just `goal.predicate.alias.kind`, without a query. doh.
- second commit: remove `AliasTerm::kind()` (instead accessing the field `AliasTerm::kind` directly)
  - this also removes the interner parameter from `AliasTerm::expect_ct`/`AliasTerm::expect_ty`, yippee

r? @BoxyUwU