### PR TITLE
Add infallible primitive type lookups to template arg resolver

### DIFF
--- a/src/etc/lldb_batchmode/runner.py
+++ b/src/etc/lldb_batchmode/runner.py
@@ -98,7 +98,7 @@ def execute_command(command_interpreter, command):
                     "registering breakpoint callback, id = " + str(breakpoint_id)
                 )
                 callback_command = f"breakpoint command add -s python {str(breakpoint_id)} -o \
-                    'import lldb_batchmode; lldb_batchmode.breakpoint_callback'"
+'import lldb_batchmode; lldb_batchmode.runner.breakpoint_callback'"
 
                 command_interpreter.HandleCommand(callback_command, res)
                 if res.Succeeded():

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -114,6 +114,8 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _dict: LLDBOpaque):
         FEATURE_FLAGS |= LLDBFeature.StaticFields
     if getattr(lldb, "eFormatterMatchCallback", None) is not None:
         FEATURE_FLAGS |= LLDBFeature.TypeRecognizers
+    if getattr(lldb, "eBasicTypeFloat128", None) is not None:
+        FEATURE_FLAGS |= LLDBFeature.Float128
 
     register_providers_compatibility()
 

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import sys
-from typing import Generator, List, TYPE_CHECKING, Optional
+from typing import Generator, Dict, List, TYPE_CHECKING, Optional
 from enum import Flag, auto
 
 from lldb import (
@@ -9,6 +9,15 @@ from lldb import (
     eBasicTypeLong,
     eBasicTypeUnsignedLong,
     eBasicTypeUnsignedChar,
+    eBasicTypeUnsignedShort,
+    eBasicTypeUnsignedLongLong,
+    eBasicTypeSignedChar,
+    eBasicTypeShort,
+    eBasicTypeLongLong,
+    eBasicTypeFloat,
+    eBasicTypeDouble,
+    eBasicTypeHalf,
+    eBasicTypeChar32,
     eFormatChar,
     eTypeIsInteger,
 )
@@ -67,6 +76,9 @@ class LLDBFeature(Flag):
     """Added in LLDB 18. Adds functions to `SBType` the inspection of a struct's static fields."""
     TypeRecognizers = auto()
     """Added in LLDB 19. Callback-based type matching for synthetic/summary providers."""
+    Float128 = auto()
+    """Added in LLDB 22.1. Adds builtin support for Float 128's, including an `eBasicTypeFloat128`,
+    a formatter, and handlers in `TypeSystemClang`"""
 
 
 FEATURE_FLAGS: LLDBFeature = LLDBFeature(0)
@@ -198,6 +210,21 @@ def get_template_args(type_name: str) -> Generator[str, None, None]:
 
 MSVC_PTR_PREFIX: List[str] = ["ref$<", "ref_mut$<", "ptr_const$<", "ptr_mut$<"]
 
+PRIMITIVE_TYPES: Dict[str, int] = {
+    "u8": eBasicTypeUnsignedChar,
+    "u16": eBasicTypeUnsignedShort,
+    "u32": eBasicTypeUnsignedLong,
+    "u64": eBasicTypeUnsignedLongLong,
+    "i8": eBasicTypeSignedChar,
+    "i16": eBasicTypeShort,
+    "i32": eBasicTypeLong,
+    "i64": eBasicTypeLongLong,
+    "f16": eBasicTypeHalf,
+    "f32": eBasicTypeFloat,
+    "f64": eBasicTypeDouble,
+    "char": eBasicTypeChar32,
+}
+
 
 def resolve_msvc_template_arg(arg_name: str, target: SBTarget) -> SBType:
     """
@@ -214,6 +241,22 @@ def resolve_msvc_template_arg(arg_name: str, target: SBTarget) -> SBType:
     current version of LLDB, so instead the types are generated via `base_type.GetPointerType()` and
     `base_type.GetArrayType()`, which bypass the PDB file and ask clang directly for the type node.
     """
+
+    # As of LLDB 22, finding primitives based on `FindFirstType` with their rust name no longer
+    # works. Instead, we can look them up by their `eBasicType` equivalent. For usize and isize,
+    # we convert them to their bit-sized counterpart before the lookup
+    if arg_name == "isize" or arg_name == "usize":
+        equivalent = f"{arg_name[0]}{target.GetAddressByteSize() * 8}"
+        return target.GetBasicType(PRIMITIVE_TYPES[equivalent])
+
+    if (basic_type := PRIMITIVE_TYPES.get(arg_name)) is not None:
+        return target.GetBasicType(basic_type)
+
+    if arg_name == "f128" and LLDBFeature.Float128 in FEATURE_FLAGS:
+        from lldb import eBasicTypeFloat128
+
+        return target.GetBasicType(eBasicTypeFloat128)
+
     result = target.FindFirstType(arg_name)
 
     if result.IsValid():


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157289)*
<!-- homu-ignore:end -->

Fixes a regression that seem to come from LLDB 22 where looking up primitive types by name on MSVC no longer works. Container types use type name lookups to resolve generics, so it causes container types (e.g. `Vec<i32>`) to fail to create their child values. 

Before:

```
(lldb) v vec_v
(alloc::vec::Vec<i32,alloc::alloc::Global>) vec_v = size=5 {}
(lldb) v vec_v[0]
error: <user expression 0>:1:6: array index 0 is not valid for "(Vec<i32,alloc::alloc::Global>) vec_v"
   1 | vec_v[0]
     | ^
```

After:

```
(lldb) v vec_v
(alloc::vec::Vec<i32,alloc::alloc::Global>) vec_v = size=5 {
  [0] = 10
  [1] = 20
  [2] = 30
  [3] = 40
  [4] = 50
}
(lldb) v vec_v[0]
(long) vec_v[0] = 10
```

This patch maps the type name to its `eBasicType` equivalent (i.e. the LLDB enum for primitive types) and looks up the type based on that. AFAIK, `eBasicType` lookups are 100% infallible. Even if the primitive type somehow isn't in the debug info, `TypeSystemClang` will invent the appropriate `SBType` object for it.

This isn't a major blocker for the test suite rework, but it does prevent me from blessing tests with container types on MSVC unless I downgrade to LLDB 21.

r? @jieyouxu, @Kobzol 