### PR TITLE
interpret: fix mir::UnOp layout computation

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -190,8 +190,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
 
             UnaryOp(un_op, ref operand) => {
-                // The operand always has the same type as the result.
-                let val = self.read_immediate(&self.eval_operand(operand, Some(dest.layout))?)?;
+                let layout = util::unop_homogeneous(un_op).then_some(dest.layout);
+                let val = self.read_immediate(&self.eval_operand(operand, layout)?)?;
                 let result = self.unary_op(un_op, &val)?;
                 assert_eq!(result.layout, dest.layout, "layout mismatch for result of {un_op:?}");
                 self.write_immediate(*result, &dest)?;

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -38,3 +38,13 @@ pub fn binop_right_homogeneous(op: mir::BinOp) -> bool {
         Offset | Shl | ShlUnchecked | Shr | ShrUnchecked => false,
     }
 }
+
+/// Classify whether an operator is "homogeneous", i.e., the operand has the
+/// same type as the result.
+#[inline]
+pub fn unop_homogeneous(op: mir::UnOp) -> bool {
+    match op {
+        mir::UnOp::Not | mir::UnOp::Neg => true,
+        mir::UnOp::PtrMetadata => false,
+    }
+}


### PR DESCRIPTION
"The operand always has the same type as the result" was correct when I wrote the comment, but more `UnOp`s have been added since, making this incorrect now. This hasn't caused issues yet because apparently the local variable layout cache means we hardly ever (never?) actually use the "known" layout.

r? @oli-obk 