### PR TITLE
Use mem::take for default replacements

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -738,7 +738,7 @@ impl EncoderState {
             // Prevent more indices from being allocated on this thread.
             local.remaining_node_index = 0;
 
-            let data = mem::replace(&mut local.encoder.data, Vec::new());
+            let data = mem::take(&mut local.encoder.data);
             self.file.lock().as_mut().unwrap().emit_raw_bytes(&data);
 
             LocalEncoderResult {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2573,7 +2573,7 @@ fn normalize_newlines(src: &mut String, normalized_pos: &mut Vec<NormalizedPos>)
     // directly, let's rather steal the contents of `src`. This makes the code
     // safe even if a panic occurs.
 
-    let mut buf = std::mem::replace(src, String::new()).into_bytes();
+    let mut buf = std::mem::take(src).into_bytes();
     let mut gap_len = 0;
     let mut tail = buf.as_mut_slice();
     let mut cursor = 0;


### PR DESCRIPTION
Fixes rust-lang/rust#157245.

This replaces two default-value `mem::replace` calls in compiler crates with the more idiomatic `mem::take`:

- `String::new()` replacement in `rustc_span::normalize_newlines`
- `Vec::new()` replacement in dep-graph serialization

I intentionally left Clippy UI tests and documentation examples unchanged because those are test/example inputs for `mem::replace` behavior rather than production cleanup targets.

Verification:

- `git diff --check`
- `./x fmt --check`
- `./x check compiler/rustc_span compiler/rustc_middle`