### PR TITLE
interpret: remove from_known_layout

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -110,7 +110,7 @@ fn eval_trivial_const_using_ecx<'tcx, R: InterpretationResult<'tcx>>(
     let layout = ecx.layout_of(ty)?;
     let (intern_kind, return_place) = setup_for_eval(ecx, cid, layout)?;
 
-    let opty = ecx.const_val_to_op(val, ty, Some(layout))?;
+    let opty = ecx.const_val_to_op(val, ty)?;
     ecx.copy_op(&opty, &return_place)?;
 
     intern_and_validate(ecx, cid, intern_kind, return_place)
@@ -199,7 +199,7 @@ pub fn mk_eval_cx_for_const_val<'tcx>(
 ) -> Option<(CompileTimeInterpCx<'tcx>, OpTy<'tcx>)> {
     let ecx = mk_eval_cx_to_read_const_val(tcx.tcx, tcx.span, typing_env, CanAccessMutGlobal::No);
     // FIXME: is it a problem to discard the error here?
-    let op = ecx.const_val_to_op(val, ty, None).discard_err()?;
+    let op = ecx.const_val_to_op(val, ty).discard_err()?;
     Some((ecx, op))
 }
 

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -752,8 +752,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
     ) -> InterpResult<'tcx> {
         use rustc_middle::mir::AssertKind::*;
         // Convert `AssertKind<Operand>` to `AssertKind<Scalar>`.
-        let eval_to_int =
-            |op| ecx.read_immediate(&ecx.eval_operand(op, None)?).map(|x| x.to_const_int());
+        let eval_to_int = |op| ecx.read_immediate(&ecx.eval_operand(op)?).map(|x| x.to_const_int());
         let err = match msg {
             BoundsCheck { len, index } => {
                 let len = eval_to_int(len)?;

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -418,7 +418,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             "spread_arg: {:?}, locals: {:#?}",
             body.spread_arg,
             body.args_iter()
-                .map(|local| (local, self.layout_of_local(self.frame(), local, None).unwrap().ty))
+                .map(|local| (local, self.layout_of_local(self.frame(), local).unwrap().ty))
                 .collect::<Vec<_>>()
         );
 
@@ -467,7 +467,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 // `layout_of_local` does more than just the instantiation we need to get the
                 // type, but the result gets cached so this avoids calling the instantiation
                 // query *again* the next time this local is accessed.
-                let ty = ecx.layout_of_local(ecx.frame(), local, None)?.ty;
+                let ty = ecx.layout_of_local(ecx.frame(), local)?.ty;
 
                 // Some arguments are special: the first (`self`) argument of a non-capturing
                 // closure; the va_list argument; and the spread_arg.
@@ -978,7 +978,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         // Get out the return value. Must happen *before* the frame is popped as we have to get the
         // local's value out.
         let return_op =
-            self.local_to_op(mir::RETURN_PLACE, None).expect("return place should always be live");
+            self.local_to_op(mir::RETURN_PLACE).expect("return place should always be live");
         // Remove the frame from the stack.
         let frame = self.pop_stack_frame_raw()?;
         // Copy the return value and remember the return continuation.

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -191,34 +191,6 @@ pub(super) fn mir_assign_valid_types<'tcx>(
     }
 }
 
-/// Use the already known layout if given (but sanity check in debug mode),
-/// or compute the layout.
-#[cfg_attr(not(debug_assertions), inline(always))]
-pub(super) fn from_known_layout<'tcx>(
-    tcx: TyCtxtAt<'tcx>,
-    typing_env: TypingEnv<'tcx>,
-    known_layout: Option<TyAndLayout<'tcx>>,
-    compute: impl FnOnce() -> InterpResult<'tcx, TyAndLayout<'tcx>>,
-) -> InterpResult<'tcx, TyAndLayout<'tcx>> {
-    match known_layout {
-        None => compute(),
-        Some(known_layout) => {
-            if cfg!(debug_assertions) {
-                let check_layout = compute()?;
-                if !mir_assign_valid_types(tcx.tcx, typing_env, check_layout, known_layout) {
-                    span_bug!(
-                        tcx.span,
-                        "expected type differs from actual type.\nexpected: {}\nactual: {}",
-                        known_layout.ty,
-                        check_layout.ty,
-                    );
-                }
-            }
-            interp_ok(known_layout)
-        }
-    }
-}
-
 /// Turn the given error into a human-readable string. Expects the string to be printed, so if
 /// `RUSTC_CTFE_BACKTRACE` is set this will show a backtrace of the rustc internals that
 /// triggered the error.
@@ -603,7 +575,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         &self,
         val: &mir::Const<'tcx>,
         span: Span,
-        layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
         let _trace = enter_trace_span!(M, const_eval::eval_mir_constant, ?val);
         let const_val = val.eval(*self.tcx, self.typing_env, span).map_err(|err| {
@@ -625,7 +596,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 err.emit_note(*self.tcx);
                 err
             })?;
-        self.const_val_to_op(const_val, val.ty(), layout)
+        self.const_val_to_op(const_val, val.ty())
     }
 
     #[must_use]

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -94,11 +94,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         let tcx = self.tcx;
         let type_id_hash = tcx.type_id_hash(ty).as_u128();
-        let op = self.const_val_to_op(
-            ConstValue::Scalar(Scalar::from_u128(type_id_hash)),
-            tcx.types.u128,
-            None,
-        )?;
+        let op = self
+            .const_val_to_op(ConstValue::Scalar(Scalar::from_u128(type_id_hash)), tcx.types.u128)?;
         self.copy_op_allow_transmute(&op, dest)?;
 
         // Give the each pointer-sized chunk provenance that knows about the type id.
@@ -189,14 +186,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 ensure_monomorphic_enough(tcx, tp_ty)?;
                 let (alloc_id, meta) = alloc_type_name(tcx, tp_ty);
                 let val = ConstValue::Slice { alloc_id, meta };
-                let val = self.const_val_to_op(val, dest.layout.ty, Some(dest.layout))?;
+                let val = self.const_val_to_op(val, dest.layout.ty)?;
                 self.copy_op(&val, dest)?;
             }
             sym::needs_drop => {
                 let tp_ty = instance.args.type_at(0);
                 ensure_monomorphic_enough(tcx, tp_ty)?;
                 let val = ConstValue::from_bool(tp_ty.needs_drop(tcx, self.typing_env));
-                let val = self.const_val_to_op(val, tcx.types.bool, Some(dest.layout))?;
+                let val = self.const_val_to_op(val, tcx.types.bool)?;
                 self.copy_op(&val, dest)?;
             }
             sym::type_id => {
@@ -283,15 +280,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     | ty::Tuple(_)
                     | ty::Error(_) => ConstValue::from_target_usize(0u64, &tcx),
                 };
-                let val = self.const_val_to_op(val, dest.layout.ty, Some(dest.layout))?;
+                let val = self.const_val_to_op(val, dest.layout.ty)?;
                 self.copy_op(&val, dest)?;
             }
 
             sym::caller_location => {
                 let span = self.find_closest_untracked_caller_location();
                 let val = self.tcx.span_as_caller_location(span);
-                let val =
-                    self.const_val_to_op(val, self.tcx.caller_location_ty(), Some(dest.layout))?;
+                let val = self.const_val_to_op(val, self.tcx.caller_location_ty())?;
                 self.copy_op(&val, dest)?;
             }
 
@@ -908,7 +904,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     ) -> InterpResult<'tcx> {
         match intrinsic {
             NonDivergingIntrinsic::Assume(op) => {
-                let op = self.eval_operand(op, None)?;
+                let op = self.eval_operand(op)?;
                 let cond = self.read_scalar(&op)?.to_bool()?;
                 if !cond {
                     throw_ub_format!("`assume` called with `false`");
@@ -920,9 +916,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 src,
                 dst,
             }) => {
-                let src = self.eval_operand(src, None)?;
-                let dst = self.eval_operand(dst, None)?;
-                let count = self.eval_operand(count, None)?;
+                let src = self.eval_operand(src)?;
+                let dst = self.eval_operand(dst)?;
+                let count = self.eval_operand(count)?;
                 self.copy_intrinsic(&src, &dst, &count, /* nonoverlapping */ true)
             }
         }

--- a/compiler/rustc_const_eval/src/interpret/mod.rs
+++ b/compiler/rustc_const_eval/src/interpret/mod.rs
@@ -23,8 +23,8 @@ mod visitor;
 pub use rustc_middle::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
 pub use self::call::FnArg;
+use self::eval_context::mir_assign_valid_types;
 pub use self::eval_context::{InterpCx, format_interp_error};
-use self::eval_context::{from_known_layout, mir_assign_valid_types};
 pub use self::intern::{
     HasStaticRootDefId, InternError, InternKind, intern_const_alloc_for_constprop,
     intern_const_alloc_recursive,

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -18,8 +18,8 @@ use tracing::trace;
 
 use super::{
     CtfeProvenance, Frame, InterpCx, InterpResult, MPlaceTy, Machine, MemPlace, MemPlaceMeta,
-    OffsetMode, PlaceTy, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub,
-    from_known_layout, interp_ok, mir_assign_valid_types, throw_ub,
+    OffsetMode, PlaceTy, Pointer, Projectable, Provenance, Scalar, alloc_range, err_ub, interp_ok,
+    mir_assign_valid_types, throw_ub,
 };
 use crate::enter_trace_span;
 
@@ -724,12 +724,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     }
 
     /// Read from a local of the current frame. Convenience method for [`InterpCx::local_at_frame_to_op`].
-    pub fn local_to_op(
-        &self,
-        local: mir::Local,
-        layout: Option<TyAndLayout<'tcx>>,
-    ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
-        self.local_at_frame_to_op(self.frame(), local, layout)
+    pub fn local_to_op(&self, local: mir::Local) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
+        self.local_at_frame_to_op(self.frame(), local)
     }
 
     /// Read from a local of a given frame.
@@ -741,9 +737,8 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         &self,
         frame: &Frame<'tcx, M::Provenance, M::FrameExtra>,
         local: mir::Local,
-        layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
-        let layout = self.layout_of_local(frame, local, layout)?;
+        let layout = self.layout_of_local(frame, local)?;
         let op = *frame.locals[local].access()?;
         if matches!(op, Operand::Immediate(_)) {
             assert!(!layout.is_unsized());
@@ -764,7 +759,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Right((local, offset, locals_addr, _)) => {
                 debug_assert!(place.layout.is_sized()); // only sized locals can ever be `Place::Local`.
                 debug_assert_eq!(locals_addr, self.frame().locals_addr());
-                let base = self.local_to_op(local, None)?;
+                let base = self.local_to_op(local)?;
                 interp_ok(match offset {
                     Some(offset) => base.offset(offset, place.layout, self)?,
                     None => {
@@ -782,7 +777,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     pub fn eval_place_to_op(
         &self,
         mir_place: mir::Place<'tcx>,
-        layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
         let _trace = enter_trace_span!(
             M,
@@ -791,11 +785,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             tracing_separate_thread = Empty
         );
 
-        // Do not use the layout passed in as argument if the base we are looking at
-        // here is not the entire place.
-        let layout = if mir_place.projection.is_empty() { layout } else { None };
-
-        let mut op = self.local_to_op(mir_place.local, layout)?;
+        let mut op = self.local_to_op(mir_place.local)?;
         // Using `try_fold` turned out to be bad for performance, hence the loop.
         for elem in mir_place.projection.iter() {
             op = self.project(&op, elem)?
@@ -832,7 +822,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     pub fn eval_operand(
         &self,
         mir_op: &mir::Operand<'tcx>,
-        layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
         let _trace =
             enter_trace_span!(M, step::eval_operand, ?mir_op, tracing_separate_thread = Empty);
@@ -840,7 +829,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         use rustc_middle::mir::Operand::*;
         let op = match mir_op {
             // FIXME: do some more logic on `move` to invalidate the old location
-            &Copy(place) | &Move(place) => self.eval_place_to_op(place, layout)?,
+            &Copy(place) | &Move(place) => self.eval_place_to_op(place)?,
 
             &RuntimeChecks(checks) => {
                 let val = M::runtime_checks(self, checks)?;
@@ -856,7 +845,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 // * During ConstProp, with `TooGeneric` or since the `required_consts` were not all
                 //   checked yet.
                 // * During CTFE, since promoteds in `const`/`static` initializer bodies can fail.
-                self.eval_mir_constant(&c, constant.span, layout)?
+                self.eval_mir_constant(&c, constant.span)?
             }
         };
         trace!("{:?}: {:?}", mir_op, op);
@@ -867,7 +856,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         &self,
         val_val: mir::ConstValue,
         ty: Ty<'tcx>,
-        layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, OpTy<'tcx, M::Provenance>> {
         // Other cases need layout.
         let adjust_scalar = |scalar| -> InterpResult<'tcx, _> {
@@ -876,8 +864,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 Scalar::Int(int) => Scalar::Int(int),
             })
         };
-        let layout =
-            from_known_layout(self.tcx, self.typing_env(), layout, || self.layout_of(ty).into())?;
+        let layout = self.layout_of(ty)?;
         let imm = match val_val {
             mir::ConstValue::Indirect { alloc_id, offset } => {
                 // This is const data, no mutation allowed.

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -521,7 +521,7 @@ where
         local: mir::Local,
     ) -> InterpResult<'tcx, PlaceTy<'tcx, M::Provenance>> {
         let frame = self.frame();
-        let layout = self.layout_of_local(frame, local, None)?;
+        let layout = self.layout_of_local(frame, local)?;
         let place = if layout.is_sized() {
             // We can just always use the `Local` for sized values.
             Place::Local { local, offset: None, locals_addr: frame.locals_addr() }
@@ -597,7 +597,7 @@ where
                     Left(place.force_mplace(self)?)
                 } else {
                     debug_assert_eq!(locals_addr, self.frame().locals_addr());
-                    debug_assert_eq!(self.layout_of_local(self.frame(), local, None)?, layout);
+                    debug_assert_eq!(self.layout_of_local(self.frame(), local)?, layout);
                     match self.frame_mut().locals[local].access_mut()? {
                         Operand::Indirect(mplace) => {
                             // The local is in memory.
@@ -999,7 +999,7 @@ where
                         // We need the layout of the local. We can NOT use the layout we got,
                         // that might e.g., be an inner field of a struct with `Scalar` layout,
                         // that has different alignment than the outer field.
-                        let local_layout = self.layout_of_local(&self.frame(), local, None)?;
+                        let local_layout = self.layout_of_local(&self.frame(), local)?;
                         assert!(local_layout.is_sized(), "unsized locals cannot be immediate");
                         let mplace = self.allocate(local_layout, MemoryKind::Stack)?;
                         // Preserve old value. (As an optimization, we can skip this if it was uninit.)

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -416,8 +416,7 @@ where
             Downcast(_, variant) => self.project_downcast(base, variant)?,
             Deref => self.deref_pointer(&base.to_op(self)?)?.into(),
             Index(local) => {
-                let layout = self.layout_of(self.tcx.types.usize)?;
-                let n = self.local_to_op(local, Some(layout))?;
+                let n = self.local_to_op(local)?;
                 let n = self.read_target_usize(&n)?;
                 self.project_index(base, n)?
             }

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -19,7 +19,7 @@ use tracing::{info_span, instrument, trace};
 use super::{
     AllocId, CtfeProvenance, FnArg, Immediate, InterpCx, InterpResult, MPlaceTy, Machine, MemPlace,
     MemPlaceMeta, MemoryKind, Operand, PlaceTy, Pointer, Provenance, ReturnAction, Scalar,
-    from_known_layout, interp_ok, throw_ub, throw_unsup,
+    interp_ok, throw_ub, throw_unsup,
 };
 use crate::{enter_trace_span, errors};
 
@@ -542,7 +542,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             None
         } else {
             // We need the layout.
-            let layout = self.layout_of_local(self.frame(), local, None)?;
+            let layout = self.layout_of_local(self.frame(), local)?;
             if layout.is_sized() { None } else { Some(layout) }
         };
 
@@ -611,19 +611,25 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         &self,
         frame: &Frame<'tcx, M::Provenance, M::FrameExtra>,
         local: mir::Local,
-        layout: Option<TyAndLayout<'tcx>>,
     ) -> InterpResult<'tcx, TyAndLayout<'tcx>> {
         let state = &frame.locals[local];
         if let Some(layout) = state.layout.get() {
             return interp_ok(layout);
         }
 
-        let layout = from_known_layout(self.tcx, self.typing_env, layout, || {
+        #[cold]
+        fn uncached<'tcx, M: Machine<'tcx>>(
+            ecx: &InterpCx<'tcx, M>,
+            frame: &Frame<'tcx, M::Provenance, M::FrameExtra>,
+            local: mir::Local,
+        ) -> InterpResult<'tcx, TyAndLayout<'tcx>> {
             let local_ty = frame.body.local_decls[local].ty;
             let local_ty =
-                self.instantiate_from_frame_and_normalize_erasing_regions(frame, local_ty)?;
-            self.layout_of(local_ty).into()
-        })?;
+                ecx.instantiate_from_frame_and_normalize_erasing_regions(frame, local_ty)?;
+            interp_ok(ecx.layout_of(local_ty)?)
+        }
+
+        let layout = uncached(self, frame, local)?;
 
         // Layouts of locals are requested a lot, so we cache them.
         state.layout.set(Some(layout));

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -19,7 +19,7 @@ use super::{
     EnteredTraceSpan, FnArg, FnVal, ImmTy, Immediate, InterpCx, InterpResult, Machine,
     MemPlaceMeta, PlaceTy, Projectable, RetagMode, interp_ok, throw_ub, throw_unsup_format,
 };
-use crate::{enter_trace_span, util};
+use crate::enter_trace_span;
 
 struct EvaluatedCalleeAndArgs<'tcx, M: Machine<'tcx>> {
     callee: FnVal<'tcx, M::ExtraFnVal>,
@@ -172,7 +172,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
             Use(ref operand, with_retag) => {
                 // Avoid recomputing the layout
-                let op = self.eval_operand(operand, Some(dest.layout))?;
+                let op = self.eval_operand(operand)?;
                 let mode = if with_retag.yes() { RetagMode::Default } else { RetagMode::None };
                 M::with_retag_mode(self, mode, |ecx| ecx.copy_op(&op, &dest))?;
             }
@@ -180,18 +180,15 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             CopyForDeref(_) => bug!("`CopyForDeref` in runtime MIR"),
 
             BinaryOp(bin_op, (ref left, ref right)) => {
-                let layout = util::binop_left_homogeneous(bin_op).then_some(dest.layout);
-                let left = self.read_immediate(&self.eval_operand(left, layout)?)?;
-                let layout = util::binop_right_homogeneous(bin_op).then_some(left.layout);
-                let right = self.read_immediate(&self.eval_operand(right, layout)?)?;
+                let left = self.read_immediate(&self.eval_operand(left)?)?;
+                let right = self.read_immediate(&self.eval_operand(right)?)?;
                 let result = self.binary_op(bin_op, &left, &right)?;
                 assert_eq!(result.layout, dest.layout, "layout mismatch for result of {bin_op:?}");
                 self.write_immediate(*result, &dest)?;
             }
 
             UnaryOp(un_op, ref operand) => {
-                // The operand always has the same type as the result.
-                let val = self.read_immediate(&self.eval_operand(operand, Some(dest.layout))?)?;
+                let val = self.read_immediate(&self.eval_operand(operand)?)?;
                 let result = self.unary_op(un_op, &val)?;
                 assert_eq!(result.layout, dest.layout, "layout mismatch for result of {un_op:?}");
                 self.write_immediate(*result, &dest)?;
@@ -231,7 +228,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
 
             Reborrow(_, mutability, place) => {
-                let op = self.eval_place_to_op(place, None)?;
+                let op = self.eval_place_to_op(place)?;
                 if mutability.is_not() {
                     // Shared generic reborrows use `CoerceShared`: a bitwise copy into a
                     // distinct same-layout target ADT.
@@ -266,14 +263,14 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
 
             Cast(cast_kind, ref operand, cast_ty) => {
-                let src = self.eval_operand(operand, None)?;
+                let src = self.eval_operand(operand)?;
                 let cast_ty =
                     self.instantiate_from_current_frame_and_normalize_erasing_regions(cast_ty)?;
                 self.cast(&src, cast_kind, cast_ty, &dest)?;
             }
 
             Discriminant(place) => {
-                let op = self.eval_place_to_op(place, None)?;
+                let op = self.eval_place_to_op(place)?;
                 let variant = self.read_discriminant(&op)?;
                 let discr = self.discriminant_for_variant(op.layout.ty, variant)?;
                 self.write_immediate(*discr, &dest)?;
@@ -282,7 +279,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             WrapUnsafeBinder(ref op, _ty) => {
                 // Constructing an unsafe binder acts like a transmute
                 // since the operand's layout does not change.
-                let op = self.eval_operand(op, None)?;
+                let op = self.eval_operand(op)?;
                 self.copy_op_allow_transmute(&op, &dest)?;
             }
         }
@@ -313,9 +310,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 let [data, meta] = &operands.raw else {
                     bug!("{kind:?} should have 2 operands, had {operands:?}");
                 };
-                let data = self.eval_operand(data, None)?;
+                let data = self.eval_operand(data)?;
                 let data = self.read_pointer(&data)?;
-                let meta = self.eval_operand(meta, None)?;
+                let meta = self.eval_operand(meta)?;
                 let meta = if meta.layout.is_zst() {
                     MemPlaceMeta::None
                 } else {
@@ -334,7 +331,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         for (field_index, operand) in operands.iter_enumerated() {
             let field_index = active_field_index.unwrap_or(field_index);
             let field_dest = self.project_field(&variant_dest, field_index)?;
-            let op = self.eval_operand(operand, Some(field_dest.layout))?;
+            let op = self.eval_operand(operand)?;
             // We validate manually below so we don't have to do it here.
             self.copy_op_no_validate(&op, &field_dest, /*allow_transmute*/ false)?;
         }
@@ -358,7 +355,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         operand: &mir::Operand<'tcx>,
         dest: &PlaceTy<'tcx, M::Provenance>,
     ) -> InterpResult<'tcx> {
-        let src = self.eval_operand(operand, None)?;
+        let src = self.eval_operand(operand)?;
         assert!(src.layout.is_sized());
         let dest = self.force_allocation(&dest)?;
         let length = dest.len(self)?;
@@ -399,7 +396,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         interp_ok(match op {
             mir::Operand::Copy(_) | mir::Operand::Constant(_) | mir::Operand::RuntimeChecks(_) => {
                 // Make a regular copy.
-                let op = self.eval_operand(op, None)?;
+                let op = self.eval_operand(op)?;
                 FnArg::Copy(op)
             }
             mir::Operand::Move(place) => {
@@ -430,7 +427,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         args: &[Spanned<mir::Operand<'tcx>>],
         dest: &mir::Place<'tcx>,
     ) -> InterpResult<'tcx, EvaluatedCalleeAndArgs<'tcx, M>> {
-        let func = self.eval_operand(func, None)?;
+        let func = self.eval_operand(func)?;
 
         // Evaluating function call arguments. The tricky part here is dealing with `Move`
         // arguments: we have to ensure no two such arguments alias. This would be most easily done
@@ -517,7 +514,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Goto { target } => self.go_to_block(target),
 
             SwitchInt { ref discr, ref targets } => {
-                let discr = self.read_immediate(&self.eval_operand(discr, None)?)?;
+                let discr = self.read_immediate(&self.eval_operand(discr)?)?;
                 trace!("SwitchInt({:?})", *discr);
 
                 // Branch to the `otherwise` case by default, if no match is found.
@@ -622,7 +619,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Assert { ref cond, expected, ref msg, target, unwind } => {
                 let ignored =
                     M::ignore_optional_overflow_checks(self) && msg.is_optional_overflow_check();
-                let cond_val = self.read_scalar(&self.eval_operand(cond, None)?)?.to_bool()?;
+                let cond_val = self.read_scalar(&self.eval_operand(cond)?)?.to_bool()?;
                 if ignored || expected == cond_val {
                     self.go_to_block(target);
                 } else {

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -12,20 +12,6 @@ pub(crate) use self::check_validity_requirement::validate_scalar_in_layout;
 pub use self::compare_types::{relate_types, sub_types};
 pub use self::type_name::type_name;
 
-/// Classify whether an operator is "left-homogeneous", i.e., the LHS has the
-/// same type as the result.
-#[inline]
-pub fn binop_left_homogeneous(op: mir::BinOp) -> bool {
-    use rustc_middle::mir::BinOp::*;
-    match op {
-        Add | AddUnchecked | Sub | SubUnchecked | Mul | MulUnchecked | Div | Rem | BitXor
-        | BitAnd | BitOr | Offset | Shl | ShlUnchecked | Shr | ShrUnchecked => true,
-        AddWithOverflow | SubWithOverflow | MulWithOverflow | Eq | Ne | Lt | Le | Gt | Ge | Cmp => {
-            false
-        }
-    }
-}
-
 /// Classify whether an operator is "right-homogeneous", i.e., the RHS has the
 /// same type as the LHS.
 #[inline]

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
                 if let Some(constant) = self
                     .ecx
                     .borrow()
-                    .eval_mir_constant(&constant.const_, constant.span, None)
+                    .eval_mir_constant(&constant.const_, constant.span)
                     .discard_err()
                 {
                     self.assign_constant(state, place, constant, &[]);

--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -602,7 +602,7 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                 }
             }
             Constant { ref value, disambiguator: _ } => {
-                self.ecx.eval_mir_constant(value, DUMMY_SP, None).discard_err()?
+                self.ecx.eval_mir_constant(value, DUMMY_SP).discard_err()?
             }
             Aggregate(variant, ref fields) => {
                 let fields =

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -487,7 +487,7 @@ impl<'a, 'tcx> TOFinder<'a, 'tcx> {
             // If we expect `lhs ?= A`, we have an opportunity if we assume `constant == A`.
             Operand::Constant(constant) => {
                 let Some(constant) =
-                    self.ecx.eval_mir_constant(&constant.const_, constant.span, None).discard_err()
+                    self.ecx.eval_mir_constant(&constant.const_, constant.span).discard_err()
                 else {
                     return;
                 };

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -266,9 +266,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             .try_normalize_erasing_regions(self.typing_env, Unnormalized::new_wip(c.const_))
             .ok()?;
 
-        self.use_ecx(|this| this.ecx.eval_mir_constant(&val, c.span, None))?
-            .as_mplace_or_imm()
-            .right()
+        self.use_ecx(|this| this.ecx.eval_mir_constant(&val, c.span))?.as_mplace_or_imm().right()
     }
 
     /// Returns the value, if any, of evaluating `place`.

--- a/src/tools/miri/src/shims/panic.rs
+++ b/src/tools/miri/src/shims/panic.rs
@@ -58,9 +58,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Forward to `panic_bounds_check` lang item.
 
                 // First arg: index.
-                let index = this.read_immediate(&this.eval_operand(index, None)?)?;
+                let index = this.read_immediate(&this.eval_operand(index)?)?;
                 // Second arg: len.
-                let len = this.read_immediate(&this.eval_operand(len, None)?)?;
+                let len = this.read_immediate(&this.eval_operand(len)?)?;
 
                 // Call the lang item.
                 let panic_bounds_check = this.tcx.lang_items().panic_bounds_check_fn().unwrap();
@@ -77,9 +77,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Forward to `panic_misaligned_pointer_dereference` lang item.
 
                 // First arg: required.
-                let required = this.read_immediate(&this.eval_operand(required, None)?)?;
+                let required = this.read_immediate(&this.eval_operand(required)?)?;
                 // Second arg: found.
-                let found = this.read_immediate(&this.eval_operand(found, None)?)?;
+                let found = this.read_immediate(&this.eval_operand(found)?)?;
 
                 // Call the lang item.
                 let panic_misaligned_pointer_dereference =


### PR DESCRIPTION
Given that we cache the layout of local variables, is this even still useful?