### PR TITLE
Use alternate means of detecting enums in `is_udt`

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -393,7 +393,7 @@ def arc_synthetic(valobj: lldb.SBValue, _dict: LLDBOpaque) -> object:
 def is_udt(type: lldb.SBType, _dict: LLDBOpaque) -> bool:
     return (
         type.GetBasicType() == lldb.eBasicTypeInvalid
-        and not type.IsScopedEnumerationType()
+        and not type.GetEnumerationIntegerType().IsValid()
         and not type.IsPointerType()
         and not type.IsArrayType()
     )


### PR DESCRIPTION
This fixes a small regression from https://github.com/rust-lang/rust/pull/155336

Flat enums are excluded from `is_udt` since LLDB natively handles them correctly. The previous logic (`SBType.IsScopedEnumerationType()`) behaved correctly for non-msvc targets, but for some reason on msvc enums don't count as scoped enumerations? 

The new logic checks the type returned by `SBType.GetEnumerationIntegerType()`. If the queried type isn't an enum, the returned type is invalid. This behaves correctly on both msvc and non-msvc targets, and its behavior doesn't conflict with sum-type enums.

As always, testing on msvc isn't really possible atm. That should change soon though =)

---

try-job: aarch64-apple