### PR TITLE
Fix unstable diagnostics in tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2719,8 +2719,10 @@ impl<'test> TestCx<'test> {
                 (&tmp.0, &tmp.1)
             }
         } else if compare_output_by_lines {
-            let mut actual_lines: Vec<&str> = actual.lines().collect();
-            let mut expected_lines: Vec<&str> = expected.lines().collect();
+            // Filter out padded empty code lines
+            let mut actual_lines: Vec<&str> = actual.lines().filter(|l| l.trim() != "|").collect();
+            let mut expected_lines: Vec<&str> =
+                expected.lines().filter(|l| l.trim() != "|").collect();
             actual_lines.sort_unstable();
             expected_lines.sort_unstable();
             if actual_lines == expected_lines {

--- a/src/tools/compiletest/src/runtest/compute_diff.rs
+++ b/src/tools/compiletest/src/runtest/compute_diff.rs
@@ -112,10 +112,11 @@ pub(crate) fn diff_by_lines(expected: &str, actual: &str) -> String {
     let mut expected_counts: HashMap<&str, usize> = HashMap::new();
     let mut actual_counts: HashMap<&str, usize> = HashMap::new();
 
-    for line in expected.lines() {
+    // Filter out padded empty code lines
+    for line in expected.lines().filter(|l| l.trim() != "|") {
         *expected_counts.entry(line).or_insert(0) += 1;
     }
-    for line in actual.lines() {
+    for line in actual.lines().filter(|l| l.trim() != "|") {
         *actual_counts.entry(line).or_insert(0) += 1;
     }
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
@@ -1,6 +1,6 @@
 //@ edition:2021
 //@ check-pass
-//@ ignore-parallel-frontend unstable liveness diagnostics
+
 #![allow(unreachable_code)]
 #![warn(unused)]
 #![allow(dead_code)]

--- a/tests/ui/lint/non-snake-case/lint-uppercase-variables.rs
+++ b/tests/ui/lint/non-snake-case/lint-uppercase-variables.rs
@@ -1,7 +1,7 @@
 #![warn(unused)]
 #![allow(dead_code)]
 #![deny(non_snake_case)]
-//@ ignore-parallel-frontend `note`s on different source lines
+
 mod foo {
     pub enum Foo { Foo }
 }

--- a/tests/ui/lint/unused/unused-assign-148960.rs
+++ b/tests/ui/lint/unused/unused-assign-148960.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ ignore-parallel-frontend unstable liveness diagnostics
+
 #![deny(unused)]
 #![allow(dead_code)]
 

--- a/tests/ui/liveness/liveness-consts.rs
+++ b/tests/ui/liveness/liveness-consts.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ ignore-parallel-frontend unstable liveness diagnostics
+
 #![warn(unused)]
 #![allow(unreachable_code)]
 

--- a/tests/ui/liveness/liveness-dead.rs
+++ b/tests/ui/liveness/liveness-dead.rs
@@ -1,4 +1,3 @@
-//@ ignore-parallel-frontend unstable liveness diagnostics
 #![allow(dead_code)]
 #![deny(unused_assignments)]
 

--- a/tests/ui/liveness/liveness-dead.stderr
+++ b/tests/ui/liveness/liveness-dead.stderr
@@ -1,5 +1,5 @@
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:10:24
+  --> $DIR/liveness-dead.rs:9:24
    |
 LL |     let mut x: isize = 3;
    |                        ^ this value is reassigned later and never used
@@ -7,13 +7,13 @@ LL |     x = 4;
    |     ----- `x` is overwritten here before the previous value is read
    |
 note: the lint level is defined here
-  --> $DIR/liveness-dead.rs:3:9
+  --> $DIR/liveness-dead.rs:2:9
    |
 LL | #![deny(unused_assignments)]
    |         ^^^^^^^^^^^^^^^^^^
 
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:18:5
+  --> $DIR/liveness-dead.rs:17:5
    |
 LL |     x = 4;
    |     ^^^^^
@@ -21,7 +21,7 @@ LL |     x = 4;
    = help: maybe it is overwritten before being read?
 
 error: value passed to `x` is never read
-  --> $DIR/liveness-dead.rs:21:7
+  --> $DIR/liveness-dead.rs:20:7
    |
 LL | fn f4(mut x: i32) {
    |       ^^^^^
@@ -29,7 +29,7 @@ LL | fn f4(mut x: i32) {
    = help: maybe it is overwritten before being read?
 
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:28:5
+  --> $DIR/liveness-dead.rs:27:5
    |
 LL |     x = 4;
    |     ^^^^^

--- a/tests/ui/liveness/liveness-unused.rs
+++ b/tests/ui/liveness/liveness-unused.rs
@@ -3,7 +3,7 @@
 #![deny(unused_assignments)]
 #![allow(dead_code, non_camel_case_types, trivial_numeric_casts, dropping_copy_types)]
 #![feature(intrinsics)]
-//@ ignore-parallel-frontend `note`s on different source lines
+
 use std::ops::AddAssign;
 
 fn f1(x: isize) {

--- a/tests/ui/liveness/liveness-upvars.rs
+++ b/tests/ui/liveness/liveness-upvars.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 //@ check-pass
-//@ ignore-parallel-frontend unstable liveness diagnostics
+
 #![feature(coroutines, stmt_expr_attributes)]
 #![warn(unused)]
 #![allow(unreachable_code)]

--- a/tests/ui/liveness/unused-assignments-diverging-branch-issue-156416.rs
+++ b/tests/ui/liveness/unused-assignments-diverging-branch-issue-156416.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-parallel-frontend unstable liveness diagnostics
+
 #![allow(dead_code)]
 #![warn(unused_assignments)]
 

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -9,7 +9,7 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:14:9
+  --> $DIR/empty-types.rs:8:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -9,7 +9,7 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:14:9
+  --> $DIR/empty-types.rs:8:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -9,7 +9,7 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/empty-types.rs:14:9
+  --> $DIR/empty-types.rs:8:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/pattern/usefulness/empty-types.rs
+++ b/tests/ui/pattern/usefulness/empty-types.rs
@@ -1,17 +1,17 @@
 //@ revisions: normal exhaustive_patterns never_pats
 //@ edition: 2024
-//@ ignore-parallel-frontend pattern matching error message mismatch
-//
-// This tests correct handling of empty types in exhaustiveness checking.
-//
-// Most of the subtlety of this file happens in scrutinee places which are not required to hold
-// valid data, namely dereferences and union field accesses. In these cases, empty arms can
-// generally not be omitted, except with `exhaustive_patterns` which ignores this..
+
 #![feature(never_type)]
 #![cfg_attr(exhaustive_patterns, feature(exhaustive_patterns))]
 #![cfg_attr(never_pats, feature(never_patterns))]
 #![allow(dead_code, unreachable_code)]
 #![deny(unreachable_patterns)]
+
+// This tests correct handling of empty types in exhaustiveness checking.
+//
+// Most of the subtlety of this file happens in scrutinee places which are not required to hold
+// valid data, namely dereferences and union field accesses. In these cases, empty arms can
+// generally not be omitted, except with `exhaustive_patterns` which ignores this..
 
 #[derive(Copy, Clone)]
 enum Void {}

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives-macro.fixed
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives-macro.fixed
@@ -1,7 +1,7 @@
 //@ edition:2018
 //@ aux-build:edition-lint-infer-outlives-macro.rs
 //@ run-rustfix
-//@ ignore-parallel-frontend `note`s on different source lines
+
 #![deny(explicit_outlives_requirements)]
 #![allow(dead_code)]
 

--- a/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives-macro.rs
+++ b/tests/ui/rust-2018/edition-lint-inter-outlives/edition-lint-infer-outlives-macro.rs
@@ -1,7 +1,7 @@
 //@ edition:2018
 //@ aux-build:edition-lint-infer-outlives-macro.rs
 //@ run-rustfix
-//@ ignore-parallel-frontend `note`s on different source lines
+
 #![deny(explicit_outlives_requirements)]
 #![allow(dead_code)]
 


### PR DESCRIPTION
The main inconsistency in changed tests happens when subdiagnostic pads the main diagnostic with an empty source line (aka "|"). Meanwhile the parallel frontend might bunch subdiagnostics on a single primary diagnostic, removing padding from some other one. So we can just ignore "|" lines.

Updates rust-lang/rust#154314
Reverts rust-lang/rust#157103