### PR TITLE
Relax test requirements for consistency

### DIFF
--- a/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs
@@ -2,12 +2,11 @@
 //@ compile-flags: --force-warn unused_variables
 //@ compile-flags: --force-warn unused_mut
 //@ check-pass
-//@ ignore-parallel-frontend `note`s on different source lines
+
 fn expect_early_pass_lint() {
     #[expect(while_true)]
     while true {
         //~^ WARNING denote infinite loops with `loop { ... }` [while_true]
-        //~| NOTE requested on the command line with `--force-warn while-true`
         //~| HELP use `loop`
         println!("I never stop")
     }
@@ -17,7 +16,6 @@ fn expect_early_pass_lint() {
 fn check_specific_lint() {
     let x = 2;
     //~^ WARNING unused variable: `x` [unused_variables]
-    //~| NOTE requested on the command line with `--force-warn unused-variables`
     //~| HELP if this is intentional, prefix it with an underscore
 }
 
@@ -29,7 +27,6 @@ fn check_multiple_lints_with_lint_group() {
 
     let mut what_does_the_fox_say = "*ding* *deng* *dung*";
     //~^ WARNING variable does not need to be mutable [unused_mut]
-    //~| NOTE requested on the command line with `--force-warn unused-mut`
     //~| HELP remove this `mut`
 
     println!("The fox says: {what_does_the_fox_say}");

--- a/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.stderr
@@ -7,7 +7,7 @@ LL |     while true {
    = note: requested on the command line with `--force-warn while-true`
 
 warning: unused variable: `x`
-  --> $DIR/force_warn_expected_lints_fulfilled.rs:18:9
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:17:9
    |
 LL |     let x = 2;
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
@@ -15,7 +15,7 @@ LL |     let x = 2;
    = note: requested on the command line with `--force-warn unused-variables`
 
 warning: variable does not need to be mutable
-  --> $DIR/force_warn_expected_lints_fulfilled.rs:30:9
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:28:9
    |
 LL |     let mut what_does_the_fox_say = "*ding* *deng* *dung*";
    |         ----^^^^^^^^^^^^^^^^^^^^^
@@ -25,13 +25,13 @@ LL |     let mut what_does_the_fox_say = "*ding* *deng* *dung*";
    = note: requested on the command line with `--force-warn unused-mut`
 
 warning: unused variable: `fox_name`
-  --> $DIR/force_warn_expected_lints_fulfilled.rs:26:9
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:24:9
    |
 LL |     let fox_name = "Sir Nibbles";
    |         ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_fox_name`
 
 warning: unused variable: `this_should_fulfill_the_expectation`
-  --> $DIR/force_warn_expected_lints_fulfilled.rs:41:9
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:38:9
    |
 LL |     let this_should_fulfill_the_expectation = "The `#[allow]` has no power here";
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_this_should_fulfill_the_expectation`


### PR DESCRIPTION
That note occurring under the first emitted warning. Test `tests/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs` fails for parallel frontend due to its inconsistent order of diagnostics, which is fine on its own. As such this PR removes these note requirements and they are now only covered by `force_warn_expected_lints_fulfilled.stderr`, which is almost the same thing.

Updates https://github.com/rust-lang/rust/issues/154314

r? @nnethercote