### PR TITLE
tests: codegen-llvm: Expect the new mangling scheme in bpf-abi-indirect-return

### DIFF
--- a/tests/codegen-llvm/bpf-abi-indirect-return.rs
+++ b/tests/codegen-llvm/bpf-abi-indirect-return.rs
@@ -16,7 +16,7 @@ fn outer(a: u64) -> u64 {
     inner_big(v).a[0] as u64
 }
 
-// CHECK-LABEL: define {{.*}} @_ZN{{.*}}inner_res{{.*}}E(
+// CHECK-LABEL: define {{.*}} @_R{{.*}}inner_res(
 // CHECK-SAME:   ptr{{[^,]*}},
 // CHECK-SAME:   i64{{[^)]*}}
 #[inline(never)]
@@ -29,7 +29,7 @@ struct Big {
     b: u64,
 }
 
-// CHECK-LABEL: define {{.*}} @_ZN{{.*}}inner_big{{.*}}E(
+// CHECK-LABEL: define {{.*}} @_R{{.*}}inner_big(
 // CHECK-SAME:   ptr{{[^,]*}},
 // CHECK-SAME:   i64{{[^)]*}}
 #[inline(never)]

--- a/tests/codegen-llvm/bpf-abi-indirect-return.rs
+++ b/tests/codegen-llvm/bpf-abi-indirect-return.rs
@@ -1,27 +1,17 @@
 // Checks that results larger than one register are returned indirectly
-//@ only-bpf
+//@ add-minicore
 //@ needs-llvm-components: bpf
 //@ compile-flags: --target bpfel-unknown-none
 
-#![no_std]
-#![no_main]
+#![crate_type = "lib"]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
 
 #[no_mangle]
 fn outer(a: u64) -> u64 {
-    let v = match inner_res(a) {
-        Ok(v) => v,
-        Err(()) => 0,
-    };
-
-    inner_big(v).a[0] as u64
-}
-
-// CHECK-LABEL: define {{.*}} @_R{{.*}}inner_res(
-// CHECK-SAME:   ptr{{[^,]*}},
-// CHECK-SAME:   i64{{[^)]*}}
-#[inline(never)]
-fn inner_res(a: u64) -> Result<u64, ()> {
-    if a == 0 { Err(()) } else { Ok(a + 1) }
+    inner_big(a).b
 }
 
 struct Big {
@@ -35,9 +25,4 @@ struct Big {
 #[inline(never)]
 fn inner_big(a: u64) -> Big {
     Big { a: [a as u16; 32], b: 42 }
-}
-
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
 }


### PR DESCRIPTION
[The new Rust symbol mangling](https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html) uses prefix `_R` instead of `@_ZN`.

Instead of keeping the test as `only-bpf`, use minicore. This way we make sure it will never get outdated again.

r? @nagisa

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
