### PR TITLE
Use `std::mem::take` instead of `std::mem::replace` with default values

### DIFF
--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -217,7 +217,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
 
         let Some(attr) = found_attr else {
             self.check_not_pub_in_root(&item.vis, self.source_map.guess_head_span(item.span));
-            let prev_in_root = mem::replace(&mut self.in_root, false);
+            let prev_in_root = mem::take(&mut self.in_root);
             visit::walk_item(self, item);
             self.in_root = prev_in_root;
             return;
@@ -255,7 +255,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
             self.collect_bang_proc_macro(item, fn_ident);
         };
 
-        let prev_in_root = mem::replace(&mut self.in_root, false);
+        let prev_in_root = mem::take(&mut self.in_root);
         visit::walk_item(self, item);
         self.in_root = prev_in_root;
     }

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -738,7 +738,7 @@ impl EncoderState {
             // Prevent more indices from being allocated on this thread.
             local.remaining_node_index = 0;
 
-            let data = mem::replace(&mut local.encoder.data, Vec::new());
+            let data = mem::take(&mut local.encoder.data);
             self.file.lock().as_mut().unwrap().emit_raw_bytes(&data);
 
             LocalEncoderResult {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2516,7 +2516,7 @@ impl<'tcx> PrettyPrinter<'tcx> for FmtPrinter<'_, 'tcx> {
         self.write_str("{")?;
         f(self)?;
         self.write_str(conversion)?;
-        let was_in_value = std::mem::replace(&mut self.in_value, false);
+        let was_in_value = std::mem::take(&mut self.in_value);
         t(self)?;
         self.in_value = was_in_value;
         self.write_str("}")?;
@@ -2529,7 +2529,7 @@ impl<'tcx> PrettyPrinter<'tcx> for FmtPrinter<'_, 'tcx> {
     ) -> Result<(), PrintError> {
         write!(self, "<")?;
 
-        let was_in_value = std::mem::replace(&mut self.in_value, false);
+        let was_in_value = std::mem::take(&mut self.in_value);
         f(self)?;
         self.in_value = was_in_value;
 

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -330,7 +330,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 visit::walk_pat(self, pat);
             }
             PatKind::Deref { .. } | PatKind::DerefPattern { .. } => {
-                let old_inside_adt = std::mem::replace(&mut self.inside_adt, false);
+                let old_inside_adt = std::mem::take(&mut self.inside_adt);
                 visit::walk_pat(self, pat);
                 self.inside_adt = old_inside_adt;
             }

--- a/compiler/rustc_passes/src/check_export.rs
+++ b/compiler/rustc_passes/src/check_export.rs
@@ -84,7 +84,7 @@ impl<'tcx> ExportableItemCollector<'tcx> {
         if find_attr!(self.tcx, def_id, ExportStable) {
             self.in_exportable_mod = true;
         }
-        let old_seen_exportable_in_mod = std::mem::replace(&mut self.seen_exportable_in_mod, false);
+        let old_seen_exportable_in_mod = std::mem::take(&mut self.seen_exportable_in_mod);
 
         intravisit::walk_item(self, item);
 

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -720,7 +720,7 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
     fn visit_anon_const(&mut self, c: &'tcx hir::AnonConst) -> Self::Result {
         // When inline const blocks are used in pattern position, paths
         // referenced by it should be considered as used.
-        let in_pat = mem::replace(&mut self.in_pat, false);
+        let in_pat = mem::take(&mut self.in_pat);
 
         self.live_symbols.insert(c.def_id);
         let result = intravisit::walk_anon_const(self, c);
@@ -733,7 +733,7 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
     fn visit_inline_const(&mut self, c: &'tcx hir::ConstBlock) -> Self::Result {
         // When inline const blocks are used in pattern position, paths
         // referenced by it should be considered as used.
-        let in_pat = mem::replace(&mut self.in_pat, false);
+        let in_pat = mem::take(&mut self.in_pat);
 
         self.live_symbols.insert(c.def_id);
         let result = intravisit::walk_inline_const(self, c);

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2573,7 +2573,7 @@ fn normalize_newlines(src: &mut String, normalized_pos: &mut Vec<NormalizedPos>)
     // directly, let's rather steal the contents of `src`. This makes the code
     // safe even if a panic occurs.
 
-    let mut buf = std::mem::replace(src, String::new()).into_bytes();
+    let mut buf = std::mem::take(src).into_bytes();
     let mut gap_len = 0;
     let mut tail = buf.as_mut_slice();
     let mut cursor = 0;


### PR DESCRIPTION
Replace `std::mem::replace(&mut x, Default::default())` and equivalent patterns (e.g. `String::new()`, `Vec::new()`, `false`) with the more idiomatic `std::mem::take(&mut x)` across the compiler source.

This improves code readability and aligns with Rust best practices, matching the clippy lint `mem_replace_with_default`.

Closes rust-lang/rust#157245.

### Changes

| File | Change |
|------|--------|
| `compiler/rustc_span/src/lib.rs` | `std::mem::replace(src, String::new())` → `std::mem::take(src)` |
| `compiler/rustc_middle/src/dep_graph/serialized.rs` | `mem::replace(&mut local.encoder.data, Vec::new())` → `mem::take(&mut local.encoder.data)` |
| `compiler/rustc_passes/src/dead.rs` | 2× `mem::replace(&mut self.in_pat, false)` → `mem::take(&mut self.in_pat)` |
| `compiler/rustc_passes/src/check_export.rs` | `std::mem::replace(&mut self.seen_exportable_in_mod, false)` → `std::mem::take(...)` |
| `compiler/rustc_mir_build/src/check_unsafety.rs` | `std::mem::replace(&mut self.inside_adt, false)` → `std::mem::take(...)` |
| `compiler/rustc_middle/src/ty/print/pretty.rs` | 2× `std::mem::replace(&mut self.in_value, false)` → `std::mem::take(...)` |
| `compiler/rustc_builtin_macros/src/proc_macro_harness.rs` | 2× `mem::replace(&mut self.in_root, false)` → `mem::take(&mut self.in_root)` |