### PR TITLE
rustdoc: Render `impl` restriction

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -628,7 +628,11 @@ fn item_trait(cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) -> impl fmt:
         let count_types = required_types.len() + provided_types.len();
         let count_consts = required_consts.len() + provided_consts.len();
         let count_methods = required_methods.len() + provided_methods.len();
-        let must_implement_one_of_functions = &tcx.trait_def(t.def_id).must_implement_one_of;
+        let &rustc_middle::ty::TraitDef {
+            must_implement_one_of: ref must_implement_one_of_functions,
+            impl_restriction,
+            ..
+        } = tcx.trait_def(t.def_id);
 
         // Output the trait definition
         wrap_item(w, |mut w| {
@@ -781,6 +785,25 @@ fn item_trait(cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) -> impl fmt:
 
         // Trait documentation
         write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
+
+        if let rustc_middle::ty::trait_def::ImplRestrictionKind::Restricted(def_id, _) =
+            impl_restriction
+        {
+            let v1;
+            let v2;
+            write!(
+                w,
+                "<div class=\"stab impl_restriction\">This trait cannot be implemented outside <code>{}</code>.</div>",
+                if cx.cache().document_private {
+                    v1 =
+                        rustc_middle::ty::print::with_resolve_crate_name!(tcx.def_path_str(def_id));
+                    v1.as_str()
+                } else {
+                    v2 = tcx.crate_name(def_id.krate);
+                    v2.as_str()
+                },
+            )?;
+        }
 
         fn trait_item(cx: &Context<'_>, m: &clean::Item, t: &clean::Item) -> impl fmt::Display {
             fmt::from_fn(|w| {

--- a/tests/rustdoc-html/impl/impl-restriction-document-private.rs
+++ b/tests/rustdoc-html/impl/impl-restriction-document-private.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: --document-private-items
+#![crate_name = "c"]
+#![feature(impl_restriction)]
+
+//@ matches c/trait.Foo.html '//*[@class="stab impl_restriction"]' \
+//      'This trait cannot be implemented outside c.$'
+//@ has c/trait.Foo.html '//*[@class="stab impl_restriction"]//code' 'c'
+pub impl(crate) trait Foo {}
+
+pub mod inner {
+    //@ matches c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]' \
+    //      'This trait cannot be implemented outside c::inner.$'
+    //@ has c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]//code' 'c::inner'
+    pub impl(self) trait Bar {}
+}

--- a/tests/rustdoc-html/impl/impl-restriction.rs
+++ b/tests/rustdoc-html/impl/impl-restriction.rs
@@ -1,0 +1,14 @@
+#![crate_name = "c"]
+#![feature(impl_restriction)]
+
+//@ matches c/trait.Foo.html '//*[@class="stab impl_restriction"]' \
+//      'This trait cannot be implemented outside c.$'
+//@ has c/trait.Foo.html '//*[@class="stab impl_restriction"]//code' 'c'
+pub impl(crate) trait Foo {}
+
+pub mod inner {
+    //@ matches c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]' \
+    //      'This trait cannot be implemented outside c.$'
+    //@ has c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]//code' 'c'
+    pub impl(self) trait Bar {}
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
According to the [Zulip conversation](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/Documenting.20.60impl.60.20restrictions/with/598960498), this PR implements the rendering of `impl` restrictions.
Following the pattern used for `#[rustc_must_implement_one_of]`, this adds an information note saying, "This trait cannot be implemented outside \<crate-name\>".
When `--document-private-items` is passed, the note instead says, "This trait cannot be implemented outside \<path-to-module\>".
The screenshots show the generated documentation for the following code:
```rust
pub mod inner {
    pub impl(self) trait Bar {}
}
```
in a crate `c`. The latter image corresponds to the case where `--document-private-items` is passed.
Tracking issue: rust-lang/rust#105077

r? @Urgau 
cc @jhpratt 

<img width="920" height="309" alt="screenshot" src="https://github.com/user-attachments/assets/586c97d6-0f41-41de-9673-eaf12b96c4a1" />
<img width="902" height="316" alt="document-private-screenshot" src="https://github.com/user-attachments/assets/56aedc38-bd05-4ece-885a-8d928a59089c" />

