### PR TITLE
Use weak linkage for EII defaults

### DIFF
--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -169,7 +169,10 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
     ) {
         for (alias, linkage, visibility) in aliases {
             let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, *alias));
-            tracing::debug!("FUNCTION ALIAS: {alias:?} {linkage:?} {visibility:?}");
+            tracing::debug!(
+                "FUNCTION ALIAS: generating fn {} that calls {aliasee_instance:?} ({alias:?} {linkage:?} {visibility:?})",
+                symbol_name.name
+            );
 
             // predefine another copy of the original instance
             // with a new symbol name

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -259,7 +259,7 @@ fn process_builtin_attrs(
 
                     codegen_fn_attrs.foreign_item_symbol_aliases.push((
                         foreign_item,
-                        if i.is_default { Linkage::LinkOnceAny } else { Linkage::External },
+                        if i.is_default { Linkage::WeakAny } else { Linkage::External },
                         Visibility::Default,
                     ));
                     codegen_fn_attrs.flags |= CodegenFnAttrFlags::EXTERNALLY_IMPLEMENTABLE_ITEM;


### PR DESCRIPTION
hard to find a test for this, but weak seems more correct (after private discussion with @bjorn3)

Also changes a log statement to make it a lil easier to see what's going on.

r? @bjorn3