### PR TITLE
Fix ICE when wrong intra-doc link on type alias

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -328,7 +328,12 @@ impl<'tcx> LinkCollector<'_, 'tcx> {
                             })
                         }
                     }
-                    _ => unreachable!(),
+                    _ => Err(UnresolvedPath {
+                        item_id,
+                        module_id,
+                        partial_res: Some(Res::Def(DefKind::TyAlias, did)),
+                        unresolved: variant_name.to_string().into(),
+                    }),
                 }
             }
             _ => Err(UnresolvedPath {

--- a/tests/rustdoc-ui/intra-doc/ty-alias-field.rs
+++ b/tests/rustdoc-ui/intra-doc/ty-alias-field.rs
@@ -1,0 +1,11 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+//~^ NOTE the lint level is defined here
+
+/// [Self::a::b]
+//~^ ERROR unresolved link to `Self::a::b`
+//~| NOTE the struct `MyStruct` has no field or associated item named `a`
+pub struct MyStruct;
+/// [Self::a::b]
+//~^ ERROR unresolved link to `Self::a::b`
+//~| NOTE the type alias `MyAlias` has no associated item named `a`
+pub type MyAlias = MyStruct;

--- a/tests/rustdoc-ui/intra-doc/ty-alias-field.stderr
+++ b/tests/rustdoc-ui/intra-doc/ty-alias-field.stderr
@@ -1,0 +1,20 @@
+error: unresolved link to `Self::a::b`
+  --> $DIR/ty-alias-field.rs:4:6
+   |
+LL | /// [Self::a::b]
+   |      ^^^^^^^^^^ the struct `MyStruct` has no field or associated item named `a`
+   |
+note: the lint level is defined here
+  --> $DIR/ty-alias-field.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unresolved link to `Self::a::b`
+  --> $DIR/ty-alias-field.rs:8:6
+   |
+LL | /// [Self::a::b]
+   |      ^^^^^^^^^^ the type alias `MyAlias` has no associated item named `a`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#157204.

I'm surprised this case wasn't uncovered before. Anyway, it was just a missing `Err` creation.

r? @camelid