### PR TITLE
test pre-stabilization items on CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-pre-stabilization/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-pre-stabilization/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  libssl-dev \
+  pkg-config \
+  xz-utils \
+  mingw-w64 \
+  zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV RUST_CONFIGURE_ARGS="--build=x86_64-unknown-linux-gnu"
+
+COPY scripts/x86_64-gnu-pre-stabilization.sh /scripts/
+ENV SCRIPT="/scripts/x86_64-gnu-pre-stabilization.sh"

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -15,8 +15,3 @@ set -ex
 
 # Run the UI test suite in `--pass=check` mode, to ensure it continues to work.
 ../x.ps1 --stage 2 test tests/ui --pass=check --host='' --target=i686-unknown-linux-gnu
-
-# Rebuild the stdlib using the new trait solver, to ensure it doesn't regress
-# until stabilization.
-RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x --stage 1 build library \
-    --host='' --target=i686-unknown-linux-gnu

--- a/src/ci/docker/scripts/x86_64-gnu-pre-stabilization.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-pre-stabilization.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+# This script tests features intended to be stabilized in 2026. We want to
+# ensure they don't regress until then.
+
+# 1. For the new trait solver, we want to:
+# - ensure it can build the standard library
+#
+# FIXME: we also need to ensure it actually bootstraps.
+
+RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x build library --stage 1
+
+# 2. For the polonius alpha, we run the UI tests under the polonius
+# compare-mode.
+#
+# Note that we keep the same rustflags to avoid needing to rebuild any stage 1
+# artifacts from the previous command. It also tests both features at the same
+# time.
+
+RUSTFLAGS_NOT_BOOTSTRAP="-Znext-solver=globally" ../x test tests/ui \
+    --compare-mode polonius --stage 1

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -152,6 +152,14 @@ pr:
     env:
       CODEGEN_BACKENDS: gcc
     <<: *job-linux-4c
+  
+  # This job tests features we want to stabilize soon, to ensure they don't
+  # regress.
+  - name: x86_64-gnu-pre-stabilization
+    doc_url: https://rustc-dev-guide.rust-lang.org/tests/pre-stabilization-ci-job.html
+    env:
+      CODEGEN_BACKENDS: llvm
+    <<: *job-linux-4c
 
 # Jobs that run when you perform a try build (@bors try)
 # These jobs automatically inherit envs.try, to avoid repeating


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157322)*
<!-- homu-ignore:end -->

This PR is part of [MCP 996](https://github.com/rust-lang/compiler-team/issues/996), and adds a new CI job dedicated to testing pre-stabilization items, with:
- the new solver, to ensure it can build the standard library (moved from where I added it in rust-lang/rust#156146). Note this is not sufficient _yet_, as we also want to test bootstrapping soon, but it's currently broken and will have to wait for a followup PR.
- the polonius alpha, by running UI tests under the polonius compare-mode