### PR TITLE
Document Repeat::last panic behavior

### DIFF
--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -101,6 +101,11 @@ impl<A: Clone> Iterator for Repeat<A> {
         Some(self.element.clone())
     }
 
+    /// Consumes the iterator and panics.
+    ///
+    /// # Panics
+    ///
+    /// This method always panics because `Repeat` is infinite.
     #[track_caller]
     fn last(self) -> Option<A> {
         panic!("iterator is infinite");

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -111,6 +111,11 @@ impl<A: Clone> Iterator for Repeat<A> {
         panic!("iterator is infinite");
     }
 
+    /// Consumes the iterator and panics.
+    ///
+    /// # Panics
+    ///
+    /// This method always panics because `Repeat` is infinite.
     #[track_caller]
     fn count(self) -> usize {
         panic!("iterator is infinite");


### PR DESCRIPTION
Fixes rust-lang/rust#149707

Documents that `Repeat::last` always panics because `Repeat` is infinite.

Tests:
- `./x fmt --check`
- `./x doc library/core`
- `./x test library/core`