### PR TITLE
windows: Elide division-by-zero checks in Instant::now()

### DIFF
--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -20,7 +20,7 @@ pub fn intervals2dur(intervals: u64) -> Duration {
 
 pub mod perf_counter {
     use super::NANOS_PER_SEC;
-    use crate::sync::atomic::{Atomic, AtomicU64, Ordering};
+    use crate::sync::atomic::{AtomicI64, Ordering};
     use crate::sys::{c, cvt};
     use crate::time::Duration;
 
@@ -32,23 +32,32 @@ pub mod perf_counter {
 
     pub fn frequency() -> i64 {
         // Either the cached result of `QueryPerformanceFrequency` or `0` for
-        // uninitialized. Storing this as a single `AtomicU64` allows us to use
+        // uninitialized. Storing this as a single `AtomicI64` allows us to use
         // `Relaxed` operations, as we are only interested in the effects on a
         // single memory location.
-        static FREQUENCY: Atomic<u64> = AtomicU64::new(0);
+        static FREQUENCY: AtomicI64 = AtomicI64::new(0);
 
         let cached = FREQUENCY.load(Ordering::Relaxed);
         // If a previous thread has filled in this global state, use that.
         if cached != 0 {
-            return cached as i64;
+            return cached;
         }
         // ... otherwise learn for ourselves ...
+        frequency_init(&FREQUENCY)
+    }
+
+    #[cold]
+    fn frequency_init(cache: &AtomicI64) -> i64 {
         let mut frequency = 0;
         unsafe {
             cvt(c::QueryPerformanceFrequency(&mut frequency)).unwrap();
         }
 
-        FREQUENCY.store(frequency as u64, Ordering::Relaxed);
+        // SAFETY: According to the MSDN entry for `QueryPerformanceFrequency`,
+        // a value of 0 will never be returned starting from Windows XP.
+        unsafe { crate::hint::assert_unchecked(frequency != 0) }
+
+        cache.store(frequency, Ordering::Relaxed);
         frequency
     }
 


### PR DESCRIPTION
This PR teaches LLVM that the frequency of the performance counter is non null so it is able to remove division by zero checks.
This removes the panic path in `mul_div_u64` and should make calls to `Instant::now()` (very slightly) faster.

As seen in the assembly (see godbolt below), telling LLVM that the frequency is non zero suffices to get the optimization, but I don't know if it could be a great idea to also update the signature of `mul_div_u64`?

MSDN page for [QueryPerformanceFrequency](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancefrequency):
> On systems that run Windows XP or later, the function will always succeed when given valid parameters and will thus never return zero.

Godbolt: https://rust.godbolt.org/z/xr6x8MrPE