### PR TITLE
Make parallel frontend alloc-id numbering deterministic and re-enable the tests

### DIFF
--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -1,5 +1,6 @@
 //! These structs are a subset of the ones found in `rustc_errors::json`.
 
+use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -90,18 +91,31 @@ pub(crate) fn rustfix_diagnostics_only(output: &str) -> String {
         .collect()
 }
 
-pub(crate) fn extract_rendered(output: &str) -> String {
-    output
-        .lines()
-        .filter_map(|line| {
-            if line.starts_with('{') {
-                if let Ok(diagnostic) = serde_json::from_str::<Diagnostic>(line) {
-                    diagnostic.rendered
-                } else if let Ok(report) = serde_json::from_str::<FutureIncompatReport>(line) {
-                    if report.future_incompat_report.is_empty() {
-                        None
-                    } else {
-                        Some(format!(
+/// Extracts the rendered diagnostics from compiler json output.
+///
+/// When `sort` is set the diagnostics are reordered by their primary source
+/// location. This is used under the parallel front-end, where diagnostics are
+/// emitted in a nondeterministic order: the alloc-id normalization in `runtest`
+/// assigns `ALLOC<n>` indices by first appearance in this text, so an unstable
+/// order would otherwise produce unstable numbering. Sorting by source location
+/// makes the numbering deterministic without changing single-threaded output.
+pub(crate) fn extract_rendered(output: &str, sort: bool) -> String {
+    let items = output.lines().filter_map(|line| {
+        if line.starts_with('{') {
+            if let Ok(diagnostic) = serde_json::from_str::<Diagnostic>(line) {
+                let primary = diagnostic
+                    .spans
+                    .iter()
+                    .find(|span| span.is_primary)
+                    .map(|span| (span.file_name.clone(), span.line_start, span.column_start));
+                diagnostic.rendered.map(|text| (primary, text))
+            } else if let Ok(report) = serde_json::from_str::<FutureIncompatReport>(line) {
+                if report.future_incompat_report.is_empty() {
+                    None
+                } else {
+                    Some((
+                        None,
+                        format!(
                             "Future incompatibility report: {}",
                             report
                                 .future_incompat_report
@@ -115,26 +129,55 @@ pub(crate) fn extract_rendered(output: &str) -> String {
                                     )
                                 })
                                 .collect::<String>()
-                        ))
-                    }
-                } else if serde_json::from_str::<ArtifactNotification>(line).is_ok() {
-                    // Ignore the notification.
-                    None
-                } else if serde_json::from_str::<UnusedExternNotification>(line).is_ok() {
-                    // Ignore the notification.
-                    None
-                } else {
-                    // This function is called for both compiler and non-compiler output,
-                    // so if the line isn't recognized as JSON from the compiler then
-                    // just print it as-is.
-                    Some(format!("{line}\n"))
+                        ),
+                    ))
                 }
+            } else if serde_json::from_str::<ArtifactNotification>(line).is_ok() {
+                // Ignore the notification.
+                None
+            } else if serde_json::from_str::<UnusedExternNotification>(line).is_ok() {
+                // Ignore the notification.
+                None
             } else {
-                // preserve non-JSON lines, such as ICEs
-                Some(format!("{}\n", line))
+                // This function is called for both compiler and non-compiler output,
+                // so if the line isn't recognized as JSON from the compiler then
+                // just print it as-is.
+                Some((None, format!("{line}\n")))
             }
-        })
-        .collect()
+        } else {
+            // preserve non-JSON lines, such as ICEs
+            Some((None, format!("{}\n", line)))
+        }
+    });
+
+    if !sort {
+        return items.map(|(_, text)| text).collect();
+    }
+
+    // Order located diagnostics by source position; ties broken by their shape
+    // (with concrete alloc ids blinded, since those are racy under `-Zthreads`).
+    // Items without a primary span keep their original relative order and follow
+    // the located diagnostics, so the trailing "aborting due to N errors" summary
+    // stays last.
+    let mut items: Vec<_> = items.collect();
+    items.sort_by(|(a_key, a_text), (b_key, b_text)| match (a_key, b_key) {
+        (Some(a_key), Some(b_key)) => {
+            a_key.cmp(b_key).then_with(|| alloc_blind(a_text).cmp(&alloc_blind(b_text)))
+        }
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    });
+    items.into_iter().map(|(_, text)| text).collect()
+}
+
+/// Replaces concrete allocation ids with a placeholder so that two diagnostics
+/// at the same source location sort deterministically by their shape rather than
+/// by the raw allocation number, which is racy under the parallel front-end.
+fn alloc_blind(rendered: &str) -> String {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"\ba(?:lloc)?\d+\b").unwrap());
+    re.replace_all(rendered, "alloc").into_owned()
 }
 
 pub(crate) fn parse_output(file_name: &str, output: &str) -> Vec<Error> {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2364,7 +2364,7 @@ impl<'test> TestCx<'test> {
             stderr = if explicit_format {
                 proc_res.stderr.clone()
             } else {
-                json::extract_rendered(&proc_res.stderr)
+                json::extract_rendered(&proc_res.stderr, self.config.parallel_frontend_enabled())
             };
             normalized_stderr = self.normalize_output(&stderr, &self.props.normalize_stderr);
         }
@@ -2960,7 +2960,7 @@ impl ProcRes {
     #[must_use]
     pub(crate) fn format_info(&self) -> String {
         fn render(name: &str, contents: &str) -> String {
-            let contents = json::extract_rendered(contents);
+            let contents = json::extract_rendered(contents, false);
             let contents = contents.trim_end();
             if contents.is_empty() {
                 format!("{name}: none")

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -1,5 +1,5 @@
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![allow(incomplete_features)]
 #![feature(adt_const_params, unsized_const_params)]
 

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.rs
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.rs
@@ -1,6 +1,6 @@
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 use std::mem::transmute;
 
 fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -1,7 +1,7 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
-//@ ignore-parallel-frontend  different alloc ids
+
 #![feature(
     slice_from_ptr_range,
     const_slice_from_ptr_range,

--- a/tests/ui/const-ptr/out_of_bounds_read.rs
+++ b/tests/ui/const-ptr/out_of_bounds_read.rs
@@ -1,6 +1,6 @@
 fn main() {
     use std::ptr;
-//@ ignore-parallel-frontend different alloc ids
+
     const DATA: [u32; 1] = [42];
 
     const PAST_END_PTR: *const u32 = unsafe { DATA.as_ptr().add(1) };

--- a/tests/ui/consts/const-compare-bytes-ub.rs
+++ b/tests/ui/consts/const-compare-bytes-ub.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics, const_cmp)]
 use std::intrinsics::compare_bytes;
 use std::mem::MaybeUninit;

--- a/tests/ui/consts/const-err-enum-discriminant.rs
+++ b/tests/ui/consts/const-err-enum-discriminant.rs
@@ -1,5 +1,5 @@
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 #[derive(Copy, Clone)]
 union Foo {
     a: isize,

--- a/tests/ui/consts/const-eval/c-variadic-fail.rs
+++ b/tests/ui/consts/const-eval/c-variadic-fail.rs
@@ -1,5 +1,5 @@
 //@ build-fail
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(c_variadic)]
 #![feature(const_c_variadic)]
 #![feature(const_trait_impl)]

--- a/tests/ui/consts/const-eval/const-pointer-values-in-various-types.rs
+++ b/tests/ui/consts/const-eval/const-pointer-values-in-various-types.rs
@@ -1,7 +1,7 @@
 //@ only-x86_64
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #[repr(C)]
 union Nonsense {
     u: usize,

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_uninit.rs
@@ -3,7 +3,7 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 use std::intrinsics;
-//@ ignore-parallel-frontend different alloc ids
+
 const BAR: &i32 = unsafe { //~ ERROR: uninitialized memory
     // Make the pointer immutable to avoid errors related to mutable pointers in constants.
     &*(intrinsics::const_make_global(intrinsics::const_allocate(4, 4)) as *const i32)

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_dangling.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
-//@ ignore-parallel-frontend different alloc ids
+
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_duplicate.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::intrinsics;
 
 const _X: () = unsafe {

--- a/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.rs
+++ b/tests/ui/consts/const-eval/heap/dealloc_intrinsic_incorrect_layout.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::intrinsics;
 
 const _X: () = unsafe {

--- a/tests/ui/consts/const-eval/heap/make-global-dangling.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-dangling.rs
@@ -1,5 +1,5 @@
 // Ensure that we can't call `const_make_global` on dangling pointers.
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 

--- a/tests/ui/consts/const-eval/heap/make-global-other.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-other.rs
@@ -1,5 +1,5 @@
 // Ensure that we can't call `const_make_global` on pointers not in the current interpreter.
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 

--- a/tests/ui/consts/const-eval/heap/make-global-twice.rs
+++ b/tests/ui/consts/const-eval/heap/make-global-twice.rs
@@ -1,5 +1,5 @@
 // Ensure that we can't call `const_make_global` twice.
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 

--- a/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.rs
+++ b/tests/ui/consts/const-eval/heap/ptr_made_global_mutated.rs
@@ -2,7 +2,7 @@
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 use std::intrinsics;
-//@ ignore-parallel-frontend different alloc ids
+
 const A: &u8 = unsafe {
     let ptr = intrinsics::const_allocate(1, 1);
     *ptr = 1;

--- a/tests/ui/consts/const-eval/issue-49296.rs
+++ b/tests/ui/consts/const-eval/issue-49296.rs
@@ -1,5 +1,5 @@
 // issue-49296: Unsafe shenigans in constants can result in missing errors
-//@ ignore-parallel-frontend different alloc ids
+
 use std::mem::transmute;
 
 const fn wat(x: u64) -> &'static u64 {

--- a/tests/ui/consts/const-eval/ptr_fragments_mixed.rs
+++ b/tests/ui/consts/const-eval/ptr_fragments_mixed.rs
@@ -1,6 +1,6 @@
 //! This mixes fragments from different pointers, in a way that we should not accept.
 //! See <https://github.com/rust-lang/rust/issues/146291>.
-//@ ignore-parallel-frontend different alloc ids
+
 static A: u8 = 123;
 static B: u8 = 123;
 

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -3,7 +3,7 @@
 // ignore-tidy-linelength
 //@ normalize-stderr: "╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼" -> "╾ALLOC_ID$1╼"
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![allow(invalid_value, unnecessary_transmutes)]
 #![feature(never_type, rustc_attrs, ptr_metadata, slice_from_ptr_range, const_slice_from_ptr_range)]
 #![feature(pattern_types, pattern_type_macro)]

--- a/tests/ui/consts/const-eval/raw-pointer-ub.rs
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.rs
@@ -4,7 +4,7 @@ const MISALIGNED_LOAD: () = unsafe {
     let _val = *ptr; //~NOTE: failed here
     //~^ERROR: based on pointer with alignment 1, but alignment 4 is required
 };
-//@ ignore-parallel-frontend different alloc ids
+
 const MISALIGNED_STORE: () = unsafe {
     let mut mem = [0u32; 8];
     let ptr = mem.as_mut_ptr().byte_add(1);

--- a/tests/ui/consts/const-eval/read_partial_ptr.rs
+++ b/tests/ui/consts/const-eval/read_partial_ptr.rs
@@ -1,5 +1,5 @@
 //! Ensure we error when trying to load from a pointer whose provenance has been messed with.
-//@ ignore-parallel-frontend different alloc ids
+
 const PARTIAL_OVERWRITE: () = {
     let mut p = &42;
     // Overwrite one byte with a no-provenance value.

--- a/tests/ui/consts/const-eval/ub-enum-overwrite.rs
+++ b/tests/ui/consts/const-eval/ub-enum-overwrite.rs
@@ -2,7 +2,7 @@ enum E {
     A(u8),
     B,
 }
-//@ ignore-parallel-frontend different alloc ids
+
 const _: u8 = {
     let mut e = E::A(1);
     let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -4,7 +4,7 @@
 //@ normalize-stderr: "0x0+" -> "0x0"
 //@ normalize-stderr: "0x[0-9](\.\.|\])" -> "0x%$1"
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(never_type)]
 #![allow(invalid_value, unnecessary_transmutes)]
 

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -12,7 +12,7 @@
 
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -2,7 +2,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here
 #![feature(rustc_attrs, ptr_metadata)]
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -6,7 +6,7 @@
 //@ normalize-stderr: "0x[0-9](\.\.|\])" -> "0x%$1"
 #![feature(pattern_types, pattern_type_macro)]
 #![allow(invalid_value)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::{mem, pat::pattern_type};
 
 #[repr(C)]

--- a/tests/ui/consts/const-eval/ub-upvars.rs
+++ b/tests/ui/consts/const-eval/ub-upvars.rs
@@ -1,7 +1,7 @@
 //@ edition:2015..2021
 //@ stderr-per-bitwidth
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here
-//@ ignore-parallel-frontend different alloc ids
+
 use std::mem;
 
 const BAD_UPVAR: &dyn FnOnce() = &{ //~ ERROR null reference

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -3,7 +3,7 @@
 #![feature(ptr_metadata)]
 
 use std::{ptr, mem};
-//@ ignore-parallel-frontend different alloc ids
+
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"

--- a/tests/ui/consts/const-eval/union-const-eval-field.rs
+++ b/tests/ui/consts/const-eval/union-const-eval-field.rs
@@ -1,7 +1,7 @@
 //@ dont-require-annotations: NOTE
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([[:xdigit:]]{2}\s){4}(__\s){4}\s+│\s+([?|\.]){4}\W{4}" -> "HEX_DUMP"
-//@ ignore-parallel-frontend different alloc ids
+
 type Field1 = i32;
 type Field2 = f32;
 type Field3 = i64;

--- a/tests/ui/consts/const-eval/union-ice.rs
+++ b/tests/ui/consts/const-eval/union-ice.rs
@@ -1,5 +1,5 @@
 //@ only-x86_64
-//@ ignore-parallel-frontend different alloc ids
+
 type Field1 = i32;
 type Field3 = i64;
 

--- a/tests/ui/consts/const-eval/union-ub.rs
+++ b/tests/ui/consts/const-eval/union-ub.rs
@@ -1,6 +1,6 @@
 //@ stderr-per-bitwidth
 //@ dont-require-annotations: NOTE
-//@ ignore-parallel-frontend different alloc ids
+
 #[repr(C)]
 union DummyUnion {
     unit: (),

--- a/tests/ui/consts/copy-intrinsic.rs
+++ b/tests/ui/consts/copy-intrinsic.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 #![feature(core_intrinsics)]
-//@ ignore-parallel-frontend different alloc ids
+
 use std::intrinsics::{copy, copy_nonoverlapping};
 use std::mem;
 

--- a/tests/ui/consts/interior-mut-const-via-union.rs
+++ b/tests/ui/consts/interior-mut-const-via-union.rs
@@ -3,7 +3,7 @@
 //
 //@ build-fail
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 use std::cell::Cell;
 use std::mem::ManuallyDrop;
 

--- a/tests/ui/consts/issue-63952.rs
+++ b/tests/ui/consts/issue-63952.rs
@@ -1,6 +1,6 @@
 // Regression test for #63952, shouldn't hang.
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct SliceRepr {

--- a/tests/ui/consts/issue-79690.rs
+++ b/tests/ui/consts/issue-79690.rs
@@ -1,7 +1,7 @@
 //@ ignore-32bit
 // This test gives a different error on 32-bit architectures.
 //@ stderr-per-bitwidth
-//@ ignore-parallel-frontend different alloc ids
+
 union Transmute<T: Copy, U: Copy> {
     t: T,
     u: U,

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
@@ -1,6 +1,6 @@
 //@ stderr-per-bitwidth
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
-//@ ignore-parallel-frontend different alloc ids
+
 // All "inner" allocations that come with a `static` are interned immutably. This means it is
 // crucial that we do not accept any form of (interior) mutability there.
 use std::sync::atomic::*;

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,7 +1,7 @@
 //! Check what happens when the error occurs inside a std function that we can't print the span of.
 //@ ignore-backends: gcc
 //@ compile-flags: -Z ui-testing=no --diagnostic-width=80
-//@ ignore-parallel-frontend different alloc ids
+
 use std::{
     mem::{self, MaybeUninit},
     ptr,

--- a/tests/ui/consts/offset_ub.rs
+++ b/tests/ui/consts/offset_ub.rs
@@ -1,5 +1,5 @@
 use std::ptr;
-//@ ignore-parallel-frontend different alloc ids
+
 //@ normalize-stderr: "0xf+" -> "0xf..f"
 //@ normalize-stderr: "0x7f+" -> "0x7f..f"
 //@ normalize-stderr: "\d+ bytes" -> "$$BYTES bytes"

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
@@ -1,6 +1,6 @@
 //@ normalize-stderr: "[[:xdigit:]]{2} __ ([[:xdigit:]]{2}\s){2}" -> "HEX_DUMP"
 #![feature(core_intrinsics)]
-//@ ignore-parallel-frontend different alloc ids
+
 const RAW_EQ_PADDING: bool = unsafe {
     std::intrinsics::raw_eq(&(1_u8, 2_u16), &(1_u8, 2_u16))
 //~^ ERROR requires initialized memory

--- a/tests/ui/type/pattern_types/validity.rs
+++ b/tests/ui/type/pattern_types/validity.rs
@@ -1,7 +1,7 @@
 //! Check that pattern types have their validity checked
 // Strip out raw byte dumps to make tests platform-independent:
 //@ normalize-stderr: "([[:xdigit:]]{2}\s){4,8}\s+│\s.{4,8}" -> "HEX_DUMP"
-//@ ignore-parallel-frontend different alloc ids
+
 #![feature(pattern_types, const_trait_impl, pattern_type_range_trait)]
 #![feature(pattern_type_macro)]
 


### PR DESCRIPTION
Part of rust-lang/rust#154314. Addresses the "different alloc ids" row (rust-lang/rust#154278).

A group of const-eval ui tests were marked `//@ ignore-parallel-frontend different alloc ids`. AllocIds are handed out from a global counter, so under `-Zthreads` the numbers in the output differ run to run. compiletest already normalizes this: it remaps `allocN` to `ALLOC{index}` by order of first appearance (`runtest.rs`), so a pure renumbering does not affect the comparison.

For most of these tests the renumbering is the only difference. Each one emits a single const-eval error, or emits its errors in a deterministic order because const items are evaluated during the analysis phase rather than during parallel mono collection, so the order of first appearance is stable and the normalized output matches the single-threaded blessing. The first commit removes the directive from those tests and blesses the line numbers that shift from removing the directive line. No test output content changes, only span line numbers.

The remaining tests emit several const-eval errors whose emission order is itself nondeterministic under the parallel front-end. That reshuffles which allocation appears first, so the order-of-first-appearance normalization assigns different `ALLOC` indices and the normalized line text differs run to run.

To fix that at the source, the second commit makes compiletest sort the rendered diagnostics by their primary source location before it renumbers allocation ids. The first-appearance order then no longer depends on the racy emission order, so the `ALLOC` numbering is stable. Ties at the same location are broken by the diagnostic text with the raw allocation numbers blinded, since those numbers are racy too. The sort only runs under the parallel front-end, where stderr is already compared line by line, so single-threaded output is unchanged. With that in place the third commit re-enables the remaining ten tests.

Validation: every re-enabled test passes single threaded and under `--parallel-frontend-threads=16 --iteration-count=100 --force-rerun` (the multi-allocation ones at 200). Removing the directive shifts span line numbers by one and nothing else; the `.32bit.stderr` files, which cannot be blessed on a 64-bit host, were updated with the same shift and verified against the `.64bit.stderr` delta. A baseline run with the sort disabled confirms all ten fail without it and that no other test changes behavior under the parallel front-end.
