### PR TITLE
Enable `clippy::mem_replace_with_default`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1964,7 +1964,7 @@ impl Emitter for SharedEmitter {
         assert_eq!(diag.is_lint, None);
         // No sensible check for `diag.emitted_at`.
 
-        let args = mem::replace(&mut diag.args, DiagArgMap::default());
+        let args = mem::take(&mut diag.args);
         drop(
             self.sender.send(SharedEmitterMessage::Diagnostic(Diagnostic {
                 span: diag.span.primary_spans().iter().map(|span| span.data()).collect::<Vec<_>>(),

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -738,7 +738,7 @@ impl EncoderState {
             // Prevent more indices from being allocated on this thread.
             local.remaining_node_index = 0;
 
-            let data = mem::replace(&mut local.encoder.data, Vec::new());
+            let data = mem::take(&mut local.encoder.data);
             self.file.lock().as_mut().unwrap().emit_raw_bytes(&data);
 
             LocalEncoderResult {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2573,7 +2573,7 @@ fn normalize_newlines(src: &mut String, normalized_pos: &mut Vec<NormalizedPos>)
     // directly, let's rather steal the contents of `src`. This makes the code
     // safe even if a panic occurs.
 
-    let mut buf = std::mem::replace(src, String::new()).into_bytes();
+    let mut buf = std::mem::take(src).into_bytes();
     let mut gap_len = 0;
     let mut tail = buf.as_mut_slice();
     let mut cursor = 0;

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -607,6 +607,7 @@ impl Step for CI {
                 "clippy::single_char_add_str".into(),
                 "clippy::to_string_in_format_args".into(),
                 "clippy::unconditional_recursion".into(),
+                "clippy::mem_replace_with_default".into(),
             ],
             forbid: vec![],
         };


### PR DESCRIPTION
Enables `clippy::mem_replace_with_default` and fixes the errors that occur as a result.

Closes rust-lang/rust#157245.