### PR TITLE
Make `Literal::byte_character_value` work with bytes as well

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1648,7 +1648,7 @@ impl Literal {
     #[unstable(feature = "proc_macro_value", issue = "136652")]
     pub fn byte_character_value(&self) -> Result<u8, ConversionErrorKind> {
         self.0.symbol.with(|symbol| match self.0.kind {
-            bridge::LitKind::Char => unescape_byte(symbol)
+            bridge::LitKind::Byte => unescape_byte(symbol)
                 .map_err(|err| ConversionErrorKind::FailedToUnescape(err.into())),
             _ => Err(ConversionErrorKind::InvalidLiteralKind),
         })

--- a/tests/ui/proc-macro/auxiliary/api/literal.rs
+++ b/tests/ui/proc-macro/auxiliary/api/literal.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 
-use proc_macro::Literal;
+use proc_macro::{EscapeError, Literal, ConversionErrorKind};
 
 pub fn test() {
     test_display_literal();
@@ -111,4 +111,17 @@ fn test_literal_value() {
     {
         assert_eq!(Literal::f32_unsuffixed(15.).f16_value().map(|f| f.to_string()), Ok("15".to_string()));
     }
+
+    assert_eq!(
+        Literal::character('A').byte_character_value(),
+        Err(ConversionErrorKind::InvalidLiteralKind),
+    );
+    assert_eq!(
+        Literal::character('é').byte_character_value(),
+        Err(ConversionErrorKind::InvalidLiteralKind),
+    );
+    assert_eq!(
+        Literal::byte_character(b'B').byte_character_value(),
+        Ok(b'B')
+    );
 }

--- a/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
+++ b/tests/ui/proc-macro/auxiliary/api/proc_macro_api_tests.rs
@@ -4,6 +4,7 @@
 #![feature(proc_macro_value)]
 #![feature(f16)]
 #![feature(cfg_target_has_reliable_f16_f128)]
+#![feature(rustc_private)]
 #![deny(dead_code)] // catch if a test function is never called
 
 extern crate proc_macro;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157338)*
<!-- homu-ignore:end -->

As noted in [this comment](https://github.com/rust-lang/rust/pull/151973#discussion_r3330177214), `byte_character_value` should work for bytes, so this PR fixes it.

r? @traviscross 