### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1964,7 +1964,7 @@ impl Emitter for SharedEmitter {
         assert_eq!(diag.is_lint, None);
         // No sensible check for `diag.emitted_at`.
 
-        let args = mem::replace(&mut diag.args, DiagArgMap::default());
+        let args = mem::take(&mut diag.args);
         drop(
             self.sender.send(SharedEmitterMessage::Diagnostic(Diagnostic {
                 span: diag.span.primary_spans().iter().map(|span| span.data()).collect::<Vec<_>>(),

--- a/compiler/rustc_middle/src/dep_graph/serialized.rs
+++ b/compiler/rustc_middle/src/dep_graph/serialized.rs
@@ -738,7 +738,7 @@ impl EncoderState {
             // Prevent more indices from being allocated on this thread.
             local.remaining_node_index = 0;
 
-            let data = mem::replace(&mut local.encoder.data, Vec::new());
+            let data = mem::take(&mut local.encoder.data);
             self.file.lock().as_mut().unwrap().emit_raw_bytes(&data);
 
             LocalEncoderResult {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2573,7 +2573,7 @@ fn normalize_newlines(src: &mut String, normalized_pos: &mut Vec<NormalizedPos>)
     // directly, let's rather steal the contents of `src`. This makes the code
     // safe even if a panic occurs.
 
-    let mut buf = std::mem::replace(src, String::new()).into_bytes();
+    let mut buf = std::mem::take(src).into_bytes();
     let mut gap_len = 0;
     let mut tail = buf.as_mut_slice();
     let mut cursor = 0;

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -20,7 +20,7 @@ pub fn intervals2dur(intervals: u64) -> Duration {
 
 pub mod perf_counter {
     use super::NANOS_PER_SEC;
-    use crate::sync::atomic::{Atomic, AtomicU64, Ordering};
+    use crate::sync::atomic::{AtomicI64, Ordering};
     use crate::sys::{c, cvt};
     use crate::time::Duration;
 
@@ -32,23 +32,32 @@ pub mod perf_counter {
 
     pub fn frequency() -> i64 {
         // Either the cached result of `QueryPerformanceFrequency` or `0` for
-        // uninitialized. Storing this as a single `AtomicU64` allows us to use
+        // uninitialized. Storing this as a single `AtomicI64` allows us to use
         // `Relaxed` operations, as we are only interested in the effects on a
         // single memory location.
-        static FREQUENCY: Atomic<u64> = AtomicU64::new(0);
+        static FREQUENCY: AtomicI64 = AtomicI64::new(0);
 
         let cached = FREQUENCY.load(Ordering::Relaxed);
         // If a previous thread has filled in this global state, use that.
         if cached != 0 {
-            return cached as i64;
+            return cached;
         }
         // ... otherwise learn for ourselves ...
+        frequency_init(&FREQUENCY)
+    }
+
+    #[cold]
+    fn frequency_init(cache: &AtomicI64) -> i64 {
         let mut frequency = 0;
         unsafe {
             cvt(c::QueryPerformanceFrequency(&mut frequency)).unwrap();
         }
 
-        FREQUENCY.store(frequency as u64, Ordering::Relaxed);
+        // SAFETY: According to the MSDN entry for `QueryPerformanceFrequency`,
+        // a value of 0 will never be returned starting from Windows XP.
+        unsafe { crate::hint::assert_unchecked(frequency != 0) }
+
+        cache.store(frequency, Ordering::Relaxed);
         frequency
     }
 

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -607,6 +607,7 @@ impl Step for CI {
                 "clippy::single_char_add_str".into(),
                 "clippy::to_string_in_format_args".into(),
                 "clippy::unconditional_recursion".into(),
+                "clippy::mem_replace_with_default".into(),
             ],
             forbid: vec![],
         };


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157328 (windows: Elide division-by-zero checks in Instant::now())
 - rust-lang/rust#157336 (Enable `clippy::mem_replace_with_default`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157328,157336)
<!-- homu-ignore:end -->

