### PR TITLE
Reduce verbosity of cycle errors when possible

### DIFF
--- a/compiler/rustc_query_impl/src/error.rs
+++ b/compiler/rustc_query_impl/src/error.rs
@@ -75,7 +75,8 @@ pub(crate) struct Cycle {
     #[subdiagnostic]
     pub cycle_usage: Option<CycleUsage>,
     #[note(
-        "see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information"
+        "for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> \
+         and <https://rustc-dev-guide.rust-lang.org/query.html>"
     )]
     pub note_span: (),
 }

--- a/compiler/rustc_query_impl/src/job.rs
+++ b/compiler/rustc_query_impl/src/job.rs
@@ -429,16 +429,23 @@ pub(crate) fn create_cycle_error<'tcx>(
         StackCount::Multiple { stack_bottom: stack_bottom.clone() }
     };
 
+    let mut prev = span;
     for i in 1..frames.len() {
         let frame = &frames[i];
         let span = frame.tagged_key.catch_default_span(tcx, frames[(i + 1) % frames.len()].span);
-        cycle_stack
-            .push(crate::error::CycleStack { span, desc: frame.tagged_key.catch_description(tcx) });
+        cycle_stack.push(crate::error::CycleStack {
+            span: if span == prev { DUMMY_SP } else { span },
+            desc: frame.tagged_key.catch_description(tcx),
+        });
+        prev = span;
     }
 
-    let cycle_usage = usage.as_ref().map(|usage| crate::error::CycleUsage {
-        span: usage.tagged_key.catch_default_span(tcx, usage.span),
-        usage: usage.tagged_key.catch_description(tcx),
+    let cycle_usage = usage.as_ref().map(|usage| {
+        let cycle_span = usage.tagged_key.catch_default_span(tcx, usage.span);
+        crate::error::CycleUsage {
+            span: if cycle_span != span { cycle_span } else { DUMMY_SP },
+            usage: usage.tagged_key.catch_description(tcx),
+        }
     });
 
     let is_all_def_kind = |def_kind| {

--- a/src/tools/miri/tests/fail/layout_cycle.stderr
+++ b/src/tools/miri/tests/fail/layout_cycle.stderr
@@ -15,7 +15,7 @@ note: cycle used when const-evaluating + checking `core::mem::SizedTypePropertie
    |
 LL |     const SIZE: usize = intrinsics::size_of::<Self>();
    |     ^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/private-type-cycle-dyn-110629.stderr
+++ b/tests/rustdoc-ui/private-type-cycle-dyn-110629.stderr
@@ -13,7 +13,7 @@ note: cycle used when checking that `Bar` is well-formed
    |
 LL | type Bar<'a, 'b> = Box<dyn PartialEq<Bar<'a, 'b>>>;
    | ^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/tests/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -25,7 +25,7 @@ note: cycle used when optimizing promoted MIR for `main`
    |
 LL |     assert_eq!(<() as Tr>::A, 0);
    |                ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -4,28 +4,16 @@ error[E0391]: cycle detected when checking if `IMPL_REF_BAR` is a trivial const
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires building MIR for `IMPL_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
-   |
-LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires building MIR for `IMPL_REF_BAR`...
 note: ...which requires checking if `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR` is a trivial const...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
    |
 LL |     const BAR: u32 = IMPL_REF_BAR;
    |     ^^^^^^^^^^^^^^
-note: ...which requires building MIR for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
-   |
-LL |     const BAR: u32 = IMPL_REF_BAR;
-   |     ^^^^^^^^^^^^^^
+   = note: ...which requires building MIR for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 11:19>::BAR`...
    = note: ...which again requires checking if `IMPL_REF_BAR` is a trivial const, completing the cycle
-note: cycle used when simplifying constant for the type system `IMPL_REF_BAR`
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
-   |
-LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when simplifying constant for the type system `IMPL_REF_BAR`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -24,18 +24,10 @@ note: ...which requires simplifying constant for the type system `FooDefault::BA
    |
 LL |     const BAR: u32 = DEFAULT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `FooDefault::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
-   |
-LL |     const BAR: u32 = DEFAULT_REF_BAR;
-   |     ^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `FooDefault::BAR`...
    = note: ...which again requires caching mir of `FooDefault::BAR` for CTFE, completing the cycle
-note: cycle used when const-evaluating + checking `FooDefault::BAR`
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
-   |
-LL |     const BAR: u32 = DEFAULT_REF_BAR;
-   |     ^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when const-evaluating + checking `FooDefault::BAR`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/tests/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -14,28 +14,16 @@ note: ...which requires simplifying constant for the type system `<impl at $DIR/
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |     ^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
-   |
-LL |     const BAR: u32 = TRAIT_REF_BAR;
-   |     ^^^^^^^^^^^^^^
-note: ...which requires caching mir of `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR` for CTFE...
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
-   |
-LL |     const BAR: u32 = TRAIT_REF_BAR;
-   |     ^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
+   = note: ...which requires caching mir of `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR` for CTFE...
 note: ...which requires elaborating drops for `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 11:28>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:22
    |
 LL |     const BAR: u32 = TRAIT_REF_BAR;
    |                      ^^^^^^^^^^^^^
    = note: ...which again requires simplifying constant for the type system `TRAIT_REF_BAR`, completing the cycle
-note: cycle used when simplifying constant for the type system `TRAIT_REF_BAR`
-  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
-   |
-LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when simplifying constant for the type system `TRAIT_REF_BAR`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-type-bounds/ambiguous-associated-type2.stderr
+++ b/tests/ui/associated-type-bounds/ambiguous-associated-type2.stderr
@@ -5,12 +5,8 @@ LL | trait Baz: Foo + Bar<Self::Item> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super traits of `Baz` with associated type name `Item` again
-note: cycle used when computing the super predicates of `Baz`
-  --> $DIR/ambiguous-associated-type2.rs:7:1
-   |
-LL | trait Baz: Foo + Bar<Self::Item> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when computing the super predicates of `Baz`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-type-bounds/implied-bounds-cycle.stderr
+++ b/tests/ui/associated-type-bounds/implied-bounds-cycle.stderr
@@ -10,7 +10,7 @@ note: cycle used when computing normalized predicates of `B`
    |
 LL | trait B: A<T: B> {}
    | ^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-type-bounds/return-type-notation/impl-trait-in-trait.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/impl-trait-in-trait.stderr
@@ -4,23 +4,15 @@ error[E0391]: cycle detected when resolving lifetimes for `IntFactory::stream`
 LL |     fn stream(self) -> impl IntFactory<stream(..): Send>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires computing function signature of `IntFactory::stream`...
-  --> $DIR/impl-trait-in-trait.rs:4:5
-   |
-LL |     fn stream(self) -> impl IntFactory<stream(..): Send>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires looking up late bound vars inside `IntFactory::stream`...
-  --> $DIR/impl-trait-in-trait.rs:4:5
-   |
-LL |     fn stream(self) -> impl IntFactory<stream(..): Send>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing function signature of `IntFactory::stream`...
+   = note: ...which requires looking up late bound vars inside `IntFactory::stream`...
    = note: ...which again requires resolving lifetimes for `IntFactory::stream`, completing the cycle
 note: cycle used when listing captured lifetimes for opaque `IntFactory::stream::{opaque#0}`
   --> $DIR/impl-trait-in-trait.rs:4:24
    |
 LL |     fn stream(self) -> impl IntFactory<stream(..): Send>;
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/impl-wf-cycle-4.stderr
+++ b/tests/ui/associated-types/impl-wf-cycle-4.stderr
@@ -6,22 +6,10 @@ LL | | where
 LL | |     T: Fn(Self::ToMatch),
    | |_________________________^
    |
-note: ...which requires computing normalized predicates of `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>`...
-  --> $DIR/impl-wf-cycle-4.rs:5:1
-   |
-LL | / impl<T> Filter for T
-LL | | where
-LL | |     T: Fn(Self::ToMatch),
-   | |_________________________^
+   = note: ...which requires computing normalized predicates of `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>`...
    = note: ...which again requires computing whether `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` has a guaranteed unsized self type, completing the cycle
-note: cycle used when checking that `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` is well-formed
-  --> $DIR/impl-wf-cycle-4.rs:5:1
-   |
-LL | / impl<T> Filter for T
-LL | | where
-LL | |     T: Fn(Self::ToMatch),
-   | |_________________________^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking that `<impl at $DIR/impl-wf-cycle-4.rs:5:1: 7:26>` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-20825.stderr
+++ b/tests/ui/associated-types/issue-20825.stderr
@@ -5,12 +5,8 @@ LL | pub trait Processor: Subscriber<Input = Self::Input> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super traits of `Processor` with associated type name `Input` again
-note: cycle used when computing the super predicates of `Processor`
-  --> $DIR/issue-20825.rs:5:1
-   |
-LL | pub trait Processor: Subscriber<Input = Self::Input> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when computing the super predicates of `Processor`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coherence/coherence-inherited-assoc-ty-cycle-err.stderr
+++ b/tests/ui/coherence/coherence-inherited-assoc-ty-cycle-err.stderr
@@ -5,12 +5,8 @@ LL | trait Trait<T> { type Assoc; }
    | ^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires building specialization graph of trait `Trait` again
-note: cycle used when coherence checking all impls of trait `Trait`
-  --> $DIR/coherence-inherited-assoc-ty-cycle-err.rs:8:1
-   |
-LL | trait Trait<T> { type Assoc; }
-   | ^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when coherence checking all impls of trait `Trait`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/closures.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/closures.stderr
@@ -4,23 +4,15 @@ error[E0391]: cycle detected when building an abstract representation for `test:
 LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
    |                                   ^^^^^^^^^^^^^
    |
-note: ...which requires building THIR for `test::{constant#0}`...
-  --> $DIR/closures.rs:3:35
-   |
-LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires type-checking `test::{constant#0}`...
-  --> $DIR/closures.rs:3:35
-   |
-LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
-   |                                   ^^^^^^^^^^^^^
+   = note: ...which requires building THIR for `test::{constant#0}`...
+   = note: ...which requires type-checking `test::{constant#0}`...
    = note: ...which again requires building an abstract representation for `test::{constant#0}`, completing the cycle
 note: cycle used when checking that `test` is well-formed
   --> $DIR/closures.rs:3:1
    |
 LL | fn test<const N: usize>() -> [u8; N + (|| 42)()] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
+++ b/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
@@ -16,7 +16,7 @@ note: cycle used when checking that `Trait` is well-formed
    |
 LL | trait Trait<const N: dyn Trait = bar> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-size_of-cycle.stderr
+++ b/tests/ui/consts/const-size_of-cycle.stderr
@@ -4,17 +4,12 @@ error[E0391]: cycle detected when evaluating type-level constant
 LL |     bytes: [u8; std::mem::size_of::<Foo>()]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/const-size_of-cycle.rs:2:17
-   |
-LL |     bytes: [u8; std::mem::size_of::<Foo>()]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
 note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 note: ...which requires simplifying constant for the type system `core::mem::SizedTypeProperties::SIZE`...
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: ...which requires const-evaluating + checking `core::mem::SizedTypeProperties::SIZE`...
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   = note: ...which requires const-evaluating + checking `core::mem::SizedTypeProperties::SIZE`...
 note: ...which requires computing layout of `Foo`...
   --> $DIR/const-size_of-cycle.rs:1:1
    |
@@ -27,12 +22,8 @@ note: ...which requires normalizing `[u8; std::mem::size_of::<Foo>()]`...
 LL |     bytes: [u8; std::mem::size_of::<Foo>()]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/const-size_of-cycle.rs:2:17
-   |
-LL |     bytes: [u8; std::mem::size_of::<Foo>()]
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking that `Foo` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -34,7 +34,7 @@ note: cycle used when checking that `S` is well-formed
    |
 LL | struct S<const S: (), const S: S = { S }>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/issue-36163.stderr
+++ b/tests/ui/consts/issue-36163.stderr
@@ -4,11 +4,7 @@ error[E0391]: cycle detected when simplifying constant for the type system `Foo:
 LL |     B = A,
    |         ^
    |
-note: ...which requires const-evaluating + checking `Foo::B::{constant#0}`...
-  --> $DIR/issue-36163.rs:4:9
-   |
-LL |     B = A,
-   |         ^
+   = note: ...which requires const-evaluating + checking `Foo::B::{constant#0}`...
 note: ...which requires simplifying constant for the type system `A`...
   --> $DIR/issue-36163.rs:1:1
    |
@@ -25,7 +21,7 @@ note: cycle used when checking that `Foo` is well-formed
    |
 LL | enum Foo {
    | ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-44415.stderr
+++ b/tests/ui/consts/issue-44415.stderr
@@ -4,16 +4,8 @@ error[E0391]: cycle detected when evaluating type-level constant
 LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
+   = note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
 note: ...which requires computing layout of `Foo`...
   --> $DIR/issue-44415.rs:5:1
    |
@@ -26,12 +18,8 @@ note: ...which requires normalizing `[u8; unsafe { intrinsics::size_of::<Foo>() 
 LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/issue-44415.rs:6:17
-   |
-LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking that `Foo` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/recursive-const-stack-overflow.stderr
+++ b/tests/ui/consts/recursive-const-stack-overflow.stderr
@@ -4,18 +4,10 @@ error[E0391]: cycle detected when checking if `FOO` is a trivial const
 LL | const FOO: usize = FOO;
    | ^^^^^^^^^^^^^^^^
    |
-note: ...which requires building MIR for `FOO`...
-  --> $DIR/recursive-const-stack-overflow.rs:3:1
-   |
-LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^
+   = note: ...which requires building MIR for `FOO`...
    = note: ...which again requires checking if `FOO` is a trivial const, completing the cycle
-note: cycle used when simplifying constant for the type system `FOO`
-  --> $DIR/recursive-const-stack-overflow.rs:3:1
-   |
-LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when simplifying constant for the type system `FOO`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0391]: cycle detected when checking if `main::BAR` is a trivial const
   --> $DIR/recursive-const-stack-overflow.rs:8:9
@@ -23,18 +15,10 @@ error[E0391]: cycle detected when checking if `main::BAR` is a trivial const
 LL |         const BAR: usize = BAR;
    |         ^^^^^^^^^^^^^^^^
    |
-note: ...which requires building MIR for `main::BAR`...
-  --> $DIR/recursive-const-stack-overflow.rs:8:9
-   |
-LL |         const BAR: usize = BAR;
-   |         ^^^^^^^^^^^^^^^^
+   = note: ...which requires building MIR for `main::BAR`...
    = note: ...which again requires checking if `main::BAR` is a trivial const, completing the cycle
-note: cycle used when simplifying constant for the type system `main::BAR`
-  --> $DIR/recursive-const-stack-overflow.rs:8:9
-   |
-LL |         const BAR: usize = BAR;
-   |         ^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when simplifying constant for the type system `main::BAR`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/recursive-zst-static.default.stderr
+++ b/tests/ui/consts/recursive-zst-static.default.stderr
@@ -17,7 +17,7 @@ LL | static B: () = A;
    | ^^^^^^^^^^^^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
    = note: cycle used when running analysis passes on crate `recursive_zst_static`
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/recursive-zst-static.unleash.stderr
+++ b/tests/ui/consts/recursive-zst-static.unleash.stderr
@@ -17,7 +17,7 @@ LL | static B: () = A;
    | ^^^^^^^^^^^^
    = note: ...which again requires evaluating initializer of static `A`, completing the cycle
    = note: cycle used when running analysis passes on crate `recursive_zst_static`
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/cycle-trait/cycle-trait-default-type-trait.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-default-type-trait.stderr
@@ -10,7 +10,7 @@ note: cycle used when checking that `Foo` is well-formed
    |
 LL | trait Foo<X = Box<dyn Foo>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-supertrait-direct.stderr
@@ -10,7 +10,7 @@ note: cycle used when checking that `Chromosome` is well-formed
    |
 LL | trait Chromosome: Chromosome {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cycle-trait/cycle-trait-supertrait-indirect.stderr
+++ b/tests/ui/cycle-trait/cycle-trait-supertrait-indirect.stderr
@@ -15,7 +15,7 @@ note: cycle used when computing the super predicates of `A`
    |
 LL | trait A: B {
    |          ^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cycle-trait/issue-12511.stderr
+++ b/tests/ui/cycle-trait/issue-12511.stderr
@@ -15,7 +15,7 @@ note: cycle used when checking that `T1` is well-formed
    |
 LL | trait T1 : T2 {
    | ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/delegation/unsupported.current.stderr
+++ b/tests/ui/delegation/unsupported.current.stderr
@@ -4,18 +4,10 @@ error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsup
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
-note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:30:25
-   |
-LL |         reuse to_reuse::opaque_ret;
-   |                         ^^^^^^^^^^
+   = note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:30:25
-   |
-LL |         reuse to_reuse::opaque_ret;
-   |                         ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
   --> $DIR/unsupported.rs:33:24
@@ -23,18 +15,10 @@ error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsup
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
-note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:33:24
-   |
-LL |         reuse ToReuse::opaque_ret;
-   |                        ^^^^^^^^^^
+   = note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:33:24
-   |
-LL |         reuse ToReuse::opaque_ret;
-   |                        ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: delegation self type is not specified
   --> $DIR/unsupported.rs:54:18

--- a/tests/ui/delegation/unsupported.next.stderr
+++ b/tests/ui/delegation/unsupported.next.stderr
@@ -4,18 +4,10 @@ error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsup
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
-note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:30:25
-   |
-LL |         reuse to_reuse::opaque_ret;
-   |                         ^^^^^^^^^^
+   = note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:30:25
-   |
-LL |         reuse to_reuse::opaque_ret;
-   |                         ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:29:5: 29:24>::opaque_ret` is compatible with trait definition
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`
   --> $DIR/unsupported.rs:33:24
@@ -23,18 +15,10 @@ error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsup
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
-note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:33:24
-   |
-LL |         reuse ToReuse::opaque_ret;
-   |                        ^^^^^^^^^^
+   = note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
    = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret::{anon_assoc#0}`, completing the cycle
-note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
-  --> $DIR/unsupported.rs:33:24
-   |
-LL |         reuse ToReuse::opaque_ret;
-   |                        ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking assoc item `opaque::<impl at $DIR/unsupported.rs:32:5: 32:25>::opaque_ret` is compatible with trait definition
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: delegation self type is not specified
   --> $DIR/unsupported.rs:54:18

--- a/tests/ui/generic-associated-types/unknown-lifetime-ice-119827.stderr
+++ b/tests/ui/generic-associated-types/unknown-lifetime-ice-119827.stderr
@@ -10,12 +10,8 @@ note: ...which requires computing type of `<impl at $DIR/unknown-lifetime-ice-11
 LL | impl Foo for Box<dyn Foo> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires finding trait impls of `Foo`, completing the cycle
-note: cycle used when checking that `Foo` is well-formed
-  --> $DIR/unknown-lifetime-ice-119827.rs:1:1
-   |
-LL | trait Foo {
-   | ^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking that `Foo` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/auto-trait-leakage/auto-trait-leak.stderr
+++ b/tests/ui/impl-trait/auto-trait-leakage/auto-trait-leak.stderr
@@ -9,26 +9,10 @@ note: ...which requires borrow-checking `cycle1`...
    |
 LL | fn cycle1() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires promoting constants in MIR for `cycle1`...
-  --> $DIR/auto-trait-leak.rs:11:1
-   |
-LL | fn cycle1() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `cycle1` contains FFI-unwind calls...
-  --> $DIR/auto-trait-leak.rs:11:1
-   |
-LL | fn cycle1() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires building MIR for `cycle1`...
-  --> $DIR/auto-trait-leak.rs:11:1
-   |
-LL | fn cycle1() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires match-checking `cycle1`...
-  --> $DIR/auto-trait-leak.rs:11:1
-   |
-LL | fn cycle1() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires promoting constants in MIR for `cycle1`...
+   = note: ...which requires checking if `cycle1` contains FFI-unwind calls...
+   = note: ...which requires building MIR for `cycle1`...
+   = note: ...which requires match-checking `cycle1`...
 note: ...which requires type-checking `cycle1`...
   --> $DIR/auto-trait-leak.rs:12:5
    |
@@ -45,26 +29,10 @@ note: ...which requires borrow-checking `cycle2`...
    |
 LL | fn cycle2() -> impl Clone {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires promoting constants in MIR for `cycle2`...
-  --> $DIR/auto-trait-leak.rs:17:1
-   |
-LL | fn cycle2() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `cycle2` contains FFI-unwind calls...
-  --> $DIR/auto-trait-leak.rs:17:1
-   |
-LL | fn cycle2() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires building MIR for `cycle2`...
-  --> $DIR/auto-trait-leak.rs:17:1
-   |
-LL | fn cycle2() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires match-checking `cycle2`...
-  --> $DIR/auto-trait-leak.rs:17:1
-   |
-LL | fn cycle2() -> impl Clone {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires promoting constants in MIR for `cycle2`...
+   = note: ...which requires checking if `cycle2` contains FFI-unwind calls...
+   = note: ...which requires building MIR for `cycle2`...
+   = note: ...which requires match-checking `cycle2`...
 note: ...which requires type-checking `cycle2`...
   --> $DIR/auto-trait-leak.rs:18:5
    |
@@ -72,12 +40,8 @@ LL |     send(cycle1().clone());
    |     ^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires evaluating trait selection obligation `cycle1::{opaque#0}: core::marker::Send`...
    = note: ...which again requires computing type of opaque `cycle1::{opaque#0}`, completing the cycle
-note: cycle used when computing type of `cycle1::{opaque#0}`
-  --> $DIR/auto-trait-leak.rs:11:16
-   |
-LL | fn cycle1() -> impl Clone {
-   |                ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when computing type of `cycle1::{opaque#0}`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
@@ -4,11 +4,7 @@ error[E0391]: cycle detected when computing type of `<impl at $DIR/method-compat
 LL |     fn foo(b: bool) -> impl Sized {
    |                        ^^^^^^^^^^
    |
-note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:24
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |                        ^^^^^^^^^^
+   = note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
    = note: ...which requires evaluating trait selection obligation `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{opaque#0}: core::marker::Send`...
 note: ...which requires computing type of opaque `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{opaque#0}`...
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:24
@@ -20,38 +16,18 @@ note: ...which requires borrow-checking `<impl at $DIR/method-compatability-via-
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires promoting constants in MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires match-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires type-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires promoting constants in MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+   = note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
+   = note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+   = note: ...which requires match-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+   = note: ...which requires type-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
 note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
@@ -14,48 +14,24 @@ note: ...which requires computing type of `<impl at $DIR/method-compatability-vi
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |                        ^^^^^^^^^^
-note: ...which requires computing type of opaque `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{opaque#0}`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:24
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |                        ^^^^^^^^^^
+   = note: ...which requires computing type of opaque `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{opaque#0}`...
 note: ...which requires borrow-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires promoting constants in MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires match-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires type-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires promoting constants in MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+   = note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
+   = note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+   = note: ...which requires match-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
+   = note: ...which requires type-checking `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
    = note: ...which again requires computing type of `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo::{anon_assoc#0}`, completing the cycle
 note: cycle used when checking assoc item `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` is compatible with trait definition
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/return-type-notation.stderr
+++ b/tests/ui/impl-trait/in-trait/return-type-notation.stderr
@@ -4,23 +4,15 @@ error[E0391]: cycle detected when resolving lifetimes for `IntFactory::stream`
 LL |     fn stream(&self) -> impl IntFactory<stream(..): IntFactory<stream(..): Send> + Send>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires computing function signature of `IntFactory::stream`...
-  --> $DIR/return-type-notation.rs:5:5
-   |
-LL |     fn stream(&self) -> impl IntFactory<stream(..): IntFactory<stream(..): Send> + Send>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires looking up late bound vars inside `IntFactory::stream`...
-  --> $DIR/return-type-notation.rs:5:5
-   |
-LL |     fn stream(&self) -> impl IntFactory<stream(..): IntFactory<stream(..): Send> + Send>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing function signature of `IntFactory::stream`...
+   = note: ...which requires looking up late bound vars inside `IntFactory::stream`...
    = note: ...which again requires resolving lifetimes for `IntFactory::stream`, completing the cycle
 note: cycle used when listing captured lifetimes for opaque `IntFactory::stream::{opaque#0}`
   --> $DIR/return-type-notation.rs:5:25
    |
 LL |     fn stream(&self) -> impl IntFactory<stream(..): IntFactory<stream(..): Send> + Send>;
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/infinite/infinite-trait-alias-recursion.stderr
+++ b/tests/ui/infinite/infinite-trait-alias-recursion.stderr
@@ -21,7 +21,7 @@ note: cycle used when checking that `T1` is well-formed
    |
 LL | trait T1 = T2;
    | ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/infinite/infinite-type-alias-mutual-recursion.gated_new.stderr
+++ b/tests/ui/infinite/infinite-type-alias-mutual-recursion.gated_new.stderr
@@ -23,7 +23,7 @@ note: cycle used when checking that `X1` is well-formed
    |
 LL | type X1 = X2;
    | ^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/infinite/infinite-type-alias-mutual-recursion.gated_old.stderr
+++ b/tests/ui/infinite/infinite-type-alias-mutual-recursion.gated_old.stderr
@@ -23,7 +23,7 @@ note: cycle used when checking that `X1` is well-formed
    |
 LL | type X1 = X2;
    | ^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/infinite/infinite-vec-type-recursion.gated.stderr
+++ b/tests/ui/infinite/infinite-vec-type-recursion.gated.stderr
@@ -13,7 +13,7 @@ note: cycle used when checking that `X` is well-formed
    |
 LL | type X = Vec<X>;
    | ^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -15,7 +15,7 @@ note: cycle used when checking that `Foo` is well-formed
    |
 LL | pub struct Foo<T = Box<dyn Trait<DefaultFoo>>>;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/layout/layout-cycle.stderr
+++ b/tests/ui/layout/layout-cycle.stderr
@@ -12,7 +12,7 @@ LL |     type I: Tr;
    = note: ...which again requires computing layout of `S<S<()>>`, completing the cycle
 note: cycle used when const-evaluating + checking `core::mem::SizedTypeProperties::SIZE`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/layout/post-mono-layout-cycle.stderr
+++ b/tests/ui/layout/post-mono-layout-cycle.stderr
@@ -12,7 +12,7 @@ LL |     type Assoc;
    = note: ...which again requires computing layout of `Wrapper<()>`, completing the cycle
 note: cycle used when computing layout of `core::option::Option<Wrapper<()>>`
   --> $SRC_DIR/core/src/option.rs:LL:COL
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/offset-of/inside-array-length.stderr
+++ b/tests/ui/offset-of/inside-array-length.stderr
@@ -33,38 +33,14 @@ error[E0391]: cycle detected when evaluating type-level constant
 LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `foo::{constant#0}`...
-  --> $DIR/inside-array-length.rs:9:27
-   |
-LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires caching mir of `foo::{constant#0}` for CTFE...
-  --> $DIR/inside-array-length.rs:9:27
-   |
-LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires elaborating drops for `foo::{constant#0}`...
-  --> $DIR/inside-array-length.rs:9:27
-   |
-LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires borrow-checking `foo::{constant#0}`...
-  --> $DIR/inside-array-length.rs:9:27
-   |
-LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires normalizing `Binder { value: ConstEvaluatable(UnevaluatedConst { kind: Anon { def_id: DefId(0:7 ~ inside_array_length[07d6]::foo::{constant#0}) }, args: ['^c_1, T/#1], .. }), bound_vars: [] }`...
-  --> $DIR/inside-array-length.rs:9:27
-   |
-LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `foo::{constant#0}`...
+   = note: ...which requires caching mir of `foo::{constant#0}` for CTFE...
+   = note: ...which requires elaborating drops for `foo::{constant#0}`...
+   = note: ...which requires borrow-checking `foo::{constant#0}`...
+   = note: ...which requires normalizing `Binder { value: ConstEvaluatable(UnevaluatedConst { kind: Anon { def_id: DefId(0:7 ~ inside_array_length[07d6]::foo::{constant#0}) }, args: ['^c_1, T/#1], .. }), bound_vars: [] }`...
    = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when normalizing `inside_array_length::::foo::{constant#0}`
-  --> $DIR/inside-array-length.rs:9:27
-   |
-LL | fn foo<'a, T: 'a>(_: [(); std::mem::offset_of!((T,), 0)]) {}
-   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when normalizing `inside_array_length::::foo::{constant#0}`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
    = note: this error originates in the macro `std::mem::offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time

--- a/tests/ui/parallel-rustc/cycle_crash-issue-135870.stderr
+++ b/tests/ui/parallel-rustc/cycle_crash-issue-135870.stderr
@@ -4,18 +4,10 @@ error[E0391]: cycle detected when checking if `FOO` is a trivial const
 LL | const FOO: usize = FOO;
    | ^^^^^^^^^^^^^^^^
    |
-note: ...which requires building MIR for `FOO`...
-  --> $DIR/cycle_crash-issue-135870.rs:6:1
-   |
-LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^
+   = note: ...which requires building MIR for `FOO`...
    = note: ...which again requires checking if `FOO` is a trivial const, completing the cycle
-note: cycle used when simplifying constant for the type system `FOO`
-  --> $DIR/cycle_crash-issue-135870.rs:6:1
-   |
-LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when simplifying constant for the type system `FOO`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.stderr
+++ b/tests/ui/parallel-rustc/default-trait-shadow-cycle-issue-151358.stderr
@@ -14,7 +14,7 @@ error[E0391]: cycle detected when getting the resolver for lowering
    = note: ...which requires getting the crate HIR...
    = note: ...which requires perform lints prior to AST lowering...
    = note: ...which again requires getting the resolver for lowering, completing the cycle
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.stderr
+++ b/tests/ui/parallel-rustc/generic-const-exprs-deadlock-issue-134978.stderr
@@ -4,16 +4,8 @@ error[E0391]: cycle detected when building an abstract representation for `funct
 LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires building THIR for `function::{constant#0}`...
-  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:17:10
-   |
-LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires type-checking `function::{constant#0}`...
-  --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:17:10
-   |
-LL |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires building THIR for `function::{constant#0}`...
+   = note: ...which requires type-checking `function::{constant#0}`...
    = note: ...which again requires building an abstract representation for `function::{constant#0}`, completing the cycle
 note: cycle used when checking that `function` is well-formed
   --> $DIR/generic-const-exprs-deadlock-issue-134978.rs:15:1
@@ -22,7 +14,7 @@ LL | / fn function<const NUM_CARDS: usize>()
 LL | | where
 LL | |     [(); Struct::<{ NUM_CARDS + 0 }>::OK]:,
    | |___________________________________________^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parallel-rustc/nested-type-alias-cycle-issue-129911.stderr
+++ b/tests/ui/parallel-rustc/nested-type-alias-cycle-issue-129911.stderr
@@ -27,7 +27,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc` is well-fo
    |
 LL |                 type Frc = Frc<{}>::Arc;;
    |                 ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:15:24
@@ -66,7 +66,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc` is well-fo
    |
 LL |             type Frc = Frc<
    |             ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:23:36
@@ -97,7 +97,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL |                         type Frc = Frc<{}>::Arc;;
    |                         ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:27:32
@@ -136,7 +136,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL |                     type Frc = Frc<
    |                     ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:35:44
@@ -167,7 +167,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<{}>::Arc;;
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:39:40
@@ -206,7 +206,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:47:52
@@ -237,7 +237,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<{}>::Arc;;
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:51:48
@@ -276,7 +276,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:60:64
@@ -307,7 +307,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<{}>::Arc;;
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:65:56
@@ -346,7 +346,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:74:64
@@ -377,7 +377,7 @@ note: cycle used when checking that `main::KooArc::{constant#0}::Frc::{constant#
    |
 LL | ...                   type Frc = Frc<{}>::Arc;;
    |                       ^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0433]: cannot find type `Frc` in this scope
   --> $DIR/nested-type-alias-cycle-issue-129911.rs:4:19

--- a/tests/ui/pattern/non-structural-match-types-cycle-err.stderr
+++ b/tests/ui/pattern/non-structural-match-types-cycle-err.stderr
@@ -9,11 +9,7 @@ note: ...which requires evaluating type-level constant...
    |
 LL |     const NONE: Option<T> = None;
    |     ^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `<impl at $DIR/non-structural-match-types-cycle-err.rs:4:1: 4:21>::NONE`...
-  --> $DIR/non-structural-match-types-cycle-err.rs:5:5
-   |
-LL |     const NONE: Option<T> = None;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `<impl at $DIR/non-structural-match-types-cycle-err.rs:4:1: 4:21>::NONE`...
 note: ...which requires computing layout of `core::option::Option<{async block@$DIR/non-structural-match-types-cycle-err.rs:18:16: 18:21}>`...
   --> $SRC_DIR/core/src/option.rs:LL:COL
 note: ...which requires computing layout of `{async block@$DIR/non-structural-match-types-cycle-err.rs:18:16: 18:21}`...
@@ -21,48 +17,24 @@ note: ...which requires computing layout of `{async block@$DIR/non-structural-ma
    |
 LL |     match Some(async {}) {
    |                ^^^^^
-note: ...which requires optimizing MIR for `defines::{closure#0}`...
-  --> $DIR/non-structural-match-types-cycle-err.rs:18:16
-   |
-LL |     match Some(async {}) {
-   |                ^^^^^
-note: ...which requires elaborating drops for `defines::{closure#0}`...
-  --> $DIR/non-structural-match-types-cycle-err.rs:18:16
-   |
-LL |     match Some(async {}) {
-   |                ^^^^^
+   = note: ...which requires optimizing MIR for `defines::{closure#0}`...
+   = note: ...which requires elaborating drops for `defines::{closure#0}`...
 note: ...which requires borrow-checking `defines`...
   --> $DIR/non-structural-match-types-cycle-err.rs:17:1
    |
 LL | fn defines() {
    | ^^^^^^^^^^^^
-note: ...which requires promoting constants in MIR for `defines`...
-  --> $DIR/non-structural-match-types-cycle-err.rs:17:1
-   |
-LL | fn defines() {
-   | ^^^^^^^^^^^^
-note: ...which requires checking if `defines` contains FFI-unwind calls...
-  --> $DIR/non-structural-match-types-cycle-err.rs:17:1
-   |
-LL | fn defines() {
-   | ^^^^^^^^^^^^
-note: ...which requires building MIR for `defines`...
-  --> $DIR/non-structural-match-types-cycle-err.rs:17:1
-   |
-LL | fn defines() {
-   | ^^^^^^^^^^^^
-note: ...which requires match-checking `defines`...
-  --> $DIR/non-structural-match-types-cycle-err.rs:17:1
-   |
-LL | fn defines() {
-   | ^^^^^^^^^^^^
+   = note: ...which requires promoting constants in MIR for `defines`...
+   = note: ...which requires checking if `defines` contains FFI-unwind calls...
+   = note: ...which requires building MIR for `defines`...
+   = note: ...which requires match-checking `defines`...
    = note: ...which again requires building THIR for `defines`, completing the cycle
 note: cycle used when unsafety-checking `defines`
   --> $DIR/non-structural-match-types-cycle-err.rs:17:1
    |
 LL | fn defines() {
    | ^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/query-system/query-cycle-printing-issue-151358.stderr
+++ b/tests/ui/query-system/query-cycle-printing-issue-151358.stderr
@@ -14,7 +14,7 @@ error[E0391]: cycle detected when getting the resolver for lowering
    = note: ...which requires getting the crate HIR...
    = note: ...which requires perform lints prior to AST lowering...
    = note: ...which again requires getting the resolver for lowering, completing the cycle
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/recursion/issue-23302-1.stderr
+++ b/tests/ui/recursion/issue-23302-1.stderr
@@ -4,18 +4,14 @@ error[E0391]: cycle detected when simplifying constant for the type system `X::A
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `X::A::{constant#0}`...
-  --> $DIR/issue-23302-1.rs:4:9
-   |
-LL |     A = X::A as isize,
-   |         ^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `X::A::{constant#0}`...
    = note: ...which again requires simplifying constant for the type system `X::A::{constant#0}`, completing the cycle
 note: cycle used when checking that `X` is well-formed
   --> $DIR/issue-23302-1.rs:3:1
    |
 LL | enum X {
    | ^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/issue-23302-2.stderr
+++ b/tests/ui/recursion/issue-23302-2.stderr
@@ -4,18 +4,14 @@ error[E0391]: cycle detected when simplifying constant for the type system `Y::A
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Y::A::{constant#0}`...
-  --> $DIR/issue-23302-2.rs:4:9
-   |
-LL |     A = Y::B as isize,
-   |         ^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `Y::A::{constant#0}`...
    = note: ...which again requires simplifying constant for the type system `Y::A::{constant#0}`, completing the cycle
 note: cycle used when checking that `Y` is well-formed
   --> $DIR/issue-23302-2.rs:3:1
    |
 LL | enum Y {
    | ^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/issue-23302-3.stderr
+++ b/tests/ui/recursion/issue-23302-3.stderr
@@ -4,28 +4,16 @@ error[E0391]: cycle detected when checking if `A` is a trivial const
 LL | const A: i32 = B;
    | ^^^^^^^^^^^^
    |
-note: ...which requires building MIR for `A`...
-  --> $DIR/issue-23302-3.rs:1:1
-   |
-LL | const A: i32 = B;
-   | ^^^^^^^^^^^^
+   = note: ...which requires building MIR for `A`...
 note: ...which requires checking if `B` is a trivial const...
   --> $DIR/issue-23302-3.rs:3:1
    |
 LL | const B: i32 = A;
    | ^^^^^^^^^^^^
-note: ...which requires building MIR for `B`...
-  --> $DIR/issue-23302-3.rs:3:1
-   |
-LL | const B: i32 = A;
-   | ^^^^^^^^^^^^
+   = note: ...which requires building MIR for `B`...
    = note: ...which again requires checking if `A` is a trivial const, completing the cycle
-note: cycle used when simplifying constant for the type system `A`
-  --> $DIR/issue-23302-3.rs:1:1
-   |
-LL | const A: i32 = B;
-   | ^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when simplifying constant for the type system `A`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/recursion/issue-26548-recursion-via-normalize.rs
+++ b/tests/ui/recursion/issue-26548-recursion-via-normalize.rs
@@ -1,8 +1,8 @@
+//~ NOTE cycle used when computing layout of `core::option::Option<<S as Mirror>::It>`
 //~? ERROR cycle detected when computing layout of `core::option::Option<S>`
-//~? NOTE see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+//~? NOTE for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 //~? NOTE ...which requires computing layout of `core::option::Option<<S as Mirror>::It>`...
 //~? NOTE ...which again requires computing layout of `core::option::Option<S>`, completing the cycle
-//~? NOTE cycle used when computing layout of `core::option::Option<<S as Mirror>::It>`
 
 trait Mirror {
     type It: ?Sized;

--- a/tests/ui/recursion/issue-26548-recursion-via-normalize.stderr
+++ b/tests/ui/recursion/issue-26548-recursion-via-normalize.stderr
@@ -9,9 +9,8 @@ LL | struct S(Option<<S as Mirror>::It>);
 note: ...which requires computing layout of `core::option::Option<<S as Mirror>::It>`...
   --> $SRC_DIR/core/src/option.rs:LL:COL
    = note: ...which again requires computing layout of `core::option::Option<S>`, completing the cycle
-note: cycle used when computing layout of `core::option::Option<<S as Mirror>::It>`
-  --> $SRC_DIR/core/src/option.rs:LL:COL
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when computing layout of `core::option::Option<<S as Mirror>::It>`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/query-cycle-issue-124901.stderr
+++ b/tests/ui/resolve/query-cycle-issue-124901.stderr
@@ -14,7 +14,7 @@ error[E0391]: cycle detected when getting the resolver for lowering
    = note: ...which requires getting the crate HIR...
    = note: ...which requires perform lints prior to AST lowering...
    = note: ...which again requires getting the resolver for lowering, completing the cycle
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/resolve-self-in-impl.stderr
+++ b/tests/ui/resolve/resolve-self-in-impl.stderr
@@ -26,7 +26,7 @@ note: cycle used when building specialization graph of trait `Tr`
    |
 LL | trait Tr<T = u8> {
    | ^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: `Self` is not valid in the self type of an impl block
   --> $DIR/resolve-self-in-impl.rs:16:6

--- a/tests/ui/sized/recursive-type-binding.stderr
+++ b/tests/ui/sized/recursive-type-binding.stderr
@@ -15,7 +15,7 @@ note: cycle used when elaborating drops for `main`
    |
 LL | fn main() {
    | ^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sized/recursive-type-coercion-from-never.stderr
+++ b/tests/ui/sized/recursive-type-coercion-from-never.stderr
@@ -15,7 +15,7 @@ note: cycle used when elaborating drops for `main`
    |
 LL | fn main() {
    | ^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sized/stack-overflow-trait-infer-98842.stderr
+++ b/tests/ui/sized/stack-overflow-trait-infer-98842.stderr
@@ -12,7 +12,7 @@ note: cycle used when const-evaluating + checking `_`
    |
 LL | const _: *const Foo = 0 as _;
    | ^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/specialization/issue-39448.stderr
+++ b/tests/ui/specialization/issue-39448.stderr
@@ -11,7 +11,7 @@ note: cycle used when building specialization graph of trait `FromA`
    |
 LL | trait FromA<T> {
    | ^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/specialization/issue-39618.stderr
+++ b/tests/ui/specialization/issue-39618.stderr
@@ -11,7 +11,7 @@ note: cycle used when building specialization graph of trait `Foo`
    |
 LL | trait Foo {
    | ^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/alias/infinite_normalization.stderr
+++ b/tests/ui/traits/alias/infinite_normalization.stderr
@@ -11,7 +11,7 @@ note: cycle used when computing normalized predicates of `foo`
    |
 LL | fn foo<T: Baz<i32>>() {}
    | ^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -12,43 +12,15 @@ error[E0391]: cycle detected when evaluating type-level constant
 LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
    |                                   ^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires checking if `accept0::{constant#0}` is a trivial const...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires building MIR for `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires building an abstract representation for `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires building THIR for `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-note: ...which requires type-checking `accept0::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `accept0::{constant#0}`...
+   = note: ...which requires checking if `accept0::{constant#0}` is a trivial const...
+   = note: ...which requires building MIR for `accept0::{constant#0}`...
+   = note: ...which requires building an abstract representation for `accept0::{constant#0}`...
+   = note: ...which requires building THIR for `accept0::{constant#0}`...
+   = note: ...which requires type-checking `accept0::{constant#0}`...
    = note: ...which again requires evaluating type-level constant, completing the cycle
-note: cycle used when checking that `accept0` is well-formed
-  --> $DIR/unsatisfied-const-trait-bound.rs:28:35
-   |
-LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                   ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when checking that `accept0` is well-formed
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0391]: cycle detected when checking if `accept1::{constant#0}` is a trivial const
   --> $DIR/unsatisfied-const-trait-bound.rs:32:49
@@ -56,43 +28,15 @@ error[E0391]: cycle detected when checking if `accept1::{constant#0}` is a trivi
 LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
    |                                                 ^^^^^^^^^^^^^
    |
-note: ...which requires building MIR for `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires building an abstract representation for `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires building THIR for `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires type-checking `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires evaluating type-level constant...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `accept1::{constant#0}`...
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
+   = note: ...which requires building MIR for `accept1::{constant#0}`...
+   = note: ...which requires building an abstract representation for `accept1::{constant#0}`...
+   = note: ...which requires building THIR for `accept1::{constant#0}`...
+   = note: ...which requires type-checking `accept1::{constant#0}`...
+   = note: ...which requires evaluating type-level constant...
+   = note: ...which requires const-evaluating + checking `accept1::{constant#0}`...
    = note: ...which again requires checking if `accept1::{constant#0}` is a trivial const, completing the cycle
-note: cycle used when const-evaluating + checking `accept1::{constant#0}`
-  --> $DIR/unsatisfied-const-trait-bound.rs:32:49
-   |
-LL | const fn accept1<T: [const] Trait>(_: Container<{ T::make() }>) {}
-   |                                                 ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when const-evaluating + checking `accept1::{constant#0}`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/solver-cycles/129541-recursive-enum-and-array-impl.current.stderr
+++ b/tests/ui/traits/solver-cycles/129541-recursive-enum-and-array-impl.current.stderr
@@ -15,7 +15,7 @@ note: cycle used when computing layout of `Hello`
    |
 LL | enum Hello {
    | ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/solver-cycles/129541-recursive-enum-and-array-impl.next.stderr
+++ b/tests/ui/traits/solver-cycles/129541-recursive-enum-and-array-impl.next.stderr
@@ -15,7 +15,7 @@ note: cycle used when computing layout of `Hello`
    |
 LL | enum Hello {
    | ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/solver-cycles/assoc-equality-cycle.stderr
+++ b/tests/ui/traits/solver-cycles/assoc-equality-cycle.stderr
@@ -5,12 +5,8 @@ LL | fn foo<T: Trait<A = T::B>>() {}
    |                     ^^^^
    |
    = note: ...which immediately requires computing the bounds for type parameter `T` again
-note: cycle used when computing explicit predicates of `foo`
-  --> $DIR/assoc-equality-cycle.rs:7:21
-   |
-LL | fn foo<T: Trait<A = T::B>>() {}
-   |                     ^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when computing explicit predicates of `foo`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/solver-cycles/self-item-cycle.stderr
+++ b/tests/ui/traits/solver-cycles/self-item-cycle.stderr
@@ -5,12 +5,8 @@ LL | trait T: Iterator<Item = Self::Item>
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: ...which immediately requires computing the super traits of `T` with associated type name `Item` again
-note: cycle used when computing the super predicates of `T`
-  --> $DIR/self-item-cycle.rs:2:1
-   |
-LL | trait T: Iterator<Item = Self::Item>
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: cycle used when computing the super predicates of `T`
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
+++ b/tests/ui/traits/trait-upcasting/cyclic-trait-resolution.stderr
@@ -10,7 +10,7 @@ note: cycle used when checking that `A` is well-formed
    |
 LL | trait A: B + A {}
    | ^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error[E0391]: cycle detected when computing the implied predicates of `A`
   --> $DIR/cyclic-trait-resolution.rs:1:14
@@ -24,7 +24,7 @@ note: cycle used when checking that `<impl at $DIR/cyclic-trait-resolution.rs:7:
    |
 LL | impl A for () {}
    | ^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-enum-variants/self-in-enum-definition.stderr
+++ b/tests/ui/type-alias-enum-variants/self-in-enum-definition.stderr
@@ -4,11 +4,7 @@ error[E0391]: cycle detected when simplifying constant for the type system `Alph
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^^^^^^^^^^^^^^
    |
-note: ...which requires const-evaluating + checking `Alpha::V3::{constant#0}`...
-  --> $DIR/self-in-enum-definition.rs:5:10
-   |
-LL |     V3 = Self::V1 {} as u8 + 2,
-   |          ^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires const-evaluating + checking `Alpha::V3::{constant#0}`...
 note: ...which requires computing layout of `Alpha`...
   --> $DIR/self-in-enum-definition.rs:2:1
    |
@@ -20,7 +16,7 @@ note: cycle used when checking that `Alpha` is well-formed
    |
 LL | enum Alpha {
    | ^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/in-where-clause.stderr
+++ b/tests/ui/type-alias-impl-trait/in-where-clause.stderr
@@ -11,41 +11,11 @@ LL | / fn foo() -> Bar
 LL | | where
 LL | |     Bar: Send,
    | |______________^
-note: ...which requires promoting constants in MIR for `foo`...
-  --> $DIR/in-where-clause.rs:9:1
-   |
-LL | / fn foo() -> Bar
-LL | | where
-LL | |     Bar: Send,
-   | |______________^
-note: ...which requires checking if `foo` contains FFI-unwind calls...
-  --> $DIR/in-where-clause.rs:9:1
-   |
-LL | / fn foo() -> Bar
-LL | | where
-LL | |     Bar: Send,
-   | |______________^
-note: ...which requires building MIR for `foo`...
-  --> $DIR/in-where-clause.rs:9:1
-   |
-LL | / fn foo() -> Bar
-LL | | where
-LL | |     Bar: Send,
-   | |______________^
-note: ...which requires match-checking `foo`...
-  --> $DIR/in-where-clause.rs:9:1
-   |
-LL | / fn foo() -> Bar
-LL | | where
-LL | |     Bar: Send,
-   | |______________^
-note: ...which requires type-checking `foo`...
-  --> $DIR/in-where-clause.rs:9:1
-   |
-LL | / fn foo() -> Bar
-LL | | where
-LL | |     Bar: Send,
-   | |______________^
+   = note: ...which requires promoting constants in MIR for `foo`...
+   = note: ...which requires checking if `foo` contains FFI-unwind calls...
+   = note: ...which requires building MIR for `foo`...
+   = note: ...which requires match-checking `foo`...
+   = note: ...which requires type-checking `foo`...
 note: ...which requires computing revealed normalized predicates of `foo::{constant#0}`...
   --> $DIR/in-where-clause.rs:13:9
    |
@@ -59,7 +29,7 @@ LL | type Bar = impl Sized;
    |            ^^^^^^^^^^
    = note: ...which again requires computing type of opaque `Bar::{opaque#0}`, completing the cycle
    = note: cycle used when evaluating trait selection obligation `Bar: core::marker::Send`
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
@@ -37,7 +37,7 @@ note: cycle used when checking that `Trait` is well-formed
    |
 LL | trait Trait<const N: dyn Trait = bar> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -42,7 +42,7 @@ note: cycle used when checking that `Foo` is well-formed
    |
 LL | trait Foo<const N: Bar<2>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: for more information, see <https://rustc-dev-guide.rust-lang.org/overview.html#queries> and <https://rustc-dev-guide.rust-lang.org/query.html>
 
 error: aborting due to 1 previous error; 2 warnings emitted
 


### PR DESCRIPTION
When pointing at each step of cycle errors, do not include the code snippet when the note points at the same place as the previous one (by setting the note's span to DUMMY_SP).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
