### PR TITLE
 GVN: Don't assume nested shared references are read-only.

### DIFF
--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -116,7 +116,7 @@ use rustc_middle::mir::interpret::{AllocRange, GlobalAlloc};
 use rustc_middle::mir::visit::*;
 use rustc_middle::mir::*;
 use rustc_middle::ty::layout::HasTypingEnv;
-use rustc_middle::ty::{self, Ty, TyCtxt, Unnormalized};
+use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt, Unnormalized};
 use rustc_mir_dataflow::{Analysis, ResultsCursor};
 use rustc_span::DUMMY_SP;
 use smallvec::SmallVec;
@@ -834,16 +834,20 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
                     {
                         return Some((projection_ty, value));
                     }
-                    // DO NOT reason the pointer value.
-                    // We cannot unify two pointers that dereference same local, because they may
-                    // have different lifetimes.
+                    // We cannot unify two references produced by dereferencing the same nested reference,
+                    // because they may have different lifetimes.
                     // ```
                     // let b: &T = *a;
                     // ... `a` is allowed to be modified. `c` and `b` have different borrowing lifetime.
                     // Unifying them will extend the lifetime of `b`.
                     // let c: &T = *a;
                     // ```
-                    if projection_ty.ty.is_ref() {
+                    // Furthermore, unifying them can also violate Stacked Borrows or Tree Borrows.
+                    // We can only unify all `*b` and `*c` separately
+                    // because nested shared references are not read-only.
+                    // For more, see <https://github.com/rust-lang/rust/issues/155884> and
+                    // <https://github.com/rust-lang/rust/issues/130853>.
+                    if self.ty_may_have_ref(projection_ty.ty) {
                         return None;
                     }
 
@@ -1686,6 +1690,59 @@ impl<'body, 'a, 'tcx> VnState<'body, 'a, 'tcx> {
         } else {
             false
         }
+    }
+
+    fn ty_may_have_ref(&self, ty: Ty<'tcx>) -> bool {
+        fn ty_may_have_ref_inner<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, depth: usize) -> bool {
+            if !tcx.recursion_limit().value_within_limit(depth) {
+                return true;
+            }
+            let depth = depth + 1;
+            match ty.kind() {
+                ty::Int(_)
+                | ty::Uint(_)
+                | ty::Float(_)
+                | ty::Bool
+                | ty::Char
+                | ty::Str
+                | ty::Never
+                | ty::FnDef(..)
+                | ty::Error(_)
+                | ty::FnPtr(..) => false,
+                ty::Tuple(fields) => {
+                    fields.iter().any(|field| ty_may_have_ref_inner(tcx, field, depth))
+                }
+                ty::Pat(ty, _) | ty::Slice(ty) | ty::Array(ty, _) => {
+                    ty_may_have_ref_inner(tcx, *ty, depth)
+                }
+                ty::Adt(adt_def, args) => {
+                    adt_def.has_param()
+                        || adt_def.has_aliases()
+                        || adt_def.all_fields().any(|field| {
+                            ty_may_have_ref_inner(
+                                tcx,
+                                field.ty(tcx, args).skip_normalization(),
+                                depth,
+                            )
+                        })
+                }
+                ty::Ref(..)
+                | ty::RawPtr(_, _)
+                | ty::Bound(..)
+                | ty::Closure(..)
+                | ty::CoroutineClosure(..)
+                | ty::Dynamic(..)
+                | ty::Foreign(_)
+                | ty::Coroutine(..)
+                | ty::CoroutineWitness(..)
+                | ty::UnsafeBinder(_)
+                | ty::Infer(_)
+                | ty::Alias(..)
+                | ty::Param(_)
+                | ty::Placeholder(_) => true,
+            }
+        }
+        ty_may_have_ref_inner(self.tcx, ty, 0)
     }
 
     /// Returns `false` if we're confident that the middle type doesn't have an

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_adt.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_adt.GVN.diff
@@ -1,0 +1,75 @@
+- // MIR for `indirect_adt` before GVN
++ // MIR for `indirect_adt` after GVN
+  
+  fn indirect_adt(_1: &Adt<'_>, _2: for<'a> fn(Adt<'a>), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: Adt<'_>;
+      let _5: ();
+      let mut _6: for<'a> fn(Adt<'a>);
+      let mut _7: Adt<'_>;
+      let _8: ();
+      let mut _9: fn();
+      let _11: ();
+      let mut _12: for<'a> fn(Adt<'a>);
+      let mut _13: Adt<'_>;
+      scope 1 {
+          debug y1 => _4;
+          let _10: Adt<'_>;
+          scope 2 {
+              debug y2 => _10;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          _4 = copy (*_1);
+          StorageLive(_5);
+          StorageLive(_6);
+          _6 = copy _2;
+          StorageLive(_7);
+          _7 = copy _4;
+-         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(copy _4) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_7);
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = copy _3;
+-         _8 = move _9() -> [return: bb2, unwind unreachable];
++         _8 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+-         _10 = copy (*_1);
++         _10 = copy _4;
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = copy _2;
+          StorageLive(_13);
+-         _13 = copy _10;
+-         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
++         _13 = copy _4;
++         _11 = copy _2(copy _4) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
+          _0 = const ();
+          StorageDead(_10);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_adt.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_adt.GVN.diff
@@ -50,16 +50,14 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
--         _10 = copy (*_1);
-+         _10 = copy _4;
+          _10 = copy (*_1);
           StorageLive(_11);
           StorageLive(_12);
           _12 = copy _2;
           StorageLive(_13);
--         _13 = copy _10;
+          _13 = copy _10;
 -         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
-+         _13 = copy _4;
-+         _11 = copy _2(copy _4) -> [return: bb3, unwind unreachable];
++         _11 = copy _2(copy _10) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_deref_1.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_deref_1.GVN.diff
@@ -31,17 +31,15 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = copy _2;
--         StorageLive(_7);
-+         nop;
+          StorageLive(_7);
           _14 = no_retag copy (_4.0: &i32);
           _7 = copy (*_14);
 -         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
-+         _5 = copy _2(copy _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(move _7) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
--         StorageDead(_7);
-+         nop;
+          StorageDead(_7);
           StorageDead(_6);
           StorageDead(_5);
           StorageLive(_8);
@@ -55,18 +53,15 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
--         _10 = copy (*_1);
-+         _10 = copy _4;
+          _10 = copy (*_1);
           StorageLive(_11);
           StorageLive(_12);
           _12 = copy _2;
           StorageLive(_13);
--         _15 = no_retag copy (_10.0: &i32);
--         _13 = copy (*_15);
+          _15 = no_retag copy (_10.0: &i32);
+          _13 = copy (*_15);
 -         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
-+         _15 = no_retag copy _14;
-+         _13 = copy _7;
-+         _11 = copy _2(copy _7) -> [return: bb3, unwind unreachable];
++         _11 = copy _2(move _13) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_deref_1.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_deref_1.GVN.diff
@@ -1,0 +1,82 @@
+- // MIR for `indirect_deref_1` before GVN
++ // MIR for `indirect_deref_1` after GVN
+  
+  fn indirect_deref_1(_1: &(&i32,), _2: fn(i32), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: (&i32,);
+      let _5: ();
+      let mut _6: fn(i32);
+      let mut _7: i32;
+      let _8: ();
+      let mut _9: fn();
+      let _11: ();
+      let mut _12: fn(i32);
+      let mut _13: i32;
+      let mut _14: &i32;
+      let mut _15: &i32;
+      scope 1 {
+          debug y1 => _4;
+          let _10: (&i32,);
+          scope 2 {
+              debug y2 => _10;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          _4 = copy (*_1);
+          StorageLive(_5);
+          StorageLive(_6);
+          _6 = copy _2;
+-         StorageLive(_7);
++         nop;
+          _14 = no_retag copy (_4.0: &i32);
+          _7 = copy (*_14);
+-         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(copy _7) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+-         StorageDead(_7);
++         nop;
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = copy _3;
+-         _8 = move _9() -> [return: bb2, unwind unreachable];
++         _8 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+-         _10 = copy (*_1);
++         _10 = copy _4;
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = copy _2;
+          StorageLive(_13);
+-         _15 = no_retag copy (_10.0: &i32);
+-         _13 = copy (*_15);
+-         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
++         _15 = no_retag copy _14;
++         _13 = copy _7;
++         _11 = copy _2(copy _7) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
+          _0 = const ();
+          StorageDead(_10);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_deref_2.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_deref_2.GVN.diff
@@ -21,17 +21,15 @@
           StorageLive(_4);
           StorageLive(_5);
           _5 = copy _2;
--         StorageLive(_6);
-+         nop;
+          StorageLive(_6);
           _12 = no_retag copy ((*_1).0: &i32);
           _6 = copy (*_12);
 -         _4 = move _5(move _6) -> [return: bb1, unwind unreachable];
-+         _4 = copy _2(copy _6) -> [return: bb1, unwind unreachable];
++         _4 = copy _2(move _6) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
--         StorageDead(_6);
-+         nop;
+          StorageDead(_6);
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_7);
@@ -48,12 +46,10 @@
           StorageLive(_10);
           _10 = copy _2;
           StorageLive(_11);
--         _13 = no_retag copy ((*_1).0: &i32);
--         _11 = copy (*_13);
+          _13 = no_retag copy ((*_1).0: &i32);
+          _11 = copy (*_13);
 -         _9 = move _10(move _11) -> [return: bb3, unwind unreachable];
-+         _13 = no_retag copy _12;
-+         _11 = copy _6;
-+         _9 = copy _2(copy _6) -> [return: bb3, unwind unreachable];
++         _9 = copy _2(move _11) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_deref_2.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_deref_2.GVN.diff
@@ -1,0 +1,67 @@
+- // MIR for `indirect_deref_2` before GVN
++ // MIR for `indirect_deref_2` after GVN
+  
+  fn indirect_deref_2(_1: &(&i32,), _2: fn(i32), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: ();
+      let mut _5: fn(i32);
+      let mut _6: i32;
+      let _7: ();
+      let mut _8: fn();
+      let _9: ();
+      let mut _10: fn(i32);
+      let mut _11: i32;
+      let mut _12: &i32;
+      let mut _13: &i32;
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = copy _2;
+-         StorageLive(_6);
++         nop;
+          _12 = no_retag copy ((*_1).0: &i32);
+          _6 = copy (*_12);
+-         _4 = move _5(move _6) -> [return: bb1, unwind unreachable];
++         _4 = copy _2(copy _6) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+-         StorageDead(_6);
++         nop;
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageLive(_7);
+          StorageLive(_8);
+          _8 = copy _3;
+-         _7 = move _8() -> [return: bb2, unwind unreachable];
++         _7 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageLive(_9);
+          StorageLive(_10);
+          _10 = copy _2;
+          StorageLive(_11);
+-         _13 = no_retag copy ((*_1).0: &i32);
+-         _11 = copy (*_13);
+-         _9 = move _10(move _11) -> [return: bb3, unwind unreachable];
++         _13 = no_retag copy _12;
++         _11 = copy _6;
++         _9 = copy _2(copy _6) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_11);
+          StorageDead(_10);
+          StorageDead(_9);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_1.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_1.GVN.diff
@@ -46,11 +46,9 @@
           StorageLive(_10);
           _10 = copy _2;
           StorageLive(_11);
--         _13 = no_retag copy ((*_1).0: &i32);
--         _11 = &(*_13);
+          _13 = no_retag copy ((*_1).0: &i32);
+          _11 = &(*_13);
 -         _9 = move _10(move _11) -> [return: bb3, unwind unreachable];
-+         _13 = no_retag copy _12;
-+         _11 = &(*_12);
 +         _9 = copy _2(move _11) -> [return: bb3, unwind unreachable];
       }
   

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_1.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_1.GVN.diff
@@ -1,0 +1,65 @@
+- // MIR for `indirect_ref_1` before GVN
++ // MIR for `indirect_ref_1` after GVN
+  
+  fn indirect_ref_1(_1: &(&i32,), _2: for<'a> fn(&'a i32), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: ();
+      let mut _5: for<'a> fn(&'a i32);
+      let mut _6: &i32;
+      let _7: ();
+      let mut _8: fn();
+      let _9: ();
+      let mut _10: for<'a> fn(&'a i32);
+      let mut _11: &i32;
+      let mut _12: &i32;
+      let mut _13: &i32;
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = copy _2;
+          StorageLive(_6);
+          _12 = no_retag copy ((*_1).0: &i32);
+          _6 = &(*_12);
+-         _4 = move _5(move _6) -> [return: bb1, unwind unreachable];
++         _4 = copy _2(move _6) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageLive(_7);
+          StorageLive(_8);
+          _8 = copy _3;
+-         _7 = move _8() -> [return: bb2, unwind unreachable];
++         _7 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageLive(_9);
+          StorageLive(_10);
+          _10 = copy _2;
+          StorageLive(_11);
+-         _13 = no_retag copy ((*_1).0: &i32);
+-         _11 = &(*_13);
+-         _9 = move _10(move _11) -> [return: bb3, unwind unreachable];
++         _13 = no_retag copy _12;
++         _11 = &(*_12);
++         _9 = copy _2(move _11) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_11);
+          StorageDead(_10);
+          StorageDead(_9);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_2.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_2.GVN.diff
@@ -53,17 +53,14 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
--         _10 = copy (*_1);
-+         _10 = copy _4;
+          _10 = copy (*_1);
           StorageLive(_11);
           StorageLive(_12);
           _12 = copy _2;
           StorageLive(_13);
--         _15 = no_retag copy (_10.0: &i32);
--         _13 = &(*_15);
+          _15 = no_retag copy (_10.0: &i32);
+          _13 = &(*_15);
 -         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
-+         _15 = no_retag copy _14;
-+         _13 = &(*_14);
 +         _11 = copy _2(move _13) -> [return: bb3, unwind unreachable];
       }
   

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_2.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_2.GVN.diff
@@ -1,0 +1,80 @@
+- // MIR for `indirect_ref_2` before GVN
++ // MIR for `indirect_ref_2` after GVN
+  
+  fn indirect_ref_2(_1: &(&i32,), _2: for<'a> fn(&'a i32), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: (&i32,);
+      let _5: ();
+      let mut _6: for<'a> fn(&'a i32);
+      let mut _7: &i32;
+      let _8: ();
+      let mut _9: fn();
+      let _11: ();
+      let mut _12: for<'a> fn(&'a i32);
+      let mut _13: &i32;
+      let mut _14: &i32;
+      let mut _15: &i32;
+      scope 1 {
+          debug y1 => _4;
+          let _10: (&i32,);
+          scope 2 {
+              debug y2 => _10;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          _4 = copy (*_1);
+          StorageLive(_5);
+          StorageLive(_6);
+          _6 = copy _2;
+          StorageLive(_7);
+          _14 = no_retag copy (_4.0: &i32);
+          _7 = &(*_14);
+-         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(move _7) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_7);
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = copy _3;
+-         _8 = move _9() -> [return: bb2, unwind unreachable];
++         _8 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+-         _10 = copy (*_1);
++         _10 = copy _4;
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = copy _2;
+          StorageLive(_13);
+-         _15 = no_retag copy (_10.0: &i32);
+-         _13 = &(*_15);
+-         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
++         _15 = no_retag copy _14;
++         _13 = &(*_14);
++         _11 = copy _2(move _13) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
+          _0 = const ();
+          StorageDead(_10);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_1.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_1.GVN.diff
@@ -19,16 +19,14 @@
           StorageLive(_4);
           StorageLive(_5);
           _5 = copy _2;
--         StorageLive(_6);
-+         nop;
+          StorageLive(_6);
           _6 = copy ((*_1).0: T);
 -         _4 = move _5(move _6) -> [return: bb1, unwind unreachable];
-+         _4 = copy _2(copy _6) -> [return: bb1, unwind unreachable];
++         _4 = copy _2(move _6) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
--         StorageDead(_6);
-+         nop;
+          StorageDead(_6);
           StorageDead(_5);
           StorageDead(_4);
           StorageLive(_7);
@@ -45,10 +43,9 @@
           StorageLive(_10);
           _10 = copy _2;
           StorageLive(_11);
--         _11 = copy ((*_1).0: T);
+          _11 = copy ((*_1).0: T);
 -         _9 = move _10(move _11) -> [return: bb3, unwind unreachable];
-+         _11 = copy _6;
-+         _9 = copy _2(copy _6) -> [return: bb3, unwind unreachable];
++         _9 = copy _2(move _11) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_1.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_1.GVN.diff
@@ -1,0 +1,62 @@
+- // MIR for `indirect_ref_t_1` before GVN
++ // MIR for `indirect_ref_t_1` after GVN
+  
+  fn indirect_ref_t_1(_1: &(T,), _2: fn(T), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: ();
+      let mut _5: fn(T);
+      let mut _6: T;
+      let _7: ();
+      let mut _8: fn();
+      let _9: ();
+      let mut _10: fn(T);
+      let mut _11: T;
+  
+      bb0: {
+          StorageLive(_4);
+          StorageLive(_5);
+          _5 = copy _2;
+-         StorageLive(_6);
++         nop;
+          _6 = copy ((*_1).0: T);
+-         _4 = move _5(move _6) -> [return: bb1, unwind unreachable];
++         _4 = copy _2(copy _6) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+-         StorageDead(_6);
++         nop;
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageLive(_7);
+          StorageLive(_8);
+          _8 = copy _3;
+-         _7 = move _8() -> [return: bb2, unwind unreachable];
++         _7 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageLive(_9);
+          StorageLive(_10);
+          _10 = copy _2;
+          StorageLive(_11);
+-         _11 = copy ((*_1).0: T);
+-         _9 = move _10(move _11) -> [return: bb3, unwind unreachable];
++         _11 = copy _6;
++         _9 = copy _2(copy _6) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_11);
+          StorageDead(_10);
+          StorageDead(_9);
+          _0 = const ();
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_2.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_2.GVN.diff
@@ -1,0 +1,77 @@
+- // MIR for `indirect_ref_t_2` before GVN
++ // MIR for `indirect_ref_t_2` after GVN
+  
+  fn indirect_ref_t_2(_1: &(T,), _2: fn(T), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: (T,);
+      let _5: ();
+      let mut _6: fn(T);
+      let mut _7: T;
+      let _8: ();
+      let mut _9: fn();
+      let _11: ();
+      let mut _12: fn(T);
+      let mut _13: T;
+      scope 1 {
+          debug y1 => _4;
+          let _10: (T,);
+          scope 2 {
+              debug y2 => _10;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          _4 = copy (*_1);
+          StorageLive(_5);
+          StorageLive(_6);
+          _6 = copy _2;
+-         StorageLive(_7);
++         nop;
+          _7 = copy (_4.0: T);
+-         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(copy _7) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+-         StorageDead(_7);
++         nop;
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = copy _3;
+-         _8 = move _9() -> [return: bb2, unwind unreachable];
++         _8 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+-         _10 = copy (*_1);
++         _10 = copy _4;
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = copy _2;
+          StorageLive(_13);
+-         _13 = copy (_10.0: T);
+-         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
++         _13 = copy _7;
++         _11 = copy _2(copy _7) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
+          _0 = const ();
+          StorageDead(_10);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_2.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_ref_t_2.GVN.diff
@@ -29,16 +29,14 @@
           StorageLive(_5);
           StorageLive(_6);
           _6 = copy _2;
--         StorageLive(_7);
-+         nop;
+          StorageLive(_7);
           _7 = copy (_4.0: T);
 -         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
-+         _5 = copy _2(copy _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(move _7) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
--         StorageDead(_7);
-+         nop;
+          StorageDead(_7);
           StorageDead(_6);
           StorageDead(_5);
           StorageLive(_8);
@@ -52,16 +50,14 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
--         _10 = copy (*_1);
-+         _10 = copy _4;
+          _10 = copy (*_1);
           StorageLive(_11);
           StorageLive(_12);
           _12 = copy _2;
           StorageLive(_13);
--         _13 = copy (_10.0: T);
+          _13 = copy (_10.0: T);
 -         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
-+         _13 = copy _7;
-+         _11 = copy _2(copy _7) -> [return: bb3, unwind unreachable];
++         _11 = copy _2(move _13) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_union.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_union.GVN.diff
@@ -1,0 +1,75 @@
+- // MIR for `indirect_union` before GVN
++ // MIR for `indirect_union` after GVN
+  
+  fn indirect_union(_1: &U<'_>, _2: for<'a> fn(U<'a>), _3: fn()) -> () {
+      debug x => _1;
+      debug out => _2;
+      debug clobber => _3;
+      let mut _0: ();
+      let _4: U<'_>;
+      let _5: ();
+      let mut _6: for<'a> fn(U<'a>);
+      let mut _7: U<'_>;
+      let _8: ();
+      let mut _9: fn();
+      let _11: ();
+      let mut _12: for<'a> fn(U<'a>);
+      let mut _13: U<'_>;
+      scope 1 {
+          debug y1 => _4;
+          let _10: U<'_>;
+          scope 2 {
+              debug y2 => _10;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_4);
+          _4 = copy (*_1);
+          StorageLive(_5);
+          StorageLive(_6);
+          _6 = copy _2;
+          StorageLive(_7);
+          _7 = copy _4;
+-         _5 = move _6(move _7) -> [return: bb1, unwind unreachable];
++         _5 = copy _2(copy _4) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_7);
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageLive(_8);
+          StorageLive(_9);
+          _9 = copy _3;
+-         _8 = move _9() -> [return: bb2, unwind unreachable];
++         _8 = copy _3() -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageLive(_10);
+-         _10 = copy (*_1);
++         _10 = copy _4;
+          StorageLive(_11);
+          StorageLive(_12);
+          _12 = copy _2;
+          StorageLive(_13);
+-         _13 = copy _10;
+-         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
++         _13 = copy _4;
++         _11 = copy _2(copy _4) -> [return: bb3, unwind unreachable];
+      }
+  
+      bb3: {
+          StorageDead(_13);
+          StorageDead(_12);
+          StorageDead(_11);
+          _0 = const ();
+          StorageDead(_10);
+          StorageDead(_4);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/const_prop/indirect_ref.indirect_union.GVN.diff
+++ b/tests/mir-opt/const_prop/indirect_ref.indirect_union.GVN.diff
@@ -50,16 +50,14 @@
           StorageDead(_9);
           StorageDead(_8);
           StorageLive(_10);
--         _10 = copy (*_1);
-+         _10 = copy _4;
+          _10 = copy (*_1);
           StorageLive(_11);
           StorageLive(_12);
           _12 = copy _2;
           StorageLive(_13);
--         _13 = copy _10;
+          _13 = copy _10;
 -         _11 = move _12(move _13) -> [return: bb3, unwind unreachable];
-+         _13 = copy _4;
-+         _11 = copy _2(copy _4) -> [return: bb3, unwind unreachable];
++         _11 = copy _2(copy _10) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {

--- a/tests/mir-opt/const_prop/indirect_ref.rs
+++ b/tests/mir-opt/const_prop/indirect_ref.rs
@@ -1,0 +1,107 @@
+//@ skip-filecheck
+//@ test-mir-pass: GVN
+//@ compile-flags: -C panic=abort
+
+#![feature(freeze)]
+
+use std::marker::Freeze;
+
+#[derive(Clone, Copy)]
+pub union U<'a> {
+    pub i: i32,
+    pub f: &'a i32,
+}
+
+// EMIT_MIR indirect_ref.indirect_union.GVN.diff
+#[inline(never)]
+pub fn indirect_union(x: &U<'_>, out: fn(U<'_>), clobber: fn()) {
+    let y1 = *x;
+    out(y1);
+    clobber();
+    let y2 = *x;
+    out(y2);
+}
+
+// EMIT_MIR indirect_ref.indirect_deref_1.GVN.diff
+#[inline(never)]
+pub fn indirect_deref_1(x: &(&i32,), out: fn(i32), clobber: fn()) {
+    let y1 = *x;
+    out(*(y1).0);
+    clobber();
+    let y2 = *x;
+    out(*(y2).0);
+}
+
+// EMIT_MIR indirect_ref.indirect_deref_2.GVN.diff
+#[inline(never)]
+pub fn indirect_deref_2(x: &(&i32,), out: fn(i32), clobber: fn()) {
+    out(*(*x).0);
+    clobber();
+    out(*(*x).0);
+}
+
+// EMIT_MIR indirect_ref.indirect_ref_1.GVN.diff
+#[inline(never)]
+pub fn indirect_ref_1(x: &(&i32,), out: fn(&i32), clobber: fn()) {
+    out((*x).0);
+    clobber();
+    out((*x).0);
+}
+
+// EMIT_MIR indirect_ref.indirect_ref_2.GVN.diff
+#[inline(never)]
+pub fn indirect_ref_2(x: &(&i32,), out: fn(&i32), clobber: fn()) {
+    let y1 = *x;
+    out((y1).0);
+    clobber();
+    let y2 = *x;
+    out((y2).0);
+}
+
+// EMIT_MIR indirect_ref.indirect_ref_t_1.GVN.diff
+#[inline(never)]
+pub fn indirect_ref_t_1<T: Copy + Freeze>(x: &(T,), out: fn(T), clobber: fn()) {
+    out((*x).0);
+    clobber();
+    out((*x).0);
+}
+
+// EMIT_MIR indirect_ref.indirect_ref_t_2.GVN.diff
+#[inline(never)]
+pub fn indirect_ref_t_2<T: Copy + Freeze>(x: &(T,), out: fn(T), clobber: fn()) {
+    let y1 = *x;
+    out((y1).0);
+    clobber();
+    let y2 = *x;
+    out((y2).0);
+}
+
+#[derive(Clone, Copy)]
+pub struct Adt<'a>(pub &'a i32);
+
+// EMIT_MIR indirect_ref.indirect_adt.GVN.diff
+#[inline(never)]
+pub fn indirect_adt(x: &Adt<'_>, out: fn(Adt), clobber: fn()) {
+    let y1 = *x;
+    out(y1);
+    clobber();
+    let y2 = *x;
+    out(y2);
+}
+
+static mut DATA: i32 = 0;
+
+fn main() {
+    let ptr = &raw mut DATA;
+    let nested_shr: &(&i32,) = unsafe { &*(&raw const ptr as *const (&i32,)) };
+    let u = U { f: nested_shr.0 };
+    indirect_union(&u, |x| assert_eq!(unsafe { *x.f }, unsafe { DATA }), || unsafe { DATA += 1 });
+    indirect_deref_1(nested_shr, |x| assert_eq!(x, unsafe { DATA }), || unsafe { DATA += 1 });
+    indirect_deref_2(nested_shr, |x| assert_eq!(x, unsafe { DATA }), || unsafe { DATA += 1 });
+    indirect_ref_1(nested_shr, |&x| assert_eq!(x, unsafe { DATA }), || unsafe { DATA += 1 });
+    indirect_ref_2(nested_shr, |&x| assert_eq!(x, unsafe { DATA }), || unsafe { DATA += 1 });
+    indirect_ref_t_1(nested_shr, |&x| assert_eq!(x, unsafe { DATA }), || unsafe { DATA += 1 });
+    indirect_ref_t_2(nested_shr, |&x| assert_eq!(x, unsafe { DATA }), || unsafe { DATA += 1 });
+    let adt = Adt(nested_shr.0);
+    indirect_adt(&adt, |x| assert_eq!(*x.0, unsafe { DATA }), || unsafe { DATA += 1 });
+}

--- a/tests/mir-opt/const_prop/indirect_ref.rs
+++ b/tests/mir-opt/const_prop/indirect_ref.rs
@@ -1,4 +1,5 @@
-//@ skip-filecheck
+//! Regression test for <https://github.com/rust-lang/rust/issues/155884>.
+//! Nested shared references may be NOT read-only.
 //@ test-mir-pass: GVN
 //@ compile-flags: -C panic=abort
 
@@ -15,6 +16,12 @@ pub union U<'a> {
 // EMIT_MIR indirect_ref.indirect_union.GVN.diff
 #[inline(never)]
 pub fn indirect_union(x: &U<'_>, out: fn(U<'_>), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_union
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1:_.*]] = copy (*_1);
+    // CHECK: copy [[out]](copy [[y1]]) -> [
+    // CHECK: [[y2:_.*]] = copy (*_1);
+    // CHECK: copy [[out]](copy [[y2]]) -> [
     let y1 = *x;
     out(y1);
     clobber();
@@ -25,6 +32,16 @@ pub fn indirect_union(x: &U<'_>, out: fn(U<'_>), clobber: fn()) {
 // EMIT_MIR indirect_ref.indirect_deref_1.GVN.diff
 #[inline(never)]
 pub fn indirect_deref_1(x: &(&i32,), out: fn(i32), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_deref_1
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1:_.*]] = copy (*_1);
+    // CHECK: [[y1_0:_.*]] = no_retag copy ([[y1]].0: &i32);
+    // CHECK: [[deref_y1_0:_.*]] = copy (*[[y1_0]]);
+    // CHECK: copy [[out]](move [[deref_y1_0]]) -> [
+    // CHECK: [[y2:_.*]] = copy (*_1);
+    // CHECK: [[y2_0:_.*]] = no_retag copy ([[y2]].0: &i32);
+    // CHECK: [[deref_y2_0:_.*]] = copy (*[[y2_0]]);
+    // CHECK: copy [[out]](move [[deref_y2_0]]) -> [
     let y1 = *x;
     out(*(y1).0);
     clobber();
@@ -35,6 +52,14 @@ pub fn indirect_deref_1(x: &(&i32,), out: fn(i32), clobber: fn()) {
 // EMIT_MIR indirect_ref.indirect_deref_2.GVN.diff
 #[inline(never)]
 pub fn indirect_deref_2(x: &(&i32,), out: fn(i32), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_deref_2
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1_0:_.*]] = no_retag copy ((*_1).0: &i32);
+    // CHECK: [[deref_y1_0:_.*]] = copy (*[[y1_0]]);
+    // CHECK: copy [[out]](move [[deref_y1_0]]) -> [
+    // CHECK: [[y2_0:_.*]] = no_retag copy ((*_1).0: &i32);
+    // CHECK: [[deref_y2_0:_.*]] = copy (*[[y2_0]]);
+    // CHECK: copy [[out]](move [[deref_y2_0]]) -> [
     out(*(*x).0);
     clobber();
     out(*(*x).0);
@@ -43,6 +68,14 @@ pub fn indirect_deref_2(x: &(&i32,), out: fn(i32), clobber: fn()) {
 // EMIT_MIR indirect_ref.indirect_ref_1.GVN.diff
 #[inline(never)]
 pub fn indirect_ref_1(x: &(&i32,), out: fn(&i32), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_ref_1
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1_0:_.*]] = no_retag copy ((*_1).0: &i32);
+    // CHECK: [[reborrow_y1_0:_.*]] = &(*[[y1_0]]);
+    // CHECK: copy [[out]](move [[reborrow_y1_0]]) -> [
+    // CHECK: [[y2_0:_.*]] = no_retag copy ((*_1).0: &i32);
+    // CHECK: [[reborrow_y2_0:_.*]] = &(*[[y2_0]]);
+    // CHECK: copy [[out]](move [[reborrow_y2_0]]) -> [
     out((*x).0);
     clobber();
     out((*x).0);
@@ -51,6 +84,16 @@ pub fn indirect_ref_1(x: &(&i32,), out: fn(&i32), clobber: fn()) {
 // EMIT_MIR indirect_ref.indirect_ref_2.GVN.diff
 #[inline(never)]
 pub fn indirect_ref_2(x: &(&i32,), out: fn(&i32), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_ref_2
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1:_.*]] = copy (*_1);
+    // CHECK: [[y1_0:_.*]] = no_retag copy ([[y1]].0: &i32);
+    // CHECK: [[reborrow_y1_0:_.*]] = &(*[[y1_0]]);
+    // CHECK: copy [[out]](move [[reborrow_y1_0]]) -> [
+    // CHECK: [[y2:_.*]] = copy (*_1);
+    // CHECK: [[y2_0:_.*]] = no_retag copy ([[y2]].0: &i32);
+    // CHECK: [[reborrow_y2_0:_.*]] = &(*[[y2_0]]);
+    // CHECK: copy [[out]](move [[reborrow_y2_0]]) -> [
     let y1 = *x;
     out((y1).0);
     clobber();
@@ -61,6 +104,12 @@ pub fn indirect_ref_2(x: &(&i32,), out: fn(&i32), clobber: fn()) {
 // EMIT_MIR indirect_ref.indirect_ref_t_1.GVN.diff
 #[inline(never)]
 pub fn indirect_ref_t_1<T: Copy + Freeze>(x: &(T,), out: fn(T), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_ref_t_1
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1_0:_.*]] = copy ((*_1).0: T);
+    // CHECK: copy [[out]](move [[y1_0]]) -> [
+    // CHECK: [[y2_0:_.*]] = copy ((*_1).0: T);
+    // CHECK: copy [[out]](move [[y2_0]]) -> [
     out((*x).0);
     clobber();
     out((*x).0);
@@ -69,6 +118,14 @@ pub fn indirect_ref_t_1<T: Copy + Freeze>(x: &(T,), out: fn(T), clobber: fn()) {
 // EMIT_MIR indirect_ref.indirect_ref_t_2.GVN.diff
 #[inline(never)]
 pub fn indirect_ref_t_2<T: Copy + Freeze>(x: &(T,), out: fn(T), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_ref_t_2
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1:_.*]] = copy (*_1);
+    // CHECK: [[y1_0:_.*]] = copy ([[y1]].0: T);
+    // CHECK: copy [[out]](move [[y1_0]]) -> [
+    // CHECK: [[y2:_.*]] = copy (*_1);
+    // CHECK: [[y2_0:_.*]] = copy ([[y2]].0: T);
+    // CHECK: copy [[out]](move [[y2_0]]) -> [
     let y1 = *x;
     out((y1).0);
     clobber();
@@ -82,6 +139,12 @@ pub struct Adt<'a>(pub &'a i32);
 // EMIT_MIR indirect_ref.indirect_adt.GVN.diff
 #[inline(never)]
 pub fn indirect_adt(x: &Adt<'_>, out: fn(Adt), clobber: fn()) {
+    // CHECK-LABEL: fn indirect_adt
+    // CHECK: out => [[out:_.*]];
+    // CHECK: [[y1:_.*]] = copy (*_1);
+    // CHECK: copy [[out]](copy [[y1]]) -> [
+    // CHECK: [[y2:_.*]] = copy (*_1);
+    // CHECK: copy [[out]](copy [[y2]]) -> [
     let y1 = *x;
     out(y1);
     clobber();

--- a/tests/mir-opt/gvn.field_borrow.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.field_borrow.GVN.panic-abort.diff
@@ -17,8 +17,7 @@
           StorageLive(_2);
           _2 = copy ((*_1).0: &u8);
           StorageLive(_3);
--         _3 = copy ((*_1).0: &u8);
-+         _3 = copy _2;
+          _3 = copy ((*_1).0: &u8);
           _0 = const ();
           StorageDead(_3);
           StorageDead(_2);

--- a/tests/mir-opt/gvn.field_borrow.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.field_borrow.GVN.panic-unwind.diff
@@ -17,8 +17,7 @@
           StorageLive(_2);
           _2 = copy ((*_1).0: &u8);
           StorageLive(_3);
--         _3 = copy ((*_1).0: &u8);
-+         _3 = copy _2;
+          _3 = copy ((*_1).0: &u8);
           _0 = const ();
           StorageDead(_3);
           StorageDead(_2);

--- a/tests/mir-opt/gvn.field_borrow_2.GVN.panic-abort.diff
+++ b/tests/mir-opt/gvn.field_borrow_2.GVN.panic-abort.diff
@@ -35,8 +35,7 @@
           StorageLive(_5);
           _5 = copy ((*_4).0: &u8);
           StorageLive(_6);
--         _6 = copy ((*_4).0: &u8);
-+         _6 = copy _5;
+          _6 = copy ((*_4).0: &u8);
           _0 = const ();
           StorageDead(_6);
           StorageDead(_5);

--- a/tests/mir-opt/gvn.field_borrow_2.GVN.panic-unwind.diff
+++ b/tests/mir-opt/gvn.field_borrow_2.GVN.panic-unwind.diff
@@ -35,8 +35,7 @@
           StorageLive(_5);
           _5 = copy ((*_4).0: &u8);
           StorageLive(_6);
--         _6 = copy ((*_4).0: &u8);
-+         _6 = copy _5;
+          _6 = copy ((*_4).0: &u8);
           _0 = const ();
           StorageDead(_6);
           StorageDead(_5);

--- a/tests/mir-opt/gvn.rs
+++ b/tests/mir-opt/gvn.rs
@@ -1125,7 +1125,7 @@ fn field_borrow(a: &FieldBorrow<'_>) {
     // CHECK: debug b => [[b:_.*]];
     // CHECK: debug c => [[c:_.*]];
     // CHECK: [[b]] = copy ((*_1).0: &u8);
-    // CHECK: [[c]] = copy [[b]];
+    // CHECK: [[c]] = copy ((*_1).0: &u8);
     let b = a.0;
     let c = a.0;
 }
@@ -1142,7 +1142,7 @@ fn field_borrow_2(a: &&FieldBorrow<'_>) {
     // CHECK: [[c]] = copy ((*[[b]]).0: &u8);
     // CHECK: [[d]] = copy (*_1);
     // CHECK: [[e]] = copy ((*[[d]]).0: &u8);
-    // CHECK: [[f]] = copy [[e]];
+    // CHECK: [[f]] = copy ((*[[d]]).0: &u8);
     let b = *a;
     let c = b.0;
     let d = *a;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/155884.

https://github.com/rust-lang/rust/pull/150485 only checks the type, whether it is a reference, which is not enough. The PR extends to other types.

cc @RalfJung @saethlin 

r? @cjgillot 