### PR TITLE
Don't track cwd for `-Zremap-cwd-prefix` in incremental compilation

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -25,7 +25,7 @@ use rustc_session::utils::{CanonicalizedPath, NativeLib};
 use rustc_session::{CompilerIO, EarlyDiagCtxt, Session, build_session, getopts};
 use rustc_span::edition::{DEFAULT_EDITION, Edition};
 use rustc_span::source_map::{RealFileLoader, SourceMapInputs};
-use rustc_span::{FileName, SourceFileHashAlgorithm, sym};
+use rustc_span::{FileName, RealFileName, RemapPathScopeComponents, SourceFileHashAlgorithm, sym};
 use rustc_target::spec::{
     CodeModel, FramePointer, LinkerFlavorCli, MergeFunctions, OnBrokenPipe, PanicStrategy,
     RelocModel, RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, TlsModel,
@@ -173,6 +173,33 @@ fn test_can_print_warnings() {
     sess_and_cfg(&["-Adead_code"], |sess, _cfg| {
         assert!(sess.dcx().can_emit_warnings());
     });
+}
+
+// `-Zremap-cwd-prefix` must not be merged into the tracked `remap_path_prefix` option:
+// storing the absolute cwd there invalidates the incremental cache across build
+// directories (see #132132). It must instead be applied via `file_path_mapping`.
+#[test]
+fn test_remap_cwd_prefix_not_in_remap_path_prefix() {
+    sess_and_cfg(
+        &["--remap-path-prefix=/explicit=mapped", "-Zremap-cwd-prefix=cwd-mapped"],
+        |sess, _cfg| {
+            // The tracked option holds only the explicit `--remap-path-prefix` entry.
+            assert_eq!(
+                sess.opts.remap_path_prefix,
+                vec![(PathBuf::from("/explicit"), PathBuf::from("mapped"))],
+            );
+
+            // ... but the cwd remapping is still applied via `file_path_mapping`.
+            let cwd = std::env::current_dir().unwrap();
+            let remapped = sess
+                .opts
+                .file_path_mapping()
+                .to_real_filename(&RealFileName::empty(), cwd.join("foo.rs"))
+                .path(RemapPathScopeComponents::DEBUGINFO)
+                .to_path_buf();
+            assert_eq!(remapped, PathBuf::from("cwd-mapped/foo.rs"));
+        },
+    );
 }
 
 #[test]

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1375,9 +1375,21 @@ pub fn host_tuple() -> &'static str {
 
 fn file_path_mapping(
     remap_path_prefix: Vec<(PathBuf, PathBuf)>,
+    remap_cwd_prefix: Option<&Path>,
     remap_path_scope: RemapPathScopeComponents,
 ) -> FilePathMapping {
-    FilePathMapping::new(remap_path_prefix.clone(), remap_path_scope)
+    // Apply `-Zremap-cwd-prefix` here rather than in `parse_remap_path_prefix`, so the
+    // absolute cwd is never stored in the tracked `remap_path_prefix` option (#132132).
+    let cwd_remap = if let Some(to) = remap_cwd_prefix
+        && let Ok(cwd) = std::env::current_dir()
+    {
+        Some((cwd, to.to_path_buf()))
+    } else {
+        None
+    };
+    // The cwd remapping is appended last: `map_prefix` tries entries in reverse order, so this
+    // keeps `-Zremap-cwd-prefix` taking precedence over `--remap-path-prefix`, as documented.
+    FilePathMapping::new(remap_path_prefix.into_iter().chain(cwd_remap).collect(), remap_path_scope)
 }
 
 impl Default for Options {
@@ -1389,7 +1401,8 @@ impl Default for Options {
         // to create a default working directory.
         let working_dir = {
             let working_dir = std::env::current_dir().unwrap();
-            let file_mapping = file_path_mapping(Vec::new(), RemapPathScopeComponents::empty());
+            let file_mapping =
+                file_path_mapping(Vec::new(), None, RemapPathScopeComponents::empty());
             file_mapping.to_real_filename(&RealFileName::empty(), &working_dir)
         };
 
@@ -1450,7 +1463,11 @@ impl Options {
     }
 
     pub fn file_path_mapping(&self) -> FilePathMapping {
-        file_path_mapping(self.remap_path_prefix.clone(), self.remap_path_scope)
+        file_path_mapping(
+            self.remap_path_prefix.clone(),
+            self.unstable_opts.remap_cwd_prefix.as_deref(),
+            self.remap_path_scope,
+        )
     }
 
     /// Returns `true` if there will be an output file generated.
@@ -2384,9 +2401,8 @@ pub fn parse_externs(
 fn parse_remap_path_prefix(
     early_dcx: &EarlyDiagCtxt,
     matches: &getopts::Matches,
-    unstable_opts: &UnstableOptions,
 ) -> Vec<(PathBuf, PathBuf)> {
-    let mut mapping: Vec<(PathBuf, PathBuf)> = matches
+    matches
         .opt_strs("remap-path-prefix")
         .into_iter()
         .map(|remap| match remap.rsplit_once('=') {
@@ -2395,15 +2411,7 @@ fn parse_remap_path_prefix(
             }
             Some((from, to)) => (PathBuf::from(from), PathBuf::from(to)),
         })
-        .collect();
-    match &unstable_opts.remap_cwd_prefix {
-        Some(to) => match std::env::current_dir() {
-            Ok(cwd) => mapping.push((cwd, to.clone())),
-            Err(_) => (),
-        },
-        None => (),
-    };
-    mapping
+        .collect()
 }
 
 fn parse_logical_env(
@@ -2661,7 +2669,7 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
 
     let externs = parse_externs(early_dcx, matches, &unstable_opts);
 
-    let remap_path_prefix = parse_remap_path_prefix(early_dcx, matches, &unstable_opts);
+    let remap_path_prefix = parse_remap_path_prefix(early_dcx, matches);
     let remap_path_scope = parse_remap_path_scope(early_dcx, matches, &unstable_opts);
 
     let pretty = parse_pretty(early_dcx, &unstable_opts);
@@ -2729,7 +2737,11 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
             early_dcx.early_fatal(format!("Current directory is invalid: {e}"));
         });
 
-        let file_mapping = file_path_mapping(remap_path_prefix.clone(), remap_path_scope);
+        let file_mapping = file_path_mapping(
+            remap_path_prefix.clone(),
+            unstable_opts.remap_cwd_prefix.as_deref(),
+            remap_path_scope,
+        );
         file_mapping.to_real_filename(&RealFileName::empty(), &working_dir)
     };
 

--- a/src/doc/unstable-book/src/compiler-flags/remap-cwd-prefix.md
+++ b/src/doc/unstable-book/src/compiler-flags/remap-cwd-prefix.md
@@ -16,6 +16,12 @@ directory from build output, while allowing the command line to be universally
 reproducible, such that the same execution will work on all machines, regardless
 of build environment.
 
+Unlike passing the equivalent mapping through `--remap-path-prefix`, the current
+working directory does not take part in incremental compilation's dependency
+tracking. Building the same sources from different directories (for example, a
+sandboxed or per-build checkout path) therefore reuses the incremental cache
+rather than invalidating it.
+
 ## Example
 ```sh
 # This would produce an absolute path to main.rs in build outputs of


### PR DESCRIPTION
## Summary

`-Zremap-cwd-prefix=<to>` defeats incremental compilation whenever the build directory changes (Bazel sandboxes, CI checkouts with per-build paths), even though the remapped output is identical:

```
[incremental] completely ignoring cache because of differing commandline arguments
```

This fixes the cwd half of rust-lang/rust#132132.

### Root cause

`-Zremap-cwd-prefix` and `--remap-path-prefix` have two separate options (`remap_cwd_prefix` and `remap_path_prefix`), but `parse_remap_path_prefix` *merges* them: it resolves `std::env::current_dir()` and pushes `(cwd, to)` onto `remap_path_prefix`, which is `[TRACKED_NO_CRATE_HASH]`. The **absolute** cwd thus enters `dep_tracking_hash(false)` (compared in `rustc_incremental::persist::load`), so the same build from a different directory purges the whole incremental session.

### Fix: apply the cwd prefix where the mapping is built, not where options are tracked

Keep each option holding exactly its own flag, and apply `-Zremap-cwd-prefix` in `file_path_mapping` — i.e. while building the (untracked) applied `FilePathMapping` — instead of in `parse_remap_path_prefix`. The absolute cwd then lives only in the runtime mapping and never in a tracked option.

**Behaviour-preserving for output:** the applied mapping is identical (the cwd entry is still appended last, so it keeps taking precedence over `--remap-path-prefix` as documented), and all emitted paths (debuginfo, diagnostics, metadata) are unchanged.

**Sound for tracking:** the cwd's effect is still tracked, by the two options that *should* carry it —

* `remap_cwd_prefix` (`[TRACKED]`) — the target prefix baked into output;
* `working_dir` (`[TRACKED]`) — and `RealFileName`'s hash already includes the real local path **only** when the path was not fully remapped (`was_fully_remapped()` = `scopes.is_all()`):

  ```rust
  if !self.was_fully_remapped() { self.local.hash(state); }
  self.maybe_remapped.hash(state);
  ```

  So under a restrictive `-Zremap-path-scope` (where the cwd can still leak into output) the real cwd stays tracked via `working_dir`; under full remapping (where it cannot leak) it is correctly ignored. Dropping the cwd from `remap_path_prefix`'s hash is therefore sound in **every** scope.

The **stable** `--remap-path-prefix` flag is entirely unchanged in data and in tracking. No SVH/crate-hash change (`remap_path_prefix` is `TRACKED_NO_CRATE_HASH`); no new types and no special-case hashing.

### Notes

* A unit test (`tests/ui`-style, in `rustc_interface`) guards against the cwd being merged back into the tracked `remap_path_prefix`, while asserting it is still applied via `file_path_mapping`.
* The unstable book entry for `-Zremap-cwd-prefix` is updated to document the incremental-cache behaviour across build directories.
* A `tests/run-make` end-to-end test (build the same sources from two directories sharing one `-Cincremental` dir, asserting cache reuse) would be a good follow-up; happy to add it here if preferred.

### Relation to stabilization (tracking issue rust-lang/rust#89434)

This is a behaviour fix to an unstable flag and does not depend on or block stabilization. It is, however, mildly relevant to one of the open questions in the tracking issue (rust-lang/rust#89434) — *"Will this always be defined to be the same as `--remap-path-prefix=$(pwd)=VALUE`?"*. After this PR the two are **no longer** equivalent for incremental compilation: a literal `--remap-path-prefix=$(pwd)=.` still bakes the absolute cwd into the tracked hash, whereas `-Zremap-cwd-prefix=.` no longer does. Worth keeping in mind whenever that question is revisited (e.g. alongside RFC 3127).

r? compiler

