### PR TITLE
compiletest: ignore SVG `y` offset in by-lines comparison

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2304,6 +2304,23 @@ impl<'test> TestCx<'test> {
         self.props.compile_flags.iter().any(|s| s.contains("--color=always"))
     }
 
+    /// Returns the lines for the by-lines comparison, normalized for the
+    /// parallel front-end: for SVG output, strip the header line and `y`
+    /// offsets; otherwise, filter out padded empty code lines (a single `|`).
+    fn lines_for_comparison(&self, output: &str) -> Vec<String> {
+        if self.force_color_svg() {
+            let strip_y = static_regex!(r#"y="\d+px""#);
+            output
+                .lines()
+                // anstyle_svg causes environment-dependent width parameter
+                .skip(1)
+                .map(|line| strip_y.replace_all(line, r#"y="0px""#).into_owned())
+                .collect()
+        } else {
+            output.lines().filter(|l| l.trim() != "|").map(str::to_owned).collect()
+        }
+    }
+
     fn load_compare_outputs(
         &self,
         proc_res: &ProcRes,
@@ -2719,10 +2736,8 @@ impl<'test> TestCx<'test> {
                 (&tmp.0, &tmp.1)
             }
         } else if compare_output_by_lines {
-            // Filter out padded empty code lines
-            let mut actual_lines: Vec<&str> = actual.lines().filter(|l| l.trim() != "|").collect();
-            let mut expected_lines: Vec<&str> =
-                expected.lines().filter(|l| l.trim() != "|").collect();
+            let mut actual_lines = self.lines_for_comparison(actual);
+            let mut expected_lines = self.lines_for_comparison(expected);
             actual_lines.sort_unstable();
             expected_lines.sort_unstable();
             if actual_lines == expected_lines {
@@ -2866,7 +2881,9 @@ impl<'test> TestCx<'test> {
         }
 
         if show_diff_by_lines {
-            write!(self.stderr, "{}", diff_by_lines(expected, actual));
+            let expected_lines = self.lines_for_comparison(expected);
+            let actual_lines = self.lines_for_comparison(actual);
+            write!(self.stderr, "{}", diff_by_lines(&expected_lines, &actual_lines));
         }
     }
 

--- a/src/tools/compiletest/src/runtest/compute_diff.rs
+++ b/src/tools/compiletest/src/runtest/compute_diff.rs
@@ -105,19 +105,18 @@ pub(crate) fn write_diff(expected: &str, actual: &str, context_size: usize) -> S
     output
 }
 
-pub(crate) fn diff_by_lines(expected: &str, actual: &str) -> String {
+pub(crate) fn diff_by_lines(expected: &[String], actual: &[String]) -> String {
     use std::collections::HashMap;
     use std::fmt::Write;
     let mut output = String::new();
     let mut expected_counts: HashMap<&str, usize> = HashMap::new();
     let mut actual_counts: HashMap<&str, usize> = HashMap::new();
 
-    // Filter out padded empty code lines
-    for line in expected.lines().filter(|l| l.trim() != "|") {
-        *expected_counts.entry(line).or_insert(0) += 1;
+    for line in expected {
+        *expected_counts.entry(line.as_str()).or_insert(0) += 1;
     }
-    for line in actual.lines().filter(|l| l.trim() != "|") {
-        *actual_counts.entry(line).or_insert(0) += 1;
+    for line in actual {
+        *actual_counts.entry(line.as_str()).or_insert(0) += 1;
     }
 
     fn write_expected_only_lines(

--- a/tests/ui/error-emitter/multiline-removal-suggestion.rs
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.rs
@@ -56,4 +56,3 @@ fn bay() -> Vec<(bool, HashSet<u8>)> {
 		.collect()
 }
 fn main() {}
-//@ ignore-parallel-frontend invalid svg(multiple threads trying to write to the same file)


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157350)*
<!-- homu-ignore:end -->

Tracked in rust-lang/rust#154314.
Closes rust-lang/rust#157606

SVG diagnostic snapshots render one terminal row per line, laid out top to bottom. Under the parallel front-end, independent diagnostics can be emitted in a different order. That permutes the rows and re-renders each one at a different vertical `y` offset, even though the content of every row is unchanged.

This change strips the `y` coordinate (and the `<svg>` header line, whose width and height are already ignored by the exact comparison) before the multiset comparison, so a reordering of whole rows is no longer treated as a difference.