### PR TITLE
Add a regression test for an unconstrained TransmuteFrom ICE

### DIFF
--- a/tests/ui/traits/next-solver/transmute-from-unconstrained.rs
+++ b/tests/ui/traits/next-solver/transmute-from-unconstrained.rs
@@ -1,0 +1,20 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/151314>.
+//!
+//! Calling a function with an unconstrained `TransmuteFrom` obligation used to
+//! trigger a `layout_of: unexpected type` ICE under the next-gen trait solver
+//! instead of reporting that type annotations are needed.
+
+//@ compile-flags: -Znext-solver=globally
+
+#![feature(transmutability)]
+
+fn assert_transmutable<T>()
+where
+    (): std::mem::TransmuteFrom<T>,
+{
+}
+
+fn main() {
+    assert_transmutable()
+    //~^ ERROR type annotations needed
+}

--- a/tests/ui/traits/next-solver/transmute-from-unconstrained.stderr
+++ b/tests/ui/traits/next-solver/transmute-from-unconstrained.stderr
@@ -1,0 +1,23 @@
+error[E0283]: type annotations needed
+  --> $DIR/transmute-from-unconstrained.rs:18:5
+   |
+LL |     assert_transmutable()
+   |     ^^^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `assert_transmutable`
+   |
+   = note: cannot satisfy `(): TransmuteFrom<_, Assume { alignment: false, lifetimes: false, safety: false, validity: false }>`
+note: required by a bound in `assert_transmutable`
+  --> $DIR/transmute-from-unconstrained.rs:13:9
+   |
+LL | fn assert_transmutable<T>()
+   |    ------------------- required by a bound in this function
+LL | where
+LL |     (): std::mem::TransmuteFrom<T>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_transmutable`
+help: consider specifying a concrete type for the type parameter `T`
+   |
+LL |     assert_transmutable::</* Type */>()
+   |                        ++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
rust-lang/rust#151314: calling a function with an unconstrained `TransmuteFrom` obligation used to ICE with `layout_of: unexpected type` under the next-gen trait solver. It now reports `type annotations needed` (E0283) as expected. Fixed in rust-lang/rust#154991, but the issue was labelled `E-needs-test` and lacked a regression test, so this adds the original reproducer so it can't silently regress.

Closes rust-lang/rust#151314
