### PR TITLE
Document potential_query_instability allow sites

### DIFF
--- a/compiler/rustc_attr_parsing/src/check_cfg.rs
+++ b/compiler/rustc_attr_parsing/src/check_cfg.rs
@@ -103,7 +103,10 @@ pub(crate) fn unexpected_cfg_name(
     (name, name_span): (Symbol, Span),
     value: Option<(Symbol, Span)>,
 ) -> errors::UnexpectedCfgName {
-    #[allow(rustc::potential_query_instability)]
+    #[allow(
+        rustc::potential_query_instability,
+        reason = "all uses either do not care about order or sort before use"
+    )]
     let possibilities: Vec<Symbol> = sess.check_config.expecteds.keys().copied().collect();
 
     let mut names_possibilities: Vec<_> = if value.is_none() {
@@ -425,7 +428,10 @@ pub(crate) fn unexpected_cfg_value(
 }
 
 fn possible_well_known_names_for_cfg_value(sess: &Session, value: Symbol) -> Vec<Symbol> {
-    #[allow(rustc::potential_query_instability)]
+    #[allow(
+        rustc::potential_query_instability,
+        reason = "the names are sorted before being returned"
+    )]
     let mut names = sess
         .check_config
         .well_known_names

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -200,7 +200,10 @@ fn parse_rust_feature_list<'a>(
             while let Some(new_feature) = new_features.pop() {
                 if features.insert(new_feature) {
                     if let Some(implied_features) = inverse_implied_features.get(&new_feature) {
-                        #[allow(rustc::potential_query_instability)]
+                        #[allow(
+                            rustc::potential_query_instability,
+                            reason = "traversal order does not change the final set"
+                        )]
                         new_features.extend(implied_features)
                     }
                 }

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -9,7 +9,7 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::default_hash_types)]
-#![allow(rustc::potential_query_instability)]
+#![allow(rustc::potential_query_instability, reason = "unordered containers are this crate's API")]
 #![cfg_attr(test, feature(test))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![feature(allocator_api)]

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -660,7 +660,10 @@ pub(super) fn try_match_macro_attr<'matcher, T: Tracker<'matcher>>(
         match result {
             Success(body_named_matches) => {
                 psess.gated_spans.merge(gated_spans_snapshot);
-                #[allow(rustc::potential_query_instability)]
+                #[allow(
+                    rustc::potential_query_instability,
+                    reason = "named matches are queried by metavariable name after merging"
+                )]
                 named_matches.extend(body_named_matches);
                 return Ok((i, rule, named_matches));
             }

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -309,7 +309,10 @@ fn transcribe_sequence<'tx, 'itp>(
             let mut repeatables = Vec::new();
             let mut non_repeatables = Vec::new();
 
-            #[allow(rustc::potential_query_instability)]
+            #[allow(
+                rustc::potential_query_instability,
+                reason = "diagnostic matching below handles equally good suggestions"
+            )]
             for (name, matcher) in interp.iter() {
                 if matcher.is_repeatable() {
                     repeatables.push(name);

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -290,7 +290,10 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
                     .and_modify(|v| match v {
                         ExpectedValues::Some(v) if !values_any_specified =>
                         {
-                            #[allow(rustc::potential_query_instability)]
+                            #[allow(
+                                rustc::potential_query_instability,
+                                reason = "extending this set does not observe insertion order"
+                            )]
                             v.extend(values.clone())
                         }
                         ExpectedValues::Some(_) => *v = ExpectedValues::Any,

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -518,7 +518,10 @@ fn extend_type_not_partial_eq<'tcx>(
             "must be annotated with `#[derive(PartialEq)]` to be usable in patterns",
         );
     }
-    #[allow(rustc::potential_query_instability)]
+    #[allow(
+        rustc::potential_query_instability,
+        reason = "the type names are sorted before emitting diagnostics"
+    )]
     let mut manual: Vec<_> = v.manual.into_iter().map(|t| t.to_string()).collect();
     manual.sort();
     for ty in manual {
@@ -526,7 +529,10 @@ fn extend_type_not_partial_eq<'tcx>(
             "`{ty}` must be annotated with `#[derive(PartialEq)]` to be usable in patterns, manual `impl`s are not sufficient; see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details"
         ));
     }
-    #[allow(rustc::potential_query_instability)]
+    #[allow(
+        rustc::potential_query_instability,
+        reason = "the type names are sorted before emitting diagnostics"
+    )]
     let mut without: Vec<_> = v.without.into_iter().map(|t| t.to_string()).collect();
     without.sort();
     for ty in without {

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -67,7 +67,10 @@ impl<V: Clone> Clone for StateData<V> {
 impl<V: JoinSemiLattice + Clone> JoinSemiLattice for StateData<V> {
     fn join(&mut self, other: &Self) -> bool {
         let mut changed = false;
-        #[allow(rustc::potential_query_instability)]
+        #[allow(
+            rustc::potential_query_instability,
+            reason = "the lattice join is applied independently for each value index"
+        )]
         for (i, v) in other.map.iter() {
             match self.map.entry(*i) {
                 StdEntry::Vacant(e) => {
@@ -552,7 +555,10 @@ impl<'tcx> Map<'tcx> {
                 *opt_place = None;
             }
         }
-        #[allow(rustc::potential_query_instability)]
+        #[allow(
+            rustc::potential_query_instability,
+            reason = "each projection is retained or removed independently"
+        )]
         self.projections.retain(|_, child| !self.inner_values[*child].is_empty());
     }
 

--- a/src/tools/clippy/clippy_lints/src/casts/needless_type_cast.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/needless_type_cast.rs
@@ -44,7 +44,10 @@ pub(super) fn check<'a>(cx: &LateContext<'a>, body: &Body<'a>) {
         ControlFlow::<()>::Continue(())
     });
 
-    #[allow(rustc::potential_query_instability)]
+    #[allow(
+        rustc::potential_query_instability,
+        reason = "the bindings are sorted by source span before being checked"
+    )]
     let mut binding_vec: Vec<_> = bindings.into_iter().collect();
     binding_vec.sort_by_key(|(_, info)| info.ty_span.lo());
 


### PR DESCRIPTION
Closes rust-lang/rust#84447.

This audits the remaining `#[allow(rustc::potential_query_instability)]` sites that did not have a local justification.

Changes:
- Add local comments explaining why unstable hash iteration does not affect the result at the remaining allow sites.
- Sort `unexpected_cfg_name` candidates before diagnostic matching so equally good suggestions are selected deterministically.
- Sort macro transcribe diagnostic buckets before typo matching for deterministic suggestions.

Verification:
- `git diff --check`
- local scan for `allow(rustc::potential_query_instability)` sites without adjacent comments: no output
- `./x fmt --check`
- `./x test tidy`
- `./x check compiler/rustc_attr_parsing compiler/rustc_expand compiler/rustc_interface compiler/rustc_codegen_ssa compiler/rustc_mir_build compiler/rustc_mir_dataflow`