### PR TITLE
Clarify MaybeUninit::zeroed padding docs

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -437,7 +437,8 @@ impl<T> MaybeUninit<T> {
     /// be null.
     ///
     /// Note that if `T` has padding bytes, those bytes are *not* preserved when the
-    /// `MaybeUninit<T>` value is returned from this function, so those bytes will *not* be zeroed.
+    /// `MaybeUninit<T>` value is returned from this function, so those bytes are not
+    /// guaranteed to be zeroed.
     ///
     /// Note that dropping a `MaybeUninit<T>` will never call `T`'s drop code.
     /// It is your responsibility to make sure `T` gets dropped if it got initialized.


### PR DESCRIPTION
Closes rust-lang/rust#111608.

This clarifies that padding bytes in `MaybeUninit::zeroed()` are not guaranteed to remain zeroed when the `MaybeUninit<T>` value is returned, matching the existing `mem::zeroed` documentation that padding is not necessarily zeroed.

Verification:
- `git diff --check`
- `./x fmt --check`
- `./x test tidy`
- `./x test library/core --doc`