### PR TITLE
Suggest `type` next to visibility for const items

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2930,12 +2930,25 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 span,
                 "use of `const` in the type system not defined as `type const`",
             );
-            if def_id.is_local() {
+            if let Some(local_def_id) = def_id.as_local() {
                 let name = tcx.def_path_str(def_id);
+                let (insertion_span, sugg) = match tcx.hir_node_by_def_id(local_def_id) {
+                    hir::Node::Item(item) if !item.vis_span.is_empty() => {
+                        (item.vis_span.shrink_to_hi(), " type")
+                    }
+                    hir::Node::ImplItem(impl_item)
+                        if let Some(vis_span) =
+                            impl_item.vis_span().filter(|span| !span.is_empty()) =>
+                    {
+                        (vis_span.shrink_to_hi(), " type")
+                    }
+                    _ => (tcx.def_span(def_id).shrink_to_lo(), "type "),
+                };
+
                 err.span_suggestion_verbose(
-                    tcx.def_span(def_id).shrink_to_lo(),
+                    insertion_span,
                     format!("add `type` before `const` for `{name}`"),
-                    format!("type "),
+                    sugg,
                     Applicability::MaybeIncorrect,
                 );
             } else {

--- a/tests/ui/const-generics/mgca/suggest-pub-type_const.fixed
+++ b/tests/ui/const-generics/mgca/suggest-pub-type_const.fixed
@@ -1,0 +1,53 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/157368>
+//! Tests suggesting `pub type const` instead of `type pub const`.
+//@ run-rustfix
+#![feature(min_generic_const_args, inherent_associated_types)]
+#![allow(dead_code)]
+
+mod impl_item {
+    pub struct Bar;
+    impl Bar {
+        pub type const PUBLIC: usize = 1;
+        pub(crate) type const RESTRICTED: usize = 1;
+        type const PRIVATE: usize = 1;
+    }
+
+    pub struct Foo1([u8; Bar::PUBLIC]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo2([u8; Bar::RESTRICTED]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo3([u8; Bar::PRIVATE]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+}
+
+mod top_level_item {
+    pub type const PUBLIC: usize = 1;
+    pub(crate) type const RESTRICTED: usize = 1;
+    type const PRIVATE: usize = 1;
+
+    pub struct Foo1([u8; PUBLIC]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo2([u8; RESTRICTED]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo3([u8; PRIVATE]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+}
+
+mod trait_item {
+    pub trait Foo {
+        type  const PUBLIC: usize;
+        //~^ ERROR: [E0449]
+        type  const RESTRICTED: usize;
+        //~^ ERROR: [E0449]
+        type const PRIVATE: usize;
+    }
+
+    pub struct Bar<T: Foo>([u8; T::PUBLIC]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Bar2<T: Foo>([u8; T::RESTRICTED]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Bar3<T: Foo>([u8; T::PRIVATE]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/suggest-pub-type_const.rs
+++ b/tests/ui/const-generics/mgca/suggest-pub-type_const.rs
@@ -1,0 +1,53 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/157368>
+//! Tests suggesting `pub type const` instead of `type pub const`.
+//@ run-rustfix
+#![feature(min_generic_const_args, inherent_associated_types)]
+#![allow(dead_code)]
+
+mod impl_item {
+    pub struct Bar;
+    impl Bar {
+        pub const PUBLIC: usize = 1;
+        pub(crate) const RESTRICTED: usize = 1;
+        const PRIVATE: usize = 1;
+    }
+
+    pub struct Foo1([u8; Bar::PUBLIC]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo2([u8; Bar::RESTRICTED]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo3([u8; Bar::PRIVATE]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+}
+
+mod top_level_item {
+    pub const PUBLIC: usize = 1;
+    pub(crate) const RESTRICTED: usize = 1;
+    const PRIVATE: usize = 1;
+
+    pub struct Foo1([u8; PUBLIC]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo2([u8; RESTRICTED]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Foo3([u8; PRIVATE]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+}
+
+mod trait_item {
+    pub trait Foo {
+        pub const PUBLIC: usize;
+        //~^ ERROR: [E0449]
+        pub(crate) const RESTRICTED: usize;
+        //~^ ERROR: [E0449]
+        const PRIVATE: usize;
+    }
+
+    pub struct Bar<T: Foo>([u8; T::PUBLIC]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Bar2<T: Foo>([u8; T::RESTRICTED]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+    pub struct Bar3<T: Foo>([u8; T::PRIVATE]);
+    //~^ ERROR: use of `const` in the type system not defined as `type const`
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/suggest-pub-type_const.stderr
+++ b/tests/ui/const-generics/mgca/suggest-pub-type_const.stderr
@@ -1,0 +1,118 @@
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/suggest-pub-type_const.rs:38:9
+   |
+LL |         pub const PUBLIC: usize;
+   |         ^^^ help: remove the qualifier
+   |
+   = note: trait items always share the visibility of their trait
+
+error[E0449]: visibility qualifiers are not permitted here
+  --> $DIR/suggest-pub-type_const.rs:40:9
+   |
+LL |         pub(crate) const RESTRICTED: usize;
+   |         ^^^^^^^^^^ help: remove the qualifier
+   |
+   = note: trait items always share the visibility of their trait
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:15:26
+   |
+LL |     pub struct Foo1([u8; Bar::PUBLIC]);
+   |                          ^^^^^^^^^^^
+   |
+help: add `type` before `const` for `impl_item::Bar::PUBLIC`
+   |
+LL |         pub type const PUBLIC: usize = 1;
+   |             ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:17:26
+   |
+LL |     pub struct Foo2([u8; Bar::RESTRICTED]);
+   |                          ^^^^^^^^^^^^^^^
+   |
+help: add `type` before `const` for `impl_item::Bar::RESTRICTED`
+   |
+LL |         pub(crate) type const RESTRICTED: usize = 1;
+   |                    ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:19:26
+   |
+LL |     pub struct Foo3([u8; Bar::PRIVATE]);
+   |                          ^^^^^^^^^^^^
+   |
+help: add `type` before `const` for `impl_item::Bar::PRIVATE`
+   |
+LL |         type const PRIVATE: usize = 1;
+   |         ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:28:26
+   |
+LL |     pub struct Foo1([u8; PUBLIC]);
+   |                          ^^^^^^
+   |
+help: add `type` before `const` for `PUBLIC`
+   |
+LL |     pub type const PUBLIC: usize = 1;
+   |         ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:30:26
+   |
+LL |     pub struct Foo2([u8; RESTRICTED]);
+   |                          ^^^^^^^^^^
+   |
+help: add `type` before `const` for `RESTRICTED`
+   |
+LL |     pub(crate) type const RESTRICTED: usize = 1;
+   |                ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:32:26
+   |
+LL |     pub struct Foo3([u8; PRIVATE]);
+   |                          ^^^^^^^
+   |
+help: add `type` before `const` for `PRIVATE`
+   |
+LL |     type const PRIVATE: usize = 1;
+   |     ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:45:33
+   |
+LL |     pub struct Bar<T: Foo>([u8; T::PUBLIC]);
+   |                                 ^^^^^^^^^
+   |
+help: add `type` before `const` for `Foo::PUBLIC`
+   |
+LL |         type pub const PUBLIC: usize;
+   |         ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:47:34
+   |
+LL |     pub struct Bar2<T: Foo>([u8; T::RESTRICTED]);
+   |                                  ^^^^^^^^^^^^^
+   |
+help: add `type` before `const` for `Foo::RESTRICTED`
+   |
+LL |         type pub(crate) const RESTRICTED: usize;
+   |         ++++
+
+error: use of `const` in the type system not defined as `type const`
+  --> $DIR/suggest-pub-type_const.rs:49:34
+   |
+LL |     pub struct Bar3<T: Foo>([u8; T::PRIVATE]);
+   |                                  ^^^^^^^^^^
+   |
+help: add `type` before `const` for `Foo::PRIVATE`
+   |
+LL |         type const PRIVATE: usize;
+   |         ++++
+
+error: aborting due to 11 previous errors
+
+For more information about this error, try `rustc --explain E0449`.


### PR DESCRIPTION
resolve: https://github.com/rust-lang/rust/issues/157368

Adjusts the `type const` suggestion to preserve visibility ordering, so `pub const` is suggested as `pub type const` instead of `type pub const`.