### PR TITLE
tests: codegen-llvm: Ignore BPF targets in c-variadic-opt

### DIFF
--- a/src/tools/compiletest/src/directives/directive_names.rs
+++ b/src/tools/compiletest/src/directives/directive_names.rs
@@ -61,6 +61,7 @@ pub(crate) const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-avr",
     "ignore-backends",
     "ignore-beta",
+    "ignore-bpf",
     "ignore-cdb",
     "ignore-compare-mode-next-solver",
     "ignore-compare-mode-polonius",

--- a/tests/codegen-llvm/cffi/c-variadic-opt.rs
+++ b/tests/codegen-llvm/cffi/c-variadic-opt.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -C opt-level=3
+//@ ignore-bpf: BPF does not support C variadics
 
 #![crate_type = "lib"]
 #![feature(c_variadic)]


### PR DESCRIPTION
BPF does not support C variadics.

r? @nagisa
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
