### PR TITLE
Parse deprecated note links separately in rustc_resolve

### DIFF
--- a/compiler/rustc_resolve/src/rustdoc.rs
+++ b/compiler/rustc_resolve/src/rustdoc.rs
@@ -412,17 +412,16 @@ pub fn may_be_doc_link(link_type: LinkType) -> bool {
 pub(crate) fn attrs_to_preprocessed_links(attrs: &[ast::Attribute]) -> Vec<Box<str>> {
     let (doc_fragments, other_attrs) =
         attrs_to_doc_fragments(attrs.iter().map(|attr| (attr, None)), false);
-    let mut doc =
-        prepare_to_doc_link_resolution(&doc_fragments).into_values().next().unwrap_or_default();
+    let doc = prepare_to_doc_link_resolution(&doc_fragments).into_values().next();
+    let mut links = doc.as_deref().map(parse_links).unwrap_or_default();
 
     for attr in other_attrs {
         if let Some(note) = attr.deprecation_note() {
-            doc += note.as_str();
-            doc += "\n";
+            links.extend(parse_links(note.as_str()));
         }
     }
 
-    parse_links(&doc)
+    links
 }
 
 /// Similar version of `markdown_links` from rustdoc.

--- a/tests/rustdoc-ui/intra-doc/deprecated-note-link-after-unclosed-code-fence.rs
+++ b/tests/rustdoc-ui/intra-doc/deprecated-note-link-after-unclosed-code-fence.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+
+// Regression test for https://github.com/rust-lang/rust/issues/157326.
+#![allow(rustdoc::invalid_rust_codeblocks)]
+#![deprecated(note = "use [Env::try_invoke] instead")]
+//! ```
+
+pub struct Env;
+
+impl Env {
+    pub fn try_invoke(&self) {}
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157326

`rustc_resolve` pre-caches intra-doc link resolutions for rustdoc. It previously parsed doc comments and `#[deprecated(note = "...")]` text as one Markdown document.