### PR TITLE
[POC] `{cwd}` placeholder in `--remap-path-prefix`

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -25,7 +25,7 @@ use rustc_session::utils::{CanonicalizedPath, NativeLib};
 use rustc_session::{CompilerIO, EarlyDiagCtxt, Session, build_session, getopts};
 use rustc_span::edition::{DEFAULT_EDITION, Edition};
 use rustc_span::source_map::{RealFileLoader, SourceMapInputs};
-use rustc_span::{FileName, SourceFileHashAlgorithm, sym};
+use rustc_span::{FileName, RealFileName, RemapPathScopeComponents, SourceFileHashAlgorithm, sym};
 use rustc_target::spec::{
     CodeModel, FramePointer, LinkerFlavorCli, MergeFunctions, OnBrokenPipe, PanicStrategy,
     RelocModel, RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, TlsModel,
@@ -172,6 +172,59 @@ fn test_can_print_warnings() {
 
     sess_and_cfg(&["-Adead_code"], |sess, _cfg| {
         assert!(sess.dcx().can_emit_warnings());
+    });
+}
+
+// `--remap-path-prefix={cwd}=...` stores the `{cwd}` placeholder verbatim (so the absolute cwd
+// never enters the tracked option and the incremental cache survives across build directories,
+// see #132132) and expands it only when the mapping is applied.
+#[test]
+fn test_remap_path_prefix_cwd_placeholder() {
+    sess_and_cfg(&["--remap-path-prefix={cwd}/sub=mapped"], |sess, _cfg| {
+        // Stored verbatim as the placeholder text, not the resolved cwd.
+        assert_eq!(
+            sess.opts.remap_path_prefix,
+            vec![(PathBuf::from("{cwd}/sub"), PathBuf::from("mapped"))],
+        );
+        // ... but expanded + applied to real paths under the cwd.
+        let cwd = std::env::current_dir().unwrap();
+        let remapped = sess
+            .opts
+            .file_path_mapping()
+            .to_real_filename(&RealFileName::empty(), cwd.join("sub").join("foo.rs"))
+            .path(RemapPathScopeComponents::DEBUGINFO)
+            .to_path_buf();
+        assert_eq!(remapped, PathBuf::from("mapped/foo.rs"));
+    });
+}
+
+// `{{cwd}}` is an escaped literal `{cwd}` directory, NOT the placeholder, and is not expanded.
+#[test]
+fn test_remap_path_prefix_escaped_braces_are_literal() {
+    sess_and_cfg(&["--remap-path-prefix={{cwd}}/x=mapped"], |sess, _cfg| {
+        assert_eq!(
+            sess.opts.remap_path_prefix,
+            vec![(PathBuf::from("{{cwd}}/x"), PathBuf::from("mapped"))],
+        );
+        // Maps the literal prefix `{cwd}/x`, and does not touch the real cwd.
+        let remapped = sess
+            .opts
+            .file_path_mapping()
+            .to_real_filename(&RealFileName::empty(), PathBuf::from("{cwd}/x/foo.rs"))
+            .path(RemapPathScopeComponents::DEBUGINFO)
+            .to_path_buf();
+        assert_eq!(remapped, PathBuf::from("mapped/foo.rs"));
+    });
+}
+
+// `-Zremap-cwd-prefix` is sugar for `--remap-path-prefix={cwd}=VALUE`: same stored placeholder.
+#[test]
+fn test_remap_cwd_prefix_stores_placeholder() {
+    sess_and_cfg(&["-Zremap-cwd-prefix=mapped"], |sess, _cfg| {
+        assert_eq!(
+            sess.opts.remap_path_prefix,
+            vec![(PathBuf::from("{cwd}"), PathBuf::from("mapped"))],
+        );
     });
 }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -7,7 +7,7 @@ use std::collections::btree_map::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsStr;
 use std::hash::Hash;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::str::{self, FromStr};
 use std::sync::LazyLock;
 use std::{cmp, fs, iter};
@@ -1373,11 +1373,43 @@ pub fn host_tuple() -> &'static str {
     (option_env!("CFG_COMPILER_HOST_TRIPLE")).expect("CFG_COMPILER_HOST_TRIPLE")
 }
 
+/// If `component` is a whole `{name}` placeholder, returns `Some(name)`. `{{`/`}}`-escaped
+/// components (e.g. `{{cwd}}`) are not placeholders and return `None`.
+fn remap_placeholder_name(component: &OsStr) -> Option<&str> {
+    let inner = component.to_str()?.strip_prefix('{')?.strip_suffix('}')?;
+    (!inner.is_empty() && !inner.contains(['{', '}'])).then_some(inner)
+}
+
+/// Expands a `--remap-path-prefix` FROM path: a `{cwd}` component becomes the working
+/// directory, and `{{`/`}}` are unescaped to `{`/`}`. Expansion happens here, at apply time;
+/// the FROM is stored with the placeholder intact, so the tracked option is stable across
+/// build directories and the incremental cache survives. See #132132.
+fn expand_remap_path_prefix(from: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for comp in from.components() {
+        match comp {
+            Component::Normal(seg) if remap_placeholder_name(seg) == Some("cwd") => {
+                out.push(std::env::current_dir().ok()?)
+            }
+            Component::Normal(seg) => match seg.to_str() {
+                Some(s) => out.push(s.replace("{{", "{").replace("}}", "}")),
+                None => out.push(seg),
+            },
+            other => out.push(other),
+        }
+    }
+    Some(out)
+}
+
 fn file_path_mapping(
     remap_path_prefix: Vec<(PathBuf, PathBuf)>,
     remap_path_scope: RemapPathScopeComponents,
 ) -> FilePathMapping {
-    FilePathMapping::new(remap_path_prefix.clone(), remap_path_scope)
+    let mapping = remap_path_prefix
+        .into_iter()
+        .filter_map(|(from, to)| Some((expand_remap_path_prefix(&from)?, to)))
+        .collect();
+    FilePathMapping::new(mapping, remap_path_scope)
 }
 
 impl Default for Options {
@@ -2396,13 +2428,23 @@ fn parse_remap_path_prefix(
             Some((from, to)) => (PathBuf::from(from), PathBuf::from(to)),
         })
         .collect();
-    match &unstable_opts.remap_cwd_prefix {
-        Some(to) => match std::env::current_dir() {
-            Ok(cwd) => mapping.push((cwd, to.clone())),
-            Err(_) => (),
-        },
-        None => (),
-    };
+    // `-Zremap-cwd-prefix=VALUE` is sugar for `--remap-path-prefix={cwd}=VALUE`. See #132132.
+    if let Some(to) = &unstable_opts.remap_cwd_prefix {
+        mapping.push((PathBuf::from("{cwd}"), to.clone()));
+    }
+    // Only `{cwd}` is a recognised placeholder; reject typos like `{cdw}`.
+    for (from, _) in &mapping {
+        for comp in from.components() {
+            if let Component::Normal(seg) = comp
+                && let Some(name) = remap_placeholder_name(seg)
+                && name != "cwd"
+            {
+                early_dcx.early_fatal(format!(
+                    "unknown placeholder `{{{name}}}` in `--remap-path-prefix`"
+                ));
+            }
+        }
+    }
     mapping
 }
 

--- a/tests/ui/errors/remap-path-prefix-unknown-placeholder.rs
+++ b/tests/ui/errors/remap-path-prefix-unknown-placeholder.rs
@@ -1,0 +1,8 @@
+// Unknown `{name}` placeholders in `--remap-path-prefix` are rejected.
+// A literal `{foo}` directory would be written `{{foo}}`.
+//
+//@ compile-flags: --remap-path-prefix={foo}=bar
+
+fn main() {}
+
+//~? ERROR unknown placeholder `{foo}` in `--remap-path-prefix`

--- a/tests/ui/errors/remap-path-prefix-unknown-placeholder.stderr
+++ b/tests/ui/errors/remap-path-prefix-unknown-placeholder.stderr
@@ -1,0 +1,2 @@
+error: unknown placeholder `{foo}` in `--remap-path-prefix`
+


### PR DESCRIPTION
> [!WARNING]
> **Proof-of-concept, do not merge.** Validates feasibility + CI ahead of a Major Change Proposal, since it adds placeholder semantics to the **stable** `--remap-path-prefix` flag. Companion to #157348 (the minimal, unstable-only fix that can land now).

## Idea

Let a `--remap-path-prefix` FROM contain a `{cwd}` placeholder:

```
--remap-path-prefix={cwd}=.
--remap-path-prefix={cwd}/lib/std=std
```

The FROM is **stored verbatim** in `remap_path_prefix`, and the placeholder is expanded to the working directory only when the `FilePathMapping` is built (apply time). So:

- The stored value is the placeholder text (`{cwd}/sub`), not the absolute cwd → its dependency hash is **stable across build directories** → the incremental cache survives (fixes the cwd half of rust-lang/rust#132132).
- No new type and no change to the field, tracking, decoder, or rustdoc — storing the template verbatim keeps `{cwd}` (placeholder) and `{{cwd}}` (escaped literal) distinct in storage, so a plain `PathBuf` is sufficient.

`-Zremap-cwd-prefix=V` is reimplemented as exactly sugar for `--remap-path-prefix={cwd}=V`, giving a path to sunset that unstable flag.

## Escaping

`format!`-style: a path component `{cwd}` is the placeholder; `{{`/`}}` are literal `{`/`}`, so a literal `{cwd}` directory is written `{{cwd}}`.

## Why `{cwd}` (vs `<cwd>`, `%cwd%`, `\(cwd)`)

- `format!` syntax — native to Rust, self-escaping (`{{`/`}}`), doesn't look path-like.
- `<cwd>` / `\(cwd)`: shell redirection / backslash issues (`\` is the Windows path separator).
- `%cwd%`: collides with cmd.exe `%VAR%` (`%CD%`).

(Hand-typed it's quoted like any tool-level token; build systems pass argv with no shell, so it arrives verbatim.)

## Open questions for the MCP

- Placeholder **syntax** + escaping (`{cwd}`, `{{`/`}}` here).
- **Unknown placeholder** handling — kept literal here; erroring may be better.
- Whole-component vs substring placeholders (whole-component here).
- Interaction with `--remap-path-scope`; relationship to [RFC 3127](https://github.com/rust-lang/rfcs/pull/3127).
- Stable-surface change → requires team sign-off (MCP).

## Tests

`{cwd}/sub` stored-verbatim + applied; escaped `{{cwd}}` stays literal; `-Zremap-cwd-prefix` → `{cwd}` equivalence.

r? compiler
