### PR TITLE
Implement rustc_public::CrateDef{,Type} for FieldDef

### DIFF
--- a/compiler/rustc_public/src/compiler_interface.rs
+++ b/compiler/rustc_public/src/compiler_interface.rs
@@ -136,6 +136,13 @@ impl<'tcx> CompilerInterface<'tcx> {
         })
     }
 
+    pub(crate) fn crate_adts(&self, crate_num: CrateNum) -> Vec<AdtDef> {
+        self.with_cx(|tables, cx| {
+            let krate = crate_num.internal(tables, cx.tcx);
+            cx.crate_adts(krate).iter().map(|did| tables.adt_def(*did)).collect()
+        })
+    }
+
     /// Retrieve all static items defined in this crate.
     pub(crate) fn crate_statics(&self, crate_num: CrateNum) -> Vec<StaticDef> {
         self.with_cx(|tables, cx| {

--- a/compiler/rustc_public/src/crate_def.rs
+++ b/compiler/rustc_public/src/crate_def.rs
@@ -165,4 +165,30 @@ macro_rules! crate_def_with_ty {
 
         impl CrateDefType for $name {}
     };
+    ( $(#[$attr:meta])*
+      $vis:vis $name:ident {
+        $(
+            $(#[$f_attr:meta])*
+            $f_vis:vis $f_name:ident: $f_ty:ty,
+        )*
+      }
+    ) => {
+        $(#[$attr])*
+        #[derive(Clone, PartialEq, Eq, Debug)]
+        $vis struct $name {
+            pub(crate) def: DefId,
+            $(
+                $(#[$f_attr])*
+                $f_vis $f_name: $f_ty,
+            )*
+        }
+
+        impl CrateDef for $name {
+            fn def_id(&self) -> DefId {
+                self.def
+            }
+        }
+
+        impl CrateDefType for $name {}
+    };
 }

--- a/compiler/rustc_public/src/lib.rs
+++ b/compiler/rustc_public/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::error::*;
 use crate::mir::mono::StaticDef;
 use crate::mir::{Body, Mutability};
 use crate::ty::{
-    AssocItem, FnDef, ForeignModuleDef, ImplDef, ProvenanceMap, Span, TraitDef, Ty,
+    AdtDef, AssocItem, FnDef, ForeignModuleDef, ImplDef, ProvenanceMap, Span, TraitDef, Ty,
     serialize_index_impl,
 };
 use crate::unstable::Stable;
@@ -113,6 +113,11 @@ impl Crate {
     /// Return a list of static items defined in this crate independent on their visibility.
     pub fn statics(&self) -> Vec<StaticDef> {
         with(|cx| cx.crate_statics(self.id))
+    }
+
+    /// Return a list of ADTs defined in this crate independent on their visibility.
+    pub fn adts(&self) -> Vec<AdtDef> {
+        with(|cx| cx.crate_adts(self.id))
     }
 }
 

--- a/compiler/rustc_public/src/ty.rs
+++ b/compiler/rustc_public/src/ty.rs
@@ -897,26 +897,11 @@ impl VariantDef {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct FieldDef {
-    /// The field definition.
-    pub(crate) def: DefId,
-
-    /// The field name.
-    pub name: Symbol,
-}
-
-impl FieldDef {
-    /// Retrieve the type of this field instantiating and normalizing it with the given arguments.
-    ///
-    /// This will assume the type can be instantiated with these arguments.
-    pub fn ty_with_args(&self, args: &GenericArgs) -> Ty {
-        with(|cx| cx.def_ty_with_args(self.def, args))
-    }
-
-    /// Retrieve the type of this field.
-    pub fn ty(&self) -> Ty {
-        with(|cx| cx.def_ty(self.def))
+crate_def_with_ty! {
+    #[derive(Serialize)]
+    pub FieldDef {
+        /// The field name.
+        pub name: Symbol,
     }
 }
 

--- a/compiler/rustc_public_bridge/src/context/impls.rs
+++ b/compiler/rustc_public_bridge/src/context/impls.rs
@@ -110,6 +110,11 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
         matches!(self.tcx.def_kind(def_id), DefKind::Static { .. }).then(|| def_id)
     }
 
+    fn filter_adt_def(&self, def_id: DefId) -> Option<DefId> {
+        matches!(self.tcx.def_kind(def_id), DefKind::Struct | DefKind::Enum | DefKind::Union)
+            .then(|| def_id)
+    }
+
     pub fn target_endian(&self) -> Endian {
         self.tcx.data_layout.endian
     }
@@ -150,6 +155,11 @@ impl<'tcx, B: Bridge> CompilerCtxt<'tcx, B> {
     /// Retrieve all static items defined in this crate.
     pub fn crate_statics(&self, crate_num: CrateNum) -> Vec<DefId> {
         filter_def_ids(self.tcx, crate_num, |def_id| self.filter_static_def(def_id))
+    }
+
+    /// Retrieve all ADTs defined in this crate.
+    pub fn crate_adts(&self, crate_num: CrateNum) -> Vec<DefId> {
+        filter_def_ids(self.tcx, crate_num, |def_id| self.filter_adt_def(def_id))
     }
 
     pub fn foreign_module(&self, mod_def: DefId) -> &ForeignModule {

--- a/tests/ui-fulldeps/rustc_public/check_attribute.rs
+++ b/tests/ui-fulldeps/rustc_public/check_attribute.rs
@@ -15,6 +15,7 @@ extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 
+use rustc_public::ty::AdtDef;
 use rustc_public::{CrateDef, CrateItems};
 use std::io::Write;
 use std::ops::ControlFlow;
@@ -25,14 +26,15 @@ const CRATE_NAME: &str = "input";
 fn test_stable_mir() -> ControlFlow<()> {
     // Find items in the local crate.
     let items = rustc_public::all_local_items();
+    let adts = rustc_public::local_crate().adts();
 
-    test_tool(&items);
+    test_tool(&items, &adts);
 
     ControlFlow::Continue(())
 }
 
 // Test tool attributes.
-fn test_tool(items: &CrateItems) {
+fn test_tool(items: &CrateItems, adts: &[AdtDef]) {
     let rustfmt_fn = *get_item(&items, "do_not_format").unwrap();
     let rustfmt_attrs = rustfmt_fn.tool_attrs(&["rustfmt".to_string(), "skip".to_string()]);
     assert_eq!(rustfmt_attrs[0].as_str(), "#[rustfmt::skip]\n");
@@ -41,10 +43,22 @@ fn test_tool(items: &CrateItems) {
     let clippy_attrs =
         clippy_fn.tool_attrs(&["clippy".to_string(), "cyclomatic_complexity".to_string()]);
     assert_eq!(clippy_attrs[0].as_str(), "#[clippy::cyclomatic_complexity = \"100\"]\n");
+
+    let cake_struct = *get_adt(adts, "Cake").unwrap();
+    let cake_variant = cake_struct.variants()[0];
+    let fields = cake_variant.fields();
+    let sugar_field = fields.iter().find(|f| f.name == "cake_sugar").unwrap();
+    let cake_attrs =
+        sugar_field.tool_attrs(&["clippy".to_string(), "struct_field_names".to_string()]);
+    assert_eq!(cake_attrs[0].as_str(), "#[clippy::struct_field_names]\n");
 }
 
 fn get_item<'a>(items: &'a CrateItems, name: &str) -> Option<&'a rustc_public::CrateItem> {
     items.iter().find(|crate_item| crate_item.trimmed_name() == name)
+}
+
+fn get_adt<'a>(adts: &'a [AdtDef], name: &str) -> Option<&'a AdtDef> {
+    adts.iter().find(|adt| adt.trimmed_name() == name)
 }
 
 /// This test will generate and analyze a dummy crate using the stable mir.
@@ -86,6 +100,15 @@ fn generate_input(path: &str) -> std::io::Result<()> {
         // A derive attribute to automatically implement a trait.
         #[derive(Debug, Clone, Copy)]
         struct Foo(u32);
+
+        // Field annotations.
+        pub struct Cake {{
+            #[clippy::struct_field_names]
+            cake_sugar: u8,
+            #[clippy::struct_field_names]
+            cake_flour: u8,
+            cake_eggs: u8
+        }}
 
         // A rustfmt tool attribute.
         #[rustfmt::skip]

--- a/tests/ui-fulldeps/rustc_public/check_ty_fold.rs
+++ b/tests/ui-fulldeps/rustc_public/check_ty_fold.rs
@@ -16,6 +16,7 @@ extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 
+use rustc_public::CrateDefType;
 use rustc_public::mir::{
     Body, FieldIdx, MirVisitor, Place, ProjectionElem,
     visit::{Location, PlaceContext},


### PR DESCRIPTION
This makes a few changes to rustc_public to make it a little easier to analyze ADT types.

* It implements `CrateDef` and `CrateDefType` for `FieldDef`, which allows easy access to the underlying `DefId`, names, and tool annotations.
* It adds `Crate::adts` to simplify stepping through all the ADTs in the crate.

Note that I did use Gemini to assist with writing this patch, but I wrote most of it, reviewed all the vode, and verified the tests pass locally.