### PR TITLE
std tests: avoid duplicating thread-local machinery

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -383,6 +383,7 @@
 #![feature(str_internals)]
 #![feature(sync_unsafe_cell)]
 #![feature(temporary_niche_types)]
+#![feature(thread_local_internals)]
 #![feature(ub_checks)]
 #![feature(uint_carryless_mul)]
 #![feature(used_with_arg)]

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -199,6 +199,7 @@ pub use id::ThreadId;
 pub use join_handle::JoinHandle;
 pub(crate) use lifecycle::ThreadInit;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg(not(test))] // we use the realstd types instead, see below
 pub use local::{AccessError, LocalKey};
 #[stable(feature = "scoped_threads", since = "1.63.0")]
 pub use scoped::{Scope, ScopedJoinHandle, scope};
@@ -210,10 +211,18 @@ pub use thread::Thread;
 // Implementation details used by the thread_local!{} macro.
 #[doc(hidden)]
 #[unstable(feature = "thread_local_internals", issue = "none")]
+#[cfg(not(test))] // we use the realstd types instead, see below
 pub mod local_impl {
     pub use super::local::thread_local_process_attrs;
     pub use crate::sys::thread_local::*;
 }
+// Under cfg(test), avoid having two instances of the thread-local machinery.
+// Things too easily get mixed up and then we end up with memory leaks because we're not calling
+// all the right dtors.
+#[cfg(test)]
+pub use realstd::thread::local_impl;
+#[cfg(test)]
+pub use realstd::thread::{AccessError, LocalKey};
 
 /// A specialized [`Result`] type for threads.
 ///


### PR DESCRIPTION
Under `cfg(test)` we have two copies of the standard library loaded, including two copies of all its global variables. Something about how that interacts with https://github.com/rust-lang/rust/pull/148799 results in memory leaks on windows-gnu targets, which are [caught by Miri](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Miri.20test-libstd.20Failure.20.282026-06.29/near/599991435).

I'm not sure if it's worth debugging this. It's easier to just avoid duplicating the thread-local machinery.

(This is something we had already done in the past, and then at some point stopped doing as Miri showed no more problems with the duplicate machinery. Now the problems are back.)

Cc @joboet @ChrisDenton 