### PR TITLE
Windows TLS: avoid atexit call in Miri

### DIFF
--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -155,9 +155,13 @@ pub fn enable() {
                     //
                     // If a main non-Rust binary is exiting, it must not be trigger the `enable` guard
                     // for the first time during process shutdown.
-                    let res = unsafe { c::atexit(free_fls_key_at_exit) };
-                    if res != 0 {
-                        rtabort!("failed to register fls atexit hook");
+                    //
+                    // Miri has no DLL unloading so we can skip this step here.
+                    if !cfg!(miri) {
+                        let res = unsafe { c::atexit(free_fls_key_at_exit) };
+                        if res != 0 {
+                            rtabort!("failed to register fls atexit hook");
+                        }
                     }
 
                     new_key

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -1400,18 +1400,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: this should return a nonzero value if this call does result in switching to another thread.
                 this.write_null(dest)?;
             }
-            "atexit" if this.frame_in_std() => {
-                let [_value] = this.check_shim_sig(
-                    shim_sig!(extern "C" fn(*const _) -> winapi::c_int),
-                    link_name,
-                    abi,
-                    args,
-                )?;
-
-                // We do not support registering atexit handlers, which is used by the thread-local destructor implementation in std.
-                // But we also do not support manually unloading DLLs, so this has no visible effect.
-                this.write_int(0, dest)?;
-            }
 
             _ => return interp_ok(EmulateItemResult::NotSupported),
         }


### PR DESCRIPTION
This was added in https://github.com/rust-lang/rust/pull/148799. I did not realize that we're actually falsely pretending that `atexit` worked, I thought we'd always return an error. Having it pretend to work when really it did nothing seems like a bad idea so let's just skip that call under `cfg(miri)`.

r? @ChrisDenton 
Cc @ohadravid 