### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/crate_level.rs
@@ -314,7 +314,7 @@ impl CombineAttributeParser for RegisterToolParser {
     const PATH: &[Symbol] = &[sym::register_tool];
     type Item = Ident;
     const CONVERT: ConvertFn<Self::Item> = |tools, _span| AttributeKind::RegisterTool(tools);
-    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(ALL_TARGETS);
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Crate)]);
     const TEMPLATE: AttributeTemplate = template!(List: &["tool1, tool2, ..."]);
     const STABILITY: AttributeStability = unstable!(register_tool);
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3810,6 +3810,11 @@ unsafe impl<T, A: Allocator> ops::DerefPure for Vec<T, A> {}
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone, A: Allocator + Clone> Clone for Vec<T, A> {
+    /// Creates a new `Vec` by deep-copying the contents of an existing `Vec`.
+    ///
+    /// This method will allocate a new `Vec` and `clone` all of `self`'s contents
+    /// into it. The capacity of the duplicate `Vec` is not forced to match the
+    /// capacity of the original.
     fn clone(&self) -> Self {
         let alloc = self.allocator().clone();
         <[T]>::to_vec_in(&**self, alloc)

--- a/tests/ui/attributes/attr-on-mac-call.rs
+++ b/tests/ui/attributes/attr-on-mac-call.rs
@@ -1,6 +1,7 @@
 //@ check-fail
 // Regression test for https://github.com/rust-lang/rust/issues/145779
 #![warn(unused_attributes)]
+#![feature(register_tool)]
 #![feature(sanitize)]
 
 fn main() {
@@ -105,5 +106,8 @@ fn main() {
     #[repr(simd)]
     //~^ WARN attribute cannot be used on macro calls
     //~| WARN previously accepted
+    unreachable!();
+    #[register_tool(xyz)]
+    //~^ WARN crate-level attribute should be an inner attribute
     unreachable!();
 }

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -1,5 +1,5 @@
 error: `#[sanitize]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:76:5
+  --> $DIR/attr-on-mac-call.rs:77:5
    |
 LL |     #[sanitize(address = "off")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     #[sanitize(address = "off")]
    = help: `#[sanitize]` can be applied to crates, functions, impl blocks, modules, and statics
 
 warning: `#[export_name]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:7:5
+  --> $DIR/attr-on-mac-call.rs:8:5
    |
 LL |     #[export_name = "x"]
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -21,7 +21,7 @@ LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: `#[naked]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:10:5
+  --> $DIR/attr-on-mac-call.rs:11:5
    |
 LL |     #[unsafe(naked)]
    |     ^^^^^^^^^^^^^^^^
@@ -30,7 +30,7 @@ LL |     #[unsafe(naked)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[track_caller]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:13:5
+  --> $DIR/attr-on-mac-call.rs:14:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     #[track_caller]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[used]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:16:5
+  --> $DIR/attr-on-mac-call.rs:17:5
    |
 LL |     #[used]
    |     ^^^^^^^
@@ -48,7 +48,7 @@ LL |     #[used]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[target_feature]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:19:5
+  --> $DIR/attr-on-mac-call.rs:20:5
    |
 LL |     #[target_feature(enable = "x")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ LL |     #[target_feature(enable = "x")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[deprecated]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:22:5
+  --> $DIR/attr-on-mac-call.rs:23:5
    |
 LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |     #[deprecated]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[inline]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:25:5
+  --> $DIR/attr-on-mac-call.rs:26:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     #[inline]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:28:5
+  --> $DIR/attr-on-mac-call.rs:29:5
    |
 LL |     #[link_name = "x"]
    |     ^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL |     #[link_name = "x"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:31:5
+  --> $DIR/attr-on-mac-call.rs:32:5
    |
 LL |     #[link_section = "__TEXT,__text"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ LL |     #[link_section = "__TEXT,__text"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_ordinal]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:34:5
+  --> $DIR/attr-on-mac-call.rs:35:5
    |
 LL |     #[link_ordinal(42)]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -102,7 +102,7 @@ LL |     #[link_ordinal(42)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[non_exhaustive]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:37:5
+  --> $DIR/attr-on-mac-call.rs:38:5
    |
 LL |     #[non_exhaustive]
    |     ^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |     #[non_exhaustive]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[proc_macro]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:40:5
+  --> $DIR/attr-on-mac-call.rs:41:5
    |
 LL |     #[proc_macro]
    |     ^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL |     #[proc_macro]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[cold]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:43:5
+  --> $DIR/attr-on-mac-call.rs:44:5
    |
 LL |     #[cold]
    |     ^^^^^^^
@@ -129,7 +129,7 @@ LL |     #[cold]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:46:5
+  --> $DIR/attr-on-mac-call.rs:47:5
    |
 LL |     #[no_mangle]
    |     ^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL |     #[no_mangle]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[deprecated]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:49:5
+  --> $DIR/attr-on-mac-call.rs:50:5
    |
 LL |     #[deprecated]
    |     ^^^^^^^^^^^^^
@@ -147,7 +147,7 @@ LL |     #[deprecated]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:52:5
+  --> $DIR/attr-on-mac-call.rs:53:5
    |
 LL |     #[automatically_derived]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -156,7 +156,7 @@ LL |     #[automatically_derived]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:55:5
+  --> $DIR/attr-on-mac-call.rs:56:5
    |
 LL |     #[macro_use]
    |     ^^^^^^^^^^^^
@@ -165,7 +165,7 @@ LL |     #[macro_use]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:58:5
+  --> $DIR/attr-on-mac-call.rs:59:5
    |
 LL |     #[must_use]
    |     ^^^^^^^^^^^
@@ -174,7 +174,7 @@ LL |     #[must_use]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:61:5
+  --> $DIR/attr-on-mac-call.rs:62:5
    |
 LL |     #[no_implicit_prelude]
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -183,7 +183,7 @@ LL |     #[no_implicit_prelude]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[path]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:64:5
+  --> $DIR/attr-on-mac-call.rs:65:5
    |
 LL |     #[path = ""]
    |     ^^^^^^^^^^^^
@@ -192,7 +192,7 @@ LL |     #[path = ""]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:67:5
+  --> $DIR/attr-on-mac-call.rs:68:5
    |
 LL |     #[ignore]
    |     ^^^^^^^^^
@@ -201,7 +201,7 @@ LL |     #[ignore]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:70:5
+  --> $DIR/attr-on-mac-call.rs:71:5
    |
 LL |     #[should_panic]
    |     ^^^^^^^^^^^^^^^
@@ -210,7 +210,7 @@ LL |     #[should_panic]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:73:5
+  --> $DIR/attr-on-mac-call.rs:74:5
    |
 LL |     #[link_name = "x"]
    |     ^^^^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ LL |     #[link_name = "x"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[repr()]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:80:5
+  --> $DIR/attr-on-mac-call.rs:81:5
    |
 LL |     #[repr()]
    |     ^^^^^^^^^
@@ -228,7 +228,7 @@ LL |     #[repr()]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: unused attribute
-  --> $DIR/attr-on-mac-call.rs:80:5
+  --> $DIR/attr-on-mac-call.rs:81:5
    |
 LL |     #[repr()]
    |     ^^^^^^^^^ help: remove this attribute
@@ -236,7 +236,7 @@ LL |     #[repr()]
    = note: using `repr` with an empty list has no effect
 
 warning: `#[repr(u8)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:85:5
+  --> $DIR/attr-on-mac-call.rs:86:5
    |
 LL |     #[repr(u8)]
    |     ^^^^^^^^^^^
@@ -245,7 +245,7 @@ LL |     #[repr(u8)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[repr(align(...))]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:89:5
+  --> $DIR/attr-on-mac-call.rs:90:5
    |
 LL |     #[repr(align(8))]
    |     ^^^^^^^^^^^^^^^^^
@@ -254,7 +254,7 @@ LL |     #[repr(align(8))]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[repr(packed)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:93:5
+  --> $DIR/attr-on-mac-call.rs:94:5
    |
 LL |     #[repr(packed)]
    |     ^^^^^^^^^^^^^^^
@@ -263,7 +263,7 @@ LL |     #[repr(packed)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[repr(C)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:97:5
+  --> $DIR/attr-on-mac-call.rs:98:5
    |
 LL |     #[repr(C)]
    |     ^^^^^^^^^^
@@ -272,7 +272,7 @@ LL |     #[repr(C)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[repr(Rust)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:101:5
+  --> $DIR/attr-on-mac-call.rs:102:5
    |
 LL |     #[repr(Rust)]
    |     ^^^^^^^^^^^^^
@@ -281,7 +281,7 @@ LL |     #[repr(Rust)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[repr(simd)]` attribute cannot be used on macro calls
-  --> $DIR/attr-on-mac-call.rs:105:5
+  --> $DIR/attr-on-mac-call.rs:106:5
    |
 LL |     #[repr(simd)]
    |     ^^^^^^^^^^^^^
@@ -289,5 +289,17 @@ LL |     #[repr(simd)]
    = help: `#[repr(simd)]` can only be applied to structs
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: aborting due to 1 previous error; 31 warnings emitted
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![register_tool]`
+  --> $DIR/attr-on-mac-call.rs:110:5
+   |
+LL |     #[register_tool(xyz)]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this macro call
+  --> $DIR/attr-on-mac-call.rs:112:5
+   |
+LL |     unreachable!();
+   |     ^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error; 32 warnings emitted
 

--- a/tests/ui/attributes/malformed-attrs.rs
+++ b/tests/ui/attributes/malformed-attrs.rs
@@ -54,6 +54,10 @@
 //~^ ERROR malformed
 #[optimize]
 //~^ ERROR malformed
+#[optimize(none, none)]
+//~^ ERROR malformed
+#[optimize(none, speed)]
+//~^ ERROR malformed
 #[cold = 1]
 //~^ ERROR malformed
 #[must_use()]

--- a/tests/ui/attributes/malformed-attrs.stderr
+++ b/tests/ui/attributes/malformed-attrs.stderr
@@ -1,5 +1,5 @@
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/malformed-attrs.rs:105:1
+  --> $DIR/malformed-attrs.rs:109:1
    |
 LL | #[cfg]
    | ^^^^^^ expected this to be a list
@@ -11,7 +11,7 @@ LL | #[cfg(predicate)]
    |      +++++++++++
 
 error[E0539]: malformed `cfg_attr` attribute input
-  --> $DIR/malformed-attrs.rs:107:1
+  --> $DIR/malformed-attrs.rs:111:1
    |
 LL | #[cfg_attr]
    | ^^^^^^^^^^^ expected this to be a list
@@ -23,13 +23,13 @@ LL | #[cfg_attr(predicate, attr1, attr2, ...)]
    |           ++++++++++++++++++++++++++++++
 
 error[E0463]: can't find crate for `wloop`
-  --> $DIR/malformed-attrs.rs:209:1
+  --> $DIR/malformed-attrs.rs:213:1
    |
 LL | extern crate wloop;
    | ^^^^^^^^^^^^^^^^^^^ can't find crate
 
 error: malformed `allow` attribute input
-  --> $DIR/malformed-attrs.rs:175:1
+  --> $DIR/malformed-attrs.rs:179:1
    |
 LL | #[allow]
    | ^^^^^^^^
@@ -45,7 +45,7 @@ LL | #[allow(lint1, lint2, lint3, reason = "...")]
    |        +++++++++++++++++++++++++++++++++++++
 
 error: malformed `expect` attribute input
-  --> $DIR/malformed-attrs.rs:177:1
+  --> $DIR/malformed-attrs.rs:181:1
    |
 LL | #[expect]
    | ^^^^^^^^^
@@ -61,7 +61,7 @@ LL | #[expect(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: malformed `warn` attribute input
-  --> $DIR/malformed-attrs.rs:179:1
+  --> $DIR/malformed-attrs.rs:183:1
    |
 LL | #[warn]
    | ^^^^^^^
@@ -77,7 +77,7 @@ LL | #[warn(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `deny` attribute input
-  --> $DIR/malformed-attrs.rs:181:1
+  --> $DIR/malformed-attrs.rs:185:1
    |
 LL | #[deny]
    | ^^^^^^^
@@ -93,7 +93,7 @@ LL | #[deny(lint1, lint2, lint3, reason = "...")]
    |       +++++++++++++++++++++++++++++++++++++
 
 error: malformed `forbid` attribute input
-  --> $DIR/malformed-attrs.rs:183:1
+  --> $DIR/malformed-attrs.rs:187:1
    |
 LL | #[forbid]
    | ^^^^^^^^^
@@ -109,19 +109,19 @@ LL | #[forbid(lint1, lint2, lint3, reason = "...")]
    |         +++++++++++++++++++++++++++++++++++++
 
 error: the `#[proc_macro]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:102:1
+  --> $DIR/malformed-attrs.rs:106:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_attribute]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:119:1
+  --> $DIR/malformed-attrs.rs:123:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
-  --> $DIR/malformed-attrs.rs:126:1
+  --> $DIR/malformed-attrs.rs:130:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -263,8 +263,48 @@ LL | #[optimize(size)]
 LL | #[optimize(speed)]
    |           +++++++
 
-error[E0565]: malformed `cold` attribute input
+error[E0805]: malformed `optimize` attribute input
   --> $DIR/malformed-attrs.rs:57:1
+   |
+LL | #[optimize(none, none)]
+   | ^^^^^^^^^^------------^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[optimize(none, none)]
+LL + #[optimize(none)]
+   |
+LL - #[optimize(none, none)]
+LL + #[optimize(size)]
+   |
+LL - #[optimize(none, none)]
+LL + #[optimize(speed)]
+   |
+
+error[E0805]: malformed `optimize` attribute input
+  --> $DIR/malformed-attrs.rs:59:1
+   |
+LL | #[optimize(none, speed)]
+   | ^^^^^^^^^^-------------^
+   |           |
+   |           expected a single argument here
+   |
+help: try changing it to one of the following valid forms of the attribute
+   |
+LL - #[optimize(none, speed)]
+LL + #[optimize(none)]
+   |
+LL - #[optimize(none, speed)]
+LL + #[optimize(size)]
+   |
+LL - #[optimize(none, speed)]
+LL + #[optimize(speed)]
+   |
+
+error[E0565]: malformed `cold` attribute input
+  --> $DIR/malformed-attrs.rs:61:1
    |
 LL | #[cold = 1]
    | ^^^^^^^---^
@@ -278,7 +318,7 @@ LL + #[cold]
    |
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:59:1
+  --> $DIR/malformed-attrs.rs:63:1
    |
 LL | #[must_use()]
    | ^^^^^^^^^^--^
@@ -296,7 +336,7 @@ LL + #[must_use]
    |
 
 error[E0565]: malformed `no_mangle` attribute input
-  --> $DIR/malformed-attrs.rs:61:1
+  --> $DIR/malformed-attrs.rs:65:1
    |
 LL | #[no_mangle = 1]
    | ^^^^^^^^^^^^---^
@@ -310,7 +350,7 @@ LL + #[no_mangle]
    |
 
 error[E0565]: malformed `naked` attribute input
-  --> $DIR/malformed-attrs.rs:63:1
+  --> $DIR/malformed-attrs.rs:67:1
    |
 LL | #[unsafe(naked())]
    | ^^^^^^^^^^^^^^--^^
@@ -324,7 +364,7 @@ LL + #[unsafe(naked)]
    |
 
 error[E0565]: malformed `track_caller` attribute input
-  --> $DIR/malformed-attrs.rs:65:1
+  --> $DIR/malformed-attrs.rs:69:1
    |
 LL | #[track_caller()]
    | ^^^^^^^^^^^^^^--^
@@ -338,7 +378,7 @@ LL + #[track_caller]
    |
 
 error[E0539]: malformed `export_name` attribute input
-  --> $DIR/malformed-attrs.rs:67:1
+  --> $DIR/malformed-attrs.rs:71:1
    |
 LL | #[export_name()]
    | ^^^^^^^^^^^^^^^^
@@ -350,7 +390,7 @@ LL + #[export_name = "name"]
    |
 
 error[E0805]: malformed `used` attribute input
-  --> $DIR/malformed-attrs.rs:69:1
+  --> $DIR/malformed-attrs.rs:73:1
    |
 LL | #[used()]
    | ^^^^^^--^
@@ -368,7 +408,7 @@ LL + #[used]
    |
 
 error: `#[used]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:69:1
+  --> $DIR/malformed-attrs.rs:73:1
    |
 LL | #[used()]
    | ^^^^^^^^^
@@ -376,7 +416,7 @@ LL | #[used()]
    = help: `#[used]` can only be applied to statics
 
 error[E0539]: malformed `crate_name` attribute input
-  --> $DIR/malformed-attrs.rs:72:1
+  --> $DIR/malformed-attrs.rs:76:1
    |
 LL | #[crate_name]
    | ^^^^^^^^^^^^^
@@ -387,7 +427,7 @@ LL | #[crate_name = "name"]
    |              ++++++++
 
 error[E0539]: malformed `target_feature` attribute input
-  --> $DIR/malformed-attrs.rs:77:1
+  --> $DIR/malformed-attrs.rs:81:1
    |
 LL | #[target_feature]
    | ^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -398,7 +438,7 @@ LL | #[target_feature(enable = "feat1, feat2")]
    |                 +++++++++++++++++++++++++
 
 error[E0565]: malformed `export_stable` attribute input
-  --> $DIR/malformed-attrs.rs:79:1
+  --> $DIR/malformed-attrs.rs:83:1
    |
 LL | #[export_stable = 1]
    | ^^^^^^^^^^^^^^^^---^
@@ -412,7 +452,7 @@ LL + #[export_stable]
    |
 
 error[E0539]: malformed `link` attribute input
-  --> $DIR/malformed-attrs.rs:81:1
+  --> $DIR/malformed-attrs.rs:85:1
    |
 LL | #[link]
    | ^^^^^^^ expected this to be a list
@@ -420,7 +460,7 @@ LL | #[link]
    = note: for more information, visit <https://doc.rust-lang.org/reference/items/external-blocks.html#the-link-attribute>
 
 error[E0539]: malformed `link_name` attribute input
-  --> $DIR/malformed-attrs.rs:85:1
+  --> $DIR/malformed-attrs.rs:89:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^
@@ -432,7 +472,7 @@ LL | #[link_name = "name"]
    |             ++++++++
 
 error[E0539]: malformed `link_section` attribute input
-  --> $DIR/malformed-attrs.rs:89:1
+  --> $DIR/malformed-attrs.rs:93:1
    |
 LL | #[link_section]
    | ^^^^^^^^^^^^^^^
@@ -444,7 +484,7 @@ LL | #[link_section = "name"]
    |                ++++++++
 
 error[E0539]: malformed `coverage` attribute input
-  --> $DIR/malformed-attrs.rs:91:1
+  --> $DIR/malformed-attrs.rs:95:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^ expected this to be a list
@@ -457,13 +497,13 @@ LL | #[coverage(on)]
    |           ++++
 
 error[E0539]: malformed `sanitize` attribute input
-  --> $DIR/malformed-attrs.rs:93:1
+  --> $DIR/malformed-attrs.rs:97:1
    |
 LL | #[sanitize]
    | ^^^^^^^^^^^ expected this to be a list
 
 error[E0565]: malformed `no_implicit_prelude` attribute input
-  --> $DIR/malformed-attrs.rs:98:1
+  --> $DIR/malformed-attrs.rs:102:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^----^
@@ -477,7 +517,7 @@ LL + #[no_implicit_prelude]
    |
 
 error[E0565]: malformed `proc_macro` attribute input
-  --> $DIR/malformed-attrs.rs:102:1
+  --> $DIR/malformed-attrs.rs:106:1
    |
 LL | #[proc_macro = 18]
    | ^^^^^^^^^^^^^----^
@@ -491,7 +531,7 @@ LL + #[proc_macro]
    |
 
 error[E0539]: malformed `instruction_set` attribute input
-  --> $DIR/malformed-attrs.rs:109:1
+  --> $DIR/malformed-attrs.rs:113:1
    |
 LL | #[instruction_set]
    | ^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -503,7 +543,7 @@ LL | #[instruction_set(set)]
    |                  +++++
 
 error[E0539]: malformed `patchable_function_entry` attribute input
-  --> $DIR/malformed-attrs.rs:111:1
+  --> $DIR/malformed-attrs.rs:115:1
    |
 LL | #[patchable_function_entry]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -514,7 +554,7 @@ LL | #[patchable_function_entry(prefix_nops = m, entry_nops = n)]
    |                           +++++++++++++++++++++++++++++++++
 
 error[E0565]: malformed `coroutine` attribute input
-  --> $DIR/malformed-attrs.rs:114:5
+  --> $DIR/malformed-attrs.rs:118:5
    |
 LL |     #[coroutine = 63] || {}
    |     ^^^^^^^^^^^^----^
@@ -528,7 +568,7 @@ LL +     #[coroutine] || {}
    |
 
 error[E0565]: malformed `proc_macro_attribute` attribute input
-  --> $DIR/malformed-attrs.rs:119:1
+  --> $DIR/malformed-attrs.rs:123:1
    |
 LL | #[proc_macro_attribute = 19]
    | ^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -542,7 +582,7 @@ LL + #[proc_macro_attribute]
    |
 
 error[E0539]: malformed `must_use` attribute input
-  --> $DIR/malformed-attrs.rs:122:1
+  --> $DIR/malformed-attrs.rs:126:1
    |
 LL | #[must_use = 1]
    | ^^^^^^^^^^^^^-^
@@ -560,7 +600,7 @@ LL + #[must_use]
    |
 
 error[E0539]: malformed `proc_macro_derive` attribute input
-  --> $DIR/malformed-attrs.rs:126:1
+  --> $DIR/malformed-attrs.rs:130:1
    |
 LL | #[proc_macro_derive]
    | ^^^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -574,7 +614,7 @@ LL | #[proc_macro_derive(TraitName, attributes(name1, name2, ...))]
    |                    ++++++++++++++++++++++++++++++++++++++++++
 
 error[E0539]: malformed `must_not_suspend` attribute input
-  --> $DIR/malformed-attrs.rs:131:1
+  --> $DIR/malformed-attrs.rs:135:1
    |
 LL | #[must_not_suspend()]
    | ^^^^^^^^^^^^^^^^^^--^
@@ -590,7 +630,7 @@ LL + #[must_not_suspend]
    |
 
 error[E0539]: malformed `cfi_encoding` attribute input
-  --> $DIR/malformed-attrs.rs:133:1
+  --> $DIR/malformed-attrs.rs:137:1
    |
 LL | #[cfi_encoding = ""]
    | ^^^^^^^^^^^^^^^^^--^
@@ -603,7 +643,7 @@ LL | #[cfi_encoding = "encoding"]
    |                   ++++++++
 
 error[E0565]: malformed `marker` attribute input
-  --> $DIR/malformed-attrs.rs:152:1
+  --> $DIR/malformed-attrs.rs:156:1
    |
 LL | #[marker = 3]
    | ^^^^^^^^^---^
@@ -617,7 +657,7 @@ LL + #[marker]
    |
 
 error[E0565]: malformed `fundamental` attribute input
-  --> $DIR/malformed-attrs.rs:154:1
+  --> $DIR/malformed-attrs.rs:158:1
    |
 LL | #[fundamental()]
    | ^^^^^^^^^^^^^--^
@@ -631,7 +671,7 @@ LL + #[fundamental]
    |
 
 error[E0565]: malformed `ffi_pure` attribute input
-  --> $DIR/malformed-attrs.rs:162:5
+  --> $DIR/malformed-attrs.rs:166:5
    |
 LL |     #[unsafe(ffi_pure = 1)]
    |     ^^^^^^^^^^^^^^^^^^---^^
@@ -645,7 +685,7 @@ LL +     #[unsafe(ffi_pure)]
    |
 
 error[E0539]: malformed `link_ordinal` attribute input
-  --> $DIR/malformed-attrs.rs:164:5
+  --> $DIR/malformed-attrs.rs:168:5
    |
 LL |     #[link_ordinal]
    |     ^^^^^^^^^^^^^^^ expected this to be a list
@@ -657,7 +697,7 @@ LL |     #[link_ordinal(ordinal)]
    |                   +++++++++
 
 error[E0565]: malformed `ffi_const` attribute input
-  --> $DIR/malformed-attrs.rs:168:5
+  --> $DIR/malformed-attrs.rs:172:5
    |
 LL |     #[unsafe(ffi_const = 1)]
    |     ^^^^^^^^^^^^^^^^^^^---^^
@@ -671,13 +711,13 @@ LL +     #[unsafe(ffi_const)]
    |
 
 error[E0539]: malformed `linkage` attribute input
-  --> $DIR/malformed-attrs.rs:170:5
+  --> $DIR/malformed-attrs.rs:174:5
    |
 LL |     #[linkage]
    |     ^^^^^^^^^^ expected this to be of the form `linkage = "..."`
 
 error[E0539]: malformed `debugger_visualizer` attribute input
-  --> $DIR/malformed-attrs.rs:185:1
+  --> $DIR/malformed-attrs.rs:189:1
    |
 LL | #[debugger_visualizer]
    | ^^^^^^^^^^^^^^^^^^^^^^ expected this to be a list
@@ -689,7 +729,7 @@ LL | #[debugger_visualizer(natvis_file = "...", gdb_script_file = "...")]
    |                      ++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0565]: malformed `automatically_derived` attribute input
-  --> $DIR/malformed-attrs.rs:187:1
+  --> $DIR/malformed-attrs.rs:191:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^----^
@@ -703,7 +743,7 @@ LL + #[automatically_derived]
    |
 
 error[E0565]: malformed `non_exhaustive` attribute input
-  --> $DIR/malformed-attrs.rs:195:1
+  --> $DIR/malformed-attrs.rs:199:1
    |
 LL | #[non_exhaustive = 1]
    | ^^^^^^^^^^^^^^^^^---^
@@ -717,7 +757,7 @@ LL + #[non_exhaustive]
    |
 
 error[E0565]: malformed `thread_local` attribute input
-  --> $DIR/malformed-attrs.rs:201:1
+  --> $DIR/malformed-attrs.rs:205:1
    |
 LL | #[thread_local()]
    | ^^^^^^^^^^^^^^--^
@@ -731,7 +771,7 @@ LL + #[thread_local]
    |
 
 error[E0565]: malformed `no_link` attribute input
-  --> $DIR/malformed-attrs.rs:205:1
+  --> $DIR/malformed-attrs.rs:209:1
    |
 LL | #[no_link()]
    | ^^^^^^^^^--^
@@ -745,7 +785,7 @@ LL + #[no_link]
    |
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/malformed-attrs.rs:207:1
+  --> $DIR/malformed-attrs.rs:211:1
    |
 LL | #[macro_use = 1]
    | ^^^^^^^^^^^^---^
@@ -763,7 +803,7 @@ LL + #[macro_use]
    |
 
 error[E0539]: malformed `macro_export` attribute input
-  --> $DIR/malformed-attrs.rs:212:1
+  --> $DIR/malformed-attrs.rs:216:1
    |
 LL | #[macro_export = 18]
    | ^^^^^^^^^^^^^^^----^
@@ -780,7 +820,7 @@ LL + #[macro_export]
    |
 
 error[E0658]: allow_internal_unsafe side-steps the unsafe_code lint
-  --> $DIR/malformed-attrs.rs:214:1
+  --> $DIR/malformed-attrs.rs:218:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -789,7 +829,7 @@ LL | #[allow_internal_unsafe = 1]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0565]: malformed `allow_internal_unsafe` attribute input
-  --> $DIR/malformed-attrs.rs:214:1
+  --> $DIR/malformed-attrs.rs:218:1
    |
 LL | #[allow_internal_unsafe = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^---^
@@ -837,13 +877,13 @@ LL | #[inline = 5]
    = note: `#[deny(ill_formed_attribute_input)]` (part of `#[deny(future_incompatible)]`) on by default
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/malformed-attrs.rs:72:1
+  --> $DIR/malformed-attrs.rs:76:1
    |
 LL | #[crate_name]
    | ^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/malformed-attrs.rs:113:1
+  --> $DIR/malformed-attrs.rs:117:1
    |
 LL | / fn test() {
 LL | |     #[coroutine = 63] || {}
@@ -853,13 +893,13 @@ LL | | }
    = note: requested on the command line with `-W unused-attributes`
 
 error: valid forms for the attribute are `#[doc = "string"]`, `#[doc(alias)]`, `#[doc(attribute)]`, `#[doc(auto_cfg)]`, `#[doc(cfg)]`, `#[doc(fake_variadic)]`, `#[doc(hidden)]`, `#[doc(html_favicon_url)]`, `#[doc(html_logo_url)]`, `#[doc(html_no_source)]`, `#[doc(html_playground_url)]`, `#[doc(html_root_url)]`, `#[doc(include)]`, `#[doc(inline)]`, `#[doc(issue_tracker_base_url)]`, `#[doc(keyword)]`, `#[doc(masked)]`, `#[doc(no_default_passes)]`, `#[doc(no_inline)]`, `#[doc(notable_trait)]`, `#[doc(passes)]`, `#[doc(plugins)]`, `#[doc(rust_logo)]`, `#[doc(search_unbox)]`, `#[doc(spotlight)]`, and `#[doc(test)]`
-  --> $DIR/malformed-attrs.rs:75:1
+  --> $DIR/malformed-attrs.rs:79:1
    |
 LL | #[doc]
    | ^^^^^^
 
 warning: `#[link]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:81:1
+  --> $DIR/malformed-attrs.rs:85:1
    |
 LL | #[link]
    | ^^^^^^^
@@ -868,7 +908,7 @@ LL | #[link]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:85:1
+  --> $DIR/malformed-attrs.rs:89:1
    |
 LL | #[link_name]
    | ^^^^^^^^^^^^
@@ -877,7 +917,7 @@ LL | #[link_name]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:95:1
+  --> $DIR/malformed-attrs.rs:99:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -886,7 +926,7 @@ LL | #[ignore()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/malformed-attrs.rs:98:1
+  --> $DIR/malformed-attrs.rs:102:1
    |
 LL | #[no_implicit_prelude = 23]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -895,7 +935,7 @@ LL | #[no_implicit_prelude = 23]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: missing options for `diagnostic::on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:137:1
+  --> $DIR/malformed-attrs.rs:141:1
    |
 LL | #[diagnostic::on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -904,7 +944,7 @@ LL | #[diagnostic::on_unimplemented]
    = note: `#[warn(malformed_diagnostic_attributes)]` (part of `#[warn(unknown_or_malformed_diagnostic_attributes)]`) on by default
 
 warning: malformed `diagnostic::on_unimplemented` attribute
-  --> $DIR/malformed-attrs.rs:139:1
+  --> $DIR/malformed-attrs.rs:143:1
    |
 LL | #[diagnostic::on_unimplemented = 1]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid option found here
@@ -912,13 +952,13 @@ LL | #[diagnostic::on_unimplemented = 1]
    = help: only `message`, `note` and `label` are allowed as options
 
 warning: `#[diagnostic::do_not_recommend]` does not expect any arguments
-  --> $DIR/malformed-attrs.rs:146:1
+  --> $DIR/malformed-attrs.rs:150:1
    |
 LL | #[diagnostic::do_not_recommend()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/malformed-attrs.rs:187:1
+  --> $DIR/malformed-attrs.rs:191:1
    |
 LL | #[automatically_derived = 18]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -927,7 +967,7 @@ LL | #[automatically_derived = 18]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:221:1
+  --> $DIR/malformed-attrs.rs:225:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^
@@ -936,7 +976,7 @@ LL | #[ignore = 1]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 error[E0308]: mismatched types
-  --> $DIR/malformed-attrs.rs:114:23
+  --> $DIR/malformed-attrs.rs:118:23
    |
 LL | fn test() {
    |          - help: a return type might be missing here: `-> _`
@@ -944,9 +984,9 @@ LL |     #[coroutine = 63] || {}
    |                       ^^^^^ expected `()`, found coroutine
    |
    = note: expected unit type `()`
-              found coroutine `{coroutine@$DIR/malformed-attrs.rs:114:23: 114:25}`
+              found coroutine `{coroutine@$DIR/malformed-attrs.rs:118:23: 118:25}`
 
-error: aborting due to 72 previous errors; 8 warnings emitted
+error: aborting due to 74 previous errors; 8 warnings emitted
 
 Some errors have detailed explanations: E0308, E0463, E0539, E0565, E0658, E0805.
 For more information about an error, try `rustc --explain E0308`.
@@ -963,7 +1003,7 @@ LL | #[inline = 5]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:95:1
+  --> $DIR/malformed-attrs.rs:99:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -974,7 +1014,7 @@ LL | #[ignore()]
 
 Future breakage diagnostic:
 error: valid forms for the attribute are `#[ignore = "reason"]` and `#[ignore]`
-  --> $DIR/malformed-attrs.rs:221:1
+  --> $DIR/malformed-attrs.rs:225:1
    |
 LL | #[ignore = 1]
    | ^^^^^^^^^^^^^

--- a/tests/ui/attributes/optimize.rs
+++ b/tests/ui/attributes/optimize.rs
@@ -40,3 +40,25 @@ fn async_block() -> impl Future<Output = ()> {
 async fn async_fn() {
     ()
 }
+
+trait Foo {
+    #[optimize(speed)] //~ ERROR attribute cannot be used on
+    fn invalid();
+    #[optimize(speed)]
+    fn valid() {}
+}
+
+impl Foo for () {
+    #[optimize(speed)]
+    fn invalid() {}
+    #[optimize(size)]
+    fn valid() {}
+}
+
+#[optimize(speed)]
+#[optimize(speed)] //~ ERROR multiple `optimize` attributes
+fn duplicate_same() {}
+
+#[optimize(speed)]
+#[optimize(size)] //~ ERROR multiple `optimize` attributes
+fn duplicate_different() {}

--- a/tests/ui/attributes/optimize.stderr
+++ b/tests/ui/attributes/optimize.stderr
@@ -30,5 +30,37 @@ LL | #[optimize(speed)]
    |
    = help: `#[optimize]` can only be applied to functions
 
-error: aborting due to 4 previous errors
+error: `#[optimize]` attribute cannot be used on required trait methods
+  --> $DIR/optimize.rs:45:5
+   |
+LL |     #[optimize(speed)]
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[optimize]` can only be applied to functions with a body
+
+error: multiple `optimize` attributes
+  --> $DIR/optimize.rs:59:1
+   |
+LL | #[optimize(speed)]
+   | ^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/optimize.rs:58:1
+   |
+LL | #[optimize(speed)]
+   | ^^^^^^^^^^^^^^^^^^
+
+error: multiple `optimize` attributes
+  --> $DIR/optimize.rs:63:1
+   |
+LL | #[optimize(size)]
+   | ^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+note: attribute also specified here
+  --> $DIR/optimize.rs:62:1
+   |
+LL | #[optimize(speed)]
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/attributes/register-tool-target.rs
+++ b/tests/ui/attributes/register-tool-target.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+#![feature(register_tool)]
+
+#[register_tool(no_valid_target)]
+//~^ WARN crate-level attribute should be an inner attribute
+fn main() {
+
+}

--- a/tests/ui/attributes/register-tool-target.stderr
+++ b/tests/ui/attributes/register-tool-target.stderr
@@ -1,0 +1,17 @@
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![register_tool]`
+  --> $DIR/register-tool-target.rs:4:1
+   |
+LL | #[register_tool(no_valid_target)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this attribute does not have an `!`, which means it is applied to this function
+  --> $DIR/register-tool-target.rs:6:1
+   |
+LL | / fn main() {
+LL | |
+LL | | }
+   | |_^
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 1 warning emitted
+

--- a/tests/ui/traits/non_lifetime_binders/late-bound-assoc-type.rs
+++ b/tests/ui/traits/non_lifetime_binders/late-bound-assoc-type.rs
@@ -1,0 +1,19 @@
+#![feature(non_lifetime_binders)]
+
+//! Regression test for https://github.com/rust-lang/rust/issues/132055.
+//! Compiler gave ICE with late-bound type parameter in nested `impl Trait` on
+//! associated type.
+
+trait Trait<T: ?Sized> {
+    type Assoc<'a> = i32;
+    //~^ ERROR associated type defaults are unstable
+}
+
+fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
+    //~^ ERROR cannot capture late-bound type parameter in nested `impl Trait`
+    //~| ERROR missing generics for associated type `Trait::Assoc`
+    //~| ERROR missing generics for associated type `Trait::Assoc`
+    //~| ERROR the trait bound `{integer}: Trait<()>` is not satisfied
+    16
+}
+//~^ ERROR `main` function not found in crate `late_bound_assoc_type`

--- a/tests/ui/traits/non_lifetime_binders/late-bound-assoc-type.stderr
+++ b/tests/ui/traits/non_lifetime_binders/late-bound-assoc-type.stderr
@@ -1,0 +1,74 @@
+error[E0658]: associated type defaults are unstable
+  --> $DIR/late-bound-assoc-type.rs:8:5
+   |
+LL |     type Assoc<'a> = i32;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #29661 <https://github.com/rust-lang/rust/issues/29661> for more information
+   = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0601]: `main` function not found in crate `late_bound_assoc_type`
+  --> $DIR/late-bound-assoc-type.rs:18:2
+   |
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/late-bound-assoc-type.rs`
+
+error: cannot capture late-bound type parameter in nested `impl Trait`
+  --> $DIR/late-bound-assoc-type.rs:12:58
+   |
+LL | fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
+   |                          - parameter defined here        ^
+
+error[E0107]: missing generics for associated type `Trait::Assoc`
+  --> $DIR/late-bound-assoc-type.rs:12:39
+   |
+LL | fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
+   |                                       ^^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/late-bound-assoc-type.rs:8:10
+   |
+LL |     type Assoc<'a> = i32;
+   |          ^^^^^ --
+help: add missing lifetime argument
+   |
+LL | fn produce() -> impl for<T> Trait<(), Assoc<'a> = impl Trait<T>> {
+   |                                            ++++
+
+error[E0107]: missing generics for associated type `Trait::Assoc`
+  --> $DIR/late-bound-assoc-type.rs:12:39
+   |
+LL | fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
+   |                                       ^^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/late-bound-assoc-type.rs:8:10
+   |
+LL |     type Assoc<'a> = i32;
+   |          ^^^^^ --
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: add missing lifetime argument
+   |
+LL | fn produce() -> impl for<T> Trait<(), Assoc<'a> = impl Trait<T>> {
+   |                                            ++++
+
+error[E0277]: the trait bound `{integer}: Trait<()>` is not satisfied
+  --> $DIR/late-bound-assoc-type.rs:12:17
+   |
+LL | fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<()>` is not implemented for `{integer}`
+...
+LL |     16
+   |     -- return type was inferred to be `{integer}` here
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/late-bound-assoc-type.rs:7:1
+   |
+LL | trait Trait<T: ?Sized> {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0107, E0277, E0601, E0658.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157297 (Add more tests for the `optimize` attribute)
 - rust-lang/rust#157377 (Add target checking to `#[register_tool]`)
 - rust-lang/rust#157138 (Add doc comment to `Vec::clone`)
 - rust-lang/rust#157400 (Add regression test for late-bound type param in nested `impl Trait`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157297,157377,157138,157400)
<!-- homu-ignore:end -->

