### PR TITLE
rustc_codegen_llvm: Fix ICE on invalid LLVM target in custom JSON

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -305,7 +305,7 @@ pub(crate) fn target_machine_factory(
             use_wasm_eh,
             large_data_threshold,
         )
-        .map_err(|err| dcx.emit_err(ParseTargetMachineConfig(err)))
+        dcx.emit_fatal(ParseTargetMachineConfig(err))
     })
 }
 

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -305,7 +305,9 @@ pub(crate) fn target_machine_factory(
             use_wasm_eh,
             large_data_threshold,
         )
-        dcx.emit_fatal(ParseTargetMachineConfig(err))
+        .unwrap_or_else(|err| {
+            dcx.emit_fatal(ParseTargetMachineConfig(err))
+        })
     })
 }
 

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -305,7 +305,7 @@ pub(crate) fn target_machine_factory(
             use_wasm_eh,
             large_data_threshold,
         )
-        .unwrap_or_else(|err| dcx.emit_fatal(ParseTargetMachineConfig(err)))
+        .map_err(|err| dcx.emit_err(ParseTargetMachineConfig(err)))
     })
 }
 

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -281,34 +281,32 @@ pub(crate) fn target_machine_factory(
         let output_obj_file = path_to_cstring_helper(config.output_obj_file);
 
         OwnedTargetMachine::new(
-            &triple,
-            &cpu,
-            &features,
-            &abi,
-            code_model,
-            reloc_model,
-            opt_level,
-            float_abi,
-            ffunction_sections,
-            fdata_sections,
-            funique_section_names,
-            trap_unreachable,
-            singlethread,
-            verbose_asm,
-            emit_stack_size_section,
-            relax_elf_relocations,
-            use_init_array,
-            &split_dwarf_file,
-            &output_obj_file,
-            debuginfo_compression,
-            use_emulated_tls,
-            use_wasm_eh,
-            large_data_threshold,
-        )
-        .unwrap_or_else(|err| {
-            dcx.emit_fatal(ParseTargetMachineConfig(err))
-        })
-    })
+                    &triple,
+                    &cpu,
+                    &features,
+                    &abi,
+                    code_model,
+                    reloc_model,
+                    opt_level,
+                    float_abi,
+                    ffunction_sections,
+                    fdata_sections,
+                    funique_section_names,
+                    trap_unreachable,
+                    singlethread,
+                    verbose_asm,
+                    emit_stack_size_section,
+                    relax_elf_relocations,
+                    use_init_array,
+                    &split_dwarf_file,
+                    &output_obj_file,
+                    debuginfo_compression,
+                    use_emulated_tls,
+                    use_wasm_eh,
+                    large_data_threshold,
+                )
+                .unwrap_or_else(|err| dcx.emit_fatal(ParseTargetMachineConfig(err)))
+            })
 }
 
 pub(crate) fn save_temp_bitcode(


### PR DESCRIPTION
In response to issue raised : rust-lang/rust#157401


Before this fix, if you put a bad llvm-target in a custom JSON file, the Rust compiler would completely crash with an Internal Compiler Error (ICE). This happened because it accidentally tripped an internal safety mechanism

The old code tried to handle the invalid target by instantly killing the compiler thread using emit_fatal(). The problem is that it killed the thread so quickly that the actual error message got destroyed during the chaotic shutdown before it could be printed to your screen. When the compiler's strict safety checks realized it created an error message but never actually showed it to the user, it panicked.

The fix:
By switching to .map_err and emit_err(), the compiler now takes a second to properly print the error to the screen, which safely defuses that drop bomb. Then, instead of forcefully killing the thread, it hands an error token (ErrorGuaranteed) back up the chain so the compiler can shut down gracefully.