### PR TITLE
allocator: refactor for stabilisation

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -58,6 +58,12 @@ unsafe extern "Rust" {
 #[lang = "global_alloc_ty"]
 pub struct Global;
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl core::alloc::AllocatorClone for Global {}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl core::alloc::StaticAllocator for Global {}
+
 /// Allocates memory with the global allocator.
 ///
 /// This function forwards calls to the [`GlobalAlloc::alloc`] method

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -206,10 +206,10 @@ use core::task::{Context, Poll};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{AllocError, Allocator, Global, Layout, StaticAllocator};
 use crate::raw_vec::RawVec;
 #[cfg(not(no_global_oom_handling))]
-use crate::str::from_boxed_utf8_unchecked;
+use crate::str::from_boxed_utf8_unchecked_in;
 
 /// Conversion related impls for `Box<_>` (`From`, `downcast`, etc)
 mod convert;
@@ -715,7 +715,7 @@ impl<T, A: Allocator> Box<T, A> {
     #[inline(always)]
     pub fn pin_in(x: T, alloc: A) -> Pin<Self>
     where
-        A: 'static + Allocator,
+        A: StaticAllocator,
     {
         Self::into_pin(Self::new_in(x, alloc))
     }
@@ -1897,11 +1897,12 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// `'static`.
     ///
     /// This function is mainly useful for data that lives for the remainder of the program's life,
-    /// i.e., memory that is meant to leak. Reconstructing ("unleaking") a `Box` from the mutable
-    /// reference returned here (e.g. via [`Box::from_raw`]) is a grey area (meaning it is possible
-    /// under specific circumstances but many seemingly harmless ways of doing it are undefined
-    /// behavior) and should be avoided. If the memory should eventually be freed, prefer to use
-    /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
+    /// i.e., memory that is meant to leak. If the memory should eventually be freed, prefer to use
+    /// [`Box::into_raw`] or [`Box::into_non_null`] instead. Reconstructing ("unleaking") a `Box` from
+    /// the mutable reference returned here (e.g. via [`Box::from_raw`]) is only possible if the
+    /// allocator is `Global`, and even then it is a grey area (meaning it is possible under specific
+    /// circumstances but many seemingly harmless ways of doing it are undefined behavior) and should
+    /// be avoided.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This
@@ -1976,7 +1977,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     #[stable(feature = "box_into_pin", since = "1.63.0")]
     pub fn into_pin(boxed: Self) -> Pin<Self>
     where
-        A: 'static,
+        A: StaticAllocator,
     {
         // It's not possible to move or replace the insides of a `Pin<Box<T>>`
         // when `T: !Unpin`, so it's safe to pin it directly without any
@@ -2065,6 +2066,8 @@ where
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
+// NB: This is not `AllocatorClone` since we don't care about allocator
+// equivalence when cloning boxes.
 impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///
@@ -2150,11 +2153,10 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl Clone for Box<str> {
+impl<A: Allocator + Clone> Clone for Box<str, A> {
     fn clone(&self) -> Self {
-        // this makes a copy of the data
-        let buf: Box<[u8]> = self.as_bytes().into();
-        unsafe { from_boxed_utf8_unchecked(buf) }
+        let buf = Box::clone_from_ref_in(self.as_bytes(), self.1.clone());
+        unsafe { from_boxed_utf8_unchecked_in(buf) }
     }
 }
 
@@ -2385,7 +2387,7 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Allocator> CoerceUnsized<Box<U, A>> fo
 // wrapped in `Pin`, since the same conversion could have been carried out
 // safely as `Box::pin((*p).clone())`.
 #[unstable(feature = "pin_coerce_unsized_trait", issue = "150112")]
-unsafe impl<T: ?Sized, A: Allocator + 'static> PinSafePointer for Box<T, A> {}
+unsafe impl<T: ?Sized, A: StaticAllocator> PinSafePointer for Box<T, A> {}
 
 // It is quite crucial that we only allow the `Global` allocator here.
 // Handling arbitrary custom allocators (which can affect the `Box` layout heavily!)

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1897,20 +1897,12 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// `'static`.
     ///
     /// This function is mainly useful for data that lives for the remainder of the program's life,
-    /// i.e., memory that is meant to leak. Reconstructing ("unleaking") a `Box` from the mutable
-    /// reference returned here (e.g. via [`Box::from_raw`]) is a grey area (meaning it is possible
-    /// under specific circumstances but many seemingly harmless ways of doing it are undefined
-    /// behavior) and should be avoided. Notably, soundly unleaking a box requires that the
-    /// allocator is `Global`. If the memory should eventually be freed, prefer to use
-   /// This function is mainly useful for data that lives for the remainder of the program's life,
-   /// i.e., memory that is meant to leak.
-   /// If the memory should eventually be freed, prefer to use
-   /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
-   /// Reconstructing ("unleaking") a `Box` from the mutable
-   /// reference returned here (e.g. via [`Box::from_raw`]) is only possible if the
-   /// allocator is `Global`, and even then it is a grey area (meaning it is possible
-   /// under specific circumstances but many seemingly harmless ways of doing it are undefined
-    /// behavior) and should be avoided.
+    /// i.e., memory that is meant to leak. If the memory should eventually be freed, prefer to use
+    /// [`Box::into_raw`] or [`Box::into_non_null`] instead. Reconstructing ("unleaking") a `Box` from
+    /// the mutable reference returned here (e.g. via [`Box::from_raw`]) is only possible if the
+    /// allocator is `Global`, and even then it is a grey area (meaning it is possible under specific
+    /// circumstances but many seemingly harmless ways of doing it are undefined behavior) and should
+    /// be avoided.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1903,8 +1903,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// behavior) and should be avoided. If the memory should eventually be freed, prefer to use
     /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
     ///
-    /// However, "unleaking" as per the above via [`Box::from_raw_in`] is only sound
-    /// for the global allocator.
+    /// Notably, soundly "unleaking" a box requires that the allocator is `Global`.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This
@@ -2068,6 +2067,8 @@ where
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
+// NB: This is not `AllocatorClone` since we don't care about allocator
+// equivalence when cloning boxes.
 impl<T: Clone, A: Allocator + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -206,10 +206,10 @@ use core::task::{Context, Poll};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{AllocError, Allocator, Global, Layout, StaticAllocator};
 use crate::raw_vec::RawVec;
 #[cfg(not(no_global_oom_handling))]
-use crate::str::from_boxed_utf8_unchecked;
+use crate::str::from_boxed_utf8_unchecked_in;
 
 /// Conversion related impls for `Box<_>` (`From`, `downcast`, etc)
 mod convert;
@@ -715,7 +715,7 @@ impl<T, A: Allocator> Box<T, A> {
     #[inline(always)]
     pub fn pin_in(x: T, alloc: A) -> Pin<Self>
     where
-        A: 'static + Allocator,
+        A: StaticAllocator,
     {
         Self::into_pin(Self::new_in(x, alloc))
     }
@@ -1903,6 +1903,9 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// behavior) and should be avoided. If the memory should eventually be freed, prefer to use
     /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
     ///
+    /// However, "unleaking" as per the above via [`Box::from_raw_in`] is only sound
+    /// for the global allocator.
+    ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This
     /// is so that there is no conflict with a method on the inner type.
@@ -1976,7 +1979,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     #[stable(feature = "box_into_pin", since = "1.63.0")]
     pub fn into_pin(boxed: Self) -> Pin<Self>
     where
-        A: 'static,
+        A: StaticAllocator,
     {
         // It's not possible to move or replace the insides of a `Pin<Box<T>>`
         // when `T: !Unpin`, so it's safe to pin it directly without any
@@ -2150,11 +2153,10 @@ impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl Clone for Box<str> {
+impl<A: Allocator + Clone> Clone for Box<str, A> {
     fn clone(&self) -> Self {
-        // this makes a copy of the data
-        let buf: Box<[u8]> = self.as_bytes().into();
-        unsafe { from_boxed_utf8_unchecked(buf) }
+        let buf = Box::clone_from_ref_in(self.as_bytes(), self.1.clone());
+        unsafe { from_boxed_utf8_unchecked_in(buf) }
     }
 }
 
@@ -2366,7 +2368,7 @@ impl<Args: Tuple, F: AsyncFn<Args> + ?Sized, A: Allocator> AsyncFn<Args> for Box
 impl<T: ?Sized + Unsize<U>, U: ?Sized, A: Allocator> CoerceUnsized<Box<U, A>> for Box<T, A> {}
 
 #[unstable(feature = "pin_coerce_unsized_trait", issue = "150112")]
-unsafe impl<T: ?Sized, A: Allocator> PinCoerceUnsized for Box<T, A> {}
+unsafe impl<T: ?Sized, A: StaticAllocator> PinCoerceUnsized for Box<T, A> {}
 
 // It is quite crucial that we only allow the `Global` allocator here.
 // Handling arbitrary custom allocators (which can affect the `Box` layout heavily!)

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1900,10 +1900,9 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// i.e., memory that is meant to leak. Reconstructing ("unleaking") a `Box` from the mutable
     /// reference returned here (e.g. via [`Box::from_raw`]) is a grey area (meaning it is possible
     /// under specific circumstances but many seemingly harmless ways of doing it are undefined
-    /// behavior) and should be avoided. If the memory should eventually be freed, prefer to use
+    /// behavior) and should be avoided. Notably, soundly unleaking a box requires that the
+    /// allocator is `Global`. If the memory should eventually be freed, prefer to use
     /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
-    ///
-    /// Notably, soundly "unleaking" a box requires that the allocator is `Global`.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1902,7 +1902,15 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// under specific circumstances but many seemingly harmless ways of doing it are undefined
     /// behavior) and should be avoided. Notably, soundly unleaking a box requires that the
     /// allocator is `Global`. If the memory should eventually be freed, prefer to use
-    /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
+   /// This function is mainly useful for data that lives for the remainder of the program's life,
+   /// i.e., memory that is meant to leak.
+   /// If the memory should eventually be freed, prefer to use
+   /// [`Box::into_raw`] or [`Box::into_non_null`] instead.
+   /// Reconstructing ("unleaking") a `Box` from the mutable
+   /// reference returned here (e.g. via [`Box::from_raw`]) is only possible if the
+   /// allocator is `Global`, and even then it is a grey area (meaning it is possible
+   /// under specific circumstances but many seemingly harmless ways of doing it are undefined
+    /// behavior) and should be avoided.
     ///
     /// Note: this is an associated function, which means that you have
     /// to call it as `Box::leak(b)` instead of `b.leak()`. This

--- a/library/alloc/src/boxed/convert.rs
+++ b/library/alloc/src/boxed/convert.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::mem;
 use core::pin::Pin;
 
-use crate::alloc::Allocator;
+use crate::alloc::{Allocator, StaticAllocator};
 #[cfg(not(no_global_oom_handling))]
 use crate::borrow::Cow;
 use crate::boxed::Box;
@@ -38,7 +38,7 @@ impl<T> From<T> for Box<T> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Pin<Box<T, A>>
 where
-    A: 'static,
+    A: StaticAllocator,
 {
     /// Converts a `Box<T>` into a `Pin<Box<T>>`. If `T` does not implement [`Unpin`], then
     /// `*boxed` will be pinned in memory and unable to be moved.

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -12,6 +12,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use core::alloc::AllocatorClone;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::iter::FusedIterator;
@@ -340,7 +341,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
         at: usize,
     ) -> Self
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // The split node is the new head node of the second part
         if let Some(mut split_node) = split_node {
@@ -383,7 +384,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
         at: usize,
     ) -> Self
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // The split node is the new tail node of the first part and owns
         // the head of the second part.
@@ -994,7 +995,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn split_off(&mut self, at: usize) -> LinkedList<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         let len = self.len();
         assert!(at <= len, "Cannot split off at a nonexistent index");
@@ -1748,7 +1749,7 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn remove_current_as_list(&mut self) -> Option<LinkedList<T, A>>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         let mut unlinked_node = self.current?;
         unsafe {
@@ -1776,7 +1777,7 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn split_after(&mut self) -> LinkedList<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         let split_off_idx = if self.index == self.list.len { 0 } else { self.index + 1 };
         if self.index == self.list.len {
@@ -1795,7 +1796,7 @@ impl<'a, T, A: Allocator> CursorMut<'a, T, A> {
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn split_before(&mut self) -> LinkedList<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         let split_off_idx = self.index;
         self.index = 0;
@@ -2167,11 +2168,14 @@ impl<T: Clone, A: Allocator + Clone> Clone for LinkedList<T, A> {
     /// resources of `self`'s elements as well.
     fn clone_from(&mut self, source: &Self) {
         let mut source_iter = source.iter();
-        if self.len() > source.len() {
-            self.split_off(source.len());
-        }
-        for (elem, source_elem) in self.iter_mut().zip(&mut source_iter) {
+        for elem in self.iter_mut() {
+            let Some(source_elem) = source_iter.next() else {
+                break;
+            };
             elem.clone_from(source_elem);
+        }
+        while self.len() > source.len() {
+            self.pop_back();
         }
         if !source_iter.is_empty() {
             self.extend(source_iter.cloned());

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -268,7 +268,7 @@ use core::{borrow, fmt, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{AllocError, Allocator, AllocatorClone, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 #[cfg(not(no_global_oom_handling))]
@@ -1775,7 +1775,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
     #[stable(feature = "rc_weak", since = "1.4.0")]
     pub fn downgrade(this: &Self) -> Weak<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         this.inner().inc_weak();
         // Make sure we do not create a dangling Weak
@@ -1856,7 +1856,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub unsafe fn increment_strong_count_in(ptr: *const T, alloc: A)
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // Retain Rc, but don't touch refcount by wrapping in ManuallyDrop
         let rc = unsafe { mem::ManuallyDrop::new(Rc::<T, A>::from_raw_in(ptr, alloc)) };
@@ -2032,7 +2032,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: ?Sized + CloneToUninit, A: Allocator + Clone> Rc<T, A> {
+impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Rc<T, A> {
     /// Makes a mutable reference into the given `Rc`.
     ///
     /// If there are other `Rc` pointers to the same allocation, then `make_mut` will
@@ -2313,7 +2313,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
 
             // Free the allocation without dropping its contents
             let (bptr, alloc) = Box::into_raw_with_allocator(src);
-            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, alloc.by_ref());
+            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, &alloc);
             drop(src);
 
             Self::from_ptr_in(ptr, alloc)
@@ -2502,7 +2502,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Rc<T, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Rc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Rc<T, A> {
     /// Makes a clone of the `Rc` pointer.
     ///
     /// This creates another pointer to the same allocation, increasing the
@@ -2527,10 +2527,10 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Rc<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Rc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Rc<T, A> {}
 
 #[unstable(feature = "share_trait", issue = "156756")]
-impl<T: ?Sized, A: Allocator + Clone> Share for Rc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> Share for Rc<T, A> {}
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -3551,7 +3551,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     #[stable(feature = "rc_weak", since = "1.4.0")]
     pub fn upgrade(&self) -> Option<Rc<T, A>>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         let inner = self.inner()?;
 
@@ -3696,7 +3696,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Weak<T, A> {
 }
 
 #[stable(feature = "rc_weak", since = "1.4.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Weak<T, A> {
     /// Makes a clone of the `Weak` pointer that points to the same allocation.
     ///
     /// # Examples
@@ -3718,7 +3718,7 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Weak<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Weak<T, A> {}
 
 #[stable(feature = "rc_weak", since = "1.4.0")]
 impl<T: ?Sized, A: Allocator> fmt::Debug for Weak<T, A> {
@@ -4418,7 +4418,7 @@ impl<T: ?Sized, A: Allocator> UniqueRc<T, A> {
     }
 }
 
-impl<T: ?Sized, A: Allocator + Clone> UniqueRc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> UniqueRc<T, A> {
     /// Creates a new weak reference to the `UniqueRc`.
     ///
     /// Attempting to upgrade this weak reference will fail before the `UniqueRc` has been converted
@@ -4607,3 +4607,6 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Rc<T, A> {
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
     }
 }
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator + ?Sized, A: AllocatorClone> AllocatorClone for Rc<T, A> {}

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -268,7 +268,7 @@ use core::{borrow, fmt, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{AllocError, Allocator, AllocatorClone, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 #[cfg(not(no_global_oom_handling))]
@@ -1775,7 +1775,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
     #[stable(feature = "rc_weak", since = "1.4.0")]
     pub fn downgrade(this: &Self) -> Weak<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         this.inner().inc_weak();
         // Make sure we do not create a dangling Weak
@@ -1856,7 +1856,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub unsafe fn increment_strong_count_in(ptr: *const T, alloc: A)
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // Retain Rc, but don't touch refcount by wrapping in ManuallyDrop
         let rc = unsafe { mem::ManuallyDrop::new(Rc::<T, A>::from_raw_in(ptr, alloc)) };
@@ -2032,7 +2032,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: ?Sized + CloneToUninit, A: Allocator + Clone> Rc<T, A> {
+impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Rc<T, A> {
     /// Makes a mutable reference into the given `Rc`.
     ///
     /// If there are other `Rc` pointers to the same allocation, then `make_mut` will
@@ -2313,7 +2313,7 @@ impl<T: ?Sized, A: Allocator> Rc<T, A> {
 
             // Free the allocation without dropping its contents
             let (bptr, alloc) = Box::into_raw_with_allocator(src);
-            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, alloc.by_ref());
+            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, &alloc);
             drop(src);
 
             Self::from_ptr_in(ptr, alloc)
@@ -2509,7 +2509,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Rc<T, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Rc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Rc<T, A> {
     /// Makes a clone of the `Rc` pointer.
     ///
     /// This creates another pointer to the same allocation, increasing the
@@ -2534,10 +2534,10 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Rc<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Rc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Rc<T, A> {}
 
 #[unstable(feature = "share_trait", issue = "156756")]
-impl<T: ?Sized, A: Allocator + Clone> Share for Rc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> Share for Rc<T, A> {}
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -3558,7 +3558,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     #[stable(feature = "rc_weak", since = "1.4.0")]
     pub fn upgrade(&self) -> Option<Rc<T, A>>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         let inner = self.inner()?;
 
@@ -3703,7 +3703,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Weak<T, A> {
 }
 
 #[stable(feature = "rc_weak", since = "1.4.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Weak<T, A> {
     /// Makes a clone of the `Weak` pointer that points to the same allocation.
     ///
     /// # Examples
@@ -3725,7 +3725,7 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Weak<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Weak<T, A> {}
 
 #[stable(feature = "rc_weak", since = "1.4.0")]
 impl<T: ?Sized, A: Allocator> fmt::Debug for Weak<T, A> {
@@ -4425,7 +4425,7 @@ impl<T: ?Sized, A: Allocator> UniqueRc<T, A> {
     }
 }
 
-impl<T: ?Sized, A: Allocator + Clone> UniqueRc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> UniqueRc<T, A> {
     /// Creates a new weak reference to the `UniqueRc`.
     ///
     /// Attempting to upgrade this weak reference will fail before the `UniqueRc` has been converted
@@ -4614,3 +4614,6 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Rc<T, A> {
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
     }
 }
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator + ?Sized, A: AllocatorClone> AllocatorClone for Rc<T, A> {}

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -906,6 +906,18 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
     unsafe { Box::from_raw(Box::into_raw(v) as *mut str) }
 }
 
+/// Internal; same as `from_boxed_utf8_unchecked` but allocator-generic. Name
+/// probably not suitable for being made `pub` as-is.
+#[must_use]
+#[inline]
+#[cfg(not(no_global_oom_handling))]
+pub(crate) unsafe fn from_boxed_utf8_unchecked_in<A: crate::alloc::Allocator>(
+    v: Box<[u8], A>,
+) -> Box<str, A> {
+    let (ptr, alloc) = Box::into_raw_with_allocator(v);
+    unsafe { Box::from_raw_in(ptr as *mut str, alloc) }
+}
+
 /// Converts leading ascii bytes in `s` by calling the `convert` function.
 ///
 /// For better average performance, this happens in chunks of `2*size_of::<usize>()`.

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -904,6 +904,22 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
     unsafe { Box::from_raw(Box::into_raw(v) as *mut str) }
 }
 
+/// Converts a boxed slice of bytes to a boxed string slice without checking
+/// that the string contains valid UTF-8 generically over the box's allocator.
+///
+/// # Safety
+///
+/// * The provided bytes must contain a valid UTF-8 sequence.
+#[unstable(feature = "allocator_api", issue = "32838")]
+#[must_use]
+#[inline]
+pub unsafe fn from_boxed_utf8_unchecked_in<A: crate::alloc::Allocator>(
+    v: Box<[u8], A>,
+) -> Box<str, A> {
+    let (ptr, alloc) = Box::into_raw_with_allocator(v);
+    unsafe { Box::from_raw_in(ptr as *mut str, alloc) }
+}
+
 /// Converts leading ascii bytes in `s` by calling the `convert` function.
 ///
 /// For better average performance, this happens in chunks of `2*size_of::<usize>()`.

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -908,6 +908,7 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
 /// probably not suitable for being made `pub` as-is.
 #[must_use]
 #[inline]
+#[cfg(not(no_global_oom_handling))]
 pub(crate) unsafe fn from_boxed_utf8_unchecked_in<A: crate::alloc::Allocator>(
     v: Box<[u8], A>,
 ) -> Box<str, A> {

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -904,16 +904,11 @@ pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
     unsafe { Box::from_raw(Box::into_raw(v) as *mut str) }
 }
 
-/// Converts a boxed slice of bytes to a boxed string slice without checking
-/// that the string contains valid UTF-8 generically over the box's allocator.
-///
-/// # Safety
-///
-/// * The provided bytes must contain a valid UTF-8 sequence.
-#[unstable(feature = "allocator_api", issue = "32838")]
+/// Internal; same as `from_boxed_utf8_unchecked` but allocator-generic. Name
+/// probably not suitable for being made `pub` as-is.
 #[must_use]
 #[inline]
-pub unsafe fn from_boxed_utf8_unchecked_in<A: crate::alloc::Allocator>(
+pub(crate) unsafe fn from_boxed_utf8_unchecked_in<A: crate::alloc::Allocator>(
     v: Box<[u8], A>,
 ) -> Box<str, A> {
     let (ptr, alloc) = Box::into_raw_with_allocator(v);

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -35,7 +35,7 @@ use core::{borrow, fmt, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{AllocError, Allocator, AllocatorClone, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::rc::is_dangling;
@@ -1939,7 +1939,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
     #[stable(feature = "arc_weak", since = "1.4.0")]
     pub fn downgrade(this: &Self) -> Weak<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // This Relaxed is OK because we're checking the value in the CAS
         // below.
@@ -2070,7 +2070,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub unsafe fn increment_strong_count_in(ptr: *const T, alloc: A)
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
         let arc = unsafe { mem::ManuallyDrop::new(Arc::from_raw_in(ptr, alloc)) };
@@ -2258,7 +2258,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
 
             // Free the allocation without dropping its contents
             let (bptr, alloc) = Box::into_raw_with_allocator(src);
-            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, alloc.by_ref());
+            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, &alloc);
             drop(src);
 
             Self::from_ptr_in(ptr, alloc)
@@ -2384,7 +2384,7 @@ impl<T: TrivialClone> ArcFromSlice<T> for Arc<[T]> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Arc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Arc<T, A> {
     /// Makes a clone of the `Arc` pointer.
     ///
     /// This creates another pointer to the same allocation, increasing the
@@ -2438,10 +2438,10 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Arc<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Arc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Arc<T, A> {}
 
 #[unstable(feature = "share_trait", issue = "156756")]
-impl<T: ?Sized, A: Allocator + Clone> Share for Arc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> Share for Arc<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized, A: Allocator> Deref for Arc<T, A> {
@@ -2463,7 +2463,7 @@ unsafe impl<T: ?Sized, A: Allocator> DerefPure for Arc<T, A> {}
 impl<T: ?Sized> LegacyReceiver for Arc<T> {}
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: ?Sized + CloneToUninit, A: Allocator + Clone> Arc<T, A> {
+impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Arc<T, A> {
     /// Makes a mutable reference into the given `Arc`.
     ///
     /// If there are other `Arc` pointers to the same allocation, then `make_mut` will
@@ -3302,7 +3302,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     #[stable(feature = "arc_weak", since = "1.4.0")]
     pub fn upgrade(&self) -> Option<Arc<T, A>>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         #[inline]
         fn checked_increment(n: usize) -> Option<usize> {
@@ -3437,7 +3437,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
 }
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Weak<T, A> {
     /// Makes a clone of the `Weak` pointer that points to the same allocation.
     ///
     /// # Examples
@@ -3469,7 +3469,7 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Weak<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Weak<T, A> {}
 
 #[stable(feature = "downgraded_weak", since = "1.10.0")]
 impl<T> Default for Weak<T> {
@@ -4057,7 +4057,7 @@ impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Arc<T, A> {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
-impl<T, A: Allocator + Clone> From<Vec<T, A>> for Arc<[T], A> {
+impl<T, A: AllocatorClone> From<Vec<T, A>> for Arc<[T], A> {
     /// Allocates a reference-counted slice and moves `v`'s items into it.
     ///
     /// # Example
@@ -4866,7 +4866,7 @@ impl<T: ?Sized, A: Allocator> UniqueArc<T, A> {
     }
 }
 
-impl<T: ?Sized, A: Allocator + Clone> UniqueArc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> UniqueArc<T, A> {
     /// Creates a new weak reference to the `UniqueArc`.
     ///
     /// Attempting to upgrade this weak reference will fail before the `UniqueArc` has been converted
@@ -4995,3 +4995,6 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Arc<T, A> {
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
     }
 }
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator + ?Sized, A: AllocatorClone> AllocatorClone for Arc<T, A> {}

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -35,7 +35,7 @@ use core::{borrow, fmt, hint};
 
 #[cfg(not(no_global_oom_handling))]
 use crate::alloc::handle_alloc_error;
-use crate::alloc::{AllocError, Allocator, Global, Layout};
+use crate::alloc::{AllocError, Allocator, AllocatorClone, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::rc::is_dangling;
@@ -1939,7 +1939,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
     #[stable(feature = "arc_weak", since = "1.4.0")]
     pub fn downgrade(this: &Self) -> Weak<T, A>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // This Relaxed is OK because we're checking the value in the CAS
         // below.
@@ -2070,7 +2070,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     pub unsafe fn increment_strong_count_in(ptr: *const T, alloc: A)
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
         let arc = unsafe { mem::ManuallyDrop::new(Arc::from_raw_in(ptr, alloc)) };
@@ -2258,7 +2258,7 @@ impl<T: ?Sized, A: Allocator> Arc<T, A> {
 
             // Free the allocation without dropping its contents
             let (bptr, alloc) = Box::into_raw_with_allocator(src);
-            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, alloc.by_ref());
+            let src = Box::from_raw_in(bptr as *mut mem::ManuallyDrop<T>, &alloc);
             drop(src);
 
             Self::from_ptr_in(ptr, alloc)
@@ -2384,7 +2384,7 @@ impl<T: TrivialClone> ArcFromSlice<T> for Arc<[T]> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Arc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Arc<T, A> {
     /// Makes a clone of the `Arc` pointer.
     ///
     /// This creates another pointer to the same allocation, increasing the
@@ -2438,10 +2438,10 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Arc<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Arc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Arc<T, A> {}
 
 #[unstable(feature = "share_trait", issue = "156756")]
-impl<T: ?Sized, A: Allocator + Clone> Share for Arc<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> Share for Arc<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized, A: Allocator> Deref for Arc<T, A> {
@@ -2471,7 +2471,7 @@ unsafe impl<T: ?Sized, A: Allocator> DerefPure for Arc<T, A> {}
 impl<T: ?Sized> LegacyReceiver for Arc<T> {}
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: ?Sized + CloneToUninit, A: Allocator + Clone> Arc<T, A> {
+impl<T: ?Sized + CloneToUninit, A: AllocatorClone> Arc<T, A> {
     /// Makes a mutable reference into the given `Arc`.
     ///
     /// If there are other `Arc` pointers to the same allocation, then `make_mut` will
@@ -3310,7 +3310,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     #[stable(feature = "arc_weak", since = "1.4.0")]
     pub fn upgrade(&self) -> Option<Arc<T, A>>
     where
-        A: Clone,
+        A: AllocatorClone,
     {
         #[inline]
         fn checked_increment(n: usize) -> Option<usize> {
@@ -3445,7 +3445,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
 }
 
 #[stable(feature = "arc_weak", since = "1.4.0")]
-impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
+impl<T: ?Sized, A: AllocatorClone> Clone for Weak<T, A> {
     /// Makes a clone of the `Weak` pointer that points to the same allocation.
     ///
     /// # Examples
@@ -3477,7 +3477,7 @@ impl<T: ?Sized, A: Allocator + Clone> Clone for Weak<T, A> {
 }
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
-impl<T: ?Sized, A: Allocator + Clone> UseCloned for Weak<T, A> {}
+impl<T: ?Sized, A: AllocatorClone> UseCloned for Weak<T, A> {}
 
 #[stable(feature = "downgraded_weak", since = "1.10.0")]
 impl<T> Default for Weak<T> {
@@ -4065,7 +4065,7 @@ impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Arc<T, A> {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
-impl<T, A: Allocator + Clone> From<Vec<T, A>> for Arc<[T], A> {
+impl<T, A: AllocatorClone> From<Vec<T, A>> for Arc<[T], A> {
     /// Allocates a reference-counted slice and moves `v`'s items into it.
     ///
     /// # Example
@@ -4874,7 +4874,7 @@ impl<T: ?Sized, A: Allocator> UniqueArc<T, A> {
     }
 }
 
-impl<T: ?Sized, A: Allocator + Clone> UniqueArc<T, A> {
+impl<T: ?Sized, A: AllocatorClone> UniqueArc<T, A> {
     /// Creates a new weak reference to the `UniqueArc`.
     ///
     /// Attempting to upgrade this weak reference will fail before the `UniqueArc` has been converted
@@ -5003,3 +5003,6 @@ unsafe impl<T: ?Sized + Allocator, A: Allocator> Allocator for Arc<T, A> {
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
     }
 }
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<T: Allocator + ?Sized, A: AllocatorClone> AllocatorClone for Arc<T, A> {}

--- a/library/alloctests/tests/arc.rs
+++ b/library/alloctests/tests/arc.rs
@@ -346,51 +346,6 @@ fn issue_158875_make_mut_dont_leak_allocator() {
     assert_eq!(Rc::strong_count(&alloc), 1); // if this is >1, we have a memory leak!
 }
 
-/// Test that `Arc::make_mut` does not cause a UAF if the allocator panics on
-/// clone when it steals the data.
-#[test]
-#[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
-fn issue_155746_make_mut_panic_safety() {
-    use std::alloc::{Allocator, System};
-    use std::panic::AssertUnwindSafe;
-
-    #[derive(Default)]
-    struct PanickingCloneAlloc {
-        do_panic: Rc<Cell<bool>>,
-    }
-    unsafe impl Allocator for PanickingCloneAlloc {
-        fn allocate(
-            &self,
-            layout: std::alloc::Layout,
-        ) -> Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError> {
-            System.allocate(layout)
-        }
-
-        unsafe fn deallocate(&self, ptr: std::ptr::NonNull<u8>, layout: std::alloc::Layout) {
-            unsafe { System.deallocate(ptr, layout) }
-        }
-    }
-    impl Clone for PanickingCloneAlloc {
-        fn clone(&self) -> Self {
-            if self.do_panic.get() { panic!() } else { Self { do_panic: self.do_panic.clone() } }
-        }
-    }
-
-    let alloc = PanickingCloneAlloc::default();
-    let mut arc = Arc::new_in(vec![vec![1]], alloc.clone());
-
-    let _weak = Arc::downgrade(&arc); // create a weak so make_mut steals the data
-
-    alloc.do_panic.set(true);
-    std::panic::catch_unwind(AssertUnwindSafe(|| {
-        Arc::make_mut(&mut arc);
-    }))
-    .unwrap_err();
-
-    assert_eq!(*arc, [[1]]);
-    assert_eq!(Arc::strong_count(&arc), 1); // if this is 0, we have a UAF!
-}
-
 #[test]
 #[should_panic = "capacity overflow"]
 fn new_uninit_slice_capacity_overflow() {

--- a/library/alloctests/tests/boxed.rs
+++ b/library/alloctests/tests/boxed.rs
@@ -211,13 +211,6 @@ unsafe impl Allocator for ConstAllocator {
         }
         Ok(new_ptr)
     }
-
-    fn by_ref(&self) -> &Self
-    where
-        Self: Sized,
-    {
-        self
-    }
 }
 
 #[allow(unused)]

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -74,7 +74,8 @@ impl fmt::Display for AllocError {
 /// * Moving, subtyping, unsize-coercing, or trait-upcasting an allocator does not change
 ///   what the allocator is equivalent to.
 /// * Copying or cloning allocator results in an allocator that's
-///   equivalent to the initial allocator.
+///   equivalent to the initial allocator, should the [`AllocatorClone`] trait
+///   be implemented.
 ///
 /// Additionally, implementors of `Allocator` may specify additional equivalences
 /// between allocators. It is the responsibility of such implementors to make sure
@@ -87,12 +88,6 @@ impl fmt::Display for AllocError {
 /// * All `Global` allocator instances are equivalent with each other.
 /// * All `System` allocator instances are equivalent with each other.
 ///
-/// Note: Currently, the interaction between cloning and unsize-coercing allocators
-/// is unsound, and there is ongoing discussion on how to revise the `Allocator` trait
-/// to fix this. See [#156920].
-///
-/// [#156920]: https://github.com/rust-lang/rust/issues/156920
-///
 /// ### Currently allocated memory
 ///
 /// Some of the methods require that a memory block is *currently allocated* by some specific allocator.
@@ -101,8 +96,6 @@ impl fmt::Display for AllocError {
 ///   the [`allocate`], [`allocate_zeroed`], [`grow`], [`grow_zeroed`], or [`shrink`] methods,
 ///   called on an allocator that's equivalent to this specific allocator; and
 /// * the memory block has not subsequently been [*invalidated*].
-///
-/// [*invalidated*]: #invalidating-memory-blocks
 ///
 /// ### Invalidating memory blocks
 ///
@@ -164,8 +157,8 @@ impl fmt::Display for AllocError {
 /// is [*currently allocated*] by the allocator points to valid memory,
 /// until that memory block is [*invalidated*]. The implementor must also
 /// not violate this invariant of `Allocator` via allocator equivalences
-/// that are in the implementor's control (e.g., via a misbehaving
-/// `impl Clone for Box<MyAllocator>`).
+/// that are in the implementor's control (e.g., via an incorrect `unsafe
+/// impl AllocatorClone for MyAllocator`).
 ///
 /// Additionally, any memory block returned by the allocator must
 /// satisfy the allocation invariants described in `core::ptr`.
@@ -175,17 +168,37 @@ impl fmt::Display for AllocError {
 /// This ensures that pointer arithmetic within the allocation
 /// (for example, `ptr.add(len)`) cannot overflow the address space.
 ///
+/// None of the allocating or deallocating methods may unwind. This restriction
+/// may be lifted in the future by ensuring unwinding out of an allocating function always
+/// aborts. If an implementor of `Allocator` also has drop glue or directly implements `Drop`,
+/// dropping the allocator must not result in an unwind.
+///
+/// Lastly, the methods on this trait must be *correct*; i.e. the layout requested
+/// must be respected, calls must zero out memory if the documentation so requires,
+/// and returning an `AllocError` from a reallocating method must indeed ensure that
+/// the old pointer was not invalidated, and de/reallocating calls must accept layouts
+/// in the ranges defined by their documentation.
+///
 /// [*currently allocated*]: #currently-allocated-memory
 /// [*invalidated*]: #invalidating-memory-blocks
+// NOTE: the above bound on allocating methods not unwinding, alongside the similar
+// bound on `AllocatorClone`, are currently load-bearing in std! see the below issues
+// and make sure they cannot be triggered before relaxing this:
+// https://rust.tf/156490
+// https://rust.tf/159982
 #[unstable(feature = "allocator_api", issue = "32838")]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
 pub const unsafe trait Allocator {
     /// Attempts to allocate a block of memory.
     ///
-    /// On success, returns a [`NonNull<[u8]>`][NonNull] meeting the size and alignment guarantees of `layout`.
+    /// On success, returns a [`NonNull<[u8]>`][NonNull] meeting the size and alignment
+    /// guarantees of `layout`. The returned block may have a larger size than specified
+    /// by `layout.size()`, and may or may not have its contents initialized.
     ///
-    /// The returned block may have a larger size than specified by `layout.size()`, and may or may
-    /// not have its contents initialized.
+    /// It is recommended that overallocating as per the above is only performed if doing so
+    /// is cheap; there is no guarantee that the caller is able to take advantage of the
+    /// returned excess. Implementors are free to e.g. provide an alternate method to query
+    /// available excess if doing so is expensive and should be left to the caller.
     ///
     /// Note that the returned block of memory is considered [*currently allocated*]
     /// with this allocator (and equivalent allocators).
@@ -200,7 +213,7 @@ pub const unsafe trait Allocator {
     /// Returning `Err` indicates that either memory is exhausted or `layout` does not meet
     /// allocator's size or alignment constraints.
     ///
-    /// Implementations are encouraged to return `Err` on memory exhaustion rather than panicking or
+    /// Implementations are encouraged to return `Err` on memory exhaustion rather than
     /// aborting, but this is not a strict requirement. (Specifically: it is *legal* to implement
     /// this trait atop an underlying native allocation library that aborts on memory exhaustion.)
     ///
@@ -217,7 +230,7 @@ pub const unsafe trait Allocator {
     /// Returning `Err` indicates that either memory is exhausted or `layout` does not meet
     /// allocator's size or alignment constraints.
     ///
-    /// Implementations are encouraged to return `Err` on memory exhaustion rather than panicking or
+    /// Implementations are encouraged to return `Err` on memory exhaustion rather than
     /// aborting, but this is not a strict requirement. (Specifically: it is *legal* to implement
     /// this trait atop an underlying native allocation library that aborts on memory exhaustion.)
     ///
@@ -239,6 +252,13 @@ pub const unsafe trait Allocator {
     /// * `ptr` must denote a block of memory [*currently allocated*] via this allocator, and
     /// * `layout` must [*fit*] that block of memory.
     ///
+    /// Note that it is *immediate* language UB for a deallocation or reallocation to
+    /// invalidate any outstanding references, smart pointers, etc.; thus, notably, an
+    /// allocator that has been moved into its own [*currently allocated*] memory may
+    /// not have its backing memory be freed, even if the allocator is never used again
+    /// afterwards. This is due to the fact that such a deallocation would invalidate the
+    /// `&self` reference passed to this method.
+    ///
     /// [*currently allocated*]: #currently-allocated-memory
     /// [*fit*]: #memory-fitting
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
@@ -252,6 +272,7 @@ pub const unsafe trait Allocator {
     /// If this returns `Ok`, then the memory block referenced by `ptr` has been [*invalidated*].
     /// The old `ptr` must not be used to access the memory, even if the allocation was grown in-place.
     /// The newly returned pointer is the only valid pointer for accessing this memory now.
+    /// All bytes past `old_layout.size()` should be assumed to be uninitialised.
     ///
     /// If this method returns `Err`, then the memory block has not been *invalidated*,
     /// and the contents of the memory block are unaltered.
@@ -273,7 +294,7 @@ pub const unsafe trait Allocator {
     /// Returns `Err` if the new layout does not meet the allocator's size and alignment
     /// constraints of the allocator, or if growing otherwise fails.
     ///
-    /// Implementations are encouraged to return `Err` on memory exhaustion rather than panicking or
+    /// Implementations are encouraged to return `Err` on memory exhaustion rather than
     /// aborting, but this is not a strict requirement. (Specifically: it is *legal* to implement
     /// this trait atop an underlying native allocation library that aborts on memory exhaustion.)
     ///
@@ -313,12 +334,9 @@ pub const unsafe trait Allocator {
     /// The memory block will contain the following contents after a successful call to
     /// `grow_zeroed`:
     ///   * Bytes `0..old_layout.size()` are preserved from the original allocation.
-    ///   * Bytes `old_layout.size()..old_size` will either be preserved or zeroed, depending on
-    ///     the allocator implementation. `old_size` refers to the size of the memory block prior
-    ///     to the `grow_zeroed` call, which may be larger than the size that was originally
-    ///     requested when it was allocated.
-    ///   * Bytes `old_size..new_size` are zeroed. `new_size` refers to the size of the memory
-    ///     block returned by the `grow_zeroed` call.
+    ///   * Bytes `old_layout.size()..new_size` are zeroed. `new_size` refers to the size
+    ///     of the memory block returned by the `grow_zeroed` call, which may be larger than
+    ///     `new_layout.size()`.
     ///
     /// # Safety
     ///
@@ -336,7 +354,7 @@ pub const unsafe trait Allocator {
     /// Returns `Err` if the new layout does not meet the allocator's size and alignment
     /// constraints of the allocator, or if growing otherwise fails.
     ///
-    /// Implementations are encouraged to return `Err` on memory exhaustion rather than panicking or
+    /// Implementations are encouraged to return `Err` on memory exhaustion rather than
     /// aborting, but this is not a strict requirement. (Specifically: it is *legal* to implement
     /// this trait atop an underlying native allocation library that aborts on memory exhaustion.)
     ///
@@ -380,6 +398,7 @@ pub const unsafe trait Allocator {
     /// If this returns `Ok`, then the memory block referenced by `ptr` has been [*invalidated*].
     /// The old `ptr` must not be used to access the memory, even if the allocation was shrunk in-place.
     /// The newly returned pointer is the only valid pointer for accessing this memory now.
+    /// All bytes past `new_layout.size()` should be assumed to be uninitialised.
     ///
     /// If this method returns `Err`, then the memory block has not been *invalidated*,
     /// and the contents of the memory block are unaltered.
@@ -401,7 +420,7 @@ pub const unsafe trait Allocator {
     /// Returns `Err` if the new layout does not meet the allocator's size and alignment
     /// constraints of the allocator, or if shrinking otherwise fails.
     ///
-    /// Implementations are encouraged to return `Err` on memory exhaustion rather than panicking or
+    /// Implementations are encouraged to return `Err` on memory exhaustion rather than
     /// aborting, but this is not a strict requirement. (Specifically: it is *legal* to implement
     /// this trait atop an underlying native allocation library that aborts on memory exhaustion.)
     ///
@@ -433,17 +452,6 @@ pub const unsafe trait Allocator {
         }
 
         Ok(new_ptr)
-    }
-
-    /// Creates a "by reference" adapter for this instance of `Allocator`.
-    ///
-    /// The returned adapter also implements `Allocator` and will simply borrow this.
-    #[inline(always)]
-    fn by_ref(&self) -> &Self
-    where
-        Self: Sized,
-    {
-        self
     }
 }
 
@@ -482,40 +490,10 @@ pub const unsafe trait Allocator {
 ///
 /// # Safety
 ///
-/// In addition to the safety requirements of `Allocator`, global allocators are
-/// subject to some additional constraints:
-///
-/// * It's undefined behavior if global allocators unwind. This restriction may
-///   be lifted in the future, but currently a panic from any of these
-///   functions may lead to memory unsafety.
-///
-/// * You must not rely on allocations actually happening, even if there are explicit
-///   heap allocations in the source. The optimizer may detect unused allocations that it can either
-///   eliminate entirely or move to the stack and thus never invoke the allocator. The
-///   optimizer may further assume that allocation is infallible, so code that used to fail due
-///   to allocator failures may now suddenly work because the optimizer worked around the
-///   need for an allocation. More concretely, the following code example is unsound, irrespective
-///   of whether your custom allocator allows counting how many allocations have happened.
-///
-///   ```rust,ignore (unsound and has placeholders)
-///   drop(Box::new(42));
-///   let number_of_heap_allocs = /* call private allocator API */;
-///   unsafe { std::hint::assert_unchecked(number_of_heap_allocs > 0); }
-///   ```
-///
-///   Note that the optimizations mentioned above are not the only
-///   optimization that can be applied. You may generally not rely on heap allocations
-///   happening if they can be removed without changing program behavior.
-///   Whether allocations happen or not is not part of the program behavior, even if it
-///   could be detected via an allocator that tracks allocations by printing or otherwise
-///   having side effects.
-///
-/// # Re-entrance
-///
-/// When implementing a global allocator, one has to be careful not to create an infinitely recursive
-/// implementation by accident, as many constructs in the Rust standard library may allocate in
-/// their implementation. For example, on some platforms, [`std::sync::Mutex`] may allocate, so using
-/// it is highly problematic in a global allocator.
+/// When implementing a global allocator, one has to be careful not to create an infinitely
+/// recursive implementation by accident, as many constructs in the Rust standard library may
+/// allocate in their implementation. For example, on some platforms, [`std::sync::Mutex`] may
+/// allocate, so using it is highly problematic in a global allocator.
 ///
 /// For this reason, one should generally stick to library features available through
 /// [`core`], and avoid using [`std`] in a global allocator. A few features from [`std`] are
@@ -535,7 +513,52 @@ pub const unsafe trait Allocator {
 /// [`unpark`]: ../../std/thread/struct.Thread.html#method.unpark
 #[unstable(feature = "allocator_api", issue = "32838")]
 #[expect(multiple_supertrait_upcastable)]
-pub unsafe trait GlobalAllocator: Allocator + Sync + 'static {}
+pub unsafe trait GlobalAllocator: StaticAllocator + Sync + 'static {}
+
+/// Marks a type's [`Clone`] implementation as sound with regard to [`Allocator`] equivalence.
+/// Implementors must ensure that, upon cloning, the two allocators are equivalent
+/// (i.e. it is possible to free memory with one that was allocated with the other).
+/// Further, mutable accesses such as moving or dropping the allocator must not invalidate
+/// its currently allocated blocks at least so long as clones exist.
+///
+/// Additionally, the bound that allocators do not unwind when (de)allocating also applies
+/// to guaranteeing allocators will not unwind when cloned.
+///
+/// It must also be the case that types which are `AllocatorClone` are either explicitly not
+/// copyable (such as by containing a `!Copy` field) or that copying them also respects allocator
+/// equivalence as if it had been a clone.
+#[unstable(feature = "allocator_api", issue = "32838")]
+pub unsafe trait AllocatorClone: Allocator + Clone {}
+
+/// Marks that an allocator and its supertypes will never invalidate currently allocated
+/// memory unless explicitly deallocated via a call to a deallocating method, even if
+/// dropped or if the allocator's lifetime expires.
+///
+/// This is a necessity in conjunction with [`Pin`], as only allocators that promise
+/// memory is never reused without a destructor running may be used to back a pinned pointer.
+///
+/// # Safety
+///
+/// Implementors must ensure that memory cannot be freed except via a call to
+/// `Allocator::deallocate`, and that subtype coercion preserves this invariant.
+///
+/// These requirements trivially apply to allocators that always maintain global state, such as
+/// `System` or `Global`. However, due to subtype coercion, it is *not* sound to implement
+/// for an arbitrary `Allocator + 'static` due to [edge-case interactions][unsound] with
+/// `Pin::clone`. Namely, an impl of `StaticAllocator for MyAllocator + 'long` guarantees that an
+/// impl of `StaticAllocator for MyAllocator + 'short` would be sound to write.
+///
+/// The following must thus be guaranteed:
+/// - the `Drop` impl of the allocator does not invalidate any allocations;
+/// - the allocator does not expose a safe API surface that allows invalidating
+///   its allocations;
+/// - the allocator's lifetime expiring does not invalidate any allocations;
+/// - the above also hold for all equivalent allocators (see [`Allocator`] docs).
+///
+/// [`Pin`]: ../../core/pin/struct.Pin.html
+/// [unsound]: https://github.com/rust-lang/rust/issues/157089
+#[unstable(feature = "allocator_api", issue = "32838")]
+pub unsafe trait StaticAllocator: Allocator {}
 
 #[unstable(feature = "allocator_api", issue = "32838")]
 #[rustc_const_unstable(feature = "const_heap", issue = "79597")]
@@ -647,3 +670,11 @@ where
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
     }
 }
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<A: Allocator + ?Sized> AllocatorClone for &A {}
+
+// If an allocator is `StaticAllocator` all equivalent allocators must also uphold
+// its semantics, and references are equivalent to the allocator they reference.
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl<A: StaticAllocator + ?Sized> StaticAllocator for &A {}

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -145,6 +145,12 @@ use crate::{hint, mem, ptr};
 #[derive_const(Clone, Default)]
 pub struct System;
 
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl core::alloc::AllocatorClone for System {}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl core::alloc::StaticAllocator for System {}
+
 impl System {
     #[inline]
     fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {

--- a/tests/ui/allocator/156920-allocator-clone.rs
+++ b/tests/ui/allocator/156920-allocator-clone.rs
@@ -1,0 +1,23 @@
+#![feature(allocator_api)]
+
+use std::{
+    alloc::{Allocator, Global, System},
+    sync::Arc,
+};
+
+pub trait MyAlloc: Allocator {}
+impl<A: Allocator> MyAlloc for A {}
+
+impl Clone for Box<dyn MyAlloc> {
+    fn clone(&self) -> Self {
+        Box::new(System)
+    }
+}
+
+fn main() {
+    let evil_arc: Arc<i32, Box<dyn MyAlloc>> = Arc::new_in(69420, Box::new(Global));
+    // clone() returns `System` instead of `Global`, but `Arc` requires equivalent allocators
+    // Make sure to not accidentally call <&Arc>::clone here.
+    let _ = <Arc<_, _> as Clone>::clone(&evil_arc);
+    //~^ ERROR: the trait bound `Box<dyn MyAlloc>: AllocatorClone` is not satisfied [E0277]
+}

--- a/tests/ui/allocator/156920-allocator-clone.stderr
+++ b/tests/ui/allocator/156920-allocator-clone.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `Box<dyn MyAlloc>: AllocatorClone` is not satisfied
+  --> $DIR/156920-allocator-clone.rs:21:14
+   |
+LL |     let _ = <Arc<_, _> as Clone>::clone(&evil_arc);
+   |              ^^^^^^^^^ the nightly-only, unstable trait `AllocatorClone` is not implemented for `Box<dyn MyAlloc>`
+   |
+   = help: the following other types implement trait `AllocatorClone`:
+             &A
+             Arc<T, A>
+             Rc<T, A>
+             System
+             std::alloc::Global
+   = note: required for `Arc<i32, Box<dyn MyAlloc>>` to implement `Clone`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/allocator/157089-box-pin-in.rs
+++ b/tests/ui/allocator/157089-box-pin-in.rs
@@ -1,0 +1,20 @@
+#![feature(allocator_api)]
+
+use std::{
+    alloc::{AllocError, Allocator, Layout},
+    pin::Pin,
+    ptr::NonNull,
+};
+
+struct UntrustedAlloc;
+unsafe impl Allocator for UntrustedAlloc {
+    fn allocate(&self, _: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        Err(AllocError)
+    }
+    unsafe fn deallocate(&self, _: NonNull<u8>, _: Layout) {}
+}
+
+pub fn main() {
+    let _: Pin<Box<i32, UntrustedAlloc>> = Box::pin_in(1, UntrustedAlloc);
+    //~^ ERROR: the trait bound `UntrustedAlloc: StaticAllocator` is not satisfied [E0277]
+}

--- a/tests/ui/allocator/157089-box-pin-in.stderr
+++ b/tests/ui/allocator/157089-box-pin-in.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `UntrustedAlloc: StaticAllocator` is not satisfied
+  --> $DIR/157089-box-pin-in.rs:18:59
+   |
+LL |     let _: Pin<Box<i32, UntrustedAlloc>> = Box::pin_in(1, UntrustedAlloc);
+   |                                            -----------    ^^^^^^^^^^^^^^ unsatisfied trait bound
+   |                                            |
+   |                                            required by a bound introduced by this call
+   |
+help: the nightly-only, unstable trait `StaticAllocator` is not implemented for `UntrustedAlloc`
+  --> $DIR/157089-box-pin-in.rs:9:1
+   |
+LL | struct UntrustedAlloc;
+   | ^^^^^^^^^^^^^^^^^^^^^
+help: the following other types implement trait `StaticAllocator`
+  --> $SRC_DIR/core/src/alloc/mod.rs:LL:COL
+   |
+   = note: `&A`
+  --> $SRC_DIR/std/src/alloc.rs:LL:COL
+   |
+   = note: `System`
+  --> $SRC_DIR/alloc/src/alloc.rs:LL:COL
+   |
+   = note: `std::alloc::Global`
+note: required by a bound in `Box::<T, A>::pin_in`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/allocator/159445-unsize-pin-box.rs
+++ b/tests/ui/allocator/159445-unsize-pin-box.rs
@@ -1,0 +1,27 @@
+#![feature(allocator_api)]
+
+use std::{
+    alloc::{AllocError, Allocator, Layout},
+    any::Any,
+    pin::Pin,
+    ptr::NonNull,
+};
+
+struct BadAlloc;
+unsafe impl Allocator for BadAlloc {
+    fn allocate(&self, _: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        unimplemented!()
+    }
+    unsafe fn deallocate(&self, _: NonNull<u8>, _: Layout) {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    // no requirements for the allocator, we are just pinning a `Box<impl Unpin>`
+    let base: Pin<Box<i32, BadAlloc>> = Pin::new(Box::new_in(1i32, BadAlloc));
+
+    // unsize coercion (must fail)
+    let _: Pin<Box<dyn Any, BadAlloc>> = base;
+    //~^ ERROR: the trait bound `BadAlloc: StaticAllocator` is not satisfied [E0277]
+}

--- a/tests/ui/allocator/159445-unsize-pin-box.stderr
+++ b/tests/ui/allocator/159445-unsize-pin-box.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `BadAlloc: StaticAllocator` is not satisfied
+  --> $DIR/159445-unsize-pin-box.rs:25:42
+   |
+LL |     let _: Pin<Box<dyn Any, BadAlloc>> = base;
+   |                                          ^^^^ unsatisfied trait bound
+   |
+help: the nightly-only, unstable trait `StaticAllocator` is not implemented for `BadAlloc`
+  --> $DIR/159445-unsize-pin-box.rs:10:1
+   |
+LL | struct BadAlloc;
+   | ^^^^^^^^^^^^^^^
+help: the following other types implement trait `StaticAllocator`
+  --> $SRC_DIR/core/src/alloc/mod.rs:LL:COL
+   |
+   = note: `&A`
+  --> $SRC_DIR/std/src/alloc.rs:LL:COL
+   |
+   = note: `System`
+  --> $SRC_DIR/alloc/src/alloc.rs:LL:COL
+   |
+   = note: `std::alloc::Global`
+   = note: required for `Box<i32, BadAlloc>` to implement `PinCoerceUnsized`
+   = note: required for the cast from `Pin<Box<i32, BadAlloc>>` to `Pin<Box<(dyn Any + 'static), BadAlloc>>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/allocator/159445-unsize-pin-box.stderr
+++ b/tests/ui/allocator/159445-unsize-pin-box.stderr
@@ -19,7 +19,7 @@ help: the following other types implement trait `StaticAllocator`
   --> $SRC_DIR/alloc/src/alloc.rs:LL:COL
    |
    = note: `std::alloc::Global`
-   = note: required for `Box<i32, BadAlloc>` to implement `PinCoerceUnsized`
+   = note: required for `Box<i32, BadAlloc>` to implement `PinSafePointer`
    = note: required for the cast from `Pin<Box<i32, BadAlloc>>` to `Pin<Box<(dyn Any + 'static), BadAlloc>>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/box/leak-alloc.rs
+++ b/tests/ui/box/leak-alloc.rs
@@ -21,7 +21,7 @@ fn use_value(_: u32) {}
 
 fn main() {
     let alloc = Alloc {};
-    let boxed = Box::new_in(10, alloc.by_ref());
+    let boxed = Box::new_in(10, &alloc);
     let theref = Box::leak(boxed);
     drop(alloc);
     //~^ ERROR cannot move out of `alloc` because it is borrowed

--- a/tests/ui/box/leak-alloc.stderr
+++ b/tests/ui/box/leak-alloc.stderr
@@ -3,8 +3,8 @@ error[E0505]: cannot move out of `alloc` because it is borrowed
    |
 LL |     let alloc = Alloc {};
    |         ----- binding `alloc` declared here
-LL |     let boxed = Box::new_in(10, alloc.by_ref());
-   |                                 ----- borrow of `alloc` occurs here
+LL |     let boxed = Box::new_in(10, &alloc);
+   |                                 ------ borrow of `alloc` occurs here
 LL |     let theref = Box::leak(boxed);
 LL |     drop(alloc);
    |          ^^^^^ move out of `alloc` occurs here
@@ -18,8 +18,8 @@ note: if `Alloc` implemented `Clone`, you could clone the value
 LL | struct Alloc {}
    | ^^^^^^^^^^^^ consider implementing `Clone` for this type
 ...
-LL |     let boxed = Box::new_in(10, alloc.by_ref());
-   |                                 ----- you could clone this value
+LL |     let boxed = Box::new_in(10, &alloc);
+   |                                  ----- you could clone this value
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157428)*
<!-- homu-ignore:end -->

Adds my current proposal per the doc in rust-lang/rust#156882 and follow-up Zulip conversations (notably for [dyn-compat](https://rust-lang.zulipchat.com/#narrow/channel/197181-t-libs.2Fwg-allocators/topic/Allocator.20dyn-safety/near/599555822)) unstably.

r? libs