### PR TITLE
Add regression test for unreachable_code with try operator

### DIFF
--- a/tests/ui/reachable/unreachable-question-mark-forbid.rs
+++ b/tests/ui/reachable/unreachable-question-mark-forbid.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![forbid(unreachable_code)]
+
+fn result() -> Result<(), ()> {
+    Ok(())?;
+    Err(())
+}
+
+fn option() -> Option<()> {
+    Some(())?;
+    None
+}
+
+fn main() {
+    let _ = result();
+    let _ = option();
+}


### PR DESCRIPTION
Fixes rust-lang/rust#76053

Adds a regression test for `#![forbid(unreachable_code)]` with the `?` operator.
