### PR TITLE
std::random: use little-endian for reproducibility

### DIFF
--- a/library/core/src/random.rs
+++ b/library/core/src/random.rs
@@ -40,7 +40,10 @@ macro_rules! impl_primitive {
             fn sample(&self, source: &mut (impl RandomSource + ?Sized)) -> $t {
                 let mut bytes = (0 as $t).to_ne_bytes();
                 source.fill_bytes(&mut bytes);
-                <$t>::from_ne_bytes(bytes)
+                // Always use little-endian for reproducibility. Since the vast majority of code is
+                // mainly or exclusively tested on LE targets, giving different PRNG results for the
+                // same seed on BE targets is a serious portability hazard.
+                <$t>::from_le_bytes(bytes)
             }
         }
     };


### PR DESCRIPTION
See added comment for rationale. Also note that `rand` has defaulted to LE for many years, apparently without any objections.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

r? @joshtriplett 
