### PR TITLE
Introduce -Zdisable-incr-comp-backend-caching

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -463,7 +463,8 @@ fn copy_all_cgu_workproducts_to_incr_comp_cache_dir(
 ) -> FxIndexMap<WorkProductId, WorkProduct> {
     let mut work_products = FxIndexMap::default();
 
-    if sess.opts.incremental.is_none() {
+    if sess.opts.incremental.is_none() || sess.opts.unstable_opts.disable_incr_comp_backend_caching
+    {
         return work_products;
     }
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -1132,7 +1132,9 @@ pub(crate) fn provide(providers: &mut Providers) {
 }
 
 pub fn determine_cgu_reuse<'tcx>(tcx: TyCtxt<'tcx>, cgu: &CodegenUnit<'tcx>) -> CguReuse {
-    if !tcx.dep_graph.is_fully_enabled() {
+    if !tcx.dep_graph.is_fully_enabled()
+        || tcx.sess.opts.unstable_opts.disable_incr_comp_backend_caching
+    {
         return CguReuse::No;
     }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2298,6 +2298,8 @@ options! {
         "Direct or use GOT indirect to reference external data symbols"),
     disable_fast_paths: bool = (false, parse_bool, [TRACKED],
         "disable various performance optimizations in trait solving"),
+    disable_incr_comp_backend_caching: bool = (false, parse_bool, [TRACKED],
+        "disable caching of compiled objects by the codegen backend during incremental compilation"),
     dual_proc_macros: bool = (false, parse_bool, [TRACKED],
         "load proc macros for both target and host, but only link to the target (default: no)"),
     dump_dep_graph: bool = (false, parse_bool, [UNTRACKED],


### PR DESCRIPTION
This disables caching of compiled objects by the codegen backend during incremental compilation. This is useful for iterating on a codegen backend without having to run the entire rustc frontend from scratch every time when recompiling the standard library. Currently cg_clif has the CG_CLIF_DISABLE_INCR_CACHE env var that does this, but once cg_clif switches to the codegen coordinator of cg_ssa, it will no longer be possible for cg_clif to implement this. It has to be implemented in cg_ssa.