### PR TITLE
rustdoc: don't link doc(hidden) associated type projections

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -20,8 +20,8 @@ use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::{ConstStability, StabilityLevel, StableSince};
 use rustc_metadata::creader::CStore;
 use rustc_middle::ty::{self, TyCtxt, TypingMode};
-use rustc_span::Symbol;
 use rustc_span::symbol::kw;
+use rustc_span::{Ident, Symbol};
 use tracing::{debug, trace};
 
 use super::url_parts_builder::UrlPartsBuilder;
@@ -1109,8 +1109,23 @@ fn print_qpath_data(qpath_data: &clean::QPathData, cx: &Context<'_>) -> impl Dis
                 Some(trait_) => href(trait_.def_id(), cx).ok(),
                 None => self_type.def_id(cx.cache()).and_then(|did| href(did, cx).ok()),
             };
+            let tcx = cx.tcx();
+            let assoc_type_is_hidden = !cx.cache().document_hidden
+                && trait_.as_ref().is_some_and(|trait_| {
+                    let trait_did = trait_.def_id();
+                    tcx.associated_items(trait_did)
+                        .find_by_ident_and_kind(
+                            tcx,
+                            Ident::with_dummy_span(assoc.name),
+                            ty::AssocTag::Type,
+                            trait_did,
+                        )
+                        .is_some_and(|assoc_item| tcx.is_doc_hidden(assoc_item.def_id))
+                });
 
-            if let Some(HrefInfo { url, rust_path, .. }) = parent_href {
+            if let Some(HrefInfo { url, rust_path, .. }) = parent_href
+                && !assoc_type_is_hidden
+            {
                 write!(
                     f,
                     "<a class=\"associatedtype\" href=\"{url}#{shortty}.{name}\" \

--- a/tests/rustdoc-html/hidden-trait-methods-with-document-hidden-items.rs
+++ b/tests/rustdoc-html/hidden-trait-methods-with-document-hidden-items.rs
@@ -29,3 +29,9 @@ impl Trait for S {
     fn f() {}
     fn g() {}
 }
+
+// Regression test for https://github.com/rust-lang/rust/issues/151454.
+//@ has foo/fn.hidden_projection.html
+//@ has - '//pre[@class="rust item-decl"]' 'T::Foo'
+//@ has - '//pre[@class="rust item-decl"]//a[@href="trait.Trait.html#associatedtype.Foo"]' 'Foo'
+pub fn hidden_projection<T: Trait>(_: T::Foo) {}

--- a/tests/rustdoc-html/hidden-trait-methods.rs
+++ b/tests/rustdoc-html/hidden-trait-methods.rs
@@ -27,3 +27,9 @@ impl Trait for S {
     fn f() {}
     fn g() {}
 }
+
+// Regression test for https://github.com/rust-lang/rust/issues/151454.
+//@ has foo/fn.hidden_projection.html
+//@ has - '//pre[@class="rust item-decl"]' 'T::Foo'
+//@ !has - '//pre[@class="rust item-decl"]//a[@href="trait.Trait.html#associatedtype.Foo"]' 'Foo'
+pub fn hidden_projection<T: Trait>(_: T::Foo) {}


### PR DESCRIPTION
Rustdoc renders associated type projections like `T::Foo` by linking `Foo` to the containing trait page and appending `#associatedtype.Foo`.

For `#[doc(hidden)]` associated types, that anchor is not rendered in normal docs, so this can produce dangling links. 

This PR checks the corresponding trait associated item before emitting the projection link.
When the associated type is hidden, rustdoc leaves the projection text plain, accounting for `--document-hidden-items` as well.

Fixes rust-lang/rust#151454.