### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -463,7 +463,8 @@ fn copy_all_cgu_workproducts_to_incr_comp_cache_dir(
 ) -> FxIndexMap<WorkProductId, WorkProduct> {
     let mut work_products = FxIndexMap::default();
 
-    if sess.opts.incremental.is_none() {
+    if sess.opts.incremental.is_none() || sess.opts.unstable_opts.disable_incr_comp_backend_caching
+    {
         return work_products;
     }
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -1132,7 +1132,9 @@ pub(crate) fn provide(providers: &mut Providers) {
 }
 
 pub fn determine_cgu_reuse<'tcx>(tcx: TyCtxt<'tcx>, cgu: &CodegenUnit<'tcx>) -> CguReuse {
-    if !tcx.dep_graph.is_fully_enabled() {
+    if !tcx.dep_graph.is_fully_enabled()
+        || tcx.sess.opts.unstable_opts.disable_incr_comp_backend_caching
+    {
         return CguReuse::No;
     }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2298,6 +2298,8 @@ options! {
         "Direct or use GOT indirect to reference external data symbols"),
     disable_fast_paths: bool = (false, parse_bool, [TRACKED],
         "disable various performance optimizations in trait solving"),
+    disable_incr_comp_backend_caching: bool = (false, parse_bool, [TRACKED],
+        "disable caching of compiled objects by the codegen backend during incremental compilation"),
     dual_proc_macros: bool = (false, parse_bool, [TRACKED],
         "load proc macros for both target and host, but only link to the target (default: no)"),
     dump_dep_graph: bool = (false, parse_bool, [UNTRACKED],

--- a/library/std/src/sys/net/connection/xous/tcplistener.rs
+++ b/library/std/src/sys/net/connection/xous/tcplistener.rs
@@ -129,12 +129,13 @@ impl TcpListener {
             0,
         ) {
             if receive_request.raw[0] != 0 {
-                // error case
-                if receive_request.raw[1] == NetError::TimedOut as u8 {
+                // Error case — code lives at byte 4 (where the send path
+                // also reads it). Byte 1 is part of the marker header.
+                if receive_request.raw[4] == NetError::TimedOut as u8 {
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "accept timed out"));
-                } else if receive_request.raw[1] == NetError::WouldBlock as u8 {
+                } else if receive_request.raw[4] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "accept would block"));
-                } else if receive_request.raw[1] == NetError::LibraryError as u8 {
+                } else if receive_request.raw[4] == NetError::LibraryError as u8 {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));

--- a/library/std/src/sys/net/connection/xous/tcpstream.rs
+++ b/library/std/src/sys/net/connection/xous/tcpstream.rs
@@ -213,11 +213,14 @@ impl TcpStream {
         } else {
             let result = receive_request.raw;
             if result[0] != 0 {
-                if result[1] == 8 {
+                // The error code lives at byte 4 of the kernel's response buffer
+                // (matches the byte the send path reads in `write` below). Byte 1
+                // is part of the marker header, not the code.
+                if result[4] == 8 {
                     // timed out
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "timeout"));
                 }
-                if result[1] == 9 {
+                if result[4] == 9 {
                     // would block
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "would block"));
                 }

--- a/library/std/src/sys/net/connection/xous/udp.rs
+++ b/library/std/src/sys/net/connection/xous/udp.rs
@@ -145,12 +145,13 @@ impl UdpSocket {
             0,
         ) {
             if receive_request.raw[0] != 0 {
-                // error case
-                if receive_request.raw[1] == NetError::TimedOut as u8 {
+                // Error case — code lives at byte 4 (where `send_message`
+                // also reads it). Byte 1 is part of the marker header.
+                if receive_request.raw[4] == NetError::TimedOut as u8 {
                     return Err(io::const_error!(io::ErrorKind::TimedOut, "recv timed out"));
-                } else if receive_request.raw[1] == NetError::WouldBlock as u8 {
+                } else if receive_request.raw[4] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "recv would block"));
-                } else if receive_request.raw[1] == NetError::LibraryError as u8 {
+                } else if receive_request.raw[4] == NetError::LibraryError as u8 {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));

--- a/tests/ui/reachable/unreachable-question-mark-forbid.rs
+++ b/tests/ui/reachable/unreachable-question-mark-forbid.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![forbid(unreachable_code)]
+
+fn result() -> Result<(), ()> {
+    Ok(())?;
+    Err(())
+}
+
+fn option() -> Option<()> {
+    Some(())?;
+    None
+}
+
+fn main() {
+    let _ = result();
+    let _ = option();
+}


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#156414 (std/sys/net/xous: read NetError code from byte 4 in recv/accept paths)
 - rust-lang/rust#157429 (Add regression test for unreachable_code with try operator)
 - rust-lang/rust#157435 (Introduce -Zdisable-incr-comp-backend-caching)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=156414,157429,157435)
<!-- homu-ignore:end -->

