### PR TITLE
rustc_target: callconv: powerpc64: Remove unreachable fallback code path

### DIFF
--- a/compiler/rustc_target/src/callconv/powerpc64.rs
+++ b/compiler/rustc_target/src/callconv/powerpc64.rs
@@ -2,7 +2,7 @@
 // Alignment of 128 bit types is not currently handled, this will
 // need to be fixed when PowerPC vector support is added.
 
-use rustc_abi::{Endian, HasDataLayout, TyAbiInterface};
+use rustc_abi::{HasDataLayout, TyAbiInterface};
 
 use crate::callconv::{Align, ArgAbi, FnAbi, Reg, RegKind, Uniform};
 use crate::spec::{HasTargetSpec, LlvmAbi, Os};
@@ -106,17 +106,13 @@ where
     Ty: TyAbiInterface<'a, C> + Copy,
     C: HasDataLayout + HasTargetSpec,
 {
-    let abi = if cx.target_spec().options.llvm_abiname == LlvmAbi::ElfV2 {
-        ELFv2
-    } else if cx.target_spec().options.llvm_abiname == LlvmAbi::ElfV1 {
-        ELFv1
-    } else if cx.target_spec().os == Os::Aix {
-        AIX
-    } else {
-        match cx.data_layout().endian {
-            Endian::Big => ELFv1,
-            Endian::Little => ELFv2,
-        }
+    let abi = match cx.target_spec().options.llvm_abiname {
+        LlvmAbi::ElfV1 => ELFv1,
+        LlvmAbi::ElfV2 => ELFv2,
+        LlvmAbi::Unspecified if cx.target_spec().os == Os::Aix => AIX,
+        // Target::check_consistency enforces that every target except AIX
+        // sets llvm_abiname to either ElfV1 or ElfV2
+        _ => unreachable!(),
     };
 
     classify(cx, &mut fn_abi.ret, abi, true);


### PR DESCRIPTION
This is effectively dead code now that we validate the target spec, so let's mark it as unreachable to avoid misleading people looking at this code.

---

Alternatively we could use `cfg_abi` in this code and match on `ElfV1` / `ElfV2` / `VecExtAbi`, but... AIX remains a mystery to me and it would boil down to the same 3 branches and an unreachable fallback.

r? @RalfJung 