### PR TITLE
Add run-pass regression test for SimplifyComparisonIntegral non-SSA miscompile

### DIFF
--- a/tests/ui/mir/simplify-comparison-integral-non-ssa-miscompile.rs
+++ b/tests/ui/mir/simplify-comparison-integral-non-ssa-miscompile.rs
@@ -1,0 +1,24 @@
+// Regression test for a miscompile in SimplifyComparisonIntegral: it rewrote a
+// switchInt on a non-SSA comparison local, dropping a later reassignment, after
+// DestinationPropagation was enabled by default. See rust-lang/rust#150904.
+
+//@ run-pass
+//@ compile-flags: -O
+
+#[inline(never)]
+fn run_my_check(v0: u64, v1: u64) -> i32 {
+    if do_check(v0, v1) { 1 } else { 0 }
+}
+
+#[inline(always)]
+fn do_check(v0: u64, v1: u64) -> bool {
+    let mut ok = v0 == 42;
+    ok &= v1 == 0;
+    ok
+}
+
+fn main() {
+    assert_eq!(run_my_check(42, 0), 1);
+    assert_eq!(run_my_check(42, 1), 0);
+    assert_eq!(run_my_check(0, 0), 0);
+}


### PR DESCRIPTION
Regression test for rust-lang/rust#150904

rust-lang/rust#142915 enabled `DestinationPropagation` by default, which let
`SimplifyComparisonIntegral` see a `switchInt` on a comparison local that is
reassigned between the `Eq` and the `switchInt` (a non-SSA local). The pass
rewrote `switchInt(_cmp)` into `switchInt(place)` without checking that `_cmp`
is written exactly once, so it used the value from `Eq` and dropped the later
reassignment, miscompiling at `-O`.

rust-lang/rust#150925 fixed this by only relating SSA locals, but it shipped with `mir-opt`
(MIR-shape) tests only - they assert the pass no longer fires on the bad
shapes, but nothing checks the compiled program actually produces the right
result. This adds that behavioral run-pass test, so the end-to-end miscompile
stays covered even if the MIR shape or surrounding passes change.

Runs locally (`./x test tests/ui/mir/simplify-comparison-integral-non-ssa-miscompile.rs` → `1 passed`)

r? @saethlin
