### PR TITLE
Avoid ICE when emitting TargetMachine config errors

### DIFF
--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -24,9 +24,12 @@ pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
-        let diag: Diag<'_, G> = self.0.into_diag(dcx, level);
+        // Reuse the formatted primary message from `LlvmError` without emitting it.
+        let diag: Diag<'_, ()> = self.0.into_diag(dcx, level);
         let (message, _) = diag.messages.first().expect("`LlvmError` with no message");
-        let message = format_diag_message(message, &diag.args);
+        let message = format_diag_message(message, &diag.args).into_owned();
+        diag.cancel();
+
         Diag::new(
             dcx,
             level,

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -220,6 +220,7 @@ fn check_unexpected_extension(check: &mut RunningCheck, file_path: &Path, ext: &
         "tests/ui/asm/named-asm-labels.s", // loading an external asm file to test named labels lint
         "tests/ui/asm/normalize-offsets-for-crlf.s", // loading an external asm file to test CRLF normalization
         "tests/ui/codegen/mismatched-data-layout.json", // testing mismatched data layout w/ custom targets
+        "tests/ui/codegen/custom-target-invalid-llvm-target.json", // testing invalid custom targets
         "tests/ui/check-cfg/my-awesome-platform.json",  // testing custom targets with cfgs
         "tests/ui/argfile/commandline-argfile-badutf8.args", // passing args via a file
         "tests/ui/argfile/commandline-argfile.args",    // passing args via a file

--- a/tests/ui/codegen/custom-target-invalid-llvm-target.json
+++ b/tests/ui/codegen/custom-target-invalid-llvm-target.json
@@ -1,0 +1,6 @@
+{
+    "llvm-target": "not-a-real-target",
+    "data-layout": "e",
+    "arch": "x86_64",
+    "target-pointer-width": 64
+}

--- a/tests/ui/codegen/custom-target-invalid-llvm-target.rs
+++ b/tests/ui/codegen/custom-target-invalid-llvm-target.rs
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/rust-lang/rust/issues/157401
+
+// ignore-tidy-target-specific-tests
+//@ check-fail
+//@ compile-flags: --target={{src-base}}/codegen/custom-target-invalid-llvm-target.json -Z unstable-options
+//@ ignore-backends: gcc
+
+fn main() {}
+
+//~? ERROR failed to parse target machine config to target machine

--- a/tests/ui/codegen/custom-target-invalid-llvm-target.stderr
+++ b/tests/ui/codegen/custom-target-invalid-llvm-target.stderr
@@ -1,0 +1,2 @@
+error: failed to parse target machine config to target machine: could not create LLVM TargetMachine for triple: not-a-real-target
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157401

`ParseTargetMachineConfig::into_diag` constructed an inner `LlvmError` diagnostic to reuse its formatted message, but did not emit or cancel that temporary diagnostic. That a root cause of the ICE.