### PR TITLE
fix windows-gnu TLS leak

### DIFF
--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -106,6 +106,7 @@ impl Drop for EnableGuard {
     }
 }
 
+/// Set up the current thread to invoke `cleanup` when it finishes.
 pub fn enable() {
     let registered = if cfg!(target_thread_local) {
         #[thread_local]

--- a/library/std/src/sys/thread_local/key/windows.rs
+++ b/library/std/src/sys/thread_local/key/windows.rs
@@ -60,6 +60,12 @@ impl LazyKey {
 
     #[inline]
     pub fn force(&'static self) -> Key {
+        if self.dtor.is_some() {
+            // Needs to be called on all threads where the key might have a non-null value!
+            // Otherwise, `run_dtors` might not be called on this thread.
+            guard::enable();
+        }
+
         match self.key.load(Acquire) {
             0 => unsafe { self.init() },
             key => key - 1,
@@ -88,6 +94,8 @@ impl LazyKey {
                 }
 
                 unsafe {
+                    // Add ourselves to the `DTORS` list, so that when `run_dtors` gets called,
+                    // our dtor is invoked.
                     register_dtor(self);
                 }
 
@@ -144,8 +152,6 @@ static DTORS: Atomic<*mut LazyKey> = AtomicPtr::new(ptr::null_mut());
 /// Should only be called once per key, otherwise loops or breaks may occur in
 /// the linked list.
 unsafe fn register_dtor(key: &'static LazyKey) {
-    guard::enable();
-
     let this = <*const LazyKey>::cast_mut(key);
     // Use acquire ordering to pass along the changes done by the previously
     // registered keys when we store the new head with release ordering.

--- a/library/std/src/sys/thread_local/mod.rs
+++ b/library/std/src/sys/thread_local/mod.rs
@@ -81,7 +81,7 @@ pub(crate) mod destructors {
 
 /// This module provides a way to schedule the execution of the destructor list
 /// and the [runtime cleanup](crate::rt::thread_cleanup) function. Calling `enable`
-/// should ensure that these functions are called at the right times.
+/// sets up the current thread to ensure that these functions are called at the right times.
 pub(crate) mod guard {
     cfg_select! {
         all(target_thread_local, target_vendor = "apple") => {

--- a/library/std/src/thread/lifecycle.rs
+++ b/library/std/src/thread/lifecycle.rs
@@ -66,7 +66,7 @@ where
     let rust_start = move || {
         let f = f.into_inner();
         let try_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            crate::sys::backtrace::__rust_begin_short_backtrace(|| hooks.run());
+            crate::sys::backtrace::__rust_begin_short_backtrace(|| hooks.inherit_and_run());
             crate::sys::backtrace::__rust_begin_short_backtrace(f)
         }));
         // SAFETY: `their_packet` as been built just above and moved by the

--- a/library/std/src/thread/spawnhook.rs
+++ b/library/std/src/thread/spawnhook.rs
@@ -144,7 +144,7 @@ pub(super) struct ChildSpawnHooks {
 
 impl ChildSpawnHooks {
     // This is run on the newly spawned thread, directly at the start.
-    pub(super) fn run(self) {
+    pub(super) fn inherit_and_run(self) {
         SPAWN_HOOKS.set(self.hooks);
         for run in self.to_run {
             run();

--- a/library/std/tests/thread_local/tests.rs
+++ b/library/std/tests/thread_local/tests.rs
@@ -408,6 +408,7 @@ fn thread_current_in_dtor() {
 // https://github.com/rust-lang/rust/pull/148799#issuecomment-3731806901
 #[cfg(target_os = "windows")]
 #[test]
+#[cfg_attr(miri, ignore)] // Miri does not support fibers
 fn fiber_does_not_trigger_dtor() {
     use core::ffi::c_void;
     use std::ptr;

--- a/tests/run-make/dynamic-loading-cdylib/foo.rs
+++ b/tests/run-make/dynamic-loading-cdylib/foo.rs
@@ -6,18 +6,36 @@ pub extern "C" fn extern_fn_1(a: u32, b: u32) -> u32 {
     a + b
 }
 
-struct NotifyOnDrop;
+#[derive(Default)]
+struct NotifyOnDrop {
+    last_result: std::cell::Cell<u32>,
+}
+
+impl NotifyOnDrop {
+    fn save_and_print(&self, result: u32) {
+        self.last_result.set(result);
+    }
+}
 
 impl Drop for NotifyOnDrop {
     fn drop(&mut self) {
-        println!("drop");
+        println!("dropping, last result: {}", self.last_result.get());
     }
+}
+
+thread_local! {
+    static FOO: NotifyOnDrop = NotifyOnDrop::default();
 }
 
 #[no_mangle]
 pub extern "C" fn extern_fn_2(a: u32, b: u32) -> u32 {
-    thread_local!(static FOO: NotifyOnDrop = NotifyOnDrop);
-    FOO.with(|_foo| {});
-    println!("extern_fn_2");
-    a * b
+    let result = a * b;
+
+    FOO.with(|foo| {
+        foo.save_and_print(result);
+    });
+
+    println!("extern_fn_2({a}, {b})");
+
+    result
 }

--- a/tests/run-make/dynamic-loading-cdylib/load_and_unload.rs
+++ b/tests/run-make/dynamic-loading-cdylib/load_and_unload.rs
@@ -101,6 +101,15 @@ fn main() {
     let result = unsafe { extern_fn_2(2, 3) };
     println!("result of extern_fn_2(2, 3): {}", result);
 
+    println!("spawning thread");
+    std::thread::spawn(move || {
+        let result = unsafe { extern_fn_2(4, 5) };
+        println!("result of extern_fn_2(4, 5) in other thread: {}", result);
+    })
+    .join()
+    .expect("Thread panicked");
+    println!("thread joined");
+
     libloading::unload(foo);
     println!("unloaded library");
 }

--- a/tests/run-make/dynamic-loading-cdylib/output_unix.txt
+++ b/tests/run-make/dynamic-loading-cdylib/output_unix.txt
@@ -1,7 +1,12 @@
 loaded library
 extern_fn_1
 result of extern_fn_1(2, 3): 5
-extern_fn_2
+extern_fn_2(2, 3)
 result of extern_fn_2(2, 3): 6
+spawning thread
+extern_fn_2(4, 5)
+result of extern_fn_2(4, 5) in other thread: 20
+dropping, last result: 20
+thread joined
 unloaded library
-drop
+dropping, last result: 6

--- a/tests/run-make/dynamic-loading-cdylib/output_windows.txt
+++ b/tests/run-make/dynamic-loading-cdylib/output_windows.txt
@@ -1,7 +1,12 @@
 loaded library
 extern_fn_1
 result of extern_fn_1(2, 3): 5
-extern_fn_2
+extern_fn_2(2, 3)
 result of extern_fn_2(2, 3): 6
-drop
+spawning thread
+extern_fn_2(4, 5)
+result of extern_fn_2(4, 5) in other thread: 20
+dropping, last result: 20
+thread joined
+dropping, last result: 6
 unloaded library


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157483)*
<!-- homu-ignore:end -->

Running the std tests on windows-gnu [has a memory leak](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Miri.20test-libstd.20Failure.20.282026-06.29/near/599991435). After lots of false leads, here's what I found:
- The `guard::enable` function needs to be called on each thread; it the ensures that when the thread finishes, cleanup is performed.
- The windows `LazyKey` calls `guard::enable` in its `init` function. That means it only gets called on the first thread that accesses this key!
- We have a `guard::enable` call in the `thread::spawn` path. However, when running tests, there are two copies of std, so there are two guards. `crate::thread::spawn` sets up the guard for the current crate (the one built with `cfg(test)`), but does not set up the guard for `realstd` (the std crate in the sysroot).

This is a regression introduced by https://github.com/rust-lang/rust/pull/148799. Previously, `guard::enable`  was pretty much a NOP on Windows so not calling it didn't cause problems.

https://github.com/rust-lang/miri-test-libstd/pull/123 has confirmed that this indeed fixes the leak.

The first commit is a drive-by fix where I found a function name kind of confusing.

r? @ChrisDenton 
Cc @joboet 