### PR TITLE
crater: reserve `only` keyword

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	shallow = true
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/lqd/cargo.git
 	shallow = true
 [submodule "src/doc/reference"]
 	path = src/doc/reference

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3181,6 +3181,8 @@ pub enum BoundPolarity {
     Negative(Span),
     /// `Type: ?Trait`
     Maybe(Span),
+    /// `Type: only Trait`,
+    Only(Span),
 }
 
 impl BoundPolarity {
@@ -3189,6 +3191,7 @@ impl BoundPolarity {
             Self::Positive => "",
             Self::Negative(_) => "!",
             Self::Maybe(_) => "?",
+            Self::Only(_) => "only",
         }
     }
 }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2773,6 +2773,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             BoundPolarity::Positive => BoundPolarity::Positive,
             BoundPolarity::Negative(span) => BoundPolarity::Negative(self.lower_span(span)),
             BoundPolarity::Maybe(span) => BoundPolarity::Maybe(self.lower_span(span)),
+            BoundPolarity::Only(span) => BoundPolarity::Only(self.lower_span(span)),
         };
         hir::TraitBoundModifiers { constness, polarity }
     }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1478,7 +1478,9 @@ impl<'a> State<'a> {
         }
         match polarity {
             ast::BoundPolarity::Positive => {}
-            ast::BoundPolarity::Negative(_) | ast::BoundPolarity::Maybe(_) => {
+            ast::BoundPolarity::Negative(_)
+            | ast::BoundPolarity::Maybe(_)
+            | ast::BoundPolarity::Only(_) => {
                 self.word(polarity.as_str());
             }
         }

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -331,7 +331,7 @@ pub(crate) struct EmptyConfusables {
 }
 
 #[derive(Diagnostic)]
-#[help("`#[{$name}{$attribute_args}]` can {$only}be applied to {$applied}")]
+#[help("`#[{$name}{$attribute_args}]` can {$only_prefix}be applied to {$applied}")]
 #[diag("`#[{$name}{$attribute_args}]` attribute cannot be used on {$target}")]
 pub(crate) struct InvalidTarget {
     #[primary_span]
@@ -345,7 +345,7 @@ pub(crate) struct InvalidTarget {
     pub name: AttrPath,
     pub target: &'static str,
     pub applied: DiagArgValue,
-    pub only: &'static str,
+    pub only_prefix: &'static str,
     pub attribute_args: &'static str,
     #[subdiagnostic]
     pub help: Option<InvalidTargetHelp>,

--- a/compiler/rustc_attr_parsing/src/target_checking.rs
+++ b/compiler/rustc_attr_parsing/src/target_checking.rs
@@ -124,12 +124,13 @@ impl<'sess> AttributeParser<'sess> {
         }
 
         let allowed_targets = allowed_targets.allowed_targets();
-        let (applied, only) = allowed_targets_applied(allowed_targets, cx.target, cx.features);
+        let (applied, only_prefix) =
+            allowed_targets_applied(allowed_targets, cx.target, cx.features);
         let diag = InvalidTarget {
             span: cx.attr_span.clone(),
             name: cx.attr_path.clone(),
             target: cx.target.plural_name(),
-            only: if only { "only " } else { "" },
+            only_prefix: if only_prefix { "only " } else { "" },
             applied: DiagArgValue::StrListSepByAnd(applied.into_iter().map(Cow::Owned).collect()),
             attribute_args,
             help: Self::target_checking_help(attribute_args, cx),

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1430,7 +1430,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 span.push_span_label(expr.span, "you could clone this value");
                 let types: Vec<_> = types.into_iter().collect();
                 let msg = match &types[..] {
-                    [only] => format!("`{only}`"),
+                    [single] => format!("`{single}`"),
                     [head @ .., last] => format!(
                         "{} and `{last}`",
                         head.iter().map(|t| format!("`{t}`")).collect::<Vec<_>>().join(", ")

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -31,6 +31,8 @@ struct CollectedBound {
     maybe: bool,
     /// `!Trait`
     negative: bool,
+    /// `only Trait`
+    only_modifier: bool,
 }
 
 impl CollectedBound {
@@ -112,6 +114,7 @@ fn collect_bounds<'a, 'tcx>(
         match ptr.modifiers.polarity {
             hir::BoundPolarity::Maybe(_) => collect_into.maybe = true,
             hir::BoundPolarity::Negative(_) => collect_into.negative = true,
+            hir::BoundPolarity::Only(_) => collect_into.only_modifier = true,
             hir::BoundPolarity::Positive => collect_into.positive = true,
         }
     });

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -986,13 +986,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 self.require_bound_to_relax_default_trait(trait_ref, span);
                 true
             }
+            hir::BoundPolarity::Only(_) => true,
         };
         let bounds = if transient { &mut Vec::new() } else { bounds };
 
         let polarity = match polarity {
-            hir::BoundPolarity::Positive | hir::BoundPolarity::Maybe(_) => {
-                ty::PredicatePolarity::Positive
-            }
+            hir::BoundPolarity::Positive
+            | hir::BoundPolarity::Maybe(_)
+            | hir::BoundPolarity::Only(_) => ty::PredicatePolarity::Positive,
             hir::BoundPolarity::Negative(_) => ty::PredicatePolarity::Negative,
         };
 

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -824,6 +824,7 @@ impl<'a> State<'a> {
             hir::BoundPolarity::Positive => {}
             hir::BoundPolarity::Negative(_) => self.word("!"),
             hir::BoundPolarity::Maybe(_) => self.word("?"),
+            hir::BoundPolarity::Only(_) => self.word_space("only"),
         }
         self.print_formal_generic_params(t.bound_generic_params);
         self.print_trait_ref(&t.trait_ref);

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1152,7 +1152,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             has_ref_dupes && missing_trait_names.len() > 1 && matches!(rcvr_ty.kind(), ty::Adt(..));
         let missing_trait_list = if should_condense {
             Some(match missing_trait_names.as_slice() {
-                [only] => only.clone(),
+                [single] => single.clone(),
                 [first, second] => format!("{first} or {second}"),
                 [rest @ .., last] => format!("{} or {last}", rest.join(", ")),
                 [] => String::new(),
@@ -1493,13 +1493,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 inherent_impls_candidate.dedup();
                 let msg = match &inherent_impls_candidate[..] {
                     [] => return,
-                    [only] => {
+                    [single] => {
                         vec![
                             StringPart::normal(format!("the {item_kind} was found for `")),
                             StringPart::highlighted(
                                 self.tcx
                                     .at(span)
-                                    .type_of(*only)
+                                    .type_of(*single)
                                     .instantiate_identity()
                                     .skip_norm_wip()
                                     .to_string(),

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -41,7 +41,7 @@ macro_rules! pluralize {
 // FIXME(estebank): this needs to be changed to go through the translation machinery.
 pub fn listify<T>(list: &[T], fmt: impl Fn(&T) -> String) -> Option<String> {
     Some(match list {
-        [only] => fmt(&only),
+        [single] => fmt(&single),
         [others @ .., last] => format!(
             "{} and {}",
             others.iter().map(|i| fmt(i)).collect::<Vec<_>>().join(", "),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1373,21 +1373,21 @@ fn report_non_exhaustive_match<'p, 'tcx>(
                 format!(" {{{indentation}{more}{suggested_arm},{indentation}}}",),
             ));
         }
-        [only] => {
-            let only = &thir[*only];
+        [single] => {
+            let single = &thir[*single];
             let (pre_indentation, is_multiline) = if let Some(snippet) =
-                sm.indentation_before(only.span)
+                sm.indentation_before(single.span)
                 && let Ok(with_trailing) =
-                    sm.span_extend_while(only.span, |c| c.is_whitespace() || c == ',')
+                    sm.span_extend_while(single.span, |c| c.is_whitespace() || c == ',')
                 && sm.is_multiline(with_trailing)
             {
                 (format!("\n{snippet}"), true)
             } else {
                 (" ".to_string(), false)
             };
-            let only_body = &thir[only.body];
+            let only_body = &thir[single.body];
             let comma = if matches!(only_body.kind, ExprKind::Block { .. })
-                && only.span.eq_ctxt(only_body.span)
+                && single.span.eq_ctxt(only_body.span)
                 && is_multiline
             {
                 ""
@@ -1395,7 +1395,7 @@ fn report_non_exhaustive_match<'p, 'tcx>(
                 ","
             };
             suggestion = Some((
-                only.span.shrink_to_hi(),
+                single.span.shrink_to_hi(),
                 format!("{comma}{pre_indentation}{suggested_arm}"),
             ));
         }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -828,7 +828,7 @@ impl<'a> Parser<'a> {
         });
         let attr_span = match &expr.attrs[..] {
             [] => unreachable!(),
-            [only] => only.span,
+            [single] => single.span,
             [first, rest @ ..] => {
                 for attr in rest {
                     err.span_label(attr.span, "");

--- a/compiler/rustc_parse/src/parser/token_type.rs
+++ b/compiler/rustc_parse/src/parser/token_type.rs
@@ -106,6 +106,7 @@ pub enum TokenType {
     KwMod,
     KwMove,
     KwMut,
+    KwOnly,
     KwPub,
     KwRaw,
     KwRef,
@@ -540,6 +541,7 @@ macro_rules! exp {
     (Mod)            => { exp!(@kw, Mod,        KwMod) };
     (Move)           => { exp!(@kw, Move,       KwMove) };
     (Mut)            => { exp!(@kw, Mut,        KwMut) };
+    (Only)           => { exp!(@kw, Only,       KwOnly) };
     (Pub)            => { exp!(@kw, Pub,        KwPub) };
     (Raw)            => { exp!(@kw, Raw,        KwRaw) };
     (Ref)            => { exp!(@kw, Ref,        KwRef) };

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -1120,6 +1120,7 @@ impl<'a> Parser<'a> {
             || self.check(exp!(OpenParen))
             || self.can_begin_maybe_const_bound()
             || self.check_keyword(exp!(Const))
+            || self.check_keyword(exp!(Only))
             || self.check_keyword(exp!(Async))
             || self.check_keyword(exp!(Use))
     }
@@ -1201,7 +1202,9 @@ impl<'a> Parser<'a> {
 
         match polarity {
             BoundPolarity::Positive => {}
-            BoundPolarity::Negative(span) | BoundPolarity::Maybe(span) => {
+            BoundPolarity::Negative(span)
+            | BoundPolarity::Maybe(span)
+            | BoundPolarity::Only(span) => {
                 return self
                     .dcx()
                     .emit_err(errors::ModifierLifetime { span, modifier: polarity.as_str() });
@@ -1265,6 +1268,8 @@ impl<'a> Parser<'a> {
         } else if self.eat(exp!(Bang)) {
             self.psess.gated_spans.gate(sym::negative_bounds, self.prev_token.span);
             BoundPolarity::Negative(self.prev_token.span)
+        } else if self.eat_keyword(exp!(Only)) {
+            BoundPolarity::Only(self.prev_token.span)
         } else {
             BoundPolarity::Positive
         };
@@ -1274,7 +1279,9 @@ impl<'a> Parser<'a> {
             BoundPolarity::Positive => {
                 // All trait bound modifiers allowed to combine with positive polarity
             }
-            BoundPolarity::Maybe(polarity_span) | BoundPolarity::Negative(polarity_span) => {
+            BoundPolarity::Maybe(polarity_span)
+            | BoundPolarity::Negative(polarity_span)
+            | BoundPolarity::Only(polarity_span) => {
                 match (asyncness, constness) {
                     (BoundAsyncness::Normal, BoundConstness::Never) => {
                         // Ok, no modifiers.
@@ -1346,7 +1353,9 @@ impl<'a> Parser<'a> {
 
         if let Some(binder_span) = binder_span {
             match modifiers.polarity {
-                BoundPolarity::Negative(polarity_span) | BoundPolarity::Maybe(polarity_span) => {
+                BoundPolarity::Negative(polarity_span)
+                | BoundPolarity::Maybe(polarity_span)
+                | BoundPolarity::Only(polarity_span) => {
                     self.dcx().emit_err(errors::BinderAndPolarity {
                         binder_span,
                         polarity_span,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -61,6 +61,7 @@ symbols! {
         Mod:                "mod",
         Move:               "move",
         Mut:                "mut",
+        Only:               "only",
         Pub:                "pub",
         Ref:                "ref",
         Return:             "return",

--- a/src/build_helper/src/lib.rs
+++ b/src/build_helper/src/lib.rs
@@ -14,7 +14,6 @@ pub mod util;
 /// The default set of crates for opt-dist to collect LLVM profiles.
 pub const LLVM_PGO_CRATES: &[&str] = &[
     "syn-2.0.101",
-    "cargo-0.87.1",
     "serde-1.0.219",
     "ripgrep-14.1.1",
     "regex-automata-0.4.8",
@@ -26,7 +25,6 @@ pub const LLVM_PGO_CRATES: &[&str] = &[
 pub const RUSTC_PGO_CRATES: &[&str] = &[
     "externs",
     "ctfe-stress-5",
-    "cargo-0.87.1",
     "token-stream-stress",
     "match-stress",
     "tuple-stress",

--- a/src/build_helper/src/lib.rs
+++ b/src/build_helper/src/lib.rs
@@ -28,7 +28,6 @@ pub const RUSTC_PGO_CRATES: &[&str] = &[
     "token-stream-stress",
     "match-stress",
     "tuple-stress",
-    "diesel-2.2.10",
     "bitmaps-3.2.1",
     "serde-1.0.219-new-solver",
 ];

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -267,6 +267,7 @@ pub(crate) fn print_generic_bound(
                 hir::BoundPolarity::Positive => "",
                 hir::BoundPolarity::Maybe(_) => "?",
                 hir::BoundPolarity::Negative(_) => "!",
+                hir::BoundPolarity::Only(_) => "only",
             })?;
             print_poly_trait(ty, cx).fmt(f)
         }

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -576,6 +576,7 @@ fn poly_trait_ref_search_pat(poly_trait_ref: &PolyTraitRef<'_>) -> (Pat, Pat) {
     .or_else(|| match polarity {
         BoundPolarity::Negative(_) => Some(Pat::Str("!")),
         BoundPolarity::Maybe(_) => Some(Pat::Str("?")),
+        BoundPolarity::Only(_) => Some(Pat::Str("only")),
         BoundPolarity::Positive => None,
     })
     .unwrap_or(trait_ref_search_pat.0);

--- a/src/tools/clippy/clippy_utils/src/paths.rs
+++ b/src/tools/clippy/clippy_utils/src/paths.rs
@@ -86,7 +86,7 @@ impl PathLookup {
     /// stdlib crates to avoid the issue of multiple [`DefId`]s being returned
     ///
     /// May return [`None`] in `no_std`/`no_core` environments
-    pub fn only(&self, cx: &LateContext<'_>) -> Option<DefId> {
+    pub fn r#only(&self, cx: &LateContext<'_>) -> Option<DefId> {
         let ids = self.get(cx);
         debug_assert!(STDLIB_STABLE_CRATES.contains(&self.path[0]));
         debug_assert!(ids.len() <= 1, "{ids:?}");

--- a/src/tools/clippy/lintcheck/src/config.rs
+++ b/src/tools/clippy/lintcheck/src/config.rs
@@ -1,6 +1,7 @@
-use clap::{Parser, Subcommand, ValueEnum};
 use std::num::NonZero;
 use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[expect(clippy::struct_excessive_bools)]
 #[derive(Parser, Clone, Debug)]
@@ -33,7 +34,7 @@ pub(crate) struct LintcheckConfig {
     pub lintcheck_results_path: PathBuf, // Overridden in new()
     /// Only process a single crate on the list
     #[clap(long, value_name = "CRATE")]
-    pub only: Option<String>,
+    pub only_crate: Option<String>,
     /// Runs cargo clippy --fix and checks if all suggestions apply
     #[clap(long, conflicts_with("max_jobs"))]
     pub fix: bool,
@@ -124,10 +125,7 @@ impl LintcheckConfig {
         for lint_name in &mut config.lint_filter {
             *lint_name = format!(
                 "clippy::{}",
-                lint_name
-                    .strip_prefix("clippy::")
-                    .unwrap_or(lint_name)
-                    .replace('_', "-")
+                lint_name.strip_prefix("clippy::").unwrap_or(lint_name).replace('_', "-")
             );
         }
 

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -836,7 +836,7 @@ impl flags::AnalysisStats {
             let name = body_id.name(db).unwrap_or_else(Name::missing);
             let module = body_id.module(db);
             let display_target = module.krate(db).to_display_target(db);
-            if let Some(only_name) = self.solely.as_deref()
+            if let Some(only_name) = self.r#only.as_deref()
                 && name.display(db, Edition::LATEST).to_string() != only_name
                 && full_name(db, || body_id.name(db), module) != only_name
             {
@@ -951,7 +951,7 @@ impl flags::AnalysisStats {
                     }
                     is_partially_unknown
                 };
-                if self.solely.is_some() && verbosity.is_spammy() {
+                if self.r#only.is_some() && verbosity.is_spammy() {
                     // in super-verbose mode for just one function, we print every single expression
                     if let Some((_, start, end)) = expr_syntax_range(db, vfs, sm(), expr_id) {
                         bar.println(format!(
@@ -1056,7 +1056,7 @@ impl flags::AnalysisStats {
                     }
                     is_partially_unknown
                 };
-                if self.solely.is_some() && verbosity.is_spammy() {
+                if self.r#only.is_some() && verbosity.is_spammy() {
                     // in super-verbose mode for just one function, we print every single pattern
                     if let Some((_, start, end)) = pat_syntax_range(db, vfs, sm(), pat_id) {
                         bar.println(format!(
@@ -1461,7 +1461,7 @@ impl flags::AnalysisStats {
         name_fn: impl Fn() -> Option<Name>,
         module: hir::Module,
     ) -> bool {
-        if let Some(only_name) = self.solely.as_deref() {
+        if let Some(only_name) = self.r#only.as_deref() {
             let name = name_fn().unwrap_or_else(Name::missing);
 
             if name.display(db, Edition::LATEST).to_string() != only_name

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -836,7 +836,7 @@ impl flags::AnalysisStats {
             let name = body_id.name(db).unwrap_or_else(Name::missing);
             let module = body_id.module(db);
             let display_target = module.krate(db).to_display_target(db);
-            if let Some(only_name) = self.only.as_deref()
+            if let Some(only_name) = self.solely.as_deref()
                 && name.display(db, Edition::LATEST).to_string() != only_name
                 && full_name(db, || body_id.name(db), module) != only_name
             {
@@ -951,7 +951,7 @@ impl flags::AnalysisStats {
                     }
                     is_partially_unknown
                 };
-                if self.only.is_some() && verbosity.is_spammy() {
+                if self.solely.is_some() && verbosity.is_spammy() {
                     // in super-verbose mode for just one function, we print every single expression
                     if let Some((_, start, end)) = expr_syntax_range(db, vfs, sm(), expr_id) {
                         bar.println(format!(
@@ -1056,7 +1056,7 @@ impl flags::AnalysisStats {
                     }
                     is_partially_unknown
                 };
-                if self.only.is_some() && verbosity.is_spammy() {
+                if self.solely.is_some() && verbosity.is_spammy() {
                     // in super-verbose mode for just one function, we print every single pattern
                     if let Some((_, start, end)) = pat_syntax_range(db, vfs, sm(), pat_id) {
                         bar.println(format!(
@@ -1461,7 +1461,7 @@ impl flags::AnalysisStats {
         name_fn: impl Fn() -> Option<Name>,
         module: hir::Module,
     ) -> bool {
-        if let Some(only_name) = self.only.as_deref() {
+        if let Some(only_name) = self.solely.as_deref() {
             let name = name_fn().unwrap_or_else(Name::missing);
 
             if name.display(db, Edition::LATEST).to_string() != only_name

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/flags.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/flags.rs
@@ -256,7 +256,7 @@ pub struct AnalysisStats {
     pub output: Option<OutputFormat>,
     pub randomize: bool,
     pub parallel: bool,
-    pub only: Option<String>,
+    pub solely: Option<String>,
     pub with_deps: bool,
     pub no_sysroot: bool,
     pub no_test: bool,

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/flags.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/flags.rs
@@ -256,7 +256,7 @@ pub struct AnalysisStats {
     pub output: Option<OutputFormat>,
     pub randomize: bool,
     pub parallel: bool,
-    pub solely: Option<String>,
+    pub only: Option<String>,
     pub with_deps: bool,
     pub no_sysroot: bool,
     pub no_test: bool,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157487)*
<!-- homu-ignore:end -->

Adds `only` keyword + removes existing instances of `only`.

Opening as draft for a crater run: t-lang wants to have `only` bounds and we want to see how bad things would break if we had it as a keyword.

The same kind of breakage at this position would also apply for the `maybe` bounds, the possible way forward for specialization, which we may also check in this PR.
