### PR TITLE
Shrink no-op drop elaboration

### DIFF
--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -1161,14 +1161,20 @@ where
         if !have_otherwise {
             values.pop();
         } else if !have_otherwise_with_drop_glue {
-            normal_blocks.push(self.goto_block(succ, unwind));
+            normal_blocks.push(succ);
             if let Unwind::To(unwind) = unwind {
-                unwind_blocks.push(self.goto_block(unwind, Unwind::InCleanup));
+                unwind_blocks.push(unwind);
+            }
+            if let Some(dropline) = dropline {
+                dropline_blocks.push(dropline);
             }
         } else {
             normal_blocks.push(self.drop_block(succ, unwind));
             if let Unwind::To(unwind) = unwind {
                 unwind_blocks.push(self.drop_block(unwind, Unwind::InCleanup));
+            }
+            if let Some(dropline) = dropline {
+                dropline_blocks.push(self.drop_block(dropline, unwind));
             }
         }
 
@@ -1590,11 +1596,6 @@ where
                 },
             )
         }
-    }
-
-    fn goto_block(&mut self, target: BasicBlock, unwind: Unwind) -> BasicBlock {
-        let block = TerminatorKind::Goto { target };
-        self.new_block(unwind, block)
     }
 
     /// Returns the block to jump to in order to test the drop flag and execute the drop.

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -799,6 +799,7 @@ where
 
                 (tcx.mk_place_field(base_place, field_idx, field_ty), subpath)
             })
+            .filter(|path| self.should_retain_for_ladder(path))
             .collect()
     }
 
@@ -876,6 +877,19 @@ where
         )
     }
 
+    /// Whether this drop is useful. This is purely an optimization to avoid generating useless blocks.
+    fn should_retain_for_ladder(&self, (place, subpath): &(Place<'tcx>, Option<D::Path>)) -> bool {
+        if !self.place_ty(*place).needs_drop(self.tcx(), self.elaborator.typing_env()) {
+            return false;
+        }
+        if let Some(subpath) = subpath
+            && let DropStyle::Dead = self.elaborator.drop_style(*subpath, DropFlagMode::Deep)
+        {
+            return false;
+        }
+        true
+    }
+
     /// Creates a full drop ladder, consisting of 2 connected half-drop-ladders
     ///
     /// For example, with 3 fields, the drop ladder is
@@ -916,7 +930,7 @@ where
     #[instrument(level = "debug", skip(self), ret)]
     fn drop_ladder(
         &mut self,
-        fields: Vec<(Place<'tcx>, Option<D::Path>)>,
+        mut fields: Vec<(Place<'tcx>, Option<D::Path>)>,
         succ: BasicBlock,
         unwind: Unwind,
         dropline: Option<BasicBlock>,
@@ -926,10 +940,7 @@ where
             "Dropline is set for cleanup drop ladder"
         );
 
-        let mut fields = fields;
-        fields.retain(|&(place, _)| {
-            self.place_ty(place).needs_drop(self.tcx(), self.elaborator.typing_env())
-        });
+        fields.retain(|path| self.should_retain_for_ladder(path));
 
         debug!("drop_ladder - fields needing drop: {:?}", fields);
 

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -1,5 +1,6 @@
 use std::{fmt, iter, mem};
 
+use itertools::Itertools;
 use rustc_abi::{FIRST_VARIANT, FieldIdx, VariantIdx};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_hir::lang_items::LangItem;
@@ -1197,27 +1198,29 @@ where
         succ: BasicBlock,
         unwind: Unwind,
     ) -> BasicBlock {
-        // If there are multiple variants, then if something
-        // is present within the enum the discriminant, tracked
-        // by the rest path, must be initialized.
-        //
-        // Additionally, we do not want to switch on the
-        // discriminant after it is free-ed, because that
-        // way lies only trouble.
-        let discr_ty = adt.repr().discr_type().to_ty(self.tcx());
-        let discr = Place::from(self.new_temp(discr_ty));
-        let discr_rv = Rvalue::Discriminant(self.place);
-        let switch_block = self.new_block_with_statements(
-            unwind,
-            vec![self.assign(discr, discr_rv)],
-            TerminatorKind::SwitchInt {
-                discr: Operand::Move(discr),
-                targets: SwitchTargets::new(
-                    values.iter().copied().zip(blocks.iter().copied()),
-                    *blocks.last().unwrap(),
-                ),
-            },
-        );
+        let switch_block = blocks.iter().copied().all_equal_value().unwrap_or_else(|_| {
+            // If there are multiple variants, then if something
+            // is present within the enum the discriminant, tracked
+            // by the rest path, must be initialized.
+            //
+            // Additionally, we do not want to switch on the
+            // discriminant after it is free-ed, because that
+            // way lies only trouble.
+            let discr_ty = adt.repr().discr_type().to_ty(self.tcx());
+            let discr = Place::from(self.new_temp(discr_ty));
+            let discr_rv = Rvalue::Discriminant(self.place);
+            self.new_block_with_statements(
+                unwind,
+                vec![self.assign(discr, discr_rv)],
+                TerminatorKind::SwitchInt {
+                    discr: Operand::Move(discr),
+                    targets: SwitchTargets::new(
+                        values.iter().copied().zip(blocks.iter().copied()),
+                        *blocks.last().unwrap(),
+                    ),
+                },
+            )
+        });
         self.drop_flag_test_block(switch_block, succ, unwind)
     }
 

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -1,0 +1,1116 @@
+- // MIR for `build` before ElaborateDrops
++ // MIR for `build` after ElaborateDrops
+  
+  fn build(_1: u64) -> Result<Big, ()> {
+      debug s => _1;
+      let mut _0: std::result::Result<Big, ()>;
+      let mut _2: Big;
+      let mut _3: std::string::String;
+      let mut _4: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, ()>, std::string::String>;
+      let mut _5: std::result::Result<std::string::String, ()>;
+      let mut _6: u64;
+      let mut _7: u64;
+      let mut _8: isize;
+      let _9: std::result::Result<std::convert::Infallible, ()>;
+      let mut _10: !;
+      let mut _11: std::result::Result<std::convert::Infallible, ()>;
+      let _12: std::string::String;
+      let mut _13: std::string::String;
+      let mut _14: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, ()>, std::string::String>;
+      let mut _15: std::result::Result<std::string::String, ()>;
+      let mut _16: u64;
+      let mut _17: u64;
+      let mut _18: isize;
+      let _19: std::result::Result<std::convert::Infallible, ()>;
+      let mut _20: !;
+      let mut _21: std::result::Result<std::convert::Infallible, ()>;
+      let _22: std::string::String;
+      let mut _23: std::string::String;
+      let mut _24: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, ()>, std::string::String>;
+      let mut _25: std::result::Result<std::string::String, ()>;
+      let mut _26: u64;
+      let mut _27: u64;
+      let mut _28: isize;
+      let _29: std::result::Result<std::convert::Infallible, ()>;
+      let mut _30: !;
+      let mut _31: std::result::Result<std::convert::Infallible, ()>;
+      let _32: std::string::String;
+      let mut _33: std::string::String;
+      let mut _34: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, ()>, std::string::String>;
+      let mut _35: std::result::Result<std::string::String, ()>;
+      let mut _36: u64;
+      let mut _37: u64;
+      let mut _38: isize;
+      let _39: std::result::Result<std::convert::Infallible, ()>;
+      let mut _40: !;
+      let mut _41: std::result::Result<std::convert::Infallible, ()>;
+      let _42: std::string::String;
+      let mut _43: std::string::String;
+      let mut _44: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, ()>, std::string::String>;
+      let mut _45: std::result::Result<std::string::String, ()>;
+      let mut _46: u64;
+      let mut _47: u64;
+      let mut _48: isize;
+      let _49: std::result::Result<std::convert::Infallible, ()>;
+      let mut _50: !;
+      let mut _51: std::result::Result<std::convert::Infallible, ()>;
+      let _52: std::string::String;
++     let mut _53: bool;
++     let mut _54: bool;
++     let mut _55: bool;
++     let mut _56: bool;
++     let mut _57: isize;
++     let mut _58: isize;
++     let mut _59: isize;
++     let mut _60: isize;
++     let mut _61: isize;
++     let mut _62: isize;
++     let mut _63: isize;
++     let mut _64: isize;
++     let mut _65: isize;
++     let mut _66: isize;
++     let mut _67: isize;
++     let mut _68: isize;
++     let mut _69: isize;
++     let mut _70: isize;
++     let mut _71: isize;
++     let mut _72: isize;
++     let mut _73: isize;
++     let mut _74: isize;
++     let mut _75: isize;
++     let mut _76: isize;
++     let mut _77: isize;
++     let mut _78: isize;
++     let mut _79: isize;
++     let mut _80: isize;
++     let mut _81: isize;
+      scope 1 {
+          debug residual => _9;
+          scope 2 {
+          }
+      }
+      scope 3 {
+          debug val => _12;
+          scope 4 {
+          }
+      }
+      scope 5 {
+          debug residual => _19;
+          scope 6 {
+          }
+      }
+      scope 7 {
+          debug val => _22;
+          scope 8 {
+          }
+      }
+      scope 9 {
+          debug residual => _29;
+          scope 10 {
+          }
+      }
+      scope 11 {
+          debug val => _32;
+          scope 12 {
+          }
+      }
+      scope 13 {
+          debug residual => _39;
+          scope 14 {
+          }
+      }
+      scope 15 {
+          debug val => _42;
+          scope 16 {
+          }
+      }
+      scope 17 {
+          debug residual => _49;
+          scope 18 {
+          }
+      }
+      scope 19 {
+          debug val => _52;
+          scope 20 {
+          }
+      }
+  
+      bb0: {
++         _56 = const false;
++         _55 = const false;
++         _54 = const false;
++         _53 = const false;
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          StorageLive(_5);
+          StorageLive(_6);
+          StorageLive(_7);
+          _7 = copy _1;
+          _6 = BitXor(move _7, const 0_u64);
+          StorageDead(_7);
+          _5 = make_one(move _6) -> [return: bb1, unwind continue];
+      }
+  
+      bb1: {
+          StorageDead(_6);
+          _4 = <Result<String, ()> as Try>::branch(move _5) -> [return: bb2, unwind: bb91];
+      }
+  
+      bb2: {
++         _56 = const true;
+          StorageDead(_5);
+          PlaceMention(_4);
+          _8 = discriminant(_4);
+          switchInt(move _8) -> [0: bb4, 1: bb5, otherwise: bb3];
+      }
+  
+      bb3: {
+          unreachable;
+      }
+  
+      bb4: {
+          StorageLive(_12);
+          _12 = move ((_4 as Continue).0: std::string::String);
+          _3 = move _12;
+-         drop(_12) -> [return: bb7, unwind: bb90];
++         goto -> bb7;
+      }
+  
+      bb5: {
+          StorageLive(_9);
+          _9 = copy ((_4 as Break).0: std::result::Result<std::convert::Infallible, ()>);
+          StorageLive(_11);
+          _11 = copy _9;
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _11) -> [return: bb6, unwind: bb90];
+      }
+  
+      bb6: {
+          StorageDead(_11);
+          StorageDead(_9);
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb60;
+      }
+  
+      bb7: {
+          StorageDead(_12);
+          StorageLive(_13);
+          StorageLive(_14);
+          StorageLive(_15);
+          StorageLive(_16);
+          StorageLive(_17);
+          _17 = copy _1;
+          _16 = BitXor(move _17, const 1_u64);
+          StorageDead(_17);
+          _15 = make_one(move _16) -> [return: bb8, unwind: bb89];
+      }
+  
+      bb8: {
+          StorageDead(_16);
+          _14 = <Result<String, ()> as Try>::branch(move _15) -> [return: bb9, unwind: bb88];
+      }
+  
+      bb9: {
++         _55 = const true;
+          StorageDead(_15);
+          PlaceMention(_14);
+          _18 = discriminant(_14);
+          switchInt(move _18) -> [0: bb10, 1: bb11, otherwise: bb3];
+      }
+  
+      bb10: {
+          StorageLive(_22);
+          _22 = move ((_14 as Continue).0: std::string::String);
+          _13 = move _22;
+-         drop(_22) -> [return: bb13, unwind: bb86];
++         goto -> bb13;
+      }
+  
+      bb11: {
+          StorageLive(_19);
+          _19 = copy ((_14 as Break).0: std::result::Result<std::convert::Infallible, ()>);
+          StorageLive(_21);
+          _21 = copy _19;
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _21) -> [return: bb12, unwind: bb86];
+      }
+  
+      bb12: {
+          StorageDead(_21);
+          StorageDead(_19);
+          StorageDead(_13);
+          drop(_3) -> [return: bb57, unwind: bb87];
+      }
+  
+      bb13: {
+          StorageDead(_22);
+          StorageLive(_23);
+          StorageLive(_24);
+          StorageLive(_25);
+          StorageLive(_26);
+          StorageLive(_27);
+          _27 = copy _1;
+          _26 = BitXor(move _27, const 2_u64);
+          StorageDead(_27);
+          _25 = make_one(move _26) -> [return: bb14, unwind: bb85];
+      }
+  
+      bb14: {
+          StorageDead(_26);
+          _24 = <Result<String, ()> as Try>::branch(move _25) -> [return: bb15, unwind: bb84];
+      }
+  
+      bb15: {
++         _54 = const true;
+          StorageDead(_25);
+          PlaceMention(_24);
+          _28 = discriminant(_24);
+          switchInt(move _28) -> [0: bb16, 1: bb17, otherwise: bb3];
+      }
+  
+      bb16: {
+          StorageLive(_32);
+          _32 = move ((_24 as Continue).0: std::string::String);
+          _23 = move _32;
+-         drop(_32) -> [return: bb19, unwind: bb81];
++         goto -> bb19;
+      }
+  
+      bb17: {
+          StorageLive(_29);
+          _29 = copy ((_24 as Break).0: std::result::Result<std::convert::Infallible, ()>);
+          StorageLive(_31);
+          _31 = copy _29;
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _31) -> [return: bb18, unwind: bb81];
+      }
+  
+      bb18: {
+          StorageDead(_31);
+          StorageDead(_29);
+          StorageDead(_23);
+          drop(_13) -> [return: bb53, unwind: bb82];
+      }
+  
+      bb19: {
+          StorageDead(_32);
+          StorageLive(_33);
+          StorageLive(_34);
+          StorageLive(_35);
+          StorageLive(_36);
+          StorageLive(_37);
+          _37 = copy _1;
+          _36 = BitXor(move _37, const 3_u64);
+          StorageDead(_37);
+          _35 = make_one(move _36) -> [return: bb20, unwind: bb80];
+      }
+  
+      bb20: {
+          StorageDead(_36);
+          _34 = <Result<String, ()> as Try>::branch(move _35) -> [return: bb21, unwind: bb79];
+      }
+  
+      bb21: {
++         _53 = const true;
+          StorageDead(_35);
+          PlaceMention(_34);
+          _38 = discriminant(_34);
+          switchInt(move _38) -> [0: bb22, 1: bb23, otherwise: bb3];
+      }
+  
+      bb22: {
+          StorageLive(_42);
+          _42 = move ((_34 as Continue).0: std::string::String);
+          _33 = move _42;
+-         drop(_42) -> [return: bb25, unwind: bb75];
++         goto -> bb25;
+      }
+  
+      bb23: {
+          StorageLive(_39);
+          _39 = copy ((_34 as Break).0: std::result::Result<std::convert::Infallible, ()>);
+          StorageLive(_41);
+          _41 = copy _39;
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _41) -> [return: bb24, unwind: bb75];
+      }
+  
+      bb24: {
+          StorageDead(_41);
+          StorageDead(_39);
+          StorageDead(_33);
+          drop(_23) -> [return: bb48, unwind: bb76];
+      }
+  
+      bb25: {
+          StorageDead(_42);
+          StorageLive(_43);
+          StorageLive(_44);
+          StorageLive(_45);
+          StorageLive(_46);
+          StorageLive(_47);
+          _47 = copy _1;
+          _46 = BitXor(move _47, const 4_u64);
+          StorageDead(_47);
+          _45 = make_one(move _46) -> [return: bb26, unwind: bb74];
+      }
+  
+      bb26: {
+          StorageDead(_46);
+          _44 = <Result<String, ()> as Try>::branch(move _45) -> [return: bb27, unwind: bb73];
+      }
+  
+      bb27: {
+          StorageDead(_45);
+          PlaceMention(_44);
+          _48 = discriminant(_44);
+          switchInt(move _48) -> [0: bb28, 1: bb29, otherwise: bb3];
+      }
+  
+      bb28: {
+          StorageLive(_52);
+          _52 = move ((_44 as Continue).0: std::string::String);
+          _43 = move _52;
+-         drop(_52) -> [return: bb31, unwind: bb68];
++         goto -> bb31;
+      }
+  
+      bb29: {
+          StorageLive(_49);
+          _49 = copy ((_44 as Break).0: std::result::Result<std::convert::Infallible, ()>);
+          StorageLive(_51);
+          _51 = copy _49;
+          _0 = <Result<Big, ()> as FromResidual<Result<Infallible, ()>>>::from_residual(move _51) -> [return: bb30, unwind: bb68];
+      }
+  
+      bb30: {
+          StorageDead(_51);
+          StorageDead(_49);
+          StorageDead(_43);
+          drop(_33) -> [return: bb43, unwind: bb69];
+      }
+  
+      bb31: {
+          StorageDead(_52);
+          _2 = Big { f0: move _3, f1: move _13, f2: move _23, f3: move _33, f4: move _43 };
+-         drop(_43) -> [return: bb32, unwind: bb63];
++         goto -> bb32;
+      }
+  
+      bb32: {
+          StorageDead(_43);
+-         drop(_33) -> [return: bb33, unwind: bb64];
++         goto -> bb33;
+      }
+  
+      bb33: {
+          StorageDead(_33);
+-         drop(_23) -> [return: bb34, unwind: bb65];
++         goto -> bb34;
+      }
+  
+      bb34: {
+          StorageDead(_23);
+-         drop(_13) -> [return: bb35, unwind: bb66];
++         goto -> bb35;
+      }
+  
+      bb35: {
+          StorageDead(_13);
+-         drop(_3) -> [return: bb36, unwind: bb67];
++         goto -> bb36;
+      }
+  
+      bb36: {
+          StorageDead(_3);
+          _0 = Result::<Big, ()>::Ok(move _2);
+-         drop(_2) -> [return: bb37, unwind: bb72];
++         goto -> bb37;
+      }
+  
+      bb37: {
+          StorageDead(_2);
+-         drop(_44) -> [return: bb38, unwind: bb78];
++         goto -> bb99;
+      }
+  
+      bb38: {
+          StorageDead(_44);
+-         drop(_34) -> [return: bb39, unwind: bb83];
++         goto -> bb107;
+      }
+  
+      bb39: {
++         _53 = const false;
+          StorageDead(_34);
+-         drop(_24) -> [return: bb40, unwind: bb87];
++         goto -> bb115;
+      }
+  
+      bb40: {
++         _54 = const false;
+          StorageDead(_24);
+-         drop(_14) -> [return: bb41, unwind: bb90];
++         goto -> bb123;
+      }
+  
+      bb41: {
++         _55 = const false;
+          StorageDead(_14);
+-         drop(_4) -> [return: bb42, unwind continue];
++         goto -> bb131;
+      }
+  
+      bb42: {
++         _56 = const false;
+          StorageDead(_4);
+          goto -> bb62;
+      }
+  
+      bb43: {
+          StorageDead(_33);
+          drop(_23) -> [return: bb44, unwind: bb70];
+      }
+  
+      bb44: {
+          StorageDead(_23);
+          drop(_13) -> [return: bb45, unwind: bb71];
+      }
+  
+      bb45: {
+          StorageDead(_13);
+          drop(_3) -> [return: bb46, unwind: bb72];
+      }
+  
+      bb46: {
+          StorageDead(_3);
+          StorageDead(_2);
+-         drop(_44) -> [return: bb47, unwind: bb78];
++         goto -> bb139;
+      }
+  
+      bb47: {
+          StorageDead(_44);
+          goto -> bb51;
+      }
+  
+      bb48: {
+          StorageDead(_23);
+          drop(_13) -> [return: bb49, unwind: bb77];
+      }
+  
+      bb49: {
+          StorageDead(_13);
+          drop(_3) -> [return: bb50, unwind: bb78];
+      }
+  
+      bb50: {
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb51;
+      }
+  
+      bb51: {
+-         drop(_34) -> [return: bb52, unwind: bb83];
++         goto -> bb147;
+      }
+  
+      bb52: {
++         _53 = const false;
+          StorageDead(_34);
+          goto -> bb55;
+      }
+  
+      bb53: {
+          StorageDead(_13);
+          drop(_3) -> [return: bb54, unwind: bb83];
+      }
+  
+      bb54: {
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb55;
+      }
+  
+      bb55: {
+-         drop(_24) -> [return: bb56, unwind: bb87];
++         goto -> bb155;
+      }
+  
+      bb56: {
++         _54 = const false;
+          StorageDead(_24);
+          goto -> bb58;
+      }
+  
+      bb57: {
+          StorageDead(_3);
+          StorageDead(_2);
+          goto -> bb58;
+      }
+  
+      bb58: {
+-         drop(_14) -> [return: bb59, unwind: bb90];
++         goto -> bb163;
+      }
+  
+      bb59: {
++         _55 = const false;
+          StorageDead(_14);
+          goto -> bb60;
+      }
+  
+      bb60: {
+-         drop(_4) -> [return: bb61, unwind continue];
++         goto -> bb171;
+      }
+  
+      bb61: {
++         _56 = const false;
+          StorageDead(_4);
+          goto -> bb62;
+      }
+  
+      bb62: {
+          return;
+      }
+  
+      bb63 (cleanup): {
+-         drop(_33) -> [return: bb64, unwind terminate(cleanup)];
++         goto -> bb64;
+      }
+  
+      bb64 (cleanup): {
+-         drop(_23) -> [return: bb65, unwind terminate(cleanup)];
++         goto -> bb65;
+      }
+  
+      bb65 (cleanup): {
+-         drop(_13) -> [return: bb66, unwind terminate(cleanup)];
++         goto -> bb66;
+      }
+  
+      bb66 (cleanup): {
+-         drop(_3) -> [return: bb67, unwind terminate(cleanup)];
++         goto -> bb67;
+      }
+  
+      bb67 (cleanup): {
+-         drop(_2) -> [return: bb72, unwind terminate(cleanup)];
++         goto -> bb72;
+      }
+  
+      bb68 (cleanup): {
+          drop(_33) -> [return: bb69, unwind terminate(cleanup)];
+      }
+  
+      bb69 (cleanup): {
+          drop(_23) -> [return: bb70, unwind terminate(cleanup)];
+      }
+  
+      bb70 (cleanup): {
+          drop(_13) -> [return: bb71, unwind terminate(cleanup)];
+      }
+  
+      bb71 (cleanup): {
+          drop(_3) -> [return: bb72, unwind terminate(cleanup)];
+      }
+  
+      bb72 (cleanup): {
+-         drop(_44) -> [return: bb78, unwind terminate(cleanup)];
++         goto -> bb175;
+      }
+  
+      bb73 (cleanup): {
+-         drop(_45) -> [return: bb74, unwind terminate(cleanup)];
++         goto -> bb74;
+      }
+  
+      bb74 (cleanup): {
+          drop(_33) -> [return: bb75, unwind terminate(cleanup)];
+      }
+  
+      bb75 (cleanup): {
+          drop(_23) -> [return: bb76, unwind terminate(cleanup)];
+      }
+  
+      bb76 (cleanup): {
+          drop(_13) -> [return: bb77, unwind terminate(cleanup)];
+      }
+  
+      bb77 (cleanup): {
+          drop(_3) -> [return: bb78, unwind terminate(cleanup)];
+      }
+  
+      bb78 (cleanup): {
+-         drop(_34) -> [return: bb83, unwind terminate(cleanup)];
++         goto -> bb178;
+      }
+  
+      bb79 (cleanup): {
+-         drop(_35) -> [return: bb80, unwind terminate(cleanup)];
++         goto -> bb80;
+      }
+  
+      bb80 (cleanup): {
+          drop(_23) -> [return: bb81, unwind terminate(cleanup)];
+      }
+  
+      bb81 (cleanup): {
+          drop(_13) -> [return: bb82, unwind terminate(cleanup)];
+      }
+  
+      bb82 (cleanup): {
+          drop(_3) -> [return: bb83, unwind terminate(cleanup)];
+      }
+  
+      bb83 (cleanup): {
+-         drop(_24) -> [return: bb87, unwind terminate(cleanup)];
++         goto -> bb181;
+      }
+  
+      bb84 (cleanup): {
+-         drop(_25) -> [return: bb85, unwind terminate(cleanup)];
++         goto -> bb85;
+      }
+  
+      bb85 (cleanup): {
+          drop(_13) -> [return: bb86, unwind terminate(cleanup)];
+      }
+  
+      bb86 (cleanup): {
+          drop(_3) -> [return: bb87, unwind terminate(cleanup)];
+      }
+  
+      bb87 (cleanup): {
+-         drop(_14) -> [return: bb90, unwind terminate(cleanup)];
++         goto -> bb184;
+      }
+  
+      bb88 (cleanup): {
+-         drop(_15) -> [return: bb89, unwind terminate(cleanup)];
++         goto -> bb89;
+      }
+  
+      bb89 (cleanup): {
+          drop(_3) -> [return: bb90, unwind terminate(cleanup)];
+      }
+  
+      bb90 (cleanup): {
+-         drop(_4) -> [return: bb92, unwind terminate(cleanup)];
++         goto -> bb187;
+      }
+  
+      bb91 (cleanup): {
+-         drop(_5) -> [return: bb92, unwind terminate(cleanup)];
++         goto -> bb92;
+      }
+  
+      bb92 (cleanup): {
+          resume;
++     }
++ 
++     bb93: {
++         goto -> bb38;
++     }
++ 
++     bb94 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb95 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb96: {
++         goto -> bb93;
++     }
++ 
++     bb97: {
++         goto -> bb93;
++     }
++ 
++     bb98 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb99: {
++         _57 = discriminant(_44);
++         switchInt(move _57) -> [0: bb96, otherwise: bb97];
++     }
++ 
++     bb100 (cleanup): {
++         _58 = discriminant(_44);
++         switchInt(move _58) -> [0: bb94, otherwise: bb98];
++     }
++ 
++     bb101: {
++         goto -> bb39;
++     }
++ 
++     bb102 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb103 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb104: {
++         goto -> bb101;
++     }
++ 
++     bb105: {
++         goto -> bb101;
++     }
++ 
++     bb106 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb107: {
++         _59 = discriminant(_34);
++         switchInt(move _59) -> [0: bb104, otherwise: bb105];
++     }
++ 
++     bb108 (cleanup): {
++         _60 = discriminant(_34);
++         switchInt(move _60) -> [0: bb102, otherwise: bb106];
++     }
++ 
++     bb109: {
++         goto -> bb40;
++     }
++ 
++     bb110 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb111 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb112: {
++         goto -> bb109;
++     }
++ 
++     bb113: {
++         goto -> bb109;
++     }
++ 
++     bb114 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb115: {
++         _61 = discriminant(_24);
++         switchInt(move _61) -> [0: bb112, otherwise: bb113];
++     }
++ 
++     bb116 (cleanup): {
++         _62 = discriminant(_24);
++         switchInt(move _62) -> [0: bb110, otherwise: bb114];
++     }
++ 
++     bb117: {
++         goto -> bb41;
++     }
++ 
++     bb118 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb119 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb120: {
++         goto -> bb117;
++     }
++ 
++     bb121: {
++         goto -> bb117;
++     }
++ 
++     bb122 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb123: {
++         _63 = discriminant(_14);
++         switchInt(move _63) -> [0: bb120, otherwise: bb121];
++     }
++ 
++     bb124 (cleanup): {
++         _64 = discriminant(_14);
++         switchInt(move _64) -> [0: bb118, otherwise: bb122];
++     }
++ 
++     bb125: {
++         goto -> bb42;
++     }
++ 
++     bb126 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb127 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb128: {
++         goto -> bb125;
++     }
++ 
++     bb129: {
++         goto -> bb125;
++     }
++ 
++     bb130 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb131: {
++         _65 = discriminant(_4);
++         switchInt(move _65) -> [0: bb128, otherwise: bb129];
++     }
++ 
++     bb132 (cleanup): {
++         _66 = discriminant(_4);
++         switchInt(move _66) -> [0: bb126, otherwise: bb130];
++     }
++ 
++     bb133: {
++         goto -> bb47;
++     }
++ 
++     bb134 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb135 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb136: {
++         goto -> bb133;
++     }
++ 
++     bb137: {
++         goto -> bb133;
++     }
++ 
++     bb138 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb139: {
++         _67 = discriminant(_44);
++         switchInt(move _67) -> [0: bb136, otherwise: bb137];
++     }
++ 
++     bb140 (cleanup): {
++         _68 = discriminant(_44);
++         switchInt(move _68) -> [0: bb134, otherwise: bb138];
++     }
++ 
++     bb141: {
++         goto -> bb52;
++     }
++ 
++     bb142 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb143 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb144: {
++         goto -> bb141;
++     }
++ 
++     bb145: {
++         goto -> bb141;
++     }
++ 
++     bb146 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb147: {
++         _69 = discriminant(_34);
++         switchInt(move _69) -> [0: bb144, otherwise: bb145];
++     }
++ 
++     bb148 (cleanup): {
++         _70 = discriminant(_34);
++         switchInt(move _70) -> [0: bb142, otherwise: bb146];
++     }
++ 
++     bb149: {
++         goto -> bb56;
++     }
++ 
++     bb150 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb151 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb152: {
++         goto -> bb149;
++     }
++ 
++     bb153: {
++         goto -> bb149;
++     }
++ 
++     bb154 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb155: {
++         _71 = discriminant(_24);
++         switchInt(move _71) -> [0: bb152, otherwise: bb153];
++     }
++ 
++     bb156 (cleanup): {
++         _72 = discriminant(_24);
++         switchInt(move _72) -> [0: bb150, otherwise: bb154];
++     }
++ 
++     bb157: {
++         goto -> bb59;
++     }
++ 
++     bb158 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb159 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb160: {
++         goto -> bb157;
++     }
++ 
++     bb161: {
++         goto -> bb157;
++     }
++ 
++     bb162 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb163: {
++         _73 = discriminant(_14);
++         switchInt(move _73) -> [0: bb160, otherwise: bb161];
++     }
++ 
++     bb164 (cleanup): {
++         _74 = discriminant(_14);
++         switchInt(move _74) -> [0: bb158, otherwise: bb162];
++     }
++ 
++     bb165: {
++         goto -> bb61;
++     }
++ 
++     bb166 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb167 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb168: {
++         goto -> bb165;
++     }
++ 
++     bb169: {
++         goto -> bb165;
++     }
++ 
++     bb170 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb171: {
++         _75 = discriminant(_4);
++         switchInt(move _75) -> [0: bb168, otherwise: bb169];
++     }
++ 
++     bb172 (cleanup): {
++         _76 = discriminant(_4);
++         switchInt(move _76) -> [0: bb166, otherwise: bb170];
++     }
++ 
++     bb173 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb174 (cleanup): {
++         goto -> bb78;
++     }
++ 
++     bb175 (cleanup): {
++         _77 = discriminant(_44);
++         switchInt(move _77) -> [0: bb173, otherwise: bb174];
++     }
++ 
++     bb176 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb177 (cleanup): {
++         goto -> bb83;
++     }
++ 
++     bb178 (cleanup): {
++         _78 = discriminant(_34);
++         switchInt(move _78) -> [0: bb176, otherwise: bb177];
++     }
++ 
++     bb179 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb180 (cleanup): {
++         goto -> bb87;
++     }
++ 
++     bb181 (cleanup): {
++         _79 = discriminant(_24);
++         switchInt(move _79) -> [0: bb179, otherwise: bb180];
++     }
++ 
++     bb182 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb183 (cleanup): {
++         goto -> bb90;
++     }
++ 
++     bb184 (cleanup): {
++         _80 = discriminant(_14);
++         switchInt(move _80) -> [0: bb182, otherwise: bb183];
++     }
++ 
++     bb185 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb186 (cleanup): {
++         goto -> bb92;
++     }
++ 
++     bb187 (cleanup): {
++         _81 = discriminant(_4);
++         switchInt(move _81) -> [0: bb185, otherwise: bb186];
+      }
+  }
+  

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -429,34 +429,34 @@
       bb37: {
           StorageDead(_2);
 -         drop(_44) -> [return: bb38, unwind: bb78];
-+         goto -> bb99;
++         goto -> bb96;
       }
   
       bb38: {
           StorageDead(_44);
 -         drop(_34) -> [return: bb39, unwind: bb83];
-+         goto -> bb107;
++         goto -> bb101;
       }
   
       bb39: {
 +         _53 = const false;
           StorageDead(_34);
 -         drop(_24) -> [return: bb40, unwind: bb87];
-+         goto -> bb115;
++         goto -> bb106;
       }
   
       bb40: {
 +         _54 = const false;
           StorageDead(_24);
 -         drop(_14) -> [return: bb41, unwind: bb90];
-+         goto -> bb123;
++         goto -> bb111;
       }
   
       bb41: {
 +         _55 = const false;
           StorageDead(_14);
 -         drop(_4) -> [return: bb42, unwind continue];
-+         goto -> bb131;
++         goto -> bb116;
       }
   
       bb42: {
@@ -484,7 +484,7 @@
           StorageDead(_3);
           StorageDead(_2);
 -         drop(_44) -> [return: bb47, unwind: bb78];
-+         goto -> bb139;
++         goto -> bb121;
       }
   
       bb47: {
@@ -510,7 +510,7 @@
   
       bb51: {
 -         drop(_34) -> [return: bb52, unwind: bb83];
-+         goto -> bb147;
++         goto -> bb126;
       }
   
       bb52: {
@@ -532,7 +532,7 @@
   
       bb55: {
 -         drop(_24) -> [return: bb56, unwind: bb87];
-+         goto -> bb155;
++         goto -> bb131;
       }
   
       bb56: {
@@ -549,7 +549,7 @@
   
       bb58: {
 -         drop(_14) -> [return: bb59, unwind: bb90];
-+         goto -> bb163;
++         goto -> bb136;
       }
   
       bb59: {
@@ -560,7 +560,7 @@
   
       bb60: {
 -         drop(_4) -> [return: bb61, unwind continue];
-+         goto -> bb171;
++         goto -> bb141;
       }
   
       bb61: {
@@ -616,7 +616,7 @@
   
       bb72 (cleanup): {
 -         drop(_44) -> [return: bb78, unwind terminate(cleanup)];
-+         goto -> bb175;
++         goto -> bb144;
       }
   
       bb73 (cleanup): {
@@ -642,7 +642,7 @@
   
       bb78 (cleanup): {
 -         drop(_34) -> [return: bb83, unwind terminate(cleanup)];
-+         goto -> bb178;
++         goto -> bb146;
       }
   
       bb79 (cleanup): {
@@ -664,7 +664,7 @@
   
       bb83 (cleanup): {
 -         drop(_24) -> [return: bb87, unwind terminate(cleanup)];
-+         goto -> bb181;
++         goto -> bb148;
       }
   
       bb84 (cleanup): {
@@ -682,7 +682,7 @@
   
       bb87 (cleanup): {
 -         drop(_14) -> [return: bb90, unwind terminate(cleanup)];
-+         goto -> bb184;
++         goto -> bb150;
       }
   
       bb88 (cleanup): {
@@ -696,7 +696,7 @@
   
       bb90 (cleanup): {
 -         drop(_4) -> [return: bb92, unwind terminate(cleanup)];
-+         goto -> bb187;
++         goto -> bb152;
       }
   
       bb91 (cleanup): {
@@ -712,8 +712,8 @@
 +         goto -> bb38;
 +     }
 + 
-+     bb94 (cleanup): {
-+         goto -> bb78;
++     bb94: {
++         goto -> bb93;
 +     }
 + 
 +     bb95 (cleanup): {
@@ -721,396 +721,256 @@
 +     }
 + 
 +     bb96: {
-+         goto -> bb93;
-+     }
-+ 
-+     bb97: {
-+         goto -> bb93;
-+     }
-+ 
-+     bb98 (cleanup): {
-+         goto -> bb78;
-+     }
-+ 
-+     bb99: {
 +         _57 = discriminant(_44);
-+         switchInt(move _57) -> [0: bb96, otherwise: bb97];
++         switchInt(move _57) -> [0: bb93, otherwise: bb94];
 +     }
 + 
-+     bb100 (cleanup): {
++     bb97 (cleanup): {
 +         _58 = discriminant(_44);
-+         switchInt(move _58) -> [0: bb94, otherwise: bb98];
++         switchInt(move _58) -> [0: bb78, otherwise: bb95];
 +     }
 + 
-+     bb101: {
++     bb98: {
 +         goto -> bb39;
 +     }
 + 
-+     bb102 (cleanup): {
++     bb99: {
++         goto -> bb98;
++     }
++ 
++     bb100 (cleanup): {
 +         goto -> bb83;
 +     }
 + 
-+     bb103 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb104: {
-+         goto -> bb101;
-+     }
-+ 
-+     bb105: {
-+         goto -> bb101;
-+     }
-+ 
-+     bb106 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb107: {
++     bb101: {
 +         _59 = discriminant(_34);
-+         switchInt(move _59) -> [0: bb104, otherwise: bb105];
++         switchInt(move _59) -> [0: bb98, otherwise: bb99];
 +     }
 + 
-+     bb108 (cleanup): {
++     bb102 (cleanup): {
 +         _60 = discriminant(_34);
-+         switchInt(move _60) -> [0: bb102, otherwise: bb106];
++         switchInt(move _60) -> [0: bb83, otherwise: bb100];
 +     }
 + 
-+     bb109: {
++     bb103: {
 +         goto -> bb40;
 +     }
 + 
-+     bb110 (cleanup): {
++     bb104: {
++         goto -> bb103;
++     }
++ 
++     bb105 (cleanup): {
 +         goto -> bb87;
 +     }
 + 
-+     bb111 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb112: {
-+         goto -> bb109;
-+     }
-+ 
-+     bb113: {
-+         goto -> bb109;
-+     }
-+ 
-+     bb114 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb115: {
++     bb106: {
 +         _61 = discriminant(_24);
-+         switchInt(move _61) -> [0: bb112, otherwise: bb113];
++         switchInt(move _61) -> [0: bb103, otherwise: bb104];
 +     }
 + 
-+     bb116 (cleanup): {
++     bb107 (cleanup): {
 +         _62 = discriminant(_24);
-+         switchInt(move _62) -> [0: bb110, otherwise: bb114];
++         switchInt(move _62) -> [0: bb87, otherwise: bb105];
 +     }
 + 
-+     bb117: {
++     bb108: {
 +         goto -> bb41;
 +     }
 + 
-+     bb118 (cleanup): {
++     bb109: {
++         goto -> bb108;
++     }
++ 
++     bb110 (cleanup): {
 +         goto -> bb90;
 +     }
 + 
-+     bb119 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb120: {
-+         goto -> bb117;
-+     }
-+ 
-+     bb121: {
-+         goto -> bb117;
-+     }
-+ 
-+     bb122 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb123: {
++     bb111: {
 +         _63 = discriminant(_14);
-+         switchInt(move _63) -> [0: bb120, otherwise: bb121];
++         switchInt(move _63) -> [0: bb108, otherwise: bb109];
 +     }
 + 
-+     bb124 (cleanup): {
++     bb112 (cleanup): {
 +         _64 = discriminant(_14);
-+         switchInt(move _64) -> [0: bb118, otherwise: bb122];
++         switchInt(move _64) -> [0: bb90, otherwise: bb110];
 +     }
 + 
-+     bb125: {
++     bb113: {
 +         goto -> bb42;
 +     }
 + 
-+     bb126 (cleanup): {
++     bb114: {
++         goto -> bb113;
++     }
++ 
++     bb115 (cleanup): {
 +         goto -> bb92;
 +     }
 + 
-+     bb127 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb128: {
-+         goto -> bb125;
-+     }
-+ 
-+     bb129: {
-+         goto -> bb125;
-+     }
-+ 
-+     bb130 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb131: {
++     bb116: {
 +         _65 = discriminant(_4);
-+         switchInt(move _65) -> [0: bb128, otherwise: bb129];
++         switchInt(move _65) -> [0: bb113, otherwise: bb114];
 +     }
 + 
-+     bb132 (cleanup): {
++     bb117 (cleanup): {
 +         _66 = discriminant(_4);
-+         switchInt(move _66) -> [0: bb126, otherwise: bb130];
++         switchInt(move _66) -> [0: bb92, otherwise: bb115];
 +     }
 + 
-+     bb133: {
++     bb118: {
 +         goto -> bb47;
 +     }
 + 
-+     bb134 (cleanup): {
++     bb119: {
++         goto -> bb118;
++     }
++ 
++     bb120 (cleanup): {
 +         goto -> bb78;
 +     }
 + 
-+     bb135 (cleanup): {
-+         goto -> bb78;
-+     }
-+ 
-+     bb136: {
-+         goto -> bb133;
-+     }
-+ 
-+     bb137: {
-+         goto -> bb133;
-+     }
-+ 
-+     bb138 (cleanup): {
-+         goto -> bb78;
-+     }
-+ 
-+     bb139: {
++     bb121: {
 +         _67 = discriminant(_44);
-+         switchInt(move _67) -> [0: bb136, otherwise: bb137];
++         switchInt(move _67) -> [0: bb118, otherwise: bb119];
 +     }
 + 
-+     bb140 (cleanup): {
++     bb122 (cleanup): {
 +         _68 = discriminant(_44);
-+         switchInt(move _68) -> [0: bb134, otherwise: bb138];
++         switchInt(move _68) -> [0: bb78, otherwise: bb120];
 +     }
 + 
-+     bb141: {
++     bb123: {
 +         goto -> bb52;
 +     }
 + 
-+     bb142 (cleanup): {
++     bb124: {
++         goto -> bb123;
++     }
++ 
++     bb125 (cleanup): {
 +         goto -> bb83;
 +     }
 + 
-+     bb143 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb144: {
-+         goto -> bb141;
-+     }
-+ 
-+     bb145: {
-+         goto -> bb141;
-+     }
-+ 
-+     bb146 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb147: {
++     bb126: {
 +         _69 = discriminant(_34);
-+         switchInt(move _69) -> [0: bb144, otherwise: bb145];
++         switchInt(move _69) -> [0: bb123, otherwise: bb124];
 +     }
 + 
-+     bb148 (cleanup): {
++     bb127 (cleanup): {
 +         _70 = discriminant(_34);
-+         switchInt(move _70) -> [0: bb142, otherwise: bb146];
++         switchInt(move _70) -> [0: bb83, otherwise: bb125];
 +     }
 + 
-+     bb149: {
++     bb128: {
 +         goto -> bb56;
 +     }
 + 
-+     bb150 (cleanup): {
++     bb129: {
++         goto -> bb128;
++     }
++ 
++     bb130 (cleanup): {
 +         goto -> bb87;
 +     }
 + 
-+     bb151 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb152: {
-+         goto -> bb149;
-+     }
-+ 
-+     bb153: {
-+         goto -> bb149;
-+     }
-+ 
-+     bb154 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb155: {
++     bb131: {
 +         _71 = discriminant(_24);
-+         switchInt(move _71) -> [0: bb152, otherwise: bb153];
++         switchInt(move _71) -> [0: bb128, otherwise: bb129];
 +     }
 + 
-+     bb156 (cleanup): {
++     bb132 (cleanup): {
 +         _72 = discriminant(_24);
-+         switchInt(move _72) -> [0: bb150, otherwise: bb154];
++         switchInt(move _72) -> [0: bb87, otherwise: bb130];
 +     }
 + 
-+     bb157: {
++     bb133: {
 +         goto -> bb59;
 +     }
 + 
-+     bb158 (cleanup): {
++     bb134: {
++         goto -> bb133;
++     }
++ 
++     bb135 (cleanup): {
 +         goto -> bb90;
 +     }
 + 
-+     bb159 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb160: {
-+         goto -> bb157;
-+     }
-+ 
-+     bb161: {
-+         goto -> bb157;
-+     }
-+ 
-+     bb162 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb163: {
++     bb136: {
 +         _73 = discriminant(_14);
-+         switchInt(move _73) -> [0: bb160, otherwise: bb161];
++         switchInt(move _73) -> [0: bb133, otherwise: bb134];
 +     }
 + 
-+     bb164 (cleanup): {
++     bb137 (cleanup): {
 +         _74 = discriminant(_14);
-+         switchInt(move _74) -> [0: bb158, otherwise: bb162];
++         switchInt(move _74) -> [0: bb90, otherwise: bb135];
 +     }
 + 
-+     bb165: {
++     bb138: {
 +         goto -> bb61;
 +     }
 + 
-+     bb166 (cleanup): {
++     bb139: {
++         goto -> bb138;
++     }
++ 
++     bb140 (cleanup): {
 +         goto -> bb92;
 +     }
 + 
-+     bb167 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb168: {
-+         goto -> bb165;
-+     }
-+ 
-+     bb169: {
-+         goto -> bb165;
-+     }
-+ 
-+     bb170 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb171: {
++     bb141: {
 +         _75 = discriminant(_4);
-+         switchInt(move _75) -> [0: bb168, otherwise: bb169];
++         switchInt(move _75) -> [0: bb138, otherwise: bb139];
 +     }
 + 
-+     bb172 (cleanup): {
++     bb142 (cleanup): {
 +         _76 = discriminant(_4);
-+         switchInt(move _76) -> [0: bb166, otherwise: bb170];
++         switchInt(move _76) -> [0: bb92, otherwise: bb140];
 +     }
 + 
-+     bb173 (cleanup): {
++     bb143 (cleanup): {
 +         goto -> bb78;
 +     }
 + 
-+     bb174 (cleanup): {
-+         goto -> bb78;
-+     }
-+ 
-+     bb175 (cleanup): {
++     bb144 (cleanup): {
 +         _77 = discriminant(_44);
-+         switchInt(move _77) -> [0: bb173, otherwise: bb174];
++         switchInt(move _77) -> [0: bb78, otherwise: bb143];
 +     }
 + 
-+     bb176 (cleanup): {
++     bb145 (cleanup): {
 +         goto -> bb83;
 +     }
 + 
-+     bb177 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb178 (cleanup): {
++     bb146 (cleanup): {
 +         _78 = discriminant(_34);
-+         switchInt(move _78) -> [0: bb176, otherwise: bb177];
++         switchInt(move _78) -> [0: bb83, otherwise: bb145];
 +     }
 + 
-+     bb179 (cleanup): {
++     bb147 (cleanup): {
 +         goto -> bb87;
 +     }
 + 
-+     bb180 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb181 (cleanup): {
++     bb148 (cleanup): {
 +         _79 = discriminant(_24);
-+         switchInt(move _79) -> [0: bb179, otherwise: bb180];
++         switchInt(move _79) -> [0: bb87, otherwise: bb147];
 +     }
 + 
-+     bb182 (cleanup): {
++     bb149 (cleanup): {
 +         goto -> bb90;
 +     }
 + 
-+     bb183 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb184 (cleanup): {
++     bb150 (cleanup): {
 +         _80 = discriminant(_14);
-+         switchInt(move _80) -> [0: bb182, otherwise: bb183];
++         switchInt(move _80) -> [0: bb90, otherwise: bb149];
 +     }
 + 
-+     bb185 (cleanup): {
++     bb151 (cleanup): {
 +         goto -> bb92;
 +     }
 + 
-+     bb186 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb187 (cleanup): {
++     bb152 (cleanup): {
 +         _81 = discriminant(_4);
-+         switchInt(move _81) -> [0: bb185, otherwise: bb186];
++         switchInt(move _81) -> [0: bb92, otherwise: bb151];
       }
   }
   

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -429,34 +429,34 @@
       bb37: {
           StorageDead(_2);
 -         drop(_44) -> [return: bb38, unwind: bb78];
-+         goto -> bb96;
++         goto -> bb94;
       }
   
       bb38: {
           StorageDead(_44);
 -         drop(_34) -> [return: bb39, unwind: bb83];
-+         goto -> bb101;
++         goto -> bb97;
       }
   
       bb39: {
 +         _53 = const false;
           StorageDead(_34);
 -         drop(_24) -> [return: bb40, unwind: bb87];
-+         goto -> bb106;
++         goto -> bb100;
       }
   
       bb40: {
 +         _54 = const false;
           StorageDead(_24);
 -         drop(_14) -> [return: bb41, unwind: bb90];
-+         goto -> bb111;
++         goto -> bb103;
       }
   
       bb41: {
 +         _55 = const false;
           StorageDead(_14);
 -         drop(_4) -> [return: bb42, unwind continue];
-+         goto -> bb116;
++         goto -> bb106;
       }
   
       bb42: {
@@ -484,7 +484,7 @@
           StorageDead(_3);
           StorageDead(_2);
 -         drop(_44) -> [return: bb47, unwind: bb78];
-+         goto -> bb121;
++         goto -> bb109;
       }
   
       bb47: {
@@ -510,7 +510,7 @@
   
       bb51: {
 -         drop(_34) -> [return: bb52, unwind: bb83];
-+         goto -> bb126;
++         goto -> bb112;
       }
   
       bb52: {
@@ -532,7 +532,7 @@
   
       bb55: {
 -         drop(_24) -> [return: bb56, unwind: bb87];
-+         goto -> bb131;
++         goto -> bb115;
       }
   
       bb56: {
@@ -549,7 +549,7 @@
   
       bb58: {
 -         drop(_14) -> [return: bb59, unwind: bb90];
-+         goto -> bb136;
++         goto -> bb118;
       }
   
       bb59: {
@@ -560,7 +560,7 @@
   
       bb60: {
 -         drop(_4) -> [return: bb61, unwind continue];
-+         goto -> bb141;
++         goto -> bb121;
       }
   
       bb61: {
@@ -616,7 +616,7 @@
   
       bb72 (cleanup): {
 -         drop(_44) -> [return: bb78, unwind terminate(cleanup)];
-+         goto -> bb144;
++         goto -> bb123;
       }
   
       bb73 (cleanup): {
@@ -642,7 +642,7 @@
   
       bb78 (cleanup): {
 -         drop(_34) -> [return: bb83, unwind terminate(cleanup)];
-+         goto -> bb146;
++         goto -> bb124;
       }
   
       bb79 (cleanup): {
@@ -664,7 +664,7 @@
   
       bb83 (cleanup): {
 -         drop(_24) -> [return: bb87, unwind terminate(cleanup)];
-+         goto -> bb148;
++         goto -> bb125;
       }
   
       bb84 (cleanup): {
@@ -682,7 +682,7 @@
   
       bb87 (cleanup): {
 -         drop(_14) -> [return: bb90, unwind terminate(cleanup)];
-+         goto -> bb150;
++         goto -> bb126;
       }
   
       bb88 (cleanup): {
@@ -696,7 +696,7 @@
   
       bb90 (cleanup): {
 -         drop(_4) -> [return: bb92, unwind terminate(cleanup)];
-+         goto -> bb152;
++         goto -> bb127;
       }
   
       bb91 (cleanup): {
@@ -713,264 +713,164 @@
 +     }
 + 
 +     bb94: {
-+         goto -> bb93;
++         _57 = discriminant(_44);
++         switchInt(move _57) -> [0: bb93, otherwise: bb93];
 +     }
 + 
 +     bb95 (cleanup): {
-+         goto -> bb78;
++         _58 = discriminant(_44);
++         switchInt(move _58) -> [0: bb78, otherwise: bb78];
 +     }
 + 
 +     bb96: {
-+         _57 = discriminant(_44);
-+         switchInt(move _57) -> [0: bb93, otherwise: bb94];
-+     }
-+ 
-+     bb97 (cleanup): {
-+         _58 = discriminant(_44);
-+         switchInt(move _58) -> [0: bb78, otherwise: bb95];
-+     }
-+ 
-+     bb98: {
 +         goto -> bb39;
 +     }
 + 
-+     bb99: {
-+         goto -> bb98;
-+     }
-+ 
-+     bb100 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb101: {
++     bb97: {
 +         _59 = discriminant(_34);
-+         switchInt(move _59) -> [0: bb98, otherwise: bb99];
++         switchInt(move _59) -> [0: bb96, otherwise: bb96];
 +     }
 + 
-+     bb102 (cleanup): {
++     bb98 (cleanup): {
 +         _60 = discriminant(_34);
-+         switchInt(move _60) -> [0: bb83, otherwise: bb100];
++         switchInt(move _60) -> [0: bb83, otherwise: bb83];
 +     }
 + 
-+     bb103: {
++     bb99: {
 +         goto -> bb40;
 +     }
 + 
-+     bb104: {
-+         goto -> bb103;
-+     }
-+ 
-+     bb105 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb106: {
++     bb100: {
 +         _61 = discriminant(_24);
-+         switchInt(move _61) -> [0: bb103, otherwise: bb104];
++         switchInt(move _61) -> [0: bb99, otherwise: bb99];
 +     }
 + 
-+     bb107 (cleanup): {
++     bb101 (cleanup): {
 +         _62 = discriminant(_24);
-+         switchInt(move _62) -> [0: bb87, otherwise: bb105];
++         switchInt(move _62) -> [0: bb87, otherwise: bb87];
 +     }
 + 
-+     bb108: {
++     bb102: {
 +         goto -> bb41;
 +     }
 + 
-+     bb109: {
-+         goto -> bb108;
-+     }
-+ 
-+     bb110 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb111: {
++     bb103: {
 +         _63 = discriminant(_14);
-+         switchInt(move _63) -> [0: bb108, otherwise: bb109];
++         switchInt(move _63) -> [0: bb102, otherwise: bb102];
 +     }
 + 
-+     bb112 (cleanup): {
++     bb104 (cleanup): {
 +         _64 = discriminant(_14);
-+         switchInt(move _64) -> [0: bb90, otherwise: bb110];
++         switchInt(move _64) -> [0: bb90, otherwise: bb90];
 +     }
 + 
-+     bb113: {
++     bb105: {
 +         goto -> bb42;
 +     }
 + 
-+     bb114: {
-+         goto -> bb113;
-+     }
-+ 
-+     bb115 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb116: {
++     bb106: {
 +         _65 = discriminant(_4);
-+         switchInt(move _65) -> [0: bb113, otherwise: bb114];
++         switchInt(move _65) -> [0: bb105, otherwise: bb105];
 +     }
 + 
-+     bb117 (cleanup): {
++     bb107 (cleanup): {
 +         _66 = discriminant(_4);
-+         switchInt(move _66) -> [0: bb92, otherwise: bb115];
++         switchInt(move _66) -> [0: bb92, otherwise: bb92];
 +     }
 + 
-+     bb118: {
++     bb108: {
 +         goto -> bb47;
 +     }
 + 
-+     bb119: {
-+         goto -> bb118;
-+     }
-+ 
-+     bb120 (cleanup): {
-+         goto -> bb78;
-+     }
-+ 
-+     bb121: {
++     bb109: {
 +         _67 = discriminant(_44);
-+         switchInt(move _67) -> [0: bb118, otherwise: bb119];
++         switchInt(move _67) -> [0: bb108, otherwise: bb108];
 +     }
 + 
-+     bb122 (cleanup): {
++     bb110 (cleanup): {
 +         _68 = discriminant(_44);
-+         switchInt(move _68) -> [0: bb78, otherwise: bb120];
++         switchInt(move _68) -> [0: bb78, otherwise: bb78];
 +     }
 + 
-+     bb123: {
++     bb111: {
 +         goto -> bb52;
 +     }
 + 
-+     bb124: {
-+         goto -> bb123;
-+     }
-+ 
-+     bb125 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb126: {
++     bb112: {
 +         _69 = discriminant(_34);
-+         switchInt(move _69) -> [0: bb123, otherwise: bb124];
++         switchInt(move _69) -> [0: bb111, otherwise: bb111];
 +     }
 + 
-+     bb127 (cleanup): {
++     bb113 (cleanup): {
 +         _70 = discriminant(_34);
-+         switchInt(move _70) -> [0: bb83, otherwise: bb125];
++         switchInt(move _70) -> [0: bb83, otherwise: bb83];
 +     }
 + 
-+     bb128: {
++     bb114: {
 +         goto -> bb56;
 +     }
 + 
-+     bb129: {
-+         goto -> bb128;
-+     }
-+ 
-+     bb130 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb131: {
++     bb115: {
 +         _71 = discriminant(_24);
-+         switchInt(move _71) -> [0: bb128, otherwise: bb129];
++         switchInt(move _71) -> [0: bb114, otherwise: bb114];
 +     }
 + 
-+     bb132 (cleanup): {
++     bb116 (cleanup): {
 +         _72 = discriminant(_24);
-+         switchInt(move _72) -> [0: bb87, otherwise: bb130];
++         switchInt(move _72) -> [0: bb87, otherwise: bb87];
 +     }
 + 
-+     bb133: {
++     bb117: {
 +         goto -> bb59;
 +     }
 + 
-+     bb134: {
-+         goto -> bb133;
-+     }
-+ 
-+     bb135 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb136: {
++     bb118: {
 +         _73 = discriminant(_14);
-+         switchInt(move _73) -> [0: bb133, otherwise: bb134];
++         switchInt(move _73) -> [0: bb117, otherwise: bb117];
 +     }
 + 
-+     bb137 (cleanup): {
++     bb119 (cleanup): {
 +         _74 = discriminant(_14);
-+         switchInt(move _74) -> [0: bb90, otherwise: bb135];
++         switchInt(move _74) -> [0: bb90, otherwise: bb90];
 +     }
 + 
-+     bb138: {
++     bb120: {
 +         goto -> bb61;
 +     }
 + 
-+     bb139: {
-+         goto -> bb138;
-+     }
-+ 
-+     bb140 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb141: {
++     bb121: {
 +         _75 = discriminant(_4);
-+         switchInt(move _75) -> [0: bb138, otherwise: bb139];
++         switchInt(move _75) -> [0: bb120, otherwise: bb120];
 +     }
 + 
-+     bb142 (cleanup): {
++     bb122 (cleanup): {
 +         _76 = discriminant(_4);
-+         switchInt(move _76) -> [0: bb92, otherwise: bb140];
++         switchInt(move _76) -> [0: bb92, otherwise: bb92];
 +     }
 + 
-+     bb143 (cleanup): {
-+         goto -> bb78;
-+     }
-+ 
-+     bb144 (cleanup): {
++     bb123 (cleanup): {
 +         _77 = discriminant(_44);
-+         switchInt(move _77) -> [0: bb78, otherwise: bb143];
++         switchInt(move _77) -> [0: bb78, otherwise: bb78];
 +     }
 + 
-+     bb145 (cleanup): {
-+         goto -> bb83;
-+     }
-+ 
-+     bb146 (cleanup): {
++     bb124 (cleanup): {
 +         _78 = discriminant(_34);
-+         switchInt(move _78) -> [0: bb83, otherwise: bb145];
++         switchInt(move _78) -> [0: bb83, otherwise: bb83];
 +     }
 + 
-+     bb147 (cleanup): {
-+         goto -> bb87;
-+     }
-+ 
-+     bb148 (cleanup): {
++     bb125 (cleanup): {
 +         _79 = discriminant(_24);
-+         switchInt(move _79) -> [0: bb87, otherwise: bb147];
++         switchInt(move _79) -> [0: bb87, otherwise: bb87];
 +     }
 + 
-+     bb149 (cleanup): {
-+         goto -> bb90;
-+     }
-+ 
-+     bb150 (cleanup): {
++     bb126 (cleanup): {
 +         _80 = discriminant(_14);
-+         switchInt(move _80) -> [0: bb90, otherwise: bb149];
++         switchInt(move _80) -> [0: bb90, otherwise: bb90];
 +     }
 + 
-+     bb151 (cleanup): {
-+         goto -> bb92;
-+     }
-+ 
-+     bb152 (cleanup): {
++     bb127 (cleanup): {
 +         _81 = discriminant(_4);
-+         switchInt(move _81) -> [0: bb92, otherwise: bb151];
++         switchInt(move _81) -> [0: bb92, otherwise: bb92];
       }
   }
   

--- a/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
+++ b/tests/mir-opt/building/fallible_struct_drop.build.ElaborateDrops.diff
@@ -59,31 +59,6 @@
 +     let mut _54: bool;
 +     let mut _55: bool;
 +     let mut _56: bool;
-+     let mut _57: isize;
-+     let mut _58: isize;
-+     let mut _59: isize;
-+     let mut _60: isize;
-+     let mut _61: isize;
-+     let mut _62: isize;
-+     let mut _63: isize;
-+     let mut _64: isize;
-+     let mut _65: isize;
-+     let mut _66: isize;
-+     let mut _67: isize;
-+     let mut _68: isize;
-+     let mut _69: isize;
-+     let mut _70: isize;
-+     let mut _71: isize;
-+     let mut _72: isize;
-+     let mut _73: isize;
-+     let mut _74: isize;
-+     let mut _75: isize;
-+     let mut _76: isize;
-+     let mut _77: isize;
-+     let mut _78: isize;
-+     let mut _79: isize;
-+     let mut _80: isize;
-+     let mut _81: isize;
       scope 1 {
           debug residual => _9;
           scope 2 {
@@ -429,34 +404,34 @@
       bb37: {
           StorageDead(_2);
 -         drop(_44) -> [return: bb38, unwind: bb78];
-+         goto -> bb94;
++         goto -> bb93;
       }
   
       bb38: {
           StorageDead(_44);
 -         drop(_34) -> [return: bb39, unwind: bb83];
-+         goto -> bb97;
++         goto -> bb94;
       }
   
       bb39: {
 +         _53 = const false;
           StorageDead(_34);
 -         drop(_24) -> [return: bb40, unwind: bb87];
-+         goto -> bb100;
++         goto -> bb95;
       }
   
       bb40: {
 +         _54 = const false;
           StorageDead(_24);
 -         drop(_14) -> [return: bb41, unwind: bb90];
-+         goto -> bb103;
++         goto -> bb96;
       }
   
       bb41: {
 +         _55 = const false;
           StorageDead(_14);
 -         drop(_4) -> [return: bb42, unwind continue];
-+         goto -> bb106;
++         goto -> bb97;
       }
   
       bb42: {
@@ -484,7 +459,7 @@
           StorageDead(_3);
           StorageDead(_2);
 -         drop(_44) -> [return: bb47, unwind: bb78];
-+         goto -> bb109;
++         goto -> bb98;
       }
   
       bb47: {
@@ -510,7 +485,7 @@
   
       bb51: {
 -         drop(_34) -> [return: bb52, unwind: bb83];
-+         goto -> bb112;
++         goto -> bb99;
       }
   
       bb52: {
@@ -532,7 +507,7 @@
   
       bb55: {
 -         drop(_24) -> [return: bb56, unwind: bb87];
-+         goto -> bb115;
++         goto -> bb100;
       }
   
       bb56: {
@@ -549,7 +524,7 @@
   
       bb58: {
 -         drop(_14) -> [return: bb59, unwind: bb90];
-+         goto -> bb118;
++         goto -> bb101;
       }
   
       bb59: {
@@ -560,7 +535,7 @@
   
       bb60: {
 -         drop(_4) -> [return: bb61, unwind continue];
-+         goto -> bb121;
++         goto -> bb102;
       }
   
       bb61: {
@@ -616,7 +591,7 @@
   
       bb72 (cleanup): {
 -         drop(_44) -> [return: bb78, unwind terminate(cleanup)];
-+         goto -> bb123;
++         goto -> bb78;
       }
   
       bb73 (cleanup): {
@@ -642,7 +617,7 @@
   
       bb78 (cleanup): {
 -         drop(_34) -> [return: bb83, unwind terminate(cleanup)];
-+         goto -> bb124;
++         goto -> bb83;
       }
   
       bb79 (cleanup): {
@@ -664,7 +639,7 @@
   
       bb83 (cleanup): {
 -         drop(_24) -> [return: bb87, unwind terminate(cleanup)];
-+         goto -> bb125;
++         goto -> bb87;
       }
   
       bb84 (cleanup): {
@@ -682,7 +657,7 @@
   
       bb87 (cleanup): {
 -         drop(_14) -> [return: bb90, unwind terminate(cleanup)];
-+         goto -> bb126;
++         goto -> bb90;
       }
   
       bb88 (cleanup): {
@@ -696,7 +671,7 @@
   
       bb90 (cleanup): {
 -         drop(_4) -> [return: bb92, unwind terminate(cleanup)];
-+         goto -> bb127;
++         goto -> bb92;
       }
   
       bb91 (cleanup): {
@@ -713,164 +688,39 @@
 +     }
 + 
 +     bb94: {
-+         _57 = discriminant(_44);
-+         switchInt(move _57) -> [0: bb93, otherwise: bb93];
-+     }
-+ 
-+     bb95 (cleanup): {
-+         _58 = discriminant(_44);
-+         switchInt(move _58) -> [0: bb78, otherwise: bb78];
-+     }
-+ 
-+     bb96: {
 +         goto -> bb39;
 +     }
 + 
-+     bb97: {
-+         _59 = discriminant(_34);
-+         switchInt(move _59) -> [0: bb96, otherwise: bb96];
-+     }
-+ 
-+     bb98 (cleanup): {
-+         _60 = discriminant(_34);
-+         switchInt(move _60) -> [0: bb83, otherwise: bb83];
-+     }
-+ 
-+     bb99: {
++     bb95: {
 +         goto -> bb40;
 +     }
 + 
-+     bb100: {
-+         _61 = discriminant(_24);
-+         switchInt(move _61) -> [0: bb99, otherwise: bb99];
-+     }
-+ 
-+     bb101 (cleanup): {
-+         _62 = discriminant(_24);
-+         switchInt(move _62) -> [0: bb87, otherwise: bb87];
-+     }
-+ 
-+     bb102: {
++     bb96: {
 +         goto -> bb41;
 +     }
 + 
-+     bb103: {
-+         _63 = discriminant(_14);
-+         switchInt(move _63) -> [0: bb102, otherwise: bb102];
-+     }
-+ 
-+     bb104 (cleanup): {
-+         _64 = discriminant(_14);
-+         switchInt(move _64) -> [0: bb90, otherwise: bb90];
-+     }
-+ 
-+     bb105: {
++     bb97: {
 +         goto -> bb42;
 +     }
 + 
-+     bb106: {
-+         _65 = discriminant(_4);
-+         switchInt(move _65) -> [0: bb105, otherwise: bb105];
-+     }
-+ 
-+     bb107 (cleanup): {
-+         _66 = discriminant(_4);
-+         switchInt(move _66) -> [0: bb92, otherwise: bb92];
-+     }
-+ 
-+     bb108: {
++     bb98: {
 +         goto -> bb47;
 +     }
 + 
-+     bb109: {
-+         _67 = discriminant(_44);
-+         switchInt(move _67) -> [0: bb108, otherwise: bb108];
-+     }
-+ 
-+     bb110 (cleanup): {
-+         _68 = discriminant(_44);
-+         switchInt(move _68) -> [0: bb78, otherwise: bb78];
-+     }
-+ 
-+     bb111: {
++     bb99: {
 +         goto -> bb52;
 +     }
 + 
-+     bb112: {
-+         _69 = discriminant(_34);
-+         switchInt(move _69) -> [0: bb111, otherwise: bb111];
-+     }
-+ 
-+     bb113 (cleanup): {
-+         _70 = discriminant(_34);
-+         switchInt(move _70) -> [0: bb83, otherwise: bb83];
-+     }
-+ 
-+     bb114: {
++     bb100: {
 +         goto -> bb56;
 +     }
 + 
-+     bb115: {
-+         _71 = discriminant(_24);
-+         switchInt(move _71) -> [0: bb114, otherwise: bb114];
-+     }
-+ 
-+     bb116 (cleanup): {
-+         _72 = discriminant(_24);
-+         switchInt(move _72) -> [0: bb87, otherwise: bb87];
-+     }
-+ 
-+     bb117: {
++     bb101: {
 +         goto -> bb59;
 +     }
 + 
-+     bb118: {
-+         _73 = discriminant(_14);
-+         switchInt(move _73) -> [0: bb117, otherwise: bb117];
-+     }
-+ 
-+     bb119 (cleanup): {
-+         _74 = discriminant(_14);
-+         switchInt(move _74) -> [0: bb90, otherwise: bb90];
-+     }
-+ 
-+     bb120: {
++     bb102: {
 +         goto -> bb61;
-+     }
-+ 
-+     bb121: {
-+         _75 = discriminant(_4);
-+         switchInt(move _75) -> [0: bb120, otherwise: bb120];
-+     }
-+ 
-+     bb122 (cleanup): {
-+         _76 = discriminant(_4);
-+         switchInt(move _76) -> [0: bb92, otherwise: bb92];
-+     }
-+ 
-+     bb123 (cleanup): {
-+         _77 = discriminant(_44);
-+         switchInt(move _77) -> [0: bb78, otherwise: bb78];
-+     }
-+ 
-+     bb124 (cleanup): {
-+         _78 = discriminant(_34);
-+         switchInt(move _78) -> [0: bb83, otherwise: bb83];
-+     }
-+ 
-+     bb125 (cleanup): {
-+         _79 = discriminant(_24);
-+         switchInt(move _79) -> [0: bb87, otherwise: bb87];
-+     }
-+ 
-+     bb126 (cleanup): {
-+         _80 = discriminant(_14);
-+         switchInt(move _80) -> [0: bb90, otherwise: bb90];
-+     }
-+ 
-+     bb127 (cleanup): {
-+         _81 = discriminant(_4);
-+         switchInt(move _81) -> [0: bb92, otherwise: bb92];
       }
   }
   

--- a/tests/mir-opt/building/fallible_struct_drop.rs
+++ b/tests/mir-opt/building/fallible_struct_drop.rs
@@ -1,0 +1,27 @@
+//@ needs-unwind
+//@ skip-filecheck
+
+#[inline(never)]
+pub fn make_one(x: u64) -> Result<String, ()> {
+    if x == u64::MAX { Err(()) } else { Ok(x.to_string()) }
+}
+
+pub struct Big {
+    f0: String,
+    f1: String,
+    f2: String,
+    f3: String,
+    f4: String,
+}
+
+// EMIT_MIR fallible_struct_drop.build.ElaborateDrops.diff
+#[inline(never)]
+pub fn build(s: u64) -> Result<Big, ()> {
+    Ok(Big {
+        f0: make_one(s ^ 0)?,
+        f1: make_one(s ^ 1)?,
+        f2: make_one(s ^ 2)?,
+        f3: make_one(s ^ 3)?,
+        f4: make_one(s ^ 4)?,
+    })
+}

--- a/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
+++ b/tests/mir-opt/coroutine/async_drop_live_dead.a-{closure#0}.coroutine_drop_async.0.panic-unwind.mir
@@ -36,7 +36,7 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
         _24 = std::future::ResumeTy(move _25);
         _23 = copy (_1.0: &mut {async fn body of a<T>()});
         _22 = discriminant((*_23));
-        switchInt(move _22) -> [0: bb17, 2: bb23, 3: bb21, 4: bb22, otherwise: bb24];
+        switchInt(move _22) -> [0: bb16, 2: bb22, 3: bb20, 4: bb21, otherwise: bb23];
     }
 
     bb1: {
@@ -51,11 +51,11 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
 
     bb3 (cleanup): {
         nop;
-        goto -> bb15;
+        goto -> bb4;
     }
 
     bb4 (cleanup): {
-        goto -> bb20;
+        goto -> bb19;
     }
 
     bb5: {
@@ -112,49 +112,45 @@ fn a::{closure#0}(_1: Pin<&mut {async fn body of a<T>()}>, _2: &mut Context<'_>)
         goto -> bb13;
     }
 
-    bb15 (cleanup): {
-        goto -> bb4;
-    }
-
-    bb16: {
+    bb15: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }
 
+    bb16: {
+        goto -> bb18;
+    }
+
     bb17: {
-        goto -> bb19;
+        goto -> bb15;
     }
 
     bb18: {
-        goto -> bb16;
+        drop(((*_23).0: T)) -> [return: bb17, unwind: bb4];
     }
 
-    bb19: {
-        drop(((*_23).0: T)) -> [return: bb18, unwind: bb4];
-    }
-
-    bb20 (cleanup): {
+    bb19 (cleanup): {
         discriminant((*_23)) = 2;
         resume;
     }
 
-    bb21: {
+    bb20: {
         StorageLive(_5);
         _5 = move _24;
         goto -> bb7;
     }
 
-    bb22: {
+    bb21: {
         StorageLive(_12);
         _12 = move _24;
         goto -> bb14;
     }
 
-    bb23: {
-        assert(const false, "`async fn` resumed after panicking") -> [success: bb23, unwind continue];
+    bb22: {
+        assert(const false, "`async fn` resumed after panicking") -> [success: bb22, unwind continue];
     }
 
-    bb24: {
+    bb23: {
         _0 = Poll::<()>::Ready(const ());
         return;
     }

--- a/tests/mir-opt/early_otherwise_branch_unwind.poll.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_unwind.poll.EarlyOtherwiseBranch.diff
@@ -10,8 +10,7 @@
       let _5: std::vec::Vec<u8>;
       let _6: u8;
       let mut _7: bool;
-      let mut _8: bool;
-      let mut _9: isize;
+      let mut _8: isize;
       scope 1 {
           debug _trailers => _5;
       }
@@ -21,9 +20,7 @@
   
       bb0: {
           _7 = const false;
-          _8 = const false;
           _7 = const true;
-          _8 = const true;
           _4 = discriminant(_1);
           switchInt(copy _4) -> [0: bb2, 1: bb4, otherwise: bb1];
       }
@@ -39,17 +36,17 @@
   
       bb3: {
           _2 = discriminant(((((_1 as Ready).0: std::result::Result<std::option::Option<std::vec::Vec<u8>>, u8>) as Ok).0: std::option::Option<std::vec::Vec<u8>>));
-          switchInt(copy _2) -> [0: bb5, 1: bb7, otherwise: bb1];
+          switchInt(move _2) -> [0: bb5, 1: bb7, otherwise: bb1];
       }
   
       bb4: {
           _0 = const ();
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb5: {
           _0 = const ();
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb6: {
@@ -57,19 +54,19 @@
           _6 = copy ((((_1 as Ready).0: std::result::Result<std::option::Option<std::vec::Vec<u8>>, u8>) as Err).0: u8);
           _0 = const ();
           StorageDead(_6);
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb7: {
           StorageLive(_5);
           _5 = move ((((((_1 as Ready).0: std::result::Result<std::option::Option<std::vec::Vec<u8>>, u8>) as Ok).0: std::option::Option<std::vec::Vec<u8>>) as Some).0: std::vec::Vec<u8>);
           _0 = const ();
-          drop(_5) -> [return: bb8, unwind: bb20];
+          drop(_5) -> [return: bb8, unwind: bb17];
       }
   
       bb8: {
           StorageDead(_5);
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb9 (cleanup): {
@@ -81,7 +78,7 @@
       }
   
       bb11: {
-          switchInt(copy _7) -> [0: bb12, otherwise: bb16];
+          switchInt(copy _7) -> [0: bb12, otherwise: bb14];
       }
   
       bb12: {
@@ -90,37 +87,24 @@
       }
   
       bb13: {
-          switchInt(copy _8) -> [0: bb14, otherwise: bb15];
-      }
-  
-      bb14: {
-          _8 = const false;
           goto -> bb12;
       }
   
+      bb14: {
+          _8 = discriminant(((_1 as Ready).0: std::result::Result<std::option::Option<std::vec::Vec<u8>>, u8>));
+          switchInt(move _8) -> [0: bb13, otherwise: bb12];
+      }
+  
       bb15: {
-          goto -> bb14;
-      }
-  
-      bb16: {
-          _9 = discriminant(((_1 as Ready).0: std::result::Result<std::option::Option<std::vec::Vec<u8>>, u8>));
-          switchInt(move _9) -> [0: bb13, otherwise: bb12];
-      }
-  
-      bb17: {
           switchInt(copy _4) -> [0: bb11, otherwise: bb10];
       }
   
-      bb18 (cleanup): {
-          switchInt(copy _3) -> [0: bb19, otherwise: bb9];
-      }
-  
-      bb19 (cleanup): {
+      bb16 (cleanup): {
           goto -> bb9;
       }
   
-      bb20 (cleanup): {
-          switchInt(copy _4) -> [0: bb18, otherwise: bb9];
+      bb17 (cleanup): {
+          switchInt(copy _4) -> [0: bb16, otherwise: bb9];
       }
   }
   

--- a/tests/mir-opt/early_otherwise_branch_unwind.unwind.EarlyOtherwiseBranch.diff
+++ b/tests/mir-opt/early_otherwise_branch_unwind.unwind.EarlyOtherwiseBranch.diff
@@ -9,17 +9,14 @@
       let mut _4: isize;
       let _5: T;
       let mut _6: bool;
-      let mut _7: bool;
-      let mut _8: isize;
+      let mut _7: isize;
       scope 1 {
           debug _v => _5;
       }
   
       bb0: {
           _6 = const false;
-          _7 = const false;
           _6 = const true;
-          _7 = const true;
           _4 = discriminant(_1);
           switchInt(copy _4) -> [0: bb4, 1: bb2, otherwise: bb1];
       }
@@ -35,34 +32,34 @@
   
       bb3: {
           _2 = discriminant(((((_1 as Some).0: std::option::Option<std::option::Option<T>>) as Some).0: std::option::Option<T>));
-          switchInt(copy _2) -> [0: bb6, 1: bb7, otherwise: bb1];
+          switchInt(move _2) -> [0: bb6, 1: bb7, otherwise: bb1];
       }
   
       bb4: {
           _0 = const ();
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb5: {
           _0 = const ();
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb6: {
           _0 = const ();
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb7: {
           StorageLive(_5);
           _5 = move ((((((_1 as Some).0: std::option::Option<std::option::Option<T>>) as Some).0: std::option::Option<T>) as Some).0: T);
           _0 = const ();
-          drop(_5) -> [return: bb8, unwind: bb20];
+          drop(_5) -> [return: bb8, unwind: bb17];
       }
   
       bb8: {
           StorageDead(_5);
-          goto -> bb17;
+          goto -> bb15;
       }
   
       bb9 (cleanup): {
@@ -74,7 +71,7 @@
       }
   
       bb11: {
-          switchInt(copy _6) -> [0: bb12, otherwise: bb16];
+          switchInt(copy _6) -> [0: bb12, otherwise: bb14];
       }
   
       bb12: {
@@ -83,37 +80,24 @@
       }
   
       bb13: {
-          switchInt(copy _7) -> [0: bb14, otherwise: bb15];
-      }
-  
-      bb14: {
-          _7 = const false;
           goto -> bb12;
       }
   
+      bb14: {
+          _7 = discriminant(((_1 as Some).0: std::option::Option<std::option::Option<T>>));
+          switchInt(move _7) -> [1: bb13, otherwise: bb12];
+      }
+  
       bb15: {
-          goto -> bb14;
-      }
-  
-      bb16: {
-          _8 = discriminant(((_1 as Some).0: std::option::Option<std::option::Option<T>>));
-          switchInt(move _8) -> [1: bb13, otherwise: bb12];
-      }
-  
-      bb17: {
           switchInt(copy _4) -> [1: bb11, otherwise: bb10];
       }
   
-      bb18 (cleanup): {
-          switchInt(copy _3) -> [1: bb19, otherwise: bb9];
-      }
-  
-      bb19 (cleanup): {
+      bb16 (cleanup): {
           goto -> bb9;
       }
   
-      bb20 (cleanup): {
-          switchInt(copy _4) -> [1: bb18, otherwise: bb9];
+      bb17 (cleanup): {
+          switchInt(copy _4) -> [1: bb16, otherwise: bb9];
       }
   }
   

--- a/tests/mir-opt/gvn_copy_aggregate.remove_storage_dead.GVN.diff
+++ b/tests/mir-opt/gvn_copy_aggregate.remove_storage_dead.GVN.diff
@@ -9,8 +9,6 @@
       let mut _4: fn() -> AlwaysSome<T>;
       let _5: T;
       let mut _6: T;
-      let mut _7: isize;
-      let mut _8: isize;
       scope 1 {
           debug v => _2;
       }
@@ -34,12 +32,11 @@
 -         _5 = move ((_3 as Some).0: T);
 -         _2 = move _5;
 -         StorageDead(_5);
+-         StorageDead(_3);
 +         nop;
 +         _5 = copy ((_3 as Some).0: T);
 +         _2 = copy _5;
 +         nop;
-          _7 = discriminant(_3);
--         StorageDead(_3);
 +         nop;
           StorageLive(_6);
 -         _6 = move _2;

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-abort.diff
@@ -86,7 +86,7 @@
       bb9: {
           StorageDead(_2);
 -         drop(_1) -> [return: bb10, unwind: bb12];
-+         goto -> bb19;
++         goto -> bb17;
       }
   
       bb10: {
@@ -110,38 +110,30 @@
 +         goto -> bb10;
 +     }
 + 
-+     bb14 (cleanup): {
-+         drop(((_1 as F).0: K)) -> [return: bb12, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb15 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb14];
-+     }
-+ 
-+     bb16: {
++     bb14: {
 +         drop(_1) -> [return: bb13, unwind: bb12];
 +     }
 + 
-+     bb17 (cleanup): {
++     bb15 (cleanup): {
 +         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb18: {
++     bb16: {
 +         _9 = discriminant(_1);
-+         switchInt(move _9) -> [0: bb13, otherwise: bb16];
++         switchInt(move _9) -> [0: bb13, otherwise: bb14];
 +     }
 + 
-+     bb19: {
-+         switchInt(copy _7) -> [0: bb13, otherwise: bb18];
++     bb17: {
++         switchInt(copy _7) -> [0: bb13, otherwise: bb16];
 +     }
 + 
-+     bb20 (cleanup): {
++     bb18 (cleanup): {
 +         _10 = discriminant(_1);
-+         switchInt(move _10) -> [0: bb15, otherwise: bb17];
++         switchInt(move _10) -> [0: bb12, otherwise: bb15];
 +     }
 + 
-+     bb21 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb20];
++     bb19 (cleanup): {
++         switchInt(copy _7) -> [0: bb12, otherwise: bb18];
       }
   }
   

--- a/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/issue_41888.main.ElaborateDrops.panic-unwind.diff
@@ -86,7 +86,7 @@
       bb9: {
           StorageDead(_2);
 -         drop(_1) -> [return: bb10, unwind continue];
-+         goto -> bb19;
++         goto -> bb17;
       }
   
       bb10: {
@@ -110,38 +110,30 @@
 +         goto -> bb10;
 +     }
 + 
-+     bb14 (cleanup): {
-+         drop(((_1 as F).0: K)) -> [return: bb12, unwind terminate(cleanup)];
-+     }
-+ 
-+     bb15 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb14];
-+     }
-+ 
-+     bb16: {
++     bb14: {
 +         drop(_1) -> [return: bb13, unwind: bb12];
 +     }
 + 
-+     bb17 (cleanup): {
++     bb15 (cleanup): {
 +         drop(_1) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb18: {
++     bb16: {
 +         _9 = discriminant(_1);
-+         switchInt(move _9) -> [0: bb13, otherwise: bb16];
++         switchInt(move _9) -> [0: bb13, otherwise: bb14];
 +     }
 + 
-+     bb19: {
-+         switchInt(copy _7) -> [0: bb13, otherwise: bb18];
++     bb17: {
++         switchInt(copy _7) -> [0: bb13, otherwise: bb16];
 +     }
 + 
-+     bb20 (cleanup): {
++     bb18 (cleanup): {
 +         _10 = discriminant(_1);
-+         switchInt(move _10) -> [0: bb15, otherwise: bb17];
++         switchInt(move _10) -> [0: bb12, otherwise: bb15];
 +     }
 + 
-+     bb21 (cleanup): {
-+         switchInt(copy _7) -> [0: bb12, otherwise: bb20];
++     bb19 (cleanup): {
++         switchInt(copy _7) -> [0: bb12, otherwise: bb18];
       }
   }
   

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-abort.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -226,7 +226,7 @@
 -     bb22: {
 -         drop(_2) -> [return: bb24, unwind: bb26];
 +     bb19: {
-+         goto -> bb26;
++         goto -> bb24;
       }
   
 -     bb23: {
@@ -245,7 +245,7 @@
 -     bb25 (cleanup): {
 -         drop(_2) -> [return: bb26, unwind terminate(cleanup)];
 +     bb22 (cleanup): {
-+         goto -> bb27;
++         goto -> bb23;
       }
   
 -     bb26 (cleanup): {
@@ -255,18 +255,6 @@
 + 
 +     bb24: {
 +         goto -> bb21;
-+     }
-+ 
-+     bb25 (cleanup): {
-+         goto -> bb23;
-+     }
-+ 
-+     bb26: {
-+         goto -> bb24;
-+     }
-+ 
-+     bb27 (cleanup): {
-+         goto -> bb23;
       }
   }
   

--- a/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
+++ b/tests/mir-opt/match_arm_scopes.complicated_match.panic-unwind.SimplifyCfg-initial.after-ElaborateDrops.after.diff
@@ -226,7 +226,7 @@
 -     bb22: {
 -         drop(_2) -> [return: bb24, unwind: bb26];
 +     bb19: {
-+         goto -> bb26;
++         goto -> bb24;
       }
   
 -     bb23: {
@@ -245,7 +245,7 @@
 -     bb25 (cleanup): {
 -         drop(_2) -> [return: bb26, unwind terminate(cleanup)];
 +     bb22 (cleanup): {
-+         goto -> bb27;
++         goto -> bb23;
       }
   
 -     bb26 (cleanup): {
@@ -255,18 +255,6 @@
 + 
 +     bb24: {
 +         goto -> bb21;
-+     }
-+ 
-+     bb25 (cleanup): {
-+         goto -> bb23;
-+     }
-+ 
-+     bb26: {
-+         goto -> bb24;
-+     }
-+ 
-+     bb27 (cleanup): {
-+         goto -> bb23;
       }
   }
   

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-abort.mir
@@ -6,9 +6,6 @@ fn unwrap(_1: Option<T>) -> T {
     let mut _2: isize;
     let _3: T;
     let mut _4: !;
-    let mut _5: isize;
-    let mut _6: isize;
-    let mut _7: isize;
     scope 1 {
         debug x => _3;
     }
@@ -32,7 +29,6 @@ fn unwrap(_1: Option<T>) -> T {
         _3 = move ((_1 as Some).0: T);
         _0 = move _3;
         StorageDead(_3);
-        _5 = discriminant(_1);
         return;
     }
 }

--- a/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
+++ b/tests/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-pre-optimizations.after.panic-unwind.mir
@@ -6,9 +6,6 @@ fn unwrap(_1: Option<T>) -> T {
     let mut _2: isize;
     let _3: T;
     let mut _4: !;
-    let mut _5: isize;
-    let mut _6: isize;
-    let mut _7: isize;
     scope 1 {
         debug x => _3;
     }
@@ -32,12 +29,10 @@ fn unwrap(_1: Option<T>) -> T {
         _3 = move ((_1 as Some).0: T);
         _0 = move _3;
         StorageDead(_3);
-        _5 = discriminant(_1);
         return;
     }
 
     bb4 (cleanup): {
-        _7 = discriminant(_1);
         resume;
     }
 }

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -8,8 +8,6 @@
       let _3: std::string::String;
       let mut _4: std::string::String;
 +     let mut _5: bool;
-+     let mut _6: isize;
-+     let mut _7: isize;
       scope 1 {
           debug s => _3;
       }
@@ -50,7 +48,7 @@
   
       bb5: {
 -         drop(_1) -> [return: bb6, unwind: bb9];
-+         goto -> bb11;
++         goto -> bb10;
       }
   
       bb6: {
@@ -73,16 +71,6 @@
 + 
 +     bb10: {
 +         goto -> bb6;
-+     }
-+ 
-+     bb11: {
-+         _6 = discriminant(_1);
-+         switchInt(move _6) -> [0: bb10, otherwise: bb10];
-+     }
-+ 
-+     bb12 (cleanup): {
-+         _7 = discriminant(_1);
-+         switchInt(move _7) -> [0: bb9, otherwise: bb9];
       }
   }
   

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -50,7 +50,7 @@
   
       bb5: {
 -         drop(_1) -> [return: bb6, unwind: bb9];
-+         goto -> bb13;
++         goto -> bb11;
       }
   
       bb6: {
@@ -76,21 +76,13 @@
 +     }
 + 
 +     bb11: {
-+         goto -> bb10;
++         _6 = discriminant(_1);
++         switchInt(move _6) -> [0: bb10, otherwise: bb10];
 +     }
 + 
 +     bb12 (cleanup): {
-+         goto -> bb9;
-+     }
-+ 
-+     bb13: {
-+         _6 = discriminant(_1);
-+         switchInt(move _6) -> [0: bb10, otherwise: bb11];
-+     }
-+ 
-+     bb14 (cleanup): {
 +         _7 = discriminant(_1);
-+         switchInt(move _7) -> [0: bb9, otherwise: bb12];
++         switchInt(move _7) -> [0: bb9, otherwise: bb9];
       }
   }
   

--- a/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
+++ b/tests/mir-opt/otherwise_drops.result_ok.ElaborateDrops.diff
@@ -50,7 +50,7 @@
   
       bb5: {
 -         drop(_1) -> [return: bb6, unwind: bb9];
-+         goto -> bb16;
++         goto -> bb13;
       }
   
       bb6: {
@@ -75,8 +75,8 @@
 +         goto -> bb6;
 +     }
 + 
-+     bb11 (cleanup): {
-+         goto -> bb9;
++     bb11: {
++         goto -> bb10;
 +     }
 + 
 +     bb12 (cleanup): {
@@ -84,25 +84,13 @@
 +     }
 + 
 +     bb13: {
-+         goto -> bb10;
-+     }
-+ 
-+     bb14: {
-+         goto -> bb10;
-+     }
-+ 
-+     bb15 (cleanup): {
-+         goto -> bb9;
-+     }
-+ 
-+     bb16: {
 +         _6 = discriminant(_1);
-+         switchInt(move _6) -> [0: bb13, otherwise: bb14];
++         switchInt(move _6) -> [0: bb10, otherwise: bb11];
 +     }
 + 
-+     bb17 (cleanup): {
++     bb14 (cleanup): {
 +         _7 = discriminant(_1);
-+         switchInt(move _7) -> [0: bb11, otherwise: bb15];
++         switchInt(move _7) -> [0: bb9, otherwise: bb12];
       }
   }
   

--- a/tests/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff
+++ b/tests/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals-before-const-prop.diff
@@ -8,8 +8,6 @@
       let _3: std::boxed::Box<()>;
       let mut _4: std::boxed::Box<()>;
 -     let mut _5: bool;
--     let mut _6: isize;
--     let mut _7: isize;
       scope 1 {
           debug x => _3;
       }
@@ -42,7 +40,6 @@
       }
   
       bb4: {
--         _6 = discriminant(_1);
           return;
       }
   }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-abort.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-abort.mir
@@ -12,9 +12,6 @@ fn method_1(_1: Guard) -> () {
     let _8: OtherDrop;
     let _9: ();
     let mut _10: bool;
-    let mut _11: isize;
-    let mut _12: isize;
-    let mut _13: isize;
     scope 1 {
         debug other_drop => _8;
     }
@@ -73,7 +70,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb18;
+        goto -> bb15;
     }
 
     bb8: {
@@ -93,7 +90,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb11 (cleanup): {
-        goto -> bb21;
+        goto -> bb12;
     }
 
     bb12 (cleanup): {
@@ -110,32 +107,5 @@ fn method_1(_1: Guard) -> () {
 
     bb15: {
         goto -> bb8;
-    }
-
-    bb16: {
-        goto -> bb15;
-    }
-
-    bb17 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb18: {
-        _11 = discriminant(_2);
-        switchInt(move _11) -> [0: bb15, otherwise: bb16];
-    }
-
-    bb19 (cleanup): {
-        _12 = discriminant(_2);
-        switchInt(move _12) -> [0: bb12, otherwise: bb17];
-    }
-
-    bb20 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb21 (cleanup): {
-        _13 = discriminant(_2);
-        switchInt(move _13) -> [0: bb12, otherwise: bb20];
     }
 }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-abort.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-abort.mir
@@ -73,7 +73,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb21;
+        goto -> bb18;
     }
 
     bb8: {
@@ -93,7 +93,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb11 (cleanup): {
-        goto -> bb25;
+        goto -> bb21;
     }
 
     bb12 (cleanup): {
@@ -112,8 +112,8 @@ fn method_1(_1: Guard) -> () {
         goto -> bb8;
     }
 
-    bb16 (cleanup): {
-        goto -> bb12;
+    bb16: {
+        goto -> bb15;
     }
 
     bb17 (cleanup): {
@@ -121,37 +121,21 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb18: {
-        goto -> bb15;
+        _11 = discriminant(_2);
+        switchInt(move _11) -> [0: bb15, otherwise: bb16];
     }
 
-    bb19: {
-        goto -> bb15;
+    bb19 (cleanup): {
+        _12 = discriminant(_2);
+        switchInt(move _12) -> [0: bb12, otherwise: bb17];
     }
 
     bb20 (cleanup): {
         goto -> bb12;
     }
 
-    bb21: {
-        _11 = discriminant(_2);
-        switchInt(move _11) -> [0: bb18, otherwise: bb19];
-    }
-
-    bb22 (cleanup): {
-        _12 = discriminant(_2);
-        switchInt(move _12) -> [0: bb16, otherwise: bb20];
-    }
-
-    bb23 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb24 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb25 (cleanup): {
+    bb21 (cleanup): {
         _13 = discriminant(_2);
-        switchInt(move _13) -> [0: bb23, otherwise: bb24];
+        switchInt(move _13) -> [0: bb12, otherwise: bb20];
     }
 }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
@@ -12,9 +12,6 @@ fn method_1(_1: Guard) -> () {
     let _8: OtherDrop;
     let _9: ();
     let mut _10: bool;
-    let mut _11: isize;
-    let mut _12: isize;
-    let mut _13: isize;
     scope 1 {
         debug other_drop => _8;
     }
@@ -73,7 +70,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb16;
+        goto -> bb15;
     }
 
     bb8: {
@@ -93,7 +90,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb11 (cleanup): {
-        goto -> bb18;
+        goto -> bb12;
     }
 
     bb12 (cleanup): {
@@ -110,20 +107,5 @@ fn method_1(_1: Guard) -> () {
 
     bb15: {
         goto -> bb8;
-    }
-
-    bb16: {
-        _11 = discriminant(_2);
-        switchInt(move _11) -> [0: bb15, otherwise: bb15];
-    }
-
-    bb17 (cleanup): {
-        _12 = discriminant(_2);
-        switchInt(move _12) -> [0: bb12, otherwise: bb12];
-    }
-
-    bb18 (cleanup): {
-        _13 = discriminant(_2);
-        switchInt(move _13) -> [0: bb12, otherwise: bb12];
     }
 }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
@@ -73,7 +73,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb21;
+        goto -> bb18;
     }
 
     bb8: {
@@ -93,7 +93,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb11 (cleanup): {
-        goto -> bb25;
+        goto -> bb21;
     }
 
     bb12 (cleanup): {
@@ -112,8 +112,8 @@ fn method_1(_1: Guard) -> () {
         goto -> bb8;
     }
 
-    bb16 (cleanup): {
-        goto -> bb12;
+    bb16: {
+        goto -> bb15;
     }
 
     bb17 (cleanup): {
@@ -121,37 +121,21 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb18: {
-        goto -> bb15;
+        _11 = discriminant(_2);
+        switchInt(move _11) -> [0: bb15, otherwise: bb16];
     }
 
-    bb19: {
-        goto -> bb15;
+    bb19 (cleanup): {
+        _12 = discriminant(_2);
+        switchInt(move _12) -> [0: bb12, otherwise: bb17];
     }
 
     bb20 (cleanup): {
         goto -> bb12;
     }
 
-    bb21: {
-        _11 = discriminant(_2);
-        switchInt(move _11) -> [0: bb18, otherwise: bb19];
-    }
-
-    bb22 (cleanup): {
-        _12 = discriminant(_2);
-        switchInt(move _12) -> [0: bb16, otherwise: bb20];
-    }
-
-    bb23 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb24 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb25 (cleanup): {
+    bb21 (cleanup): {
         _13 = discriminant(_2);
-        switchInt(move _13) -> [0: bb23, otherwise: bb24];
+        switchInt(move _13) -> [0: bb12, otherwise: bb20];
     }
 }

--- a/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_expr_drop_order_unwind.method_1.ElaborateDrops.after.panic-unwind.mir
@@ -73,7 +73,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb7: {
-        goto -> bb18;
+        goto -> bb16;
     }
 
     bb8: {
@@ -93,7 +93,7 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb11 (cleanup): {
-        goto -> bb21;
+        goto -> bb18;
     }
 
     bb12 (cleanup): {
@@ -113,29 +113,17 @@ fn method_1(_1: Guard) -> () {
     }
 
     bb16: {
-        goto -> bb15;
+        _11 = discriminant(_2);
+        switchInt(move _11) -> [0: bb15, otherwise: bb15];
     }
 
     bb17 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb18: {
-        _11 = discriminant(_2);
-        switchInt(move _11) -> [0: bb15, otherwise: bb16];
-    }
-
-    bb19 (cleanup): {
         _12 = discriminant(_2);
-        switchInt(move _12) -> [0: bb12, otherwise: bb17];
+        switchInt(move _12) -> [0: bb12, otherwise: bb12];
     }
 
-    bb20 (cleanup): {
-        goto -> bb12;
-    }
-
-    bb21 (cleanup): {
+    bb18 (cleanup): {
         _13 = discriminant(_2);
-        switchInt(move _13) -> [0: bb12, otherwise: bb20];
+        switchInt(move _13) -> [0: bb12, otherwise: bb12];
     }
 }


### PR DESCRIPTION
Drop elaboration can be very verbose, especially when locals are move-from by parts. This happens a lot with `?` desugaring for instance.

I start from the example given in https://github.com/rust-lang/rust/issues/157463 and attempt to shrink the generated code.

The remaining empty `goto` blocks come from resetting drop flags. The cost/benefit of the refactor was less interesting.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
