### PR TITLE
Support attributes in type info reflection 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "rustc_abi",
  "rustc_apfloat",
  "rustc_ast",
+ "rustc_ast_pretty",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_hir",

--- a/compiler/rustc_const_eval/Cargo.toml
+++ b/compiler/rustc_const_eval/Cargo.toml
@@ -9,6 +9,7 @@ either = "1"
 rustc_abi = { path = "../rustc_abi" }
 rustc_apfloat = "0.2.0"
 rustc_ast = { path = "../rustc_ast" }
+rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_hir = { path = "../rustc_hir" }

--- a/compiler/rustc_const_eval/src/const_eval/type_info.rs
+++ b/compiler/rustc_const_eval/src/const_eval/type_info.rs
@@ -5,9 +5,11 @@ use std::borrow::Cow;
 use rustc_abi::{ExternAbi, FieldIdx};
 use rustc_ast::Mutability;
 use rustc_hir::LangItem;
+use rustc_hir::attrs::HasAttrs;
 use rustc_middle::span_bug;
 use rustc_middle::ty::layout::TyAndLayout;
 use rustc_middle::ty::{self, Const, FnHeader, FnSigTys, ScalarInt, Ty, TyCtxt};
+use rustc_span::def_id::DefId;
 use rustc_span::{Symbol, sym};
 
 use crate::const_eval::CompileTimeMachine;
@@ -219,6 +221,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
         layout: TyAndLayout<'tcx>,
         name: Option<Symbol>,
         idx: u64,
+        field_def_id: Option<DefId>,
     ) -> InterpResult<'tcx> {
         for (field_idx, field_ty_field) in
             place.layout.ty.ty_adt_def().unwrap().non_enum_variant().fields.iter_enumerated()
@@ -245,6 +248,9 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                         &field_place,
                     )?;
                 }
+                sym::attributes => {
+                    self.write_attributes_type_info(field_place, field_def_id)?;
+                }
                 other => {
                     span_bug!(self.tcx.def_span(field_ty_field.did), "unimplemented field {other}")
                 }
@@ -266,7 +272,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
             fields.len() as u64,
             |this, i, place| {
                 let field_ty = fields[i as usize];
-                this.write_field(field_ty, place, tuple_layout, None, i)
+                this.write_field(field_ty, place, tuple_layout, None, i, None)
             },
         )
     }
@@ -466,6 +472,80 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
             }
         }
 
+        interp_ok(())
+    }
+
+    /// Writes the `attributes` slice for a given `DefId` (or an empty slice if `None`).
+    ///
+    /// Only attributes that remain in unparsed form (`Attribute::Unparsed`) are reflected.
+    /// Attributes the compiler parses into dedicated internal representations (e.g. `#[repr]`) are excluded.
+    pub(crate) fn write_attributes_type_info(
+        &mut self,
+        place: impl Writeable<'tcx, CtfeProvenance>,
+        def_id: Option<DefId>,
+    ) -> InterpResult<'tcx> {
+        let attrs: Vec<(&[rustc_span::Symbol], String)> = match def_id {
+            Some(def_id) => {
+                let all_attrs = def_id.get_attrs(&self.tcx.tcx);
+                all_attrs
+                    .iter()
+                    .filter_map(|attr| match attr {
+                        rustc_hir::Attribute::Unparsed(item) => {
+                            let args_str = match &item.args {
+                                rustc_hir::AttrArgs::Empty => String::new(),
+                                rustc_hir::AttrArgs::Delimited(delim) => {
+                                    rustc_ast_pretty::pprust::tts_to_string(&delim.tokens)
+                                }
+                                rustc_hir::AttrArgs::Eq { expr, .. } => {
+                                    expr.symbol.as_str().to_owned()
+                                }
+                            };
+                            Some((&*item.path.segments, args_str))
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            }
+            None => Vec::new(),
+        };
+
+        self.allocate_fill_and_write_slice_ptr(place, attrs.len() as u64, |this, i, place| {
+            let (path_segments, ref args) = attrs[i as usize];
+            this.write_attribute_type_info(place, path_segments, args)
+        })
+    }
+
+    /// Writes a single `type_info::Attribute` to the given place.
+    ///
+    /// For the `path` field, joins all segments with `"::"` (e.g. `[clippy, complexity]` becomes
+    /// `"clippy::complexity"`).
+    fn write_attribute_type_info(
+        &mut self,
+        place: impl Writeable<'tcx, CtfeProvenance>,
+        path_segments: &[rustc_span::Symbol],
+        args: &str,
+    ) -> InterpResult<'tcx> {
+        for (field_idx, field) in
+            place.layout().ty.ty_adt_def().unwrap().non_enum_variant().fields.iter_enumerated()
+        {
+            let field_place = self.project_field(&place, field_idx)?;
+
+            match field.name {
+                sym::path => {
+                    let path_str: String =
+                        path_segments.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("::");
+                    let path_place = self.allocate_str_dedup(&path_str)?;
+                    let ptr = self.mplace_to_imm_ptr(&path_place, None)?;
+                    self.write_immediate(*ptr, &field_place)?;
+                }
+                sym::args => {
+                    let args_place = self.allocate_str_dedup(args)?;
+                    let ptr = self.mplace_to_imm_ptr(&args_place, None)?;
+                    self.write_immediate(*ptr, &field_place)?;
+                }
+                other => span_bug!(self.tcx.def_span(field.did), "unimplemented field {other}"),
+            }
+        }
         interp_ok(())
     }
 }

--- a/compiler/rustc_const_eval/src/const_eval/type_info/adt.rs
+++ b/compiler/rustc_const_eval/src/const_eval/type_info/adt.rs
@@ -26,7 +26,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                 let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
                 self.write_struct_type_info(
                     place,
-                    (adt_ty, adt_def.variant(VariantIdx::ZERO)),
+                    (adt_ty, adt_def, adt_def.variant(VariantIdx::ZERO)),
                     generics,
                 )?;
                 variant
@@ -36,7 +36,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                 let place = self.project_field(&variant_place, FieldIdx::ZERO)?;
                 self.write_union_type_info(
                     place,
-                    (adt_ty, adt_def.variant(VariantIdx::ZERO)),
+                    (adt_ty, adt_def, adt_def.variant(VariantIdx::ZERO)),
                     generics,
                 )?;
                 variant
@@ -54,10 +54,10 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
     pub(crate) fn write_struct_type_info(
         &mut self,
         place: impl Writeable<'tcx, CtfeProvenance>,
-        struct_: (Ty<'tcx>, &'tcx VariantDef),
+        struct_: (Ty<'tcx>, AdtDef<'tcx>, &'tcx VariantDef),
         generics: &'tcx GenericArgs<'tcx>,
     ) -> InterpResult<'tcx> {
-        let (struct_ty, struct_def) = struct_;
+        let (struct_ty, adt_def, struct_def) = struct_;
         let struct_layout = self.layout_of(struct_ty)?;
 
         for (field_idx, field) in
@@ -74,6 +74,9 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                     let is_non_exhaustive = struct_def.is_field_list_non_exhaustive();
                     self.write_scalar(Scalar::from_bool(is_non_exhaustive), &field_place)?
                 }
+                sym::attributes => {
+                    self.write_attributes_type_info(field_place, Some(adt_def.did()))?
+                }
                 other => span_bug!(self.tcx.def_span(field.did), "unimplemented field {other}"),
             }
         }
@@ -84,10 +87,10 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
     pub(crate) fn write_union_type_info(
         &mut self,
         place: impl Writeable<'tcx, CtfeProvenance>,
-        union_: (Ty<'tcx>, &'tcx VariantDef),
+        union_: (Ty<'tcx>, AdtDef<'tcx>, &'tcx VariantDef),
         generics: &'tcx GenericArgs<'tcx>,
     ) -> InterpResult<'tcx> {
-        let (union_ty, union_def) = union_;
+        let (union_ty, adt_def, union_def) = union_;
         let union_layout = self.layout_of(union_ty)?;
 
         for (field_idx, field) in
@@ -103,6 +106,9 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                 sym::non_exhaustive => {
                     let is_non_exhaustive = union_def.is_field_list_non_exhaustive();
                     self.write_scalar(Scalar::from_bool(is_non_exhaustive), &field_place)?
+                }
+                sym::attributes => {
+                    self.write_attributes_type_info(field_place, Some(adt_def.did()))?
                 }
                 other => span_bug!(self.tcx.def_span(field.did), "unimplemented field {other}"),
             }
@@ -133,15 +139,18 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                         enum_def.variants().len() as u64,
                         |this, i, place| {
                             let variant_idx = VariantIdx::from_usize(i as usize);
-                            let variant_def = &enum_def.variants()[variant_idx];
+                            let variant_def = enum_def.variant(variant_idx);
                             let variant_layout = enum_layout.for_variant(this, variant_idx);
-                            this.write_enum_variant(place, (variant_layout, &variant_def), generics)
+                            this.write_enum_variant(place, (variant_layout, variant_def), generics)
                         },
                     )?;
                 }
                 sym::non_exhaustive => {
                     let is_non_exhaustive = enum_def.is_variant_list_non_exhaustive();
                     self.write_scalar(Scalar::from_bool(is_non_exhaustive), &field_place)?
+                }
+                sym::attributes => {
+                    self.write_attributes_type_info(field_place, Some(enum_def.did()))?
                 }
                 other => span_bug!(self.tcx.def_span(field.did), "unimplemented field {other}"),
             }
@@ -175,6 +184,9 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
                     let is_non_exhaustive = variant_def.is_field_list_non_exhaustive();
                     self.write_scalar(Scalar::from_bool(is_non_exhaustive), &field_place)?
                 }
+                sym::attributes => {
+                    self.write_attributes_type_info(field_place, Some(variant_def.def_id))?
+                }
                 other => span_bug!(self.tcx.def_span(field_def.did), "unimplemented field {other}"),
             }
         }
@@ -195,7 +207,7 @@ impl<'tcx> InterpCx<'tcx, CompileTimeMachine<'tcx>> {
             |this, i, place| {
                 let field_def = &variant_def.fields[FieldIdx::from_usize(i as usize)];
                 let field_ty = field_def.ty(*this.tcx, generics).skip_norm_wip();
-                this.write_field(field_ty, place, variant_layout, Some(field_def.name), i)
+                this.write_field(field_ty, place, variant_layout, Some(field_def.name), i, Some(field_def.did))
             },
         )
     }

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -117,6 +117,8 @@ pub struct Field {
     pub ty: TypeId,
     /// Offset in bytes from the parent type
     pub offset: usize,
+    /// Attributes applied to the field.
+    pub attributes: &'static [Attribute],
 }
 
 /// Compile-time type information about arrays.
@@ -180,6 +182,8 @@ pub struct Struct {
     pub fields: &'static [Field],
     /// Whether the struct field list is non-exhaustive.
     pub non_exhaustive: bool,
+    /// Attributes applied to the struct.
+    pub attributes: &'static [Attribute],
 }
 
 /// Compile-time type information about unions.
@@ -191,6 +195,10 @@ pub struct Union {
     pub generics: &'static [Generic],
     /// All fields of the union.
     pub fields: &'static [Field],
+    /// Whether the union field list is non-exhaustive.
+    pub non_exhaustive: bool,
+    /// Attributes applied to the union.
+    pub attributes: &'static [Attribute],
 }
 
 /// Compile-time type information about enums.
@@ -204,6 +212,8 @@ pub struct Enum {
     pub variants: &'static [Variant],
     /// Whether the enum variant list is non-exhaustive.
     pub non_exhaustive: bool,
+    /// Attributes applied to the enum.
+    pub attributes: &'static [Attribute],
 }
 
 /// Compile-time type information about variants of enums.
@@ -217,6 +227,8 @@ pub struct Variant {
     pub fields: &'static [Field],
     /// Whether the enum variant fields is non-exhaustive.
     pub non_exhaustive: bool,
+    /// Attributes applied to the variant.
+    pub attributes: &'static [Attribute],
 }
 
 /// Compile-time type information about instantiated generics of structs, enum and union variants.
@@ -256,6 +268,18 @@ pub struct GenericType {
 pub struct Const {
     /// The const's type.
     pub ty: TypeId,
+}
+
+/// Compile-time information about an attribute applied to a type, field, or variant.
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+#[unstable(feature = "type_info", issue = "146922")]
+pub struct Attribute {
+    /// The path of the attribute (e.g., `"allow"` or `"clippy::complexity"`).
+    pub path: &'static str,
+    /// The arguments of the attribute as a string (e.g., `"dead_code"`).
+    /// Empty string when the attribute has no arguments.
+    pub args: &'static str,
 }
 
 /// Compile-time type information about `bool`.

--- a/library/coretests/tests/mem/type_info.rs
+++ b/library/coretests/tests/mem/type_info.rs
@@ -517,3 +517,318 @@ fn test_dynamic_traits() {
         assert!(sync.trait_ty.is_auto);
     }
 }
+
+#[test]
+fn test_attributes() {
+    use TypeKind::*;
+
+    const {
+        #[allow(dead_code)]
+        struct AttrStruct {
+            #[allow(dead_code)]
+            field_a: u8,
+            field_b: u16,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<AttrStruct>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "dead_code");
+
+        assert!(ty.fields[0].attributes.len() == 1);
+        assert!(ty.fields[0].attributes[0].path == "allow");
+        assert!(ty.fields[0].attributes[0].args == "dead_code");
+
+        assert!(ty.fields[1].attributes.len() == 0);
+    }
+
+    const {
+        #[allow(dead_code)]
+        enum AttrEnum {
+            #[allow(unused)]
+            VariantA(u32),
+            VariantB,
+        }
+
+        let Type { kind: Enum(ty), .. } = Type::of::<AttrEnum>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "allow");
+
+        assert!(ty.variants[0].attributes.len() == 1);
+        assert!(ty.variants[0].attributes[0].path == "allow");
+        assert!(ty.variants[0].attributes[0].args == "unused");
+
+        assert!(ty.variants[1].attributes.len() == 0);
+    }
+
+    const {
+        struct NoAttrs {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<NoAttrs>() else { panic!() };
+        assert!(ty.attributes.len() == 0);
+        assert!(ty.fields[0].attributes.len() == 0);
+    }
+
+    const {
+        #[allow(dead_code)]
+        union AttrUnion {
+            #[allow(dead_code)]
+            a: u32,
+            b: f32,
+        }
+
+        let Type { kind: Union(ty), .. } = Type::of::<AttrUnion>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "dead_code");
+
+        assert!(ty.fields[0].attributes.len() == 1);
+        assert!(ty.fields[0].attributes[0].path == "allow");
+        assert!(ty.fields[0].attributes[0].args == "dead_code");
+
+        assert!(ty.fields[1].attributes.len() == 0);
+    }
+
+    const {
+        #[allow(dead_code)]
+        #[allow(unused)]
+        struct MultiAttr {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<MultiAttr>() else { panic!() };
+        assert!(ty.attributes.len() == 2);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "dead_code");
+        assert!(ty.attributes[1].path == "allow");
+        assert!(ty.attributes[1].args == "unused");
+    }
+
+    const {
+        #[non_exhaustive]
+        struct EmptyArgs {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<EmptyArgs>() else { panic!() };
+        // #[non_exhaustive] is a parsed built-in attribute, not reflected here.
+        assert!(ty.non_exhaustive);
+        assert!(ty.attributes.len() == 0);
+    }
+
+    const {
+        #[allow(dead_code)]
+        enum FieldAttrEnum {
+            Variant {
+                #[allow(unused)]
+                a: u32,
+                b: u8,
+            },
+        }
+
+        let Type { kind: Enum(ty), .. } = Type::of::<FieldAttrEnum>() else { panic!() };
+        assert!(ty.variants[0].fields[0].attributes.len() == 1);
+        assert!(ty.variants[0].fields[0].attributes[0].path == "allow");
+        assert!(ty.variants[0].fields[0].attributes[0].args == "unused");
+        assert!(ty.variants[0].fields[1].attributes.len() == 0);
+    }
+
+    const {
+        #[deny(missing_docs)]
+        #[allow(dead_code)]
+        #[warn(unused)]
+        struct LayeredAttrs {
+            #[allow(dead_code, unused_variables)]
+            #[deny(unused_imports)]
+            field_a: u32,
+
+            #[allow(dead_code)]
+            #[warn(unused_assignments)]
+            field_b: u8,
+
+            #[forbid(unsafe_code)]
+            #[allow(dead_code)]
+            field_c: u16,
+
+            #[allow(dead_code)]
+            field_d: u64,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<LayeredAttrs>() else { panic!() };
+        assert!(ty.attributes.len() == 3);
+        assert!(ty.attributes[0].path == "deny");
+        assert!(ty.attributes[0].args == "missing_docs");
+        assert!(ty.attributes[1].path == "allow");
+        assert!(ty.attributes[1].args == "dead_code");
+        assert!(ty.attributes[2].path == "warn");
+        assert!(ty.attributes[2].args == "unused");
+
+        assert!(ty.fields[0].attributes.len() == 2);
+        assert!(ty.fields[0].attributes[0].path == "allow");
+        assert!(ty.fields[0].attributes[0].args == "dead_code, unused_variables");
+        assert!(ty.fields[0].attributes[1].path == "deny");
+        assert!(ty.fields[0].attributes[1].args == "unused_imports");
+
+        assert!(ty.fields[1].attributes.len() == 2);
+        assert!(ty.fields[1].attributes[0].path == "allow");
+        assert!(ty.fields[1].attributes[0].args == "dead_code");
+        assert!(ty.fields[1].attributes[1].path == "warn");
+        assert!(ty.fields[1].attributes[1].args == "unused_assignments");
+
+        assert!(ty.fields[2].attributes.len() == 2);
+        assert!(ty.fields[2].attributes[0].path == "forbid");
+        assert!(ty.fields[2].attributes[0].args == "unsafe_code");
+        assert!(ty.fields[2].attributes[1].path == "allow");
+        assert!(ty.fields[2].attributes[1].args == "dead_code");
+
+        assert!(ty.fields[3].attributes.len() == 1);
+        assert!(ty.fields[3].attributes[0].path == "allow");
+        assert!(ty.fields[3].attributes[0].args == "dead_code");
+    }
+
+    const {
+        #[allow(dead_code)]
+        #[deny(unused)]
+        enum LayeredAttrsEnum {
+            #[allow(dead_code)]
+            #[warn(unused_variables)]
+            VariantA {
+                #[forbid(unsafe_code)]
+                x: u32,
+                y: u8,
+            },
+            #[allow(dead_code)]
+            VariantB,
+            #[allow(unused)]
+            VariantC(u8),
+        }
+
+        let Type { kind: Enum(ty), .. } = Type::of::<LayeredAttrsEnum>() else { panic!() };
+        assert!(ty.attributes.len() == 2);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "dead_code");
+        assert!(ty.attributes[1].path == "deny");
+        assert!(ty.attributes[1].args == "unused");
+
+        assert!(ty.variants[0].attributes.len() == 2);
+        assert!(ty.variants[0].attributes[0].path == "allow");
+        assert!(ty.variants[0].attributes[0].args == "dead_code");
+        assert!(ty.variants[0].attributes[1].path == "warn");
+        assert!(ty.variants[0].attributes[1].args == "unused_variables");
+        assert!(ty.variants[0].fields[0].attributes.len() == 1);
+        assert!(ty.variants[0].fields[0].attributes[0].path == "forbid");
+        assert!(ty.variants[0].fields[0].attributes[0].args == "unsafe_code");
+        assert!(ty.variants[0].fields[1].attributes.len() == 0);
+
+        assert!(ty.variants[1].attributes.len() == 1);
+        assert!(ty.variants[1].attributes[0].path == "allow");
+        assert!(ty.variants[1].attributes[0].args == "dead_code");
+        assert!(ty.variants[1].fields.len() == 0);
+
+        assert!(ty.variants[2].attributes.len() == 1);
+        assert!(ty.variants[2].attributes[0].path == "allow");
+        assert!(ty.variants[2].attributes[0].args == "unused");
+        assert!(ty.variants[2].fields[0].attributes.len() == 0);
+    }
+
+    const {
+        #[non_exhaustive]
+        #[allow(dead_code)]
+        #[deny(unused)]
+        struct MixedAttrs {
+            #[allow(dead_code)]
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<MixedAttrs>() else { panic!() };
+        assert!(ty.non_exhaustive);
+        assert!(ty.attributes.len() == 2);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "dead_code");
+        assert!(ty.attributes[1].path == "deny");
+        assert!(ty.attributes[1].args == "unused");
+    }
+
+    const {
+        #[rustfmt::skip]
+        struct NamespacedAttr {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<NamespacedAttr>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "rustfmt::skip");
+        assert!(ty.attributes[0].args == "");
+    }
+
+    const {
+        struct TupleFieldAttrs(#[allow(dead_code)] u8, u16);
+
+        let Type { kind: Struct(ty), .. } = Type::of::<TupleFieldAttrs>() else { panic!() };
+        assert!(ty.fields.len() == 2);
+        assert!(ty.fields[0].attributes.len() == 1);
+        assert!(ty.fields[0].attributes[0].path == "allow");
+        assert!(ty.fields[0].attributes[0].args == "dead_code");
+        assert!(ty.fields[1].attributes.len() == 0);
+    }
+
+    const {
+        let Type { kind: Enum(ty), .. } = Type::of::<Option<i32>>() else { panic!() };
+        let _ = ty.attributes;
+        let _ = ty.variants[0].attributes;
+        let _ = ty.variants[1].attributes;
+    }
+
+    const {
+        #[cfg_attr(test, allow(dead_code))]
+        struct CfgAttrTest {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<CfgAttrTest>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "dead_code");
+    }
+
+    const {
+        #[allow(unused_attributes)]
+        #[allow()]
+        struct EmptyDelim {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<EmptyDelim>() else { panic!() };
+        assert!(ty.attributes.len() == 2);
+        assert!(ty.attributes[0].path == "allow");
+        assert!(ty.attributes[0].args == "unused_attributes");
+        assert!(ty.attributes[1].path == "allow");
+        assert!(ty.attributes[1].args == "");
+    }
+
+    const {
+        #[rustfmt::skip(some::path)]
+        struct PathArg {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<PathArg>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "rustfmt::skip");
+        assert!(ty.attributes[0].args == "some::path");
+    }
+
+    const {
+        #[rustfmt::skip(a::b, c::d)]
+        struct MultiPathArg {
+            x: u8,
+        }
+
+        let Type { kind: Struct(ty), .. } = Type::of::<MultiPathArg>() else { panic!() };
+        assert!(ty.attributes.len() == 1);
+        assert!(ty.attributes[0].path == "rustfmt::skip");
+        assert!(ty.attributes[0].args == "a::b, c::d");
+    }
+}

--- a/tests/ui/reflection/attributes.rs
+++ b/tests/ui/reflection/attributes.rs
@@ -1,0 +1,112 @@
+//@ run-pass
+//@ aux-build:attributes_aux.rs
+
+#![feature(type_info)]
+#![feature(register_tool)]
+#![register_tool(my_tool)]
+#![allow(dead_code)]
+
+extern crate attributes_aux;
+
+use std::mem::type_info::{Type, TypeKind};
+
+#[allow(dead_code)]
+#[doc = "A test struct"]
+struct AttrStruct {
+    #[allow(unused)]
+    first: u8,
+    second: u16,
+}
+
+#[rustfmt::skip]
+struct ToolAttr {
+    x: u8,
+}
+
+#[my_tool::category = "test_value"]
+struct EqAttr {
+    x: u8,
+}
+
+#[repr(C)]
+#[allow(dead_code)]
+struct ReprCStruct {
+    x: u32,
+    y: u8,
+}
+
+fn main() {
+    // #[doc = "..."] is a parsed built-in attribute, not reflected in `attributes`.
+    let Type { kind: TypeKind::Struct(ty), .. } = (const { Type::of::<AttrStruct>() }) else {
+        panic!()
+    };
+    assert_eq!(ty.attributes.len(), 1); // only `allow`, not `doc`
+    assert_eq!(ty.attributes[0].path, "allow");
+    assert_eq!(ty.attributes[0].args, "dead_code");
+    assert_eq!(ty.fields[0].attributes.len(), 1);
+    assert_eq!(ty.fields[0].attributes[0].path, "allow");
+
+    let Type { kind: TypeKind::Struct(ty), .. } = (const { Type::of::<ToolAttr>() }) else {
+        panic!()
+    };
+    assert_eq!(ty.attributes.len(), 1);
+    assert_eq!(ty.attributes[0].path, "rustfmt::skip");
+    assert_eq!(ty.attributes[0].args, "");
+
+    let Type { kind: TypeKind::Struct(ty), .. } = (const { Type::of::<EqAttr>() }) else {
+        panic!()
+    };
+    assert_eq!(ty.attributes.len(), 1);
+    assert_eq!(ty.attributes[0].path, "my_tool::category");
+    assert_eq!(ty.attributes[0].args, "test_value");
+
+    // #[repr(C)] is a parsed built-in attribute, not reflected in `attributes`.
+    let Type { kind: TypeKind::Struct(ty), .. } = (const { Type::of::<ReprCStruct>() }) else {
+        panic!()
+    };
+    assert_eq!(ty.attributes.len(), 1); // only `allow`, not `repr`
+    assert_eq!(ty.attributes[0].path, "allow");
+    assert_eq!(ty.attributes[0].args, "dead_code");
+
+    // Cross-crate: only tool/custom attributes survive metadata serialization.
+    let Type { kind: TypeKind::Enum(ty), .. } =
+        (const { Type::of::<attributes_aux::CrossCrateEnum>() })
+    else {
+        panic!()
+    };
+
+    assert!(ty.non_exhaustive);
+    assert_eq!(ty.attributes.len(), 1);
+    assert_eq!(ty.attributes[0].path, "my_tool::enum_tag");
+    assert_eq!(ty.attributes[0].args, "cross_crate");
+
+    assert_eq!(ty.variants.len(), 2);
+    assert_eq!(ty.variants[0].attributes.len(), 1);
+    assert_eq!(ty.variants[0].attributes[0].path, "my_tool::variant_tag");
+    assert_eq!(ty.variants[0].attributes[0].args, "variant_a");
+    assert_eq!(ty.variants[0].fields.len(), 1);
+    assert_eq!(ty.variants[0].fields[0].attributes.len(), 1);
+    assert_eq!(ty.variants[0].fields[0].attributes[0].path, "my_tool::field_tag");
+    assert_eq!(ty.variants[0].fields[0].attributes[0].args, "variant_field");
+
+    assert_eq!(ty.variants[1].attributes.len(), 1);
+    assert_eq!(ty.variants[1].attributes[0].path, "my_tool::empty_variant_tag");
+    assert_eq!(ty.variants[1].attributes[0].args, "");
+
+    let Type { kind: TypeKind::Struct(ty), .. } =
+        (const { Type::of::<attributes_aux::CrossCrateStruct>() })
+    else {
+        panic!()
+    };
+
+    assert!(ty.non_exhaustive);
+    // Same as above: only tool/custom attributes are visible cross-crate.
+    assert_eq!(ty.attributes.len(), 1);
+    assert_eq!(ty.attributes[0].path, "my_tool::struct_tag");
+    assert_eq!(ty.attributes[0].args, "cross_crate_struct");
+    assert_eq!(ty.fields.len(), 2);
+    assert_eq!(ty.fields[0].attributes.len(), 1);
+    assert_eq!(ty.fields[0].attributes[0].path, "my_tool::field_tag");
+    assert_eq!(ty.fields[0].attributes[0].args, "public_field");
+    assert!(ty.fields[1].attributes.is_empty());
+}

--- a/tests/ui/reflection/auxiliary/attributes_aux.rs
+++ b/tests/ui/reflection/auxiliary/attributes_aux.rs
@@ -1,0 +1,27 @@
+#![crate_name = "attributes_aux"]
+#![feature(register_tool)]
+#![register_tool(my_tool)]
+#![allow(dead_code)]
+
+#[doc = "Cross-crate struct used for reflection tests."]
+#[allow(dead_code)]
+#[non_exhaustive]
+#[my_tool::struct_tag = "cross_crate_struct"]
+pub struct CrossCrateStruct {
+    #[my_tool::field_tag = "public_field"]
+    pub first: u8,
+    #[allow(unused_variables)]
+    pub second: u16,
+}
+
+#[doc = "Cross-crate enum used for reflection tests."]
+#[allow(dead_code)]
+#[non_exhaustive]
+#[my_tool::enum_tag = "cross_crate"]
+pub enum CrossCrateEnum {
+    #[allow(dead_code)]
+    #[my_tool::variant_tag = "variant_a"]
+    VariantA(#[my_tool::field_tag = "variant_field"] u8),
+    #[my_tool::empty_variant_tag]
+    VariantB,
+}


### PR DESCRIPTION
Tracking issue: rust-lang/rust#146922

This PR adds support for inspecting attributes through type reflection. It adds a new `Attribute` struct, plus an `attributes` field on `Struct`, `Enum`, `Union`, `Variant`, and `Field`

```
#[my_tool::category = "test_value"]
struct Bar {
    x: u8,
}

match const { Type::of::<Bar>() }.kind {
    TypeKind::Struct(s) => {
        assert_eq!(s.attributes[0].path, "my_tool::category");
        assert_eq!(s.attributes[0].args, "test_value");
    }
    _ => unreachable!(),
}
```
Only unparsed attributes are reflected (lint, tool, and custom attributes). 


r? @oli-obk