### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -3908,6 +3908,13 @@ pub struct EiiImpl {
     pub is_default: bool,
 }
 
+#[derive(Clone, Encodable, Decodable, Debug, Walkable, PartialEq, Eq)]
+pub enum DelegationSource {
+    Single,
+    List,
+    Glob,
+}
+
 #[derive(Clone, Encodable, Decodable, Debug, Walkable)]
 pub struct Delegation {
     /// Path resolution id.
@@ -3918,7 +3925,7 @@ pub struct Delegation {
     pub rename: Option<Ident>,
     pub body: Option<Box<Block>>,
     /// The item was expanded from a glob delegation item.
-    pub from_glob: bool,
+    pub source: DelegationSource,
 }
 
 impl Delegation {

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -431,6 +431,7 @@ macro_rules! common_visitor_and_walkers {
             Delegation,
             DelegationMac,
             DelegationSuffixes,
+            DelegationSource,
             DelimArgs,
             DelimSpan,
             EnumDef,

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -37,24 +37,29 @@
 //! also be emitted during HIR ty lowering.
 
 use std::iter;
+use std::ops::ControlFlow;
 
 use ast::visit::Visitor;
 use hir::def::{DefKind, Res};
 use hir::{BodyId, HirId};
 use rustc_abi::ExternAbi;
 use rustc_ast as ast;
+use rustc_ast::node_id::NodeMap;
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_hir::attrs::{AttributeKind, InlineAttr};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, FnDeclFlags};
 use rustc_middle::span_bug;
-use rustc_middle::ty::{Asyncness, TyCtxt};
+use rustc_middle::ty::{Asyncness, PerOwnerResolverData, TyCtxt};
 use rustc_span::symbol::kw;
 use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol};
 
 use crate::delegation::generics::{GenericsGenerationResult, GenericsGenerationResults};
-use crate::errors::{CycleInDelegationSignatureResolution, UnresolvedDelegationCallee};
+use crate::errors::{
+    CycleInDelegationSignatureResolution, DelegationAttemptedBlockWithDefsDeletion,
+    DelegationBlockSpecifiedWhenNoParams, UnresolvedDelegationCallee,
+};
 use crate::{
     AllowReturnTypeNotation, ImplTraitContext, ImplTraitPosition, LoweringContext, ParamMode,
     ResolverAstLoweringExt, index_crate,
@@ -198,10 +203,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let (param_count, c_variadic) = self.param_count(sig_id);
 
+        if !self.check_block_soundness(delegation, sig_id, is_method, param_count) {
+            return self.generate_delegation_error(span, delegation);
+        }
+
         let mut generics = self.uplift_delegation_generics(delegation, sig_id, is_method);
 
         let (body_id, call_expr_id) =
-            self.lower_delegation_body(delegation, is_method, param_count, &mut generics, span);
+            self.lower_delegation_body(delegation, sig_id, param_count, &mut generics, span);
 
         let decl = self.lower_delegation_decl(
             sig_id,
@@ -225,6 +234,82 @@ impl<'hir> LoweringContext<'_, 'hir> {
         });
 
         DelegationResults { body_id, sig, ident, generics }
+    }
+
+    fn check_block_soundness(
+        &self,
+        delegation: &Delegation,
+        sig_id: DefId,
+        is_method: bool,
+        param_count: usize,
+    ) -> bool {
+        let Some(block) = delegation.body.as_ref() else { return true };
+        let should_generate_block = self.should_generate_block(delegation, sig_id, is_method);
+
+        // Report an error if user has explicitly specified delegation's target expression
+        // in a single delegation when reused function has no params.
+        if param_count == 0 && should_generate_block {
+            self.dcx().emit_err(DelegationBlockSpecifiedWhenNoParams { span: block.span });
+            return false;
+        }
+
+        struct DefinitionsFinder<'a> {
+            all_owners: &'a NodeMap<PerOwnerResolverData<'a>>,
+            // `self.owner.node_id_to_def_id`
+            nested_def_ids: &'a NodeMap<LocalDefId>,
+        }
+
+        impl<'a> ast::visit::Visitor<'a> for DefinitionsFinder<'a> {
+            type Result = ControlFlow<()>;
+
+            fn visit_id(&mut self, id: NodeId) -> Self::Result {
+                /*
+                    (from `tests\ui\delegation\target-expr-removal-defs-inside.rs`):
+                    ```rust
+                        reuse impl Trait for S1 {
+                            some::path::<{ fn foo() {} }>::xd();
+                            fn foo() {}
+                            self.0
+                        }
+                    ```
+
+                    Constant from unresolved path will be in `nested_owners`,
+                    `fn foo() {}` will not be in `nested_owners` but will be in `owners`,
+                    both have `LocalDefId`, so we check those two maps.
+                */
+                match self.all_owners.contains_key(&id) || self.nested_def_ids.contains_key(&id) {
+                    true => ControlFlow::Break(()),
+                    false => ControlFlow::Continue(()),
+                }
+            }
+        }
+
+        let mut collector = DefinitionsFinder {
+            all_owners: &self.resolver.owners,
+            nested_def_ids: &self.owner.node_id_to_def_id,
+        };
+
+        let contains_defs = collector.visit_block(block).is_break();
+
+        // If there are definitions inside and we can't delete target expression, so report an error.
+        // FIXME(fn_delegation): support deletion of target expression with defs inside.
+        if !should_generate_block && contains_defs {
+            self.dcx().emit_err(DelegationAttemptedBlockWithDefsDeletion { span: block.span });
+            return false;
+        }
+
+        true
+    }
+
+    fn should_generate_block(
+        &self,
+        delegation: &Delegation,
+        sig_id: DefId,
+        is_method: bool,
+    ) -> bool {
+        is_method
+            || matches!(self.tcx.def_kind(sig_id), DefKind::Fn)
+            || matches!(delegation.source, DelegationSource::Single)
     }
 
     fn add_attrs_if_needed(&mut self, span: Span, sig_id: DefId) {
@@ -415,7 +500,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_delegation_body(
         &mut self,
         delegation: &Delegation,
-        is_method: bool,
+        sig_id: DefId,
         param_count: usize,
         generics: &mut GenericsGenerationResults<'hir>,
         span: Span,
@@ -428,6 +513,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
             let mut args: Vec<hir::Expr<'_>> = Vec::with_capacity(param_count);
             let mut stmts: &[hir::Stmt<'hir>] = &[];
 
+            let is_method = this.is_method(sig_id, span);
+
             for idx in 0..param_count {
                 let (param, pat_node_id) = this.generate_param(is_method, idx, span);
                 parameters.push(param);
@@ -437,6 +524,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                 let arg = if let Some(block) = block
                     && idx == 0
+                    && this.should_generate_block(delegation, sig_id, is_method)
                 {
                     let mut self_resolver = SelfResolver {
                         ctxt: this,
@@ -465,17 +553,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 };
 
                 args.push(arg);
-            }
-
-            // If we have no params in signature function but user still wrote some code in
-            // delegation body, then add this code as first arg, eventually an error will be shown,
-            // also nested delegations may need to access information about this code (#154332),
-            // so it is better to leave this code as opposed to bodies of extern functions,
-            // which are completely erased from existence.
-            if param_count == 0
-                && let Some(block) = block
-            {
-                args.push(this.lower_block_expr(&block));
             }
 
             let (final_expr, hir_id) =

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -535,3 +535,17 @@ pub(crate) struct CycleInDelegationSignatureResolution {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("delegation's target expression is specified for function with no params")]
+pub(crate) struct DelegationBlockSpecifiedWhenNoParams {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag("attempted to delete delegation's target expression that contains definitions inside")]
+pub(crate) struct DelegationAttemptedBlockWithDefsDeletion {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/macro_attrs.rs
@@ -35,7 +35,6 @@ const MACRO_USE_TEMPLATE: AttributeTemplate = template!(
 const MACRO_USE_ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowListWarnRest(&[
     Allow(Target::Mod),
     Allow(Target::ExternCrate),
-    Allow(Target::Crate),
     Error(Target::WherePredicate),
 ]);
 

--- a/compiler/rustc_codegen_llvm/src/errors.rs
+++ b/compiler/rustc_codegen_llvm/src/errors.rs
@@ -24,9 +24,12 @@ pub(crate) struct ParseTargetMachineConfig<'a>(pub LlvmError<'a>);
 
 impl<G: EmissionGuarantee> Diagnostic<'_, G> for ParseTargetMachineConfig<'_> {
     fn into_diag(self, dcx: DiagCtxtHandle<'_>, level: Level) -> Diag<'_, G> {
-        let diag: Diag<'_, G> = self.0.into_diag(dcx, level);
+        // Reuse the formatted primary message from `LlvmError` without emitting it.
+        let diag: Diag<'_, ()> = self.0.into_diag(dcx, level);
         let (message, _) = diag.messages.first().expect("`LlvmError` with no message");
-        let message = format_diag_message(message, &diag.args);
+        let message = format_diag_message(message, &diag.args).into_owned();
+        diag.cancel();
+
         Diag::new(
             dcx,
             level,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -2066,7 +2066,11 @@ fn build_single_delegations<'a, Node: InvocationCollectorNode>(
                 ident: rename.unwrap_or(ident),
                 rename,
                 body: deleg.body.clone(),
-                from_glob,
+                source: if from_glob {
+                    ast::DelegationSource::Glob
+                } else {
+                    ast::DelegationSource::List
+                },
             })),
             tokens: None,
         }

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -33,6 +33,7 @@
 //! debugging, you can make changes inside those crates and quickly run main.rs
 //! to read the debug logs.
 
+use std::cell::Cell;
 use std::env::{self, VarError};
 use std::fmt::{self, Display};
 use std::fs::File;
@@ -40,12 +41,12 @@ use std::io::{self, IsTerminal};
 use std::sync::Mutex;
 
 use tracing::dispatcher::SetGlobalDefaultError;
-use tracing::{Event, Subscriber};
+use tracing::{Event, Subscriber, span};
 use tracing_subscriber::filter::{Directive, EnvFilter, LevelFilter};
 use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::fmt::format::{self, FmtSpan, FormatEvent, FormatFields};
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
-use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::{Layer, Registry};
 // Re-export tracing
 pub use {tracing, tracing_core, tracing_subscriber};
@@ -175,6 +176,7 @@ where
             .with_thread_ids(verbose_thread_ids)
             .with_thread_names(verbose_thread_ids)
             .with_span_events(FmtSpan::ACTIVE);
+        let fmt_layer = NonrecursiveLayer { inner: fmt_layer };
         Layer::boxed(fmt_layer)
     } else {
         let mut layer = tracing_tree::HierarchicalLayer::default()
@@ -284,5 +286,107 @@ impl Display for Error {
 impl From<SetGlobalDefaultError> for Error {
     fn from(tracing_error: SetGlobalDefaultError) -> Self {
         Error::AlreadyInit(tracing_error)
+    }
+}
+
+thread_local! {
+    static NONRECURSIVE_GUARD_LOCK: Cell<bool> = const { Cell::new(false) };
+}
+
+struct NonrecursiveGuard;
+
+impl NonrecursiveGuard {
+    fn lock() -> Option<NonrecursiveGuard> {
+        if !NONRECURSIVE_GUARD_LOCK.replace(true) { Some(NonrecursiveGuard) } else { None }
+    }
+}
+
+impl Drop for NonrecursiveGuard {
+    fn drop(&mut self) {
+        NONRECURSIVE_GUARD_LOCK.set(false);
+    }
+}
+
+/// Many debug messages that rustc emits produce additional debug messages when formatting the
+/// arguments to the original debug message. [`tracing_tree::HierarchicalLayer`] (used by the
+/// default output format) filters these out, but [`tracing_subscriber::fmt::format::Json`] (used by
+/// `RUSTC_LOG_FORMAT_JSON`) does not. So, implement a simple recursion check to filter these
+/// messages out.
+struct NonrecursiveLayer<S> {
+    inner: S,
+}
+
+impl<S: Subscriber, L: Layer<S>> Layer<S> for NonrecursiveLayer<L> {
+    fn on_register_dispatch(&self, subscriber: &tracing::Dispatch) {
+        self.inner.on_register_dispatch(subscriber)
+    }
+
+    fn on_layer(&mut self, subscriber: &mut S) {
+        self.inner.on_layer(subscriber)
+    }
+
+    fn register_callsite(
+        &self,
+        metadata: &'static tracing::Metadata<'static>,
+    ) -> tracing_core::Interest {
+        self.inner.register_callsite(metadata)
+    }
+
+    fn enabled(&self, metadata: &tracing::Metadata<'_>, ctx: Context<'_, S>) -> bool {
+        self.inner.enabled(metadata, ctx)
+    }
+
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_new_span(attrs, id, ctx)
+        }
+    }
+
+    fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_record(span, values, ctx)
+        }
+    }
+
+    fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_follows_from(span, follows, ctx)
+        }
+    }
+
+    fn event_enabled(&self, event: &Event<'_>, ctx: Context<'_, S>) -> bool {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.event_enabled(event, ctx)
+        } else {
+            false
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_event(event, ctx)
+        }
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_enter(id, ctx)
+        }
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_exit(id, ctx)
+        }
+    }
+
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        if let Some(_) = NonrecursiveGuard::lock() {
+            self.inner.on_close(id, ctx)
+        }
+    }
+
+    fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: Context<'_, S>) {
+        self.inner.on_id_change(old, new, ctx)
     }
 }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -909,7 +909,7 @@ impl<'a> Parser<'a> {
                 ident,
                 rename,
                 body: self.parse_delegation_body()?,
-                from_glob: false,
+                source: DelegationSource::Single,
             }))
         })
     }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -18,7 +18,7 @@ use rustc_feature::BUILTIN_ATTRIBUTE_MAP;
 use rustc_hir::attrs::diagnostic::Directive;
 use rustc_hir::attrs::{
     AttributeKind, DocAttribute, DocInline, EiiDecl, EiiImpl, EiiImplResolution, InlineAttr,
-    ReprAttr,
+    OptimizeAttr, ReprAttr,
 };
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalModDefId;
@@ -163,6 +163,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
         self.check_repr(attrs, span, target, item, hir_id);
         self.check_rustc_force_inline(hir_id, attrs, target);
         self.check_mix_no_mangle_export(hir_id, attrs);
+        self.check_optimize_and_inline(attrs);
     }
 
     /// Called by [`Self::check_attributes()`] to check a single attribute which is
@@ -1579,6 +1580,17 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     export_name_attr,
                 },
             );
+        }
+    }
+
+    fn check_optimize_and_inline(&self, attrs: &[Attribute]) {
+        if let Some(optimize_span) =
+            find_attr!(attrs, Optimize(OptimizeAttr::DoNotOptimize, span) => *span)
+            && let Some((inline_attr, inline_span)) =
+                find_attr!(attrs, Inline(inline_attr, span) => (inline_attr, *span))
+            && inline_attr != &InlineAttr::Never
+        {
+            self.dcx().emit_err(errors::BothOptimizeNoneAndInline { optimize_span, inline_span });
         }
     }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -179,6 +179,16 @@ pub(crate) struct BothFfiConstAndPure {
 }
 
 #[derive(Diagnostic)]
+#[diag("`#[optimize(none)]` cannot be used with `#[inline]` attributes")]
+pub(crate) struct BothOptimizeNoneAndInline {
+    #[primary_span]
+    #[label("`#[optimize(none)]` here")]
+    pub optimize_span: Span,
+    #[label("`#[inline]` here")]
+    pub inline_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag("attribute should be applied to an `extern` block with non-Rust ABI")]
 #[warning(
     "this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!"

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 
 use rustc_ast::visit::{self, AssocCtxt, Visitor, WalkItemKind};
 use rustc_ast::{
-    self as ast, AssocItem, AssocItemKind, Block, ConstItem, DUMMY_NODE_ID, Delegation, Fn,
-    ForeignItem, ForeignItemKind, Inline, Item, ItemKind, NodeId, StaticItem, StmtKind, TraitAlias,
-    TyAlias,
+    self as ast, AssocItem, AssocItemKind, Block, ConstItem, DUMMY_NODE_ID, Delegation,
+    DelegationSource, Fn, ForeignItem, ForeignItemKind, Inline, Item, ItemKind, NodeId, StaticItem,
+    StmtKind, TraitAlias, TyAlias,
 };
 use rustc_attr_parsing::AttributeParser;
 use rustc_expand::base::{ResolverExpand, SyntaxExtension, SyntaxExtensionKind};
@@ -1461,7 +1461,7 @@ impl<'a, 'ra, 'tcx> DefCollector<'a, 'ra, 'tcx> {
             let parent = self.parent_scope.module.expect_local();
             let expansion = self.parent_scope.expansion;
             self.r.define_local(parent, ident, ns, self.res(def_id), vis, item.span, expansion);
-        } else if !matches!(&item.kind, AssocItemKind::Delegation(deleg) if deleg.from_glob)
+        } else if !matches!(&item.kind, AssocItemKind::Delegation(d) if d.source == DelegationSource::Glob)
             && ident.name != kw::Underscore
         {
             // Don't add underscore names, they cannot be looked up anyway.

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_gnu.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, FramePointer, SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target,
+    TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -15,6 +16,11 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
+            // Enable the Cortex-A53 errata 843419 mitigation by default
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--fix-cortex-a53-843419"],
+            ),
             features: "+v8a,+outline-atomics".into(),
             // the AAPCS64 expects use of non-leaf frame pointers per
             // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_musl.rs
@@ -1,5 +1,6 @@
 use crate::spec::{
-    Arch, FramePointer, SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base,
+    Arch, Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target,
+    TargetMetadata, TargetOptions, base,
 };
 
 pub(crate) fn target() -> Target {
@@ -29,6 +30,11 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: Arch::AArch64,
         options: TargetOptions {
+            // Enable the Cortex-A53 errata 843419 mitigation by default
+            pre_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-Wl,--fix-cortex-a53-843419"],
+            ),
             // the AAPCS64 expects use of non-leaf frame pointers per
             // https://github.com/ARM-software/abi-aa/blob/4492d1570eb70c8fd146623e0db65b2d241f12e7/aapcs64/aapcs64.rst#the-frame-pointer
             // and we tend to encounter interesting bugs in AArch64 unwinding code if we do not

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -20,30 +20,35 @@ impl Drop for TokenStream {
 }
 
 impl<S> Encode<S> for TokenStream {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         mem::ManuallyDrop::new(self).handle.encode(w, s);
     }
 }
 
 impl<S> Encode<S> for &TokenStream {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self.handle.encode(w, s);
     }
 }
 
 impl<S> Decode<'_, '_, S> for TokenStream {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut S) -> Self {
         TokenStream { handle: handle::Handle::decode(r, s) }
     }
 }
 
 impl Encode<()> for crate::TokenStream {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut ()) {
         self.0.encode(w, s)
     }
 }
 
 impl Decode<'_, '_, ()> for crate::TokenStream {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut ()) -> Self {
         crate::TokenStream(Some(Decode::decode(r, s)))
     }
@@ -58,12 +63,14 @@ impl !Send for Span {}
 impl !Sync for Span {}
 
 impl<S> Encode<S> for Span {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self.handle.encode(w, s);
     }
 }
 
 impl<S> Decode<'_, '_, S> for Span {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut S) -> Self {
         Span { handle: handle::Handle::decode(r, s) }
     }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -162,9 +162,11 @@ struct Marked<T, M> {
 
 impl<T, M> Mark for Marked<T, M> {
     type Unmarked = T;
+    #[inline]
     fn mark(unmarked: Self::Unmarked) -> Self {
         Marked { value: unmarked, _marker: marker::PhantomData }
     }
+    #[inline]
     fn unmark(self) -> Self::Unmarked {
         self.value
     }
@@ -174,6 +176,7 @@ impl<'a, T> Mark for &'a Marked<T, client::TokenStream> {
     fn mark(_: Self::Unmarked) -> Self {
         unreachable!()
     }
+    #[inline]
     fn unmark(self) -> Self::Unmarked {
         &self.value
     }
@@ -181,10 +184,12 @@ impl<'a, T> Mark for &'a Marked<T, client::TokenStream> {
 
 impl<T: Mark> Mark for Vec<T> {
     type Unmarked = Vec<T::Unmarked>;
+    #[inline]
     fn mark(unmarked: Self::Unmarked) -> Self {
         // Should be a no-op due to std's in-place collect optimizations.
         unmarked.into_iter().map(T::mark).collect()
     }
+    #[inline]
     fn unmark(self) -> Self::Unmarked {
         // Should be a no-op due to std's in-place collect optimizations.
         self.into_iter().map(T::unmark).collect()
@@ -196,9 +201,11 @@ macro_rules! mark_noop {
         $(
             impl Mark for $ty {
                 type Unmarked = Self;
+                #[inline]
                 fn mark(unmarked: Self::Unmarked) -> Self {
                     unmarked
                 }
+                #[inline]
                 fn unmark(self) -> Self::Unmarked {
                     self
                 }
@@ -276,11 +283,13 @@ macro_rules! mark_compound {
     (struct $name:ident <$($T:ident),+> { $($field:ident),* $(,)? }) => {
         impl<$($T: Mark),+> Mark for $name <$($T),+> {
             type Unmarked = $name <$($T::Unmarked),+>;
+            #[inline]
             fn mark(unmarked: Self::Unmarked) -> Self {
                 $name {
                     $($field: Mark::mark(unmarked.$field)),*
                 }
             }
+            #[inline]
             fn unmark(self) -> Self::Unmarked {
                 $name {
                     $($field: Mark::unmark(self.$field)),*
@@ -291,6 +300,7 @@ macro_rules! mark_compound {
     (enum $name:ident <$($T:ident),+> { $($variant:ident $(($field:ident))?),* $(,)? }) => {
         impl<$($T: Mark),+> Mark for $name <$($T),+> {
             type Unmarked = $name <$($T::Unmarked),+>;
+            #[inline]
             fn mark(unmarked: Self::Unmarked) -> Self {
                 match unmarked {
                     $($name::$variant $(($field))? => {
@@ -298,6 +308,7 @@ macro_rules! mark_compound {
                     })*
                 }
             }
+            #[inline]
             fn unmark(self) -> Self::Unmarked {
                 match self {
                     $($name::$variant $(($field))? => {

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -17,12 +17,14 @@ pub(super) trait Decode<'a, 's, S>: Sized {
 macro_rules! rpc_encode_decode {
     (le $ty:ty) => {
         impl<S> Encode<S> for $ty {
+            #[inline]
             fn encode(self, w: &mut Buffer, _: &mut S) {
                 w.extend_from_array(&self.to_le_bytes());
             }
         }
 
         impl<S> Decode<'_, '_, S> for $ty {
+            #[inline]
             fn decode(r: &mut &[u8], _: &mut S) -> Self {
                 const N: usize = size_of::<$ty>();
 
@@ -44,6 +46,7 @@ macro_rules! rpc_encode_decode {
         impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
             for $name $(<$($T),+>)?
         {
+            #[inline]
             fn decode(r: &mut &'a [u8], s: &mut S) -> Self {
                 $name {
                     $($field: Decode::decode(r, s)),*
@@ -59,6 +62,7 @@ macro_rules! rpc_encode_decode {
             $(const $variant: u8 = Tag::$variant as u8;)*
 
             impl<S, $($($T: Encode<S>),+)?> Encode<S> for $name $(<$($T),+>)? {
+                #[inline]
                 fn encode(self, w: &mut Buffer, s: &mut S) {
                     match self {
                         $($name::$variant $(($field))* => {
@@ -72,6 +76,7 @@ macro_rules! rpc_encode_decode {
             impl<'a, S, $($($T: for<'s> Decode<'a, 's, S>),+)?> Decode<'a, '_, S>
                 for $name $(<$($T),+>)?
             {
+                #[inline]
                 fn decode(r: &mut &'a [u8], s: &mut S) -> Self {
                     match u8::decode(r, s) {
                         $($variant => {
@@ -87,20 +92,24 @@ macro_rules! rpc_encode_decode {
 }
 
 impl<S> Encode<S> for () {
+    #[inline]
     fn encode(self, _: &mut Buffer, _: &mut S) {}
 }
 
 impl<S> Decode<'_, '_, S> for () {
+    #[inline]
     fn decode(_: &mut &[u8], _: &mut S) -> Self {}
 }
 
 impl<S> Encode<S> for u8 {
+    #[inline]
     fn encode(self, w: &mut Buffer, _: &mut S) {
         w.push(self);
     }
 }
 
 impl<S> Decode<'_, '_, S> for u8 {
+    #[inline]
     fn decode(r: &mut &[u8], _: &mut S) -> Self {
         let x = r[0];
         *r = &r[1..];
@@ -117,6 +126,7 @@ const MAX_USIZE_SIZE: usize = 8;
 
 #[cfg(not(target_pointer_width = "64"))]
 impl<S> Encode<S> for usize {
+    #[inline]
     fn encode(self, w: &mut Buffer, _: &mut S) {
         const N: usize = size_of::<usize>();
 
@@ -131,6 +141,7 @@ impl<S> Encode<S> for usize {
 
 #[cfg(not(target_pointer_width = "64"))]
 impl<S> Decode<'_, '_, S> for usize {
+    #[inline]
     fn decode(r: &mut &[u8], _: &mut S) -> Self {
         const N: usize = size_of::<usize>();
         const {
@@ -146,12 +157,14 @@ impl<S> Decode<'_, '_, S> for usize {
 }
 
 impl<S> Encode<S> for bool {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         (self as u8).encode(w, s);
     }
 }
 
 impl<S> Decode<'_, '_, S> for bool {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut S) -> Self {
         match u8::decode(r, s) {
             0 => false,
@@ -162,18 +175,21 @@ impl<S> Decode<'_, '_, S> for bool {
 }
 
 impl<S> Encode<S> for NonZero<u32> {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self.get().encode(w, s);
     }
 }
 
 impl<S> Decode<'_, '_, S> for NonZero<u32> {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut S) -> Self {
         Self::new(u32::decode(r, s)).unwrap()
     }
 }
 
 impl<S, A: Encode<S>, B: Encode<S>> Encode<S> for (A, B) {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self.0.encode(w, s);
         self.1.encode(w, s);
@@ -183,12 +199,14 @@ impl<S, A: Encode<S>, B: Encode<S>> Encode<S> for (A, B) {
 impl<'a, S, A: for<'s> Decode<'a, 's, S>, B: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S>
     for (A, B)
 {
+    #[inline]
     fn decode(r: &mut &'a [u8], s: &mut S) -> Self {
         (Decode::decode(r, s), Decode::decode(r, s))
     }
 }
 
 impl<S> Encode<S> for &str {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         let bytes = self.as_bytes();
         bytes.len().encode(w, s);
@@ -197,6 +215,7 @@ impl<S> Encode<S> for &str {
 }
 
 impl<'a, S> Decode<'a, '_, S> for &'a str {
+    #[inline]
     fn decode(r: &mut &'a [u8], s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let xs = &r[..len];
@@ -206,18 +225,21 @@ impl<'a, S> Decode<'a, '_, S> for &'a str {
 }
 
 impl<S> Encode<S> for String {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self[..].encode(w, s);
     }
 }
 
 impl<S> Decode<'_, '_, S> for String {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut S) -> Self {
         <&str>::decode(r, s).to_string()
     }
 }
 
 impl<S, T: Encode<S>> Encode<S> for Vec<T> {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self.len().encode(w, s);
         for x in self {
@@ -227,6 +249,7 @@ impl<S, T: Encode<S>> Encode<S> for Vec<T> {
 }
 
 impl<'a, S, T: for<'s> Decode<'a, 's, S>> Decode<'a, '_, S> for Vec<T> {
+    #[inline]
     fn decode(r: &mut &'a [u8], s: &mut S) -> Self {
         let len = usize::decode(r, s);
         let mut vec = Vec::with_capacity(len);
@@ -289,12 +312,14 @@ impl PanicMessage {
 }
 
 impl<S> Encode<S> for PanicMessage {
+    #[inline]
     fn encode(self, w: &mut Buffer, s: &mut S) {
         self.as_str().encode(w, s);
     }
 }
 
 impl<S> Decode<'_, '_, S> for PanicMessage {
+    #[inline]
     fn decode(r: &mut &[u8], s: &mut S) -> Self {
         match Option::<String>::decode(r, s) {
             Some(s) => PanicMessage::String(s),

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -20,8 +20,8 @@ use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::{ConstStability, StabilityLevel, StableSince};
 use rustc_metadata::creader::CStore;
 use rustc_middle::ty::{self, TyCtxt, TypingMode};
-use rustc_span::Symbol;
 use rustc_span::symbol::kw;
+use rustc_span::{Ident, Symbol};
 use tracing::{debug, trace};
 
 use super::url_parts_builder::UrlPartsBuilder;
@@ -1109,8 +1109,23 @@ fn print_qpath_data(qpath_data: &clean::QPathData, cx: &Context<'_>) -> impl Dis
                 Some(trait_) => href(trait_.def_id(), cx).ok(),
                 None => self_type.def_id(cx.cache()).and_then(|did| href(did, cx).ok()),
             };
+            let tcx = cx.tcx();
+            let assoc_type_is_hidden = !cx.cache().document_hidden
+                && trait_.as_ref().is_some_and(|trait_| {
+                    let trait_did = trait_.def_id();
+                    tcx.associated_items(trait_did)
+                        .find_by_ident_and_kind(
+                            tcx,
+                            Ident::with_dummy_span(assoc.name),
+                            ty::AssocTag::Type,
+                            trait_did,
+                        )
+                        .is_some_and(|assoc_item| tcx.is_doc_hidden(assoc_item.def_id))
+                });
 
-            if let Some(HrefInfo { url, rust_path, .. }) = parent_href {
+            if let Some(HrefInfo { url, rust_path, .. }) = parent_href
+                && !assoc_type_is_hidden
+            {
                 write!(
                     f,
                     "<a class=\"associatedtype\" href=\"{url}#{shortty}.{name}\" \

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -220,6 +220,7 @@ fn check_unexpected_extension(check: &mut RunningCheck, file_path: &Path, ext: &
         "tests/ui/asm/named-asm-labels.s", // loading an external asm file to test named labels lint
         "tests/ui/asm/normalize-offsets-for-crlf.s", // loading an external asm file to test CRLF normalization
         "tests/ui/codegen/mismatched-data-layout.json", // testing mismatched data layout w/ custom targets
+        "tests/ui/codegen/custom-target-invalid-llvm-target.json", // testing invalid custom targets
         "tests/ui/check-cfg/my-awesome-platform.json",  // testing custom targets with cfgs
         "tests/ui/argfile/commandline-argfile-badutf8.args", // passing args via a file
         "tests/ui/argfile/commandline-argfile.args",    // passing args via a file

--- a/tests/rustdoc-html/hidden-trait-methods-with-document-hidden-items.rs
+++ b/tests/rustdoc-html/hidden-trait-methods-with-document-hidden-items.rs
@@ -29,3 +29,9 @@ impl Trait for S {
     fn f() {}
     fn g() {}
 }
+
+// Regression test for https://github.com/rust-lang/rust/issues/151454.
+//@ has foo/fn.hidden_projection.html
+//@ has - '//pre[@class="rust item-decl"]' 'T::Foo'
+//@ has - '//pre[@class="rust item-decl"]//a[@href="trait.Trait.html#associatedtype.Foo"]' 'Foo'
+pub fn hidden_projection<T: Trait>(_: T::Foo) {}

--- a/tests/rustdoc-html/hidden-trait-methods.rs
+++ b/tests/rustdoc-html/hidden-trait-methods.rs
@@ -27,3 +27,9 @@ impl Trait for S {
     fn f() {}
     fn g() {}
 }
+
+// Regression test for https://github.com/rust-lang/rust/issues/151454.
+//@ has foo/fn.hidden_projection.html
+//@ has - '//pre[@class="rust item-decl"]' 'T::Foo'
+//@ !has - '//pre[@class="rust item-decl"]//a[@href="trait.Trait.html#associatedtype.Foo"]' 'Foo'
+pub fn hidden_projection<T: Trait>(_: T::Foo) {}

--- a/tests/ui/attributes/attr-on-mac-call.stderr
+++ b/tests/ui/attributes/attr-on-mac-call.stderr
@@ -161,7 +161,7 @@ warning: `#[macro_use]` attribute cannot be used on macro calls
 LL |     #[macro_use]
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on macro calls

--- a/tests/ui/attributes/optimize-smoke-test.rs
+++ b/tests/ui/attributes/optimize-smoke-test.rs
@@ -1,0 +1,25 @@
+//! Basic smoke test for `#[optimize(..)]` attributes.
+//@ run-pass
+
+#![feature(optimize_attribute)]
+
+#[optimize(speed)]
+fn optimized_speed() -> i32 {
+    42
+}
+
+#[optimize(size)]
+fn optimized_size() -> i32 {
+    42
+}
+
+#[optimize(none)]
+fn optimized_none() -> i32 {
+    42
+}
+
+fn main() {
+    assert_eq!(optimized_speed(), 42);
+    assert_eq!(optimized_size(), 42);
+    assert_eq!(optimized_none(), 42);
+}

--- a/tests/ui/attributes/optimize.rs
+++ b/tests/ui/attributes/optimize.rs
@@ -62,3 +62,15 @@ fn duplicate_same() {}
 #[optimize(speed)]
 #[optimize(size)] //~ ERROR multiple `optimize` attributes
 fn duplicate_different() {}
+
+#[optimize(none)] //~ ERROR `#[optimize(none)]` cannot be used with `#[inline]` attributes
+#[inline]
+fn inline_conflict_a() {}
+
+#[inline(always)]
+#[optimize(none)] //~ ERROR `#[optimize(none)]` cannot be used with `#[inline]` attributes
+fn inline_conflict_b() {}
+
+#[inline(never)]
+#[optimize(none)]
+fn inline_conflict_c() {}

--- a/tests/ui/attributes/optimize.stderr
+++ b/tests/ui/attributes/optimize.stderr
@@ -62,5 +62,21 @@ note: attribute also specified here
 LL | #[optimize(speed)]
    | ^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors
+error: `#[optimize(none)]` cannot be used with `#[inline]` attributes
+  --> $DIR/optimize.rs:66:1
+   |
+LL | #[optimize(none)]
+   | ^^^^^^^^^^^^^^^^^ `#[optimize(none)]` here
+LL | #[inline]
+   | --------- `#[inline]` here
+
+error: `#[optimize(none)]` cannot be used with `#[inline]` attributes
+  --> $DIR/optimize.rs:71:1
+   |
+LL | #[inline(always)]
+   | ----------------- `#[inline]` here
+LL | #[optimize(none)]
+   | ^^^^^^^^^^^^^^^^^ `#[optimize(none)]` here
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/codegen/custom-target-invalid-llvm-target.json
+++ b/tests/ui/codegen/custom-target-invalid-llvm-target.json
@@ -1,0 +1,6 @@
+{
+    "llvm-target": "not-a-real-target",
+    "data-layout": "e",
+    "arch": "x86_64",
+    "target-pointer-width": 64
+}

--- a/tests/ui/codegen/custom-target-invalid-llvm-target.rs
+++ b/tests/ui/codegen/custom-target-invalid-llvm-target.rs
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/rust-lang/rust/issues/157401
+
+// ignore-tidy-target-specific-tests
+//@ check-fail
+//@ compile-flags: --target={{src-base}}/codegen/custom-target-invalid-llvm-target.json -Z unstable-options
+//@ ignore-backends: gcc
+
+fn main() {}
+
+//~? ERROR failed to parse target machine config to target machine

--- a/tests/ui/codegen/custom-target-invalid-llvm-target.stderr
+++ b/tests/ui/codegen/custom-target-invalid-llvm-target.stderr
@@ -1,0 +1,2 @@
+error: failed to parse target machine config to target machine: could not create LLVM TargetMachine for triple: not-a-real-target
+

--- a/tests/ui/delegation/delegation-first-arg.rs
+++ b/tests/ui/delegation/delegation-first-arg.rs
@@ -1,0 +1,86 @@
+#![feature(fn_delegation)]
+
+trait Trait: Sized {
+    fn value(self) {}
+    fn r#ref(&self) {}
+    fn mut_ref(&mut self) {}
+
+    fn static_empty() {}
+    fn static_one_param(x: usize) {}
+}
+
+struct S;
+impl Trait for S {}
+
+struct F(S);
+// In glob delegations silently remove first arg if no params or generate default
+// first arg (`arg0`) if it is a static function.
+reuse impl Trait for F { self.0 }
+//~^ ERROR: type annotations needed
+//~| ERROR: type annotations needed
+
+struct F1(S);
+impl F1 {
+    reuse Trait::{value, r#ref, mut_ref} { self.0 }
+
+    // Error is reported as user has explicitly specified block when no params.
+    reuse <S as Trait>::static_empty { self.0 }
+    //~^ ERROR: delegation's target expression is specified for function with no params
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+
+    reuse <S as Trait>::static_one_param { self.0 }
+    //~^ ERROR: `usize` is a primitive type and therefore doesn't have fields
+}
+
+struct F2(S);
+impl F2 {
+    // In list delegations silently remove first arg if it is not a method.
+    reuse <S as Trait>::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+}
+
+mod trait_to_reuse {
+    use super::Trait;
+
+    pub fn value(_: impl Trait) {}
+    pub fn r#ref(_: &impl Trait) {}
+    pub fn mut_ref(_: &mut impl Trait) {}
+
+    pub fn static_empty() {}
+    pub fn static_one_param(x: usize) {}
+}
+
+struct F3(S);
+impl Trait for F3 {
+    reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+    //~^ ERROR: mismatched types
+    //~| ERROR: mismatched types
+}
+
+struct F4(S);
+impl F4 {
+    reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+    //~^ ERROR: no field `0` on type `impl Trait`
+    //~| ERROR: no field `0` on type `&impl Trait`
+    //~| ERROR: no field `0` on type `&mut impl Trait`
+    //~| ERROR: `usize` is a primitive type and therefore doesn't have fields
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~| ERROR: delegation's target expression is specified for function with no params
+}
+
+mod to_reuse {
+    pub fn empty() {}
+    pub fn one_param(x: usize) {}
+}
+
+// Error is reported as user has explicitly specified block when no params.
+reuse to_reuse::empty { self + 1 }
+//~^ ERROR: delegation's target expression is specified for function with no params
+//~| ERROR: this function takes 0 arguments but 1 argument was supplied
+
+reuse to_reuse::one_param { self + 1 }
+
+reuse to_reuse::{empty as empty1, one_param as one_param1} { self + 1 }
+//~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+//~| ERROR: delegation's target expression is specified for function with no params
+
+fn main() {}

--- a/tests/ui/delegation/delegation-first-arg.stderr
+++ b/tests/ui/delegation/delegation-first-arg.stderr
@@ -1,0 +1,203 @@
+error: delegation's target expression is specified for function with no params
+  --> $DIR/delegation-first-arg.rs:27:38
+   |
+LL |     reuse <S as Trait>::static_empty { self.0 }
+   |                                      ^^^^^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/delegation-first-arg.rs:61:83
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                                                   ^^^^^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/delegation-first-arg.rs:76:23
+   |
+LL | reuse to_reuse::empty { self + 1 }
+   |                       ^^^^^^^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/delegation-first-arg.rs:82:60
+   |
+LL | reuse to_reuse::{empty as empty1, one_param as one_param1} { self + 1 }
+   |                                                            ^^^^^^^^^^^^
+
+error[E0283]: type annotations needed
+  --> $DIR/delegation-first-arg.rs:18:1
+   |
+LL | reuse impl Trait for F { self.0 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `Trait`
+help: the following types implement trait `Trait`
+  --> $DIR/delegation-first-arg.rs:13:1
+   |
+LL | impl Trait for S {}
+   | ^^^^^^^^^^^^^^^^ `S`
+...
+LL | reuse impl Trait for F { self.0 }
+   | ^^^^^^^^^^^^^^^^^^^^^^ `F`
+...
+LL | impl Trait for F3 {
+   | ^^^^^^^^^^^^^^^^^ `F3`
+
+error[E0283]: type annotations needed
+  --> $DIR/delegation-first-arg.rs:18:1
+   |
+LL | reuse impl Trait for F { self.0 }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: the type must implement `Trait`
+help: the following types implement trait `Trait`
+  --> $DIR/delegation-first-arg.rs:13:1
+   |
+LL | impl Trait for S {}
+   | ^^^^^^^^^^^^^^^^ `S`
+...
+LL | reuse impl Trait for F { self.0 }
+   | ^^^^^^^^^^^^^^^^^^^^^^ `F`
+...
+LL | impl Trait for F3 {
+   | ^^^^^^^^^^^^^^^^^ `F3`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/delegation-first-arg.rs:27:25
+   |
+LL |     reuse <S as Trait>::static_empty { self.0 }
+   |                         ^^^^^^^^^^^^ ---------- unexpected argument
+   |
+note: associated function defined here
+  --> $DIR/delegation-first-arg.rs:8:8
+   |
+LL |     fn static_empty() {}
+   |        ^^^^^^^^^^^^
+help: remove the extra argument
+   |
+LL -     reuse <S as Trait>::static_empty { self.0 }
+LL +     reuse <S as Trait>::static_empt{ self.0 }
+   |
+
+error[E0610]: `usize` is a primitive type and therefore doesn't have fields
+  --> $DIR/delegation-first-arg.rs:31:49
+   |
+LL |     reuse <S as Trait>::static_one_param { self.0 }
+   |                                                 ^
+
+error[E0308]: mismatched types
+  --> $DIR/delegation-first-arg.rs:54:85
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                   ----- arguments to this function are incorrect    ^^^^^^ expected `&_`, found `S`
+   |
+   = note: expected reference `&_`
+                 found struct `S`
+note: function defined here
+  --> $DIR/delegation-first-arg.rs:45:12
+   |
+LL |     pub fn r#ref(_: &impl Trait) {}
+   |            ^^^^^ --------------
+help: consider borrowing here
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { &self.0 }
+   |                                                                                     +
+
+error[E0308]: mismatched types
+  --> $DIR/delegation-first-arg.rs:54:85
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                          -------                                    ^^^^^^ expected `&mut _`, found `S`
+   |                                          |
+   |                                          arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut _`
+                         found struct `S`
+note: function defined here
+  --> $DIR/delegation-first-arg.rs:46:12
+   |
+LL |     pub fn mut_ref(_: &mut impl Trait) {}
+   |            ^^^^^^^ ------------------
+help: consider mutably borrowing here
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { &mut self.0 }
+   |                                                                                     ++++
+
+error[E0609]: no field `0` on type `impl Trait`
+  --> $DIR/delegation-first-arg.rs:61:90
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                                                          ^ unknown field
+
+error[E0609]: no field `0` on type `&impl Trait`
+  --> $DIR/delegation-first-arg.rs:61:90
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                                                          ^ unknown field
+
+error[E0609]: no field `0` on type `&mut impl Trait`
+  --> $DIR/delegation-first-arg.rs:61:90
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                                                          ^ unknown field
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/delegation-first-arg.rs:61:51
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                   ^^^^^^^^^^^^                    ---------- unexpected argument
+   |
+note: function defined here
+  --> $DIR/delegation-first-arg.rs:48:12
+   |
+LL |     pub fn static_empty() {}
+   |            ^^^^^^^^^^^^
+help: remove the extra argument
+   |
+LL -     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+LL +     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empt{ self.0 }
+   |
+
+error[E0610]: `usize` is a primitive type and therefore doesn't have fields
+  --> $DIR/delegation-first-arg.rs:61:90
+   |
+LL |     reuse trait_to_reuse::{value, r#ref, mut_ref, static_empty, static_one_param} { self.0 }
+   |                                                                                          ^
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/delegation-first-arg.rs:76:17
+   |
+LL | reuse to_reuse::empty { self + 1 }
+   |                 ^^^^^ ------------ unexpected argument
+   |
+note: function defined here
+  --> $DIR/delegation-first-arg.rs:71:12
+   |
+LL |     pub fn empty() {}
+   |            ^^^^^
+help: remove the extra argument
+   |
+LL - reuse to_reuse::empty { self + 1 }
+LL + reuse to_reuse::empt{ self + 1 }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/delegation-first-arg.rs:82:18
+   |
+LL | reuse to_reuse::{empty as empty1, one_param as one_param1} { self + 1 }
+   |                  ^^^^^                                     ------------ unexpected argument
+   |
+note: function defined here
+  --> $DIR/delegation-first-arg.rs:71:12
+   |
+LL |     pub fn empty() {}
+   |            ^^^^^
+help: remove the extra argument
+   |
+LL - reuse to_reuse::{empty as empty1, one_param as one_param1} { self + 1 }
+LL + reuse to_reuse::{empt{ self + 1 }
+   |
+
+error: aborting due to 17 previous errors
+
+Some errors have detailed explanations: E0061, E0283, E0308, E0609, E0610.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155128.stderr
@@ -1,8 +1,20 @@
+error: delegation's target expression is specified for function with no params
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:36:18
+   |
+LL |       reuse a as b {
+   |  __________________^
+LL | |
+LL | |         fn foo<T>() {};
+LL | |         foo
+LL | |     }
+   | |_____^
+
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/hir-crate-items-before-lowering-ices.rs:36:11
    |
 LL |       reuse a as b {
    |  ___________^______-
+LL | |
 LL | |         fn foo<T>() {};
 LL | |         foo
 LL | |     }
@@ -19,6 +31,6 @@ LL -     reuse a as b {
 LL +     reuse {
    |
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155164.stderr
@@ -1,5 +1,5 @@
 error: complex const arguments must be placed inside of a `const` block
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:46:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:47:13
    |
 LL | /             {
 LL | |

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.ice_155202.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find value `async` in this scope
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:65:13
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:13
    |
 LL |             async || {};
    |             ^^^^^ not found in this scope
 
 error[E0308]: mismatched types
-  --> $DIR/hir-crate-items-before-lowering-ices.rs:65:22
+  --> $DIR/hir-crate-items-before-lowering-ices.rs:66:22
    |
 LL |             async || {};
    |                      ^^ expected `bool`, found `()`

--- a/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
+++ b/tests/ui/delegation/hir-crate-items-before-lowering-ices.rs
@@ -33,7 +33,8 @@ mod ice_155127 {
 mod ice_155128 {
     fn a() {}
 
-    reuse a as b { //[ice_155128]~ ERROR: this function takes 0 arguments but 1 argument was supplied
+    reuse a as b { //[ice_155128]~ ERROR: delegation's target expression is specified for function with no params
+        //[ice_155128]~^ ERROR: this function takes 0 arguments but 1 argument was supplied
         fn foo<T>() {};
         foo
     }

--- a/tests/ui/delegation/inner-attr.rs
+++ b/tests/ui/delegation/inner-attr.rs
@@ -3,6 +3,7 @@
 fn a() {}
 
 reuse a as b { #![rustc_dummy] self } //~ ERROR an inner attribute is not permitted in this context
-//~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+//~^ ERROR: delegation's target expression is specified for function with no params
+//~| ERROR: this function takes 0 arguments but 1 argument was supplied
 
 fn main() {}

--- a/tests/ui/delegation/inner-attr.stderr
+++ b/tests/ui/delegation/inner-attr.stderr
@@ -9,6 +9,12 @@ LL | fn main() {}
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
 
+error: delegation's target expression is specified for function with no params
+  --> $DIR/inner-attr.rs:5:14
+   |
+LL | reuse a as b { #![rustc_dummy] self }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/inner-attr.rs:5:7
    |
@@ -26,6 +32,6 @@ LL - reuse a as b { #![rustc_dummy] self }
 LL + reuse { #![rustc_dummy] self }
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/self-coercion-static-free.rs
+++ b/tests/ui/delegation/self-coercion-static-free.rs
@@ -20,10 +20,11 @@ struct S(F);
 
 impl Trait for S {
     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
-        let _ = self;
-        S::static_self()
         //~^ ERROR: mismatched types
         //~| ERROR: mismatched types
+        //~| ERROR: mismatched types
+        let _ = self;
+        S::static_self()
     }
 }
 
@@ -31,10 +32,11 @@ struct S1(Box<Box<Box<Box<Box<Box<F>>>>>>);
 
 impl Trait for S1 {
     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
-        let _ = self;
-        S1::static_self()
         //~^ ERROR: mismatched types
         //~| ERROR: mismatched types
+        //~| ERROR: mismatched types
+        let _ = self;
+        S1::static_self()
     }
 }
 

--- a/tests/ui/delegation/self-coercion-static-free.stderr
+++ b/tests/ui/delegation/self-coercion-static-free.stderr
@@ -1,81 +1,103 @@
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:24:9
+  --> $DIR/self-coercion-static-free.rs:22:26
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
-   |                                        -------------- arguments to this function are incorrect
-LL |         let _ = self;
-LL |         S::static_self()
-   |         ^^^^^^^^^^^^^^^^ expected `&mut F`, found `F`
+   |                          ^^^^^^^^^^^^
+   |                          |
+   |                          expected `F`, found `S`
+   |                          arguments to this function are incorrect
    |
+note: associated function defined here
+  --> $DIR/self-coercion-static-free.rs:10:8
+   |
+LL |     fn static_value(_: Self) -> i32 { 1 }
+   |        ^^^^^^^^^^^^ -------
+
+error[E0308]: mismatched types
+  --> $DIR/self-coercion-static-free.rs:22:40
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                                        ^^^^^^^^^^^^^^
+   |                                        |
+   |                                        expected `&mut F`, found `&mut S`
+   |                                        arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut F`
+              found mutable reference `&mut S`
 note: associated function defined here
   --> $DIR/self-coercion-static-free.rs:11:8
    |
 LL |     fn static_mut_ref(_: &mut Self) -> i32 { 2 }
    |        ^^^^^^^^^^^^^^ ------------
-help: consider mutably borrowing here
-   |
-LL |         &mut S::static_self()
-   |         ++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:24:9
+  --> $DIR/self-coercion-static-free.rs:22:56
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
-   |                                                        ---------- arguments to this function are incorrect
-LL |         let _ = self;
-LL |         S::static_self()
-   |         ^^^^^^^^^^^^^^^^ expected `&F`, found `F`
+   |                                                        ^^^^^^^^^^
+   |                                                        |
+   |                                                        expected `&F`, found `&S`
+   |                                                        arguments to this function are incorrect
    |
+   = note: expected reference `&F`
+              found reference `&S`
 note: associated function defined here
   --> $DIR/self-coercion-static-free.rs:12:8
    |
 LL |     fn static_ref(_: &Self) -> i32 { 3 }
    |        ^^^^^^^^^^ --------
-help: consider borrowing here
-   |
-LL |         &S::static_self()
-   |         +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:35:9
+  --> $DIR/self-coercion-static-free.rs:34:26
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
-   |                                        -------------- arguments to this function are incorrect
-LL |         let _ = self;
-LL |         S1::static_self()
-   |         ^^^^^^^^^^^^^^^^^ expected `&mut F`, found `F`
+   |                          ^^^^^^^^^^^^
+   |                          |
+   |                          expected `F`, found `S1`
+   |                          arguments to this function are incorrect
    |
+note: associated function defined here
+  --> $DIR/self-coercion-static-free.rs:10:8
+   |
+LL |     fn static_value(_: Self) -> i32 { 1 }
+   |        ^^^^^^^^^^^^ -------
+
+error[E0308]: mismatched types
+  --> $DIR/self-coercion-static-free.rs:34:40
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                                        ^^^^^^^^^^^^^^
+   |                                        |
+   |                                        expected `&mut F`, found `&mut S1`
+   |                                        arguments to this function are incorrect
+   |
+   = note: expected mutable reference `&mut F`
+              found mutable reference `&mut S1`
 note: associated function defined here
   --> $DIR/self-coercion-static-free.rs:11:8
    |
 LL |     fn static_mut_ref(_: &mut Self) -> i32 { 2 }
    |        ^^^^^^^^^^^^^^ ------------
-help: consider mutably borrowing here
-   |
-LL |         &mut S1::static_self()
-   |         ++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:35:9
+  --> $DIR/self-coercion-static-free.rs:34:56
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
-   |                                                        ---------- arguments to this function are incorrect
-LL |         let _ = self;
-LL |         S1::static_self()
-   |         ^^^^^^^^^^^^^^^^^ expected `&F`, found `F`
+   |                                                        ^^^^^^^^^^
+   |                                                        |
+   |                                                        expected `&F`, found `&S1`
+   |                                                        arguments to this function are incorrect
    |
+   = note: expected reference `&F`
+              found reference `&S1`
 note: associated function defined here
   --> $DIR/self-coercion-static-free.rs:12:8
    |
 LL |     fn static_ref(_: &Self) -> i32 { 3 }
    |        ^^^^^^^^^^ --------
-help: consider borrowing here
-   |
-LL |         &S1::static_self()
-   |         +
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:48:43
+  --> $DIR/self-coercion-static-free.rs:50:43
    |
 LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    |                         -------           ^ expected `&mut _`, found `F`
@@ -85,7 +107,7 @@ LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    = note: expected mutable reference `&mut _`
                          found struct `F`
 note: function defined here
-  --> $DIR/self-coercion-static-free.rs:44:12
+  --> $DIR/self-coercion-static-free.rs:46:12
    |
 LL |     pub fn mut_ref(_: &mut impl Trait) -> i32 { 2 }
    |            ^^^^^^^ ------------------
@@ -95,7 +117,7 @@ LL | reuse to_reuse::{value, mut_ref, r#ref} { &mut F }
    |                                           ++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:48:43
+  --> $DIR/self-coercion-static-free.rs:50:43
    |
 LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    |                                  -----    ^ expected `&_`, found `F`
@@ -105,7 +127,7 @@ LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    = note: expected reference `&_`
                  found struct `F`
 note: function defined here
-  --> $DIR/self-coercion-static-free.rs:45:12
+  --> $DIR/self-coercion-static-free.rs:47:12
    |
 LL |     pub fn r#ref(_: &impl Trait) -> i32 { 3 }
    |            ^^^^^ --------------
@@ -114,6 +136,6 @@ help: consider borrowing here
 LL | reuse to_reuse::{value, mut_ref, r#ref} { &F }
    |                                           +
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/delegation/target-expr-removal-defs-inside.rs
+++ b/tests/ui/delegation/target-expr-removal-defs-inside.rs
@@ -1,0 +1,76 @@
+#![feature(fn_delegation)]
+
+pub trait Trait: Sized {
+    fn static_self() -> F { F }
+
+    fn static_value(_: Self) -> i32 { 1 }
+    fn static_mut_ref(_: &mut Self) -> i32 { 2 }
+    fn static_ref(_: &Self) -> i32 { 3 }
+}
+
+struct F;
+impl Trait for F {}
+
+struct S(F);
+
+reuse impl Trait for S {
+    //~^ ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: method `static_self` has an incompatible type for trait
+    //~| ERROR: method `static_value` has 0 parameters but the declaration in trait `Trait::static_value` has 1
+    //~| ERROR: method `static_mut_ref` has 0 parameters but the declaration in trait `Trait::static_mut_ref` has 1
+    //~| ERROR: method `static_ref` has 0 parameters but the declaration in trait `Trait::static_ref` has 1
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    struct Def {}
+    self.0
+}
+
+struct S1(F);
+reuse impl Trait for S1 {
+    //~^ ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: method `static_self` has an incompatible type for trait
+    //~| ERROR: method `static_value` has 0 parameters but the declaration in trait `Trait::static_value` has 1
+    //~| ERROR: method `static_mut_ref` has 0 parameters but the declaration in trait `Trait::static_mut_ref` has 1
+    //~| ERROR: method `static_ref` has 0 parameters but the declaration in trait `Trait::static_ref` has 1
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    some::path::<{ fn foo() {} }>::xd();
+    //~^ ERROR: cannot find module or crate `some` in this scope
+    //~| ERROR: cannot find module or crate `some` in this scope
+    //~| ERROR: cannot find module or crate `some` in this scope
+    //~| ERROR: cannot find module or crate `some` in this scope
+    self.0
+}
+
+struct S2(F);
+reuse impl Trait for S2 {
+    //~^ ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: attempted to delete delegation's target expression that contains definitions inside
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: method `static_self` has an incompatible type for trait
+    //~| ERROR: method `static_value` has 0 parameters but the declaration in trait `Trait::static_value` has 1
+    //~| ERROR: method `static_mut_ref` has 0 parameters but the declaration in trait `Trait::static_mut_ref` has 1
+    //~| ERROR: method `static_ref` has 0 parameters but the declaration in trait `Trait::static_ref` has 1
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    fn foo() {}
+    self.0
+}
+
+fn main() {}

--- a/tests/ui/delegation/target-expr-removal-defs-inside.stderr
+++ b/tests/ui/delegation/target-expr-removal-defs-inside.stderr
@@ -1,0 +1,683 @@
+error[E0433]: cannot find module or crate `some` in this scope
+  --> $DIR/target-expr-removal-defs-inside.rs:49:5
+   |
+LL |     some::path::<{ fn foo() {} }>::xd();
+   |     ^^^^ use of unresolved module or unlinked crate `some`
+   |
+   = help: you might be missing a crate named `some`
+
+error[E0433]: cannot find module or crate `some` in this scope
+  --> $DIR/target-expr-removal-defs-inside.rs:49:5
+   |
+LL |     some::path::<{ fn foo() {} }>::xd();
+   |     ^^^^ use of unresolved module or unlinked crate `some`
+   |
+   = help: you might be missing a crate named `some`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0433]: cannot find module or crate `some` in this scope
+  --> $DIR/target-expr-removal-defs-inside.rs:49:5
+   |
+LL |     some::path::<{ fn foo() {} }>::xd();
+   |     ^^^^ use of unresolved module or unlinked crate `some`
+   |
+   = help: you might be missing a crate named `some`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0433]: cannot find module or crate `some` in this scope
+  --> $DIR/target-expr-removal-defs-inside.rs:49:5
+   |
+LL |     some::path::<{ fn foo() {} }>::xd();
+   |     ^^^^ use of unresolved module or unlinked crate `some`
+   |
+   = help: you might be missing a crate named `some`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:16:24
+   |
+LL |   reuse impl Trait for S {
+   |  ________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:16:24
+   |
+LL |   reuse impl Trait for S {
+   |  ________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:16:24
+   |
+LL |   reuse impl Trait for S {
+   |  ________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:16:24
+   |
+LL |   reuse impl Trait for S {
+   |  ________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:35:25
+   |
+LL |   reuse impl Trait for S1 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:35:25
+   |
+LL |   reuse impl Trait for S1 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:35:25
+   |
+LL |   reuse impl Trait for S1 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:35:25
+   |
+LL |   reuse impl Trait for S1 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:58:25
+   |
+LL |   reuse impl Trait for S2 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:58:25
+   |
+LL |   reuse impl Trait for S2 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:58:25
+   |
+LL |   reuse impl Trait for S2 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: attempted to delete delegation's target expression that contains definitions inside
+  --> $DIR/target-expr-removal-defs-inside.rs:58:25
+   |
+LL |   reuse impl Trait for S2 {
+   |  _________________________^
+...  |
+LL | |     self.0
+LL | | }
+   | |_^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0053]: method `static_self` has an incompatible type for trait
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected `F`, found `()`
+   |
+note: type in trait
+  --> $DIR/target-expr-removal-defs-inside.rs:4:25
+   |
+LL |     fn static_self() -> F { F }
+   |                         ^
+   = note: expected signature `fn() -> F`
+              found signature `fn() -> ()`
+help: change the output type to match the trait
+   |
+LL - reuse impl Trait for S {
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -     struct Def {}
+LL -     self.0
+LL - }
+LL +  -> F
+   |
+
+error[E0050]: method `static_value` has 0 parameters but the declaration in trait `Trait::static_value` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL |       fn static_value(_: Self) -> i32 { 1 }
+   |                          ---- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0050]: method `static_mut_ref` has 0 parameters but the declaration in trait `Trait::static_mut_ref` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL |       fn static_mut_ref(_: &mut Self) -> i32 { 2 }
+   |                            --------- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0050]: method `static_ref` has 0 parameters but the declaration in trait `Trait::static_ref` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL |       fn static_ref(_: &Self) -> i32 { 3 }
+   |                        ----- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0053]: method `static_self` has an incompatible type for trait
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected `F`, found `()`
+   |
+note: type in trait
+  --> $DIR/target-expr-removal-defs-inside.rs:4:25
+   |
+LL |     fn static_self() -> F { F }
+   |                         ^
+   = note: expected signature `fn() -> F`
+              found signature `fn() -> ()`
+help: change the output type to match the trait
+   |
+LL - reuse impl Trait for S1 {
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -     some::path::<{ fn foo() {} }>::xd();
+LL -
+LL -
+LL -
+LL -
+LL -     self.0
+LL - }
+LL +  -> F
+   |
+
+error[E0050]: method `static_value` has 0 parameters but the declaration in trait `Trait::static_value` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL |       fn static_value(_: Self) -> i32 { 1 }
+   |                          ---- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0050]: method `static_mut_ref` has 0 parameters but the declaration in trait `Trait::static_mut_ref` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL |       fn static_mut_ref(_: &mut Self) -> i32 { 2 }
+   |                            --------- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0050]: method `static_ref` has 0 parameters but the declaration in trait `Trait::static_ref` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL |       fn static_ref(_: &Self) -> i32 { 3 }
+   |                        ----- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0053]: method `static_self` has an incompatible type for trait
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected `F`, found `()`
+   |
+note: type in trait
+  --> $DIR/target-expr-removal-defs-inside.rs:4:25
+   |
+LL |     fn static_self() -> F { F }
+   |                         ^
+   = note: expected signature `fn() -> F`
+              found signature `fn() -> ()`
+help: change the output type to match the trait
+   |
+LL - reuse impl Trait for S2 {
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -     fn foo() {}
+LL -     self.0
+LL - }
+LL +  -> F
+   |
+
+error[E0050]: method `static_value` has 0 parameters but the declaration in trait `Trait::static_value` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL |       fn static_value(_: Self) -> i32 { 1 }
+   |                          ---- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0050]: method `static_mut_ref` has 0 parameters but the declaration in trait `Trait::static_mut_ref` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL |       fn static_mut_ref(_: &mut Self) -> i32 { 2 }
+   |                            --------- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0050]: method `static_ref` has 0 parameters but the declaration in trait `Trait::static_ref` has 1
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL |       fn static_ref(_: &Self) -> i32 { 3 }
+   |                        ----- trait requires 1 parameter
+...
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | |_^ expected 1 parameter, found 0
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL |    reuse impl Trait for S {
+   |   _^                      -
+   |  |________________________|
+...  ||
+LL | ||     self.0
+LL | || }
+   | ||_^ unexpected argument
+   |  |_|
+   |
+   |
+note: associated function defined here
+  --> $DIR/target-expr-removal-defs-inside.rs:4:8
+   |
+LL |     fn static_self() -> F { F }
+   |        ^^^^^^^^^^^
+help: remove the extra argument
+   |
+LL - reuse impl Trait for S {
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -     struct Def {}
+LL -     self.0
+LL - }
+LL + reuse impl Trait for S }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `F`
+   |   expected `()` because of default return type
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:16:1
+   |
+LL | / reuse impl Trait for S {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL |    reuse impl Trait for S1 {
+   |   _^                       -
+   |  |_________________________|
+...  ||
+LL | ||     self.0
+LL | || }
+   | ||_^ unexpected argument
+   |  |_|
+   |
+   |
+note: associated function defined here
+  --> $DIR/target-expr-removal-defs-inside.rs:4:8
+   |
+LL |     fn static_self() -> F { F }
+   |        ^^^^^^^^^^^
+help: remove the extra argument
+   |
+LL - reuse impl Trait for S1 {
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -     some::path::<{ fn foo() {} }>::xd();
+LL -
+LL -
+LL -
+LL -
+LL -     self.0
+LL - }
+LL + reuse impl Trait for S1 }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `F`
+   |   expected `()` because of default return type
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:35:1
+   |
+LL | / reuse impl Trait for S1 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL |    reuse impl Trait for S2 {
+   |   _^                       -
+   |  |_________________________|
+...  ||
+LL | ||     self.0
+LL | || }
+   | ||_^ unexpected argument
+   |  |_|
+   |
+   |
+note: associated function defined here
+  --> $DIR/target-expr-removal-defs-inside.rs:4:8
+   |
+LL |     fn static_self() -> F { F }
+   |        ^^^^^^^^^^^
+help: remove the extra argument
+   |
+LL - reuse impl Trait for S2 {
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -
+LL -     fn foo() {}
+LL -     self.0
+LL - }
+LL + reuse impl Trait for S2 }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `F`
+   |   expected `()` because of default return type
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/target-expr-removal-defs-inside.rs:58:1
+   |
+LL | / reuse impl Trait for S2 {
+...  |
+LL | |     self.0
+LL | | }
+   | | ^- help: consider using a semicolon here: `;`
+   | | |
+   | |_expected `()`, found `i32`
+   |   expected `()` because of default return type
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 43 previous errors
+
+Some errors have detailed explanations: E0050, E0053, E0061, E0308, E0433.
+For more information about an error, try `rustc --explain E0050`.

--- a/tests/ui/delegation/target-expr-removal-free-to-free.rs
+++ b/tests/ui/delegation/target-expr-removal-free-to-free.rs
@@ -1,0 +1,12 @@
+#![feature(fn_delegation)]
+
+mod to_reuse {
+    pub fn foo(x: usize) -> usize { x }
+    pub fn bar() -> () { () }
+}
+
+reuse to_reuse::{foo, bar} { self + 1 }
+//~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+//~| ERROR: delegation's target expression is specified for function with no params
+
+fn main() {}

--- a/tests/ui/delegation/target-expr-removal-free-to-free.stderr
+++ b/tests/ui/delegation/target-expr-removal-free-to-free.stderr
@@ -1,0 +1,26 @@
+error: delegation's target expression is specified for function with no params
+  --> $DIR/target-expr-removal-free-to-free.rs:8:28
+   |
+LL | reuse to_reuse::{foo, bar} { self + 1 }
+   |                            ^^^^^^^^^^^^
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/target-expr-removal-free-to-free.rs:8:23
+   |
+LL | reuse to_reuse::{foo, bar} { self + 1 }
+   |                       ^^^  ------------ unexpected argument
+   |
+note: function defined here
+  --> $DIR/target-expr-removal-free-to-free.rs:5:12
+   |
+LL |     pub fn bar() -> () { () }
+   |            ^^^
+help: remove the extra argument
+   |
+LL - reuse to_reuse::{foo, bar} { self + 1 }
+LL + reuse to_reuse::{foo, ba{ self + 1 }
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/target-expression-removal-pass.rs
+++ b/tests/ui/delegation/target-expression-removal-pass.rs
@@ -1,0 +1,39 @@
+//@ run-pass
+
+#![feature(fn_delegation)]
+
+trait Trait: Sized {
+    fn by_value(self) -> i32 { 1 }
+    fn by_mut_ref(&mut self) -> i32 { 2 }
+    fn by_ref(&self) -> i32 { 3 }
+
+    fn static_self() -> F { F }
+
+    fn static_value(_: F) -> i32 { 1 }
+    fn static_mut_ref(_: &mut F) -> i32 { 2 }
+    fn static_ref(_: &F) -> i32 { 3 }
+}
+
+#[derive(Default, Eq, PartialEq, Debug)]
+struct F;
+impl Trait for F {}
+
+struct S(F);
+
+impl Trait for S {
+    // Delegation's expression is removed from static functions.
+    reuse <F as Trait>::* { self.0 }
+}
+
+fn main() {
+    let mut s = S(F);
+    assert_eq!(s.by_mut_ref(), 2);
+    assert_eq!(s.by_ref(), 3);
+    assert_eq!(s.by_value(), 1);
+
+    assert_eq!(S::static_self(), F);
+
+    assert_eq!(S::static_value(F), 1);
+    assert_eq!(S::static_mut_ref(&mut F), 2);
+    assert_eq!(S::static_ref(&F), 3);
+}

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.rs
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.rs
@@ -3,7 +3,8 @@
 mod test_ice {
     fn a() {}
 
-    reuse a as b { //~ ERROR: this function takes 0 arguments but 1 argument was supplied
+    reuse a as b { //~ ERROR: delegation's target expression is specified for function with no params
+        //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
         let closure = || {
             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
 
@@ -23,7 +24,34 @@ mod test_2 {
     }
 
     reuse to_reuse::zero_args { self }
-    //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~^ ERROR: delegation's target expression is specified for function with no params
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~| ERROR: mismatched types
+}
+
+mod nested_delegations {
+    fn a() {}
+
+    reuse a as b { //~ ERROR: delegation's target expression is specified for function with no params
+        //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+        let closure = || {
+            reuse a as b { //~ ERROR: delegation's target expression is specified for function with no params
+                //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+                fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+
+                reuse foo::<String, 1, String> as bar;
+                bar(&"".to_string(), &"".to_string());
+
+                reuse a as b { //~ ERROR: delegation's target expression is specified for function with no params
+                    //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+                    reuse foo::<String, 1, String> as bar;
+                    bar(&"".to_string(), &"".to_string());
+                }
+            }
+        };
+
+        closure();
+    }
 }
 
 fn main() {}

--- a/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
+++ b/tests/ui/delegation/zero-args-delegations-ice-154332.stderr
@@ -1,8 +1,63 @@
+error: delegation's target expression is specified for function with no params
+  --> $DIR/zero-args-delegations-ice-154332.rs:6:18
+   |
+LL |       reuse a as b {
+   |  __________________^
+LL | |
+LL | |         let closure = || {
+LL | |             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+...  |
+LL | |         closure();
+LL | |     }
+   | |_____^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/zero-args-delegations-ice-154332.rs:26:31
+   |
+LL |     reuse to_reuse::zero_args { self }
+   |                               ^^^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/zero-args-delegations-ice-154332.rs:35:18
+   |
+LL |       reuse a as b {
+   |  __________________^
+LL | |
+LL | |         let closure = || {
+LL | |             reuse a as b {
+...  |
+LL | |         closure();
+LL | |     }
+   | |_____^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/zero-args-delegations-ice-154332.rs:38:26
+   |
+LL |               reuse a as b {
+   |  __________________________^
+LL | |
+LL | |                 fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+...  |
+LL | |             }
+   | |_____________^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/zero-args-delegations-ice-154332.rs:45:30
+   |
+LL |                   reuse a as b {
+   |  ______________________________^
+LL | |
+LL | |                     reuse foo::<String, 1, String> as bar;
+LL | |                     bar(&"".to_string(), &"".to_string());
+LL | |                 }
+   | |_________________^
+
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/zero-args-delegations-ice-154332.rs:6:11
    |
 LL |       reuse a as b {
    |  ___________^______-
+LL | |
 LL | |         let closure = || {
 LL | |             fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
 ...  |
@@ -22,13 +77,13 @@ LL +     reuse {
    |
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
-  --> $DIR/zero-args-delegations-ice-154332.rs:25:21
+  --> $DIR/zero-args-delegations-ice-154332.rs:26:21
    |
 LL |     reuse to_reuse::zero_args { self }
    |                     ^^^^^^^^^ -------- unexpected argument
    |
 note: function defined here
-  --> $DIR/zero-args-delegations-ice-154332.rs:20:16
+  --> $DIR/zero-args-delegations-ice-154332.rs:21:16
    |
 LL |         pub fn zero_args() -> i32 {
    |                ^^^^^^^^^
@@ -38,6 +93,91 @@ LL -     reuse to_reuse::zero_args { self }
 LL +     reuse to_reuse::zero_arg{ self }
    |
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/zero-args-delegations-ice-154332.rs:26:21
+   |
+LL |     reuse to_reuse::zero_args { self }
+   |                     ^^^^^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |     reuse to_reuse::zero_args; { self }
+   |                              +
+help: try adding a return type
+   |
+LL -     reuse to_reuse::zero_args { self }
+LL +     reuse to_reuse:: -> i32 { self }
+   |
 
-For more information about this error, try `rustc --explain E0061`.
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/zero-args-delegations-ice-154332.rs:35:11
+   |
+LL |       reuse a as b {
+   |  ___________^______-
+LL | |
+LL | |         let closure = || {
+LL | |             reuse a as b {
+...  |
+LL | |         closure();
+LL | |     }
+   | |_____- unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/zero-args-delegations-ice-154332.rs:33:8
+   |
+LL |     fn a() {}
+   |        ^
+help: remove the extra argument
+   |
+LL -     reuse a as b {
+LL +     reuse {
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/zero-args-delegations-ice-154332.rs:38:19
+   |
+LL |               reuse a as b {
+   |  ___________________^______-
+LL | |
+LL | |                 fn foo<'a, 'b, T: Clone, const N: usize, U: Clone>(_t: &'a T, _u: &'b U) {}
+...  |
+LL | |             }
+   | |_____________- unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/zero-args-delegations-ice-154332.rs:33:8
+   |
+LL |     fn a() {}
+   |        ^
+help: remove the extra argument
+   |
+LL -             reuse a as b {
+LL +             reuse {
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/zero-args-delegations-ice-154332.rs:45:23
+   |
+LL |                   reuse a as b {
+   |  _______________________^______-
+LL | |
+LL | |                     reuse foo::<String, 1, String> as bar;
+LL | |                     bar(&"".to_string(), &"".to_string());
+LL | |                 }
+   | |_________________- unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/zero-args-delegations-ice-154332.rs:33:8
+   |
+LL |     fn a() {}
+   |        ^
+help: remove the extra argument
+   |
+LL -                 reuse a as b {
+LL +                 reuse {
+   |
+
+error: aborting due to 11 previous errors
+
+Some errors have detailed explanations: E0061, E0308.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/delegation/zero-args-delegations-ice-154427.rs
+++ b/tests/ui/delegation/zero-args-delegations-ice-154427.rs
@@ -1,0 +1,21 @@
+#![feature(fn_delegation)]
+
+mod ice_154427 {
+    trait Trait {
+        fn foo();
+    }
+    struct F;
+    struct S;
+    mod to_reuse {
+        use super::F;
+        pub fn foo(_: F) {}
+    }
+    impl Trait for S {
+        reuse to_reuse::foo { self }
+        //~^ ERROR: delegation's target expression is specified for function with no params
+    }
+
+    fn main() {}
+}
+
+fn main() {}

--- a/tests/ui/delegation/zero-args-delegations-ice-154427.stderr
+++ b/tests/ui/delegation/zero-args-delegations-ice-154427.stderr
@@ -1,0 +1,8 @@
+error: delegation's target expression is specified for function with no params
+  --> $DIR/zero-args-delegations-ice-154427.rs:14:29
+   |
+LL |         reuse to_reuse::foo { self }
+   |                             ^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -42,7 +42,10 @@
 #![allow(x5300)] //~ WARN unknown lint: `x5300`
 #![forbid(x5200)] //~ WARN unknown lint: `x5200`
 #![deny(x5100)] //~ WARN unknown lint: `x5100`
-#![macro_use] // (allowed if no argument; see issue-43160-gating-of-macro_use.rs)
+#![macro_use] //~ WARN attribute cannot be used on
+//~| WARN previously accepted
+//~| HELP can be applied to
+//~| HELP remove the attribute
 // skipping testing of cfg
 // skipping testing of cfg_attr
 #![should_panic] //~ WARN attribute cannot be used on

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,5 +1,5 @@
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     mod inner { #![macro_escape] }
    = help: try an outer attribute: `#[macro_use]`
 
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:469:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
@@ -43,151 +43,151 @@ LL | #![deny(x5100)]
    |         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:110:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:113:8
    |
 LL | #[warn(x5400)]
    |        ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:113:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:116:25
    |
 LL |     mod inner { #![warn(x5400)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:116:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:119:12
    |
 LL |     #[warn(x5400)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:119:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:122:12
    |
 LL |     #[warn(x5400)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:122:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:125:12
    |
 LL |     #[warn(x5400)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:125:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:128:12
    |
 LL |     #[warn(x5400)] impl S { }
    |            ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:129:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:132:9
    |
 LL | #[allow(x5300)]
    |         ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:132:26
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:135:26
    |
 LL |     mod inner { #![allow(x5300)] }
    |                          ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:135:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:138:13
    |
 LL |     #[allow(x5300)] fn f() { }
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:138:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:141:13
    |
 LL |     #[allow(x5300)] struct S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:141:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:144:13
    |
 LL |     #[allow(x5300)] type T = S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:144:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:147:13
    |
 LL |     #[allow(x5300)] impl S { }
    |             ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:148:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:151:10
    |
 LL | #[forbid(x5200)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:151:27
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:154:27
    |
 LL |     mod inner { #![forbid(x5200)] }
    |                           ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:154:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:157:14
    |
 LL |     #[forbid(x5200)] fn f() { }
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:157:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:160:14
    |
 LL |     #[forbid(x5200)] struct S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:160:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:163:14
    |
 LL |     #[forbid(x5200)] type T = S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:163:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:166:14
    |
 LL |     #[forbid(x5200)] impl S { }
    |              ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:167:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:170:8
    |
 LL | #[deny(x5100)]
    |        ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:170:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:173:25
    |
 LL |     mod inner { #![deny(x5100)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:173:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:176:12
    |
 LL |     #[deny(x5100)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:176:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:179:12
    |
 LL |     #[deny(x5100)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:179:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:182:12
    |
 LL |     #[deny(x5100)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:182:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:185:12
    |
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
 warning: the feature `rust1` has been stable since 1.0.0 and no longer requires an attribute to enable
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:99:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:102:12
    |
 LL | #![feature(rust1)]
    |            ^^^^^
@@ -195,7 +195,7 @@ LL | #![feature(rust1)]
    = note: `#[warn(stable_features)]` on by default
 
 warning: attribute should be applied to an `extern` block with non-Rust ABI
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:722:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:725:5
    |
 LL |     #[link(name = "x")] extern "Rust" {}
    |     ^^^^^^^^^^^^^^^^^^^
@@ -208,43 +208,43 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: `#[macro_use]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:190:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:193:5
    |
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:196:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:199:5
    |
 LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:202:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:205:5
    |
 LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:208:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:211:5
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_export]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:215:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:218:1
    |
 LL | #[macro_export]
    | ^^^^^^^^^^^^^^^
@@ -253,7 +253,7 @@ LL | #[macro_export]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_export]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:221:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:224:17
    |
 LL |     mod inner { #![macro_export] }
    |                 ^^^^^^^^^^^^^^^^
@@ -262,7 +262,7 @@ LL |     mod inner { #![macro_export] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_export]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:230:5
    |
 LL |     #[macro_export] fn f() { }
    |     ^^^^^^^^^^^^^^^
@@ -271,7 +271,7 @@ LL |     #[macro_export] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_export]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:233:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:236:5
    |
 LL |     #[macro_export] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -280,7 +280,7 @@ LL |     #[macro_export] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_export]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:239:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:242:5
    |
 LL |     #[macro_export] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -289,7 +289,7 @@ LL |     #[macro_export] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_export]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:245:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:248:5
    |
 LL |     #[macro_export] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -298,7 +298,7 @@ LL |     #[macro_export] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[path]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:256:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:259:5
    |
 LL |     #[path = "3800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^
@@ -307,7 +307,7 @@ LL |     #[path = "3800"] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[path]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:262:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:265:5
    |
 LL |     #[path = "3800"]  struct S;
    |     ^^^^^^^^^^^^^^^^
@@ -316,7 +316,7 @@ LL |     #[path = "3800"]  struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[path]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:268:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:271:5
    |
 LL |     #[path = "3800"] type T = S;
    |     ^^^^^^^^^^^^^^^^
@@ -325,7 +325,7 @@ LL |     #[path = "3800"] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[path]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:274:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:277:5
    |
 LL |     #[path = "3800"] impl S { }
    |     ^^^^^^^^^^^^^^^^
@@ -334,7 +334,7 @@ LL |     #[path = "3800"] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:281:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:284:1
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -343,7 +343,7 @@ LL | #[automatically_derived]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:287:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:290:17
    |
 LL |     mod inner { #![automatically_derived] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -352,7 +352,7 @@ LL |     mod inner { #![automatically_derived] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:293:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:296:5
    |
 LL |     #[automatically_derived] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -361,7 +361,7 @@ LL |     #[automatically_derived] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:299:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:302:5
    |
 LL |     #[automatically_derived] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -370,7 +370,7 @@ LL |     #[automatically_derived] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:305:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:308:5
    |
 LL |     #[automatically_derived] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -379,7 +379,7 @@ LL |     #[automatically_derived] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:311:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:314:5
    |
 LL |     #[automatically_derived] trait W { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -388,7 +388,7 @@ LL |     #[automatically_derived] trait W { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[automatically_derived]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:317:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:320:5
    |
 LL |     #[automatically_derived] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -397,7 +397,7 @@ LL |     #[automatically_derived] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:326:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:329:1
    |
 LL | #[no_mangle]
    | ^^^^^^^^^^^^
@@ -406,7 +406,7 @@ LL | #[no_mangle]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:335:17
    |
 LL |     mod inner { #![no_mangle] }
    |                 ^^^^^^^^^^^^^
@@ -415,7 +415,7 @@ LL |     mod inner { #![no_mangle] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:340:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:343:5
    |
 LL |     #[no_mangle] struct S;
    |     ^^^^^^^^^^^^
@@ -424,7 +424,7 @@ LL |     #[no_mangle] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:346:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:349:5
    |
 LL |     #[no_mangle] type T = S;
    |     ^^^^^^^^^^^^
@@ -433,7 +433,7 @@ LL |     #[no_mangle] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:352:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:355:5
    |
 LL |     #[no_mangle] impl S { }
    |     ^^^^^^^^^^^^
@@ -442,7 +442,7 @@ LL |     #[no_mangle] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:359:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:362:9
    |
 LL |         #[no_mangle] fn foo();
    |         ^^^^^^^^^^^^
@@ -451,7 +451,7 @@ LL |         #[no_mangle] fn foo();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_mangle]` attribute cannot be used on provided trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:365:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:368:9
    |
 LL |         #[no_mangle] fn bar() {}
    |         ^^^^^^^^^^^^
@@ -460,7 +460,7 @@ LL |         #[no_mangle] fn bar() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:376:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^
@@ -469,7 +469,7 @@ LL | #[should_panic]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:379:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:382:17
    |
 LL |     mod inner { #![should_panic] }
    |                 ^^^^^^^^^^^^^^^^
@@ -478,7 +478,7 @@ LL |     mod inner { #![should_panic] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:387:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:390:5
    |
 LL |     #[should_panic] struct S;
    |     ^^^^^^^^^^^^^^^
@@ -487,7 +487,7 @@ LL |     #[should_panic] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:393:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:396:5
    |
 LL |     #[should_panic] type T = S;
    |     ^^^^^^^^^^^^^^^
@@ -496,7 +496,7 @@ LL |     #[should_panic] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[should_panic]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:399:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:402:5
    |
 LL |     #[should_panic] impl S { }
    |     ^^^^^^^^^^^^^^^
@@ -505,7 +505,7 @@ LL |     #[should_panic] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:406:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:409:1
    |
 LL | #[ignore]
    | ^^^^^^^^^
@@ -514,7 +514,7 @@ LL | #[ignore]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:412:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:415:17
    |
 LL |     mod inner { #![ignore] }
    |                 ^^^^^^^^^^
@@ -523,7 +523,7 @@ LL |     mod inner { #![ignore] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:420:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:423:5
    |
 LL |     #[ignore] struct S;
    |     ^^^^^^^^^
@@ -532,7 +532,7 @@ LL |     #[ignore] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:426:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:429:5
    |
 LL |     #[ignore] type T = S;
    |     ^^^^^^^^^
@@ -541,7 +541,7 @@ LL |     #[ignore] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:432:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:435:5
    |
 LL |     #[ignore] impl S { }
    |     ^^^^^^^^^
@@ -550,7 +550,7 @@ LL |     #[ignore] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:443:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:446:5
    |
 LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -559,7 +559,7 @@ LL |     #[no_implicit_prelude] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:449:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:452:5
    |
 LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -568,7 +568,7 @@ LL |     #[no_implicit_prelude] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:455:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:458:5
    |
 LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -577,7 +577,7 @@ LL |     #[no_implicit_prelude] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[no_implicit_prelude]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:461:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:464:5
    |
 LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -586,49 +586,49 @@ LL |     #[no_implicit_prelude] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_escape]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:5
    |
 LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_escape]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_escape]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:482:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:485:5
    |
 LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_escape]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_escape]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:488:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:491:5
    |
 LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_escape]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_escape]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:494:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:497:5
    |
 LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
    |
-   = help: `#[macro_escape]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_escape]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:501:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:504:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:503:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:506:1
    |
 LL | / mod no_std {
 LL | |
@@ -638,61 +638,61 @@ LL | | }
    | |_^
 
 warning: the `#![no_std]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:505:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:508:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:508:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:511:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:508:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:511:15
    |
 LL |     #[no_std] fn f() { }
    |               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:512:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:515:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:512:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:515:15
    |
 LL |     #[no_std] struct S;
    |               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:516:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:519:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:516:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:519:15
    |
 LL |     #[no_std] type T = S;
    |               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_std]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:520:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:523:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:520:15
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:523:15
    |
 LL |     #[no_std] impl S { }
    |               ^^^^^^^^^^
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:542:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:545:1
    |
 LL | #[cold]
    | ^^^^^^^
@@ -701,7 +701,7 @@ LL | #[cold]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[cold]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:549:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:552:17
    |
 LL |     mod inner { #![cold] }
    |                 ^^^^^^^^
@@ -710,7 +710,7 @@ LL |     mod inner { #![cold] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[cold]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:557:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:560:5
    |
 LL |     #[cold] struct S;
    |     ^^^^^^^
@@ -719,7 +719,7 @@ LL |     #[cold] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[cold]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:563:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:566:5
    |
 LL |     #[cold] type T = S;
    |     ^^^^^^^
@@ -728,7 +728,7 @@ LL |     #[cold] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[cold]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:569:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:572:5
    |
 LL |     #[cold] impl S { }
    |     ^^^^^^^
@@ -737,7 +737,7 @@ LL |     #[cold] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:576:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:579:1
    |
 LL | #[link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -746,7 +746,7 @@ LL | #[link_name = "1900"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on foreign modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:582:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:585:5
    |
 LL |     #[link_name = "1900"]
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -755,7 +755,7 @@ LL |     #[link_name = "1900"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:589:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:592:17
    |
 LL |     mod inner { #![link_name="1900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -764,7 +764,7 @@ LL |     mod inner { #![link_name="1900"] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:595:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:598:5
    |
 LL |     #[link_name = "1900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -773,7 +773,7 @@ LL |     #[link_name = "1900"] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:601:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:604:5
    |
 LL |     #[link_name = "1900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -782,7 +782,7 @@ LL |     #[link_name = "1900"] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:607:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:610:5
    |
 LL |     #[link_name = "1900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -791,7 +791,7 @@ LL |     #[link_name = "1900"] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:613:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:616:5
    |
 LL |     #[link_name = "1900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -800,7 +800,7 @@ LL |     #[link_name = "1900"] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:620:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:623:1
    |
 LL | #[link_section = ",1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -809,7 +809,7 @@ LL | #[link_section = ",1800"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:626:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:629:17
    |
 LL |     mod inner { #![link_section=",1800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -818,7 +818,7 @@ LL |     mod inner { #![link_section=",1800"] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:634:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:637:5
    |
 LL |     #[link_section = ",1800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -827,7 +827,7 @@ LL |     #[link_section = ",1800"] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:640:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:643:5
    |
 LL |     #[link_section = ",1800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -836,7 +836,7 @@ LL |     #[link_section = ",1800"] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:649:5
    |
 LL |     #[link_section = ",1800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -845,7 +845,7 @@ LL |     #[link_section = ",1800"] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on traits
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:652:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:655:5
    |
 LL |     #[link_section = ",1800"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -854,7 +854,7 @@ LL |     #[link_section = ",1800"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on required trait methods
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:658:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:661:9
    |
 LL |         #[link_section = ",1800"]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -863,7 +863,7 @@ LL |         #[link_section = ",1800"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:686:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:689:1
    |
 LL | #[link(name = "x")]
    | ^^^^^^^^^^^^^^^^^^^
@@ -872,7 +872,7 @@ LL | #[link(name = "x")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:692:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:695:17
    |
 LL |     mod inner { #![link(name = "x")] }
    |                 ^^^^^^^^^^^^^^^^^^^^
@@ -881,7 +881,7 @@ LL |     mod inner { #![link(name = "x")] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:698:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:701:5
    |
 LL |     #[link(name = "x")] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^
@@ -890,7 +890,7 @@ LL |     #[link(name = "x")] fn f() { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:704:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:707:5
    |
 LL |     #[link(name = "x")] struct S;
    |     ^^^^^^^^^^^^^^^^^^^
@@ -899,7 +899,7 @@ LL |     #[link(name = "x")] struct S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:713:5
    |
 LL |     #[link(name = "x")] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^
@@ -908,7 +908,7 @@ LL |     #[link(name = "x")] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:719:5
    |
 LL |     #[link(name = "x")] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^
@@ -917,7 +917,7 @@ LL |     #[link(name = "x")] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:742:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:745:1
    |
 LL | #[must_use]
    | ^^^^^^^^^^^
@@ -926,7 +926,7 @@ LL | #[must_use]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on modules
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:747:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:750:17
    |
 LL |     mod inner { #![must_use] }
    |                 ^^^^^^^^^^^^
@@ -935,7 +935,7 @@ LL |     mod inner { #![must_use] }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:759:5
    |
 LL |     #[must_use] type T = S;
    |     ^^^^^^^^^^^
@@ -944,7 +944,7 @@ LL |     #[must_use] type T = S;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:761:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:5
    |
 LL |     #[must_use] impl S { }
    |     ^^^^^^^^^^^
@@ -953,13 +953,13 @@ LL |     #[must_use] impl S { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:767:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:1
    |
 LL | #[windows_subsystem = "windows"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:769:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:772:1
    |
 LL | / mod windows_subsystem {
 LL | |
@@ -969,67 +969,67 @@ LL | | }
    | |_^
 
 warning: the `#![windows_subsystem]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:771:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:17
    |
 LL |     mod inner { #![windows_subsystem="windows"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:5
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:38
    |
 LL |     #[windows_subsystem = "windows"] fn f() { }
    |                                      ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:5
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:38
    |
 LL |     #[windows_subsystem = "windows"] struct S;
    |                                      ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:5
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:38
    |
 LL |     #[windows_subsystem = "windows"] type T = S;
    |                                      ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![windows_subsystem]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:5
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:38
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:38
    |
 LL |     #[windows_subsystem = "windows"] impl S { }
    |                                      ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:796:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:798:1
    |
 LL | / mod crate_name {
 LL | |
@@ -1039,67 +1039,67 @@ LL | | }
    | |_^
 
 warning: the `#![crate_name]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:797:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:800:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:800:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:803:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:800:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:803:28
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:807:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:804:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:807:28
    |
 LL |     #[crate_name = "0900"] struct S;
    |                            ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:811:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:808:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:811:28
    |
 LL |     #[crate_name = "0900"] type T = S;
    |                            ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_name]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:812:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:815:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:812:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:815:28
    |
 LL |     #[crate_name = "0900"] impl S { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:817:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:820:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:819:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:822:1
    |
 LL | / mod crate_type {
 LL | |
@@ -1109,67 +1109,67 @@ LL | | }
    | |_^
 
 warning: the `#![crate_type]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:821:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:824:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:824:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:827:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:824:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:827:28
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:828:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:831:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:828:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:831:28
    |
 LL |     #[crate_type = "0800"] struct S;
    |                            ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:832:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:835:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:832:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:835:28
    |
 LL |     #[crate_type = "0800"] type T = S;
    |                            ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![crate_type]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:836:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:839:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:836:28
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:839:28
    |
 LL |     #[crate_type = "0800"] impl S { }
    |                            ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:841:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:844:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:843:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:846:1
    |
 LL | / mod feature {
 LL | |
@@ -1179,67 +1179,67 @@ LL | | }
    | |_^
 
 warning: the `#![feature]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:845:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:848:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:848:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:851:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:848:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:851:23
    |
 LL |     #[feature(x0600)] fn f() { }
    |                       ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:852:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:855:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:852:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:855:23
    |
 LL |     #[feature(x0600)] struct S;
    |                       ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:856:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:859:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:856:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:859:23
    |
 LL |     #[feature(x0600)] type T = S;
    |                       ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![feature]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:863:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:860:23
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:863:23
    |
 LL |     #[feature(x0600)] impl S { }
    |                       ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:866:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:869:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:868:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:871:1
    |
 LL | / mod no_main_1 {
 LL | |
@@ -1249,67 +1249,67 @@ LL | | }
    | |_^
 
 warning: the `#![no_main]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:870:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:873:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:873:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:876:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:873:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:876:16
    |
 LL |     #[no_main] fn f() { }
    |                ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:877:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:880:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:877:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:880:16
    |
 LL |     #[no_main] struct S;
    |                ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:881:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:884:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:881:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:884:16
    |
 LL |     #[no_main] type T = S;
    |                ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_main]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:885:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:888:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:885:16
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:888:16
    |
 LL |     #[no_main] impl S { }
    |                ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:890:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:893:1
    |
 LL | #[no_builtins]
    | ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:892:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:895:1
    |
 LL | / mod no_builtins {
 LL | |
@@ -1319,67 +1319,67 @@ LL | | }
    | |_^
 
 warning: the `#![no_builtins]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:894:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:897:17
    |
 LL |     mod inner { #![no_builtins] }
    |                 ^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:897:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:5
    |
 LL |     #[no_builtins] fn f() { }
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:897:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:900:20
    |
 LL |     #[no_builtins] fn f() { }
    |                    ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:901:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:904:5
    |
 LL |     #[no_builtins] struct S;
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:901:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:904:20
    |
 LL |     #[no_builtins] struct S;
    |                    ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:905:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:908:5
    |
 LL |     #[no_builtins] type T = S;
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:905:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:908:20
    |
 LL |     #[no_builtins] type T = S;
    |                    ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![no_builtins]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:909:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:912:5
    |
 LL |     #[no_builtins] impl S { }
    |     ^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:909:20
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:912:20
    |
 LL |     #[no_builtins] impl S { }
    |                    ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:914:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:917:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:916:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:919:1
    |
 LL | / mod recursion_limit {
 LL | |
@@ -1389,67 +1389,67 @@ LL | | }
    | |_^
 
 warning: the `#![recursion_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:918:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:921:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:921:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:924:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:921:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:924:31
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:925:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:928:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:925:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:928:31
    |
 LL |     #[recursion_limit="0200"] struct S;
    |                               ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:929:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:932:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:929:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:932:31
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |                               ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![recursion_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:933:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:936:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:933:31
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:936:31
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |                               ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:938:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:941:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:940:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:943:1
    |
 LL | / mod type_length_limit {
 LL | |
@@ -1459,61 +1459,70 @@ LL | | }
    | |_^
 
 warning: the `#![type_length_limit]` attribute can only be used at the crate root
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:942:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:945:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:945:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:948:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this function
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:945:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:948:33
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |                                 ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:949:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:952:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this struct
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:949:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:952:33
    |
 LL |     #[type_length_limit="0100"] struct S;
    |                                 ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:953:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:956:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this type alias
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:953:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:956:33
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |                                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![type_length_limit]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:957:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:960:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: this attribute does not have an `!`, which means it is applied to this implementation block
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:957:33
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:960:33
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |                                 ^^^^^^^^^^
 
+warning: `#[macro_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
+   |
+LL | #![macro_use]
+   | ^^^^^^^^^^^^^
+   |
+   = help: `#[macro_use]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
 warning: `#[should_panic]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:48:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:51:1
    |
 LL | #![should_panic]
    | ^^^^^^^^^^^^^^^^
@@ -1522,7 +1531,7 @@ LL | #![should_panic]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[ignore]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:52:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
    |
 LL | #![ignore]
    | ^^^^^^^^^^
@@ -1531,7 +1540,7 @@ LL | #![ignore]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[proc_macro_derive]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:60:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
    |
 LL | #![proc_macro_derive(Test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1540,7 +1549,7 @@ LL | #![proc_macro_derive(Test)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[cold]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:65:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:68:1
    |
 LL | #![cold]
    | ^^^^^^^^
@@ -1549,7 +1558,7 @@ LL | #![cold]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:69:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:72:1
    |
 LL | #![link(name = "x")]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -1558,7 +1567,7 @@ LL | #![link(name = "x")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_name]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:73:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:76:1
    |
 LL | #![link_name = "1900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -1567,7 +1576,7 @@ LL | #![link_name = "1900"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[link_section]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:78:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:81:1
    |
 LL | #![link_section = ",1800"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1576,7 +1585,7 @@ LL | #![link_section = ",1800"]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[must_use]` attribute cannot be used on crates
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:83:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:86:1
    |
 LL | #![must_use]
    | ^^^^^^^^^^^^
@@ -1584,5 +1593,5 @@ LL | #![must_use]
    = help: `#[must_use]` can be applied to data types, functions, and traits
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-warning: 169 warnings emitted
+warning: 170 warnings emitted
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_escape.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_escape.rs
@@ -7,5 +7,7 @@
 
 #![macro_escape]
 //~^ WARN `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
+//~| WARN cannot be used on crates
+//~| WARN previously accepted
 
 fn main() {}

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_escape.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_escape.stderr
@@ -6,5 +6,15 @@ LL | #![macro_escape]
    |
    = help: try an outer attribute: `#[macro_use]`
 
-warning: 1 warning emitted
+warning: `#[macro_escape]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-macro_escape.rs:8:1
+   |
+LL | #![macro_escape]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = help: `#[macro_escape]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: requested on the command line with `-W unused-attributes`
+
+warning: 2 warnings emitted
 

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.rs
@@ -5,6 +5,8 @@
 
 #![macro_use(my_macro)]
 //~^ ERROR arguments to `macro_use` are not allowed here
+//~| WARN cannot be used on
+//~| WARN previously accepted
 
 #[macro_use(my_macro)]
 //~^ ERROR arguments to `macro_use` are not allowed here

--- a/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/tests/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -1,11 +1,11 @@
 error: arguments to `macro_use` are not allowed here
-  --> $DIR/issue-43106-gating-of-macro_use.rs:12:17
+  --> $DIR/issue-43106-gating-of-macro_use.rs:14:17
    |
 LL |     mod inner { #![macro_use(my_macro)] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arguments to `macro_use` are not allowed here
-  --> $DIR/issue-43106-gating-of-macro_use.rs:9:1
+  --> $DIR/issue-43106-gating-of-macro_use.rs:11:1
    |
 LL | #[macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #![macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0539]: malformed `macro_use` attribute input
-  --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
+  --> $DIR/issue-43106-gating-of-macro_use.rs:17:5
    |
 LL |     #[macro_use = "2700"] struct S;
    |     ^^^^^^^^^^^^--------^
@@ -35,42 +35,51 @@ LL +     #[macro_use] struct S;
    |
 
 warning: `#[macro_use]` attribute cannot be used on structs
-  --> $DIR/issue-43106-gating-of-macro_use.rs:15:5
+  --> $DIR/issue-43106-gating-of-macro_use.rs:17:5
    |
 LL |     #[macro_use = "2700"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: requested on the command line with `-W unused-attributes`
 
 warning: `#[macro_use]` attribute cannot be used on functions
-  --> $DIR/issue-43106-gating-of-macro_use.rs:20:5
+  --> $DIR/issue-43106-gating-of-macro_use.rs:22:5
    |
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on type aliases
-  --> $DIR/issue-43106-gating-of-macro_use.rs:24:5
+  --> $DIR/issue-43106-gating-of-macro_use.rs:26:5
    |
 LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 warning: `#[macro_use]` attribute cannot be used on inherent impl blocks
-  --> $DIR/issue-43106-gating-of-macro_use.rs:28:5
+  --> $DIR/issue-43106-gating-of-macro_use.rs:30:5
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
-error: aborting due to 4 previous errors; 4 warnings emitted
+warning: `#[macro_use]` attribute cannot be used on crates
+  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
+   |
+LL | #![macro_use(my_macro)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `#[macro_use]` can be applied to extern crates and modules
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+error: aborting due to 4 previous errors; 5 warnings emitted
 
 For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/issues/issue-29485.rs
+++ b/tests/ui/issues/issue-29485.rs
@@ -1,11 +1,8 @@
 //@ run-pass
-#![allow(unused_attributes)]
 //@ aux-build:issue-29485.rs
 //@ needs-unwind
 //@ needs-threads
 //@ ignore-backends: gcc
-
-#[feature(recover)]
 
 extern crate a;
 

--- a/tests/ui/lint/unused/unused-attr-macro-rules.stderr
+++ b/tests/ui/lint/unused/unused-attr-macro-rules.stderr
@@ -4,7 +4,7 @@ error: `#[macro_use]` attribute cannot be used on macro defs
 LL | #[macro_use]
    | ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 note: the lint level is defined here
   --> $DIR/unused-attr-macro-rules.rs:1:9

--- a/tests/ui/where-clauses/unsupported_attribute.stderr
+++ b/tests/ui/where-clauses/unsupported_attribute.stderr
@@ -64,7 +64,7 @@ error: `#[macro_use]` attribute cannot be used on where predicates
 LL |     #[macro_use] T: Trait,
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
 
 error: `#[macro_use]` attribute cannot be used on where predicates
   --> $DIR/unsupported_attribute.rs:20:5
@@ -72,7 +72,7 @@ error: `#[macro_use]` attribute cannot be used on where predicates
 LL |     #[macro_use] 'a: 'static,
    |     ^^^^^^^^^^^^
    |
-   = help: `#[macro_use]` can be applied to crates, extern crates, and modules
+   = help: `#[macro_use]` can be applied to extern crates and modules
 
 error: most attributes are not supported in `where` clauses
   --> $DIR/unsupported_attribute.rs:21:5

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1498,6 +1498,7 @@ libs = [
     "@nia-e",
     "@LawnGnome",
     "@clarfonthey",
+    "@aapoalas",
 ]
 infra-ci = [
     "@Mark-Simulacrum",


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#155453 (apply Cortex-A53 errata 843419 mitigation to the AArch64 Linux targets)
 - rust-lang/rust#156798 (delegation: do not always generate first argument)
 - rust-lang/rust#157438 (rustdoc: don't link doc(hidden) associated type projections)
 - rust-lang/rust#157450 (mark `Encode`, `Decode`, `Mark` impls as `#[inline]`)
 - rust-lang/rust#157190 (Silence recursive RUSTC_LOG_FORMAT_JSON messages)
 - rust-lang/rust#157396 (Add @aapoalas to libs review rotation)
 - rust-lang/rust#157470 (Avoid ICE when emitting TargetMachine config errors)
 - rust-lang/rust#157474 (Forbid optimize(none) with inline(always) or inline.)
 - rust-lang/rust#157475 (Add a smoke test for the optimize attribute.)
 - rust-lang/rust#157479 (Warn when `#[macro_use]` or `#[macro_escape]` is used on the crate root)
 - rust-lang/rust#157486 (Remove unused attributes from issue-29485.rs.)

Failed merges:

 - rust-lang/rust#157485 (Rename `errors.rs` file to `diagnostics.rs`)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=155453,156798,157438,157450,157190,157396,157470,157474,157475,157479,157485,157486)
<!-- homu-ignore:end -->

