### PR TITLE
Rename `SyncView::{as_pin => as_pin_ref}`

### DIFF
--- a/library/core/src/sync/sync_view.rs
+++ b/library/core/src/sync/sync_view.rs
@@ -188,7 +188,7 @@ impl<T: ?Sized + Sync> SyncView<T> {
     #[rustc_const_unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
-    pub const fn as_pin(self: Pin<&Self>) -> Pin<&T> {
+    pub const fn as_pin_ref(self: Pin<&Self>) -> Pin<&T> {
         // SAFETY: `SyncView` can only produce `&T` if itself is unpinned
         // `Pin::map_unchecked` is not const, so we do this conversion manually
         unsafe { Pin::new_unchecked(&self.get_ref().inner) }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This addresses the resolution of a naming concern from rust-lang/rust#98407.

r? BurntSushi