### PR TITLE
std tests: skip a slow test on Miri

### DIFF
--- a/library/std/src/sys/process/unix/unsupported/wait_status/tests.rs
+++ b/library/std/src/sys/process/unix/unsupported/wait_status/tests.rs
@@ -8,6 +8,7 @@
 // I.e. we're using Linux as a proxy for "trad unix".
 #[cfg(target_os = "linux")]
 #[test]
+#[cfg_attr(miri, ignore)] // Miri is too slow
 fn compare_with_linux() {
     use super::ExitStatus as Emulated;
     use crate::os::unix::process::ExitStatusExt as _;


### PR DESCRIPTION
This is just a big loop to compare exit status handling, and the loop is a bit too big for Miri.