### PR TITLE
Add `tests/debuginfo` data classes to define schema

### DIFF
--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -1,4 +1,5 @@
-# Contains the class definitions outlining the schema of the test data
+"""Contains the class definitions outlining the schema of the test data. For LLDB conversion
+from/into these types, see `./from_lldb.py`"""
 
 import enum
 import json
@@ -78,7 +79,7 @@ def from_dict(ty: type[Any], data: JsonType):
     """Translates a dictionary into an instance of the given dataclass type (with possibly nested
     dataclasses).
 
-    Relies on accurate type hints for the dataclass's fields, and the standard `dataclass.__init__`
+    Relies on accurate type hints for the dataclass's fields, and the default `dataclass.__init__`
     definition."""
 
     # Optional isn't a constructor, so we have to "unwrap" it.
@@ -295,19 +296,31 @@ generated for this test yet, consider using the `--bless` option."
         return result
 
     def save_blessing(self, metadata: BlessMetadata):
-        """Writes the entirety of `self` to the input file. Used to finalize changes made by
-        one or more `TestData.bless_variable` calls."""
+        """Writes the entirety of `self` to the env var `LLDB_BATCHMODE_INPUT_DATA_PATH`, which is
+        set by `compiletest` before running `lldb_batchmode. Used to finalize changes made by one or
+        more `from_lldb.bless_variable` calls.
+
+        This function should be called exactly once, right before
+        `lldb_batchmode.runner.main` exits if the following conditions are met:
+
+        1. No other exceptions or error states occurred
+        2. `BLESS == True`
+        3. At least one `repr` pseudo-command was processed
+
+        This prevents us from saving incomplete data or invalid data. It also prevents us from
+        creating input data files for tests that do not need it.
+        """
 
         self.bless_metadata = metadata
         path = os.environ["LLDB_BATCHMODE_INPUT_DATA_PATH"]
-        # dumping directly to a file is somewhat unsafe. If the json ends up malformed, we could
-        # end up overwriting valid test data with a complete mess. Since the in-memory data
-        # typically *isn't* malformed, the `--bless` will pass and make it seem like nothing is
-        # wrong.
+        # dumping directly to a file is somewhat unsafe. If the `Variable`/`Type` data ends up in a
+        # state that cannot be serialized correctly, the json ends up malformed, and we could end up
+        # overwriting valid test data with a complete mess. Since the in-memory data is typically
+        # completely valid, the testing logic will pass and make it seem like nothing is wrong.
 
         # While we could rely on git to help revert the test file, it's better to just not allow it
-        # to save malformed json in the first place. Thus, we dump the JSON, re-read it, and then
-        # only when that succeeds do we save it.
+        # to save malformed json in the first place. Thus, we dump the JSON, re-read it to check
+        # for `JSONDecodeError`, and write it to the target file if no error occurred.
         x = json.dumps(asdict(self), indent=" ")
         _ = json.loads(x)
 

--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -46,6 +46,7 @@ def get_target() -> Target:
 BLESS: Final[bool] = os.environ["LLDB_BATCHMODE_BLESS_TEST_DATA"] == "1"
 """Global constant set by `compiletest` that determines whether or not we are blessing the test
 data."""
+
 TARGET: Final[Target] = get_target()
 """Global constant set by `compiletest`. Determines which target the tests were run for, thus which
 set of test input we check."""
@@ -142,6 +143,7 @@ class Field:
     type: str
     """The fully qualified name of the field's type. Full type information should be looked up
     via `TargetData.types`"""
+
     offset: ByteSize
 
 
@@ -154,18 +156,17 @@ class Type:
     basic_type: int
     """The `lldb.eBasicType` value associated with this type. Tested due to our use of it in type
     recognizer functions."""
+
     type_class: int
     """The `lldb.eTypeClass` value associated with thjs type. Tested due to our use of it in type
     recognizer functions."""
+
     fields: list[Field]
-    """
-    Stored as a list due to our reliance on `SBType.GetFieldAtIndex()`
-    """
+    """Stored as a list due to our reliance on `SBType.GetFieldAtIndex()`"""
+
     generic_params: list[str]
-    """
-    Stored as a list due to our reliance on `SBType.GetTemplateArgumentType()` and the sequential
-    behavior of `lldb_providers.get_template_args`
-    """
+    """Stored as a list due to our reliance on `SBType.GetTemplateArgumentType()` and the sequential
+    behavior of `lldb_providers.get_template_args`"""
     # FIXME the only way we can look up static fields is by name (as of lldb 22), so we need a way
     # to discover them. ATM only sum-type enums on MSVC use static fields, and those are fixed
     # values, so it's not super urgent.
@@ -184,9 +185,11 @@ class Child:
     name: str
     """The name used to access the child. If the parent object has a synthetic, the child name can
     be overridden."""
+
     type: str
     """The fully qualified name of the child's type. Full type information should be looked up
     via `TargetData.types`"""
+
     value: Optional[Primitive]
     children: list["Child"]
     """Children are stored as a list because of our use of `GetChildAtIndex()`. Providers can also
@@ -199,25 +202,33 @@ class Variable:
     type: str
     """The fully qualified name of the variable's type. Full type information should be looked up
     via `TargetData.types`"""
+
     pretty_type_name: Optional[str]
     """Type names can be overridden by `SyntehticProvider.get_type_name()` in LLDB and by
     `type_printer` in GDB"""
+
     pretty_print: Optional[str]
     """The string-result of pretty printing the value (`SBValue.GetSummary` for LLDB,
     `pretty_printer.to_string` for GDB). `None` for aggregates with no summary provider."""
+
     value: Optional[Primitive]
     """`None` if the object does not have a primitive representation."""
+
     synthetic: Optional[str]
     """The class/function name of the synthetic provider (lldb) or pretty printer (gdb).
     `None` if the object does not have a synthetic provider"""
+
     summary: Optional[str]
     """The function name of the summary provider. `None` if the object does not have a summary
     provider, or if the test data is for GDB"""
+
     format: Optional[int]
     """The `lldb.eFormat` enum variant associated with this type (if applicable)."""
+
     # Stored as a list instead of a dict because child order matters
     children: list[Child]
-    """A list of children provided by the object. If the object has a synthetic provider, the """
+    """A list of children provided by the object. If the object has a synthetic provider, the
+    children are the result of the provider's `get_child_at_index` function"""
 
 
 @dataclass(slots=True)
@@ -237,11 +248,13 @@ class TargetData:
     bless_metadata: BlessMetadata = field(default_factory=BlessMetadata)
     """Miscellaneous data included to make diagnosing issues easier. This data is not intended to be
     tested against."""
+
     types: dict[str, Type] = field(default_factory=dict)
     """
     A map of type names to types. Contains all types present in the test's variables, including the
     types of fields and child objects.
     """
+
     # If we ever decide that it makes sense to check the same variable twice at the same breakpoint
     # this will need to be converted to a list
     breakpoints: list[dict[str, Variable]] = field(default_factory=list)

--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -100,7 +100,7 @@ def from_dict(ty: type[Any], data: JsonType):
         if isinstance(val_ty, str):
             val_ty = annot_to_ty(val_ty)
 
-        if val_ty is Variable or val_ty is Child or val_ty is Field:
+        if val_ty in [Variable, Child, Type, Field]:
             return {k: from_dict(val_ty, data[k]) for k in data.keys()}
 
     # map dict -> dataclass, recursing for each field
@@ -142,8 +142,7 @@ class Field:
     type: str
     """The fully qualified name of the field's type. Full type information should be looked up
     via `TargetData.types`"""
-    offset: int
-    """In bytes"""
+    offset: ByteSize
 
 
 @dataclass(slots=True)
@@ -250,7 +249,7 @@ class TargetData:
     dictionary mapping variable names to their respective test data."""
 
 
-@dataclass(slots=True, init=False)
+@dataclass(slots=True)
 class TestData:
     """
     Top-level container for all test data.

--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -65,7 +65,6 @@ def annot_to_ty(annot: str) -> type[Any]:
         "dict": dict,
         "str": str,
         "ByteSize": int,
-        "TestData": TestData,
         "TargetData": TargetData,
         "Variable": Variable,
         "Type": Type,
@@ -244,6 +243,20 @@ class BlessMetadata:
 
 @dataclass(slots=True)
 class TargetData:
+    """
+    Top-level container for all test data.
+
+    Due to the differences between PDB and DWARF debug info, we cannot guarantee their output
+    will be identical. Since LLDB can handle both, we need to conditionally select the correct
+    test data to use.
+
+    Additionally, since there are differences in the internals of some structs based on OS (e.g.
+    `PathBuf`/`OsString`), we need to be aware of whether we're on Windows or not.
+
+    A global var `TARGET` is set to the current variant upon `lldb_batchmode`'s instantiation using
+    an env var passed from `compiletest` and is not expected to change afterwards.
+    """
+
     bless_metadata: BlessMetadata = field(default_factory=BlessMetadata)
     """Miscellaneous data included to make diagnosing issues easier. This data is not intended to be
     tested against."""
@@ -260,30 +273,9 @@ class TargetData:
     """Each element corresponds to one stopping point in the test. The element itself is a
     dictionary mapping variable names to their respective test data."""
 
-
-@dataclass(slots=True)
-class TestData:
-    """
-    Top-level container for all test data.
-
-    Due to the differences between PDB and DWARF debug info, we cannot guarantee their output
-    will be identical. Since LLDB can handle both, we need to conditionally select the correct
-    test data to use.
-
-    Additionally, since there are differences in the internals of some structs based on OS (e.g.
-    `PathBuf`/`OsString`), we need to be aware of whether we're on Windows or not.
-
-    A global var `TARGET` is set to the current variant upon `lldb_batchmode`'s instantiation using
-    an env var passed from `compiletest` and is not expected to change afterwards.
-    """
-
-    non_windows: TargetData = field(default_factory=TargetData)
-    windows_gnu: TargetData = field(default_factory=TargetData)
-    windows_msvc: TargetData = field(default_factory=TargetData)
-
     @staticmethod
-    def initialize() -> "TestData":
-        result = TestData()
+    def initialize() -> "TargetData":
+        result = TargetData()
         path = os.environ["LLDB_BATCHMODE_INPUT_DATA_PATH"]
         if not os.path.isfile(path):
             if BLESS:
@@ -296,47 +288,17 @@ generated for this test yet, consider using the `--bless` option."
 
         with open(path, "r") as f:
             try:
-                data: dict[str, JsonType] = json.load(f)
+                result = from_dict(TargetData, json.load(f))
             except json.decoder.JSONDecodeError:
                 print("Warning: Malformed input data, reverting to default")
-                result.non_windows = TargetData()
-                result.windows_gnu = TargetData()
-                result.windows_msvc = TargetData()
-                return result
-
-        if BLESS and TARGET == Target.WindowsGnu:
-            result.windows_gnu = TargetData()
-        else:
-            result.windows_gnu = from_dict(TargetData, data["windows_gnu"])
-
-        if BLESS and TARGET == Target.WindowsMsvc:
-            result.windows_msvc = TargetData()
-        else:
-            result.windows_msvc = from_dict(TargetData, data["windows_msvc"])
-
-        if BLESS and TARGET == Target.NonWindows:
-            result.non_windows = TargetData()
-        else:
-            result.non_windows = from_dict(TargetData, data["non_windows"])
 
         return result
-
-    def get_target_data(self) -> TargetData:
-        """Retrieves data from the target specified by `compiletest`"""
-
-        if TARGET == Target.WindowsGnu:
-            return self.windows_gnu
-
-        if TARGET == Target.WindowsMsvc:
-            return self.windows_msvc
-
-        return self.non_windows
 
     def save_blessing(self, metadata: BlessMetadata):
         """Writes the entirety of `self` to the input file. Used to finalize changes made by
         one or more `TestData.bless_variable` calls."""
 
-        self.get_target_data().bless_metadata = metadata
+        self.bless_metadata = metadata
         path = os.environ["LLDB_BATCHMODE_INPUT_DATA_PATH"]
         # dumping directly to a file is somewhat unsafe. If the json ends up malformed, we could
         # end up overwriting valid test data with a complete mess. Since the in-memory data

--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -150,7 +150,6 @@ class Field:
 @dataclass(slots=True)
 class Type:
     size: ByteSize
-    align: ByteSize
     # When GDB support is added to the test framework, basic_type and type_class will probably be
     # converted to a wrapper IntEnum that converts GDB's equivalent information to
     basic_type: int

--- a/src/etc/lldb_batchmode/common.py
+++ b/src/etc/lldb_batchmode/common.py
@@ -1,0 +1,342 @@
+# Contains the class definitions outlining the schema of the test data
+
+import enum
+import json
+import os
+from dataclasses import asdict, dataclass, field, fields, is_dataclass
+from types import NoneType
+from typing import Any, Optional, get_origin, Final
+
+char = str
+Primitive = int | float | bool | char
+ByteSize = int
+
+# see: default json decoder docs https://docs.python.org/3/library/json.html#json.JSONDecoder
+# The types we're dealing with can only be: int, str, float, list, dict, bool, and None
+JsonType = int | str | float | list["JsonType"] | bool | None | dict[str, "JsonType"]
+
+
+class Target(enum.Enum):
+    """Due to the differences between PDB and DWARF debug info, we cannot guarantee their output
+    will be identical. Since LLDB can handle both, we need to conditionally select the correct
+    test data to use.
+
+    Additionally, since there are differences in the internals of some structs based on OS (e.g.
+    `PathBuf`/`OsString`), we need to be aware of whether we're on Windows or not.
+
+    A global var `TARGET` is set to the current variant upon `lldb_test.py`'s instantiation using an
+    env var passed from `compiletest` and is not expected to change afterwards."""
+
+    NonWindows = "non_windows"
+    WindowsGnu = "windows_gnu"
+    WindowsMsvc = "windows_msvc"
+
+
+def get_target() -> Target:
+    # set by compiletest when launching LLDB
+    t: str = os.environ["LLDB_BATCHMODE_TARGET_TRIPLE"]
+    if t.endswith("windows-msvc"):
+        return Target.WindowsMsvc
+    if t.endswith("windows-gnu") or t.endswith("windows-gnullvm"):
+        return Target.WindowsGnu
+
+    return Target.NonWindows
+
+
+BLESS: Final[bool] = os.environ["LLDB_BATCHMODE_BLESS_TEST_DATA"] == "1"
+"""Global constant set by `compiletest` that determines whether or not we are blessing the test
+data."""
+TARGET: Final[Target] = get_target()
+"""Global constant set by `compiletest`. Determines which target the tests were run for, thus which
+set of test input we check."""
+
+
+def annot_to_ty(annot: str) -> type[Any]:
+    """Fallback to resolve a string type annotation to its actual type (e.g. `"Variable"` ->
+    `Variable`). For types with generics, the generic is ignored."""
+
+    return {
+        "int": int,
+        "float": float,
+        "bool": bool,
+        "None": NoneType,
+        "list": list,
+        "dict": dict,
+        "str": str,
+        "ByteSize": int,
+        "TestData": TestData,
+        "TargetData": TargetData,
+        "Variable": Variable,
+        "Type": Type,
+        "Field": Field,
+        "Child": Child,
+        "BlessMetadata": BlessMetadata,
+    }.get(annot.split("[", 1)[0], type[Any])
+
+
+def from_dict(ty: type[Any], data: JsonType):
+    """Translates a dictionary into an instance of the given dataclass type (with possibly nested
+    dataclasses).
+
+    Relies on accurate type hints for the dataclass's fields, and the standard `dataclass.__init__`
+    definition."""
+
+    # Optional isn't a constructor, so we have to "unwrap" it.
+    if get_origin(ty) is Optional:
+        ty = ty.__args__[0]
+
+    # recurse into lists
+    if isinstance(data, list):
+        # pulls the generic type from the list (e.g. `list[int]` -> `int`)
+        inner = ty.__args__[0]
+        if isinstance(inner, str):
+            inner = annot_to_ty(inner)
+
+        return [from_dict(inner, i) for i in data]
+
+    if get_origin(ty) is dict and ty.__args__[0] is str:
+        assert isinstance(data, dict)
+        val_ty = ty.__args__[1]
+        if isinstance(val_ty, str):
+            val_ty = annot_to_ty(val_ty)
+
+        if val_ty is Variable or val_ty is Child or val_ty is Field:
+            return {k: from_dict(val_ty, data[k]) for k in data.keys()}
+
+    # map dict -> dataclass, recursing for each field
+    if is_dataclass(ty):
+        assert isinstance(data, dict)
+
+        field_types = {f.name: f.type for f in fields(ty)}
+
+        try:
+            field_map = {}
+
+            for f in data:
+                f_type = field_types[f]
+
+                # type annotations can be strings, so we need to resolve them to their actual type
+                if isinstance(f_type, str):
+                    f_type = annot_to_ty(f_type)
+
+                field_map[f] = from_dict(f_type, data[f])
+
+            # if you've never seen this before, `**` is the splat operator. It expands a mapping
+            # type (in this case a dict) to keyword arguments. The ordering of the mapping does not
+            # matter, only that the mapping's keys match the functions keyword args, and
+            # `len(mapping)` == the number of keyword args.
+            return ty(**field_map)
+        except KeyError as e:
+            print(
+                f"Unable to convert dict to {ty}: Invalid field name {e}. If the test schema was \
+changed intentionally, use the `--bless` option to update test data to the new schema."
+            )
+
+    # for any other type, we don't need to do any processing
+    return data
+
+
+@dataclass(slots=True)
+class Field:
+    name: str
+    type: str
+    """The fully qualified name of the field's type. Full type information should be looked up
+    via `TargetData.types`"""
+    offset: int
+    """In bytes"""
+
+
+@dataclass(slots=True)
+class Type:
+    size: ByteSize
+    align: ByteSize
+    # When GDB support is added to the test framework, basic_type and type_class will probably be
+    # converted to a wrapper IntEnum that converts GDB's equivalent information to
+    basic_type: int
+    """The `lldb.eBasicType` value associated with this type. Tested due to our use of it in type
+    recognizer functions."""
+    type_class: int
+    """The `lldb.eTypeClass` value associated with thjs type. Tested due to our use of it in type
+    recognizer functions."""
+    fields: list[Field]
+    """
+    Stored as a list due to our reliance on `SBType.GetFieldAtIndex()`
+    """
+    generic_params: list[str]
+    """
+    Stored as a list due to our reliance on `SBType.GetTemplateArgumentType()` and the sequential
+    behavior of `lldb_providers.get_template_args`
+    """
+    # FIXME the only way we can look up static fields is by name (as of lldb 22), so we need a way
+    # to discover them. ATM only sum-type enums on MSVC use static fields, and those are fixed
+    # values, so it's not super urgent.
+    # static_fields: list[StaticField]
+
+
+@dataclass(slots=True)
+class Child:
+    """Similar to `Variable`, but carries less information since we primarily test top-level
+    values (and assume values of these child types have been tested thoroughly elsewhere).
+
+    Note that if the type has a synthetic provider (lldb) or pretty printer (gdb), the child names
+    and types can be set to anything at all, so we do need to test these separately from the
+    parent's type's fields."""
+
+    name: str
+    """The name used to access the child. If the parent object has a synthetic, the child name can
+    be overridden."""
+    type: str
+    """The fully qualified name of the child's type. Full type information should be looked up
+    via `TargetData.types`"""
+    value: Optional[Primitive]
+    children: list["Child"]
+    """Children are stored as a list because of our use of `GetChildAtIndex()`. Providers can also
+    dictate the order that children populate, so it's important to ensure that stays consistent too.
+    """
+
+
+@dataclass(slots=True)
+class Variable:
+    type: str
+    """The fully qualified name of the variable's type. Full type information should be looked up
+    via `TargetData.types`"""
+    pretty_type_name: Optional[str]
+    """Type names can be overridden by `SyntehticProvider.get_type_name()` in LLDB and by
+    `type_printer` in GDB"""
+    pretty_print: Optional[str]
+    """The string-result of pretty printing the value (`SBValue.GetSummary` for LLDB,
+    `pretty_printer.to_string` for GDB). `None` for aggregates with no summary provider."""
+    value: Optional[Primitive]
+    """`None` if the object does not have a primitive representation."""
+    synthetic: Optional[str]
+    """The class/function name of the synthetic provider (lldb) or pretty printer (gdb).
+    `None` if the object does not have a synthetic provider"""
+    summary: Optional[str]
+    """The function name of the summary provider. `None` if the object does not have a summary
+    provider, or if the test data is for GDB"""
+    format: Optional[int]
+    """The `lldb.eFormat` enum variant associated with this type (if applicable)."""
+    # Stored as a list instead of a dict because child order matters
+    children: list[Child]
+    """A list of children provided by the object. If the object has a synthetic provider, the """
+
+
+@dataclass(slots=True)
+class BlessMetadata:
+    """
+    Contains additional context about the tools at the time the test data was generated
+    """
+
+    python_version: str = ""
+    debugger_version: str = ""
+    # FIXME (todo)
+    # feature_flags: str
+
+
+@dataclass(slots=True)
+class TargetData:
+    bless_metadata: BlessMetadata = field(default_factory=BlessMetadata)
+    """Miscellaneous data included to make diagnosing issues easier. This data is not intended to be
+    tested against."""
+    types: dict[str, Type] = field(default_factory=dict)
+    """
+    A map of type names to types. Contains all types present in the test's variables, including the
+    types of fields and child objects.
+    """
+    # If we ever decide that it makes sense to check the same variable twice at the same breakpoint
+    # this will need to be converted to a list
+    breakpoints: list[dict[str, Variable]] = field(default_factory=list)
+    """Each element corresponds to one stopping point in the test. The element itself is a
+    dictionary mapping variable names to their respective test data."""
+
+
+@dataclass(slots=True, init=False)
+class TestData:
+    """
+    Top-level container for all test data.
+
+    Due to the differences between PDB and DWARF debug info, we cannot guarantee their output
+    will be identical. Since LLDB can handle both, we need to conditionally select the correct
+    test data to use.
+
+    Additionally, since there are differences in the internals of some structs based on OS (e.g.
+    `PathBuf`/`OsString`), we need to be aware of whether we're on Windows or not.
+
+    A global var `TARGET` is set to the current variant upon `lldb_batchmode`'s instantiation using
+    an env var passed from `compiletest` and is not expected to change afterwards.
+    """
+
+    non_windows: TargetData = field(default_factory=TargetData)
+    windows_gnu: TargetData = field(default_factory=TargetData)
+    windows_msvc: TargetData = field(default_factory=TargetData)
+
+    @staticmethod
+    def initialize() -> "TestData":
+        result = TestData()
+        path = os.environ["LLDB_BATCHMODE_INPUT_DATA_PATH"]
+        if not os.path.isfile(path):
+            if BLESS:
+                return result
+            else:
+                raise Exception(
+                    f"Invalid input data path: '{path}'\nIf test data has not been \
+generated for this test yet, consider using the `--bless` option."
+                )
+
+        with open(path, "r") as f:
+            try:
+                data: dict[str, JsonType] = json.load(f)
+            except json.decoder.JSONDecodeError:
+                print("Warning: Malformed input data, reverting to default")
+                result.non_windows = TargetData()
+                result.windows_gnu = TargetData()
+                result.windows_msvc = TargetData()
+                return result
+
+        if BLESS and TARGET == Target.WindowsGnu:
+            result.windows_gnu = TargetData()
+        else:
+            result.windows_gnu = from_dict(TargetData, data["windows_gnu"])
+
+        if BLESS and TARGET == Target.WindowsMsvc:
+            result.windows_msvc = TargetData()
+        else:
+            result.windows_msvc = from_dict(TargetData, data["windows_msvc"])
+
+        if BLESS and TARGET == Target.NonWindows:
+            result.non_windows = TargetData()
+        else:
+            result.non_windows = from_dict(TargetData, data["non_windows"])
+
+        return result
+
+    def get_target_data(self) -> TargetData:
+        """Retrieves data from the target specified by `compiletest`"""
+
+        if TARGET == Target.WindowsGnu:
+            return self.windows_gnu
+
+        if TARGET == Target.WindowsMsvc:
+            return self.windows_msvc
+
+        return self.non_windows
+
+    def save_blessing(self, metadata: BlessMetadata):
+        """Writes the entirety of `self` to the input file. Used to finalize changes made by
+        one or more `TestData.bless_variable` calls."""
+
+        self.get_target_data().bless_metadata = metadata
+        path = os.environ["LLDB_BATCHMODE_INPUT_DATA_PATH"]
+        # dumping directly to a file is somewhat unsafe. If the json ends up malformed, we could
+        # end up overwriting valid test data with a complete mess. Since the in-memory data
+        # typically *isn't* malformed, the `--bless` will pass and make it seem like nothing is
+        # wrong.
+
+        # While we could rely on git to help revert the test file, it's better to just not allow it
+        # to save malformed json in the first place. Thus, we dump the JSON, re-read it, and then
+        # only when that succeeds do we save it.
+        x = json.dumps(asdict(self), indent=" ")
+        _ = json.loads(x)
+
+        with open(path, "w") as f:
+            f.write(x)

--- a/src/etc/lldb_batchmode/from_lldb.py
+++ b/src/etc/lldb_batchmode/from_lldb.py
@@ -1,0 +1,293 @@
+# Contains LLDB conversion functions from LLDB's in-memory representations to the test classes
+# defined in `.common`
+
+from struct import unpack, calcsize
+
+import lldb
+import lldb_lookup
+
+from .common import (
+    TARGET,
+    Child,
+    Field,
+    Target,
+    TargetData,
+    TestData,
+    Type,
+    Variable,
+)
+
+_UNSIGNED_INT_TYPES = {
+    lldb.eBasicTypeUnsignedChar,
+    lldb.eBasicTypeUnsignedShort,
+    lldb.eBasicTypeUnsignedInt,
+    lldb.eBasicTypeUnsignedLong,
+    lldb.eBasicTypeUnsignedLongLong,
+    lldb.eBasicTypeUnsignedInt128,
+}
+
+_FLOAT_TYPES = {
+    lldb.eBasicTypeHalf,
+    lldb.eBasicTypeFloat,
+    lldb.eBasicTypeDouble,
+    # FIXME: lldb added support for Float128 in 22.1, but python has no native
+    # support for it (even through `ctypes` or other alternatives). The best we
+    # can probably manage is comparing the raw bytes and/or trusting LLDB's output.
+    lldb.eBasicTypeFloat128,
+}
+
+_SIZE_TO_FLOAT_FMT = {
+    2: "e",
+    4: "f",
+    8: "d",
+}
+
+_SIZE_TO_INT_FMT = {
+    1: "b",
+    2: "h",
+    4: "l",
+    8: "q",
+    # python doesn't have native support for u128 so we manually reconstruct it from 2 64-bit ints
+    16: "qq",
+}
+
+
+def type_unpack_fmt(kind: int, size: int) -> str:
+    # we can't just map directly from lldb.eBasicType -> format string because lldb.eBasicType types
+    # aren't the same size on every target (even if targets have the same word size). e.g. On
+    # windows, isize = lldb.eBasicTypeLongLong, on linux with identical hardware,
+    # isize = lldb.eBasicTypeLong.
+    # Conversely, python's struct.unpack format specifiers ARE consistenly sized.
+
+    if kind in _FLOAT_TYPES:
+        return _SIZE_TO_FLOAT_FMT[size]
+
+    if kind == lldb.eBasicTypeBool:
+        return "?"
+
+    if kind == lldb.eBasicTypeChar32:
+        return "4s"
+
+    fmt = _SIZE_TO_INT_FMT[size]
+
+    if kind in _UNSIGNED_INT_TYPES:
+        fmt.upper()
+
+    return fmt
+
+
+def decode_primitive(valobj: lldb.SBValue) -> int | float | bool | str:
+    data: lldb.SBData = valobj.GetData()
+
+    type: lldb.SBType = valobj.GetType().GetCanonicalType()
+    kind = type.GetBasicType()
+
+    assert kind != lldb.eBasicTypeInvalid, f"{valobj.name} is not a primtive"
+
+    is_big_endian = data.GetByteOrder() == lldb.eByteOrderBig
+
+    buf = data.ReadRawData(lldb.SBError(), 0, data.GetByteSize())
+
+    if is_big_endian or kind == lldb.eBasicTypeChar32:
+        endian = ">"
+    else:
+        endian = "<"
+
+    format = endian + type_unpack_fmt(kind, type.GetByteSize())
+    # sanity check
+    assert calcsize(format) == data.GetByteSize()
+
+    got = unpack(format, buf)
+
+    if kind == lldb.eBasicTypeChar32:
+        got = got[0].decode("utf-32")
+    elif kind in [lldb.eBasicTypeInt128, lldb.eBasicTypeUnsignedInt128]:
+        # python doesn't have native support for u128 so we manually construct from 2 64-bit ints
+        hi = got[0] if is_big_endian else got[1]
+        lo = got[1] if is_big_endian else got[0]
+
+        got = lo | (hi << 64)
+    else:
+        got = got[0]
+
+    return got
+
+
+def get_summary_or_value(valobj: lldb.SBValue) -> str | None:
+    """`SBValue.GetSummary` only prints summaries from summary providers. It returns `None` if there
+    is no summary provider, rather than printing the default representation of the value. Often we
+    want any printable representation at all, so this function falls back to `SBValue.GetValue`.
+    That covers things like primitives and flat enums that typically don't have summary providers.
+    """
+    summary = valobj.GetSummary()
+    if summary is None:
+        return valobj.GetValue()
+
+    return summary
+
+
+def field_from_lldb(field: lldb.SBTypeMember) -> Field:
+    return Field(field.GetName(), field.GetType().GetName(), field.GetOffsetInBytes())
+
+
+def get_generics(ty: lldb.SBType, sbtarget: lldb.SBTarget) -> list[lldb.SBType]:
+    name = ty.GetName()
+    # FIXME Rust doesn't output template *values* (the `10` in `ArrayVec<u8, 10>`), only
+    # template args (the `u8` in `ArrayVec<u8, 10>`). That means these can possibly have
+    # different results. That's not a big deal, I don't think anything in the std library uses
+    # template values at the moment.
+    # Eventually we can either change `get_template_args` to skip template values OR update
+    # rustc to output them for DWARF debug info. Also, since it's target-specific behavior, it
+    # shouldn't actually cause tests not to work.
+    if TARGET == Target.WindowsMsvc:
+        return [
+            lldb_lookup.resolve_msvc_template_arg(x, sbtarget)
+            for x in lldb_lookup.get_template_args(name)
+        ]
+    else:
+        return [
+            ty.GetTemplateArgumentType(i)
+            for i in range(ty.GetNumberOfTemplateArguments())
+        ]
+
+
+def type_from_lldb(ty: lldb.SBType, sbtarget: lldb.SBTarget) -> Type:
+    generic_types = get_generics(ty, sbtarget)
+    generics = [g.GetName() for g in generic_types]
+
+    return Type(
+        ty.GetByteSize(),
+        ty.GetByteAlign(),
+        ty.GetBasicType(),
+        ty.GetTypeClass(),
+        [field_from_lldb(ty.GetFieldAtIndex(i)) for i in range(ty.GetNumberOfFields())],
+        generics,
+    )
+
+
+def child_from_lldb(child: lldb.SBValue) -> Child:
+    sbtype: lldb.SBType = child.GetType()
+
+    if not sbtype.IsPointerType() and sbtype.GetBasicType() != lldb.eBasicTypeInvalid:
+        value = decode_primitive(child)
+    else:
+        value = None
+
+    children = [
+        child_from_lldb(child.GetChildAtIndex(i)) for i in range(child.GetNumChildren())
+    ]
+
+    return Child(child.GetName(), child.GetType().GetName(), value, children)
+
+
+def variable_from_lldb(var: lldb.SBValue) -> Variable:
+    sbtype = var.GetType()
+    type_name = sbtype.GetName()
+
+    pretty_type_name = var.GetDisplayTypeName()
+
+    if pretty_type_name == type_name:
+        pretty_type_name = None
+
+    # We never want to store pointer values since they are expected to change from run to run.
+    # For now, we also only want to record values for primitives. In the future, we may support
+    # testing the `get_value` output from syntheticproviders, but the current visualizers do not
+    # implement this so it isn't urgent.
+    if not sbtype.IsPointerType() and sbtype.GetBasicType() != lldb.eBasicTypeInvalid:
+        value = decode_primitive(var)
+    else:
+        value = None
+
+    if (synth := var.GetTypeSynthetic()).IsValid():
+        synthetic = synth.GetData().strip()
+    else:
+        synthetic = None
+
+    if (summ := var.GetTypeSummary()).IsValid():
+        summary = summ.GetData().strip()
+    else:
+        summary = None
+
+    if (fmt := var.GetTypeFormat()).IsValid():
+        format = fmt.GetFormat()
+    else:
+        format = None
+
+    pretty_print = get_summary_or_value(var)
+
+    children = [
+        child_from_lldb(var.GetChildAtIndex(i)) for i in range(var.GetNumChildren())
+    ]
+
+    return Variable(
+        type_name,
+        pretty_type_name,
+        pretty_print,
+        value,
+        synthetic,
+        summary,
+        format,
+        children,
+    )
+
+
+def bless_variable(
+    test_data: TestData, var_name: str, breakpoint_idx: int, frame: lldb.SBFrame
+):
+    """Updates the mapping with data generated from the given variable. Only affects the mapping
+    of the current target and breakpoint. This function **does not** write to the input file.
+    Update all necessary vars, then write the entire input data at once using
+    `TestData.save_blessing`"""
+    valobj = frame.FindVariable(var_name)
+    if not valobj.IsValid():
+        # FIXME (todo) error handling
+        raise Exception(f"<bless error: Cannot find variable {var_name}>")
+
+    target_data = test_data.get_target_data()
+
+    if len(target_data.breakpoints) <= breakpoint_idx:
+        target_data.breakpoints.append({})
+
+    var_data = variable_from_lldb(valobj)
+    target_data.breakpoints[breakpoint_idx][var_name] = var_data
+
+    bless_type(target_data, valobj.GetType(), valobj.GetTarget())
+
+    # We also need to bless the types of the valobj's children, as they may not appear in the type
+    # or fields.
+    for i in range(valobj.GetNumChildren()):
+        bless_type(target_data, valobj.GetChildAtIndex(i).GetType(), valobj.GetTarget())
+
+
+def bless_type(target_data: TargetData, type: lldb.SBType, sbtarget: lldb.SBTarget):
+    """Recursively adds the type and all types of its fields to the `target_data.types` mapping"""
+
+    t_name = type.GetName()
+    t_data = type_from_lldb(type, sbtarget)
+    if t_name in target_data.types:
+        # If the type already exists in the type map, we don't need to process any further. We do
+        # need to check that the type data is actually identical to its mapping before moving on.
+        # It shouldn't ever be different, but better safe than sorry.
+        assert target_data.types[t_name] == t_data
+        return
+
+    # We need to add this type first just in case the type contains itself.
+    target_data.types[t_name] = t_data
+
+    # For types we haven't seen, we need to recursively handle the types of all of the fields and
+    # generics
+    for i in range(type.GetNumberOfFields()):
+        field = type.GetFieldAtIndex(i)
+        f_type = field.GetType()
+        f_type_name = f_type.GetName()
+
+        if f_type_name not in target_data.types:
+            bless_type(target_data, f_type, sbtarget)
+
+    for generic in get_generics(type, sbtarget):
+        # FIXME the purpose of this check is to gracefully handle generic *values* (e.g. the `2` in
+        # `ArrayVec<u8, 2>`) that slipped through the msvc template arg handling. At some point,
+        # `lldb_providers.get_template_args` should be made to output whether or not a template arg
+        # is a value, but for now this should be fine.
+        if generic.IsValid():
+            bless_type(target_data, generic, sbtarget)

--- a/src/etc/lldb_batchmode/from_lldb.py
+++ b/src/etc/lldb_batchmode/from_lldb.py
@@ -1,5 +1,12 @@
-# Contains LLDB conversion functions from LLDB's in-memory representations to the test classes
-# defined in `.common`
+"""Contains LLDB conversion functions from LLDB's in-memory representations to the test classes
+defined in `./common.py`.
+
+We primarily interface with the following LLDB classes:
+
+* [`SBValue`](https://lldb.llvm.org/python_api/lldb.SBValue.html)
+* [`SBType`](https://lldb.llvm.org/python_api/lldb.SBType.html)
+* [`SBTypeMember`](https://lldb.llvm.org/python_api/lldb.SBTypeMember.html)
+"""
 
 from struct import unpack, calcsize
 
@@ -118,6 +125,7 @@ def get_summary_or_value(valobj: lldb.SBValue) -> str | None:
     want any printable representation at all, so this function falls back to `SBValue.GetValue`.
     That covers things like primitives and flat enums that typically don't have summary providers.
     """
+
     summary = valobj.GetSummary()
     if summary is None:
         return valobj.GetValue()
@@ -130,6 +138,22 @@ def field_from_lldb(field: lldb.SBTypeMember) -> Field:
 
 
 def get_generics(ty: lldb.SBType, sbtarget: lldb.SBTarget) -> list[lldb.SBType]:
+    """Platform-agnostic equivalent to `SBType.template_args`. `SBType`'s template functions do not
+    work correctly with PDB debug info because PDB has no way to represent template parameters.
+
+    Due to the DWARF spec using
+    C++-centric terminology (e.g. `DW_TAG_template_type_parameter`), the following terms are
+    interchangable:
+
+    * template type param/arg <-> generic param
+    * template value param/arg <-> const generic param
+
+    The difference between "param" and "arg" is largely irrelevant for our purposes.
+    Pre-parameterized types (e.g. `Vec<T>`, which could be parameterized to `Vec<u8>`, LLDB calls
+    this "template specialization") are not reflected in the DWARF data at all, and are largely an
+    LLDB/clang implementation detail that isn't directly exposed to us.
+    """
+
     name = ty.GetName()
     # FIXME Rust doesn't output template *values* (the `10` in `ArrayVec<u8, 10>`), only
     # template args (the `u8` in `ArrayVec<u8, 10>`). That means these can possibly have
@@ -232,10 +256,11 @@ def variable_from_lldb(var: lldb.SBValue) -> Variable:
 def bless_variable(
     target_data: TargetData, var_name: str, breakpoint_idx: int, frame: lldb.SBFrame
 ):
-    """Updates the mapping with data generated from the given variable. Only affects the mapping
-    of the current target and breakpoint. This function **does not** write to the input file.
-    Update all necessary vars, then write the entire input data at once using
-    `TestData.save_blessing`"""
+    """Updates the given `TargetData` with data generated from the given variable at the given
+    breakpoint. This function **does not** write to the input file. Please see
+    `TargetData.save_blessing` for more info on when and how to save the data.
+    """
+
     valobj = frame.FindVariable(var_name)
     if not valobj.IsValid():
         # FIXME (todo) error handling

--- a/src/etc/lldb_batchmode/from_lldb.py
+++ b/src/etc/lldb_batchmode/from_lldb.py
@@ -157,7 +157,6 @@ def type_from_lldb(ty: lldb.SBType, sbtarget: lldb.SBTarget) -> Type:
 
     return Type(
         ty.GetByteSize(),
-        ty.GetByteAlign(),
         ty.GetBasicType(),
         ty.GetTypeClass(),
         [field_from_lldb(ty.GetFieldAtIndex(i)) for i in range(ty.GetNumberOfFields())],

--- a/src/etc/lldb_batchmode/from_lldb.py
+++ b/src/etc/lldb_batchmode/from_lldb.py
@@ -12,7 +12,6 @@ from .common import (
     Field,
     Target,
     TargetData,
-    TestData,
     Type,
     Variable,
 )
@@ -231,7 +230,7 @@ def variable_from_lldb(var: lldb.SBValue) -> Variable:
 
 
 def bless_variable(
-    test_data: TestData, var_name: str, breakpoint_idx: int, frame: lldb.SBFrame
+    target_data: TargetData, var_name: str, breakpoint_idx: int, frame: lldb.SBFrame
 ):
     """Updates the mapping with data generated from the given variable. Only affects the mapping
     of the current target and breakpoint. This function **does not** write to the input file.
@@ -241,8 +240,6 @@ def bless_variable(
     if not valobj.IsValid():
         # FIXME (todo) error handling
         raise Exception(f"<bless error: Cannot find variable {var_name}>")
-
-    target_data = test_data.get_target_data()
 
     if len(target_data.breakpoints) <= breakpoint_idx:
         target_data.breakpoints.append({})

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -39,6 +39,9 @@ from lldb_providers import (
     MSVCTupleSyntheticProvider,
     ClangEncodedEnumSummaryProvider,
     StructSummaryProvider,
+    # re-exports
+    get_template_args as get_template_args,
+    resolve_msvc_template_arg as resolve_msvc_template_arg,
 )
 from rust_types import (
     ENUM_DISR_FIELD_NAME,


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157529)*
<!-- homu-ignore:end -->

Part of https://github.com/rust-lang/rust/issues/148483

This is part 1 of 3(?) of upstreaming the new testing infrastructure, after which we can start converting the existing tests and/or replacing old tests with new, better written tests. This patch includes the test data format (in the form of several `@dataclass` classes), as well as serialization/deserialization. `common.py` includes a LOT of comments regarding what information is stored and why we store it. If anything is missing or unclear, please let me know. Some information about GDB that I knew off the top of my head I filled in, the rest will be filled in once GDB support is added. 

The next patches will include the `compiletest` plumbing, comparison logic, and error handling.

---

Serialization to JSON is as simple as using the builtin `json.dumps` with `dataclasses.asdict(test_data)`. Deserializing the JSON data is taken care of by `from_dict`, which uses the type annotations (which exist and can be manipulated at runtime 🤢), to detect when a `dict` is actually a dataclass, and then dispatches it to the dataclass's constructor. It's kinda magic, but I hopefully left enough comments that it should make sense. Doing it this way means we never really have to touch this function again, it should Just Work™ even if we adjust the dataclasses themselves.

Converting from LLDB is very straightforward. The only difference between this and my mock-up is how types are handled. Before, I stored full type data for the variable and for the type's field's types (recursively). This lead to a lot of redundant information. Since any given type's data is unique and unchanging for a given target in a given session (as guaranteed by LLDB), we can store exactly 1 instance of each `Type`. Variables and children store their type as a `str`, which can be looked up in `TargetData.types` to test against the appropriate type data. This assumes that type names can't collide, which isn't *entirely* true, but the only instances I've encountered are either LLDB bugs or resulted in LLDB itself crashing anyway, so it should be fine for a highly constrained testing environment like this.

Static fields are currently not handled. As discussed on zulip, we're targeting `x86_64-unknown-linux-gnu` first. The only static fields that Rust outputs are for sum-type enums on msvc targets. Static fields can only be accessed by name (nearly everything else we access we can get an item count and look up by index in a loop). I'm considering my options for how I want to handle those. Realistically, it's not super urgent and can be slotted in at any time (and might serve as a good test later down the road of updating existing test data to a new schema).

r? @jieyouxu, @Kobzol 

