### PR TITLE
ci: bump x86_64-gnu base image to 26.04

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR updates the x86_64-gnu CI Docker base image from  22.04 to  26.04.

r? @Kobzol