### PR TITLE
Reject `#[repr(packed)]` on `#[pin_v2]` types

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1633,6 +1633,18 @@ fn check_scalable_vector(tcx: TyCtxt<'_>, span: Span, def_id: LocalDefId, scalab
 pub(super) fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: ty::AdtDef<'_>) {
     let repr = def.repr();
     if repr.packed() {
+        // `#[pin_v2]` on a packed type is unsound: drop glue for a packed type moves an
+        // over-aligned field to an aligned location before running its destructor, which would
+        // move a structurally pinned field out from under a `Pin<&mut _>` that was handed out.
+        if def.is_pin_project()
+            && let Some(pin_v2_span) = find_attr!(tcx, def.did(), PinV2(span) => *span)
+        {
+            tcx.dcx().emit_err(errors::PinV2OnPacked {
+                span: sp,
+                pin_v2_span,
+                adt_name: tcx.item_name(def.did()),
+            });
+        }
         if let Some(reprs) = find_attr!(tcx, def.did(), Repr { reprs, .. } => reprs) {
             for (r, _) in reprs {
                 if let ReprPacked(pack) = r

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1636,12 +1636,10 @@ pub(super) fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: ty::AdtDef<'_>) {
         // `#[pin_v2]` on a packed type is unsound: drop glue for a packed type moves an
         // over-aligned field to an aligned location before running its destructor, which would
         // move a structurally pinned field out from under a `Pin<&mut _>` that was handed out.
-        if def.is_pin_project()
-            && let Some(pin_v2_span) = find_attr!(tcx, def.did(), PinV2(span) => *span)
-        {
+        if def.is_pin_project() {
             tcx.dcx().emit_err(errors::PinV2OnPacked {
                 span: sp,
-                pin_v2_span,
+                pin_v2_span: find_attr!(tcx, def.did(), PinV2(span) => *span),
                 adt_name: tcx.item_name(def.did()),
             });
         }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -2035,3 +2035,16 @@ pub(crate) struct PinV2WithoutPinDrop {
     pub pin_v2_span: Option<Span>,
     pub adt_name: Symbol,
 }
+
+#[derive(Diagnostic)]
+#[diag("`#[pin_v2]` types may not have `#[repr(packed)]`")]
+#[note(
+    "fields of a `#[repr(packed)]` type can be under-aligned, so a structurally pinned field may be moved to a properly aligned location, which `Pin` does not allow"
+)]
+pub(crate) struct PinV2OnPacked {
+    #[primary_span]
+    pub span: Span,
+    #[note("`{$adt_name}` is marked `#[pin_v2]` here")]
+    pub pin_v2_span: Span,
+    pub adt_name: Symbol,
+}

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -2045,6 +2045,6 @@ pub(crate) struct PinV2OnPacked {
     #[primary_span]
     pub span: Span,
     #[note("`{$adt_name}` is marked `#[pin_v2]` here")]
-    pub pin_v2_span: Span,
+    pub pin_v2_span: Option<Span>,
     pub adt_name: Symbol,
 }

--- a/tests/ui/pin-ergonomics/pin_v2-packed.rs
+++ b/tests/ui/pin-ergonomics/pin_v2-packed.rs
@@ -1,0 +1,42 @@
+//! `#[pin_v2]` is not allowed on `#[repr(packed)]` types.
+//!
+//! Drop glue for a packed type moves an over-aligned field to an aligned location before running
+//! its destructor. That move carries along any structurally pinned leaf, so a value handed out as
+//! `Pin<&mut _>` would be moved before it is dropped, violating `Pin`'s invariant.
+//!
+//! Regression test for <https://github.com/rust-lang/rust/issues/157011>.
+
+#![feature(pin_ergonomics)]
+#![allow(incomplete_features)]
+
+use std::marker::PhantomPinned;
+
+#[pin_v2]
+#[repr(packed)]
+struct Packed { //~ ERROR `#[pin_v2]` types may not have `#[repr(packed)]`
+    field: PhantomPinned,
+}
+
+// The generic case from the issue: alignment of `T` is unknown at definition time, so this is
+// rejected regardless of how it is later monomorphized.
+#[pin_v2]
+#[repr(C, packed(4))]
+struct PackedN<T>(T);
+//~^ ERROR `#[pin_v2]` types may not have `#[repr(packed)]`
+
+#[pin_v2]
+#[repr(packed)]
+union PackedUnion { //~ ERROR `#[pin_v2]` types may not have `#[repr(packed)]`
+    field: (),
+}
+
+// Allowed: `#[pin_v2]` without `#[repr(packed)]` still compiles.
+#[pin_v2]
+#[repr(C)]
+struct Unpacked<T>(T);
+
+// Allowed: `#[repr(packed)]` without `#[pin_v2]` is unaffected by the ban.
+#[repr(packed)]
+struct PackedNoPin(u8);
+
+fn main() {}

--- a/tests/ui/pin-ergonomics/pin_v2-packed.stderr
+++ b/tests/ui/pin-ergonomics/pin_v2-packed.stderr
@@ -1,0 +1,41 @@
+error: `#[pin_v2]` types may not have `#[repr(packed)]`
+  --> $DIR/pin_v2-packed.rs:16:1
+   |
+LL | struct Packed {
+   | ^^^^^^^^^^^^^
+   |
+   = note: fields of a `#[repr(packed)]` type can be under-aligned, so a structurally pinned field may be moved to a properly aligned location, which `Pin` does not allow
+note: `Packed` is marked `#[pin_v2]` here
+  --> $DIR/pin_v2-packed.rs:14:1
+   |
+LL | #[pin_v2]
+   | ^^^^^^^^^
+
+error: `#[pin_v2]` types may not have `#[repr(packed)]`
+  --> $DIR/pin_v2-packed.rs:24:1
+   |
+LL | struct PackedN<T>(T);
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: fields of a `#[repr(packed)]` type can be under-aligned, so a structurally pinned field may be moved to a properly aligned location, which `Pin` does not allow
+note: `PackedN` is marked `#[pin_v2]` here
+  --> $DIR/pin_v2-packed.rs:22:1
+   |
+LL | #[pin_v2]
+   | ^^^^^^^^^
+
+error: `#[pin_v2]` types may not have `#[repr(packed)]`
+  --> $DIR/pin_v2-packed.rs:29:1
+   |
+LL | union PackedUnion {
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: fields of a `#[repr(packed)]` type can be under-aligned, so a structurally pinned field may be moved to a properly aligned location, which `Pin` does not allow
+note: `PackedUnion` is marked `#[pin_v2]` here
+  --> $DIR/pin_v2-packed.rs:27:1
+   |
+LL | #[pin_v2]
+   | ^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#157011

`#[repr(packed)]` can store an over-aligned field below its alignment, and the drop glue for a packed type moves that field to a properly aligned spot before dropping it. When the field is structurally pinned, that move pulls it out from under a `Pin<&mut _>` we already handed out, which breaks the pin invariant. The repro in the issue makes it pretty clear: it prints one address during pinned access and a different one on drop.

So the fix just rejects the combo at the type definition. If a type is both `#[pin_v2]` and `#[repr(packed)]`, it no longer compiles. The check sits in `check_packed` in `rustc_hir_analysis`, so it catches the concrete case and the generic one too (like `One<T>`, where we don't know `T`'s alignment yet), with no layout or monomorphization needed.

One thing I want to be upfront about: this is necessary but don't solve the problem entirely. Sure, it stops the spelling the issue used, but you can still trigger the same move-on-drop through an explicit `&pin mut` / `ref pin mut` projection with no `#[pin_v2]` anywhere. Leaving that broader case open is intentional, imo the narrow ban is the right call for now, and the leftover stays tracked on the pin ergonomics tracking issue rust-lang/rust#130494.

This is the direction we landed on with `@workingjubilee` over on Zulip, lgtm from their side: https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/.60pin_v2.60.20is.20unsound.20with.20.60packed.60/with/600522893

Tests live in `tests/ui/pin-ergonomics/pin_v2-packed.rs`: the three rejected shapes (packed struct, generic `packed(4)` struct, packed union), plus two controls that still compile fine, `#[pin_v2]` without packed and packed without `#[pin_v2]`.

*Disclosure: AI tooling was used on the code changes, and everything was strictly validated by me before sending to remote.*
