### PR TITLE
Suggest using comma to separate valid attribute list items

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -30,8 +30,8 @@ use thin_vec::ThinVec;
 
 use crate::ShouldEmit;
 use crate::session_diagnostics::{
-    InvalidMetaItem, InvalidMetaItemQuoteIdentSugg, InvalidMetaItemRemoveNegSugg, MetaBadDelim,
-    MetaBadDelimSugg, SuffixedLiteralInAttribute,
+    ExpectedComma, InvalidMetaItem, InvalidMetaItemQuoteIdentSugg, InvalidMetaItemRemoveNegSugg,
+    MetaBadDelim, MetaBadDelimSugg, SuffixedLiteralInAttribute,
 };
 
 #[derive(Clone, Debug)]
@@ -704,6 +704,29 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         self.parser.dcx().create_err(err)
     }
 
+    fn should_continue_parsing_meta_items(&mut self) -> Result<bool, Diag<'sess>> {
+        if self.parser.eat(exp!(Comma)) {
+            return Ok(true);
+        } else if self.parser.token == token::Eof {
+            return Ok(false);
+        }
+
+        let mut snapshot = self.parser.create_snapshot_for_diagnostic();
+        if matches!(self.should_emit, ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed }) {
+            let span = self.parser.prev_token.span.shrink_to_hi();
+            self.should_emit = ShouldEmit::Nothing;
+            match self.parse_meta_item_inner() {
+                Ok(_) => {
+                    return Err(self.parser.dcx().create_err(ExpectedComma { span }));
+                }
+                Err(e) => {
+                    e.cancel();
+                }
+            }
+        }
+        snapshot.unexpected_any()
+    }
+
     fn parse(
         tokens: TokenStream,
         psess: &'sess ParseSess,
@@ -724,13 +747,9 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
         while this.parser.token != token::Eof {
             sub_parsers.push(this.parse_meta_item_inner()?);
 
-            if !this.parser.eat(exp!(Comma)) {
+            if !this.should_continue_parsing_meta_items()? {
                 break;
             }
-        }
-
-        if parser.token != token::Eof {
-            parser.unexpected()?;
         }
 
         Ok(MetaItemListParser { sub_parsers, span })

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -1032,3 +1032,16 @@ pub(crate) struct SanitizeInvalidStatic {
     pub span: Span,
     pub field: &'static str,
 }
+
+#[derive(Diagnostic)]
+#[diag("attribute items not separated with `,`")]
+pub(crate) struct ExpectedComma {
+    #[primary_span]
+    #[suggestion(
+        "try adding `,` here",
+        code = ",",
+        applicability = "maybe-incorrect",
+        style = "short"
+    )]
+    pub span: Span,
+}

--- a/tests/ui/on-unimplemented/expected-comma-found-token.rs
+++ b/tests/ui/on-unimplemented/expected-comma-found-token.rs
@@ -4,7 +4,7 @@
 #![feature(rustc_attrs)]
 
 #[rustc_on_unimplemented(
-    message="the message"
-    label="the label" //~ ERROR expected `,`, found `label`
+    message="the message" //~ ERROR attribute items not separated with `,`
+    label="the label"
 )]
 trait T {}

--- a/tests/ui/on-unimplemented/expected-comma-found-token.stderr
+++ b/tests/ui/on-unimplemented/expected-comma-found-token.stderr
@@ -1,10 +1,8 @@
-error: expected `,`, found `label`
-  --> $DIR/expected-comma-found-token.rs:8:5
+error: attribute items not separated with `,`
+  --> $DIR/expected-comma-found-token.rs:7:26
    |
 LL |     message="the message"
-   |                          - expected `,`
-LL |     label="the label"
-   |     ^^^^^ unexpected token
+   |                          ^ help: try adding `,` here
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
If the parser encounters a missing comma in an attribute arg list and the next item is valid, suggest adding the comma.

For example:
```
error: attribute items not separated with `,`
  --> $DIR/expected-comma-found-token.rs:7:26
   |
LL |     message="the message"
   |                          ^ help: try adding `,` here
```