### PR TITLE
Remove comments already covered by rustdoc

### DIFF
--- a/library/std/src/os/motor/ffi.rs
+++ b/library/std/src/os/motor/ffi.rs
@@ -5,9 +5,6 @@ use crate::ffi::{OsStr, OsString};
 use crate::sys::{AsInner, IntoInner};
 
 /// Motor OS–specific extensions to [`OsString`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 pub impl(self) trait OsStringExt {
     /// Yields the underlying UTF-8 string of this [`OsString`].
     ///
@@ -23,9 +20,6 @@ impl OsStringExt for OsString {
 }
 
 /// Motor OS–specific extensions to [`OsString`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 pub impl(self) trait OsStrExt {
     /// Gets the underlying UTF-8 string view of the [`OsStr`] slice.
     ///

--- a/library/std/src/os/unix/ffi/os_str.rs
+++ b/library/std/src/os/unix/ffi/os_str.rs
@@ -7,9 +7,6 @@ use crate::sys::{AsInner, FromInner, IntoInner};
 // Keep this in mind when applying changes to this file that only apply to `unix`.
 
 /// Platform-specific extensions to [`OsString`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait OsStringExt {
     /// Creates an [`OsString`] from a byte vector.
@@ -38,9 +35,6 @@ impl OsStringExt for OsString {
 }
 
 /// Platform-specific extensions to [`OsStr`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait OsStrExt {
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -1008,7 +1008,7 @@ impl DirEntryExt for fs::DirEntry {
     }
 }
 
-/// Sealed Unix-specific extension methods for [`fs::DirEntry`].
+/// Unix-specific extension methods for [`fs::DirEntry`].
 #[unstable(feature = "dir_entry_ext2", issue = "85573")]
 pub impl(self) trait DirEntryExt2 {
     /// Returns a reference to the underlying `OsStr` of this entry's filename.

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -30,9 +30,6 @@ cfg_select! {
 }
 
 /// Unix-specific extensions to the [`process::Command`] builder.
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait CommandExt {
     /// Sets the child process's user ID. This translates to a
@@ -286,9 +283,6 @@ impl CommandExt for process::Command {
 ///
 /// A Unix wait status (a Rust `ExitStatus`) can represent a Unix exit status, but can also
 /// represent other kinds of process event.
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait ExitStatusExt {
     /// Creates a new `ExitStatus` or `ExitStatusError` from the raw underlying integer status

--- a/library/std/src/os/windows/ffi.rs
+++ b/library/std/src/os/windows/ffi.rs
@@ -62,9 +62,6 @@ use crate::sys::os_str::Buf;
 use crate::sys::{AsInner, FromInner};
 
 /// Windows-specific extensions to [`OsString`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait OsStringExt {
     /// Creates an `OsString` from a potentially ill-formed UTF-16 slice of
@@ -96,9 +93,6 @@ impl OsStringExt for OsString {
 }
 
 /// Windows-specific extensions to [`OsStr`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub impl(self) trait OsStrExt {
     /// Re-encodes an `OsStr` as a wide character sequence, i.e., potentially

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -148,9 +148,6 @@ impl From<OwnedHandle> for process::ChildStderr {
 }
 
 /// Windows-specific extensions to [`process::ExitStatus`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "exit_status_from", since = "1.12.0")]
 pub impl(self) trait ExitStatusExt {
     /// Creates a new `ExitStatus` from the raw underlying `u32` return value of
@@ -167,9 +164,6 @@ impl ExitStatusExt for process::ExitStatus {
 }
 
 /// Windows-specific extensions to the [`process::Command`] builder.
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
 pub impl(self) trait CommandExt {
     /// Sets the [process creation flags][1] to be passed to `CreateProcess`.
@@ -456,9 +450,6 @@ impl ChildExt for process::Child {
 }
 
 /// Windows-specific extensions to [`process::ExitCode`].
-///
-/// This trait is sealed: it cannot be implemented outside the standard library.
-/// This is so that future additional methods are not breaking changes.
 #[unstable(feature = "windows_process_exit_code_from", issue = "111688")]
 pub impl(self) trait ExitCodeExt {
     /// Creates a new `ExitCode` from the raw underlying `u32` return value of


### PR DESCRIPTION
Since rust-lang/rust#157310 was merged, rustdoc renders `impl` restrictions. As such, these comments are no longer necessary.