### PR TITLE
use .sort_unstable() if deduplicating anyways

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1107,7 +1107,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 // same line) then we use the more verbose span output (`file.rs:col:ll`).
                 let mut lines: Vec<_> =
                     loop_spans.iter().map(|sp| sm.lookup_char_pos(sp.lo()).line).collect();
-                lines.sort();
+                lines.sort_unstable();
                 lines.dedup();
                 let fmt_span = |span: Span| {
                     if lines.len() == loop_spans.len() {

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -422,7 +422,7 @@ impl<'tcx> BorrowExplanation<'tcx> {
                         _ => None,
                     })
                     .collect::<Vec<Span>>();
-                preds.sort();
+                preds.sort_unstable();
                 preds.dedup();
                 if !preds.is_empty() {
                     let s = if preds.len() == 1 { "" } else { "s" };

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -754,14 +754,14 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         span,
                     });
                 } else {
-                    binds_to.sort();
+                    binds_to.sort_unstable();
                     binds_to.dedup();
 
                     self.add_move_error_details(err, &binds_to, &[]);
                 }
             }
             GroupedMoveError::MovesFromValue { mut binds_to, .. } => {
-                binds_to.sort();
+                binds_to.sort_unstable();
                 binds_to.dedup();
                 let desugar_spans = self.add_move_error_suggestions(err, &binds_to);
                 self.add_move_error_details(err, &binds_to, &desugar_spans);

--- a/compiler/rustc_borrowck/src/polonius/dump.rs
+++ b/compiler/rustc_borrowck/src/polonius/dump.rs
@@ -358,7 +358,7 @@ fn emit_mermaid_nll_regions<'tcx>(
         (min, max)
     };
     let mut ordered_edges: Vec<_> = regioncx.outlives_constraints().collect();
-    ordered_edges.sort_by_key(|c| constraint_key(c));
+    ordered_edges.sort_unstable_by_key(|c| constraint_key(c));
     ordered_edges.dedup_by_key(|c| constraint_key(c));
 
     for outlives in ordered_edges {

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1170,7 +1170,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             .iter()
             .flat_map(|(_location, subset_errors)| subset_errors.iter())
             .collect();
-        subset_errors.sort();
+        subset_errors.sort_unstable();
         subset_errors.dedup();
 
         for &(longer_fr, shorter_fr) in subset_errors.into_iter() {

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -1087,7 +1087,7 @@ fn report_invalid_references(
         let mut indexes: Vec<_> = invalid_refs.iter().map(|&(index, _, _, _)| index).collect();
         // Avoid `invalid reference to positional arguments 7 and 7 (there is 1 argument)`
         // for `println!("{7:7$}", 1);`
-        indexes.sort();
+        indexes.sort_unstable();
         indexes.dedup();
         let span: MultiSpan = if !parser.is_source_literal || parser.arg_places.is_empty() {
             MultiSpan::from_span(fmt_span)

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1136,7 +1136,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// recursively.
     #[must_use]
     pub fn dump_allocs<'a>(&'a self, mut allocs: Vec<AllocId>) -> DumpAllocs<'a, 'tcx, M> {
-        allocs.sort();
+        allocs.sort_unstable();
         allocs.dedup();
         DumpAllocs { ecx: self, allocs }
     }

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -77,9 +77,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         let mut sorted_vtable: Vec<_> = vtable_dyn_type.without_auto_traits().collect();
         let mut sorted_expected: Vec<_> = expected_dyn_type.without_auto_traits().collect();
         // `skip_binder` here is okay because `stable_cmp` doesn't look at binders
-        sorted_vtable.sort_by(|a, b| a.skip_binder().stable_cmp(*self.tcx, &b.skip_binder()));
+        sorted_vtable
+            .sort_unstable_by(|a, b| a.skip_binder().stable_cmp(*self.tcx, &b.skip_binder()));
         sorted_vtable.dedup();
-        sorted_expected.sort_by(|a, b| a.skip_binder().stable_cmp(*self.tcx, &b.skip_binder()));
+        sorted_expected
+            .sort_unstable_by(|a, b| a.skip_binder().stable_cmp(*self.tcx, &b.skip_binder()));
         sorted_expected.dedup();
 
         if sorted_vtable.len() != sorted_expected.len() {

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -661,7 +661,7 @@ impl SelfProfiler {
 
             // Warn about any unknown event names
             if !unknown_events.is_empty() {
-                unknown_events.sort();
+                unknown_events.sort_unstable();
                 unknown_events.dedup();
 
                 warn!(

--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -69,7 +69,7 @@
 //!         for &(s,t) in v {
 //!             nodes.push(s); nodes.push(t);
 //!         }
-//!         nodes.sort();
+//!         nodes.sort_unstable();
 //!         nodes.dedup();
 //!         nodes.into()
 //!     }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -1014,7 +1014,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .filter_map(format_pred)
             .map(|(p, _)| format!("`{p}`"))
             .collect();
-        bounds.sort();
+        bounds.sort_unstable();
         bounds.dedup();
 
         let mut err = self.dcx().struct_span_err(
@@ -1036,7 +1036,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             if !tcx.sess.source_map().is_span_accessible(span) {
                 continue;
             }
-            bounds.sort();
+            bounds.sort_unstable();
             bounds.dedup();
             let msg = match &bounds[..] {
                 [bound] => format!("doesn't satisfy {bound}"),

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1547,7 +1547,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     // Highlight each generic parameter in use.
                     for (param, uses) in hir_generics.params.iter().zip(&mut generic_uses) {
-                        uses.sort();
+                        uses.sort_unstable();
                         uses.dedup();
                         if let Some(param_list) = listify(uses, |&idx| {
                             params_with_generics[idx].1.display(idx.as_usize()).to_string()

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1164,7 +1164,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if !self.tcx.sess.source_map().is_span_accessible(span) {
                 continue;
             }
-            bounds.sort();
+            bounds.sort_unstable();
             bounds.dedup();
             let is_ty_span = Some(span) == ty_span;
             if is_ty_span && should_condense {
@@ -2036,7 +2036,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 .filter_map(|pred| format_pred(**pred))
                 .map(|(p, _)| format!("`{p}`"))
                 .collect();
-            preds.sort();
+            preds.sort_unstable();
             preds.dedup();
             let availability_note = if all_trait_bounds_for_rcvr
                 && has_ref_dupes
@@ -2132,7 +2132,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        bound_list.sort_by(|(_, a), (_, b)| a.cmp(b)); // Sort alphabetically.
+        bound_list.sort_unstable_by(|(_, a), (_, b)| a.cmp(b)); // Sort alphabetically.
         bound_list.dedup_by(|(_, a), (_, b)| a == b); // #35677
         bound_list.sort_by_key(|(pos, _)| *pos); // Keep the original predicate order.
 
@@ -3632,7 +3632,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 traits.push(trait_pred.def_id());
             }
         }
-        traits.sort_by_key(|&id| self.tcx.def_path_str(id));
+        traits.sort_unstable_by_key(|&id| self.tcx.def_path_str(id));
         traits.dedup();
 
         let len = traits.len();
@@ -3666,7 +3666,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         unsatisfied_predicates: &UnsatisfiedPredicates<'tcx>,
     ) -> bool {
         let mut derives = self.note_predicate_source_and_get_derives(err, unsatisfied_predicates);
-        derives.sort();
+        derives.sort_unstable();
         derives.dedup();
 
         let mut derives_grouped = Vec::<(String, Span, String)>::new();
@@ -4038,7 +4038,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         valid_out_of_scope_traits.retain(|id| self.tcx.is_user_visible_dep(id.krate));
         if !valid_out_of_scope_traits.is_empty() {
             let mut candidates = valid_out_of_scope_traits;
-            candidates.sort_by_key(|&id| self.tcx.def_path_str(id));
+            candidates.sort_unstable_by_key(|&id| self.tcx.def_path_str(id));
             candidates.dedup();
 
             // `TryFrom` and `FromIterator` have no methods
@@ -4489,8 +4489,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if !candidates.is_empty() {
             // Sort local crate results before others
-            candidates
-                .sort_by_key(|&info| (!info.def_id.is_local(), self.tcx.def_path_str(info.def_id)));
+            candidates.sort_unstable_by_key(|&info| {
+                (!info.def_id.is_local(), self.tcx.def_path_str(info.def_id))
+            });
             candidates.dedup();
 
             let param_type = match *rcvr_ty.kind() {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1450,7 +1450,7 @@ pub fn collect_crate_types(
         if base.is_empty() {
             base.push(default_output_for_target(session));
         } else {
-            base.sort();
+            base.sort_unstable();
             base.dedup();
         }
     }

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -360,7 +360,7 @@ pub fn suggest_constraining_type_params<'a>(
         }
 
         let mut constraint = constraints.iter().map(|&(c, _, _)| c).collect::<Vec<_>>();
-        constraint.sort();
+        constraint.sort_unstable();
         constraint.dedup();
         let all_known = constraints.iter().all(|&(_, def_id, _)| def_id.is_some());
         let all_stable = constraints.iter().all(|&(_, _, stable)| stable.is_empty());
@@ -374,7 +374,7 @@ pub fn suggest_constraining_type_params<'a>(
                     Some(def_id) => format!("`{}`", tcx.item_name(def_id)),
                 })
                 .collect::<Vec<_>>();
-            trait_names.sort();
+            trait_names.sort_unstable();
             trait_names.dedup();
             let n = trait_names.len();
             let stable = if all_stable { "" } else { "unstable " };
@@ -390,7 +390,7 @@ pub fn suggest_constraining_type_params<'a>(
                     Some(def_id) => format!("{stable}trait `{}`", tcx.item_name(def_id)),
                 })
                 .collect::<Vec<_>>();
-            trait_names.sort();
+            trait_names.sort_unstable();
             trait_names.dedup();
             match listify(&trait_names, |t| t.to_string()) {
                 Some(names) => names,

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -96,7 +96,7 @@ pub(super) fn extract_refined_covspans<'tcx>(
     // Sort the holes, and merge overlapping/adjacent holes.
     let mut holes = node.hole_spans.iter().copied().map(|span| Hole { span }).collect::<Vec<_>>();
 
-    holes.sort_by(|a, b| compare_spans(a.span, b.span));
+    holes.sort_unstable_by(|a, b| compare_spans(a.span, b.span));
     holes.dedup_by(|b, a| a.merge_if_overlapping_or_adjacent(b));
 
     // Discard any span that overlaps with a hole.

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -830,7 +830,7 @@ fn simplify_conditions(body: &Body<'_>, entry_states: &mut IndexVec<BasicBlock, 
             .iter()
             .flat_map(|&index| state.targets[index].iter().copied())
             .collect();
-        targets.sort();
+        targets.sort_unstable();
         targets.dedup();
         trace!(?targets);
 
@@ -1002,7 +1002,7 @@ impl<'a, 'tcx> OpportunitySet<'a, 'tcx> {
             .iter()
             .flat_map(|&index| std::mem::take(&mut state.targets[index]))
             .collect();
-        targets.sort();
+        targets.sort_unstable();
         targets.dedup();
         trace!(?targets);
 

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -1199,7 +1199,7 @@ fn collect_and_partition_mono_items(tcx: TyCtxt<'_>, (): ()) -> MonoItemPartitio
                 output.push_str(" @@");
                 let mut empty = Vec::new();
                 let cgus = item_to_cgus.get_mut(i).unwrap_or(&mut empty);
-                cgus.sort_by_key(|(name, _)| *name);
+                cgus.sort_unstable_by_key(|(name, _)| *name);
                 cgus.dedup();
                 for &(ref cgu_name, linkage) in cgus.iter() {
                     output.push(' ');

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -730,10 +730,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let BindingError { name, target, origin, could_be_path } = binding_error;
 
                 let mut target_sp = target.iter().map(|pat| pat.span).collect::<Vec<_>>();
-                target_sp.sort();
+                target_sp.sort_unstable();
                 target_sp.dedup();
                 let mut origin_sp = origin.iter().map(|(span, _)| *span).collect::<Vec<_>>();
-                origin_sp.sort();
+                origin_sp.sort_unstable();
                 origin_sp.dedup();
 
                 let msp = MultiSpan::from_spans(target_sp.clone());
@@ -756,13 +756,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     for pat in &target {
                         target_visitor.visit_pat(pat);
                     }
-                    target_visitor.identifiers.sort();
+                    target_visitor.identifiers.sort_unstable();
                     target_visitor.identifiers.dedup();
                     let mut origin_visitor = BindingVisitor::default();
                     for (_, pat) in &origin {
                         origin_visitor.visit_pat(pat);
                     }
-                    origin_visitor.identifiers.sort();
+                    origin_visitor.identifiers.sort_unstable();
                     origin_visitor.identifiers.dedup();
                     // Find if the binding could have been a typo
                     if let Some(typo) =
@@ -1878,7 +1878,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         if !derives.is_empty() {
             // We found an exact match for the missing attribute in a `derive` macro. Suggest it.
             let mut derives: Vec<String> = derives.into_iter().map(|d| d.to_string()).collect();
-            derives.sort();
+            derives.sort_unstable();
             derives.dedup();
             let msg = match &derives[..] {
                 [derive] => format!(" `{derive}`"),
@@ -1926,7 +1926,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 && let Some(macros) = all_attrs.get(&best_match)
             {
                 let mut macros: Vec<String> = macros.into_iter().map(|d| d.to_string()).collect();
-                macros.sort();
+                macros.sort_unstable();
                 macros.dedup();
                 let msg = match &macros[..] {
                     [] => return,
@@ -2611,7 +2611,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             )
             .filter(|c| !c.to_string().is_empty())
             .collect::<Vec<_>>();
-        candidates.sort();
+        candidates.sort_unstable();
         candidates.dedup();
         find_best_match_for_name(&candidates, ident, None).filter(|sugg| *sugg != ident)
     }
@@ -3604,7 +3604,7 @@ fn show_candidates(
     // we want consistent results across executions, but candidates are produced
     // by iterating through a hash map, so make sure they are ordered:
     for path_strings in [&mut accessible_path_strings, &mut inaccessible_path_strings] {
-        path_strings.sort_by(|a, b| a.0.cmp(&b.0));
+        path_strings.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         path_strings.dedup_by(|a, b| a.0 == b.0);
         let core_path_strings =
             path_strings.extract_if(.., |p| p.0.starts_with("core::")).collect::<Vec<_>>();

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1765,7 +1765,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         if is_redundant && !redundant_span.is_empty() {
             let mut redundant_spans: Vec<_> = redundant_span.present_items().collect();
-            redundant_spans.sort();
+            redundant_spans.sort_unstable();
             redundant_spans.dedup();
             self.lint_buffer.dyn_buffer_lint(
                 REDUNDANT_IMPORTS,

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -172,7 +172,7 @@ impl StableCrateId {
 
         // We don't want the stable crate ID to depend on the order of
         // -C metadata arguments, so sort them:
-        metadata.sort();
+        metadata.sort_unstable();
         // Every distinct -C metadata value is only incorporated once:
         metadata.dedup();
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             spans.push(sup_origin.span());
         }
         // We dedup the spans *ignoring* expansion context.
-        spans.sort();
+        spans.sort_unstable();
         spans.dedup_by_key(|span| (span.lo(), span.hi()));
 
         // We try to make the output have fewer overlapping spans if possible.

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -741,9 +741,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
         }
         let mut crate_names: Vec<_> = crates.iter().map(|n| format!("`{n}`")).collect();
-        crate_names.sort();
+        crate_names.sort_unstable();
         crate_names.dedup();
-        post.sort();
+        post.sort_unstable();
         post.dedup();
 
         if self.tainted_by_errors().is_some()

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2107,7 +2107,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 })
                 .collect();
 
-            impl_candidates.sort_by_key(|(tr, _)| tr.to_string());
+            impl_candidates.sort_unstable_by_key(|(tr, _)| tr.to_string());
             impl_candidates.dedup();
             impl_candidates
         };
@@ -2340,14 +2340,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // Check if the trait is the same in all cases. If so, we'll only show the type.
             let mut traits: Vec<_> =
                 candidates.iter().map(|(c, _)| c.print_only_trait_path().to_string()).collect();
-            traits.sort();
+            traits.sort_unstable();
             traits.dedup();
             // FIXME: this could use a better heuristic, like just checking
             // that args[1..] is the same.
             let all_traits_equal = traits.len() == 1;
             let mut types: Vec<_> =
                 candidates.iter().map(|(c, _)| c.self_ty().to_string()).collect();
-            types.sort();
+            types.sort_unstable();
             types.dedup();
             let all_types_equal = types.len() == 1;
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -643,7 +643,7 @@ pub fn report_dyn_incompatibility<'tcx>(
     if trait_span.is_some() {
         let mut potential_solutions: Vec<_> =
             reported_violations.into_iter().map(|violation| violation.solution()).collect();
-        potential_solutions.sort();
+        potential_solutions.sort_unstable();
         // Allows us to skip suggesting that the same item should be moved to another trait multiple times.
         potential_solutions.dedup();
         for solution in potential_solutions {

--- a/library/compiler-builtins/libm-test/src/generate/edge_cases.rs
+++ b/library/compiler-builtins/libm-test/src/generate/edge_cases.rs
@@ -76,7 +76,7 @@ fn float_edge_cases<F: Float>(
     }
 
     // Some results may overlap so deduplicate the vector to save test cycles.
-    values.sort_by_key(|x| x.to_bits());
+    values.sort_unstable_by_key(|x| x.to_bits());
     values.dedup_by_key(|x| x.to_bits());
 
     let count = ret.len().try_into().unwrap();
@@ -185,7 +185,7 @@ where
         values.retain(|v| *v <= max);
     }
 
-    values.sort();
+    values.sort_unstable();
     values.dedup();
     let count = values.len().try_into().unwrap();
 

--- a/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
+++ b/library/stdarch/crates/intrinsic-test/src/arm/mod.rs
@@ -41,7 +41,7 @@ impl SupportedArchitectureTest for ArmArchitectureTest {
         let mut intrinsics =
             get_neon_intrinsics(&cli_options.filename).expect("Error parsing input file");
 
-        intrinsics.sort_by(|a, b| a.name.cmp(&b.name));
+        intrinsics.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         intrinsics.dedup();
 
         let sample_percentage: usize = cli_options.sample_percentage as usize;

--- a/library/stdarch/crates/intrinsic-test/src/x86/mod.rs
+++ b/library/stdarch/crates/intrinsic-test/src/x86/mod.rs
@@ -73,7 +73,7 @@ impl SupportedArchitectureTest for X86ArchitectureTest {
         let mut intrinsics =
             get_xml_intrinsics(&cli_options.filename).expect("Error parsing input file");
 
-        intrinsics.sort_by(|a, b| a.name.cmp(&b.name));
+        intrinsics.sort_unstable_by(|a, b| a.name.cmp(&b.name));
         intrinsics.dedup_by(|a, b| a.name == b.name);
 
         let sample_percentage: usize = cli_options.sample_percentage as usize;

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -477,13 +477,13 @@ impl Step for Llvm {
         }
 
         if !enabled_llvm_projects.is_empty() {
-            enabled_llvm_projects.sort();
+            enabled_llvm_projects.sort_unstable();
             enabled_llvm_projects.dedup();
             cfg.define("LLVM_ENABLE_PROJECTS", enabled_llvm_projects.join(";"));
         }
 
         if !enabled_llvm_runtimes.is_empty() {
-            enabled_llvm_runtimes.sort();
+            enabled_llvm_runtimes.sort_unstable();
             enabled_llvm_runtimes.dedup();
             cfg.define("LLVM_ENABLE_RUNTIMES", enabled_llvm_runtimes.join(";"));
         }

--- a/src/bootstrap/src/core/builder/cli_paths.rs
+++ b/src/bootstrap/src/core/builder/cli_paths.rs
@@ -59,7 +59,7 @@ pub(crate) fn remap_paths(paths: &mut Vec<PathBuf>) {
             }
         }
     }
-    remove.sort();
+    remove.sort_unstable();
     remove.dedup();
     for idx in remove.into_iter().rev() {
         paths.remove(idx);

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -802,7 +802,7 @@ impl SerializedSearchIndex {
             .iter()
             .filter_map(|entry_data| Some(names[entry_data.as_ref()?.krate].as_bytes()))
             .collect();
-        crates.sort();
+        crates.sort_unstable();
         crates.dedup();
         serialized_root.extend_from_slice(&perform_write_strings(
             doc_root,

--- a/src/tools/collect-license-metadata/src/licenses.rs
+++ b/src/tools/collect-license-metadata/src/licenses.rs
@@ -43,7 +43,7 @@ impl License {
     fn simplify(&mut self) {
         self.remove_copyright_prefixes();
         self.remove_trailing_dots();
-        self.copyright.sort();
+        self.copyright.sort_unstable();
         self.copyright.dedup();
     }
 

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -765,8 +765,8 @@ fn modified_tests(config: &Config, dir: &Utf8Path) -> Result<Vec<Utf8PathBuf>, S
                 |f| if Utf8Path::new(&f).exists() { f.canonicalize_utf8().ok() } else { None },
             )
             .collect();
-        full_paths.dedup();
         full_paths.sort_unstable();
+        full_paths.dedup();
         full_paths
     };
     Ok(full_paths)

--- a/src/tools/rust-analyzer/crates/cfg/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/cfg/src/lib.rs
@@ -173,9 +173,9 @@ pub struct CfgDiff {
 impl CfgDiff {
     /// Create a new CfgDiff.
     pub fn new(mut enable: Vec<CfgAtom>, mut disable: Vec<CfgAtom>) -> CfgDiff {
-        enable.sort();
+        enable.sort_unstable();
         enable.dedup();
-        disable.sort();
+        disable.sort_unstable();
         disable.dedup();
         for i in (0..enable.len()).rev() {
             if let Some(j) = disable.iter().position(|atom| *atom == enable[i]) {

--- a/src/tools/rust-analyzer/crates/hir-ty/src/next_solver/predicate.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/next_solver/predicate.rs
@@ -142,11 +142,11 @@ impl<'db> rustc_type_ir::relate::Relate<DbInterner<'db>> for BoundExistentialPre
         let mut a_v: Vec<_> = a.into_iter().collect();
         let mut b_v: Vec<_> = b.into_iter().collect();
         // `skip_binder` here is okay because `stable_cmp` doesn't look at binders
-        a_v.sort_by(|a, b| {
+        a_v.sort_unstable_by(|a, b| {
             stable_cmp_existential_predicate(a.as_ref().skip_binder(), b.as_ref().skip_binder())
         });
         a_v.dedup();
-        b_v.sort_by(|a, b| {
+        b_v.sort_unstable_by(|a, b| {
             stable_cmp_existential_predicate(a.as_ref().skip_binder(), b.as_ref().skip_binder())
         });
         b_v.dedup();

--- a/src/tools/rust-analyzer/crates/ide-assists/src/handlers/auto_import.rs
+++ b/src/tools/rust-analyzer/crates/ide-assists/src/handlers/auto_import.rs
@@ -106,7 +106,7 @@ pub(crate) fn auto_import(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Opt
     let scope = ImportScope::find_insert_use_container(&syntax_under_caret, &ctx.sema)?;
 
     // we aren't interested in different namespaces
-    proposed_imports.sort_by(|a, b| a.import_path.cmp(&b.import_path));
+    proposed_imports.sort_unstable_by(|a, b| a.import_path.cmp(&b.import_path));
     proposed_imports.dedup_by(|a, b| a.import_path == b.import_path);
 
     let current_module = ctx.sema.scope(scope.as_syntax_node()).map(|scope| scope.module());

--- a/src/tools/rust-analyzer/crates/ide-assists/src/handlers/inline_type_alias.rs
+++ b/src/tools/rust-analyzer/crates/ide-assists/src/handlers/inline_type_alias.rs
@@ -375,7 +375,7 @@ fn create_replacement(
     }
 
     // Deduplicate removals to avoid intersecting changes
-    removals.sort_by_key(|n| n.text_range().start());
+    removals.sort_unstable_by_key(|n| n.text_range().start());
     removals.dedup();
 
     // Remove GenericArgList entirely if all its args are being removed (avoids empty angle brackets)

--- a/src/tools/rust-analyzer/crates/ide-assists/src/handlers/qualify_path.rs
+++ b/src/tools/rust-analyzer/crates/ide-assists/src/handlers/qualify_path.rs
@@ -75,7 +75,7 @@ pub(crate) fn qualify_path(acc: &mut Assists, ctx: &AssistContext<'_, '_>) -> Op
     };
 
     // we aren't interested in different namespaces
-    proposed_imports.sort_by(|a, b| a.import_path.cmp(&b.import_path));
+    proposed_imports.sort_unstable_by(|a, b| a.import_path.cmp(&b.import_path));
     proposed_imports.dedup_by(|a, b| a.import_path == b.import_path);
 
     let current_edition =

--- a/src/tools/rust-analyzer/crates/load-cargo/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/load-cargo/src/lib.rs
@@ -276,9 +276,9 @@ impl ProjectFolders {
                     roots[k].include.extend(r.include);
                     roots[k].exclude.extend(r.exclude);
                 }
-                roots[k].include.sort();
-                roots[k].exclude.sort();
+                roots[k].include.sort_unstable();
                 roots[k].include.dedup();
+                roots[k].exclude.sort_unstable();
                 roots[k].exclude.dedup();
             }
         }

--- a/src/tools/rust-analyzer/crates/project-model/src/workspace.rs
+++ b/src/tools/rust-analyzer/crates/project-model/src/workspace.rs
@@ -851,7 +851,7 @@ impl ProjectWorkspace {
                             exclude.push(pkg_root.join("examples"));
                             exclude.push(pkg_root.join("benches"));
                         }
-                        include.sort();
+                        include.sort_unstable();
                         include.dedup();
                         PackageRoot { is_local, include, exclude }
                     })
@@ -914,7 +914,7 @@ impl ProjectWorkspace {
                             exclude.push(pkg_root.join("examples"));
                             exclude.push(pkg_root.join("benches"));
                         }
-                        include.sort();
+                        include.sort_unstable();
                         include.dedup();
                         PackageRoot { is_local, include, exclude }
                     })
@@ -1738,7 +1738,7 @@ fn extend_crate_graph_with_sysroot(
         marker_set.extend(sysroot_crate_graph.transitive_deps(cid));
     }
 
-    marker_set.sort();
+    marker_set.sort_unstable();
     marker_set.dedup();
 
     // Remove all crates except the ones we are interested in to keep the sysroot graph small.

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/analysis_stats.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/cli/analysis_stats.rs
@@ -366,7 +366,7 @@ impl flags::AnalysisStats {
             }
         });
 
-        file_ids.sort();
+        file_ids.sort_unstable();
         file_ids.dedup();
 
         if self.run_all_ide_things {

--- a/src/tools/rust-analyzer/crates/vfs/src/file_set.rs
+++ b/src/tools/rust-analyzer/crates/vfs/src/file_set.rs
@@ -177,7 +177,7 @@ impl FileSetConfigBuilder {
                     entries.push((buf, i as u64));
                 }
             }
-            entries.sort();
+            entries.sort_unstable();
             entries.dedup_by(|(a, _), (b, _)| a == b);
             fst::Map::from_iter(entries).unwrap()
         };

--- a/src/tools/rust-analyzer/xtask/src/codegen/grammar/ast_src.rs
+++ b/src/tools/rust-analyzer/xtask/src/codegen/grammar/ast_src.rs
@@ -205,12 +205,12 @@ pub(crate) fn generate_kind_src(
         panic!("Punctuation {punct:?} is not used in grammar");
     }
     keywords.extend(RESERVED.iter().copied());
-    keywords.sort();
+    keywords.sort_unstable();
     keywords.dedup();
-    contextual_keywords.sort();
+    contextual_keywords.sort_unstable();
     contextual_keywords.dedup();
     let mut edition_dependent_keywords: Vec<(&_, _)> = EDITION_DEPENDENT_KEYWORDS.to_vec();
-    edition_dependent_keywords.sort();
+    edition_dependent_keywords.sort_unstable();
     edition_dependent_keywords.dedup();
 
     keywords.retain(|&it| !contextual_keywords.contains(&it));

--- a/src/tools/rustfmt/src/imports.rs
+++ b/src/tools/rustfmt/src/imports.rs
@@ -637,7 +637,7 @@ impl UseTree {
         // Recursively normalize elements of a list use (including sorting the list).
         if let UseSegmentKind::List(list) = last.kind {
             let mut list = list.into_iter().map(UseTree::normalize).collect::<Vec<_>>();
-            list.sort();
+            list.sort_unstable();
             list.dedup();
             last = UseSegment {
                 kind: UseSegmentKind::List(list),
@@ -832,7 +832,7 @@ fn merge_rest(
         UseTree::from_path(a[len..].to_vec(), DUMMY_SP),
         UseTree::from_path(b[len..].to_vec(), DUMMY_SP),
     ];
-    list.sort();
+    list.sort_unstable();
     list.dedup();
     let mut new_path = b[..len].to_vec();
     let kind = UseSegmentKind::List(list);
@@ -897,7 +897,7 @@ fn merge_use_trees_inner(trees: &mut Vec<UseTree>, use_tree: UseTree, merge_by: 
         }
     }
     trees.push(use_tree);
-    trees.sort();
+    trees.sort_unstable();
     trees.dedup();
 }
 

--- a/src/tools/tidy/src/extra_checks/mod.rs
+++ b/src/tools/tidy/src/extra_checks/mod.rs
@@ -601,7 +601,7 @@ fn create_venv_at_path(path: &Path) -> Result<(), Error> {
         let ret = if found.is_empty() {
             Error::MissingReq("python3", "python file checks", None)
         } else {
-            found.sort();
+            found.sort_unstable();
             found.dedup();
             Error::Version {
                 program: "python3",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

We might as well use `.sort_unstable()` which can be much, *much* faster than normal `.sort()` since we're `.dedup()`'ing anyways afterwards, see the results in the chart here where the unstable variant is at the top (for the most favorable `u64` case, albeit).

https://github.com/Voultapher/sort-research-rs/blob/main/writeup/unreasonable/text.md#various-generic-algorithms

I expect

* all tests to pass
* maybe a couple of benchmarks to have a small % bump for perf

The best boon here is that the unstable sorting variants allocate much less, and thus might help out with some of the hotter compiler pass transforms/analysis.