### PR TITLE
Add `BTree::append()` change to 1.96.0 relnotes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -77,6 +77,7 @@ Compatibility Notes
 - [For `export_name`, `link_name`, and `link_section` attributes, if multiple of the same attribute is present, the first one now takes precedence.](https://github.com/rust-lang/rust/pull/153041)
 - [Update the minimum external LLVM to 21](https://github.com/rust-lang/rust/pull/153684)
 - On `avr` targets, C's `double` type is 32-bit by default, so [change `c_double` to `f32` on `avr` targets to match](https://github.com/rust-lang/rust/pull/154647). This is a breaking change, but necessary to make `c_double` match C's double.
+- [`BTreeMap::append()` was optimized, which may now cause panics for types with incorrect `Ord` impls](https://github.com/rust-lang/rust/pull/153107)
 
 <a id="1.96.0-Internal-Changes"></a>
 


### PR DESCRIPTION
This change affected someone's code, reported in https://github.com/rust-lang/rust/issues/157436.

I copied the text from https://github.com/rust-lang/rust/issues/157496, but I figured that it belonged to the "Compatibility Notes" section, not "Internal Changes".

See discussion at https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/Procedure.20for.20modifying.20past.20release.20notes/with/600817427

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
