### PR TITLE
Link LLVM dynamically on x86_64-apple

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/157205
+Last change is for: https://github.com/rust-lang/rust/pull/157557

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -467,6 +467,7 @@ auto:
         --enable-profiler
         --disable-docs
         --set rust.jemalloc
+        --set llvm.link-shared=true
         --set rust.lto=thin
         --set rust.codegen-units=1
       # Ensure that host tooling is built to support our minimum support macOS version.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157557)*
<!-- homu-ignore:end -->

Link LLVM dynamically on x86_64-apple just like we did for aarch64-apple-darwin
* https://github.com/rust-lang/rust/pull/157205

r? @ZuseZ4 