### PR TITLE
chore: Update annotate-snippets to 0.12.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
@@ -3958,7 +3958,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.12.15",
+ "annotate-snippets 0.12.16",
  "anstream",
  "anstyle",
  "derive_setters",

--- a/compiler/rustc_errors/Cargo.toml
+++ b/compiler/rustc_errors/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-annotate-snippets = { version = "0.12.15", features = ["simd"] }
+annotate-snippets = { version = "0.12.16", features = ["simd"] }
 anstream = "0.6.20"
 anstyle = "1.0.13"
 derive_setters = "0.1.6"


### PR DESCRIPTION
This PR updates `annotate-snippets` to [`0.12.16`](https://github.com/rust-lang/annotate-snippets-rs/blob/main/CHANGELOG.md#01216---2026-05-06) which fixes highlighting for indented code: https://github.com/rust-lang/annotate-snippets-rs/issues/405

Also fixes https://github.com/rust-lang/rust/issues/155873 (the same problem)