### PR TITLE
In `copy_nonoverlapping`, use `mul nuw nsw` to compute the byte size

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     .layout_of(bx.typing_env().as_query_input(pointee))
                     .expect("expected pointee to have a layout");
                 let elem_size = pointee_layout.layout.size().bytes();
-                let bytes = bx.mul(count, bx.const_usize(elem_size));
+                let bytes = bx.unchecked_sumul(count, bx.const_usize(elem_size));
 
                 let align = pointee_layout.layout.align.abi;
                 let dst = dst_val.immediate();

--- a/tests/codegen-llvm/intrinsics/copy_nonoverlapping.rs
+++ b/tests/codegen-llvm/intrinsics/copy_nonoverlapping.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//@ only-64bit (so I don't need to worry about usize)
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+// This deals in a count of elements, not bytes, so we need to multiply.
+// Ensure we preserve UB from a count too high to be valid.
+use std::intrinsics::copy_nonoverlapping;
+
+// CHECK-LABEL: @copy_u16(
+#[no_mangle]
+pub unsafe fn copy_u16(src: *const u16, dst: *mut u16, count: usize) {
+    // CHECK: [[BYTES:%.+]] = mul nuw nsw i64 %count, 2
+    // CHECK: call void @llvm.memcpy.p0.p0.i64(ptr align 2 %dst, ptr align 2 %src, i64 [[BYTES]], i1 false)
+    copy_nonoverlapping(src, dst, count)
+}


### PR DESCRIPTION
Seems like we might as well?  Adding these flags means the optimizer can tell the limited range on the count of items -- like how we use these flags (rust-lang/rust#136575) when calculating `size_of_val` for a slice.

Today we use a wrapping multiplication, which mean that `copy_nonoverlapping::<u32>(src, dst, 0x40000000_00000001)` appears like 4 bytes -- a perfectly reasonable size! -- once it gets to the `memcpy` call.

If I'm understanding <https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html#safety> properly, this is just exploiting existing UB, since `src` and `dst` must each be inside an allocation, and those allocations can be at most `isize::MAX` bytes.  (Plus, fundamentally, to be non-overlapping there's not enough space in the address space to be bigger than `isize::MAX`.)

cc @RalfJung to make sure this is ok, as requested last he found out I was newly exploiting some UB in codegen 🙃 
r? codegen
