### PR TITLE
Avoid computing layout of enums with non-int discriminants

### DIFF
--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -707,6 +707,18 @@ fn layout_of_uncached<'tcx>(
             let discr_range_of_repr =
                 |min, max| abi::Integer::discr_range_of_repr(tcx, ty, &def.repr(), min, max);
 
+            // We shouldn't be computing the layout of discrs that fail typeck
+            if def.is_enum() {
+                for v in def.variants() {
+                    if let ty::VariantDiscr::Explicit(def_id) = v.discr
+                        && let Some(local_did) = def_id.as_local()
+                        && let Some(guar) = tcx.typeck(local_did).tainted_by_errors
+                    {
+                        return Err(error(cx, LayoutError::ReferencesError(guar)));
+                    }
+                }
+            }
+
             let discriminants_iter = || {
                 def.is_enum()
                     .then(|| def.discriminants(tcx).map(|(v, d)| (v, d.val as i128)))

--- a/tests/crashes/138660.rs
+++ b/tests/crashes/138660.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #138660
-enum A {
-    V1(isize) = 1..=10,
-    V0 = 1..=10,
-}
-const B: &'static [A] = &[A::V0, A::V1(111)];
-fn main() {}

--- a/tests/ui/enum-discriminant/non-int-discriminant-promoted-ice-138660.rs
+++ b/tests/ui/enum-discriminant/non-int-discriminant-promoted-ice-138660.rs
@@ -1,0 +1,13 @@
+// Previously, enums with non-int discrs ICEd during CTFE of promoteds.
+
+enum A {
+//~^ ERROR `#[repr(inttype)]` must be specified
+    V1(isize) = 1..=10,
+    //~^ ERROR mismatched types
+    V0 = 1..=10,
+    //~^ ERROR mismatched types
+}
+
+const B: &'static [A] = &[A::V0, A::V1(111)];
+
+fn main() {}

--- a/tests/ui/enum-discriminant/non-int-discriminant-promoted-ice-138660.stderr
+++ b/tests/ui/enum-discriminant/non-int-discriminant-promoted-ice-138660.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/non-int-discriminant-promoted-ice-138660.rs:5:17
+   |
+LL |     V1(isize) = 1..=10,
+   |                 ^^^^^^ expected `isize`, found `RangeInclusive<{integer}>`
+   |
+   = note: expected type `isize`
+            found struct `std::ops::RangeInclusive<{integer}>`
+   = note: enum variant discriminant can only be of a primitive type compatible with the enum's `repr`
+
+error[E0308]: mismatched types
+  --> $DIR/non-int-discriminant-promoted-ice-138660.rs:7:10
+   |
+LL |     V0 = 1..=10,
+   |          ^^^^^^ expected `isize`, found `RangeInclusive<{integer}>`
+   |
+   = note: expected type `isize`
+            found struct `std::ops::RangeInclusive<{integer}>`
+   = note: enum variant discriminant can only be of a primitive type compatible with the enum's `repr`
+
+error[E0732]: `#[repr(inttype)]` must be specified for enums with explicit discriminants and non-unit variants
+  --> $DIR/non-int-discriminant-promoted-ice-138660.rs:3:1
+   |
+LL | enum A {
+   | ^^^^^^
+LL |
+LL |     V1(isize) = 1..=10,
+   |                 ------ explicit discriminant on non-unit variant specified here
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0732.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/enum-discriminant/size-of-discriminant-no-cycle.rs
+++ b/tests/ui/enum-discriminant/size-of-discriminant-no-cycle.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+// Ensure that `size_of::<Thing>()` as a discriminant does not cause a cycle error.
+
+enum Thing {
+    Variant = size_of::<Thing>() as isize,
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157562)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Currently, enums with explicit non-int discriminants, such as `1..=10`, correctly error with E0308 and E0732 during typeck. However, `layout_of` never sees this error, since `AdtDef::discriminants()` falls back to a default value when `eval_explicit_discr` returns an `Err`, causing the layout of the enum to be broken. If this enum then appears in a promoted, we expect CTFE to fail; however, since `layout_of` technically "succeeded," just with a broken layout, our enum isn't in `allowed_in_infallible`, so CTFE expects it to succeed. CTFE failing then causes us to ICE with `"interpret const eval failure of...which is not in required_consts"`.

This PR modifies `layout_of_uncached` in `compiler/rustc_ty_utils/src/layout.rs` to typeck all explicit enum discriminants before computing layout, and early-returns with a `LayoutError::ReferncesError` if eval fails. CTFE then sees this `LayoutError` as `allowed_in_infallible`, avoiding the ICE.

fixes rust-lang/rust#138660