### PR TITLE
stabilize size_of_val_raw, align_of_val_raw, Layout::for_value_raw

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,7 +146,6 @@
 #![feature(io_slice_as_bytes)]
 #![feature(iter_advance_by)]
 #![feature(iter_next_chunk)]
-#![feature(layout_for_ptr)]
 #![feature(legacy_receiver_trait)]
 #![feature(likely_unlikely)]
 #![feature(local_waker)]

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -230,8 +230,7 @@ impl Layout {
     ///
     /// - If `T` is `Sized`, this function is always safe to call.
     /// - If the unsized tail of `T` is:
-    ///     - a [slice] `[U]` or `str`, then the length of the slice tail must be an initialized
-    ///       integer, and the size of the *entire value*
+    ///     - a [slice] `[U]`, `str`, or a [trait object] `dyn Trait`, then the size of the *entire value*
     ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
     ///       For the special case where the dynamic tail length is 0, this function
     ///       is safe to call.
@@ -239,10 +238,6 @@ impl Layout {
     //        then we would stop compilation as even the "statically known" part of the type would
     //        already be too big (or the call may be in dead code and optimized away, but then it
     //        doesn't matter).
-    ///     - a [trait object] `dyn Trait`, then the vtable part of the pointer must point
-    ///       to a valid vtable for `Trait`, and the size
-    ///       of the *entire value* (dynamic tail length + statically sized prefix)
-    ///       must fit in `isize`.
     ///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
     ///       function. If more kinds of unsized tails get introduced in the future, the documentation
     ///       of this function will have to be extended before it can be used for such types.

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -243,13 +243,9 @@ impl Layout {
     ///       to a valid vtable for `Trait`, and the size
     ///       of the *entire value* (dynamic tail length + statically sized prefix)
     ///       must fit in `isize`.
-    ///     - an (unstable) [extern type], then this function is always safe to
-    ///       call, but may panic or otherwise return the wrong value, as the
-    ///       extern type's layout is not known. This is the same behavior as
-    ///       [`Layout::for_value`] on a reference to an extern type tail.
-    ///     - No other kind of unsized tail currently exists. If more kinds of unsized tails get
-    ///       introduced in the future, the documentation of this function will have to be extended
-    ///       before it can be used for such types.
+    ///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
+    ///       function. If more kinds of unsized tails get introduced in the future, the documentation
+    ///       of this function will have to be extended before it can be used for such types.
     ///
     /// Here, *unsized tail* refers to the type obtained by recursively descending through the last
     /// field of a tuple or struct until we arrived at a built-in unsized type.

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -230,29 +230,42 @@ impl Layout {
     ///
     /// - If `T` is `Sized`, this function is always safe to call.
     /// - If the unsized tail of `T` is:
-    ///     - a [slice], then the length of the slice tail must be an initialized
+    ///     - a [slice] `[U]` or `str`, then the length of the slice tail must be an initialized
     ///       integer, and the size of the *entire value*
     ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
     ///       For the special case where the dynamic tail length is 0, this function
     ///       is safe to call.
-    ///     - a [trait object], then the vtable part of the pointer must point
-    ///       to a valid vtable for the type `T` acquired by an unsizing coercion,
-    ///       and the size of the *entire value*
-    ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+    //        NOTE: the reason this is safe is that if an overflow were to occur already with size 0,
+    //        then we would stop compilation as even the "statically known" part of the type would
+    //        already be too big (or the call may be in dead code and optimized away, but then it
+    //        doesn't matter).
+    ///     - a [trait object] `dyn Trait`, then the vtable part of the pointer must point
+    ///       to a valid vtable for `Trait`, and the size
+    ///       of the *entire value* (dynamic tail length + statically sized prefix)
+    ///       must fit in `isize`.
     ///     - an (unstable) [extern type], then this function is always safe to
     ///       call, but may panic or otherwise return the wrong value, as the
     ///       extern type's layout is not known. This is the same behavior as
     ///       [`Layout::for_value`] on a reference to an extern type tail.
-    ///     - otherwise, it is conservatively not allowed to call this function.
+    ///     - No other kind of unsized tail currently exists. If more kinds of unsized tails get
+    ///       introduced in the future, the documentation of this function will have to be extended
+    ///       before it can be used for such types.
+    ///
+    /// Here, *unsized tail* refers to the type obtained by recursively descending through the last
+    /// field of a tuple or struct until we arrived at a built-in unsized type.
+    ///
+    /// As a consequence of these rules, it is the case that whenever it is allowed to convert `val`
+    /// into a shared reference, then it is also allowed to invoke this function.
     ///
     /// [trait object]: ../../book/ch17-02-trait-objects.html
     /// [extern type]: ../../unstable-book/language-features/extern-types.html
-    #[unstable(feature = "layout_for_ptr", issue = "69835")]
+    #[stable(feature = "layout_for_ptr", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "layout_for_ptr", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
-    pub const unsafe fn for_value_raw<T: ?Sized>(t: *const T) -> Self {
+    pub const unsafe fn for_value_raw<T: ?Sized>(val: *const T) -> Self {
         // SAFETY: we pass along the prerequisites of these functions to the caller
-        let (size, alignment) = unsafe { (mem::size_of_val_raw(t), Alignment::of_val_raw(t)) };
+        let (size, alignment) = unsafe { (mem::size_of_val_raw(val), Alignment::of_val_raw(val)) };
         // SAFETY: see rationale in `new` for why this is using the unsafe variant
         unsafe { Layout::from_size_alignment_unchecked(size, alignment) }
     }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -423,8 +423,8 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// This function is only safe to call if the following conditions hold:
 ///
 /// - If `T` is `Sized`, this function is always safe to call.
-/// - If the unsized tail of `T` is:
-///     - a [slice], then the length of the slice tail must be an initialized
+/// - If the *unsized tail* of `T` is:
+///     - a [slice] `[U]` or `str`, then the length of the slice tail must be an initialized
 ///       integer, and the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
 ///       For the special case where the dynamic tail length is 0, this function
@@ -433,15 +433,23 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 //        then we would stop compilation as even the "statically known" part of the type would
 //        already be too big (or the call may be in dead code and optimized away, but then it
 //        doesn't matter).
-///     - a [trait object], then the vtable part of the pointer must point
-///       to a valid vtable acquired by an unsizing coercion, and the size
+///     - a [trait object] `dyn Trait`, then the vtable part of the pointer must point
+///       to a valid vtable for `Trait`, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
 ///       must fit in `isize`.
 ///     - an (unstable) [extern type], then this function is always safe to
 ///       call, but may panic or otherwise return the wrong value, as the
 ///       extern type's layout is not known. This is the same behavior as
 ///       [`size_of_val`] on a reference to a type with an extern type tail.
-///     - otherwise, it is conservatively not allowed to call this function.
+///     - No other kind of unsized tail currently exists. If more kinds of unsized tails get
+///       introduced in the future, the documentation of this function will have to be extended
+///       before it can be used for such types.
+///
+/// Here, *unsized tail* refers to the type obtained by recursively descending through the last
+/// field of a tuple or struct until we arrived at a built-in unsized type.
+///
+/// As a consequence of these rules, it is the case that whenever it is allowed to convert `val`
+/// into a shared reference, then it is also allowed to invoke this function.
 ///
 /// [`size_of::<T>()`]: size_of
 /// [trait object]: ../../book/ch17-02-trait-objects.html
@@ -450,7 +458,6 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// # Examples
 ///
 /// ```
-/// #![feature(layout_for_ptr)]
 /// use std::mem;
 ///
 /// assert_eq!(4, size_of_val(&5i32));
@@ -461,7 +468,8 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// ```
 #[inline]
 #[must_use]
-#[unstable(feature = "layout_for_ptr", issue = "69835")]
+#[stable(feature = "layout_for_ptr", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_stable(feature = "layout_for_ptr", since = "CURRENT_RUSTC_VERSION")]
 pub const unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
     // SAFETY: the caller must provide a valid raw pointer
     unsafe { intrinsics::size_of_val(val) }
@@ -597,20 +605,32 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// - If `T` is `Sized`, this function is always safe to call.
 /// - If the unsized tail of `T` is:
-///     - a [slice], then the length of the slice tail must be an initialized
+///     - a [slice] `[U]` or `str`, then the length of the slice tail must be an initialized
 ///       integer, and the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
 ///       For the special case where the dynamic tail length is 0, this function
 ///       is safe to call.
-///     - a [trait object], then the vtable part of the pointer must point
-///       to a valid vtable acquired by an unsizing coercion, and the size
+//        NOTE: the reason this is safe is that if an overflow were to occur already with size 0,
+//        then we would stop compilation as even the "statically known" part of the type would
+//        already be too big (or the call may be in dead code and optimized away, but then it
+//        doesn't matter).
+///     - a [trait object] `dyn Trait`, then the vtable part of the pointer must point
+///       to a valid vtable for `Trait`, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
 ///       must fit in `isize`.
 ///     - an (unstable) [extern type], then this function is always safe to
 ///       call, but may panic or otherwise return the wrong value, as the
 ///       extern type's layout is not known. This is the same behavior as
 ///       [`align_of_val`] on a reference to a type with an extern type tail.
-///     - otherwise, it is conservatively not allowed to call this function.
+///     - No other kind of unsized tail currently exists. If more kinds of unsized tails get
+///       introduced in the future, the documentation of this function will have to be extended
+///       before it can be used for such types.
+///
+/// Here, *unsized tail* refers to the type obtained by recursively descending through the last
+/// field of a tuple or struct until we arrived at a built-in unsized type.
+///
+/// As a consequence of these rules, it is the case that whenever it is allowed to convert `val`
+/// into a shared reference, then it is also allowed to invoke this function.
 ///
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html
@@ -618,7 +638,6 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 /// # Examples
 ///
 /// ```
-/// #![feature(layout_for_ptr)]
 /// use std::mem;
 ///
 /// assert_eq!(4, unsafe { mem::align_of_val_raw(&5i32) });
@@ -630,7 +649,8 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 /// [type-layout]: ../../reference/type-layout.html#r-layout.primitive
 #[inline]
 #[must_use]
-#[unstable(feature = "layout_for_ptr", issue = "69835")]
+#[stable(feature = "layout_for_ptr", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_stable(feature = "layout_for_ptr", since = "CURRENT_RUSTC_VERSION")]
 pub const unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
     // SAFETY: the caller must provide a valid raw pointer
     unsafe { intrinsics::align_of_val(val) }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -437,13 +437,9 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///       to a valid vtable for `Trait`, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
 ///       must fit in `isize`.
-///     - an (unstable) [extern type], then this function is always safe to
-///       call, but may panic or otherwise return the wrong value, as the
-///       extern type's layout is not known. This is the same behavior as
-///       [`size_of_val`] on a reference to a type with an extern type tail.
-///     - No other kind of unsized tail currently exists. If more kinds of unsized tails get
-///       introduced in the future, the documentation of this function will have to be extended
-///       before it can be used for such types.
+///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
+///       function. If more kinds of unsized tails get introduced in the future, the documentation
+///       of this function will have to be extended before it can be used for such types.
 ///
 /// Here, *unsized tail* refers to the type obtained by recursively descending through the last
 /// field of a tuple or struct until we arrived at a built-in unsized type.
@@ -618,13 +614,9 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///       to a valid vtable for `Trait`, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
 ///       must fit in `isize`.
-///     - an (unstable) [extern type], then this function is always safe to
-///       call, but may panic or otherwise return the wrong value, as the
-///       extern type's layout is not known. This is the same behavior as
-///       [`align_of_val`] on a reference to a type with an extern type tail.
-///     - No other kind of unsized tail currently exists. If more kinds of unsized tails get
-///       introduced in the future, the documentation of this function will have to be extended
-///       before it can be used for such types.
+///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
+///       function. If more kinds of unsized tails get introduced in the future, the documentation
+///       of this function will have to be extended before it can be used for such types.
 ///
 /// Here, *unsized tail* refers to the type obtained by recursively descending through the last
 /// field of a tuple or struct until we arrived at a built-in unsized type.

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -424,8 +424,7 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// - If `T` is `Sized`, this function is always safe to call.
 /// - If the *unsized tail* of `T` is:
-///     - a [slice] `[U]` or `str`, then the length of the slice tail must be an initialized
-///       integer, and the size of the *entire value*
+///     - a [slice] `[U]`, `str`, or a [trait object] `dyn Trait`, then the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
 ///       For the special case where the dynamic tail length is 0, this function
 ///       is safe to call.
@@ -433,10 +432,6 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 //        then we would stop compilation as even the "statically known" part of the type would
 //        already be too big (or the call may be in dead code and optimized away, but then it
 //        doesn't matter).
-///     - a [trait object] `dyn Trait`, then the vtable part of the pointer must point
-///       to a valid vtable for `Trait`, and the size
-///       of the *entire value* (dynamic tail length + statically sized prefix)
-///       must fit in `isize`.
 ///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
 ///       function. If more kinds of unsized tails get introduced in the future, the documentation
 ///       of this function will have to be extended before it can be used for such types.
@@ -601,8 +596,7 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// - If `T` is `Sized`, this function is always safe to call.
 /// - If the unsized tail of `T` is:
-///     - a [slice] `[U]` or `str`, then the length of the slice tail must be an initialized
-///       integer, and the size of the *entire value*
+///     - a [slice] `[U]`, `str`, or a [trait object] `dyn Trait`, then the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
 ///       For the special case where the dynamic tail length is 0, this function
 ///       is safe to call.
@@ -610,10 +604,6 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 //        then we would stop compilation as even the "statically known" part of the type would
 //        already be too big (or the call may be in dead code and optimized away, but then it
 //        doesn't matter).
-///     - a [trait object] `dyn Trait`, then the vtable part of the pointer must point
-///       to a valid vtable for `Trait`, and the size
-///       of the *entire value* (dynamic tail length + statically sized prefix)
-///       must fit in `isize`.
 ///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
 ///       function. If more kinds of unsized tails get introduced in the future, the documentation
 ///       of this function will have to be extended before it can be used for such types.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -82,7 +82,6 @@
 #![feature(iter_partition_in_place)]
 #![feature(iterator_try_collect)]
 #![feature(iterator_try_reduce)]
-#![feature(layout_for_ptr)]
 #![feature(macro_metavar_expr_concat)]
 #![feature(maybe_uninit_fill)]
 #![feature(maybe_uninit_uninit_array_transpose)]

--- a/src/tools/miri/tests/pass/intrinsics/intrinsics.rs
+++ b/src/tools/miri/tests/pass/intrinsics/intrinsics.rs
@@ -1,6 +1,6 @@
 //@compile-flags: -Zmiri-permissive-provenance
 //@run-native
-#![feature(core_intrinsics, layout_for_ptr, ptr_metadata)]
+#![feature(core_intrinsics, ptr_metadata)]
 //! Tests for various intrinsics that do not fit anywhere else.
 
 use std::intrinsics;

--- a/src/tools/miri/tests/pass/issues/issue-3200-packed-field-offset.rs
+++ b/src/tools/miri/tests/pass/issues/issue-3200-packed-field-offset.rs
@@ -1,4 +1,3 @@
-#![feature(layout_for_ptr)]
 use std::mem;
 
 #[repr(packed, C)]

--- a/src/tools/miri/tests/pass/issues/issue-3200-packed2-field-offset.rs
+++ b/src/tools/miri/tests/pass/issues/issue-3200-packed2-field-offset.rs
@@ -1,4 +1,3 @@
-#![feature(layout_for_ptr)]
 use std::mem;
 
 #[repr(packed(4))]

--- a/src/tools/miri/tests/pass/issues/issue-miri-2123.rs
+++ b/src/tools/miri/tests/pass/issues/issue-miri-2123.rs
@@ -1,4 +1,4 @@
-#![feature(ptr_metadata, layout_for_ptr)]
+#![feature(ptr_metadata)]
 
 use std::{mem, ptr};
 

--- a/src/tools/miri/tests/pass/slices.rs
+++ b/src/tools/miri/tests/pass/slices.rs
@@ -3,7 +3,6 @@
 //@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 //@compile-flags: -Zmiri-strict-provenance
 #![feature(slice_partition_dedup)]
-#![feature(layout_for_ptr)]
 
 use std::{ptr, slice};
 

--- a/tests/ui/consts/const-size_of_val-align_of_val.rs
+++ b/tests/ui/consts/const-size_of_val-align_of_val.rs
@@ -1,7 +1,5 @@
 //@ run-pass
 
-#![feature(layout_for_ptr)]
-
 use std::{mem, ptr};
 
 struct Foo(#[allow(dead_code)] u32);

--- a/tests/ui/packed/issue-118537-field-offset-ice.rs
+++ b/tests/ui/packed/issue-118537-field-offset-ice.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-#![feature(layout_for_ptr)]
 use std::mem;
 
 #[repr(packed(4))]

--- a/tests/ui/packed/issue-118537-field-offset.rs
+++ b/tests/ui/packed/issue-118537-field-offset.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-#![feature(layout_for_ptr)]
 use std::mem;
 
 #[repr(packed, C)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157572)*
<!-- homu-ignore:end -->

Stabilizes versions of `size_of_val_raw` and friends that can be invoked on raw pointers, which means they can be used even if one does not have a pointer to a "valid value". This was held up for a while because figuring out the exact safety requirements is tricky, but I think the ones we now have had for a while (plus the minor clarifications in this PR) are "good enough": we basically do case distinction on the unsized tail of the type, and spell out the appropriate requirement for each case. This avoids making blanket statements about future kinds of DST that we may introduce eventually.

These are the requirements I should we should stabilize:

```
    /// - If `T` is `Sized`, this function is always safe to call.
    /// - If the unsized tail of `T` is:
    ///     - a [slice] `[U]`, `str`, or a [trait object] `dyn Trait`, then the size of the *entire value*
    ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
    ///       For the special case where the dynamic tail length is 0, this function
    ///       is safe to call.
    //        NOTE: the reason this is safe is that if an overflow were to occur already with size 0,
    //        then we would stop compilation as even the "statically known" part of the type would
    //        already be too big (or the call may be in dead code and optimized away, but then it
    //        doesn't matter).
    ///     - No other kind of unsized tail currently exists that satisfies the trait bounds for this
    ///       function. If more kinds of unsized tails get introduced in the future, the documentation
    ///       of this function will have to be extended before it can be used for such types.
```

Going over the open questions from the [tracking issue](https://github.com/rust-lang/rust/issues/69835):
-  What should the exact safety requirements of these functions be? -> the currently documented requirement look good to me.
- How should this interact with extern types? -> what we document looks good here; we can still adjust this until extern types are stabilized.
- Are the functions sound to call on invalid data pointers? -> for the unsized tails that currently exist: yes; that's kind of the only reason to use them.

Cc @rust-lang/opsem @rust-lang/lang
(FCP should probably include both teams, unless lang is okay with fully delegating this to t-opsem)
I'll nominate the tracking issue for libs-api so we can get their approval as well for how the operation is exposed.

Fixes https://github.com/rust-lang/rust/issues/69835
