### PR TITLE
avoid tearing `dbg!` prints, implemented using `super let`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -595,31 +595,38 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         });
         let Some(var_info) = var_info else { return };
         let arg_name = var_info.name;
-        struct MatchArgFinder {
-            expr_span: Span,
-            match_arg_span: Option<Span>,
+        struct DbgArgFinder<'tcx> {
+            tcx: TyCtxt<'tcx>,
+            move_span: Span,
             arg_name: Symbol,
+            dbg_arg_span: Option<Span> = None,
         }
-        impl Visitor<'_> for MatchArgFinder {
+        impl Visitor<'_> for DbgArgFinder<'_> {
             fn visit_expr(&mut self, e: &hir::Expr<'_>) {
-                // dbg! is expanded into a match pattern, we need to find the right argument span
-                if let hir::ExprKind::Match(expr, ..) = &e.kind
+                // dbg! is expanded into assignments, we need to find the right argument span
+                if let hir::ExprKind::Assign(_, arg, _) = &e.kind
                     && let hir::ExprKind::Path(hir::QPath::Resolved(
                         _,
                         path @ Path { segments: [seg], .. },
-                    )) = &expr.kind
+                    )) = &arg.kind
                     && seg.ident.name == self.arg_name
-                    && self.expr_span.source_callsite().contains(expr.span)
+                    && self.move_span.source_equal(arg.span)
+                    && e.span.macro_backtrace().any(|expn| {
+                        expn.macro_def_id.is_some_and(|macro_def_id| {
+                            self.tcx.is_diagnostic_item(sym::dbg_macro, macro_def_id)
+                        })
+                    })
                 {
-                    self.match_arg_span = Some(path.span);
+                    self.dbg_arg_span = Some(path.span);
+                    return;
                 }
                 hir::intravisit::walk_expr(self, e);
             }
         }
 
-        let mut finder = MatchArgFinder { expr_span: move_span, match_arg_span: None, arg_name };
+        let mut finder = DbgArgFinder { tcx: self.infcx.tcx, move_span, arg_name, .. };
         finder.visit_expr(body);
-        if let Some(macro_arg_span) = finder.match_arg_span {
+        if let Some(macro_arg_span) = finder.dbg_arg_span {
             err.span_suggestion_verbose(
                 macro_arg_span.shrink_to_lo(),
                 "consider borrowing instead of transferring ownership",

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -753,6 +753,7 @@ symbols! {
         custom_mir,
         custom_test_frameworks,
         d32,
+        dbg_macro,
         dead_code,
         dead_code_pub_in_binary,
         dealloc,

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -496,7 +496,9 @@ extern crate std as realstd;
 
 // The standard macros that are not built-in to the compiler.
 #[macro_use]
-mod macros;
+#[doc(hidden)]
+#[unstable(feature = "std_internals", issue = "none")]
+pub mod macros;
 
 // The runtime entry point and a few unstable public functions used by the
 // compiler

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -350,6 +350,7 @@ macro_rules! eprintln {
 /// [`debug!`]: https://docs.rs/log/*/log/macro.debug.html
 /// [`log`]: https://crates.io/crates/log
 #[macro_export]
+#[allow_internal_unstable(std_internals)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "dbg_macro")]
 #[stable(feature = "dbg_macro", since = "1.32.0")]
 macro_rules! dbg {
@@ -360,27 +361,67 @@ macro_rules! dbg {
     () => {
         $crate::eprintln!("[{}:{}:{}]", $crate::file!(), $crate::line!(), $crate::column!())
     };
-    ($val:expr $(,)?) => {
-        // Use of `match` here is intentional because it affects the lifetimes
-        // of temporaries - https://stackoverflow.com/a/48732525/1063961
-        match $val {
-            tmp => {
-                $crate::eprintln!("[{}:{}:{}] {} = {:#?}",
-                    $crate::file!(),
-                    $crate::line!(),
-                    $crate::column!(),
-                    $crate::stringify!($val),
-                    // The `&T: Debug` check happens here (not in the format literal desugaring)
-                    // to avoid format literal related messages and suggestions.
-                    &&tmp as &dyn $crate::fmt::Debug,
-                );
-                tmp
-            }
-        }
-    };
     ($($val:expr),+ $(,)?) => {
-        ($($crate::dbg!($val)),+,)
+        $crate::macros::dbg_internal!(() () ($($val),+))
     };
+}
+
+/// Internal macro that processes a list of expressions, binds their results, calls `eprint!` with
+/// the collected information, and returns all the evaluated expressions in a tuple.
+///
+/// E.g. `dbg_internal!(() () (1, 2))` expands into
+/// ```rust, ignore
+/// {
+///     let tmp_1;
+///     let tmp_2;
+///     super let _ = (tmp_1 = 1);
+///     super let _ = (tmp_2 = 2);
+///     eprint!("...", &tmp_1, &tmp_2, /* some other arguments */);
+///     (tmp_1, tmp_2)
+/// }
+/// ```
+///
+/// This is necessary so that `dbg!` outputs don't get torn, see #136703.
+/// `super let` is used to avoid creating a temporary scope around `dbg!`'s arguments. Nested
+/// `match` is insufficient because match arms introduce temporary scopes (#153850) and using a
+/// single match on a tuple containing all the arguments is insufficient because of an imprecision
+/// in the borrow-checker (see #155902).
+#[doc(hidden)]
+#[allow_internal_unstable(std_internals, super_let)]
+#[rustc_macro_transparency = "semiopaque"]
+#[unstable(feature = "std_internals", issue = "none")]
+pub macro dbg_internal {
+    (($($piece:literal),+) ($($processed:expr => $bound:ident),+) ()) => {{
+        $(let $bound);+;
+        $(super let _ = ($bound = $processed));+;
+        $crate::eprint!(
+            $crate::concat!($($piece),+),
+            $(
+                $crate::stringify!($processed),
+                // The `&T: Debug` check happens here (not in the format literal desugaring)
+                // to avoid format literal related messages and suggestions.
+                &&$bound as &dyn $crate::fmt::Debug
+            ),+,
+            // The location returned here is that of the macro invocation, so
+            // it will be the same for all expressions. Thus, label these
+            // arguments so that they can be reused in every piece of the
+            // formatting template.
+            file=$crate::file!(),
+            line=$crate::line!(),
+            column=$crate::column!()
+        );
+        // Comma separate the variables only when necessary so that this will
+        // not yield a tuple for a single expression, but rather just parenthesize
+        // the expression.
+        ($($bound),+)
+    }},
+    (($($piece:literal),*) ($($processed:expr => $bound:ident),*) ($val:expr $(,$rest:expr)*)) => {
+        $crate::macros::dbg_internal!(
+            ($($piece,)* "[{file}:{line}:{column}] {} = {:#?}\n")
+            ($($processed => $bound,)* $val => tmp)
+            ($($rest),*)
+        )
+    },
 }
 
 #[doc(hidden)]

--- a/src/tools/clippy/clippy_lints/src/dbg_macro.rs
+++ b/src/tools/clippy/clippy_lints/src/dbg_macro.rs
@@ -75,51 +75,61 @@ impl LateLintPass<'_> for DbgMacro {
                 "the `dbg!` macro is intended as a debugging tool",
                 |diag| {
                     let mut applicability = Applicability::MachineApplicable;
-                    let (sugg_span, suggestion) =
-                        match is_async_move_desugar(expr).unwrap_or(expr).peel_drop_temps().kind {
-                            // dbg!()
-                            ExprKind::Block(..) => {
-                                // If the `dbg!` macro is a "free" statement and not contained within other expressions,
-                                // remove the whole statement.
-                                if let Node::Stmt(_) = cx.tcx.parent_hir_node(expr.hir_id)
-                                    && let Some(semi_span) =
-                                        cx.sess().source_map().mac_call_stmt_semi_span(macro_call.span)
-                                {
-                                    (macro_call.span.to(semi_span), String::new())
-                                } else {
-                                    (macro_call.span, String::from("()"))
-                                }
-                            },
-                            // dbg!(1)
-                            ExprKind::Match(val, ..) => (
-                                macro_call.span,
+                    let dbg_expn = is_async_move_desugar(expr).unwrap_or(expr).peel_drop_temps();
+                    // `dbg!` always expands to a block. If it was given arguments, it assigns names to them
+                    // using `super let _ = (tmp = $arg);` statements.
+                    let ExprKind::Block(block, _) = dbg_expn.kind else {
+                        unreachable!()
+                    };
+                    let args: Vec<_> = block
+                        .stmts
+                        .iter()
+                        .filter_map(|stmt| {
+                            if let StmtKind::Let(LetStmt {
+                                super_: Some(_),
+                                init: Some(init),
+                                ..
+                            }) = stmt.kind
+                                && let ExprKind::Assign(_, arg, _) = init.kind
+                            {
+                                Some(arg)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
+                    let (sugg_span, suggestion) = match args.as_slice() {
+                        // dbg!()
+                        [] => {
+                            // If the `dbg!` macro is a "free" statement and not contained within other expressions,
+                            // remove the whole statement.
+                            if let Node::Stmt(_) = cx.tcx.parent_hir_node(expr.hir_id)
+                                && let Some(semi_span) = cx.sess().source_map().mac_call_stmt_semi_span(macro_call.span)
+                            {
+                                (macro_call.span.to(semi_span), String::new())
+                            } else {
+                                (macro_call.span, String::from("()"))
+                            }
+                        },
+                        // dbg!(1) => 1
+                        [val] => {
+                            let suggestion =
                                 snippet_with_applicability(cx, val.span.source_callsite(), "..", &mut applicability)
-                                    .to_string(),
-                            ),
-                            // dbg!(2, 3)
-                            ExprKind::Tup(
-                                [
-                                    Expr {
-                                        kind: ExprKind::Match(first, ..),
-                                        ..
-                                    },
-                                    ..,
-                                    Expr {
-                                        kind: ExprKind::Match(last, ..),
-                                        ..
-                                    },
-                                ],
-                            ) => {
-                                let snippet = snippet_with_applicability(
-                                    cx,
-                                    first.span.source_callsite().to(last.span.source_callsite()),
-                                    "..",
-                                    &mut applicability,
-                                );
-                                (macro_call.span, format!("({snippet})"))
-                            },
-                            _ => unreachable!(),
-                        };
+                                    .to_string();
+                            (macro_call.span, suggestion)
+                        },
+                        // dbg!(2, 3) => (2, 3)
+                        [first, .., last] => {
+                            let snippet = snippet_with_applicability(
+                                cx,
+                                first.span.source_callsite().to(last.span.source_callsite()),
+                                "..",
+                                &mut applicability,
+                            );
+                            (macro_call.span, format!("({snippet})"))
+                        },
+                    };
 
                     diag.span_suggestion(
                         sugg_span,

--- a/src/tools/clippy/clippy_utils/src/sym.rs
+++ b/src/tools/clippy/clippy_utils/src/sym.rs
@@ -202,7 +202,6 @@ generate! {
     cx,
     cycle,
     cyclomatic_complexity,
-    dbg_macro,
     de,
     debug_struct,
     deprecated_in_future,

--- a/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.stderr
+++ b/src/tools/miri/tests/fail/dangling_pointers/dangling_primitive.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: memory access failed: ALLOC has been freed, so this p
   --> tests/fail/dangling_pointers/dangling_primitive.rs:LL:CC
    |
 LL |         dbg!(*ptr);
-   |         ^^^^^^^^^^ Undefined Behavior occurred here
+   |              ^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/src/tools/miri/tests/fail/function_calls/return_pointer_on_unwind.stderr
+++ b/src/tools/miri/tests/fail/function_calls/return_pointer_on_unwind.stderr
@@ -7,7 +7,7 @@ error: Undefined Behavior: reading memory at ALLOC[0x0..0x4], but memory is unin
   --> tests/fail/function_calls/return_pointer_on_unwind.rs:LL:CC
    |
 LL |     dbg!(x.0);
-   |     ^^^^^^^^^ Undefined Behavior occurred here
+   |          ^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/ui/borrowck/dbg-issue-120327.rs
+++ b/tests/ui/borrowck/dbg-issue-120327.rs
@@ -1,67 +1,44 @@
+//! Diagnostic test for <https://github.com/rust-lang/rust/issues/120327>: suggest borrowing
+//! variables passed to `dbg!` that are later used.
+//@ dont-require-annotations: HELP
+
 fn s() -> String {
     let a = String::new();
-    dbg!(a);
+    dbg!(a); //~ HELP consider borrowing instead of transferring ownership
     return a; //~ ERROR use of moved value:
 }
 
 fn m() -> String {
     let a = String::new();
-    dbg!(1, 2, a, 1, 2);
+    dbg!(1, 2, a, 1, 2); //~ HELP consider borrowing instead of transferring ownership
     return a; //~ ERROR use of moved value:
 }
 
 fn t(a: String) -> String {
     let b: String = "".to_string();
-    dbg!(a, b);
+    dbg!(a, b); //~ HELP consider borrowing instead of transferring ownership
     return b; //~ ERROR use of moved value:
 }
 
 fn x(a: String) -> String {
     let b: String = "".to_string();
-    dbg!(a, b);
+    dbg!(a, b); //~ HELP consider borrowing instead of transferring ownership
     return a; //~ ERROR use of moved value:
 }
 
-macro_rules! my_dbg {
-    () => {
-        eprintln!("[{}:{}:{}]", file!(), line!(), column!())
-    };
-    ($val:expr $(,)?) => {
-        match $val {
-            tmp => {
-                eprintln!("[{}:{}:{}] {} = {:#?}",
-                    file!(), line!(), column!(), stringify!($val), &tmp);
-                tmp
-            }
-        }
-    };
-    ($($val:expr),+ $(,)?) => {
-        ($(my_dbg!($val)),+,)
-    };
-}
-
-fn test_my_dbg() -> String {
-    let b: String = "".to_string();
-    my_dbg!(b, 1);
-    return b; //~ ERROR use of moved value:
-}
-
-fn test_not_macro() -> String {
-    let a = String::new();
-    let _b = match a {
-        tmp => {
-            eprintln!("dbg: {}", tmp);
-            tmp
-        }
-    };
-    return a; //~ ERROR use of moved value:
+fn two_of_them(a: String) -> String {
+    dbg!(a, a); //~ ERROR use of moved value
+    //~| HELP consider borrowing instead of transferring ownership
+    //~| HELP consider borrowing instead of transferring ownership
+    return a; //~ ERROR use of moved value
 }
 
 fn get_expr(_s: String) {}
 
+// The suggestion is purely syntactic; applying it here will result in a type error.
 fn test() {
     let a: String = "".to_string();
-    let _res = get_expr(dbg!(a));
+    let _res = get_expr(dbg!(a)); //~ HELP consider borrowing instead of transferring ownership
     let _l = a.len(); //~ ERROR borrow of moved value
 }
 

--- a/tests/ui/borrowck/dbg-issue-120327.stderr
+++ b/tests/ui/borrowck/dbg-issue-120327.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `a`
-  --> $DIR/dbg-issue-120327.rs:4:12
+  --> $DIR/dbg-issue-120327.rs:8:12
    |
 LL |     let a = String::new();
    |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
@@ -14,7 +14,7 @@ LL |     dbg!(&a);
    |          +
 
 error[E0382]: use of moved value: `a`
-  --> $DIR/dbg-issue-120327.rs:10:12
+  --> $DIR/dbg-issue-120327.rs:14:12
    |
 LL |     let a = String::new();
    |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
@@ -29,7 +29,7 @@ LL |     dbg!(1, 2, &a, 1, 2);
    |                +
 
 error[E0382]: use of moved value: `b`
-  --> $DIR/dbg-issue-120327.rs:16:12
+  --> $DIR/dbg-issue-120327.rs:20:12
    |
 LL |     let b: String = "".to_string();
    |         - move occurs because `b` has type `String`, which does not implement the `Copy` trait
@@ -44,7 +44,7 @@ LL |     dbg!(a, &b);
    |             +
 
 error[E0382]: use of moved value: `a`
-  --> $DIR/dbg-issue-120327.rs:22:12
+  --> $DIR/dbg-issue-120327.rs:26:12
    |
 LL | fn x(a: String) -> String {
    |      - move occurs because `a` has type `String`, which does not implement the `Copy` trait
@@ -59,46 +59,40 @@ help: consider borrowing instead of transferring ownership
 LL |     dbg!(&a, b);
    |          +
 
-error[E0382]: use of moved value: `b`
-  --> $DIR/dbg-issue-120327.rs:46:12
-   |
-LL |             tmp => {
-   |             --- value moved here
-...
-LL |     let b: String = "".to_string();
-   |         - move occurs because `b` has type `String`, which does not implement the `Copy` trait
-LL |     my_dbg!(b, 1);
-LL |     return b;
-   |            ^ value used here after move
-   |
-help: consider borrowing instead of transferring ownership
-   |
-LL |     my_dbg!(&b, 1);
-   |             +
-help: borrow this binding in the pattern to avoid moving the value
-   |
-LL |             ref tmp => {
-   |             +++
-
 error[E0382]: use of moved value: `a`
-  --> $DIR/dbg-issue-120327.rs:57:12
+  --> $DIR/dbg-issue-120327.rs:33:12
    |
-LL |     let a = String::new();
-   |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
-LL |     let _b = match a {
-LL |         tmp => {
-   |         --- value moved here
+LL | fn two_of_them(a: String) -> String {
+   |                - move occurs because `a` has type `String`, which does not implement the `Copy` trait
+LL |     dbg!(a, a);
+   |     ---------- value moved here
 ...
 LL |     return a;
    |            ^ value used here after move
    |
-help: borrow this binding in the pattern to avoid moving the value
+help: consider borrowing instead of transferring ownership
    |
-LL |         ref tmp => {
-   |         +++
+LL |     dbg!(a, &a);
+   |             +
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/dbg-issue-120327.rs:30:5
+   |
+LL | fn two_of_them(a: String) -> String {
+   |                - move occurs because `a` has type `String`, which does not implement the `Copy` trait
+LL |     dbg!(a, a);
+   |     ^^^^^^^^^^
+   |     |
+   |     value moved here
+   |     value used here after move
+   |
+help: consider borrowing instead of transferring ownership
+   |
+LL |     dbg!(a, &a);
+   |             +
 
 error[E0382]: borrow of moved value: `a`
-  --> $DIR/dbg-issue-120327.rs:65:14
+  --> $DIR/dbg-issue-120327.rs:42:14
    |
 LL |     let a: String = "".to_string();
    |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait

--- a/tests/ui/borrowck/dbg-issue-120327.stderr
+++ b/tests/ui/borrowck/dbg-issue-120327.stderr
@@ -4,10 +4,14 @@ error[E0382]: use of moved value: `a`
 LL |     let a = String::new();
    |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
 LL |     dbg!(a);
-   |     ------- value moved here
+   |          - value moved here
 LL |     return a;
    |            ^ value used here after move
    |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     dbg!(a.clone());
+   |           ++++++++
 help: consider borrowing instead of transferring ownership
    |
 LL |     dbg!(&a);
@@ -19,10 +23,14 @@ error[E0382]: use of moved value: `a`
 LL |     let a = String::new();
    |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
 LL |     dbg!(1, 2, a, 1, 2);
-   |     ------------------- value moved here
+   |                - value moved here
 LL |     return a;
    |            ^ value used here after move
    |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     dbg!(1, 2, a.clone(), 1, 2);
+   |                 ++++++++
 help: consider borrowing instead of transferring ownership
    |
 LL |     dbg!(1, 2, &a, 1, 2);
@@ -34,10 +42,14 @@ error[E0382]: use of moved value: `b`
 LL |     let b: String = "".to_string();
    |         - move occurs because `b` has type `String`, which does not implement the `Copy` trait
 LL |     dbg!(a, b);
-   |     ---------- value moved here
+   |             - value moved here
 LL |     return b;
    |            ^ value used here after move
    |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     dbg!(a, b.clone());
+   |              ++++++++
 help: consider borrowing instead of transferring ownership
    |
 LL |     dbg!(a, &b);
@@ -50,13 +62,36 @@ LL | fn x(a: String) -> String {
    |      - move occurs because `a` has type `String`, which does not implement the `Copy` trait
 LL |     let b: String = "".to_string();
 LL |     dbg!(a, b);
-   |     ---------- value moved here
+   |          - value moved here
 LL |     return a;
    |            ^ value used here after move
    |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     dbg!(a.clone(), b);
+   |           ++++++++
 help: consider borrowing instead of transferring ownership
    |
 LL |     dbg!(&a, b);
+   |          +
+
+error[E0382]: use of moved value: `a`
+  --> $DIR/dbg-issue-120327.rs:30:13
+   |
+LL | fn two_of_them(a: String) -> String {
+   |                - move occurs because `a` has type `String`, which does not implement the `Copy` trait
+LL |     dbg!(a, a);
+   |          -  ^ value used here after move
+   |          |
+   |          value moved here
+   |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     dbg!(a.clone(), a);
+   |           ++++++++
+help: consider borrowing instead of transferring ownership
+   |
+LL |     dbg!(&a, a);
    |          +
 
 error[E0382]: use of moved value: `a`
@@ -65,27 +100,15 @@ error[E0382]: use of moved value: `a`
 LL | fn two_of_them(a: String) -> String {
    |                - move occurs because `a` has type `String`, which does not implement the `Copy` trait
 LL |     dbg!(a, a);
-   |     ---------- value moved here
+   |             - value moved here
 ...
 LL |     return a;
    |            ^ value used here after move
    |
-help: consider borrowing instead of transferring ownership
+help: consider cloning the value if the performance cost is acceptable
    |
-LL |     dbg!(a, &a);
-   |             +
-
-error[E0382]: use of moved value: `a`
-  --> $DIR/dbg-issue-120327.rs:30:5
-   |
-LL | fn two_of_them(a: String) -> String {
-   |                - move occurs because `a` has type `String`, which does not implement the `Copy` trait
-LL |     dbg!(a, a);
-   |     ^^^^^^^^^^
-   |     |
-   |     value moved here
-   |     value used here after move
-   |
+LL |     dbg!(a, a.clone());
+   |              ++++++++
 help: consider borrowing instead of transferring ownership
    |
 LL |     dbg!(a, &a);
@@ -97,10 +120,14 @@ error[E0382]: borrow of moved value: `a`
 LL |     let a: String = "".to_string();
    |         - move occurs because `a` has type `String`, which does not implement the `Copy` trait
 LL |     let _res = get_expr(dbg!(a));
-   |                         ------- value moved here
+   |                              - value moved here
 LL |     let _l = a.len();
    |              ^ value borrowed here after move
    |
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     let _res = get_expr(dbg!(a.clone()));
+   |                               ++++++++
 help: consider borrowing instead of transferring ownership
    |
 LL |     let _res = get_expr(dbg!(&a));

--- a/tests/ui/liveness/liveness-upvars.rs
+++ b/tests/ui/liveness/liveness-upvars.rs
@@ -99,7 +99,7 @@ pub fn g<T: Default>(mut v: T) {
 }
 
 pub fn h<T: Copy + Default + std::fmt::Debug>() {
-    let mut z = T::default();
+    let mut z = T::default(); //~ WARN unused variable: `z`
     let _ = move |b| {
         loop {
             if b {

--- a/tests/ui/liveness/liveness-upvars.stderr
+++ b/tests/ui/liveness/liveness-upvars.stderr
@@ -157,6 +157,14 @@ LL |                 z = T::default();
    |
    = help: maybe it is overwritten before being read?
 
+warning: unused variable: `z`
+  --> $DIR/liveness-upvars.rs:102:9
+   |
+LL |     let mut z = T::default();
+   |         ^^^^^ help: if this is intentional, prefix it with an underscore: `_z`
+   |
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+
 warning: value captured by `state` is never read
   --> $DIR/liveness-upvars.rs:132:9
    |
@@ -198,5 +206,5 @@ LL |         s = yield ();
 LL |         s = 3;
    |         ----- `s` is overwritten here before the previous value is read
 
-warning: 24 warnings emitted
+warning: 25 warnings emitted
 

--- a/tests/ui/mismatched_types/mismatched-types-issue-126222.fixed
+++ b/tests/ui/mismatched_types/mismatched-types-issue-126222.fixed
@@ -12,7 +12,7 @@ fn main() {
     fn mismatch_types2() -> i32 {
         match 2 {
             x => {
-                return dbg!(x) //~ ERROR mismatched types
+                return dbg!(x); //~ ERROR mismatched types
             }
         }
         todo!()
@@ -27,7 +27,7 @@ fn main() {
 
     fn mismatch_types4() -> i32 {
         match 1 {
-            _ => {return dbg!(1)} //~ ERROR mismatched types
+            _ => {return dbg!(1);} //~ ERROR mismatched types
         }
         todo!()
     }

--- a/tests/ui/mismatched_types/mismatched-types-issue-126222.stderr
+++ b/tests/ui/mismatched_types/mismatched-types-issue-126222.stderr
@@ -1,8 +1,11 @@
 error[E0308]: mismatched types
   --> $DIR/mismatched-types-issue-126222.rs:7:18
    |
-LL |             x => dbg!(x),
-   |                  ^^^^^^^ expected `()`, found integer
+LL | /         match 1 {
+LL | |             x => dbg!(x),
+   | |                  ^^^^^^^ expected `()`, found integer
+LL | |         }
+   | |_________- expected this to be `()`
    |
 help: you might have meant to return this value
    |
@@ -12,19 +15,27 @@ LL |             x => return dbg!(x),
 error[E0308]: mismatched types
   --> $DIR/mismatched-types-issue-126222.rs:15:17
    |
-LL |                 dbg!(x)
-   |                 ^^^^^^^ expected `()`, found integer
+LL | /         match 2 {
+LL | |             x => {
+LL | |                 dbg!(x)
+   | |                 ^^^^^^^ expected `()`, found integer
+LL | |             }
+LL | |         }
+   | |_________- expected this to be `()`
    |
 help: you might have meant to return this value
    |
-LL |                 return dbg!(x)
-   |                 ++++++
+LL |                 return dbg!(x);
+   |                 ++++++        +
 
 error[E0308]: mismatched types
   --> $DIR/mismatched-types-issue-126222.rs:23:18
    |
-LL |             _ => dbg!(1)
-   |                  ^^^^^^^ expected `()`, found integer
+LL | /         match 1 {
+LL | |             _ => dbg!(1)
+   | |                  ^^^^^^^ expected `()`, found integer
+LL | |         }
+   | |_________- expected this to be `()`
    |
 help: you might have meant to return this value
    |
@@ -34,13 +45,16 @@ LL |             _ => return dbg!(1)
 error[E0308]: mismatched types
   --> $DIR/mismatched-types-issue-126222.rs:30:19
    |
-LL |             _ => {dbg!(1)}
-   |                   ^^^^^^^ expected `()`, found integer
+LL | /         match 1 {
+LL | |             _ => {dbg!(1)}
+   | |                   ^^^^^^^ expected `()`, found integer
+LL | |         }
+   | |_________- expected this to be `()`
    |
 help: you might have meant to return this value
    |
-LL |             _ => {return dbg!(1)}
-   |                   ++++++
+LL |             _ => {return dbg!(1);}
+   |                   ++++++        +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-move-semantics.stderr
+++ b/tests/ui/rfcs/rfc-2361-dbg-macro/dbg-macro-move-semantics.stderr
@@ -1,13 +1,21 @@
 error[E0382]: use of moved value: `a`
-  --> $DIR/dbg-macro-move-semantics.rs:9:13
+  --> $DIR/dbg-macro-move-semantics.rs:9:18
    |
 LL |     let a = NoCopy(0);
    |         - move occurs because `a` has type `NoCopy`, which does not implement the `Copy` trait
 LL |     let _ = dbg!(a);
-   |             ------- value moved here
+   |                  - value moved here
 LL |     let _ = dbg!(a);
-   |             ^^^^^^^ value used here after move
+   |                  ^ value used here after move
    |
+note: if `NoCopy` implemented `Clone`, you could clone the value
+  --> $DIR/dbg-macro-move-semantics.rs:4:1
+   |
+LL | struct NoCopy(usize);
+   | ^^^^^^^^^^^^^ consider implementing `Clone` for this type
+...
+LL |     let _ = dbg!(a);
+   |                  - you could clone this value
 help: consider borrowing instead of transferring ownership
    |
 LL |     let _ = dbg!(&a);


### PR DESCRIPTION
Fixes rust-lang/rust#136703.

This is a revival of rust-lang/rust#149869 using the approach from rust-lang/rust#155915. `super let` statements aren't the cleanest for this in their current state (it required a bit of trickery), but I'll be working on making temporary scoping in macros nicer soon.

r? libs