### PR TITLE
Fix diagnostics for non-exhaustive destructuring assignments (#157553)

### DIFF
--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -1241,12 +1241,14 @@ pub(crate) struct PatternNotCovered<'s, 'tcx> {
     pub(crate) misc_suggestion: Option<MiscPatternSuggestion>,
 }
 
-#[derive(Subdiagnostic)]
+#[derive(Subdiagnostic, Debug)]
 #[note(
-    "`let` bindings require an \"irrefutable pattern\", like a `struct` or an `enum` with only one variant"
+    "{$descr} require an \"irrefutable pattern\", like a `struct` or an `enum` with only one variant"
 )]
 #[note("for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html")]
-pub(crate) struct Inform;
+pub(crate) struct Inform {
+    pub(crate) descr: &'static str,
+}
 
 #[derive(Subdiagnostic)]
 #[label(

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -60,7 +60,7 @@ pub(crate) fn check_match(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), Err
 
     for param in thir.params.iter() {
         if let Some(ref pattern) = param.pat {
-            visitor.check_binding_is_irrefutable(pattern, origin, None, None);
+            visitor.check_binding_is_irrefutable(pattern, origin, None, None, None);
         }
     }
     visitor.error
@@ -436,7 +436,29 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         assert!(self.let_source != LetSource::None);
         let scrut = scrutinee.map(|id| &self.thir[id]);
         if let LetSource::PlainLet = self.let_source {
-            self.check_binding_is_irrefutable(pat, "local binding", scrut, Some(span));
+            // `lhs = rhs` destructuring assignments are lowered to a `let` tagged
+            // `AssignDesugar`; report them as assignments, not `let` bindings (#157553).
+            if let hir::Node::LetStmt(&hir::LetStmt {
+                source: hir::LocalSource::AssignDesugar,
+                ..
+            }) = self.tcx.hir_node(self.hir_source)
+            {
+                self.check_binding_is_irrefutable(
+                    pat,
+                    "assignment",
+                    Some(Inform { descr: "destructuring assignments" }),
+                    scrut,
+                    None,
+                );
+            } else {
+                self.check_binding_is_irrefutable(
+                    pat,
+                    "local binding",
+                    Some(Inform { descr: "`let` bindings" }),
+                    scrut,
+                    Some(span),
+                );
+            }
         } else if let Ok(Irrefutable) = self.is_let_irrefutable(pat, scrut) {
             if span.from_expansion() {
                 self.lint_single_let(span, None, None);
@@ -539,6 +561,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
                 self.check_binding_is_irrefutable(
                     &pat_field.pattern,
                     "`for` loop binding",
+                    None,
                     None,
                     None,
                 );
@@ -645,6 +668,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         &mut self,
         pat: &'p Pat<'tcx>,
         origin: &str,
+        inform: Option<Inform>,
         scrut: Option<&Expr<'tcx>>,
         sp: Option<Span>,
     ) {
@@ -657,7 +681,6 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             return;
         }
 
-        let inform = sp.is_some().then_some(Inform);
         let mut let_suggestion = None;
         let mut misc_suggestion = None;
         let mut interpreted_as_const = None;

--- a/tests/ui/destructuring-assignment/non-exhaustive-destructure.rs
+++ b/tests/ui/destructuring-assignment/non-exhaustive-destructure.rs
@@ -1,4 +1,4 @@
 fn main() {
     None = Some(3);
-    //~^ ERROR refutable pattern in local binding
+    //~^ ERROR refutable pattern in assignment
 }

--- a/tests/ui/destructuring-assignment/refutable-enum-assignment.rs
+++ b/tests/ui/destructuring-assignment/refutable-enum-assignment.rs
@@ -1,0 +1,11 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/157553>.
+
+enum Foo {
+    One,
+    Two,
+}
+
+fn main() {
+    Foo::One = Foo::One;
+    //~^ ERROR refutable pattern in assignment
+}

--- a/tests/ui/destructuring-assignment/refutable-enum-assignment.stderr
+++ b/tests/ui/destructuring-assignment/refutable-enum-assignment.stderr
@@ -1,12 +1,20 @@
 error[E0005]: refutable pattern in assignment
-  --> $DIR/non-exhaustive-destructure.rs:2:5
+  --> $DIR/refutable-enum-assignment.rs:9:5
    |
-LL |     None = Some(3);
-   |     ^^^^ pattern `Some(_)` not covered
+LL |     Foo::One = Foo::One;
+   |     ^^^^^^^^ pattern `Foo::Two` not covered
    |
    = note: destructuring assignments require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
-   = note: the matched value is of type `Option<i32>`
+note: `Foo` defined here
+  --> $DIR/refutable-enum-assignment.rs:3:6
+   |
+LL | enum Foo {
+   |      ^^^
+LL |     One,
+LL |     Two,
+   |     --- not covered
+   = note: the matched value is of type `Foo`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Assigning to a refutable pattern (e.g. `Foo::One = Foo::One;`) is a destructuring assignment, which is lowered to a `let` binding. When the pattern was refutable, the refutability check reported it as a `let` binding. This detects the `AssignDesugar` origin during match checking and reports it as an assignment instead, dropping the `let`-specific note and suggestion.

Fixes rust-lang/rust#157553.