### PR TITLE
Importing suggestion reported twice when reporting privacy error

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2307,7 +2307,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
 
         self.mention_default_field_values(source, ident, &mut err);
 
-        if let Some((this_res, outer_ident)) = outermost_res {
+        let shown_candidates = if let Some((this_res, outer_ident)) = outermost_res {
             let mut import_suggestions = self.lookup_import_candidates(
                 outer_ident,
                 this_res.ns().unwrap_or(Namespace::TypeNS),
@@ -2338,7 +2338,10 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 };
                 err.subdiagnostic(label);
             }
-        }
+            !point_to_def
+        } else {
+            false
+        };
 
         let mut non_exhaustive = None;
         // If an ADT is foreign and marked as `non_exhaustive`, then that's
@@ -2476,8 +2479,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         // 2) the use isn't nested, otherwise `dedup_span` is one ident in `{...}`.
         //
         // See issue #156060.
-        let can_replace_use =
-            !single_nested && !outermost_res.is_some_and(|(_, outer)| outer.span != ident.span);
+        let can_replace_use = !shown_candidates
+            && !single_nested
+            && !outermost_res.is_some_and(|(_, outer)| outer.span != ident.span);
         if can_replace_use {
             // We prioritize shorter paths, non-core imports and direct imports over the
             // alternatives.

--- a/tests/ui/resolve/import-suggestion-duplicated-importing-same-item.rs
+++ b/tests/ui/resolve/import-suggestion-duplicated-importing-same-item.rs
@@ -1,0 +1,16 @@
+mod A {
+    pub struct A;
+    //~^ NOTE ...and refers to the unit struct `A` which is defined here
+    //~| NOTE you could import this directly
+}
+
+mod B {
+    use crate::A::A;
+    //~^ NOTE the unit struct import `A` is defined here...
+}
+
+fn main() {
+    B::A;
+    //~^ ERROR unit struct import `A` is private [E0603]
+    //~| NOTE private unit struct import
+}

--- a/tests/ui/resolve/import-suggestion-duplicated-importing-same-item.stderr
+++ b/tests/ui/resolve/import-suggestion-duplicated-importing-same-item.stderr
@@ -1,0 +1,25 @@
+error[E0603]: unit struct import `A` is private
+  --> $DIR/import-suggestion-duplicated-importing-same-item.rs:13:8
+   |
+LL |     B::A;
+   |        ^ private unit struct import
+   |
+note: the unit struct import `A` is defined here...
+  --> $DIR/import-suggestion-duplicated-importing-same-item.rs:8:9
+   |
+LL |     use crate::A::A;
+   |         ^^^^^^^^^^^
+note: ...and refers to the unit struct `A` which is defined here
+  --> $DIR/import-suggestion-duplicated-importing-same-item.rs:2:5
+   |
+LL |     pub struct A;
+   |     ^^^^^^^^^^^^^ you could import this directly
+help: consider importing this unit struct instead
+   |
+LL -     B::A;
+LL +     A::A;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0603`.


### PR DESCRIPTION
cc rust-lang/rust#157454

This is a first fix proposal

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
