### PR TITLE
Use `mul nuw nsw` in `intrinsics::copy`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -27,7 +27,7 @@ fn copy_intrinsic<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     let layout = bx.layout_of(ty);
     let size = layout.size;
     let align = layout.align.abi;
-    let size = bx.mul(bx.const_usize(size.bytes()), count);
+    let size = bx.unchecked_sumul(bx.const_usize(size.bytes()), count);
     let flags = if volatile { MemFlags::VOLATILE } else { MemFlags::empty() };
     if allow_overlap {
         bx.memmove(dst, align, src, align, size, flags);

--- a/tests/codegen-llvm/copy.rs
+++ b/tests/codegen-llvm/copy.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
+//@ only-64bit (so I don't need to worry about usize)
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+// This deals in a count of elements, not bytes, so we need to multiply.
+// Ensure we preserve UB from a count too high to be valid.
+use std::intrinsics::copy;
+
+// CHECK-LABEL: @copy_u16(
+#[no_mangle]
+pub unsafe fn copy_u16(src: *const u16, dst: *mut u16, count: usize) {
+    // CHECK: [[BYTES:%.+]] = mul nuw nsw i64 2, %count
+    // CHECK: call void @llvm.memmove.p0.p0.i64(ptr align 2 %dst, ptr align 2 %src, i64 [[BYTES]], i1 false)
+    copy(src, dst, count)
+}


### PR DESCRIPTION
Essentially the same as rust-lang/rust#157560, just for `copy` instead of `copy_nonoverlapping`.

> Yeah, in fact both copy and copy_nonoverlapping could use this since we know the result must be at most isize::MAX else it cannot be inbounds.
> ~ https://github.com/rust-lang/rust/pull/157560#issuecomment-4642072687

r? saethlin 
