### PR TITLE
Suggest comma multiple

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -30,8 +30,8 @@ use thin_vec::ThinVec;
 
 use crate::ShouldEmit;
 use crate::session_diagnostics::{
-    ExpectedComma, InvalidMetaItem, InvalidMetaItemQuoteIdentSugg, InvalidMetaItemRemoveNegSugg,
-    MetaBadDelim, MetaBadDelimSugg, SuffixedLiteralInAttribute,
+    AdditionalCommaSuggestion, ExpectedComma, InvalidMetaItem, InvalidMetaItemQuoteIdentSugg,
+    InvalidMetaItemRemoveNegSugg, MetaBadDelim, MetaBadDelimSugg, SuffixedLiteralInAttribute,
 };
 
 #[derive(Clone, Debug)]
@@ -713,15 +713,30 @@ impl<'a, 'sess> MetaItemListParserContext<'a, 'sess> {
 
         let mut snapshot = self.parser.create_snapshot_for_diagnostic();
         if matches!(self.should_emit, ShouldEmit::ErrorsAndLints { recovery: Recovery::Allowed }) {
-            let span = self.parser.prev_token.span.shrink_to_hi();
-            self.should_emit = ShouldEmit::Nothing;
-            match self.parse_meta_item_inner() {
-                Ok(_) => {
-                    return Err(self.parser.dcx().create_err(ExpectedComma { span }));
+            let mut missing_commas = ThinVec::new();
+            let mut found_comma = false;
+            while self.parser.token != token::Eof {
+                let span = self.parser.prev_token.span.shrink_to_hi();
+                self.should_emit = ShouldEmit::Nothing;
+                match self.parse_meta_item_inner() {
+                    Ok(_) => {
+                        if !found_comma {
+                            missing_commas.push(span);
+                        }
+                    }
+                    Err(e) => {
+                        e.cancel();
+                        break;
+                    }
                 }
-                Err(e) => {
-                    e.cancel();
-                }
+                found_comma = self.parser.eat(exp!(Comma));
+            }
+
+            let mut missing_commas = missing_commas.into_iter();
+            if let Some(span) = missing_commas.next() {
+                let additional =
+                    missing_commas.map(|span| AdditionalCommaSuggestion { span }).collect();
+                return Err(self.parser.dcx().create_err(ExpectedComma { span, additional }));
             }
         }
         snapshot.unexpected_any()

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -1044,4 +1044,13 @@ pub(crate) struct ExpectedComma {
         style = "short"
     )]
     pub span: Span,
+    #[subdiagnostic]
+    pub additional: Vec<AdditionalCommaSuggestion>,
+}
+
+#[derive(Subdiagnostic)]
+#[suggestion("try adding `,` here", code = ",", applicability = "maybe-incorrect", style = "short")]
+pub(crate) struct AdditionalCommaSuggestion {
+    #[primary_span]
+    pub span: Span,
 }

--- a/tests/ui/parser/attribute/attr-missing-comma.rs
+++ b/tests/ui/parser/attribute/attr-missing-comma.rs
@@ -1,0 +1,7 @@
+fn main() {}
+
+#[deprecated(
+    since = "since" //~ ERROR attribute items not separated with `,`
+    note = "note"
+)]
+fn f0() {}

--- a/tests/ui/parser/attribute/attr-missing-comma.rs
+++ b/tests/ui/parser/attribute/attr-missing-comma.rs
@@ -5,3 +5,10 @@ fn main() {}
     note = "note"
 )]
 fn f0() {}
+
+#[link(
+    name = "name" //~ ERROR attribute items not separated with `,`
+    kind = "static"
+    modifiers = "modifiers"
+)]
+fn f1() {}

--- a/tests/ui/parser/attribute/attr-missing-comma.stderr
+++ b/tests/ui/parser/attribute/attr-missing-comma.stderr
@@ -1,0 +1,8 @@
+error: attribute items not separated with `,`
+  --> $DIR/attr-missing-comma.rs:4:20
+   |
+LL |     since = "since"
+   |                    ^ help: try adding `,` here
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/attribute/attr-missing-comma.stderr
+++ b/tests/ui/parser/attribute/attr-missing-comma.stderr
@@ -4,5 +4,20 @@ error: attribute items not separated with `,`
 LL |     since = "since"
    |                    ^ help: try adding `,` here
 
-error: aborting due to 1 previous error
+error: attribute items not separated with `,`
+  --> $DIR/attr-missing-comma.rs:10:18
+   |
+LL |     name = "name"
+   |                  ^
+   |
+help: try adding `,` here
+   |
+LL |     name = "name",
+   |                  +
+help: try adding `,` here
+   |
+LL |     kind = "static",
+   |                    +
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Following from rust-lang/rust#157545

If there are multiple missing comma's, suggest fixing all of them in one step to avoid error cascade.

For example:
```
error: attribute items not separated with `,`
   |
LL |     name = "name"
   |                  ^ help: try adding `,` here
```
followed by
```
error: attribute items not separated with `,`
   |
LL |     kind = "static"
   |                    ^ help: try adding `,` here
```
after adding the comma.

Now this becomes one error:
```
error: attribute items not separated with `,`
  --> $DIR/attr-missing-comma.rs:10:18
   |
LL |     name = "name"
   |                  ^
   |
help: try adding `,` here
   |
LL |     name = "name",
   |                  +
help: try adding `,` here
   |
LL |     kind = "static",
   |                    +
```
