### PR TITLE
Fix the spans for custom inner attributes.

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -793,7 +793,10 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                     )
                                 ) =>
                         {
-                            rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)
+                            rustc_parse::fake_token_stream_for_out_of_line_module(
+                                &self.cx.sess.psess,
+                                item_inner,
+                            )
                         }
                         Annotatable::Item(item_inner) if item_inner.tokens.is_none() => {
                             rustc_parse::fake_token_stream_for_item(&self.cx.sess.psess, item_inner)

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -789,7 +789,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                         _,
                                         _,
                                         ModKind::Unloaded
-                                            | ModKind::Loaded(_, Inline::No { .. }, _),
+                                            | ModKind::Loaded(_, Inline::No { .. }, _), // Only for out of line modules, as inline modules don't need a fake token stream, as they have already been parsed before.
                                     )
                                 ) =>
                         {

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -261,7 +261,6 @@ pub fn fake_token_stream_for_out_of_line_module(
     item: &ast::Item,
 ) -> TokenStream {
     let ItemKind::Mod(_, _, mod_kind) = &item.kind else { panic!() };
-    // FIXME: Perhaps we should load the module if it is unloaded, instead of panicking?
     let ModKind::Loaded(_, _, mod_spans) = mod_kind else { panic!() };
 
     let inner_span = mod_spans.inner_span;

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -256,18 +256,66 @@ pub fn fake_token_stream_for_item(psess: &ParseSess, item: &ast::Item) -> TokenS
     unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, Some(item.span)))
 }
 
+#[allow(unused)]
 pub fn fake_token_stream_for_out_of_line_module(
     psess: &ParseSess,
     item: &ast::Item,
 ) -> TokenStream {
-    let ItemKind::Mod(_, _, mod_kind) = &item.kind else { panic!() };
-    let ModKind::Loaded(_, _, mod_spans) = mod_kind else { panic!() };
+    if item.tokens.is_some() {
+        panic!("Gained.")
+    } else {
+        let ItemKind::Mod(_, _, mod_kind) = &item.kind else { panic!() };
+        let ModKind::Loaded(items, _, mod_spans) = mod_kind else { panic!() };
 
-    let inner_span = mod_spans.inner_span;
-    let filename = psess.source_map().span_to_filename(inner_span);
+        let inner_span = mod_spans.inner_span;
+        let filename = psess.source_map().span_to_filename(inner_span);
 
-    let source = pprust::item_to_string(item);
-    unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, None))
+        let source_file = psess.source_map().get_source_file(&filename).unwrap();
+
+        let source_weird =
+            source_file.src.as_ref().unwrap().as_str().split_once('\n').unwrap().1.to_owned();
+        //panic!("{source_weird}");
+
+        //let source = pprust::item_to_string(item);
+        //panic!("{source}");
+        //unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, None))
+        //unwrap_or_emit_fatal(source_file_to_stream(psess, source_file, None, StripTokens::Shebang))
+
+        /*
+        self.print_inner_attributes(&item.attrs);
+        for item in items {
+            self.print_item(item);
+        }
+        */
+
+        let mut source_new = String::new();
+        for attribute in &item.attrs {
+            if attribute.style == ast::AttrStyle::Inner {
+                source_new += &pprust::attribute_to_string(attribute);
+                //source_new += "\n";
+            }
+        }
+        for item in items {
+            source_new += &pprust::item_to_string(item);
+            //source_new += "\n";
+        }
+
+        let source = pprust::item_to_string(item);
+
+        //panic!("SOURCE\n{source}\nSOURCE NEW\n{source_new}");
+
+        unwrap_or_emit_fatal(lexer::lex_token_trees(
+            psess,
+            &source_weird,
+            source_file.start_pos,
+            None,
+            StripTokens::Shebang,
+        ))
+    }
+
+    //if let Some()
+    //let token_stream = TokenStream::from_ast(item);
+    //panic!("{token_stream:?}");
 }
 
 pub fn fake_token_stream_for_foreign_item(

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -13,9 +13,8 @@ use std::path::{Path, PathBuf};
 use std::str::Utf8Error;
 use std::sync::Arc;
 
-use rustc_ast as ast;
-use rustc_ast::token;
 use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::{self as ast, ItemKind, ModKind, token};
 use rustc_ast_pretty::pprust;
 use rustc_errors::{Diag, EmissionGuarantee, FatalError, PResult, pluralize};
 pub use rustc_lexer::UNICODE_VERSION;
@@ -255,6 +254,21 @@ pub fn fake_token_stream_for_item(psess: &ParseSess, item: &ast::Item) -> TokenS
     let source = pprust::item_to_string(item);
     let filename = FileName::macro_expansion_source_code(&source);
     unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, Some(item.span)))
+}
+
+pub fn fake_token_stream_for_out_of_line_module(
+    psess: &ParseSess,
+    item: &ast::Item,
+) -> TokenStream {
+    let ItemKind::Mod(_, _, mod_kind) = &item.kind else { panic!() };
+    // FIXME: Perhaps we should load the module if it is unloaded, instead of panicking?
+    let ModKind::Loaded(_, _, mod_spans) = mod_kind else { panic!() };
+
+    let inner_span = mod_spans.inner_span;
+    let filename = psess.source_map().span_to_filename(inner_span);
+
+    let source = pprust::item_to_string(item);
+    unwrap_or_emit_fatal(source_str_to_stream(psess, filename, source, None))
 }
 
 pub fn fake_token_stream_for_foreign_item(

--- a/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans-module.rs
+++ b/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans-module.rs
@@ -1,0 +1,2 @@
+#![custom_inner_attribute_spans::check_spans]
+fn garlic() {}

--- a/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans-module.rs
+++ b/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans-module.rs
@@ -1,2 +1,9 @@
 #![custom_inner_attribute_spans::check_spans]
-fn garlic() {}
+//#![custom_inner_attribute_spans::check_spans]
+
+fn garlic() {
+    let bad = 0;
+    bad = 1;
+}
+
+trait Brains {}

--- a/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans.rs
+++ b/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans.rs
@@ -4,15 +4,15 @@ use proc_macro::{TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn check_spans(_: TokenStream, item: TokenStream) -> TokenStream {
-    let mut item = item.into_iter();
+    let mut item_iterator = item.clone().into_iter();
 
     for _ in 0..4 {
-        item.next().unwrap();
+        item_iterator.next().unwrap();
     }
 
-    let span = item.next().unwrap().span();
+    let span = item_iterator.next().unwrap().span();
     let file = span.file();
 
     assert!(file.contains("auxiliary/custom-inner-attribute-spans-module.rs"));
-    TokenStream::new()
+    item
 }

--- a/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans.rs
+++ b/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans.rs
@@ -1,0 +1,18 @@
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, TokenTree};
+
+#[proc_macro_attribute]
+pub fn check_spans(_: TokenStream, item: TokenStream) -> TokenStream {
+    let mut item = item.into_iter();
+
+    for _ in 0..4 {
+        item.next().unwrap();
+    }
+
+    let span = item.next().unwrap().span();
+    let file = span.file();
+
+    assert!(file.contains("auxiliary/custom-inner-attribute-spans-module.rs"));
+    TokenStream::new()
+}

--- a/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans.rs
+++ b/tests/ui/proc-macro/auxiliary/custom-inner-attribute-spans.rs
@@ -4,15 +4,31 @@ use proc_macro::{TokenStream, TokenTree};
 
 #[proc_macro_attribute]
 pub fn check_spans(_: TokenStream, item: TokenStream) -> TokenStream {
-    let mut item_iterator = item.clone().into_iter();
-
-    for _ in 0..4 {
-        item_iterator.next().unwrap();
-    }
-
-    let span = item_iterator.next().unwrap().span();
-    let file = span.file();
-
-    assert!(file.contains("auxiliary/custom-inner-attribute-spans-module.rs"));
     item
+    //let token_tree = item.into_iter().nth(4).unwrap();
+    //let span = token_tree.span();
+    //panic!("{} in {} for {}", span.line(), span.file(), token_tree)
+
+    // panic!("{}", item);
+    // let mut item_iterator = item.into_iter();
+
+    // for _ in 0..4 {
+    //     item_iterator.next();
+    // }
+
+    // let TokenTree::Group(group) = item_iterator.next().unwrap() else {
+    //     panic!("These should be the module braces.");
+    // };
+
+    // let mut group = group.stream().into_iter();
+    // //group.next();
+    // let token_tree = group.next().expect("Token tree.");
+    // let span = token_tree.span();
+    // let file = span.file();
+
+    // panic!("{} in {}", span.line(), file);
+
+    // assert!(file.contains("custom-inner-attribute-spans-module.rs"));
+    // //"mod tester { #![custom_inner_attribute_spans::check_spans] }".parse().unwrap()
+    // TokenStream::new()
 }

--- a/tests/ui/proc-macro/custom-inner-attribute-spans.rs
+++ b/tests/ui/proc-macro/custom-inner-attribute-spans.rs
@@ -1,0 +1,14 @@
+//@ build-pass
+//@ proc-macro: custom-inner-attribute-spans.rs
+//@ ignore-backends: gcc
+
+#![feature(proc_macro_hygiene)]
+#![feature(custom_inner_attributes)]
+
+#[macro_use]
+extern crate custom_inner_attribute_spans;
+
+#[path = "auxiliary/custom-inner-attribute-spans-module.rs"]
+mod tester;
+
+fn main() {}


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/54726

I was playing around with this feature, and noticed that spans were incorrectly assigned to the `mod name;` statement.
The code doesn't seem too complicated, and so this is my attempt at a fix.

This notably does change what tokens are passed to the macro.
Previously the `mod name;` statement was given the macro, and now that is no longer the case.
If the `mod name;` tokens are desired, let me know, and I'll try my best to return them.

Amongst the tests that previously passed, and now do not, this change in error message is unintended.
I'm not too familiar with the code, and haven't yet ascertained what caused it. Guidance would be appreciated, but otherwise I'll keep hunting through the code until I work out how to restore this error.
```
-       error[E0658]: custom inner attributes are unstable
-         --> $DIR/inner-attr-file-mod.rs:11:1
+       error: an inner attribute is not permitted in this context
+         --> $DIR/module_with_attrs.rs:3:1
```