### PR TITLE
Emit error for unused target expression in glob and list delegations

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -31,7 +31,8 @@ use rustc_data_structures::tagged_ptr::Tag;
 use rustc_macros::{Decodable, Encodable, StableHash, Walkable};
 pub use rustc_span::AttrId;
 use rustc_span::{
-    ByteSymbol, DUMMY_SP, ErrorGuaranteed, Ident, Span, Spanned, Symbol, kw, respan, sym,
+    ByteSymbol, DUMMY_SP, ErrorGuaranteed, Ident, LocalExpnId, Span, Spanned, Symbol, kw, respan,
+    sym,
 };
 use thin_vec::{ThinVec, thin_vec};
 
@@ -3906,10 +3907,10 @@ pub struct EiiImpl {
     pub is_default: bool,
 }
 
-#[derive(Clone, Encodable, Decodable, Debug, Walkable, PartialEq, Eq)]
+#[derive(Clone, Copy, Encodable, Decodable, Debug, PartialEq, Eq)]
 pub enum DelegationSource {
     Single,
-    List,
+    List(LocalExpnId),
     Glob,
 }
 
@@ -3923,6 +3924,7 @@ pub struct Delegation {
     pub rename: Option<Ident>,
     pub body: Option<Box<Block>>,
     /// The item was expanded from a glob delegation item.
+    #[visitable(ignore)]
     pub source: DelegationSource,
 }
 

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -431,7 +431,6 @@ macro_rules! common_visitor_and_walkers {
             Delegation,
             DelegationMac,
             DelegationSuffixes,
-            DelegationSource,
             DelimArgs,
             DelimSpan,
             EnumDef,

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -62,7 +62,7 @@ use crate::diagnostics::{
 };
 use crate::{
     AllowReturnTypeNotation, ImplTraitContext, ImplTraitPosition, LoweringContext, ParamMode,
-    ResolverAstLoweringExt, index_crate,
+    index_crate,
 };
 
 mod generics;
@@ -126,7 +126,7 @@ pub(crate) fn delegations_resolutions(
         let delegation = ast_index[def_id].delegation().expect("processing delegations");
         let span = delegation.last_segment_span();
 
-        if let Some(info) = resolver.delegation_info(def_id) {
+        if let Some(info) = tcx.resolutions(()).delegation_infos.get(&def_id) {
             let res = info.resolution_id.map(|id| check_for_cycles(tcx, id, span).map(|_| id));
             result.insert(def_id, res.flatten());
         } else {
@@ -143,8 +143,6 @@ pub(crate) fn delegations_resolutions(
 fn check_for_cycles(tcx: TyCtxt<'_>, mut def_id: DefId, span: Span) -> Result<(), ErrorGuaranteed> {
     let mut visited: FxHashSet<DefId> = Default::default();
 
-    let (resolver, _) = &*tcx.hir_crate(()).delayed_resolver.borrow();
-
     loop {
         visited.insert(def_id);
 
@@ -152,7 +150,7 @@ fn check_for_cycles(tcx: TyCtxt<'_>, mut def_id: DefId, span: Span) -> Result<()
         // it means that we refer to another delegation as a callee, so in order to obtain
         // a signature DefId we obtain NodeId of the callee delegation and try to get signature from it.
         if let Some(local_id) = def_id.as_local()
-            && let Some(info) = resolver.delegation_info(local_id)
+            && let Some(info) = tcx.resolutions(()).delegation_infos.get(&local_id)
             && let Ok(id) = info.resolution_id
         {
             def_id = id;
@@ -209,10 +207,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let mut generics = self.uplift_delegation_generics(delegation, sig_id, is_method);
 
-        let (body_id, call_expr_id) =
+        let (body_id, call_expr_id, unused_target_expr) =
             self.lower_delegation_body(delegation, sig_id, param_count, &mut generics, span);
 
         let decl = self.lower_delegation_decl(
+            delegation.source,
             sig_id,
             param_count,
             c_variadic,
@@ -220,6 +219,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             &generics,
             delegation.id,
             call_expr_id,
+            unused_target_expr,
         );
 
         let sig = self.lower_delegation_sig(sig_id, decl, span);
@@ -375,6 +375,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     fn lower_delegation_decl(
         &mut self,
+        source: DelegationSource,
         sig_id: DefId,
         param_count: usize,
         c_variadic: bool,
@@ -382,6 +383,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         generics: &GenericsGenerationResults<'hir>,
         call_path_node_id: NodeId,
         call_expr_id: HirId,
+        unused_target_expr: bool,
     ) -> &'hir hir::FnDecl<'hir> {
         // The last parameter in C variadic functions is skipped in the signature,
         // like during regular lowering.
@@ -406,6 +408,17 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     parent_args_segment_id: generics.parent.args_segment_id,
                     self_ty_id: generics.self_ty_id,
                     propagate_self_ty: generics.propagate_self_ty,
+                    group_id: {
+                        let id = match source {
+                            DelegationSource::Single => None,
+                            DelegationSource::List(expn_id) => Some(expn_id),
+                            DelegationSource::Glob => {
+                                Some(self.tcx.expn_that_defined(self.owner.def_id).expect_local())
+                            }
+                        };
+
+                        id.map(|id| (id, unused_target_expr))
+                    },
                 })),
             )),
             span,
@@ -504,9 +517,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
         param_count: usize,
         generics: &mut GenericsGenerationResults<'hir>,
         span: Span,
-    ) -> (BodyId, HirId) {
+    ) -> (BodyId, HirId, bool) {
         let block = delegation.body.as_deref();
         let mut call_expr_id = HirId::INVALID;
+        let mut unused_target_expr = false;
 
         let block_id = self.lower_body(|this| {
             let mut parameters: Vec<hir::Param<'_>> = Vec::with_capacity(param_count);
@@ -514,6 +528,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
             let mut stmts: &[hir::Stmt<'hir>] = &[];
 
             let is_method = this.is_method(sig_id, span);
+            let should_generate_block = this.should_generate_block(delegation, sig_id, is_method);
+
+            // Consider non-specified target expression as generated,
+            // as we do not want to emit error when target expression is
+            // not specified.
+            unused_target_expr = block.is_some() && (param_count == 0 || !should_generate_block);
 
             for idx in 0..param_count {
                 let (param, pat_node_id) = this.generate_param(is_method, idx, span);
@@ -524,7 +544,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
                 let arg = if let Some(block) = block
                     && idx == 0
-                    && this.should_generate_block(delegation, sig_id, is_method)
+                    && should_generate_block
                 {
                     let mut self_resolver = SelfResolver {
                         ctxt: this,
@@ -565,7 +585,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         debug_assert_ne!(call_expr_id, HirId::INVALID);
 
-        (block_id, call_expr_id)
+        (block_id, call_expr_id, unused_target_expr)
     }
 
     fn finalize_body_lowering(

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -62,7 +62,7 @@ use rustc_macros::extension;
 use rustc_middle::hir::{self as mid_hir};
 use rustc_middle::queries::Providers;
 use rustc_middle::span_bug;
-use rustc_middle::ty::{DelegationInfo, PerOwnerResolverData, ResolverAstLowering, TyCtxt};
+use rustc_middle::ty::{PerOwnerResolverData, ResolverAstLowering, TyCtxt};
 use rustc_session::errors::add_feature_diagnostics;
 use rustc_span::symbol::{Ident, Symbol, kw, sym};
 use rustc_span::{DUMMY_SP, DesugaringKind, Span};
@@ -304,10 +304,6 @@ impl<'tcx> ResolverAstLowering<'tcx> {
     /// should appear at the enclosing `PolyTraitRef`.
     fn extra_lifetime_params(&self, id: NodeId) -> &[(Ident, NodeId, MissingLifetimeKind)] {
         self.extra_lifetime_params_map.get(&id).map_or(&[], |v| &v[..])
-    }
-
-    fn delegation_info(&self, id: LocalDefId) -> Option<&DelegationInfo> {
-        self.delegation_infos.get(&id)
     }
 
     fn owner_def_id(&self, id: NodeId) -> LocalDefId {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -8,9 +8,9 @@ use rustc_ast::tokenstream::TokenStream;
 use rustc_ast::visit::{self, AssocCtxt, Visitor, VisitorResult, try_visit, walk_list};
 use rustc_ast::{
     self as ast, AssocItemKind, AstNodeWrapper, AttrArgs, AttrItemKind, AttrStyle, AttrVec,
-    DUMMY_NODE_ID, DelegationSuffixes, EarlyParsedAttribute, ExprKind, ForeignItemKind, HasAttrs,
-    HasNodeId, Inline, ItemKind, MacStmtStyle, MetaItemInner, MetaItemKind, ModKind, NodeId,
-    PatKind, StmtKind, TyKind, token,
+    DUMMY_NODE_ID, DelegationSource, DelegationSuffixes, EarlyParsedAttribute, ExprKind,
+    ForeignItemKind, HasAttrs, HasNodeId, Inline, ItemKind, MacStmtStyle, MetaItemInner,
+    MetaItemKind, ModKind, NodeId, PatKind, StmtKind, TyKind, token,
 };
 use rustc_ast_pretty::pprust;
 use rustc_attr_parsing::parser::AllowExprMetavar;
@@ -992,7 +992,12 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
 
                 type Node = AstNodeWrapper<Box<ast::AssocItem>, ImplItemTag>;
                 let single_delegations = build_single_delegations::<Node>(
-                    self.cx, deleg, &item, &suffixes, item.span, true,
+                    self.cx,
+                    deleg,
+                    &item,
+                    &suffixes,
+                    item.span,
+                    DelegationSource::Glob,
                 );
                 // `-Zmacro-stats` ignores these because they don't seem important.
                 fragment_kind.expect_from_annotatables(single_delegations.map(|item| {
@@ -2041,8 +2046,12 @@ fn build_single_delegations<'a, Node: InvocationCollectorNode>(
     item: &'a ast::Item<Node::ItemKind>,
     suffixes: &'a [(Ident, Option<Ident>)],
     item_span: Span,
-    from_glob: bool,
+    source: DelegationSource,
 ) -> impl Iterator<Item = ast::Item<Node::ItemKind>> + 'a {
+    debug_assert_ne!(source, DelegationSource::Single);
+
+    let from_glob = source == DelegationSource::Glob;
+
     if suffixes.is_empty() {
         // Report an error for now, to avoid keeping stem for resolution and
         // stability checks.
@@ -2066,11 +2075,7 @@ fn build_single_delegations<'a, Node: InvocationCollectorNode>(
                 ident: rename.unwrap_or(ident),
                 rename,
                 body: deleg.body.clone(),
-                source: if from_glob {
-                    ast::DelegationSource::Glob
-                } else {
-                    ast::DelegationSource::List
-                },
+                source,
             })),
             tokens: None,
         }
@@ -2414,7 +2419,12 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                     };
 
                     let single_delegations = build_single_delegations::<Node>(
-                        self.cx, deleg, item, suffixes, item.span, false,
+                        self.cx,
+                        deleg,
+                        item,
+                        suffixes,
+                        item.span,
+                        DelegationSource::List(LocalExpnId::fresh_empty()),
                     );
                     Node::flatten_outputs(single_delegations.map(|item| {
                         let mut item = Node::from_item(item);

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -25,7 +25,8 @@ use rustc_index::IndexVec;
 use rustc_macros::{Decodable, Encodable, StableHash};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{
-    BytePos, DUMMY_SP, DesugaringKind, ErrorGuaranteed, Ident, Span, Spanned, Symbol, kw, sym,
+    BytePos, DUMMY_SP, DesugaringKind, ErrorGuaranteed, Ident, LocalExpnId, Span, Spanned, Symbol,
+    kw, sym,
 };
 use rustc_target::asm::InlineAsmRegOrRegClass;
 use smallvec::SmallVec;
@@ -3875,6 +3876,7 @@ pub struct DelegationInfo {
     pub child_args_segment_id: Option<HirId>,
     pub self_ty_id: Option<HirId>,
     pub propagate_self_ty: bool,
+    pub group_id: Option<(LocalExpnId, bool /* unused_target_expr */)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, StableHash)]

--- a/compiler/rustc_hir_analysis/src/delegation.rs
+++ b/compiler/rustc_hir_analysis/src/delegation.rs
@@ -5,9 +5,9 @@
 use std::debug_assert_matches;
 
 use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::PathSegment;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_hir::{DelegationInfo, PathSegment};
 use rustc_middle::ty::{
     self, EarlyBinder, Ty, TyCtxt, TypeFoldable, TypeFolder, TypeSuperFoldable, TypeVisitableExt,
 };
@@ -71,19 +71,6 @@ enum SelfPositionKind {
     None,
 }
 
-pub fn opt_get_delegation_info(
-    tcx: TyCtxt<'_>,
-    delegation_id: LocalDefId,
-) -> Option<&DelegationInfo> {
-    tcx.hir_node(tcx.local_def_id_to_hir_id(delegation_id))
-        .fn_sig()
-        .and_then(|sig| sig.decl.opt_delegation_info())
-}
-
-fn get_delegation_info(tcx: TyCtxt<'_>, delegation_id: LocalDefId) -> &DelegationInfo {
-    opt_get_delegation_info(tcx, delegation_id).expect("processing delegation")
-}
-
 fn create_self_position_kind(
     tcx: TyCtxt<'_>,
     delegation_id: LocalDefId,
@@ -96,7 +83,7 @@ fn create_self_position_kind(
         | (FnKind::AssocTrait, FnKind::Free) => SelfPositionKind::Zero,
 
         (FnKind::Free, FnKind::AssocTrait) => {
-            let propagate_self_ty = get_delegation_info(tcx, delegation_id).propagate_self_ty;
+            let propagate_self_ty = tcx.hir_delegation_info(delegation_id).propagate_self_ty;
             SelfPositionKind::AfterLifetimes(propagate_self_ty)
         }
 
@@ -282,7 +269,7 @@ fn get_parent_and_inheritance_kind<'tcx>(
 }
 
 fn get_delegation_self_ty_or_err(tcx: TyCtxt<'_>, delegation_id: LocalDefId) -> Ty<'_> {
-    get_delegation_info(tcx, delegation_id)
+    tcx.hir_delegation_info(delegation_id)
         .self_ty_id
         .map(|id| {
             let ctx = ItemCtxt::new(tcx, delegation_id);
@@ -644,7 +631,7 @@ pub(crate) fn delegation_user_specified_args<'tcx>(
     tcx: TyCtxt<'tcx>,
     delegation_id: LocalDefId,
 ) -> (&'tcx [ty::GenericArg<'tcx>], &'tcx [ty::GenericArg<'tcx>]) {
-    let info = get_delegation_info(tcx, delegation_id);
+    let info = tcx.hir_delegation_info(delegation_id);
 
     let get_segment = |hir_id| -> Option<(&'tcx PathSegment<'tcx>, DefId)> {
         let segment = tcx.hir_node(hir_id).expect_path_segment();

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -7,7 +7,6 @@ use rustc_hir::def::{self, CtorKind, Namespace, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::{self as hir, HirId, LangItem, find_attr};
 use rustc_hir_analysis::autoderef::Autoderef;
-use rustc_hir_analysis::delegation::opt_get_delegation_info;
 use rustc_infer::infer::BoundRegionConversionTime;
 use rustc_infer::traits::{Obligation, ObligationCause, ObligationCauseCode};
 use rustc_middle::ty::adjustment::{
@@ -701,7 +700,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // by comparing their hir ids (otherwise we will encounter errors in nested delegations,
         // see tests\ui\delegation\impl-reuse-pass.rs:237).
         let parent_def = self.tcx.hir_get_parent_item(call_expr.hir_id).def_id;
-        let Some(info) = opt_get_delegation_info(self.tcx, parent_def) else { return None };
+        let Some(info) = self.tcx.hir_opt_delegation_info(parent_def) else {
+            return None;
+        };
 
         if call_expr.hir_id != info.call_expr_id {
             return None;

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -13,7 +13,6 @@ use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::{Expr, ExprKind, FnRetTy, HirId, LangItem, Node, QPath, is_range_literal};
 use rustc_hir_analysis::check::potentially_plural_count;
-use rustc_hir_analysis::delegation::opt_get_delegation_info;
 use rustc_hir_analysis::hir_ty_lowering::{HirTyLowerer, ResolvedStructPath};
 use rustc_index::IndexVec;
 use rustc_infer::infer::{BoundRegionConversionTime, DefineOpaqueTypes, InferOk, TypeTrace};
@@ -341,7 +340,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // If we are processing first arg of delegation then we could have adjusted it
             // in `execute_delegation_aware_arguments_check`.
-            let checked_ty = opt_get_delegation_info(self.tcx, self.body_id)
+            let checked_ty = self
+                .tcx
+                .hir_opt_delegation_info(self.body_id)
                 .and_then(|_| self.typeck_results.borrow().node_type_opt(provided_arg.hir_id))
                 .unwrap_or_else(|| self.check_expr_with_expectation(provided_arg, expectation));
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1083,6 +1083,8 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
     // to use `hir_crate_items`.
     tcx.ensure_done().hir_crate_items(());
 
+    rustc_passes::delegation::check_glob_and_list_delegations_target_expr(tcx);
+
     let sess = tcx.sess;
     sess.time("misc_checking_1", || {
         par_fns(&mut [

--- a/compiler/rustc_middle/src/hir/map.rs
+++ b/compiler/rustc_middle/src/hir/map.rs
@@ -865,6 +865,14 @@ impl<'tcx> TyCtxt<'tcx> {
         self.opt_hir_owner_node(def_id)?.fn_decl()?.opt_delegation_sig_id()
     }
 
+    pub fn hir_opt_delegation_info(self, def_id: LocalDefId) -> Option<&'tcx DelegationInfo> {
+        self.opt_hir_owner_node(def_id)?.fn_decl()?.opt_delegation_info()
+    }
+
+    pub fn hir_delegation_info(self, delegation_id: LocalDefId) -> &'tcx DelegationInfo {
+        self.hir_opt_delegation_info(delegation_id).expect("processing delegation")
+    }
+
     #[inline]
     fn hir_opt_ident(self, id: HirId) -> Option<Ident> {
         match self.hir_node(id) {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -201,6 +201,9 @@ pub struct ResolverGlobalCtxt {
     pub doc_link_traits_in_scope: FxIndexMap<LocalDefId, Vec<DefId>>,
     pub all_macro_rules: UnordSet<Symbol>,
     pub stripped_cfg_items: Vec<StrippedCfgItem>,
+    // Information about delegations which is used when handling recursive delegations
+    // and ensures easy access to delegation-only `LocalDefId`s.
+    pub delegation_infos: FxIndexMap<LocalDefId, DelegationInfo>,
 }
 
 #[derive(Debug)]
@@ -257,13 +260,10 @@ pub struct ResolverAstLowering<'tcx> {
     /// Lints that were emitted by the resolver and early lints.
     pub lint_buffer: Steal<LintBuffer>,
 
-    // Information about delegations which is used when handling recursive delegations
-    pub delegation_infos: LocalDefIdMap<DelegationInfo>,
-
     pub disambiguators: LocalDefIdMap<Steal<PerParentDisambiguatorState>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, StableHash)]
 pub struct DelegationInfo {
     // `DefId` (either the resolution at delegation.id or item_id in case of a trait impl) for signature resolution,
     // for details see https://github.com/rust-lang/rust/issues/118212#issuecomment-2160686914

--- a/compiler/rustc_passes/src/delegation.rs
+++ b/compiler/rustc_passes/src/delegation.rs
@@ -1,0 +1,32 @@
+use rustc_data_structures::fx::FxIndexMap;
+use rustc_macros::Diagnostic;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+pub fn check_glob_and_list_delegations_target_expr(tcx: TyCtxt<'_>) {
+    let mut delegations_by_group_id = FxIndexMap::default();
+
+    for &id in tcx.resolutions(()).delegation_infos.keys() {
+        if let Some(info) = tcx.hir_opt_delegation_info(id)
+            && let Some((group_id, unused_target_expr)) = info.group_id
+        {
+            delegations_by_group_id
+                .entry(group_id)
+                .or_insert_with(|| (true, tcx.def_span(id)))
+                .0 &= unused_target_expr;
+        }
+    }
+
+    for (_, (unused_target_expr, span)) in delegations_by_group_id {
+        if unused_target_expr {
+            tcx.dcx().emit_err(DelegationTargetExprDeletedEverywhere { span });
+        }
+    }
+}
+
+#[derive(Diagnostic)]
+#[diag("unused target expression is specified for glob or list delegation")]
+struct DelegationTargetExprDeletedEverywhere {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -11,6 +11,7 @@ mod check_attr;
 mod check_export;
 pub mod dead;
 mod debugger_visualizer;
+pub mod delegation;
 mod diagnostic_items;
 mod eii;
 pub mod entry;

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1506,7 +1506,7 @@ pub struct Resolver<'ra, 'tcx> {
     /// Generic args to suggest for required params (e.g. `<'_>`, `<_, _>`), if any.
     item_required_generic_args_suggestions: FxHashMap<LocalDefId, String> = default::fx_hash_map(),
     delegation_fn_sigs: LocalDefIdMap<DelegationFnSig> = Default::default(),
-    delegation_infos: LocalDefIdMap<DelegationInfo> = Default::default(),
+    delegation_infos: FxIndexMap<LocalDefId, DelegationInfo>,
 
     main_def: Option<MainDefinition> = None,
     trait_impls: FxIndexMap<DefId, Vec<LocalDefId>>,
@@ -1871,6 +1871,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             doc_link_traits_in_scope: Default::default(),
             current_crate_outer_attr_insert_span,
             disambiguators: Default::default(),
+            delegation_infos: Default::default(),
             ..
         };
 
@@ -1991,6 +1992,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             doc_link_traits_in_scope: self.doc_link_traits_in_scope,
             all_macro_rules: self.all_macro_rules,
             stripped_cfg_items,
+            delegation_infos: self.delegation_infos,
         };
         let ast_lowering = ty::ResolverAstLowering {
             partial_res_map: self.partial_res_map,
@@ -1998,7 +2000,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             next_node_id: self.next_node_id,
             owners: self.owners,
             lint_buffer: Steal::new(self.lint_buffer),
-            delegation_infos: self.delegation_infos,
             disambiguators,
         };
         ResolverOutputs { global_ctxt, ast_lowering }

--- a/tests/ui/delegation/self-coercion-static-free.rs
+++ b/tests/ui/delegation/self-coercion-static-free.rs
@@ -23,6 +23,7 @@ impl Trait for S {
         //~^ ERROR: mismatched types
         //~| ERROR: mismatched types
         //~| ERROR: mismatched types
+        //~| ERROR: unused target expression is specified for glob or list delegation
         let _ = self;
         S::static_self()
     }
@@ -35,6 +36,7 @@ impl Trait for S1 {
         //~^ ERROR: mismatched types
         //~| ERROR: mismatched types
         //~| ERROR: mismatched types
+        //~| ERROR: unused target expression is specified for glob or list delegation
         let _ = self;
         S1::static_self()
     }

--- a/tests/ui/delegation/self-coercion-static-free.stderr
+++ b/tests/ui/delegation/self-coercion-static-free.stderr
@@ -1,3 +1,15 @@
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/self-coercion-static-free.rs:22:26
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                          ^^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/self-coercion-static-free.rs:35:26
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
+   |                          ^^^^^^^^^^^^
+
 error[E0308]: mismatched types
   --> $DIR/self-coercion-static-free.rs:22:26
    |
@@ -48,7 +60,7 @@ LL |     fn static_ref(_: &Self) -> i32 { 3 }
    |        ^^^^^^^^^^ --------
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:34:26
+  --> $DIR/self-coercion-static-free.rs:35:26
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
    |                          ^^^^^^^^^^^^
@@ -63,7 +75,7 @@ LL |     fn static_value(_: Self) -> i32 { 1 }
    |        ^^^^^^^^^^^^ -------
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:34:40
+  --> $DIR/self-coercion-static-free.rs:35:40
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
    |                                        ^^^^^^^^^^^^^^
@@ -80,7 +92,7 @@ LL |     fn static_mut_ref(_: &mut Self) -> i32 { 2 }
    |        ^^^^^^^^^^^^^^ ------------
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:34:56
+  --> $DIR/self-coercion-static-free.rs:35:56
    |
 LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} {
    |                                                        ^^^^^^^^^^
@@ -97,7 +109,7 @@ LL |     fn static_ref(_: &Self) -> i32 { 3 }
    |        ^^^^^^^^^^ --------
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:50:43
+  --> $DIR/self-coercion-static-free.rs:52:43
    |
 LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    |                         -------           ^ expected `&mut _`, found `F`
@@ -107,7 +119,7 @@ LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    = note: expected mutable reference `&mut _`
                          found struct `F`
 note: function defined here
-  --> $DIR/self-coercion-static-free.rs:46:12
+  --> $DIR/self-coercion-static-free.rs:48:12
    |
 LL |     pub fn mut_ref(_: &mut impl Trait) -> i32 { 2 }
    |            ^^^^^^^ ------------------
@@ -117,7 +129,7 @@ LL | reuse to_reuse::{value, mut_ref, r#ref} { &mut F }
    |                                           ++++
 
 error[E0308]: mismatched types
-  --> $DIR/self-coercion-static-free.rs:50:43
+  --> $DIR/self-coercion-static-free.rs:52:43
    |
 LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    |                                  -----    ^ expected `&_`, found `F`
@@ -127,7 +139,7 @@ LL | reuse to_reuse::{value, mut_ref, r#ref} { F }
    = note: expected reference `&_`
                  found struct `F`
 note: function defined here
-  --> $DIR/self-coercion-static-free.rs:47:12
+  --> $DIR/self-coercion-static-free.rs:49:12
    |
 LL |     pub fn r#ref(_: &impl Trait) -> i32 { 3 }
    |            ^^^^^ --------------
@@ -136,6 +148,6 @@ help: consider borrowing here
 LL | reuse to_reuse::{value, mut_ref, r#ref} { &F }
    |                                           +
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/delegation/unused-target-expr-in-glob-or-list.rs
+++ b/tests/ui/delegation/unused-target-expr-in-glob-or-list.rs
@@ -1,0 +1,208 @@
+#![feature(fn_delegation)]
+
+pub trait Trait: Sized {
+    fn static_self() -> F { F }
+    fn static_self2() -> F { F }
+
+    fn static_value(_: F) -> i32 { 1 }
+    fn static_mut_ref(_: &mut F) -> i32 { 2 }
+    fn static_ref(_: &F) -> i32 { 3 }
+}
+
+#[derive(Default, Eq, PartialEq, Debug)]
+pub struct F;
+impl Trait for F {}
+
+struct S(F);
+impl Trait for S {
+    reuse <F as Trait>::* { self.0 }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S1(F);
+impl S1 {
+    reuse <F as Trait>::* { self.0 }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S2(F);
+impl Trait for S2 {
+    reuse <F as Trait>::{static_self} { self.0 }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S3(F);
+impl Trait for S3 {
+    reuse <F as Trait>::{static_self, static_value} { self.0 }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S4(F);
+impl Trait for S4 {
+    reuse <F as Trait>::{static_self, static_value, static_mut_ref, static_ref} { self.0 }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S5(F);
+impl Trait for S5 {
+    reuse <F as Trait>::{static_self, static_value, static_mut_ref, static_ref} { }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S6(F);
+impl Trait for S6 {
+    // Error about unused target expression is not emitted when error delegation is generated.
+    reuse UnresolvedTrait::* { self.0 }
+    //~^ ERROR: cannot find type `UnresolvedTrait` in this scope
+}
+
+struct S7(F);
+impl Trait for S7 {
+    reuse <F as Trait>::*;
+}
+
+struct S8(F);
+impl Trait for S8 {
+    reuse <F as Trait>::{static_self, static_self2} { { F } }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+struct S9;
+impl S9 {
+    reuse <F as Trait>::{static_self, static_self2} { { F } }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+
+    reuse <F as Trait>::{static_value, static_mut_ref, static_ref} { }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+}
+
+trait Trait2 {
+    reuse <F as Trait>::{static_self, static_self2} { { F } }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+
+    reuse <F as Trait>::{static_value, static_mut_ref} { }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+
+    reuse <F as Trait>::{static_ref};
+}
+
+mod free_to_trait1 {
+    use super::{F, Trait};
+
+    reuse <F as Trait>::{static_self, static_self2} { { F } }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+
+    reuse <F as Trait>::{static_value, static_mut_ref} { }
+    //~^ ERROR: unused target expression is specified for glob or list delegation
+
+    reuse <F as Trait>::{static_ref};
+}
+
+mod macros {
+    use super::*;
+
+    macro_rules! delegation {
+        () => {
+            impl Trait for S {
+                reuse <F as Trait>::static_self { self.0 }
+                //~^ ERROR: delegation's target expression is specified for function with no params
+                //~| ERROR: mismatched types
+                //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+                //~| ERROR: method `static_self` has an incompatible type for trait
+                reuse <F as Trait>::static_value { self.0 }
+                //~^ ERROR: no field `0` on type `F`
+                reuse <F as Trait>::static_mut_ref { self.0 }
+                //~^ ERROR: no field `0` on type `&mut F`
+                reuse <F as Trait>::static_ref { self.0 }
+                //~^ ERROR: no field `0` on type `&F`
+            }
+        };
+    }
+
+    struct S(F);
+    delegation!();
+
+    macro_rules! delegation2 {
+        () => {
+            reuse <F as Trait>::static_self { self.0 }
+            //~^ ERROR: delegation's target expression is specified for function with no params
+            //~| ERROR: mismatched types
+            //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+            //~| ERROR: method `static_self` has an incompatible type for trait
+            reuse <F as Trait>::static_value { self.0 }
+            //~^ ERROR: no field `0` on type `F`
+            reuse <F as Trait>::static_mut_ref { self.0 }
+            //~^ ERROR: no field `0` on type `&mut F`
+            reuse <F as Trait>::static_ref { self.0 }
+            //~^ ERROR: no field `0` on type `&F`
+        };
+    }
+
+    struct S1(F);
+    impl Trait for S1 {
+        delegation2!();
+    }
+}
+
+mod free_list {
+    mod to_reuse {
+        pub fn value() -> i32 { 1 }
+        pub fn mut_ref() -> i32 { 2 }
+        pub fn r#ref() -> i32 { 3 }
+    }
+
+    reuse to_reuse::{value, mut_ref, r#ref} { () }
+    //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: mismatched types
+    //~| ERROR: delegation's target expression is specified for function with no params
+    //~| ERROR: delegation's target expression is specified for function with no params
+    //~| ERROR: delegation's target expression is specified for function with no params
+
+    reuse to_reuse::{value as value2} { }
+    //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+    //~| ERROR: mismatched types
+    //~| ERROR: delegation's target expression is specified for function with no params
+}
+
+mod to_free {
+    trait Trait {
+        fn value() -> i32 { 1 }
+        fn mut_ref() -> i32 { 2 }
+        fn r#ref() -> i32 { 3 }
+    }
+
+    mod to_reuse {
+        pub fn value() -> i32 { 1 }
+        pub fn mut_ref() -> i32 { 2 }
+        pub fn r#ref() -> i32 { 3 }
+    }
+
+    struct F;
+    impl Trait for F {}
+
+    struct S(F);
+    impl Trait for S {
+        reuse to_reuse::{value, mut_ref, r#ref} { () }
+        //~^ ERROR: unused target expression is specified for glob or list delegation
+    }
+
+    struct S2;
+    impl S2 {
+        reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+        //~^ ERROR: this function takes 0 arguments but 1 argument was supplied
+        //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+        //~| ERROR: this function takes 0 arguments but 1 argument was supplied
+        //~| ERROR: mismatched types
+        //~| ERROR: mismatched types
+        //~| ERROR: mismatched types
+        //~| ERROR: delegation's target expression is specified for function with no params
+        //~| ERROR: delegation's target expression is specified for function with no params
+        //~| ERROR: delegation's target expression is specified for function with no params
+    }
+}
+
+fn main() {}

--- a/tests/ui/delegation/unused-target-expr-in-glob-or-list.stderr
+++ b/tests/ui/delegation/unused-target-expr-in-glob-or-list.stderr
@@ -1,0 +1,569 @@
+error[E0433]: cannot find type `UnresolvedTrait` in this scope
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:55:11
+   |
+LL |     reuse UnresolvedTrait::* { self.0 }
+   |           ^^^^^^^^^^^^^^^ use of undeclared type `UnresolvedTrait`
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:45
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                                             ^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:45
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                                             ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:45
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                                             ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:165:39
+   |
+LL |     reuse to_reuse::{value as value2} { }
+   |                                       ^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:49
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                                 ^^^^^^^^^
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:49
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                                 ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:49
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                                 ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:107:49
+   |
+LL |                 reuse <F as Trait>::static_self { self.0 }
+   |                                                 ^^^^^^^^^^
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: delegation's target expression is specified for function with no params
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:127:45
+   |
+LL |             reuse <F as Trait>::static_self { self.0 }
+   |                                             ^^^^^^^^^^
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:18:25
+   |
+LL |     reuse <F as Trait>::* { self.0 }
+   |                         ^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:24:25
+   |
+LL |     reuse <F as Trait>::* { self.0 }
+   |                         ^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:30:26
+   |
+LL |     reuse <F as Trait>::{static_self} { self.0 }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:36:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_value} { self.0 }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:42:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_value, static_mut_ref, static_ref} { self.0 }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:48:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_value, static_mut_ref, static_ref} { }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:66:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_self2} { { F } }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:72:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_self2} { { F } }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:75:26
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref, static_ref} { }
+   |                          ^^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:80:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_self2} { { F } }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:83:26
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref} { }
+   |                          ^^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:92:26
+   |
+LL |     reuse <F as Trait>::{static_self, static_self2} { { F } }
+   |                          ^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:95:26
+   |
+LL |     reuse <F as Trait>::{static_value, static_mut_ref} { }
+   |                          ^^^^^^^^^^^^
+
+error: unused target expression is specified for glob or list delegation
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:189:26
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                          ^^^^^
+
+error[E0053]: method `static_self` has an incompatible type for trait
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:107:37
+   |
+LL |                 reuse <F as Trait>::static_self { self.0 }
+   |                                     ^^^^^^^^^^^ expected `F`, found `()`
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+note: type in trait
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:4:25
+   |
+LL |     fn static_self() -> F { F }
+   |                         ^
+   = note: expected signature `fn() -> F`
+              found signature `fn() -> ()`
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: change the output type to match the trait
+   |
+LL -                 reuse <F as Trait>::static_self { self.0 }
+LL +                 reuse <F as Trait>:: -> F { self.0 }
+   |
+
+error[E0053]: method `static_self` has an incompatible type for trait
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:127:33
+   |
+LL |             reuse <F as Trait>::static_self { self.0 }
+   |                                 ^^^^^^^^^^^ expected `F`, found `()`
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+note: type in trait
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:4:25
+   |
+LL |     fn static_self() -> F { F }
+   |                         ^
+   = note: expected signature `fn() -> F`
+              found signature `fn() -> ()`
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: change the output type to match the trait
+   |
+LL -             reuse <F as Trait>::static_self { self.0 }
+LL +             reuse <F as Trait>:: -> F { self.0 }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:107:37
+   |
+LL |                 reuse <F as Trait>::static_self { self.0 }
+   |                                     ^^^^^^^^^^^ ---------- unexpected argument
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+note: associated function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:4:8
+   |
+LL |     fn static_self() -> F { F }
+   |        ^^^^^^^^^^^
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:107:37
+   |
+LL |                 reuse <F as Trait>::static_self { self.0 }
+   |                                     ^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |                                     |
+   |                                     expected `()`, found `F`
+   |                                     expected `()` because of default return type
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `0` on type `F`
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:112:57
+   |
+LL |                 reuse <F as Trait>::static_value { self.0 }
+   |                                                         ^ unknown field
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `0` on type `&mut F`
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:114:59
+   |
+LL |                 reuse <F as Trait>::static_mut_ref { self.0 }
+   |                                                           ^ unknown field
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `0` on type `&F`
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:116:55
+   |
+LL |                 reuse <F as Trait>::static_ref { self.0 }
+   |                                                       ^ unknown field
+...
+LL |     delegation!();
+   |     ------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:127:33
+   |
+LL |             reuse <F as Trait>::static_self { self.0 }
+   |                                 ^^^^^^^^^^^ ---------- unexpected argument
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+note: associated function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:4:8
+   |
+LL |     fn static_self() -> F { F }
+   |        ^^^^^^^^^^^
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:127:33
+   |
+LL |             reuse <F as Trait>::static_self { self.0 }
+   |                                 ^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |                                 |
+   |                                 expected `()`, found `F`
+   |                                 expected `()` because of default return type
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `0` on type `F`
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:132:53
+   |
+LL |             reuse <F as Trait>::static_value { self.0 }
+   |                                                     ^ unknown field
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `0` on type `&mut F`
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:134:55
+   |
+LL |             reuse <F as Trait>::static_mut_ref { self.0 }
+   |                                                       ^ unknown field
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0609]: no field `0` on type `&F`
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:136:51
+   |
+LL |             reuse <F as Trait>::static_ref { self.0 }
+   |                                                   ^ unknown field
+...
+LL |         delegation2!();
+   |         -------------- in this macro invocation
+   |
+   = note: this error originates in the macro `delegation2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:22
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                      ^^^^^                  ------ unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:149:16
+   |
+LL |         pub fn value() -> i32 { 1 }
+   |                ^^^^^
+help: remove the extra argument
+   |
+LL -     reuse to_reuse::{value, mut_ref, r#ref} { () }
+LL +     reuse to_reuse::{valu{ () }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:22
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                      ^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |     reuse to_reuse::{value;, mut_ref, r#ref} { () }
+   |                           +
+help: try adding a return type
+   |
+LL -     reuse to_reuse::{value, mut_ref, r#ref} { () }
+LL +     reuse to_reuse::{ -> i32, mut_ref, r#ref} { () }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:29
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                             ^^^^^^^         ------ unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:150:16
+   |
+LL |         pub fn mut_ref() -> i32 { 2 }
+   |                ^^^^^^^
+help: remove the extra argument
+   |
+LL -     reuse to_reuse::{value, mut_ref, r#ref} { () }
+LL +     reuse to_reuse::{value, mut_re{ () }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:29
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                             ^^^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |     reuse to_reuse::{value, mut_ref;, r#ref} { () }
+   |                                    +
+help: try adding a return type
+   |
+LL -     reuse to_reuse::{value, mut_ref, r#ref} { () }
+LL +     reuse to_reuse::{value,  -> i32, r#ref} { () }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:38
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                                      ^^^^^  ------ unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:151:16
+   |
+LL |         pub fn r#ref() -> i32 { 3 }
+   |                ^^^^^
+help: remove the extra argument
+   |
+LL -     reuse to_reuse::{value, mut_ref, r#ref} { () }
+LL +     reuse to_reuse::{value, mut_ref, r#re{ () }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:154:38
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref} { () }
+   |                                      ^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |     reuse to_reuse::{value, mut_ref, r#ref;} { () }
+   |                                           +
+help: try adding a return type
+   |
+LL -     reuse to_reuse::{value, mut_ref, r#ref} { () }
+LL +     reuse to_reuse::{value, mut_ref,  -> i32} { () }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:165:22
+   |
+LL |     reuse to_reuse::{value as value2} { }
+   |                      ^^^^^            --- unexpected argument of type `()`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:149:16
+   |
+LL |         pub fn value() -> i32 { 1 }
+   |                ^^^^^
+help: remove the extra argument
+   |
+LL -     reuse to_reuse::{value as value2} { }
+LL +     reuse to_reuse::{valu{ }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:165:22
+   |
+LL |     reuse to_reuse::{value as value2} { }
+   |                      ^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |     reuse to_reuse::{value; as value2} { }
+   |                           +
+help: try adding a return type
+   |
+LL -     reuse to_reuse::{value as value2} { }
+LL +     reuse to_reuse::{ -> i32 as value2} { }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:26
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                          ^^^^^                  --------- unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:179:16
+   |
+LL |         pub fn value() -> i32 { 1 }
+   |                ^^^^^
+help: remove the extra argument
+   |
+LL -         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+LL +         reuse to_reuse::{valu{ 1 + 1 }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:26
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                          ^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |         reuse to_reuse::{value;, mut_ref, r#ref} { 1 + 1 }
+   |                               +
+help: try adding a return type
+   |
+LL -         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+LL +         reuse to_reuse::{ -> i32, mut_ref, r#ref} { 1 + 1 }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:33
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                 ^^^^^^^         --------- unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:180:16
+   |
+LL |         pub fn mut_ref() -> i32 { 2 }
+   |                ^^^^^^^
+help: remove the extra argument
+   |
+LL -         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+LL +         reuse to_reuse::{value, mut_re{ 1 + 1 }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:33
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                 ^^^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |         reuse to_reuse::{value, mut_ref;, r#ref} { 1 + 1 }
+   |                                        +
+help: try adding a return type
+   |
+LL -         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+LL +         reuse to_reuse::{value,  -> i32, r#ref} { 1 + 1 }
+   |
+
+error[E0061]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:42
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                          ^^^^^  --------- unexpected argument of type `{integer}`
+   |
+note: function defined here
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:181:16
+   |
+LL |         pub fn r#ref() -> i32 { 3 }
+   |                ^^^^^
+help: remove the extra argument
+   |
+LL -         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+LL +         reuse to_reuse::{value, mut_ref, r#re{ 1 + 1 }
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/unused-target-expr-in-glob-or-list.rs:195:42
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+   |                                          ^^^^^ expected `()`, found `i32`
+   |
+help: consider using a semicolon here
+   |
+LL |         reuse to_reuse::{value, mut_ref, r#ref;} { 1 + 1 }
+   |                                               +
+help: try adding a return type
+   |
+LL -         reuse to_reuse::{value, mut_ref, r#ref} { 1 + 1 }
+LL +         reuse to_reuse::{value, mut_ref,  -> i32} { 1 + 1 }
+   |
+
+error: aborting due to 50 previous errors
+
+Some errors have detailed explanations: E0053, E0061, E0308, E0433, E0609.
+For more information about an error, try `rustc --explain E0053`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157601)*
<!-- homu-ignore:end -->

This PR emits error if unuse  target expression is specified for glob delegation. Second part of rust-lang/rust#156798.

Part of rust-lang/rust#118212.
r? @petrochenkov