### PR TITLE
rustdoc: Remove unnecessary fast path

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3068,18 +3068,6 @@ fn repr_attribute<'tcx>(
         return is_public.then(|| "#[repr(transparent)]".into());
     }
 
-    // Fast path which avoids looking through the variants and fields in
-    // the common case of no `#[repr]` or in the case of `#[repr(Rust)]`.
-    // FIXME: This check is not very robust / forward compatible!
-    if !repr.c()
-        && !repr.simd()
-        && repr.int.is_none()
-        && repr.pack.is_none()
-        && repr.align.is_none()
-    {
-        return None;
-    }
-
     // The repr is public iff all components are public and visible.
     let is_public = adt
         .variants()


### PR DESCRIPTION
I added this "fast path" prematurely in PR https://github.com/rust-lang/rust/pull/116882.
It's not actually necessary as this perf run shows: https://github.com/rust-lang/rust/pull/146483#issuecomment-3338621615 (https://perf.rust-lang.org/compare.html?start=40ace17fc3891155bad26a50d60a9ab07b83bf8e&end=a77816d56c8fdadab64ae3f9fe1a653bfdb975a8&stat=instructions:u).

Let's remove it since makes it slightly more annoying to add new reprs (one would need to update two places).