### PR TITLE
Fixed Doc Comment Typo in Linewritershim

### DIFF
--- a/library/std/src/io/buffered/linewritershim.rs
+++ b/library/std/src/io/buffered/linewritershim.rs
@@ -40,9 +40,10 @@ impl<'a, W: ?Sized + Write> LineWriterShim<'a, W> {
         self.buffer.buffer()
     }
 
-    /// Flushes the buffer iff the last byte is a newline (indicating that an
-    /// earlier write only succeeded partially, and we want to retry flushing
-    /// the buffered line before continuing with a subsequent write).
+    /// Flushes the buffer if and only if the last byte is a newline
+    /// (indicating that an earlier write only succeeded partially, and we
+    /// want to retry flushing the buffered line before continuing with a
+    /// subsequent write).
     fn flush_if_completed_line(&mut self) -> io::Result<()> {
         match self.buffered().last().copied() {
             Some(b'\n') => self.buffer.flush_buf(),


### PR DESCRIPTION
The doc comment of the `flush_if_completed_line`
function spelt 'if' as 'iff'.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
