### PR TITLE
fix: build-std on 32 bit arm with 64 bit time

### DIFF
--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -396,10 +396,7 @@ impl Socket {
                 } else {
                     dur.as_secs() as libc::time_t
                 };
-                let mut timeout = libc::timeval {
-                    tv_sec: secs,
-                    tv_usec: dur.subsec_micros() as libc::suseconds_t,
-                };
+                let mut timeout = libc::timeval { tv_sec: secs, tv_usec: dur.subsec_micros() as _ };
                 if timeout.tv_sec == 0 && timeout.tv_usec == 0 {
                     timeout.tv_usec = 1;
                 }


### PR DESCRIPTION
Infer target type of `tv_usec`.

The libc crate has support for building with 64 bit time on 32 bit
platforms, configurable currently via environment variable or cfg directives.
When building using 64 bit time, the tv_usec field will be aliased to `__suseconds64_t` instead of `suseconds_t` causing the `build-std` feature to not be able to build the standard library due to a type mismatch.
Adopting the same convention as in https://github.com/rust-lang/rust/blob/1b29cfdbee8ee37333f4b24afb936350eb57e705/library/std/src/sys/net/connection/socket/solid.rs#L151 fixes the issue, supporting 64 bit time on 32 bit arm platforms.

Another option would be using cfg attributes for this but from what I can tell there are no existing such attributes for time bits in the std and they would essentially duplicate the ones already present in the libc crate https://github.com/rust-lang/libc/blob/e27c7f1e2b281d7c551e6b394b897b4ff0a230e6/build.rs#L16


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
