### PR TITLE
Improve invalid cfg predicate error

### DIFF
--- a/bad_error.rs
+++ b/bad_error.rs
@@ -1,6 +1,0 @@
-// Hint: expected_specific_argument
-#![feature(cfg_version)]
-#[cfg(does_not_exist())]
-fn test() {}
-
-fn main() {}

--- a/bad_error.rs
+++ b/bad_error.rs
@@ -1,0 +1,6 @@
+// Hint: expected_specific_argument
+#![feature(cfg_version)]
+#[cfg(does_not_exist())]
+fn test() {}
+
+fn main() {}

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -103,8 +103,11 @@ pub fn parse_cfg_entry(
                 Some(sym::target) => parse_cfg_entry_target(cx, list, meta.span())?,
                 Some(sym::version) => parse_cfg_entry_version(cx, list, meta.span())?,
                 _ => {
-                    let possibilities = &[sym::any, sym::all, sym::not, sym::target, sym::version];
-                    return Err(cx.adcx().expected_specific_argument(meta.span(), possibilities));
+                    let mut possibilities = vec![sym::any, sym::all, sym::not, sym::target];
+                    if cx.features().cfg_version() {
+                        possibilities.push(sym::version);
+                    }
+                    return Err(cx.adcx().expected_specific_argument(meta.span(), &possibilities));
                 }
             },
             a @ (ArgParser::NoArgs | ArgParser::NameValue(_)) => {

--- a/compiler/rustc_attr_parsing/src/attributes/cfg.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/cfg.rs
@@ -103,10 +103,8 @@ pub fn parse_cfg_entry(
                 Some(sym::target) => parse_cfg_entry_target(cx, list, meta.span())?,
                 Some(sym::version) => parse_cfg_entry_version(cx, list, meta.span())?,
                 _ => {
-                    return Err(cx.emit_err(session_diagnostics::InvalidPredicate {
-                        span: meta.span(),
-                        predicate: meta.path().to_string(),
-                    }));
+                    let possibilities = &[sym::any, sym::all, sym::not, sym::target, sym::version];
+                    return Err(cx.adcx().expected_specific_argument(meta.span(), possibilities));
                 }
             },
             a @ (ArgParser::NoArgs | ArgParser::NameValue(_)) => {

--- a/compiler/rustc_attr_parsing/src/session_diagnostics.rs
+++ b/compiler/rustc_attr_parsing/src/session_diagnostics.rs
@@ -14,15 +14,6 @@ use crate::AttributeTemplate;
 use crate::context::Suggestion;
 
 #[derive(Diagnostic)]
-#[diag("invalid predicate `{$predicate}`", code = E0537)]
-pub(crate) struct InvalidPredicate {
-    #[primary_span]
-    pub span: Span,
-
-    pub predicate: String,
-}
-
-#[derive(Diagnostic)]
 #[diag("{$attr_str} attribute cannot have empty value")]
 pub(crate) struct DocAliasEmpty<'a> {
     #[primary_span]

--- a/compiler/rustc_error_codes/src/error_codes/E0537.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0537.md
@@ -1,3 +1,4 @@
+#### Note: this error code is no longer emitted by the compiler
 An unknown predicate was used inside the `cfg` attribute.
 
 Erroneous code example:

--- a/compiler/rustc_error_codes/src/error_codes/E0537.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0537.md
@@ -3,7 +3,7 @@ An unknown predicate was used inside the `cfg` attribute.
 
 Erroneous code example:
 
-```compile_fail,E0537
+```compile_fail,E0539
 #[cfg(unknown())] // error: invalid predicate `unknown`
 pub fn something() {}
 

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
@@ -29,5 +29,5 @@ static FOO: usize = 0;
 fn main() {
     let _a = cfg!(unsafe(foo));
     //~^ ERROR: expected identifier, found keyword `unsafe`
-    //~^^ ERROR: invalid predicate `r#unsafe`
+    //~^^ ERROR: malformed `cfg` macro input [E0539]
 }

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
@@ -33,11 +33,20 @@ help: escape `unsafe` to use it as an identifier
 LL |     let _a = cfg!(r#unsafe(foo));
    |                   ++
 
-error[E0537]: invalid predicate `r#unsafe`
-  --> $DIR/extraneous-unsafe-attributes.rs:30:19
+error[E0539]: malformed `cfg` macro input
+  --> $DIR/extraneous-unsafe-attributes.rs:30:14
    |
 LL |     let _a = cfg!(unsafe(foo));
-   |                   ^^^^^^^^^^^
+   |              ^^^^^-----------^
+   |                   |
+   |                   valid arguments are `any`, `all`, `not`, `target` or `version`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL -     let _a = cfg!(unsafe(foo));
+LL +     let _a = cfg!(predicate);
+   |
 
 error: `ignore` is not an unsafe attribute
   --> $DIR/extraneous-unsafe-attributes.rs:12:3
@@ -81,4 +90,4 @@ LL | #[unsafe(used)]
 
 error: aborting due to 10 previous errors
 
-For more information about this error, try `rustc --explain E0537`.
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
@@ -39,7 +39,7 @@ error[E0539]: malformed `cfg` macro input
 LL |     let _a = cfg!(unsafe(foo));
    |              ^^^^^-----------^
    |                   |
-   |                   valid arguments are `any`, `all`, `not`, `target` or `version`
+   |                   valid arguments are `any`, `all`, `not` or `target`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: must be of the form

--- a/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.rs
@@ -1,4 +1,4 @@
-#[cfg(foo(bar))] //~ ERROR invalid predicate `foo`
+#[cfg(foo(bar))] //~ ERROR malformed `cfg` attribute input [E0539]
 fn check() {}
 
 fn main() {}

--- a/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.stderr
@@ -4,7 +4,7 @@ error[E0539]: malformed `cfg` attribute input
 LL | #[cfg(foo(bar))]
    | ^^^^^^--------^^
    |       |
-   |       valid arguments are `any`, `all`, `not`, `target` or `version`
+   |       valid arguments are `any`, `all`, `not` or `target`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: must be of the form

--- a/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-invalid-predicate.stderr
@@ -1,9 +1,18 @@
-error[E0537]: invalid predicate `foo`
-  --> $DIR/cfg-attr-invalid-predicate.rs:1:7
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/cfg-attr-invalid-predicate.rs:1:1
    |
 LL | #[cfg(foo(bar))]
-   |       ^^^^^^^^
+   | ^^^^^^--------^^
+   |       |
+   |       valid arguments are `any`, `all`, `not`, `target` or `version`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(foo(bar))]
+LL + #[cfg(predicate)]
+   |
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0537`.
+For more information about this error, try `rustc --explain E0539`.

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.rs
@@ -35,7 +35,7 @@ struct S5;
 struct S6;
 
 #[cfg(a())] //~ ERROR malformed `cfg` attribute input
-//~| NOTE valid arguments are `any`, `all`, `not`, `target` or `version`
+//~| NOTE valid arguments are `any`, `all`, `not` or `target`
 //~| NOTE for more information, visit
 struct S7;
 

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.rs
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.rs
@@ -34,7 +34,9 @@ struct S5;
 //~| NOTE for more information, visit
 struct S6;
 
-#[cfg(a())] //~ ERROR invalid predicate `a`
+#[cfg(a())] //~ ERROR malformed `cfg` attribute input
+//~| NOTE valid arguments are `any`, `all`, `not`, `target` or `version`
+//~| NOTE for more information, visit
 struct S7;
 
 #[cfg(a = 10)] //~ ERROR malformed `cfg` attribute input

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -95,7 +95,7 @@ error[E0539]: malformed `cfg` attribute input
 LL | #[cfg(a())]
    | ^^^^^^---^^
    |       |
-   |       valid arguments are `any`, `all`, `not`, `target` or `version`
+   |       valid arguments are `any`, `all`, `not` or `target`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
 help: must be of the form

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -89,14 +89,23 @@ LL - #[cfg(a::b)]
 LL + #[cfg(predicate)]
    |
 
-error[E0537]: invalid predicate `a`
-  --> $DIR/cfg-attr-syntax-validation.rs:37:7
+error[E0539]: malformed `cfg` attribute input
+  --> $DIR/cfg-attr-syntax-validation.rs:37:1
    |
 LL | #[cfg(a())]
-   |       ^^^
+   | ^^^^^^---^^
+   |       |
+   |       valid arguments are `any`, `all`, `not`, `target` or `version`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
+help: must be of the form
+   |
+LL - #[cfg(a())]
+LL + #[cfg(predicate)]
+   |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:40:1
+  --> $DIR/cfg-attr-syntax-validation.rs:42:1
    |
 LL | #[cfg(a = 10)]
    | ^^^^^^^^^^--^^
@@ -111,7 +120,7 @@ LL + #[cfg(predicate)]
    |
 
 error[E0539]: malformed `cfg` attribute input
-  --> $DIR/cfg-attr-syntax-validation.rs:45:1
+  --> $DIR/cfg-attr-syntax-validation.rs:47:1
    |
 LL | #[cfg(a = b"hi")]
    | ^^^^^^^^^^-^^^^^^
@@ -121,7 +130,7 @@ LL | #[cfg(a = b"hi")]
    = note: expected a normal string literal, not a byte string literal
 
 error: expected a literal (`1u8`, `1.0f32`, `"string"`, etc.) here, found `expr` metavariable
-  --> $DIR/cfg-attr-syntax-validation.rs:51:25
+  --> $DIR/cfg-attr-syntax-validation.rs:53:25
    |
 LL |         #[cfg(feature = $expr)]
    |                         ^^^^^
@@ -133,5 +142,5 @@ LL | generate_s10!(concat!("nonexistent"));
 
 error: aborting due to 10 previous errors
 
-Some errors have detailed explanations: E0537, E0539, E0565, E0805.
-For more information about an error, try `rustc --explain E0537`.
+Some errors have detailed explanations: E0539, E0565, E0805.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.rs
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.rs
@@ -16,7 +16,7 @@ struct S5;
 #[cfg_attr(a::b)] //~ ERROR malformed `cfg_attr` attribute input
 struct S6;
 
-#[cfg_attr(a())] //~ ERROR invalid predicate `a`
+#[cfg_attr(a())] //~ ERROR malformed `cfg_attr` attribute input [E0539]
 struct S7;
 
 #[cfg_attr(a = 10)] //~ ERROR malformed `cfg_attr` attribute input

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -73,7 +73,7 @@ error[E0539]: malformed `cfg_attr` attribute input
 LL | #[cfg_attr(a())]
    | ^^^^^^^^^^^---^^
    |            |
-   |            valid arguments are `any`, `all`, `not`, `target` or `version`
+   |            valid arguments are `any`, `all`, `not` or `target`
    |
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: must be of the form

--- a/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg_attr-attr-syntax-validation.stderr
@@ -67,11 +67,20 @@ LL - #[cfg_attr(a::b)]
 LL + #[cfg_attr(predicate, attr1, attr2, ...)]
    |
 
-error[E0537]: invalid predicate `a`
-  --> $DIR/cfg_attr-attr-syntax-validation.rs:19:12
+error[E0539]: malformed `cfg_attr` attribute input
+  --> $DIR/cfg_attr-attr-syntax-validation.rs:19:1
    |
 LL | #[cfg_attr(a())]
-   |            ^^^
+   | ^^^^^^^^^^^---^^
+   |            |
+   |            valid arguments are `any`, `all`, `not`, `target` or `version`
+   |
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+help: must be of the form
+   |
+LL - #[cfg_attr(a())]
+LL + #[cfg_attr(predicate, attr1, attr2, ...)]
+   |
 
 error[E0539]: malformed `cfg_attr` attribute input
   --> $DIR/cfg_attr-attr-syntax-validation.rs:22:1
@@ -177,5 +186,5 @@ LL | #[cfg_attr(true, link_section)]
 
 error: aborting due to 13 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0537, E0539, E0565, E0805.
-For more information about an error, try `rustc --explain E0537`.
+Some errors have detailed explanations: E0539, E0565, E0805.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/macros/cfg_select.rs
+++ b/tests/ui/macros/cfg_select.rs
@@ -188,7 +188,7 @@ cfg_select! {
 
 cfg_select! {
     a() => {}
-    //~^ ERROR invalid predicate `a` [E0537]
+    //~^ ERROR malformed `cfg_select` macro input [E0539]
 }
 
 cfg_select! {

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -37,11 +37,11 @@ error[E0565]: malformed `cfg_select` macro input
 LL |     a::b => {}
    |     ^^^^ expected a valid identifier here
 
-error[E0537]: invalid predicate `a`
+error[E0539]: malformed `cfg_select` macro input
   --> $DIR/cfg_select.rs:190:5
    |
 LL |     a() => {}
-   |     ^^^
+   |     ^^^ valid arguments are `any`, `all`, `not`, `target` or `version`
 
 error: expected one of `(`, `::`, `=>`, or `=`, found `+`
   --> $DIR/cfg_select.rs:195:7
@@ -185,5 +185,5 @@ LL |     cfg!() => {}
 
 error: aborting due to 17 previous errors; 7 warnings emitted
 
-Some errors have detailed explanations: E0537, E0565, E0753.
-For more information about an error, try `rustc --explain E0537`.
+Some errors have detailed explanations: E0539, E0565, E0753.
+For more information about an error, try `rustc --explain E0539`.

--- a/tests/ui/macros/cfg_select.stderr
+++ b/tests/ui/macros/cfg_select.stderr
@@ -41,7 +41,7 @@ error[E0539]: malformed `cfg_select` macro input
   --> $DIR/cfg_select.rs:190:5
    |
 LL |     a() => {}
-   |     ^^^ valid arguments are `any`, `all`, `not`, `target` or `version`
+   |     ^^^ valid arguments are `any`, `all`, `not` or `target`
 
 error: expected one of `(`, `::`, `=>`, or `=`, found `+`
   --> $DIR/cfg_select.rs:195:7

--- a/tests/ui/span/E0537.rs
+++ b/tests/ui/span/E0537.rs
@@ -1,4 +1,0 @@
-#[cfg(unknown())] //~ ERROR E0537
-pub fn something() {}
-
-pub fn main() {}

--- a/tests/ui/span/E0537.stderr
+++ b/tests/ui/span/E0537.stderr
@@ -1,9 +1,0 @@
-error[E0537]: invalid predicate `unknown`
-  --> $DIR/E0537.rs:1:7
-   |
-LL | #[cfg(unknown())]
-   |       ^^^^^^^^^
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0537`.


### PR DESCRIPTION
I have improved the error that is emitted when a non-existant cfg attribute is used. I removed the InvalidPredicate diagnostic, which does not provide much information, and used the function `expected_specific_argument` instead. This provides a nice link to the documentation. I have also blessed and updated the ui tests that broke because of this change.

Before:
```
error[E0537]: invalid predicate `does_not_exist`
 --> bad_error.rs:2:7
  |
2 | #[cfg(does_not_exist())]
  |       ^^^^^^^^^^^^^^^^

error: aborting due to 1 previous error
```

After:
```
error[E0539]: malformed `cfg` attribute input
 --> bad_error.rs:2:1
  |
2 | #[cfg(does_not_exist())]
  | ^^^^^^----------------^^
  |       |
  |       valid arguments are `any`, `all`, `not`, `target` or `version`
  |
  = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute>
help: must be of the form
  |
2 - #[cfg(does_not_exist())]
2 + #[cfg(predicate)]
  |
```

r? @JonathanBrouwer