### PR TITLE
Disable retagging for variadic arguments in const-eval

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -502,8 +502,12 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     let mplace = ecx.force_allocation(&place)?;
 
                     // Consume the remaining arguments by putting them into the variable argument
-                    // list.
-                    let varargs = ecx.allocate_varargs(&mut caller_args, &mut callee_args_abis)?;
+                    // list. We disable retagging to avoid creating protected tags. Protection should
+                    // only use callee-side information, and the varargs have no static callee-side type.
+                    let varargs = M::with_retag_mode(ecx, RetagMode::None, |ecx| {
+                        ecx.allocate_varargs(&mut caller_args, &mut callee_args_abis)
+                    })?;
+
                     // When the frame is dropped, these variable arguments are deallocated.
                     ecx.frame_mut().va_list = varargs.clone();
                     let key = ecx.va_list_ptr(varargs.into());

--- a/src/tools/miri/tests/pass/both_borrows/c_variadics.rs
+++ b/src/tools/miri/tests/pass/both_borrows/c_variadics.rs
@@ -1,0 +1,21 @@
+//@revisions: stack tree tree_implicit_writes
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
+//@[tree]compile-flags: -Zmiri-tree-borrows
+#![feature(c_variadic)]
+
+fn main() {
+    unsafe extern "C" fn write_with_first_arg(
+        ptr_to_val: *mut i32,
+        _hidden_mut_ref_to_val: ...
+    ) {
+        // Retagging needs to be disabled for arguments
+        // within the VaList. Otherwise, this write access
+        // will be undefined behavior.
+        unsafe { *ptr_to_val = 32; }
+    }
+
+    let mut val: i32 = 0;
+    unsafe {
+        write_with_first_arg(&raw mut val, &val);
+    }
+}


### PR DESCRIPTION
Fixes [#5058](https://github.com/rust-lang/miri/issues/5058) in Miri.

Retags occur on typed copies, which happen when we pass variadic arguments to a function. At the moment, variadic arguments receive `RetagMode::FnEntry` retags, which protects their permissions for the duration of the call. However, protection needs to be based on callee-side information, and the callee has now way of knowing what's contained within its `VaList`.

This PR disables retagging entirely when copying variable arguments. It also adds a new, passing test case that would originally fail before this change.

cc: @RalfJung, @folkertdev 
