### PR TITLE
rustc_resolve: point the label span at the segment that could not be resolved

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -332,15 +332,15 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     PathResult::NonModule(partial_res) => {
                         expected_found_error(partial_res.expect_full_res())
                     }
-                    PathResult::Failed {
-                        span, label, suggestion, message, segment_name, ..
-                    } => Err(VisResolutionError::FailedToResolve(
-                        span,
-                        segment_name,
-                        label,
-                        suggestion,
-                        message,
-                    )),
+                    PathResult::Failed { label, suggestion, message, segment, .. } => {
+                        Err(VisResolutionError::FailedToResolve(
+                            segment.span,
+                            segment.name,
+                            label,
+                            suggestion,
+                            message,
+                        ))
+                    }
                     PathResult::Indeterminate => Err(VisResolutionError::Indeterminate(path.span)),
                 }
             }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -1144,10 +1144,14 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         const MAX_LABEL_COUNT: usize = 10;
 
         for (import, err) in errors.into_iter().take(MAX_LABEL_COUNT) {
+            let label_span = match err.segment {
+                Some(segment) => segment.span,
+                None => err.span,
+            };
             if let Some(label) = &label {
-                diag.span_label(err.span, label.clone());
+                diag.span_label(label_span, label.clone());
             } else if let Some(label) = &err.label {
-                diag.span_label(err.span, label.clone());
+                diag.span_label(label_span, label.clone());
             }
 
             if let Some((suggestions, msg, applicability)) = err.suggestion {

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -359,7 +359,7 @@ struct UnresolvedImportError {
     note: Option<String>,
     suggestion: Option<Suggestion>,
     candidates: Option<Vec<ImportSuggestion>>,
-    segment: Option<Symbol>,
+    segment: Option<Ident>,
     /// comes from `PathRes::Failed { module }`
     module: Option<DefId>,
     on_unknown_attr: Option<OnUnknownData>,
@@ -1081,7 +1081,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             Some(def_id) if self.mods_with_parse_errors.contains(&def_id) => false,
             // If we've encountered something like `use _;`, we've already emitted an error stating
             // that `_` is not a valid identifier, so we ignore that resolve error.
-            _ => err.segment != Some(kw::Underscore),
+            _ => err.segment.map(|s| s.name) != Some(kw::Underscore),
         });
         if errors.is_empty() {
             self.tcx.dcx().delayed_bug("expected a parse or \"`_` can't be an identifier\" error");
@@ -1109,7 +1109,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let this = errors.iter().map(|(_import, err)| {
 
                     // Is this unwrap_or reachable?
-                    err.segment.unwrap_or(kw::Underscore)
+                    err.segment.map(|s|s.name).unwrap_or(kw::Underscore)
                 }).join(", ");
 
                 let args = FormatArgs {
@@ -1192,7 +1192,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 && let Some(segment) = err.segment
                 && let Some(module) = err.module
             {
-                self.find_cfg_stripped(&mut diag, &segment, module)
+                self.find_cfg_stripped(&mut diag, &segment.name, module)
             }
         }
 
@@ -1329,7 +1329,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             PathResult::Failed {
                 is_error_from_last_segment: false,
                 span,
-                segment_name,
+                segment,
                 label,
                 suggestion,
                 module,
@@ -1344,7 +1344,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     self.report_error(
                         span,
                         ResolutionError::FailedToResolve {
-                            segment: segment_name,
+                            segment: segment.name,
                             label,
                             suggestion,
                             module,
@@ -1360,7 +1360,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 label,
                 suggestion,
                 module,
-                segment_name,
+                segment,
                 note,
                 ..
             } => {
@@ -1386,7 +1386,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                 Applicability::MaybeIncorrect,
                             )),
                             candidates: None,
-                            segment: Some(segment_name),
+                            segment: Some(segment),
                             module,
                             on_unknown_attr: import.on_unknown_attr.clone(),
                         },
@@ -1396,7 +1396,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             note,
                             suggestion,
                             candidates: None,
-                            segment: Some(segment_name),
+                            segment: Some(segment),
                             module,
                             on_unknown_attr: import.on_unknown_attr.clone(),
                         },
@@ -1691,7 +1691,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                             None
                         }
                     }),
-                    segment: Some(ident.name),
+                    segment: Some(ident),
                     on_unknown_attr: import.on_unknown_attr.clone(),
                 })
             } else {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -5015,7 +5015,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 label,
                 suggestion,
                 module,
-                segment_name,
+                segment,
                 error_implied_by_parse_error: _,
                 message,
                 note: _,
@@ -5023,7 +5023,7 @@ impl<'a, 'ast, 'ra, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 return Err(respan(
                     span,
                     ResolutionError::FailedToResolve {
-                        segment: segment_name,
+                        segment: segment.name,
                         label,
                         suggestion,
                         module,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -477,8 +477,8 @@ enum PathResult<'ra> {
         ///
         /// In this case, `module` will point to `a`.
         module: Option<ModuleOrUniformRoot<'ra>>,
-        /// The segment name of target
-        segment_name: Symbol,
+        /// The segment of target
+        segment: Ident,
         error_implied_by_parse_error: bool,
         message: String,
         note: Option<String>,
@@ -507,7 +507,7 @@ impl<'ra> PathResult<'ra> {
         };
         PathResult::Failed {
             span: ident.span,
-            segment_name: ident.name,
+            segment: ident,
             label,
             suggestion,
             is_error_from_last_segment,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -959,9 +959,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 path_res @ (PathResult::NonModule(..) | PathResult::Failed { .. }) => {
                     let mut suggestion = None;
                     let (span, message, label, module, segment) = match path_res {
-                        PathResult::Failed {
-                            span, label, module, segment_name, message, ..
-                        } => {
+                        PathResult::Failed { span, label, module, segment, message, .. } => {
                             // try to suggest if it's not a macro, maybe a function
                             if let PathResult::NonModule(partial_res) = self
                                 .cm()
@@ -980,7 +978,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                     Applicability::MaybeIncorrect,
                                 ));
                             }
-                            (span, message, label, module, segment_name)
+                            (span, message, label, module, segment.name)
                         }
                         PathResult::NonModule(partial_res) => {
                             let found_an = partial_res.base_res().article();

--- a/tests/ui/cfg/diagnostics-reexport.stderr
+++ b/tests/ui/cfg/diagnostics-reexport.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `a::x`
   --> $DIR/diagnostics-reexport.rs:12:9
    |
 LL | pub use a::x;
-   |         ^^^^ no `x` in `a`
+   |         ^^^-
+   |            |
+   |            no `x` in `a`
    |
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:18:12

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `super::inner::doesnt_exist`
   --> $DIR/diagnostics-same-crate.rs:32:9
    |
 LL |     use super::inner::doesnt_exist;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ no `doesnt_exist` in `inner`
+   |         ^^^^^^^^^^^^^^------------
+   |                       |
+   |                       no `doesnt_exist` in `inner`
    |
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13

--- a/tests/ui/cfg/reserved-macro-names-rename.stderr
+++ b/tests/ui/cfg/reserved-macro-names-rename.stderr
@@ -20,7 +20,9 @@ error[E0432]: unresolved import `not_found`
   --> $DIR/reserved-macro-names-rename.rs:27:9
    |
 LL |     use not_found as cfg; // trigger "unresolved import", not "cfg reserved".
-   |         ^^^^^^^^^^^^^^^^ no external crate `not_found`
+   |         ---------^^^^^^^
+   |         |
+   |         no external crate `not_found`
 
 error[E0659]: `cfg` is ambiguous
   --> $DIR/reserved-macro-names-rename.rs:17:9

--- a/tests/ui/diagnostic_namespace/on_unknown/incorrect_format_string.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/incorrect_format_string.stderr
@@ -2,7 +2,9 @@ error[E0432]: foo {}
   --> $DIR/incorrect_format_string.rs:5:5
    |
 LL | use std::does_not_exist;
-   |     ^^^^^^^^^^^^^^^^^^^ no `does_not_exist` in the root
+   |     ^^^^^--------------
+   |          |
+   |          no `does_not_exist` in the root
    |
    = note: unresolved import `std::does_not_exist`
 
@@ -10,7 +12,9 @@ error[E0432]: foo {A}
   --> $DIR/incorrect_format_string.rs:10:5
    |
 LL | use std::does_not_exist2;
-   |     ^^^^^^^^^^^^^^^^^^^^ no `does_not_exist2` in the root
+   |     ^^^^^---------------
+   |          |
+   |          no `does_not_exist2` in the root
    |
    = note: unresolved import `std::does_not_exist2`
 
@@ -18,19 +22,25 @@ error[E0432]: unresolved import `std::does_not_exist3`
   --> $DIR/incorrect_format_string.rs:15:5
    |
 LL | use std::does_not_exist3;
-   |     ^^^^^^^^^^^^^^^^^^^^ foo {}
+   |     ^^^^^---------------
+   |          |
+   |          foo {}
 
 error[E0432]: unresolved import `std::does_not_exist4`
   --> $DIR/incorrect_format_string.rs:20:5
    |
 LL | use std::does_not_exist4;
-   |     ^^^^^^^^^^^^^^^^^^^^ foo {A}
+   |     ^^^^^---------------
+   |          |
+   |          foo {A}
 
 error[E0432]: unresolved import `std::does_not_exist5`
   --> $DIR/incorrect_format_string.rs:25:5
    |
 LL | use std::does_not_exist5;
-   |     ^^^^^^^^^^^^^^^^^^^^ no `does_not_exist5` in the root
+   |     ^^^^^---------------
+   |          |
+   |          no `does_not_exist5` in the root
    |
    = note: foo {}
 
@@ -38,7 +48,9 @@ error[E0432]: unresolved import `std::does_not_exist6`
   --> $DIR/incorrect_format_string.rs:33:5
    |
 LL | use std::does_not_exist6;
-   |     ^^^^^^^^^^^^^^^^^^^^ no `does_not_exist6` in the root
+   |     ^^^^^---------------
+   |          |
+   |          no `does_not_exist6` in the root
    |
    = note: foo {Self} {ItemContext} {Trait} {A}
 

--- a/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/malformed_attribute.stderr
@@ -2,7 +2,9 @@ error[E0432]: Foo
   --> $DIR/malformed_attribute.rs:16:5
    |
 LL | use std::str::NotExisting;
-   |     ^^^^^^^^^^^^^^^^^^^^^ no `NotExisting` in `str`
+   |     ^^^^^^^^^^-----------
+   |               |
+   |               no `NotExisting` in `str`
    |
    = note: unresolved import `std::str::NotExisting`
 

--- a/tests/ui/diagnostic_namespace/on_unknown/multiple_errors.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/multiple_errors.stderr
@@ -13,8 +13,9 @@ error[E0432]: custom message
   --> $DIR/multiple_errors.rs:19:15
    |
 LL |     use std::{Whatever, vec::NonExisting, vec::Vec, *};
-   |               ^^^^^^^^  ^^^^^^^^^^^^^^^^ custom label
-   |               |
+   |               ^^^^^^^^  ^^^^^-----------
+   |               |              |
+   |               |              custom label
    |               custom label
    |
    = note: unresolved imports `std::Whatever`, `std::vec::NonExisting`

--- a/tests/ui/diagnostic_namespace/on_unknown/point_at_macro_argument.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown/point_at_macro_argument.rs
@@ -1,0 +1,31 @@
+//! Test that the `label` span points at the identifier passed to the macro.
+
+#![feature(diagnostic_on_unknown)]
+#![crate_type = "lib"]
+
+mod things {}
+
+macro_rules! mac {
+    ($thing: ident) => {{
+        const _x: u32 = {
+            #[diagnostic::on_unknown(label = "you did the bad thing")]
+            use things::$thing;
+            //~^ ERROR unresolved import `things::what` [E0432]
+            //~| ERROR unresolved import `things::what2` [E0432]
+            $thing
+        };
+    }};
+}
+
+fn stuff() {
+    mac!(what);
+    //~^ NOTE you did the bad thing
+    //~| NOTE in this expansion of mac!
+
+    mac!(//~ NOTE in this expansion of mac!
+
+        what2
+        //~^ NOTE you did the bad thing
+
+    );
+}

--- a/tests/ui/diagnostic_namespace/on_unknown/point_at_macro_argument.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/point_at_macro_argument.stderr
@@ -1,0 +1,33 @@
+error[E0432]: unresolved import `things::what`
+  --> $DIR/point_at_macro_argument.rs:12:17
+   |
+LL |             use things::$thing;
+   |                 ^^^^^^^^^^^^^^
+...
+LL |     mac!(what);
+   |     ----------
+   |     |    |
+   |     |    you did the bad thing
+   |     in this macro invocation
+   |
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0432]: unresolved import `things::what2`
+  --> $DIR/point_at_macro_argument.rs:12:17
+   |
+LL |               use things::$thing;
+   |                   ^^^^^^^^^^^^^^
+...
+LL | /     mac!(
+LL | |
+LL | |         what2
+   | |         ----- you did the bad thing
+...  |
+LL | |     );
+   | |_____- in this macro invocation
+   |
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/diagnostic_namespace/on_unknown/this_format_argument.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/this_format_argument.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `foo::Foo`
   --> $DIR/this_format_argument.rs:7:5
    |
 LL | use foo::Foo;
-   |     ^^^^^^^^ no `Foo` in `foo`
+   |     ^^^^^---
+   |          |
+   |          no `Foo` in `foo`
    |
    = note: the name of this item is a single ident: `Foo`
 
@@ -51,7 +53,9 @@ error[E0432]: unresolved import `foo::Foo`
   --> $DIR/this_format_argument.rs:42:5
    |
 LL | use foo::Foo as DoNotUseForThisParam;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `Foo` in `foo`
+   |     ^^^^^---^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          no `Foo` in `foo`
    |
    = note: the name of this item is a single ident: `Foo`
 

--- a/tests/ui/diagnostic_namespace/on_unknown/unknown_import.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown/unknown_import.stderr
@@ -2,7 +2,9 @@ error[E0432]: first message
   --> $DIR/unknown_import.rs:12:5
    |
 LL | use foo::Foo;
-   |     ^^^^^^^^ first label
+   |     ^^^^^---
+   |          |
+   |          first label
    |
    = note: unresolved import `foo::Foo`
    = note: custom note

--- a/tests/ui/feature-gates/feature-gate-diagnostic-on-unknown.stderr
+++ b/tests/ui/feature-gates/feature-gate-diagnostic-on-unknown.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `std::vec::NotExisting`
   --> $DIR/feature-gate-diagnostic-on-unknown.rs:5:5
    |
 LL | use std::vec::NotExisting;
-   |     ^^^^^^^^^^^^^^^^^^^^^ no `NotExisting` in `vec`
+   |     ^^^^^^^^^^-----------
+   |               |
+   |               no `NotExisting` in `vec`
 
 error: unknown diagnostic attribute
   --> $DIR/feature-gate-diagnostic-on-unknown.rs:3:15

--- a/tests/ui/imports/bad-import-in-nested.stderr
+++ b/tests/ui/imports/bad-import-in-nested.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `super::super::C::D::AA`
   --> $DIR/bad-import-in-nested.rs:10:21
    |
 LL |         use super::{super::C::D::AA, AA as _};
-   |                     ^^^^^^^^^^^^^^^ no `AA` in `C::D`
+   |                     ^^^^^^^^^^^^^--
+   |                                  |
+   |                                  no `AA` in `C::D`
    |
    = help: consider importing this type alias instead:
            crate::A::AA
@@ -20,7 +22,9 @@ error[E0432]: unresolved import `crate::C::BB`
   --> $DIR/bad-import-in-nested.rs:23:20
    |
 LL |     use crate::{A, C::BB};
-   |                    ^^^^^ no `BB` in `C`
+   |                    ^^^--
+   |                       |
+   |                       no `BB` in `C`
    |
    = help: consider importing this type alias instead:
            crate::A::BB

--- a/tests/ui/imports/bad-import-with-rename.stderr
+++ b/tests/ui/imports/bad-import-with-rename.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::D::B`
   --> $DIR/bad-import-with-rename.rs:8:9
    |
 LL |     use crate::D::B as _;
-   |         ^^^^^^^^^^^^^^^^ no `B` in `D`
+   |         ^^^^^^^^^^-^^^^^
+   |                   |
+   |                   no `B` in `D`
    |
 help: consider importing this type alias instead
    |
@@ -14,7 +16,9 @@ error[E0432]: unresolved import `crate::D::B2`
   --> $DIR/bad-import-with-rename.rs:11:9
    |
 LL |     use crate::D::B2;
-   |         ^^^^^^^^^^^^ no `B2` in `D`
+   |         ^^^^^^^^^^--
+   |                   |
+   |                   no `B2` in `D`
    |
 help: consider importing this type alias instead
    |

--- a/tests/ui/imports/import-loop-2.stderr
+++ b/tests/ui/imports/import-loop-2.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::b::x`
   --> $DIR/import-loop-2.rs:2:13
    |
 LL |     pub use crate::b::x;
-   |             ^^^^^^^^^^^ no `x` in `b`
+   |             ^^^^^^^^^^-
+   |                       |
+   |                       no `x` in `b`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import-loop.stderr
+++ b/tests/ui/imports/import-loop.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::y::x`
   --> $DIR/import-loop.rs:4:13
    |
 LL |     pub use crate::y::x;
-   |             ^^^^^^^^^^^ no `x` in `y`
+   |             ^^^^^^^^^^-
+   |                       |
+   |                       no `x` in `y`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import.stderr
+++ b/tests/ui/imports/import.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `zed::baz`
   --> $DIR/import.rs:5:5
    |
 LL | use zed::baz;
-   |     ^^^^^^^^ no `baz` in `zed`
+   |     ^^^^^---
+   |          |
+   |          no `baz` in `zed`
    |
 help: a similar name exists in the module
    |

--- a/tests/ui/imports/import4.stderr
+++ b/tests/ui/imports/import4.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::b::foo`
   --> $DIR/import4.rs:1:17
    |
 LL | mod a { pub use crate::b::foo; }
-   |                 ^^^^^^^^^^^^^ no `foo` in `b`
+   |                 ^^^^^^^^^^---
+   |                           |
+   |                           no `foo` in `b`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-113953.stderr
+++ b/tests/ui/imports/issue-113953.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-113953.rs:3:5
    |
 LL | use unresolved as u8;
-   |     ^^^^^^^^^^^^^^^^ no external crate `unresolved`
+   |     ----------^^^^^^
+   |     |
+   |     no external crate `unresolved`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-114682-5.stderr
+++ b/tests/ui/imports/issue-114682-5.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `issue_114682_5_extern_1::Url`
   --> $DIR/issue-114682-5.rs:10:5
    |
 LL | use issue_114682_5_extern_1::Url;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `Url` in `types::issue_114682_5_extern_1`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                              |
+   |                              no `Url` in `types::issue_114682_5_extern_1`
    |
 help: consider importing this struct instead
    |

--- a/tests/ui/imports/issue-13404.stderr
+++ b/tests/ui/imports/issue-13404.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `b::f`
   --> $DIR/issue-13404.rs:2:5
    |
 LL | use b::f;
-   |     ^^^^ no `f` in `b`
+   |     ^^^-
+   |        |
+   |        no `f` in `b`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-2937.stderr
+++ b/tests/ui/imports/issue-2937.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `m::f`
   --> $DIR/issue-2937.rs:1:5
    |
 LL | use m::f as x;
-   |     ^^^^^^^^^ no `f` in `m`
+   |     ^^^-^^^^^
+   |        |
+   |        no `f` in `m`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-32833.stderr
+++ b/tests/ui/imports/issue-32833.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `bar::Foo`
   --> $DIR/issue-32833.rs:2:5
    |
 LL | use bar::Foo;
-   |     ^^^^^^^^ no `Foo` in `bar`
+   |     ^^^^^---
+   |          |
+   |          no `Foo` in `bar`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-53512.stderr
+++ b/tests/ui/imports/issue-53512.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `m::assert`
   --> $DIR/issue-53512.rs:4:5
    |
 LL | use m::assert;
-   |     ^^^^^^^^^ no `assert` in `m`
+   |     ^^^------
+   |        |
+   |        no `assert` in `m`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-56125.stderr
+++ b/tests/ui/imports/issue-56125.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `empty::issue_56125`
   --> $DIR/issue-56125.rs:17:9
    |
 LL |     use empty::issue_56125;
-   |         ^^^^^^^^^^^^^^^^^^ no `issue_56125` in `m3::empty`
+   |         ^^^^^^^-----------
+   |                |
+   |                no `issue_56125` in `m3::empty`
    |
 help: consider importing one of these modules instead
    |

--- a/tests/ui/imports/issue-57015.stderr
+++ b/tests/ui/imports/issue-57015.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `single_err::something`
   --> $DIR/issue-57015.rs:11:5
    |
 LL | use single_err::something;
-   |     ^^^^^^^^^^^^^^^^^^^^^ no `something` in `single_err`
+   |     ^^^^^^^^^^^^---------
+   |                 |
+   |                 no `something` in `single_err`
    |
 help: consider importing this module instead
    |

--- a/tests/ui/imports/issue-59764.stderr
+++ b/tests/ui/imports/issue-59764.stderr
@@ -90,7 +90,9 @@ error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:54:31
    |
 LL |     use issue_59764::{foobaz, foo::makro};
-   |                               ^^^^^^^^^^ no `makro` in `foo`
+   |                               ^^^^^-----
+   |                                    |
+   |                                    no `makro` in `foo`
    |
    = note: this could be because a macro annotated with `#[macro_export]` will be exported at the root of the crate instead of the module where it is defined
 help: a macro with this name exists at the root of the crate
@@ -177,7 +179,9 @@ error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:102:9
    |
 LL |     use issue_59764::foo::makro as baz;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `makro` in `foo`
+   |         ^^^^^^^^^^^^^^^^^^-----^^^^^^^
+   |                           |
+   |                           no `makro` in `foo`
    |
    = note: this could be because a macro annotated with `#[macro_export]` will be exported at the root of the crate instead of the module where it is defined
 help: a macro with this name exists at the root of the crate
@@ -190,7 +194,9 @@ error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:107:33
    |
 LL |     use issue_59764::foo::{baz, makro as foobar};
-   |                                 ^^^^^^^^^^^^^^^ no `makro` in `foo`
+   |                                 -----^^^^^^^^^^
+   |                                 |
+   |                                 no `makro` in `foo`
    |
    = note: this could be because a macro annotated with `#[macro_export]` will be exported at the root of the crate instead of the module where it is defined
 help: a macro with this name exists at the root of the crate
@@ -203,7 +209,9 @@ error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:120:17
    |
 LL |                 makro as foobar}
-   |                 ^^^^^^^^^^^^^^^ no `makro` in `foo`
+   |                 -----^^^^^^^^^^
+   |                 |
+   |                 no `makro` in `foo`
    |
    = note: this could be because a macro annotated with `#[macro_export]` will be exported at the root of the crate instead of the module where it is defined
 help: a macro with this name exists at the root of the crate
@@ -219,7 +227,9 @@ error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:127:5
    |
 LL | use issue_59764::foo::makro;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ no `makro` in `foo`
+   |     ^^^^^^^^^^^^^^^^^^-----
+   |                       |
+   |                       no `makro` in `foo`
    |
    = note: this could be because a macro annotated with `#[macro_export]` will be exported at the root of the crate instead of the module where it is defined
 help: a macro with this name exists at the root of the crate

--- a/tests/ui/imports/issue-85992.stderr
+++ b/tests/ui/imports/issue-85992.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::empty`
   --> $DIR/issue-85992.rs:8:5
    |
 LL | use crate::empty;
-   |     ^^^^^^^^^^^^ no `empty` in the root
+   |     ^^^^^^^-----
+   |            |
+   |            no `empty` in the root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/point_macro_input.rs
+++ b/tests/ui/imports/point_macro_input.rs
@@ -14,7 +14,6 @@ macro_rules! mac2 {
         const _x: u32 = {
             use things::$thing;
             //~^ ERROR unresolved import `things::what2` [E0432]
-            //~| NOTE no `what2` in `things`
             $thing
         };
     }}
@@ -32,6 +31,6 @@ fn foo(){
     mac2!(//~ NOTE in this expansion of mac2!
 
         what2
-
+        //~^ NOTE no `what2` in `things`
     );
 }

--- a/tests/ui/imports/point_macro_input.rs
+++ b/tests/ui/imports/point_macro_input.rs
@@ -5,7 +5,7 @@ mod things { }
 macro_rules! mac1 {
     ($thing: ident) => {{
         const _x: u32 = things::$thing;
-        //~^NOTE due to this macro variable
+        //~^ NOTE due to this macro variable
     }}
 }
 

--- a/tests/ui/imports/point_macro_input.rs
+++ b/tests/ui/imports/point_macro_input.rs
@@ -1,0 +1,37 @@
+#![crate_type = "lib"]
+
+mod things { }
+
+macro_rules! mac1 {
+    ($thing: ident) => {{
+        const _x: u32 = things::$thing;
+        //~^NOTE due to this macro variable
+    }}
+}
+
+macro_rules! mac2 {
+    ($thing: ident) => {{
+        const _x: u32 = {
+            use things::$thing;
+            //~^ ERROR unresolved import `things::what2` [E0432]
+            //~| NOTE no `what2` in `things`
+            $thing
+        };
+    }}
+}
+
+
+fn foo(){
+    mac1!(
+
+        what1
+        //~^ ERROR cannot find value `what1` in module `things` [E0425]
+        //~| NOTE not found in `things`
+
+    );
+    mac2!(//~ NOTE in this expansion of mac2!
+
+        what2
+
+    );
+}

--- a/tests/ui/imports/point_macro_input.stderr
+++ b/tests/ui/imports/point_macro_input.stderr
@@ -1,0 +1,28 @@
+error[E0432]: unresolved import `things::what2`
+  --> $DIR/point_macro_input.rs:15:17
+   |
+LL |               use things::$thing;
+   |                   ^^^^^^^^^^^^^^ no `what2` in `things`
+...
+LL | /     mac2!(
+LL | |
+LL | |         what2
+LL | |
+LL | |     );
+   | |_____- in this macro invocation
+   |
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find value `what1` in module `things`
+  --> $DIR/point_macro_input.rs:27:9
+   |
+LL |         const _x: u32 = things::$thing;
+   |                                 ------ due to this macro variable
+...
+LL |         what1
+   |         ^^^^^ not found in `things`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0425, E0432.
+For more information about an error, try `rustc --explain E0425`.

--- a/tests/ui/imports/point_macro_input.stderr
+++ b/tests/ui/imports/point_macro_input.stderr
@@ -2,11 +2,12 @@ error[E0432]: unresolved import `things::what2`
   --> $DIR/point_macro_input.rs:15:17
    |
 LL |               use things::$thing;
-   |                   ^^^^^^^^^^^^^^ no `what2` in `things`
+   |                   ^^^^^^^^^^^^^^
 ...
 LL | /     mac2!(
 LL | |
 LL | |         what2
+   | |         ----- no `what2` in `things`
 LL | |
 LL | |     );
    | |_____- in this macro invocation
@@ -14,7 +15,7 @@ LL | |     );
    = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `what1` in module `things`
-  --> $DIR/point_macro_input.rs:27:9
+  --> $DIR/point_macro_input.rs:26:9
    |
 LL |         const _x: u32 = things::$thing;
    |                                 ------ due to this macro variable

--- a/tests/ui/imports/shadow-glob-module-resolution-2.stderr
+++ b/tests/ui/imports/shadow-glob-module-resolution-2.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `e`
   --> $DIR/shadow-glob-module-resolution-2.rs:14:5
    |
 LL | use e as b;
-   |     ^^^^^^ no `e` in the root
+   |     -^^^^^
+   |     |
+   |     no `e` in the root
    |
 help: a similar name exists in the module
    |

--- a/tests/ui/imports/show-private-items-issue-138626.stderr
+++ b/tests/ui/imports/show-private-items-issue-138626.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::two::foo::Foo`
   --> $DIR/show-private-items-issue-138626.rs:17:13
    |
 LL |     pub use crate::two::foo::Foo;
-   |             ^^^^^^^^^^^^^^^^^^^^ no `Foo` in `two::foo`
+   |             ^^^^^^^^^^^^^^^^^---
+   |                              |
+   |                              no `Foo` in `two::foo`
    |
 note: struct `two::foo::bar::Foo` exists but is inaccessible
   --> $DIR/show-private-items-issue-138626.rs:13:13

--- a/tests/ui/imports/unresolved-imports-used.stderr
+++ b/tests/ui/imports/unresolved-imports-used.stderr
@@ -2,13 +2,17 @@ error[E0432]: unresolved import `qux::bar`
   --> $DIR/unresolved-imports-used.rs:11:5
    |
 LL | use qux::bar;
-   |     ^^^^^^^^ no `bar` in `qux`
+   |     ^^^^^---
+   |          |
+   |          no `bar` in `qux`
 
 error[E0432]: unresolved import `qux::bar2`
   --> $DIR/unresolved-imports-used.rs:14:5
    |
 LL | use qux::bar2;
-   |     ^^^^^^^^^ no `bar2` in `qux`
+   |     ^^^^^----
+   |          |
+   |          no `bar2` in `qux`
 
 error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-imports-used.rs:12:5

--- a/tests/ui/macros/compile_error_macro-suppress-errors.stderr
+++ b/tests/ui/macros/compile_error_macro-suppress-errors.stderr
@@ -14,7 +14,9 @@ error[E0432]: unresolved import `crate::another_module::NotExist`
   --> $DIR/compile_error_macro-suppress-errors.rs:11:13
    |
 LL |         use crate::another_module::NotExist;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `NotExist` in `another_module`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^--------
+   |                                    |
+   |                                    no `NotExist` in `another_module`
 
 error[E0433]: cannot find `Hello` in `another_module`
   --> $DIR/compile_error_macro-suppress-errors.rs:37:55

--- a/tests/ui/privacy/privacy2.stderr
+++ b/tests/ui/privacy/privacy2.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `bar::foo`
   --> $DIR/privacy2.rs:22:9
    |
 LL |     use bar::foo;
-   |         ^^^^^^^^ no `foo` in `bar`
+   |         ^^^^^---
+   |              |
+   |              no `foo` in `bar`
 
 error[E0603]: function import `foo` is private
   --> $DIR/privacy2.rs:29:20

--- a/tests/ui/privacy/privacy3.stderr
+++ b/tests/ui/privacy/privacy3.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `bar::gpriv`
   --> $DIR/privacy3.rs:23:9
    |
 LL |     use bar::gpriv;
-   |         ^^^^^^^^^^ no `gpriv` in `bar`
+   |         ^^^^^-----
+   |              |
+   |              no `gpriv` in `bar`
 
 error: requires `sized` lang_item
   --> $DIR/privacy3.rs:13:20

--- a/tests/ui/proc-macro/import.stderr
+++ b/tests/ui/proc-macro/import.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `test_macros::empty_derive`
   --> $DIR/import.rs:5:5
    |
 LL | use test_macros::empty_derive;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `empty_derive` in the root
+   |     ^^^^^^^^^^^^^------------
+   |                  |
+   |                  no `empty_derive` in the root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/mixed-site-span.stderr
+++ b/tests/ui/proc-macro/mixed-site-span.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:49:5
    |
 LL |     invoke_with_crate!{input proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                              |
+   |                              no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +12,9 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:50:5
    |
 LL |     invoke_with_ident!{input proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                              |
+   |                              no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +22,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:51:5
    |
 LL |     invoke_with_crate!{call proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                             |
+   |                             no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +32,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:52:5
    |
 LL |     invoke_with_ident!{call proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                             |
+   |                             no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +42,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:53:5
    |
 LL |     invoke_with_ident!{hello call proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                                   |
+   |                                   no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +52,9 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:56:5
    |
 LL |     invoke_with_ident!{krate input proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                                    |
+   |                                    no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a similar name exists in the module
@@ -55,7 +67,9 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:57:5
    |
 LL |     with_crate!{krate input proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                             |
+   |                             no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a similar name exists in the module
@@ -68,7 +82,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:58:5
    |
 LL |     with_crate!{krate call proc_macro_item}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                            |
+   |                            no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a similar name exists in the module
@@ -81,7 +97,9 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:62:28
    |
 LL |         invoke_with_ident!{$crate input proc_macro_item}
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |                            ^^^^^^^^^^^^^---------------
+   |                                         |
+   |                                         no `proc_macro_item` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -97,7 +115,9 @@ error[E0432]: unresolved import `$crate::proc_macro_item`
   --> $DIR/mixed-site-span.rs:63:21
    |
 LL |         with_crate!{$crate input proc_macro_item}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |                     ^^^^^^^^^^^^^---------------
+   |                                  |
+   |                                  no `proc_macro_item` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -113,7 +133,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:64:9
    |
 LL |         with_crate!{$crate call proc_macro_item}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                                 |
+   |                                 no `proc_macro_item` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -129,7 +151,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:67:9
    |
 LL |         invoke_with_ident!{$crate call proc_macro_item}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------^
+   |                                        |
+   |                                        no `proc_macro_item` in the root
 LL |     }}
 LL |     test!();
    |     ------- in this macro invocation
@@ -140,7 +164,9 @@ error[E0432]: unresolved import `$crate::TokenItem`
   --> $DIR/mixed-site-span.rs:89:5
    |
 LL |     invoke_with_ident!{krate input TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                                    |
+   |                                    no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -153,7 +179,9 @@ error[E0432]: unresolved import `$crate::TokenItem`
   --> $DIR/mixed-site-span.rs:90:5
    |
 LL |     with_crate!{krate input TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                             |
+   |                             no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -166,7 +194,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:91:5
    |
 LL |     with_crate!{krate call TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                            |
+   |                            no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -179,7 +209,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:94:5
    |
 LL |     invoke_with_crate!{mixed TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                              |
+   |                              no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -193,7 +225,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:95:5
    |
 LL |     invoke_with_ident!{mixed TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                              |
+   |                              no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -207,7 +241,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:96:5
    |
 LL |     invoke_with_ident!{krate mixed TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                                    |
+   |                                    no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -221,7 +257,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:97:5
    |
 LL |     with_crate!{krate mixed TokenItem}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                             |
+   |                             no `TokenItem` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -234,7 +272,9 @@ error[E0432]: unresolved import `$crate::TokenItem`
   --> $DIR/mixed-site-span.rs:101:28
    |
 LL |         invoke_with_ident!{$crate input TokenItem}
-   |                            ^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |                            ^^^^^^^^^^^^^---------
+   |                                         |
+   |                                         no `TokenItem` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -250,7 +290,9 @@ error[E0432]: unresolved import `$crate::TokenItem`
   --> $DIR/mixed-site-span.rs:102:21
    |
 LL |         with_crate!{$crate input TokenItem}
-   |                     ^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |                     ^^^^^^^^^^^^^---------
+   |                                  |
+   |                                  no `TokenItem` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -266,7 +308,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:103:9
    |
 LL |         with_crate!{$crate call TokenItem}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                                 |
+   |                                 no `TokenItem` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -282,7 +326,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:106:9
    |
 LL |         invoke_with_ident!{$crate mixed TokenItem}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                                         |
+   |                                         no `TokenItem` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -299,7 +345,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:107:9
    |
 LL |         with_crate!{$crate mixed TokenItem}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^---------^
+   |                                  |
+   |                                  no `TokenItem` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -315,7 +363,9 @@ error[E0432]: unresolved import `$crate::ItemUse`
   --> $DIR/mixed-site-span.rs:131:5
    |
 LL |     invoke_with_crate!{input ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                              |
+   |                              no `ItemUse` in the root
    |
    = note: this error originates in the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -329,7 +379,9 @@ error[E0432]: unresolved import `$crate::ItemUse`
   --> $DIR/mixed-site-span.rs:132:5
    |
 LL |     invoke_with_ident!{input ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                              |
+   |                              no `ItemUse` in the root
    |
    = note: this error originates in the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -343,7 +395,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:135:5
    |
 LL |     invoke_with_crate!{mixed ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                              |
+   |                              no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -357,7 +411,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:136:5
    |
 LL |     invoke_with_ident!{mixed ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                              |
+   |                              no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -371,7 +427,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:137:5
    |
 LL |     invoke_with_ident!{krate mixed ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                                    |
+   |                                    no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -385,7 +443,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:138:5
    |
 LL |     with_crate!{krate mixed ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                             |
+   |                             no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -398,7 +458,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:140:5
    |
 LL |     invoke_with_crate!{call ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                             |
+   |                             no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -412,7 +474,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:141:5
    |
 LL |     invoke_with_ident!{call ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                             |
+   |                             no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -426,7 +490,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:142:5
    |
 LL |     invoke_with_ident!{hello call ItemUse}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                                   |
+   |                                   no `ItemUse` in the root
    |
    = note: this error originates in the macro `with_crate` which comes from the expansion of the macro `invoke_with_ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -440,7 +506,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:145:9
    |
 LL |         invoke_with_ident!{$crate mixed ItemUse}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                                         |
+   |                                         no `ItemUse` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -457,7 +525,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:146:9
    |
 LL |         with_crate!{$crate mixed ItemUse}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                                  |
+   |                                  no `ItemUse` in the root
 ...
 LL |     test!();
    |     ------- in this macro invocation
@@ -473,7 +543,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:148:9
    |
 LL |         invoke_with_ident!{$crate call ItemUse}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                                        |
+   |                                        no `ItemUse` in the root
 LL |     }}
 LL |     test!();
    |     ------- in this macro invocation
@@ -490,7 +562,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:155:1
    |
 LL | use_input_crate!{proc_macro_item}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   | ^^^^^^^^^^^^^^^^^---------------^
+   |                  |
+   |                  no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `use_input_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -498,7 +572,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:156:1
    |
 LL | use_input_krate!{proc_macro_item}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   | ^^^^^^^^^^^^^^^^^---------------^
+   |                  |
+   |                  no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `use_input_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -506,7 +582,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:159:1
    |
 LL | use_call_crate!{proc_macro_item}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   | ^^^^^^^^^^^^^^^^---------------^
+   |                 |
+   |                 no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `use_call_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -514,7 +592,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:160:1
    |
 LL | use_call_krate!{proc_macro_item}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `proc_macro_item` in the root
+   | ^^^^^^^^^^^^^^^^---------------^
+   |                 |
+   |                 no `proc_macro_item` in the root
    |
    = note: this error originates in the macro `use_call_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -522,7 +602,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:165:1
    |
 LL | use_mixed_crate!{TokenItem}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   | ^^^^^^^^^^^^^^^^^---------^
+   |                  |
+   |                  no `TokenItem` in the root
    |
    = note: this error originates in the macro `use_mixed_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -536,7 +618,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:166:1
    |
 LL | use_mixed_krate!{TokenItem}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `TokenItem` in the root
+   | ^^^^^^^^^^^^^^^^^---------^
+   |                  |
+   |                  no `TokenItem` in the root
    |
    = note: this error originates in the macro `use_mixed_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct instead
@@ -550,7 +634,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:171:1
    |
 LL | use_input_crate!{ItemUse}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   | ^^^^^^^^^^^^^^^^^-------^
+   |                  |
+   |                  no `ItemUse` in the root
    |
    = note: this error originates in the macro `use_input_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -558,7 +644,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:172:1
    |
 LL | use_input_krate!{ItemUse}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   | ^^^^^^^^^^^^^^^^^-------^
+   |                  |
+   |                  no `ItemUse` in the root
    |
    = note: this error originates in the macro `use_input_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -566,7 +654,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:173:1
    |
 LL | use_mixed_crate!{ItemUse}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   | ^^^^^^^^^^^^^^^^^-------^
+   |                  |
+   |                  no `ItemUse` in the root
    |
    = note: this error originates in the macro `use_mixed_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -574,7 +664,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:174:1
    |
 LL | use_mixed_krate!{ItemUse}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   | ^^^^^^^^^^^^^^^^^-------^
+   |                  |
+   |                  no `ItemUse` in the root
    |
    = note: this error originates in the macro `use_mixed_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -582,7 +674,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:175:1
    |
 LL | use_call_crate!{ItemUse}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   | ^^^^^^^^^^^^^^^^-------^
+   |                 |
+   |                 no `ItemUse` in the root
    |
    = note: this error originates in the macro `use_call_crate` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -590,7 +684,9 @@ error[E0432]: unresolved import `$crate`
   --> $DIR/mixed-site-span.rs:176:1
    |
 LL | use_call_krate!{ItemUse}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ no `ItemUse` in the root
+   | ^^^^^^^^^^^^^^^^-------^
+   |                 |
+   |                 no `ItemUse` in the root
    |
    = note: this error originates in the macro `use_call_krate` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/resolve/issue-5035.stderr
+++ b/tests/ui/resolve/issue-5035.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::ImportError`
   --> $DIR/issue-5035.rs:7:5
    |
 LL | use crate::ImportError;
-   |     ^^^^^^^^^^^^^^^^^^ no `ImportError` in the root
+   |     ^^^^^^^-----------
+   |            |
+   |            no `ImportError` in the root
 
 error[E0404]: expected trait, found type alias `K`
   --> $DIR/issue-5035.rs:5:6

--- a/tests/ui/resolve/underscore-bindings-disambiguators.stderr
+++ b/tests/ui/resolve/underscore-bindings-disambiguators.stderr
@@ -2,13 +2,17 @@ error[E0432]: unresolved import `X`
   --> $DIR/underscore-bindings-disambiguators.rs:25:5
    |
 LL | use X as Y;
-   |     ^^^^^^ no `X` in the root
+   |     -^^^^^
+   |     |
+   |     no `X` in the root
 
 error[E0432]: unresolved import `Z`
   --> $DIR/underscore-bindings-disambiguators.rs:26:5
    |
 LL | use Z as W;
-   |     ^^^^^^ no `Z` in the root
+   |     -^^^^^
+   |     |
+   |     no `Z` in the root
 
 error[E0080]: evaluation panicked: not yet implemented
   --> $DIR/underscore-bindings-disambiguators.rs:19:19

--- a/tests/ui/rust-2018/uniform-paths/issue-54253.stderr
+++ b/tests/ui/rust-2018/uniform-paths/issue-54253.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::version`
   --> $DIR/issue-54253.rs:10:9
    |
 LL |     use crate::version;
-   |         ^^^^^^^^^^^^^^ no `version` in the root
+   |         ^^^^^^^-------
+   |                |
+   |                no `version` in the root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/self_type_keyword-2.stderr
+++ b/tests/ui/self/self_type_keyword-2.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `self::Self`
   --> $DIR/self_type_keyword-2.rs:1:5
    |
 LL | use self::Self as Foo;
-   |     ^^^^^^^^^^^^^^^^^ no `Self` in the root
+   |     ^^^^^^----^^^^^^^
+   |           |
+   |           no `Self` in the root
 
 error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/self_type_keyword-2.rs:4:9

--- a/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
+++ b/tests/ui/simd/portable-intrinsics-arent-exposed.stderr
@@ -14,7 +14,9 @@ error[E0432]: unresolved import `std::simd::intrinsics`
   --> $DIR/portable-intrinsics-arent-exposed.rs:6:5
    |
 LL | use std::simd::intrinsics;
-   |     ^^^^^^^^^^^^^^^^^^^^^ no `intrinsics` in `simd`
+   |     ^^^^^^^^^^^----------
+   |                |
+   |                no `intrinsics` in `simd`
    |
 help: consider importing this module instead
    |

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -2,13 +2,17 @@ error[E0432]: unresolved import `main`
   --> $DIR/inaccessible-test-modules.rs:6:5
    |
 LL | use main as x;
-   |     ^^^^^^^^^ no `main` in the root
+   |     ----^^^^^
+   |     |
+   |     no `main` in the root
 
 error[E0432]: unresolved import `test`
   --> $DIR/inaccessible-test-modules.rs:7:5
    |
 LL | use test as y;
-   |     ^^^^^^^^^ no `test` in the root
+   |     ----^^^^^
+   |     |
+   |     no `test` in the root
    |
 help: consider importing this module instead
    |

--- a/tests/ui/unresolved/unresolved-import-avoid-suggesting-global-path.stderr
+++ b/tests/ui/unresolved/unresolved-import-avoid-suggesting-global-path.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `module::SomeUsefulType`
   --> $DIR/unresolved-import-avoid-suggesting-global-path.rs:18:9
    |
 LL |     use module::SomeUsefulType;
-   |         ^^^^^^^^^^^^^^^^^^^^^^ no `SomeUsefulType` in `hygiene::module`
+   |         ^^^^^^^^--------------
+   |                 |
+   |                 no `SomeUsefulType` in `hygiene::module`
    |
 help: consider importing this struct instead
    |
@@ -14,7 +16,9 @@ error[E0432]: unresolved import `module::SomeUsefulType`
   --> $DIR/unresolved-import-avoid-suggesting-global-path.rs:28:9
    |
 LL |     use module::SomeUsefulType;
-   |         ^^^^^^^^^^^^^^^^^^^^^^ no `SomeUsefulType` in `glob::module`
+   |         ^^^^^^^^--------------
+   |                 |
+   |                 no `SomeUsefulType` in `glob::module`
    |
 help: consider importing this struct instead
    |

--- a/tests/ui/unresolved/unresolved-import-recovery.stderr
+++ b/tests/ui/unresolved/unresolved-import-recovery.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `crate::unresolved`
   --> $DIR/unresolved-import-recovery.rs:4:13
    |
 LL |     pub use crate::unresolved;
-   |             ^^^^^^^^^^^^^^^^^ no `unresolved` in the root
+   |             ^^^^^^^----------
+   |                    |
+   |                    no `unresolved` in the root
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unresolved/unresolved-import-suggest-disambiguated-crate-name.stderr
+++ b/tests/ui/unresolved/unresolved-import-suggest-disambiguated-crate-name.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `module::SomeUsefulType`
   --> $DIR/unresolved-import-suggest-disambiguated-crate-name.rs:19:9
    |
 LL | pub use module::SomeUsefulType;
-   |         ^^^^^^^^^^^^^^^^^^^^^^ no `SomeUsefulType` in `module`
+   |         ^^^^^^^^--------------
+   |                 |
+   |                 no `SomeUsefulType` in `module`
    |
 help: consider importing this struct instead
    |

--- a/tests/ui/unresolved/unresolved-import.stderr
+++ b/tests/ui/unresolved/unresolved-import.stderr
@@ -13,7 +13,9 @@ error[E0432]: unresolved import `bar::Baz`
   --> $DIR/unresolved-import.rs:8:5
    |
 LL | use bar::Baz as x;
-   |     ^^^^^^^^^^^^^ no `Baz` in `bar`
+   |     ^^^^^---^^^^^
+   |          |
+   |          no `Baz` in `bar`
    |
 help: a similar name exists in the module
    |
@@ -25,7 +27,9 @@ error[E0432]: unresolved import `food::baz`
   --> $DIR/unresolved-import.rs:14:5
    |
 LL | use food::baz;
-   |     ^^^^^^^^^ no `baz` in `food`
+   |     ^^^^^^---
+   |           |
+   |           no `baz` in `food`
    |
 note: module `food::zug::baz` exists but is inaccessible
   --> $DIR/unresolved-import.rs:34:9
@@ -42,7 +46,9 @@ error[E0432]: unresolved import `food::beens`
   --> $DIR/unresolved-import.rs:20:12
    |
 LL | use food::{beens as Foo};
-   |            ^^^^^^^^^^^^ no `beens` in `food`
+   |            -----^^^^^^^
+   |            |
+   |            no `beens` in `food`
    |
 help: a similar name exists in the module
    |

--- a/tests/ui/use/use-from-trait-xc.stderr
+++ b/tests/ui/use/use-from-trait-xc.stderr
@@ -50,7 +50,9 @@ error[E0432]: unresolved import `use_from_trait_xc::Baz::new`
   --> $DIR/use-from-trait-xc.rs:23:5
    |
 LL | use use_from_trait_xc::Baz::new as baznew;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `new` in `sub::Baz`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^---^^^^^^^^^^
+   |                             |
+   |                             no `new` in `sub::Baz`
 
 error[E0603]: struct `Foo` is private
   --> $DIR/use-from-trait-xc.rs:14:24


### PR DESCRIPTION
This is part of work that @weiznich and I are doing for `#[diagnostic::on_unknown]`.

This means that you can put the attribute in macro_rules macros and have the label message point at the input the user gave. It's imo also the right thing to point the span at in general.
```rust
mod things {}

macro_rules! mac {
    ($thing: ident) => {{
        const _x: u32 = {
            #[diagnostic::on_unknown(label = "you did the bad thing")]
            use things::$thing;
            //~^ERROR unresolved import `things::what` [E0432]
            //~|ERROR unresolved import `things::what2` [E0432]
            $thing
        };
    }};
}
```
```
LL | |         what2
   | |         ----- you did the bad thing
```
See also the first and last commit for what these messages look(ed) like.

cc @estebank 