### PR TITLE
Use infer tys for synthetic params when lowering const paths point to fns

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2866,7 +2866,27 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     did,
                     path.segments.last().unwrap(),
                 );
-                ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, did, args))
+
+                if self.tcx().generics_of(did).own_synthetic_params_count() == 0 {
+                    ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, did, args))
+                } else {
+                    let tcx = self.tcx();
+                    let generics = tcx.generics_of(did);
+
+                    // Use infer tys for synthetic params; otherwise the impl header's trait ref may
+                    // contain callee-owned synthetic params and fail when instantiated with impl args.
+                    // See issue #155834
+                    let args = args.iter().enumerate().map(|(index, arg)| {
+                        let param = generics.param_at(index, tcx);
+                        if param.kind.is_synthetic() {
+                            self.ty_infer(Some(param), span).into()
+                        } else {
+                            arg
+                        }
+                    });
+
+                    ty::Const::zero_sized(tcx, Ty::new_fn_def(tcx, did, args))
+                }
             }
 
             // Exhaustive match to be clear about what exactly we're considering to be

--- a/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.rs
+++ b/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.rs
@@ -1,0 +1,13 @@
+// Regression test for issue #155834
+
+#![expect(incomplete_features)]
+#![feature(min_generic_const_args)]
+
+trait Trait {}
+
+impl<'t> Trait for [(); N] {}
+//~^ ERROR the placeholder `_` is not allowed within types on item signatures for implementations
+
+fn N(arg: impl Trait) {}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.stderr
+++ b/tests/ui/const-generics/mgca/bad-impl-trait-with-apit.stderr
@@ -1,0 +1,9 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/bad-impl-trait-with-apit.rs:8:25
+   |
+LL | impl<'t> Trait for [(); N] {}
+   |                         ^ not allowed in type signatures
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0121`.

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.rs
@@ -4,6 +4,7 @@ trait A<T> {}
 trait Trait<const N: usize> {}
 
 impl A<[usize; fn_item]> for () {}
+//~^ ERROR: the placeholder `_` is not allowed within types on item signatures for implementations
 
 fn fn_item(_: impl Trait<usize>) {}
 //~^ ERROR: type provided when a constant was expected

--- a/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.stderr
+++ b/tests/ui/const-generics/mgca/synth-gen-arg-ice-158152.stderr
@@ -1,5 +1,11 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for implementations
+  --> $DIR/synth-gen-arg-ice-158152.rs:6:16
+   |
+LL | impl A<[usize; fn_item]> for () {}
+   |                ^^^^^^^ not allowed in type signatures
+
 error[E0747]: type provided when a constant was expected
-  --> $DIR/synth-gen-arg-ice-158152.rs:8:26
+  --> $DIR/synth-gen-arg-ice-158152.rs:9:26
    |
 LL | fn fn_item(_: impl Trait<usize>) {}
    |                          ^^^^^
@@ -9,6 +15,7 @@ help: if this generic argument was intended as a const parameter, surround it wi
 LL | fn fn_item(_: impl Trait<{ usize }>) {}
    |                          +       +
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0747`.
+Some errors have detailed explanations: E0121, E0747.
+For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
```rust
#![feature(min_generic_const_args)]

trait Trait {}
impl<'t> Trait for [(); N] {}
fn N(arg: impl Trait) {}
```

1. `arg: impl Trait` implies a synthetic param `<impl Trait>` and the obligation `_: Trait`;
2. when matching `impl Trait for [(); N]`, lowering const arg `N` fills in that synthetic param, so the impl header contains `<[(); N::<impl Trait>] as Trait>`;
3. then instantiating this header with the impl's args causing a param/arg mismatch and ICE.

This PR uses infer tys for synthetic params. Although this will emit the error in `ItemCtxt` because infer tys are not allowed here. I think that is reasonable, because `N` omits the synthetic parameter, though we cannot write the ty explicitly anywhere.

Fixes https://github.com/rust-lang/rust/issues/155834