### PR TITLE
Autogenerate unstable compiler flag stubs for unstable-book

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -82,6 +82,7 @@ book!(
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct UnstableBook {
+    build_compiler: Compiler,
     target: TargetSelection,
 }
 
@@ -97,11 +98,24 @@ impl Step for UnstableBook {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(UnstableBook { target: run.target });
+        // Bump the stage to 2, because the unstable book requires an in-tree compiler.
+        // At the same time, since this step is enabled by default, we don't want `x doc` to fail
+        // in stage 1.
+        let stage = if run.builder.config.is_explicit_stage() || run.builder.top_stage >= 2 {
+            run.builder.top_stage
+        } else {
+            2
+        };
+
+        run.builder.ensure(UnstableBook {
+            build_compiler: prepare_doc_compiler(run.builder, run.target, stage),
+            target: run.target,
+        });
     }
 
     fn run(self, builder: &Builder<'_>) {
-        builder.ensure(UnstableBookGen { target: self.target });
+        builder
+            .ensure(UnstableBookGen { build_compiler: self.build_compiler, target: self.target });
         builder.ensure(RustbookSrc {
             target: self.target,
             name: "unstable-book".to_owned(),
@@ -1265,6 +1279,7 @@ impl Step for ErrorIndex {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct UnstableBookGen {
+    build_compiler: Compiler,
     target: TargetSelection,
 }
 
@@ -1281,11 +1296,15 @@ impl Step for UnstableBookGen {
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(UnstableBookGen { target: run.target });
+        run.builder.ensure(UnstableBookGen {
+            build_compiler: prepare_doc_compiler(run.builder, run.target, run.builder.top_stage),
+            target: run.target,
+        });
     }
 
     fn run(self, builder: &Builder<'_>) {
         let target = self.target;
+        let rustc_path = builder.rustc(self.build_compiler);
 
         builder.info(&format!("Generating unstable book md files ({target})"));
         let out = builder.md_doc_out(target).join("unstable-book");
@@ -1295,6 +1314,7 @@ impl Step for UnstableBookGen {
         cmd.arg(builder.src.join("library"));
         cmd.arg(builder.src.join("compiler"));
         cmd.arg(builder.src.join("src"));
+        cmd.arg(rustc_path);
         cmd.arg(out);
 
         cmd.run(builder);

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -1098,12 +1098,12 @@ mod snapshot {
             ctx
                 .config("dist")
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
@@ -1150,12 +1150,12 @@ mod snapshot {
                 .path("rustc-docs")
                 .args(&["--set", "build.compiler-docs=true"])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
@@ -1208,15 +1208,15 @@ mod snapshot {
                 "rust.lld=true",
             ])
             .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 0 <host> -> LldWrapper 1 <host>
         [build] rustc 0 <host> -> WasmComponentLd 1 <host>
         [build] rustc 0 <host> -> LlvmBitcodeLinker 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
@@ -1284,18 +1284,18 @@ mod snapshot {
                 .hosts(&[&host_target()])
                 .targets(&[&host_target(), TEST_TRIPLE_1])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
-        [doc] unstable-book (book) <target1>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
+        [build] rustc 1 <host> -> std 1 <target1>
+        [doc] unstable-book (book) <target1>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
         [doc] book/2018-edition (book) <host>
-        [build] rustc 1 <host> -> std 1 <target1>
         [doc] book (book) <target1>
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
@@ -1360,12 +1360,13 @@ mod snapshot {
                 .hosts(&[&host_target(), TEST_TRIPLE_1])
                 .targets(&[&host_target()])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
+        [build] rustc 1 <host> -> std 1 <target1>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
@@ -1377,7 +1378,6 @@ mod snapshot {
         [build] rustc 1 <host> -> error-index 2 <host>
         [doc] rustc 1 <host> -> error-index 2 <host>
         [build] llvm <target1>
-        [build] rustc 1 <host> -> std 1 <target1>
         [build] rustc 1 <host> -> rustc 2 <target1>
         [build] rustc 1 <host> -> error-index 2 <target1>
         [doc] rustc 1 <host> -> error-index 2 <target1>
@@ -1423,18 +1423,18 @@ mod snapshot {
                 .hosts(&[&host_target(), TEST_TRIPLE_1])
                 .targets(&[&host_target(), TEST_TRIPLE_1])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
-        [doc] unstable-book (book) <target1>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
+        [build] rustc 1 <host> -> std 1 <target1>
+        [doc] unstable-book (book) <target1>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
         [doc] book/2018-edition (book) <host>
-        [build] rustc 1 <host> -> std 1 <target1>
         [doc] book (book) <target1>
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
@@ -1508,12 +1508,12 @@ mod snapshot {
                 .hosts(&[])
                 .targets(&[TEST_TRIPLE_1])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <target1>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <target1>
         [doc] book (book) <target1>
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
@@ -1551,13 +1551,13 @@ mod snapshot {
                 .targets(&[TEST_TRIPLE_1])
                 .args(&["--set", "rust.channel=nightly", "--set", "build.extended=true"])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <target1>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 0 <host> -> WasmComponentLd 1 <host>
         [build] rustc 1 <host> -> std 1 <target1>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <target1>
         [doc] book (book) <target1>
         [doc] book/first-edition (book) <target1>
         [doc] book/second-edition (book) <target1>
@@ -1695,13 +1695,13 @@ mod snapshot {
                 .config("dist")
                 .args(&["--set", "rust.codegen-backends=['llvm', 'cranelift']"])
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 0 <host> -> rustc_codegen_cranelift 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
@@ -1778,12 +1778,12 @@ mod snapshot {
                 .config("dist")
                 .path("rustc-docs")
                 .render_steps(), @r"
-        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
-        [build] rustc 0 <host> -> Rustbook 1 <host>
-        [doc] unstable-book (book) <host>
         [build] llvm <host>
         [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustc 1 <host> -> std 1 <host>
+        [build] rustc 0 <host> -> UnstableBookGen 1 <host>
+        [build] rustc 0 <host> -> Rustbook 1 <host>
+        [doc] unstable-book (book) <host>
         [doc] book (book) <host>
         [doc] book/first-edition (book) <host>
         [doc] book/second-edition (book) <host>
@@ -2533,6 +2533,9 @@ mod snapshot {
         insta::assert_snapshot!(
             ctx.config("doc")
                 .render_steps(), @r"
+        [build] llvm <host>
+        [build] rustc 0 <host> -> rustc 1 <host>
+        [build] rustc 1 <host> -> std 1 <host>
         [build] rustc 0 <host> -> UnstableBookGen 1 <host>
         [build] rustc 0 <host> -> Rustbook 1 <host>
         [doc] unstable-book (book) <host>
@@ -2542,14 +2545,11 @@ mod snapshot {
         [doc] book/2018-edition (book) <host>
         [build] rustdoc 0 <host>
         [doc] rustc 0 <host> -> standalone 1 <host>
-        [build] llvm <host>
-        [build] rustc 0 <host> -> rustc 1 <host>
         [build] rustdoc 1 <host>
         [doc] rustc 1 <host> -> std 1 <host> crates=[alloc,compiler_builtins,core,panic_abort,panic_unwind,proc_macro,rustc-std-workspace-core,std,std_detect,sysroot,test,unwind]
         [build] rustc 0 <host> -> error-index 1 <host>
         [doc] rustc 0 <host> -> error-index 1 <host>
         [doc] nomicon (book) <host>
-        [build] rustc 1 <host> -> std 1 <host>
         [doc] rustc 1 <host> -> reference (book) 2 <host>
         [doc] rustdoc (book) <host>
         [doc] rust-by-example (book) <host>
@@ -2901,10 +2901,10 @@ mod snapshot {
                 }), @r"
         [build] llvm <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> rustc 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> UnstableBookGen 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> Rustbook 1 <x86_64-unknown-linux-gnu>
         [doc] unstable-book (book) <x86_64-unknown-linux-gnu>
-        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
         [doc] book (book) <x86_64-unknown-linux-gnu>
         [doc] book/first-edition (book) <x86_64-unknown-linux-gnu>
         [doc] book/second-edition (book) <x86_64-unknown-linux-gnu>
@@ -2960,10 +2960,10 @@ mod snapshot {
                 }), @r"
         [build] llvm <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> rustc 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> UnstableBookGen 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> Rustbook 1 <x86_64-unknown-linux-gnu>
         [doc] unstable-book (book) <x86_64-unknown-linux-gnu>
-        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
         [doc] book (book) <x86_64-unknown-linux-gnu>
         [doc] book/first-edition (book) <x86_64-unknown-linux-gnu>
         [doc] book/second-edition (book) <x86_64-unknown-linux-gnu>
@@ -3048,10 +3048,10 @@ mod snapshot {
         [build] llvm <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> rustc 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> WasmComponentLd 1 <x86_64-unknown-linux-gnu>
+        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> UnstableBookGen 1 <x86_64-unknown-linux-gnu>
         [build] rustc 0 <x86_64-unknown-linux-gnu> -> Rustbook 1 <x86_64-unknown-linux-gnu>
         [doc] unstable-book (book) <x86_64-unknown-linux-gnu>
-        [build] rustc 1 <x86_64-unknown-linux-gnu> -> std 1 <x86_64-unknown-linux-gnu>
         [doc] book (book) <x86_64-unknown-linux-gnu>
         [doc] book/first-edition (book) <x86_64-unknown-linux-gnu>
         [doc] book/second-edition (book) <x86_64-unknown-linux-gnu>

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -125,6 +125,7 @@ fn copy_recursive(from: &Path, to: &Path) {
 
 fn collect_compiler_flags(rustc_path: impl AsRef<Path>) -> Features {
     let mut rustc = Command::new(rustc_path.as_ref());
+    rustc.env("RUSTC_BOOTSTRAP", "1");
     rustc.arg("-Zhelp");
     let output = t!(rustc.output());
     let help_str = t!(String::from_utf8(output.stdout));

--- a/src/tools/unstable-book-gen/src/main.rs
+++ b/src/tools/unstable-book-gen/src/main.rs
@@ -4,12 +4,15 @@ use std::collections::BTreeSet;
 use std::env;
 use std::fs::{self, write};
 use std::path::Path;
+use std::process::Command;
 
 use tidy::diagnostics::RunningCheck;
-use tidy::features::{Features, collect_env_vars, collect_lang_features, collect_lib_features};
+use tidy::features::{
+    Feature, Features, Status, collect_env_vars, collect_lang_features, collect_lib_features,
+};
 use tidy::t;
 use tidy::unstable_book::{
-    ENV_VARS_DIR, LANG_FEATURES_DIR, LIB_FEATURES_DIR, PATH_STR,
+    COMPILER_FLAGS_DIR, ENV_VARS_DIR, LANG_FEATURES_DIR, LIB_FEATURES_DIR, PATH_STR,
     collect_unstable_book_section_file_names, collect_unstable_feature_names,
 };
 
@@ -39,8 +42,15 @@ fn set_to_summary_str(set: &BTreeSet<String>, dir: &str) -> String {
         .fold("".to_owned(), |s, a| s + &a + "\n")
 }
 
-fn generate_summary(path: &Path, lang_features: &Features, lib_features: &Features) {
-    let compiler_flags = collect_unstable_book_section_file_names(&path.join("src/compiler-flags"));
+fn generate_summary(
+    path: &Path,
+    lang_features: &Features,
+    lib_features: &Features,
+    compiler_flags: &Features,
+) {
+    let compiler_flags =
+        &collect_unstable_book_section_file_names(&path.join("src/compiler-flags"))
+            | &collect_unstable_feature_names(&compiler_flags);
     let compiler_env_vars =
         collect_unstable_book_section_file_names(&path.join("src/compiler-environment-variables"));
 
@@ -113,14 +123,47 @@ fn copy_recursive(from: &Path, to: &Path) {
     }
 }
 
+fn collect_compiler_flags(rustc_path: impl AsRef<Path>) -> Features {
+    let mut rustc = Command::new(rustc_path.as_ref());
+    rustc.arg("-Zhelp");
+    let output = t!(rustc.output());
+    let help_str = t!(String::from_utf8(output.stdout));
+    let parts = help_str.split("\n    -Z").collect::<Vec<_>>();
+    assert!(!parts[1..].is_empty(), "no -Z options were found");
+
+    let mut features = Features::new();
+    for part in parts.into_iter().skip(1) {
+        let (name, description) =
+            part.split_once("--").expect("name and description should be delimited by '--'");
+        let name = name.trim().trim_end_matches("=val");
+        let description = description.trim();
+
+        features.insert(
+            name.replace('-', "_"),
+            Feature {
+                level: Status::Unstable,
+                since: None,
+                has_gate_test: false,
+                tracking_issue: None,
+                file: "".into(),
+                line: 0,
+                description: Some(description.to_owned()),
+            },
+        );
+    }
+    features
+}
+
 fn main() {
     let library_path_str = env::args_os().nth(1).expect("library/ path required");
     let compiler_path_str = env::args_os().nth(2).expect("compiler/ path required");
     let src_path_str = env::args_os().nth(3).expect("src/ path required");
-    let dest_path_str = env::args_os().nth(4).expect("destination path required");
+    let rustc_path_str = env::args_os().nth(4).expect("rustc path required");
+    let dest_path_str = env::args_os().nth(5).expect("destination path required");
     let library_path = Path::new(&library_path_str);
     let compiler_path = Path::new(&compiler_path_str);
     let src_path = Path::new(&src_path_str);
+    let rustc_path = Path::new(&rustc_path_str);
     let dest_path = Path::new(&dest_path_str);
 
     let lang_features = collect_lang_features(compiler_path, &mut RunningCheck::new_noop());
@@ -129,6 +172,7 @@ fn main() {
         .filter(|&(ref name, _)| !lang_features.contains_key(name))
         .collect();
     let env_vars = collect_env_vars(compiler_path);
+    let compiler_flags = collect_compiler_flags(rustc_path);
 
     let doc_src_path = src_path.join(PATH_STR);
 
@@ -144,9 +188,14 @@ fn main() {
         &dest_path.join(LIB_FEATURES_DIR),
         &lib_features,
     );
+    generate_feature_files(
+        &doc_src_path.join(COMPILER_FLAGS_DIR),
+        &dest_path.join(COMPILER_FLAGS_DIR),
+        &compiler_flags,
+    );
     generate_env_files(&doc_src_path.join(ENV_VARS_DIR), &dest_path.join(ENV_VARS_DIR), &env_vars);
 
     copy_recursive(&doc_src_path, &dest_path);
 
-    generate_summary(&dest_path, &lang_features, &lib_features);
+    generate_summary(&dest_path, &lang_features, &lib_features, &compiler_flags);
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Closes https://github.com/rust-lang/rust/issues/141525.

Based on old PR https://github.com/rust-lang/rust/pull/142135.

Parses `rustc -Zhelp` to generate doc stubs for unstable compiler flags if any are missing. 
