### PR TITLE
Reorder `impl` restriction rendering and add bottom margin

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -783,9 +783,6 @@ fn item_trait(cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) -> impl fmt:
             }
         })?;
 
-        // Trait documentation
-        write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
-
         if let rustc_middle::ty::trait_def::ImplRestrictionKind::Restricted(def_id, _) =
             impl_restriction
         {
@@ -793,7 +790,7 @@ fn item_trait(cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) -> impl fmt:
             let v2;
             write!(
                 w,
-                "<div class=\"stab impl_restriction\">This trait cannot be implemented outside <code>{}</code>.</div>",
+                "<div class=\"impl-restriction\">ⓘ <i>This trait cannot be implemented outside <code>{}</code>.</i></div>",
                 if cx.cache().document_private {
                     v1 =
                         rustc_middle::ty::print::with_resolve_crate_name!(tcx.def_path_str(def_id));
@@ -804,6 +801,9 @@ fn item_trait(cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) -> impl fmt:
                 },
             )?;
         }
+
+        // Trait documentation
+        write!(w, "{}", document(cx, it, None, HeadingOffset::H2))?;
 
         fn trait_item(cx: &Context<'_>, m: &clean::Item, t: &clean::Item) -> impl fmt::Display {
             fmt::from_fn(|w| {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1179,6 +1179,10 @@ div.where {
 	margin-left: calc(var(--docblock-indent) + var(--impl-items-indent));
 }
 
+.impl-restriction {
+	margin-bottom: 0.75em;
+}
+
 #synthetic-implementors-list:not(.loaded), #implementors-list:not(.loaded) {
 	/* To prevent layout shift when loading the page with extra implementors being loaded
 	   from JS, we hide the list until it's complete. */

--- a/tests/rustdoc-html/impl/impl-restriction-document-private.rs
+++ b/tests/rustdoc-html/impl/impl-restriction-document-private.rs
@@ -2,14 +2,14 @@
 #![crate_name = "c"]
 #![feature(impl_restriction)]
 
-//@ matches c/trait.Foo.html '//*[@class="stab impl_restriction"]' \
+//@ matches c/trait.Foo.html '//*[@class="impl-restriction"]' \
 //      'This trait cannot be implemented outside c.$'
-//@ has c/trait.Foo.html '//*[@class="stab impl_restriction"]//code' 'c'
+//@ has c/trait.Foo.html '//*[@class="impl-restriction"]//code' 'c'
 pub impl(crate) trait Foo {}
 
 pub mod inner {
-    //@ matches c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]' \
+    //@ matches c/inner/trait.Bar.html '//*[@class="impl-restriction"]' \
     //      'This trait cannot be implemented outside c::inner.$'
-    //@ has c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]//code' 'c::inner'
+    //@ has c/inner/trait.Bar.html '//*[@class="impl-restriction"]//code' 'c::inner'
     pub impl(self) trait Bar {}
 }

--- a/tests/rustdoc-html/impl/impl-restriction.rs
+++ b/tests/rustdoc-html/impl/impl-restriction.rs
@@ -1,14 +1,14 @@
 #![crate_name = "c"]
 #![feature(impl_restriction)]
 
-//@ matches c/trait.Foo.html '//*[@class="stab impl_restriction"]' \
+//@ matches c/trait.Foo.html '//*[@class="impl-restriction"]' \
 //      'This trait cannot be implemented outside c.$'
-//@ has c/trait.Foo.html '//*[@class="stab impl_restriction"]//code' 'c'
+//@ has c/trait.Foo.html '//*[@class="impl-restriction"]//code' 'c'
 pub impl(crate) trait Foo {}
 
 pub mod inner {
-    //@ matches c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]' \
+    //@ matches c/inner/trait.Bar.html '//*[@class="impl-restriction"]' \
     //      'This trait cannot be implemented outside c.$'
-    //@ has c/inner/trait.Bar.html '//*[@class="stab impl_restriction"]//code' 'c'
+    //@ has c/inner/trait.Bar.html '//*[@class="impl-restriction"]//code' 'c'
     pub impl(self) trait Bar {}
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR moves the `impl` restriction rendering above the trait description.
It also adds an ⓘ marker, italicizes the text, and adds a bottom margin.
Tracking issue: rust-lang/rust#105077

before:
<img width="1108" height="651" alt="image" src="https://github.com/user-attachments/assets/520d95cf-a648-44e7-8036-e453cfbdf569" />

after:
<img width="1085" height="671" alt="image" src="https://github.com/user-attachments/assets/84493e56-6227-433b-93d0-4fcbe28ac00c" />


r? @GuillaumeGomez 
cc @Urgau @jhpratt 

