### PR TITLE
Report duplicate relaxed bounds during ast lowering

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -325,7 +325,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let ident = self.lower_ident(*ident);
                 let (generics, (ty, rhs)) = self.lower_generics(
                     generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         let ty = this.lower_ty_alloc(
@@ -379,7 +378,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     );
 
                     let itctx = ImplTraitContext::Universal;
-                    let (generics, decl) = this.lower_generics(generics, id, itctx, |this| {
+                    let (generics, decl) = this.lower_generics(generics, itctx, |this| {
                         this.lower_fn_decl(decl, id, *fn_sig_span, FnDeclKind::Fn, coroutine_kind)
                     });
                     let sig = hir::FnSig {
@@ -433,7 +432,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 add_ty_alias_where_clause(&mut generics, after_where_clause, true);
                 let (generics, ty) = self.lower_generics(
                     &generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| match ty {
                         None => {
@@ -460,7 +458,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let ident = self.lower_ident(*ident);
                 let (generics, variants) = self.lower_generics(
                     generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         this.arena.alloc_from_iter(
@@ -474,7 +471,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let ident = self.lower_ident(*ident);
                 let (generics, struct_def) = self.lower_generics(
                     generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| this.lower_variant_data(hir_id, i, struct_def),
                 );
@@ -484,7 +480,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let ident = self.lower_ident(*ident);
                 let (generics, vdata) = self.lower_generics(
                     generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| this.lower_variant_data(hir_id, i, vdata),
                 );
@@ -512,7 +507,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // parent lifetime.
                 let itctx = ImplTraitContext::Universal;
                 let (generics, (of_trait, lowered_ty)) =
-                    self.lower_generics(ast_generics, id, itctx, |this| {
+                    self.lower_generics(ast_generics, itctx, |this| {
                         let of_trait = of_trait
                             .as_deref()
                             .map(|of_trait| this.lower_trait_impl_header(of_trait));
@@ -554,7 +549,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let ident = self.lower_ident(*ident);
                 let (generics, (safety, items, bounds)) = self.lower_generics(
                     generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         let bounds = this.lower_param_bounds(
@@ -585,7 +579,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let ident = self.lower_ident(*ident);
                 let (generics, bounds) = self.lower_generics(
                     generics,
-                    id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         this.lower_param_bounds(
@@ -797,14 +790,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
             ForeignItemKind::Fn(Fn { sig, ident, generics, define_opaque, .. }) => {
                 let fdec = &sig.decl;
                 let itctx = ImplTraitContext::Universal;
-                let (generics, (decl, fn_args)) =
-                    self.lower_generics(generics, i.id, itctx, |this| {
-                        (
-                            // Disallow `impl Trait` in foreign items.
-                            this.lower_fn_decl(fdec, i.id, sig.span, FnDeclKind::ExternFn, None),
-                            this.lower_fn_params_to_idents(fdec),
-                        )
-                    });
+                let (generics, (decl, fn_args)) = self.lower_generics(generics, itctx, |this| {
+                    (
+                        // Disallow `impl Trait` in foreign items.
+                        this.lower_fn_decl(fdec, i.id, sig.span, FnDeclKind::ExternFn, None),
+                        this.lower_fn_params_to_idents(fdec),
+                    )
+                });
 
                 // Unmarked safety in unsafe block defaults to unsafe.
                 let header = self.lower_fn_header(sig.header, hir::Safety::Unsafe, attrs);
@@ -994,7 +986,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             }) => {
                 let (generics, kind) = self.lower_generics(
                     generics,
-                    i.id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         let ty = this.lower_ty_alloc(
@@ -1096,7 +1087,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 add_ty_alias_where_clause(&mut generics, after_where_clause, false);
                 let (generics, kind) = self.lower_generics(
                     &generics,
-                    i.id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         let ty = ty.as_ref().map(|x| {
@@ -1259,7 +1249,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 *ident,
                 self.lower_generics(
                     generics,
-                    i.id,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                     |this| {
                         let ty = this.lower_ty_alloc(
@@ -1304,7 +1293,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     *ident,
                     self.lower_generics(
                         &generics,
-                        i.id,
                         ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                         |this| match ty {
                             None => {
@@ -1743,7 +1731,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     ) -> (&'hir hir::Generics<'hir>, hir::FnSig<'hir>) {
         let header = self.lower_fn_header(sig.header, hir::Safety::Safe, attrs);
         let itctx = ImplTraitContext::Universal;
-        let (generics, decl) = self.lower_generics(generics, id, itctx, |this| {
+        let (generics, decl) = self.lower_generics(generics, itctx, |this| {
             this.lower_fn_decl(&sig.decl, id, sig.span, kind, coroutine_kind)
         });
         (generics, hir::FnSig { header, decl, span: self.lower_span(sig.span) })
@@ -1891,7 +1879,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_generics<T>(
         &mut self,
         generics: &Generics,
-        parent_node_id: NodeId,
         itctx: ImplTraitContext,
         f: impl FnOnce(&mut Self) -> T,
     ) -> (&'hir hir::Generics<'hir>, T) {
@@ -1925,7 +1912,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             .collect();
 
         // Introduce extra lifetimes if late resolution tells us to.
-        let extra_lifetimes = self.resolver.extra_lifetime_params(parent_node_id);
+        let extra_lifetimes = self.resolver.extra_lifetime_params(self.owner.id);
         params.extend(extra_lifetimes.into_iter().map(|&(ident, node_id, kind)| {
             self.lifetime_res_to_generic_param(
                 ident,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -11,6 +11,7 @@ use rustc_hir::{
 };
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::span_bug;
+use rustc_middle::ty::data_structures::IndexMap;
 use rustc_middle::ty::{ResolverAstLowering, TyCtxt};
 use rustc_span::def_id::DefId;
 use rustc_span::edit_distance::find_best_match_for_name;
@@ -1098,7 +1099,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         hir::TraitItemKind::Type(
                             this.lower_param_bounds(
                                 bounds,
-                                RelaxedBoundPolicy::Allowed,
+                                RelaxedBoundPolicy::Allowed(&mut Default::default()),
                                 ImplTraitContext::Disallowed(ImplTraitPosition::Generic),
                             ),
                             ty,
@@ -1886,6 +1887,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
         assert!(self.impl_trait_bounds.is_empty());
 
         let mut predicates: SmallVec<[hir::WherePredicate<'hir>; 4]> = SmallVec::new();
+        // We need to make sure that generic params don't have multiple relaxed bounds for the same trait
+        // across generic param bounds and where bounds.
+        let mut dedup_map: IndexMap<LocalDefId, _> = Default::default();
         predicates.extend(generics.params.iter().filter_map(|param| {
             self.lower_generic_bound_predicate(
                 param.ident,
@@ -1894,18 +1898,16 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 &param.bounds,
                 param.colon_span,
                 generics.span,
-                RelaxedBoundPolicy::Allowed,
+                RelaxedBoundPolicy::Allowed(
+                    dedup_map.entry(self.local_def_id(param.id)).or_default(),
+                ),
                 itctx,
                 PredicateOrigin::GenericParam,
             )
         }));
-        predicates.extend(
-            generics
-                .where_clause
-                .predicates
-                .iter()
-                .map(|predicate| self.lower_where_predicate(predicate, &generics.params)),
-        );
+        predicates.extend(generics.where_clause.predicates.iter().map(|predicate| {
+            self.lower_where_predicate(predicate, &generics.params, &mut dedup_map)
+        }));
 
         let mut params: SmallVec<[hir::GenericParam<'hir>; 4]> = self
             .lower_generic_params_mut(&generics.params, hir::GenericParamSource::Generics)
@@ -1981,7 +1983,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         bounds: &[GenericBound],
         colon_span: Option<Span>,
         parent_span: Span,
-        rbp: RelaxedBoundPolicy,
+        rbp: RelaxedBoundPolicy<'_>,
         itctx: ImplTraitContext,
         origin: PredicateOrigin,
     ) -> Option<hir::WherePredicate<'hir>> {
@@ -2046,6 +2048,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         &mut self,
         pred: &WherePredicate,
         params: &[ast::GenericParam],
+        dedup_map: &mut IndexMap<LocalDefId, IndexMap<DefId, Span>>,
     ) -> hir::WherePredicate<'hir> {
         let hir_id = self.lower_node_id(pred.id);
         let span = self.lower_span(pred.span);
@@ -2062,7 +2065,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     && let Res::Def(DefKind::TyParam, def_id) = res
                     && params.iter().any(|p| def_id == self.local_def_id(p.id).to_def_id())
                 {
-                    RelaxedBoundPolicy::Allowed
+                    RelaxedBoundPolicy::Allowed(dedup_map.entry(def_id.expect_local()).or_default())
                 } else {
                     RelaxedBoundPolicy::Forbidden(RelaxedBoundForbiddenReason::WhereBound)
                 };
@@ -2092,7 +2095,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     ),
                     bounds: self.lower_param_bounds(
                         bounds,
-                        RelaxedBoundPolicy::Allowed,
+                        RelaxedBoundPolicy::Allowed(&mut Default::default()),
                         ImplTraitContext::Disallowed(ImplTraitPosition::Bound),
                     ),
                     in_where_clause: true,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -43,14 +43,15 @@ use rustc_ast::visit::Visitor;
 use rustc_ast::{self as ast, *};
 use rustc_attr_parsing::{AttributeParser, OmitDoc, Recovery, ShouldEmit};
 use rustc_data_structures::fingerprint::Fingerprint;
-use rustc_data_structures::fx::FxIndexSet;
+use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hash::{StableHash, StableHasher};
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::tagged_ptr::TaggedRef;
+use rustc_errors::codes::*;
 use rustc_errors::{DiagArgFromDisplay, DiagCtxtHandle};
 use rustc_hir::def::{DefKind, LifetimeRes, Namespace, PartialRes, PerNS, Res};
-use rustc_hir::def_id::{CRATE_DEF_ID, LOCAL_CRATE, LocalDefId};
+use rustc_hir::def_id::{CRATE_DEF_ID, DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::definitions::PerParentDisambiguatorState;
 use rustc_hir::lints::DelayedLint;
 use rustc_hir::{
@@ -319,10 +320,19 @@ impl<'tcx> ResolverAstLowering<'tcx> {
 ///
 /// Relaxed bounds should only be allowed in places where we later
 /// (namely during HIR ty lowering) perform *sized elaboration*.
-#[derive(Clone, Copy, Debug)]
-enum RelaxedBoundPolicy {
-    Allowed,
+#[derive(Debug)]
+enum RelaxedBoundPolicy<'a> {
+    /// The `DefId` refers to the trait that is being relaxed.
+    Allowed(&'a mut FxIndexMap<DefId, Span>),
     Forbidden(RelaxedBoundForbiddenReason),
+}
+impl RelaxedBoundPolicy<'_> {
+    fn reborrow(&mut self) -> RelaxedBoundPolicy<'_> {
+        match self {
+            RelaxedBoundPolicy::Allowed(m) => RelaxedBoundPolicy::Allowed(m),
+            RelaxedBoundPolicy::Forbidden(reason) => RelaxedBoundPolicy::Forbidden(*reason),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -1551,9 +1561,13 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         }
                         path
                     }
-                    ImplTraitContext::InBinding => hir::TyKind::TraitAscription(
-                        self.lower_param_bounds(bounds, RelaxedBoundPolicy::Allowed, itctx),
-                    ),
+                    ImplTraitContext::InBinding => {
+                        hir::TyKind::TraitAscription(self.lower_param_bounds(
+                            bounds,
+                            RelaxedBoundPolicy::Allowed(&mut Default::default()),
+                            itctx,
+                        ))
+                    }
                     ImplTraitContext::FeatureGated(position, feature) => {
                         let guar = self
                             .tcx
@@ -1676,7 +1690,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let opaque_ty_span = self.mark_span_with_reason(DesugaringKind::OpaqueTy, span, None);
 
         self.lower_opaque_inner(opaque_ty_node_id, origin, opaque_ty_span, |this| {
-            this.lower_param_bounds(bounds, RelaxedBoundPolicy::Allowed, itctx)
+            this.lower_param_bounds(
+                bounds,
+                RelaxedBoundPolicy::Allowed(&mut Default::default()),
+                itctx,
+            )
         })
     }
 
@@ -1970,7 +1988,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_param_bound(
         &mut self,
         tpb: &GenericBound,
-        rbp: RelaxedBoundPolicy,
+        rbp: RelaxedBoundPolicy<'_>,
         itctx: ImplTraitContext,
     ) -> hir::GenericBound<'hir> {
         match tpb {
@@ -2209,7 +2227,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_poly_trait_ref(
         &mut self,
         PolyTraitRef { bound_generic_params, modifiers, trait_ref, span, parens: _ }: &PolyTraitRef,
-        rbp: RelaxedBoundPolicy,
+        rbp: RelaxedBoundPolicy<'_>,
         itctx: ImplTraitContext,
     ) -> hir::PolyTraitRef<'hir> {
         let bound_generic_params =
@@ -2233,7 +2251,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         &self,
         trait_ref: hir::TraitRef<'_>,
         span: Span,
-        rbp: RelaxedBoundPolicy,
+        rbp: RelaxedBoundPolicy<'_>,
     ) {
         // Even though feature `more_maybe_bounds` enables the user to relax all default bounds
         // other than `Sized` in a lot more positions (thereby bypassing the given policy), we don't
@@ -2245,7 +2263,23 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // question: E.g., `?Sized` & `?Move` most likely won't be allowed in all the same places).
 
         match rbp {
-            RelaxedBoundPolicy::Allowed => return,
+            RelaxedBoundPolicy::Allowed(dedup_map) => {
+                // `trait_def_id` only returns `None` for errors during resolution.
+                let Some(trait_def_id) = trait_ref.trait_def_id() else { return };
+                let tcx = self.tcx;
+                let err = |s| {
+                    let name = tcx.item_name(trait_def_id);
+                    tcx.dcx()
+                        .struct_span_err(
+                            vec![span, s],
+                            format!("duplicate relaxed `{name}` bounds"),
+                        )
+                        .with_code(E0203)
+                        .emit();
+                };
+                dedup_map.entry(trait_def_id).and_modify(|&mut s| err(s)).or_insert(span);
+                return;
+            }
             RelaxedBoundPolicy::Forbidden(reason) => {
                 let gate = |context, subject| {
                     let extended = self.tcx.features().more_maybe_bounds();
@@ -2307,7 +2341,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_param_bounds(
         &mut self,
         bounds: &[GenericBound],
-        rbp: RelaxedBoundPolicy,
+        rbp: RelaxedBoundPolicy<'_>,
         itctx: ImplTraitContext,
     ) -> hir::GenericBounds<'hir> {
         self.arena.alloc_from_iter(self.lower_param_bounds_mut(bounds, rbp, itctx))
@@ -2316,10 +2350,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_param_bounds_mut(
         &mut self,
         bounds: &[GenericBound],
-        rbp: RelaxedBoundPolicy,
+        mut rbp: RelaxedBoundPolicy<'_>,
         itctx: ImplTraitContext,
     ) -> impl Iterator<Item = hir::GenericBound<'hir>> {
-        bounds.iter().map(move |bound| self.lower_param_bound(bound, rbp, itctx))
+        bounds.iter().map(move |bound| self.lower_param_bound(bound, rbp.reborrow(), itctx))
     }
 
     #[instrument(level = "debug", skip(self), ret)]
@@ -2353,7 +2387,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             bounds,
             /* colon_span */ None,
             span,
-            RelaxedBoundPolicy::Allowed,
+            RelaxedBoundPolicy::Allowed(&mut Default::default()),
             ImplTraitContext::Universal,
             hir::PredicateOrigin::ImplTrait,
         );

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -14,7 +14,6 @@ use rustc_middle::ty::{
 };
 use rustc_span::{ErrorGuaranteed, Ident, Span, kw};
 use rustc_trait_selection::traits;
-use smallvec::SmallVec;
 use tracing::{debug, instrument};
 
 use crate::errors;
@@ -83,19 +82,6 @@ fn search_bounds_for<'tcx>(
             }
         }
     }
-}
-
-fn collect_relaxed_bounds<'tcx>(
-    hir_bounds: &'tcx [hir::GenericBound<'tcx>],
-    context: ImpliedBoundsContext<'tcx>,
-) -> SmallVec<[&'tcx PolyTraitRef<'tcx>; 1]> {
-    let mut relaxed_bounds: SmallVec<[_; 1]> = SmallVec::new();
-    search_bounds_for(hir_bounds, context, |ptr| {
-        if matches!(ptr.modifiers.polarity, hir::BoundPolarity::Maybe(_)) {
-            relaxed_bounds.push(ptr);
-        }
-    });
-    relaxed_bounds
 }
 
 fn collect_bounds<'a, 'tcx>(
@@ -192,18 +178,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 }
             }
             ImpliedBoundsContext::TyParam(..) | ImpliedBoundsContext::AssociatedTypeOrImplTrait => {
-                // Report invalid relaxed bounds.
-                // FIXME: Since we only call this validation function here in this function, we only
-                //        fully validate relaxed bounds in contexts where we perform
-                //        "sized elaboration". In most cases that doesn't matter because we *usually*
-                //        reject such relaxed bounds outright during AST lowering.
-                //        However, this can easily get out of sync! Ideally, we would perform this step
-                //        where we are guaranteed to catch *all* bounds like in
-                //        `Self::lower_poly_trait_ref`. List of concrete issues:
-                //        FIXME(more_maybe_bounds): We don't call this for trait object tys, supertrait
-                //                                  bounds, trait alias bounds, assoc type bounds (ATB)!
-                let bounds = collect_relaxed_bounds(hir_bounds, context);
-                self.reject_duplicate_relaxed_bounds(bounds);
             }
         }
 
@@ -285,28 +259,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     ) -> bool {
         let collected = collect_bounds(hir_bounds, context, trait_def_id);
         !find_attr!(self.tcx(), crate, RustcNoImplicitBounds) && !collected.any()
-    }
-
-    fn reject_duplicate_relaxed_bounds(&self, relaxed_bounds: SmallVec<[&PolyTraitRef<'_>; 1]>) {
-        let tcx = self.tcx();
-
-        let mut grouped_bounds = FxIndexMap::<_, Vec<_>>::default();
-
-        for bound in &relaxed_bounds {
-            if let Res::Def(DefKind::Trait, trait_def_id) = bound.trait_ref.path.res {
-                grouped_bounds.entry(trait_def_id).or_default().push(bound.span);
-            }
-        }
-
-        for (trait_def_id, spans) in grouped_bounds {
-            if spans.len() > 1 {
-                let name = tcx.item_name(trait_def_id);
-                self.dcx()
-                    .struct_span_err(spans, format!("duplicate relaxed `{name}` bounds"))
-                    .with_code(E0203)
-                    .emit();
-            }
-        }
     }
 
     pub(crate) fn require_bound_to_relax_default_trait(

--- a/tests/ui/trait-bounds/duplicate-relaxed-bounds.rs
+++ b/tests/ui/trait-bounds/duplicate-relaxed-bounds.rs
@@ -10,6 +10,13 @@ trait Trait {
     type Type: ?Sized + ?Sized;
     //~^ ERROR duplicate relaxed `Sized` bounds
     //~| ERROR duplicate relaxed `Sized` bounds
+
+    // Make sure, should we ever allow such where bounds,
+    // we still detect duplicate relaxed bounds.
+    type Type2: ?Sized
+    where
+        Self::Type: ?Sized;
+    //~^ ERROR this relaxed bound is not permitted here
 }
 
 // We used to emit an additional error about "multiple relaxed default bounds".
@@ -18,5 +25,13 @@ trait Trait {
 // the only (stable) default trait, so we're fine.
 fn not_dupes<T: ?Sized + ?Iterator>() {}
 //~^ ERROR bound modifier `?` can only be applied to `Sized`
+
+// Demonstrate that we do detect dupes from where bounds
+fn where_dupes<T: ?Sized>()
+//~^ ERROR duplicate relaxed `Sized` bounds
+where
+    T: ?Sized,
+{
+}
 
 fn main() {}

--- a/tests/ui/trait-bounds/duplicate-relaxed-bounds.rs
+++ b/tests/ui/trait-bounds/duplicate-relaxed-bounds.rs
@@ -9,7 +9,6 @@ trait Trait {
     // even on *associated types* like here. Test that we no longer do that.
     type Type: ?Sized + ?Sized;
     //~^ ERROR duplicate relaxed `Sized` bounds
-    //~| ERROR duplicate relaxed `Sized` bounds
 
     // Make sure, should we ever allow such where bounds,
     // we still detect duplicate relaxed bounds.

--- a/tests/ui/trait-bounds/duplicate-relaxed-bounds.stderr
+++ b/tests/ui/trait-bounds/duplicate-relaxed-bounds.stderr
@@ -1,11 +1,3 @@
-error: this relaxed bound is not permitted here
-  --> $DIR/duplicate-relaxed-bounds.rs:18:21
-   |
-LL |         Self::Type: ?Sized;
-   |                     ^^^^^^
-   |
-   = note: in this context, relaxed bounds are only allowed on type parameters defined on the closest item
-
 error[E0203]: duplicate relaxed `Sized` bounds
   --> $DIR/duplicate-relaxed-bounds.rs:1:13
    |
@@ -17,6 +9,29 @@ error[E0203]: duplicate relaxed `Iterator` bounds
    |
 LL | fn dupes<T: ?Sized + ?Sized + ?Iterator + ?Iterator>() {}
    |                               ^^^^^^^^^   ^^^^^^^^^
+
+error[E0203]: duplicate relaxed `Sized` bounds
+  --> $DIR/duplicate-relaxed-bounds.rs:10:16
+   |
+LL |     type Type: ?Sized + ?Sized;
+   |                ^^^^^^   ^^^^^^
+
+error: this relaxed bound is not permitted here
+  --> $DIR/duplicate-relaxed-bounds.rs:17:21
+   |
+LL |         Self::Type: ?Sized;
+   |                     ^^^^^^
+   |
+   = note: in this context, relaxed bounds are only allowed on type parameters defined on the closest item
+
+error[E0203]: duplicate relaxed `Sized` bounds
+  --> $DIR/duplicate-relaxed-bounds.rs:29:19
+   |
+LL | fn where_dupes<T: ?Sized>()
+   |                   ^^^^^^
+...
+LL |     T: ?Sized,
+   |        ^^^^^^
 
 error: bound modifier `?` can only be applied to `Sized`
   --> $DIR/duplicate-relaxed-bounds.rs:1:31
@@ -31,34 +46,11 @@ LL | fn dupes<T: ?Sized + ?Sized + ?Iterator + ?Iterator>() {}
    |                                           ^^^^^^^^^
 
 error: bound modifier `?` can only be applied to `Sized`
-  --> $DIR/duplicate-relaxed-bounds.rs:26:26
+  --> $DIR/duplicate-relaxed-bounds.rs:25:26
    |
 LL | fn not_dupes<T: ?Sized + ?Iterator>() {}
    |                          ^^^^^^^^^
 
-error[E0203]: duplicate relaxed `Sized` bounds
-  --> $DIR/duplicate-relaxed-bounds.rs:30:19
-   |
-LL | fn where_dupes<T: ?Sized>()
-   |                   ^^^^^^
-...
-LL |     T: ?Sized,
-   |        ^^^^^^
-
-error[E0203]: duplicate relaxed `Sized` bounds
-  --> $DIR/duplicate-relaxed-bounds.rs:10:16
-   |
-LL |     type Type: ?Sized + ?Sized;
-   |                ^^^^^^   ^^^^^^
-
-error[E0203]: duplicate relaxed `Sized` bounds
-  --> $DIR/duplicate-relaxed-bounds.rs:10:16
-   |
-LL |     type Type: ?Sized + ?Sized;
-   |                ^^^^^^   ^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 9 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0203`.

--- a/tests/ui/trait-bounds/duplicate-relaxed-bounds.stderr
+++ b/tests/ui/trait-bounds/duplicate-relaxed-bounds.stderr
@@ -1,3 +1,11 @@
+error: this relaxed bound is not permitted here
+  --> $DIR/duplicate-relaxed-bounds.rs:18:21
+   |
+LL |         Self::Type: ?Sized;
+   |                     ^^^^^^
+   |
+   = note: in this context, relaxed bounds are only allowed on type parameters defined on the closest item
+
 error[E0203]: duplicate relaxed `Sized` bounds
   --> $DIR/duplicate-relaxed-bounds.rs:1:13
    |
@@ -23,10 +31,19 @@ LL | fn dupes<T: ?Sized + ?Sized + ?Iterator + ?Iterator>() {}
    |                                           ^^^^^^^^^
 
 error: bound modifier `?` can only be applied to `Sized`
-  --> $DIR/duplicate-relaxed-bounds.rs:19:26
+  --> $DIR/duplicate-relaxed-bounds.rs:26:26
    |
 LL | fn not_dupes<T: ?Sized + ?Iterator>() {}
    |                          ^^^^^^^^^
+
+error[E0203]: duplicate relaxed `Sized` bounds
+  --> $DIR/duplicate-relaxed-bounds.rs:30:19
+   |
+LL | fn where_dupes<T: ?Sized>()
+   |                   ^^^^^^
+...
+LL |     T: ?Sized,
+   |        ^^^^^^
 
 error[E0203]: duplicate relaxed `Sized` bounds
   --> $DIR/duplicate-relaxed-bounds.rs:10:16
@@ -42,6 +59,6 @@ LL |     type Type: ?Sized + ?Sized;
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 7 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0203`.


### PR DESCRIPTION
Instead of during hir-ty-lowering.

Not sure it is worth erroring on at all, but it's better to do it directly during lowering instead of collecting bounds after the fact.