### PR TITLE
incremental: stronger backed-off retry when finalizing session dir on Windows (#86929)

### DIFF
--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -355,7 +355,7 @@ pub fn finalize_session_directory(sess: &Session, svh: Option<Svh>) {
     let new_path = incr_comp_session_dir.parent().unwrap().join(&*sub_dir_name);
     debug!("finalize_session_directory() - new path: {}", new_path.display());
 
-    match rename_path_with_retry(&*incr_comp_session_dir, &new_path, 3) {
+    match rename_path_with_retry(&*incr_comp_session_dir, &new_path, 12) {
         Ok(_) => {
             debug!("finalize_session_directory() - directory renamed successfully");
 
@@ -887,23 +887,36 @@ fn safe_remove_file(p: &Path) -> io::Result<()> {
     }
 }
 
-// On Windows the compiler would sometimes fail to rename the session directory because
-// the OS thought something was still being accessed in it. So we retry a few times to give
-// the OS time to catch up.
+// On Windows, finalizing the incremental session directory occasionally fails
+// with ERROR_ACCESS_DENIED while renaming the `-working` directory to its final
+// name. Instrumenting the compiler (logging every memory-map of the incremental
+// files plus the finalize rename) shows that by the time the rename runs, rustc
+// has already dropped every mapping of the files inside the directory
+// (work-products.bin / dep-graph.bin / query-cache.bin) -- nothing rustc owns is
+// still mapped. The denial comes from the OS still releasing the just-unmapped
+// files' backing sections; a directory cannot be renamed while a file inside it
+// is in that transient state. Under parallel build load this window is routinely
+// longer than a flat 3x50ms retry, so the warning fires for most crates on warm
+// rebuilds. Since nothing is held on the rustc side, the robust fix is a longer,
+// backed-off retry rather than dropping a mapping earlier.
+//
+// This strengthens the retry added in https://github.com/rust-lang/rust/pull/95304.
 // See https://github.com/rust-lang/rust/issues/86929.
-fn rename_path_with_retry(from: &Path, to: &Path, mut retries_left: usize) -> std::io::Result<()> {
+fn rename_path_with_retry(from: &Path, to: &Path, max_retries: usize) -> std::io::Result<()> {
+    let mut attempt = 0;
     loop {
         match std_fs::rename(from, to) {
             Ok(()) => return Ok(()),
-            Err(e) => {
-                if retries_left > 0 && e.kind() == ErrorKind::PermissionDenied {
-                    // Try again after a short waiting period.
-                    std::thread::sleep(Duration::from_millis(50));
-                    retries_left -= 1;
-                } else {
-                    return Err(e);
-                }
+            Err(e) if attempt < max_retries && e.kind() == ErrorKind::PermissionDenied => {
+                // Back off with meaningful steps. The Windows sleep granularity is
+                // ~15ms, so sub-15ms waits would round up to a single tick and add
+                // no real spacing; start at 10ms and grow, capping at 100ms.
+                // 10, 20, 40, 80, then 100ms; ~1s total budget over 12 attempts.
+                let backoff_ms = (10u64 << attempt.min(4)).min(100);
+                std::thread::sleep(Duration::from_millis(backoff_ms));
+                attempt += 1;
             }
+            Err(e) => return Err(e),
         }
     }
 }


### PR DESCRIPTION
Reduces the spurious `error finalizing incremental compilation session directory ...-working: Access is denied. (os error 5)` warnings on Windows (rust-lang/rust#86929).

These have been reported for years; they're harmless to the build itself but noisy, and they break tooling that parses compiler output. They're most common on warm incremental rebuilds under parallel load.

### Background

The existing retry was added in rust-lang/rust#95304, which wraps the finalize rename in a flat `3 × 50ms` retry. That helped but didn't eliminate the warning — rust-lang/rust#86929 has continued to be reported since it merged. The author of rust-lang/rust#95304 noted they couldn't produce a deterministic regression test for it, which matches my experience: the failure is a timing race that is hard to trigger on demand in a quiet system but common under real build load.

### Root cause

I built an instrumented compiler that logs every memory-map of the incremental files (resolving each mapping's backing path) alongside the finalize rename, and reproduced the failure under parallel load.

In every captured failure, **rustc had already dropped all of its mappings** of the files inside the `-working` directory (`work-products.bin`, `dep-graph.bin`, `query-cache.bin`) before the rename ran. Nothing rustc owns is still mapped at finalize.

So the `ERROR_ACCESS_DENIED` is **not** rustc holding a handle across the rename. It's the OS still releasing the just-unmapped files' backing sections: a directory can't be renamed while a file inside it is in that transient post-unmap state. Under parallel build load this window is routinely longer than `3 × 50ms`, so the warning fires for most crates on each warm rebuild.

Because nothing is held on the rustc side, the right fix is to make the existing retry robust rather than to drop a mapping earlier (there's nothing left to drop earlier).

### Change

Replace the flat `3 × 50ms` retry with a backed-off schedule: `10, 20, 40, 80, then 100ms`, capped, for ~1s total budget over 12 attempts. Windows' sleep granularity is ~15ms, so the schedule deliberately starts at 10ms and grows rather than using sub-tick waits that would round up to a single tick and add no real spacing.

The retry only runs on `PermissionDenied` and is a no-op on other platforms (the first rename succeeds), so this is Windows-only in practice and behavior-neutral elsewhere.

### A note on testing

Like rust-lang/rust#95304, I don't have a deterministic regression test — the failure is an OS-timing race that doesn't reproduce reliably in a quiet CI-like environment. I verified the change by reproducing the warning under load with an instrumented build and confirming the backed-off retry absorbs the window. I'm happy to tune the schedule or attempt budget, or gate it behind `cfg(windows)` explicitly, per reviewer preference.

Opening as a **draft** for discussion.

r? compiler
