### PR TITLE
wasm32-wasip1-threads: Correct llvm target name

### DIFF
--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip1_threads.rs
@@ -60,7 +60,7 @@ pub(crate) fn target() -> Target {
     options.features = "+atomics,+bulk-memory,+mutable-globals".into();
 
     Target {
-        llvm_target: "wasm32-wasi".into(),
+        llvm_target: "wasm32-wasip1-threads".into(),
         metadata: TargetMetadata {
             description: None,
             tier: Some(2),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Intends to fix rust-lang/rust#131007, a problem with cross-compiling Rust+C++ to wasm32-wasip1-threads: clang will be told to compile for `--target=wasm32-wasi`, which it interprets as `wasm32-wasip1`, which is not compatible with `wasm32-wasip1-threads`.

I wonder if there might be any compatibility issue or something depending on the old incorrect name...