### PR TITLE
Windows TLS - Only register the `atexit` hook when `cleanup` can be unloaded

### DIFF
--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -2154,6 +2154,8 @@ GENERIC_ALL
 GENERIC_EXECUTE
 GENERIC_READ
 GENERIC_WRITE
+GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT
 GetActiveProcessorCount
 getaddrinfo
 GetCommandLineW
@@ -2178,6 +2180,7 @@ GetFullPathNameW
 GetLastError
 GetModuleFileNameW
 GetModuleHandleA
+GetModuleHandleExW
 GetModuleHandleW
 GetOverlappedResult
 getpeername

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -56,6 +56,7 @@ windows_link::link!("kernel32.dll" "system" fn GetFullPathNameW(lpfilename : PCW
 windows_link::link!("kernel32.dll" "system" fn GetLastError() -> WIN32_ERROR);
 windows_link::link!("kernel32.dll" "system" fn GetModuleFileNameW(hmodule : HMODULE, lpfilename : PWSTR, nsize : u32) -> u32);
 windows_link::link!("kernel32.dll" "system" fn GetModuleHandleA(lpmodulename : PCSTR) -> HMODULE);
+windows_link::link!("kernel32.dll" "system" fn GetModuleHandleExW(dwflags : u32, lpmodulename : PCWSTR, phmodule : *mut HMODULE) -> BOOL);
 windows_link::link!("kernel32.dll" "system" fn GetModuleHandleW(lpmodulename : PCWSTR) -> HMODULE);
 windows_link::link!("kernel32.dll" "system" fn GetOverlappedResult(hfile : HANDLE, lpoverlapped : *const OVERLAPPED, lpnumberofbytestransferred : *mut u32, bwait : BOOL) -> BOOL);
 windows_link::link!("kernel32.dll" "system" fn GetProcAddress(hmodule : HMODULE, lpprocname : PCSTR) -> FARPROC);
@@ -2716,6 +2717,8 @@ pub const GENERIC_EXECUTE: GENERIC_ACCESS_RIGHTS = 536870912u32;
 pub const GENERIC_READ: GENERIC_ACCESS_RIGHTS = 2147483648u32;
 pub const GENERIC_WRITE: GENERIC_ACCESS_RIGHTS = 1073741824u32;
 pub type GETFINALPATHNAMEBYHANDLE_FLAGS = u32;
+pub const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 4u32;
+pub const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: u32 = 2u32;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GUID {

--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -159,9 +159,11 @@ pub fn enable() {
                     //
                     // Miri has no DLL unloading so we can skip this step here.
                     if !cfg!(miri) {
-                        let res = unsafe { c::atexit(free_fls_key_at_exit) };
-                        if res != 0 {
-                            rtabort!("failed to register fls atexit hook");
+                        if cleanup_is_unloadable() {
+                            let res = unsafe { c::atexit(free_fls_key_at_exit) };
+                            if res != 0 {
+                                rtabort!("failed to register fls atexit hook");
+                            }
                         }
                     }
 
@@ -177,6 +179,48 @@ pub fn enable() {
         // Setting the key's value to non-zero will cause the dtor callback to be called when the thread exits.
         unsafe { set(key, ptr::without_provenance(1)) };
     }
+}
+
+/// Checks if `cleanup` is in a different module from the main executable,
+/// using `GetModuleHandleExW(FLAG_FROM_ADDRESS, cleanup) != GetModuleHandleW(ptr::null())`.
+///
+/// If `cleanup` lives in the main executable, its code cannot be unmapped
+/// before process exit, so no unload hook is needed.
+///
+/// If it lives in a DLL, the DLL may be unloaded while the process keeps
+/// running, so the FLS callback must be unregistered before that image is
+/// unmapped.
+///
+/// On failure, return true, which assumes it can be unloaded.
+fn cleanup_is_unloadable() -> bool {
+    // Get a handle to the module of `cleanup`.
+    let cleanup_module = {
+        let mut handle: c::HMODULE = ptr::null_mut();
+
+        let res = unsafe {
+            c::GetModuleHandleExW(
+                c::GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
+                    | c::GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                cleanup as *const () as c::PCWSTR,
+                &mut handle,
+            )
+        };
+
+        if res == c::FALSE || handle.is_null() {
+            return true;
+        }
+
+        handle
+    };
+
+    // Get a handle to the file used to create the calling process (.exe file).
+    let main_exe_module = unsafe { c::GetModuleHandleW(ptr::null()) };
+
+    if main_exe_module.is_null() {
+        return true;
+    }
+
+    cleanup_module != main_exe_module
 }
 
 extern "C" fn free_fls_key_at_exit() {

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -104,8 +104,8 @@ use crate::fmt;
 ///    If a process loads a Rust `cdylib`, it must not cause the Rust TLS destructor support
 //     to be initialized for the first time during process shutdown.
 ///
-///    When dynamically unloading a Rust `cdylib`, threads with pending TLS destructors
-///    may run during the unload or may be leaked.
+///    When dynamically unloading a Rust `cdylib`, pending TLS destructors may run
+//     during the unload or may be leaked.
 ///
 /// [converted into a fiber]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-convertthreadtofiber
 /// [converted back into a thread]: https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-convertfibertothread

--- a/tests/run-make/dynamic-loading-cdylib/load_and_unload.rs
+++ b/tests/run-make/dynamic-loading-cdylib/load_and_unload.rs
@@ -88,6 +88,9 @@ mod libloading {
 type ExternFn = unsafe extern "C" fn(u32, u32) -> u32;
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    assert_eq!(args.len(), 2, "This program should be run with one argument");
+
     let foo = libloading::load("foo").expect("Failed to load library");
     println!("loaded library");
 
@@ -110,6 +113,13 @@ fn main() {
     .expect("Thread panicked");
     println!("thread joined");
 
-    libloading::unload(foo);
-    println!("unloaded library");
+    match args[1].as_str() {
+        "unload" => {
+            println!("unloading library");
+            libloading::unload(foo);
+            println!("unloaded library");
+        }
+        "load_only" => println!("dropping library handle without unloading"),
+        arg => panic!("unexpected argument: {}", arg),
+    }
 }

--- a/tests/run-make/dynamic-loading-cdylib/output_load_only_unix.txt
+++ b/tests/run-make/dynamic-loading-cdylib/output_load_only_unix.txt
@@ -8,5 +8,5 @@ extern_fn_2(4, 5)
 result of extern_fn_2(4, 5) in other thread: 20
 dropping, last result: 20
 thread joined
+dropping library handle without unloading
 dropping, last result: 6
-unloaded library

--- a/tests/run-make/dynamic-loading-cdylib/output_load_only_windows.txt
+++ b/tests/run-make/dynamic-loading-cdylib/output_load_only_windows.txt
@@ -1,0 +1,12 @@
+loaded library
+extern_fn_1
+result of extern_fn_1(2, 3): 5
+extern_fn_2(2, 3)
+result of extern_fn_2(2, 3): 6
+spawning thread
+extern_fn_2(4, 5)
+result of extern_fn_2(4, 5) in other thread: 20
+dropping, last result: 20
+thread joined
+dropping library handle without unloading
+dropping, last result: 6

--- a/tests/run-make/dynamic-loading-cdylib/output_unload_unix.txt
+++ b/tests/run-make/dynamic-loading-cdylib/output_unload_unix.txt
@@ -8,5 +8,6 @@ extern_fn_2(4, 5)
 result of extern_fn_2(4, 5) in other thread: 20
 dropping, last result: 20
 thread joined
+unloading library
 unloaded library
 dropping, last result: 6

--- a/tests/run-make/dynamic-loading-cdylib/output_unload_windows.txt
+++ b/tests/run-make/dynamic-loading-cdylib/output_unload_windows.txt
@@ -1,0 +1,13 @@
+loaded library
+extern_fn_1
+result of extern_fn_1(2, 3): 5
+extern_fn_2(2, 3)
+result of extern_fn_2(2, 3): 6
+spawning thread
+extern_fn_2(4, 5)
+result of extern_fn_2(4, 5) in other thread: 20
+dropping, last result: 20
+thread joined
+unloading library
+dropping, last result: 6
+unloaded library

--- a/tests/run-make/dynamic-loading-cdylib/rmake.rs
+++ b/tests/run-make/dynamic-loading-cdylib/rmake.rs
@@ -7,23 +7,25 @@
 
 //@ ignore-cross-compile
 
-use run_make_support::{diff, run, rustc};
+use run_make_support::{diff, run_with_args, rustc};
 
 fn main() {
     rustc().input("foo.rs").run();
 
     rustc().crate_type("bin").crate_name("load_and_unload_bin").input("load_and_unload.rs").run();
 
-    let out_raw = run("load_and_unload_bin").stdout_utf8();
+    for command_arg in ["unload", "load_only"] {
+        let out_raw = run_with_args("load_and_unload_bin", &[command_arg]).stdout_utf8();
 
-    #[cfg(windows)]
-    let output_filename = "output_windows.txt";
-    #[cfg(unix)]
-    let output_filename = "output_unix.txt";
+        #[cfg(windows)]
+        let output_filename = format!("output_{}_windows.txt", command_arg);
+        #[cfg(unix)]
+        let output_filename = format!("output_{}_unix.txt", command_arg);
 
-    diff()
-        .expected_file(output_filename)
-        .actual_text("actual", out_raw)
-        .normalize(r#"\r"#, "")
-        .run();
+        diff()
+            .expected_file(output_filename)
+            .actual_text("actual", out_raw)
+            .normalize(r#"\r"#, "")
+            .run();
+    }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Followup to rust-lang/rust#148799 - One of the motivations was to remove the "Synchronization in thread-local destructors" limitation (see the [docs](https://doc.rust-lang.org/std/thread/struct.LocalKey.html#synchronization-in-thread-local-destructors)). However, it is still _possible_ to deadlock on Windows with a destructor that uses a `join`, but **only** during an application shutdown.

(Edited. The original PR leaked the dtors when a DLL was unloaded.)

This is because calling `FlsFree` from the `atexit` hook _from the main executable_ can deadlock if other threads are also running FLS destructors.

This PR tweaks the implementation to only register the hook if `cleanup` can be unloaded, meaning we are loaded as a DLL.

This has an added benefit of not triggering `FlsFree` at all during normal application shutdown, which is the most common case and is now handled more naturally by the Windows runtime (which calls the FLS hooks without holding the load-lock).

Checking if the `cleanup` hook is unload-able is done by checking if it is in the same module as the main exe `GetModuleHandleExW(FLAG_FROM_ADDRESS, cleanup) == GetModuleHandleW(ptr::null())`.


<details>

<summary>Join-on-Drop on Process Exit Deadlock Example</summary>

```rust
use std::thread::JoinHandle;
use std::time::Duration;

struct JoinOnDrop(Option<JoinHandle<()>>);

impl Drop for JoinOnDrop {
    fn drop(&mut self) {
        println!("Joining thread... ({:?})", std::thread::current());
        self.0.take().unwrap().join().unwrap();
        println!("Thread joined");
    }
}

thread_local! {
    static HANDLE: JoinOnDrop = {
        let thread = std::thread::spawn(|| {   
            println!("Starting...");
            std::thread::sleep(Duration::from_secs(3));
            println!("Done ({:?})", std::thread::current());
        });

        JoinOnDrop(Some(thread))
    };
}


fn main() {
    let thread = std::thread::spawn(|| {
        HANDLE.with(|_| {
            println!("Some other thread ({:?})", std::thread::current());
        })
    });

    // ***Here***, because we do not join beforehand, the drops are called from atexit which is done while in loader-lock, so the the binary will deadlock.
    // thread.join().unwrap();
    std::thread::sleep(Duration::from_secs(1));

    println!("Done ({:?})", std::thread::current());
}
```
</details>

r? @ChrisDenton 