### PR TITLE
Keep rename-imported main alive in dead-code analysis under `--test`

### DIFF
--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -1,6 +1,7 @@
 // Code that generates a test runner to run all the tests in a crate
 
 use std::mem;
+use std::sync::atomic::Ordering;
 
 use rustc_ast as ast;
 use rustc_ast::attr::contains_name;
@@ -202,7 +203,7 @@ impl<'a> MutVisitor for EntryPointCleaner<'a> {
         // clash with the one we're going to add, but mark it as
         // #[allow(dead_code)] to avoid printing warnings.
         match entry_point_type(&item, self.depth == 0) {
-            EntryPointType::MainNamed | EntryPointType::RustcMainAttr => {
+            EntryPointType::RustcMainAttr => {
                 let allow_dead_code = attr::mk_attr_nested_word(
                     &self.sess.psess.attr_id_generator,
                     ast::AttrStyle::Outer,
@@ -213,8 +214,9 @@ impl<'a> MutVisitor for EntryPointCleaner<'a> {
                 );
                 item.attrs.retain(|attr| !attr.has_name(sym::rustc_main));
                 item.attrs.push(allow_dead_code);
+                self.sess.removed_rustc_main_attr.store(true, Ordering::Relaxed);
             }
-            EntryPointType::None | EntryPointType::OtherMain => {}
+            EntryPointType::None | EntryPointType::MainNamed | EntryPointType::OtherMain => {}
         };
     }
 }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -5,6 +5,7 @@
 
 use std::mem;
 use std::ops::ControlFlow;
+use std::sync::atomic::Ordering;
 
 use hir::def_id::{LocalDefIdMap, LocalDefIdSet};
 use rustc_abi::FieldIdx;
@@ -921,6 +922,21 @@ fn create_and_seed_worklist(tcx: TyCtxt<'_>) -> SeedWorklists {
     let mut worklist = Vec::new();
 
     if let Some((def_id, _)) = tcx.entry_fn(())
+        && let Some(local_def_id) = def_id.as_local()
+    {
+        worklist.push(WorkItem {
+            id: local_def_id,
+            propagated: ComesFromAllowExpect::No,
+            own: ComesFromAllowExpect::No,
+        });
+    }
+
+    // Under `--test`, what `main` resolves to is the would-be entry point of a normal build,
+    // so keep it live, unless a stripped user `#[rustc_main]` would have been the entry instead.
+    if tcx.sess.is_test_crate()
+        && !tcx.sess.removed_rustc_main_attr.load(Ordering::Relaxed)
+        && let Some(main_def) = tcx.resolutions(()).main_def
+        && let Some(def_id) = main_def.opt_fn_def_id()
         && let Some(local_def_id) = def_id.as_local()
     {
         worklist.push(WorkItem {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -181,6 +181,10 @@ pub struct Session {
     ///
     /// The value is the `DepNodeIndex` of the node encodes the used feature.
     pub used_features: Lock<FxHashMap<Symbol, u32>>,
+
+    /// Whether the test harness removed a user-written `#[rustc_main]` attribute
+    /// while generating the synthetic test entry point.
+    pub removed_rustc_main_attr: AtomicBool,
 }
 
 #[derive(Clone, Copy)]
@@ -1133,6 +1137,7 @@ pub fn build_session(
         thin_lto_supported: true,                  // filled by `run_compiler`
         mir_opt_bisect_eval_count: AtomicUsize::new(0),
         used_features: Lock::default(),
+        removed_rustc_main_attr: AtomicBool::new(false),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/tests/ui/lint/dead-code/imported_main_dead_code_under_test.rs
+++ b/tests/ui/lint/dead-code/imported_main_dead_code_under_test.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+//@ compile-flags: --test
+
+// Regression test for https://github.com/rust-lang/rust/issues/157608: a function used
+// as `main` via a rename import was wrongly reported as dead code under `--test`.
+
+#![deny(dead_code)]
+
+fn different_main() {
+    println!("Hello from different_main");
+}
+
+use different_main as main;

--- a/tests/ui/lint/dead-code/imported_main_glob_under_test.rs
+++ b/tests/ui/lint/dead-code/imported_main_glob_under_test.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ compile-flags: --test
+
+#![deny(dead_code)]
+
+mod m {
+    pub fn main() {}
+}
+
+use m::*;

--- a/tests/ui/lint/dead-code/imported_main_path_under_test.rs
+++ b/tests/ui/lint/dead-code/imported_main_path_under_test.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+//@ compile-flags: --test
+
+#![deny(dead_code)]
+
+mod m {
+    pub fn main() {}
+}
+
+use m::main;

--- a/tests/ui/lint/dead-code/imported_main_renamed_from_mod_under_test.rs
+++ b/tests/ui/lint/dead-code/imported_main_renamed_from_mod_under_test.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+//@ compile-flags: --test
+
+
+#![deny(dead_code)]
+
+mod m {
+    pub fn other() {}
+}
+
+use m::other as main;

--- a/tests/ui/lint/dead-code/lint-dead-code-2-under-test.rs
+++ b/tests/ui/lint/dead-code/lint-dead-code-2-under-test.rs
@@ -1,0 +1,22 @@
+//@ compile-flags: --test
+
+// A `fn main` demoted by an explicit `#[rustc_main]` on another function is dead code and
+// must be flagged under `--test` just like in a normal build.
+
+#![allow(unused_variables)]
+#![deny(dead_code)]
+#![feature(rustc_attrs)]
+
+fn dead_fn() {} //~ ERROR: function `dead_fn` is never used
+
+fn used_fn() {}
+
+#[rustc_main]
+fn actual_main() {
+    used_fn();
+}
+
+// this is not main
+fn main() { //~ ERROR: function `main` is never used
+    dead_fn();
+}

--- a/tests/ui/lint/dead-code/lint-dead-code-2-under-test.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-2-under-test.stderr
@@ -1,0 +1,20 @@
+error: function `dead_fn` is never used
+  --> $DIR/lint-dead-code-2-under-test.rs:10:4
+   |
+LL | fn dead_fn() {}
+   |    ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-dead-code-2-under-test.rs:7:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: function `main` is never used
+  --> $DIR/lint-dead-code-2-under-test.rs:20:4
+   |
+LL | fn main() {
+   |    ^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/lint/dead-code/submodule_main_not_entry_under_test.rs
+++ b/tests/ui/lint/dead-code/submodule_main_not_entry_under_test.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: --test
+
+#![deny(dead_code)]
+
+fn main() {}
+
+mod m {
+    pub fn main() {} //~ ERROR: function `main` is never used
+}

--- a/tests/ui/lint/dead-code/submodule_main_not_entry_under_test.stderr
+++ b/tests/ui/lint/dead-code/submodule_main_not_entry_under_test.stderr
@@ -1,0 +1,14 @@
+error: function `main` is never used
+  --> $DIR/submodule_main_not_entry_under_test.rs:8:12
+   |
+LL |     pub fn main() {}
+   |            ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/submodule_main_not_entry_under_test.rs:3:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/157646)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#157608.

A function used as `main` via a rename import was wrongly reported as dead code under `--test`. The dead-code pass only seeded `entry_fn`, which `--test` replaces with the test harness' main; now it also seeds the resolver's `main_def`.