### PR TITLE
Start using comptime for reflection intrinsics and their wrapper functions

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1122,6 +1122,9 @@ fn should_encode_mir(
                     && reachable_set.contains(&def_id)
                     && (tcx.generics_of(def_id).requires_monomorphization(tcx)
                         || tcx.cross_crate_inlinable(def_id)));
+            // Comptime fns do not have optimized MIR at all.
+            let opt =
+                opt && !matches!(tcx.constness(def_id), hir::Constness::Const { always: true });
             // The function has a `const` modifier or is in a `const trait`.
             let is_const_fn = tcx.is_const_fn(def_id.to_def_id());
             (is_const_fn, opt)

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1789,6 +1789,14 @@ impl<'tcx> TyCtxt<'tcx> {
                     | DefKind::Ctor(..)
                     | DefKind::AnonConst
                     | DefKind::InlineConst => self.mir_for_ctfe(def),
+                    DefKind::Fn | DefKind::AssocFn
+                        if matches!(
+                            self.constness(def),
+                            hir::Constness::Const { always: true }
+                        ) =>
+                    {
+                        self.mir_for_ctfe(def)
+                    }
                     // If the caller wants `mir_for_ctfe` of a function they should not be using
                     // `instance_mir`, so we'll assume const fn also wants the optimized version.
                     _ => self.optimized_mir(def),

--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -1,7 +1,7 @@
 use rustc_hir::attrs::InlineAttr;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::LocalDefId;
-use rustc_hir::find_attr;
+use rustc_hir::{self as hir, find_attr};
 use rustc_middle::bug;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
@@ -41,6 +41,12 @@ fn cross_crate_inlinable(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
         // bodies even when the backend would implement something better, we stop
         // the MIR inliner from ever inlining an intrinsic.
         return true;
+    }
+
+    if let hir::Constness::Const { always: true } = tcx.constness(def_id) {
+        // Comptime functions only exist during const eval and can never be passed
+        // to codegen. The const eval MIR pipeline also doesn't inline anything at all.
+        return false;
     }
 
     // Obey source annotations first; this is important because it means we can use

--- a/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
+++ b/compiler/rustc_mir_transform/src/deduce_param_attrs.rs
@@ -9,6 +9,7 @@
 //! after `optimized_mir`! We check for things that are *not* guaranteed to be preserved by MIR
 //! transforms, such as which local variables happen to be mutated.
 
+use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_index::IndexVec;
 use rustc_middle::middle::deduced_param_attrs::{DeducedParamAttrs, UsageSummary};
@@ -202,6 +203,12 @@ pub(super) fn deduced_param_attrs<'tcx>(
 
     // Don't deduce any attributes for functions that have no MIR.
     if !tcx.is_mir_available(def_id) {
+        return &[];
+    }
+
+    if let hir::Constness::Const { always: true } = tcx.constness(def_id) {
+        // Comptime functions only exist during const eval and can never be passed
+        // to codegen.
         return &[];
     }
 

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -511,7 +511,18 @@ fn inner_mir_for_ctfe(tcx: TyCtxt<'_>, def: LocalDefId) -> Body<'_> {
     };
 
     let mut body = remap_mir_for_const_eval_select(tcx, body, hir::Constness::Const { always });
-    pm::run_passes(tcx, &mut body, &[&ctfe_limit::CtfeLimit], None, pm::Optimizations::Allowed);
+    // FIXME(reflection): probably need to look at this for comptime closures
+    let passes: &[&dyn MirPass<'_>] = if matches!(tcx.def_kind(def), DefKind::Fn | DefKind::AssocFn)
+        && matches!(tcx.constness(def), hir::Constness::Const { always: true })
+    {
+        // Need to generate mentioned items, as all functions are expected to have them, but for const
+        // fns we just look at the optimized MIR, which generates it. For comptime fns, there is no
+        // optimized MIR.
+        &[&ctfe_limit::CtfeLimit, &mentioned_items::MentionedItems]
+    } else {
+        &[&ctfe_limit::CtfeLimit]
+    };
+    pm::run_passes(tcx, &mut body, passes, None, pm::Optimizations::Allowed);
 
     body
 }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -785,9 +785,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn trait_info_of<
-        T: ptr::Pointee<Metadata = ptr::DynMetadata<T>> + ?Sized + 'static,
-    >(
+    #[rustc_comptime]
+    pub fn trait_info_of<T: ptr::Pointee<Metadata = ptr::DynMetadata<T>> + ?Sized + 'static>(
         self,
     ) -> Option<TraitImpl<T>> {
         // SAFETY: The vtable was obtained for `T`, so it is guaranteed to be `DynMetadata<T>`.
@@ -812,7 +811,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn trait_info_of_trait_type_id(
+    #[rustc_comptime]
+    pub fn trait_info_of_trait_type_id(
         self,
         trait_represented_by_type_id: TypeId,
     ) -> Option<TraitImpl<*const ()>> {

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2874,11 +2874,12 @@ pub const unsafe fn size_of_val<T: ?Sized>(ptr: *const T) -> usize;
 pub const unsafe fn align_of_val<T: ?Sized>(ptr: *const T) -> usize;
 
 #[rustc_intrinsic]
+#[rustc_comptime]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 /// Check if a type represented by a `TypeId` implements a trait represented by a `TypeId`.
 /// It can only be called at compile time, the backends do
 /// not implement it. If it implements the trait the dyn metadata gets returned for vtable access.
-pub const fn type_id_vtable(
+pub fn type_id_vtable(
     _id: crate::any::TypeId,
     _trait: crate::any::TypeId,
 ) -> Option<ptr::DynMetadata<*const ()>> {

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2923,7 +2923,8 @@ pub const fn type_name<T: ?Sized>() -> &'static str;
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
-pub const fn type_id<T: ?Sized>() -> crate::any::TypeId;
+#[rustc_comptime]
+pub fn type_id<T: ?Sized>() -> crate::any::TypeId;
 
 /// Tests (at compile-time) if two [`crate::any::TypeId`] instances identify the
 /// same type. This is necessary because at const-eval time the actual discriminating
@@ -2945,7 +2946,8 @@ pub const fn type_id_eq(a: crate::any::TypeId, b: crate::any::TypeId) -> bool {
 /// The more user-friendly version of this intrinsic is [`core::any::TypeId::size`].
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
+#[rustc_comptime]
+pub fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
     panic!("`TypeId::size` can only be called at compile-time")
 }
 
@@ -2954,7 +2956,8 @@ pub const fn size_of_type_id(_id: crate::any::TypeId) -> Option<usize> {
 /// The more user-friendly version of this intrinsic is [`core::any::TypeId::variants`].
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_id_variants(_id: crate::any::TypeId) -> usize {
+#[rustc_comptime]
+pub fn type_id_variants(_id: crate::any::TypeId) -> usize {
     panic!("`TypeId::variants` can only be called at compile-time")
 }
 
@@ -2963,7 +2966,8 @@ pub const fn type_id_variants(_id: crate::any::TypeId) -> usize {
 /// The more user-friendly version of this intrinsic is [`core::any::TypeId::fields`].
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> usize {
+#[rustc_comptime]
+pub fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> usize {
     panic!("`TypeId::fields` can only be called at compile-time")
 }
 
@@ -2974,7 +2978,8 @@ pub const fn type_id_fields(_id: crate::any::TypeId, _variant_index: usize) -> u
 /// [`FieldRepresentingType`]: crate::field::FieldRepresentingType
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn type_id_field_representing_type(
+#[rustc_comptime]
+pub fn type_id_field_representing_type(
     _id: crate::any::TypeId,
     _variant_index: usize,
     _field_index: usize,
@@ -2989,7 +2994,8 @@ pub const fn type_id_field_representing_type(
 /// [`FieldRepresentingType`]: crate::field::FieldRepresentingType
 #[rustc_intrinsic]
 #[unstable(feature = "core_intrinsics", issue = "none")]
-pub const fn field_representing_type_actual_type_id(
+#[rustc_comptime]
+pub fn field_representing_type_actual_type_id(
     _frt_type_id: crate::any::TypeId,
 ) -> crate::any::TypeId {
     panic!("`FieldId::type_id` can only be called at compile-time")

--- a/library/core/src/mem/type_info.rs
+++ b/library/core/src/mem/type_info.rs
@@ -374,7 +374,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn size(self) -> Option<usize> {
+    #[rustc_comptime]
+    pub fn size(self) -> Option<usize> {
         intrinsics::size_of_type_id(self)
     }
 
@@ -399,7 +400,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn variants(self) -> usize {
+    #[rustc_comptime]
+    pub fn variants(self) -> usize {
         intrinsics::type_id_variants(self)
     }
 
@@ -461,7 +463,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn fields(self, variant_index: usize) -> usize {
+    #[rustc_comptime]
+    pub fn fields(self, variant_index: usize) -> usize {
         intrinsics::type_id_fields(self, variant_index)
     }
 
@@ -527,7 +530,8 @@ impl TypeId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn field(self, variant_index: usize, field_index: usize) -> FieldId {
+    #[rustc_comptime]
+    pub fn field(self, variant_index: usize, field_index: usize) -> FieldId {
         FieldId {
             frt_type_id: intrinsics::type_id_field_representing_type(
                 self,
@@ -571,7 +575,8 @@ impl FieldId {
     /// ```
     #[unstable(feature = "type_info", issue = "146922")]
     #[rustc_const_unstable(feature = "type_info", issue = "146922")]
-    pub const fn type_id(self) -> TypeId {
+    #[rustc_comptime]
+    pub fn type_id(self) -> TypeId {
         intrinsics::field_representing_type_actual_type_id(self.frt_type_id)
     }
 }

--- a/tests/ui/reflection/reflection_methods_in_runtime_code.rs
+++ b/tests/ui/reflection/reflection_methods_in_runtime_code.rs
@@ -1,0 +1,10 @@
+//@run-fail
+
+#![feature(type_info)]
+
+trait Trait {}
+
+fn main() {
+    // Test the (lack of) usability of comptime fns in runtime code.
+    std::any::TypeId::of::<[u8; usize::MAX]>().trait_info_of::<dyn Trait>();
+}

--- a/tests/ui/reflection/reflection_methods_in_runtime_code.rs
+++ b/tests/ui/reflection/reflection_methods_in_runtime_code.rs
@@ -1,5 +1,3 @@
-//@run-fail
-
 #![feature(type_info)]
 
 trait Trait {}
@@ -7,4 +5,5 @@ trait Trait {}
 fn main() {
     // Test the (lack of) usability of comptime fns in runtime code.
     std::any::TypeId::of::<[u8; usize::MAX]>().trait_info_of::<dyn Trait>();
+    //~^ ERROR: comptime fns can only be called at compile time
 }

--- a/tests/ui/reflection/reflection_methods_in_runtime_code.stderr
+++ b/tests/ui/reflection/reflection_methods_in_runtime_code.stderr
@@ -1,0 +1,8 @@
+error: comptime fns can only be called at compile time
+  --> $DIR/reflection_methods_in_runtime_code.rs:7:5
+   |
+LL |     std::any::TypeId::of::<[u8; usize::MAX]>().trait_info_of::<dyn Trait>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
r? @fee1-dead 

follow-up to rust-lang/rust#148820 

I needed to add some more rustc code because turns out I forgot to add tests to the previous PR which actually codegen while using comptime fns. Check builds never try to create optimized MIR, so no code ever hit the assert that prevents creating optimized MIR for comptime fns. 
