### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -352,7 +352,8 @@ impl<'a> AstValidator<'a> {
 
     fn check_fn_decl(&self, fn_decl: &FnDecl, self_semantic: SelfSemantic) {
         self.check_decl_num_args(fn_decl);
-        self.check_decl_cvariadic_pos(fn_decl);
+        let c_variadic_span = self.check_decl_cvariadic_pos(fn_decl);
+        self.check_decl_splatting(fn_decl, c_variadic_span);
         self.check_decl_attrs(fn_decl);
         self.check_decl_self_param(fn_decl, self_semantic);
     }
@@ -370,16 +371,58 @@ impl<'a> AstValidator<'a> {
     /// Emits an error if a function declaration has a variadic parameter in the
     /// beginning or middle of parameter list.
     /// Example: `fn foo(..., x: i32)` will emit an error.
-    fn check_decl_cvariadic_pos(&self, fn_decl: &FnDecl) {
+    /// If a C-variadic parameter is found, returns its span.
+    fn check_decl_cvariadic_pos(&self, fn_decl: &FnDecl) -> Option<Span> {
+        let mut c_variadic_span = None;
+
         match &*fn_decl.inputs {
             [ps @ .., _] => {
                 for Param { ty, span, .. } in ps {
                     if let TyKind::CVarArgs = ty.kind {
+                        c_variadic_span = Some(*span);
                         self.dcx().emit_err(diagnostics::FnParamCVarArgsNotLast { span: *span });
                     }
                 }
             }
             _ => {}
+        }
+
+        if let Some(Param { ty, span, .. }) = &fn_decl.inputs.last()
+            && let TyKind::CVarArgs = ty.kind
+        {
+            c_variadic_span = Some(*span);
+        }
+
+        c_variadic_span
+    }
+
+    /// Emits an error if a function declaration has more than one splatted argument, with a
+    /// C-variadic parameter, or a splat at an unsupported index (for performance).
+    /// Example: `fn foo(#[splat] x: (), #[splat] y: ())` will emit an error.
+    fn check_decl_splatting(&self, fn_decl: &FnDecl, c_variadic_span: Option<Span>) {
+        let (splatted_arg_indexes, mut splatted_spans): (Vec<u16>, Vec<Span>) = fn_decl
+            .inputs
+            .iter()
+            .enumerate()
+            .filter_map(|(index, arg)| {
+                arg.attrs
+                    .iter()
+                    .any(|attr| attr.has_name(sym::splat))
+                    .then_some((u16::try_from(index).unwrap(), arg.span))
+            })
+            .unzip();
+
+        // Multiple splatted arguments are invalid: we can't know which arguments go in each splat.
+        if splatted_arg_indexes.len() > 1 {
+            self.dcx()
+                .emit_err(diagnostics::DuplicateSplattedArgs { spans: splatted_spans.clone() });
+        }
+
+        if let Some(c_variadic_span) = c_variadic_span
+            && !splatted_spans.is_empty()
+        {
+            splatted_spans.push(c_variadic_span);
+            self.dcx().emit_err(diagnostics::CVarArgsAndSplat { spans: splatted_spans });
         }
     }
 
@@ -396,6 +439,7 @@ impl<'a> AstValidator<'a> {
                     sym::deny,
                     sym::expect,
                     sym::forbid,
+                    sym::splat,
                     sym::warn,
                 ];
                 !attr.has_any_name(&arr) && rustc_attr_parsing::is_builtin_attr(*attr)

--- a/compiler/rustc_ast_passes/src/diagnostics.rs
+++ b/compiler/rustc_ast_passes/src/diagnostics.rs
@@ -124,6 +124,22 @@ pub(crate) struct FnParamCVarArgsNotLast {
 }
 
 #[derive(Diagnostic)]
+#[diag("multiple `#[splat]`s are not allowed in the same function")]
+#[help("remove `#[splat]` from all but one argument")]
+pub(crate) struct DuplicateSplattedArgs {
+    #[primary_span]
+    pub spans: Vec<Span>,
+}
+
+#[derive(Diagnostic)]
+#[diag("`...` and `#[splat]` are not allowed in the same function")]
+#[help("remove `#[splat]` or remove `...`")]
+pub(crate) struct CVarArgsAndSplat {
+    #[primary_span]
+    pub spans: Vec<Span>,
+}
+
+#[derive(Diagnostic)]
 #[diag("documentation comments cannot be applied to function parameters")]
 pub(crate) struct FnParamDocComment {
     #[primary_span]
@@ -131,6 +147,7 @@ pub(crate) struct FnParamDocComment {
     pub span: Span,
 }
 
+// FIXME(splat): add splat to the allowed built-in attributes when it is complete/stabilized
 #[derive(Diagnostic)]
 #[diag(
     "allow, cfg, cfg_attr, deny, expect, forbid, and warn are the only allowed built-in attributes in function parameters"

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -500,6 +500,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(pin_ergonomics, "pinned reference syntax is experimental");
     gate_all!(postfix_match, "postfix match is experimental");
     gate_all!(return_type_notation, "return type notation is experimental");
+    gate_all!(splat, "`fn(#[splat] (a, ...))` is incomplete", "call as func((a, ...)) instead");
     gate_all!(super_let, "`super let` is experimental");
     gate_all!(try_blocks_heterogeneous, "`try bikeshed` expression is experimental");
     gate_all!(unnamed_enum_variants, "unnamed enum variants are experimental");

--- a/compiler/rustc_attr_parsing/src/attributes/mod.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/mod.rs
@@ -69,6 +69,7 @@ pub(crate) mod rustc_allocator;
 pub(crate) mod rustc_dump;
 pub(crate) mod rustc_internal;
 pub(crate) mod semantics;
+pub(crate) mod splat;
 pub(crate) mod stability;
 pub(crate) mod test_attrs;
 pub(crate) mod traits;

--- a/compiler/rustc_attr_parsing/src/attributes/splat.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/splat.rs
@@ -1,0 +1,16 @@
+//! Attribute parsing for the `#[splat]` function argument overloading attribute.
+//! This attribute modifies typecheck to support overload resolution, then modifies codegen for performance.
+
+use rustc_feature::AttributeStability;
+
+use super::prelude::*;
+
+pub(crate) struct SplatParser;
+
+impl NoArgsAttributeParser for SplatParser {
+    const PATH: &[Symbol] = &[sym::splat];
+    const ALLOWED_TARGETS: AllowedTargets = AllowedTargets::AllowList(&[Allow(Target::Param)]);
+    const STABILITY: AttributeStability =
+        unstable!(splat, "the `#[splat]` attribute is experimental");
+    const CREATE: fn(Span) -> AttributeKind = AttributeKind::Splat;
+}

--- a/compiler/rustc_attr_parsing/src/context.rs
+++ b/compiler/rustc_attr_parsing/src/context.rs
@@ -57,6 +57,7 @@ use crate::attributes::rustc_allocator::*;
 use crate::attributes::rustc_dump::*;
 use crate::attributes::rustc_internal::*;
 use crate::attributes::semantics::{ComptimeParser, *};
+use crate::attributes::splat::*;
 use crate::attributes::stability::*;
 use crate::attributes::test_attrs::*;
 use crate::attributes::traits::*;
@@ -323,6 +324,7 @@ attribute_parsers!(
         Single<WithoutArgs<RustcStrictCoherenceParser>>,
         Single<WithoutArgs<RustcTrivialFieldReadsParser>>,
         Single<WithoutArgs<RustcUnsafeSpecializationMarkerParser>>,
+        Single<WithoutArgs<SplatParser>>,
         Single<WithoutArgs<ThreadLocalParser>>,
         Single<WithoutArgs<TrackCallerParser>>,
         // tidy-alphabetical-end

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -208,6 +208,12 @@ pub static BUILTIN_ATTRIBUTES: &[Symbol] = &[
     // - https://github.com/rust-lang/rust/issues/130494
     sym::pin_v2,
 
+    // The `#[splat]` attribute is part of the `splat` experiment
+    // that improves the ergonomics of function overloading, tracked in:
+    //
+    // - https://github.com/rust-lang/rust/issues/153629
+    sym::splat,
+
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -721,6 +721,9 @@ declare_features! (
     (unstable, sparc_target_feature, "1.84.0", Some(132783)),
     /// Allows specialization of implementations (RFC 1210).
     (incomplete, specialization, "1.7.0", Some(31844)),
+    /// Experimental "splatting" of function call arguments at the call site.
+    /// e.g. `foo(a, b, c)` calls `#[splat] fn foo((a: A, b: B, c: C))`.
+    (incomplete, splat, "CURRENT_RUSTC_VERSION", Some(153629)),
     /// Allows using `#[rustc_align_static(...)]` on static items.
     (unstable, static_align, "1.91.0", Some(146177)),
     /// Allows attributes on expressions and non-item statements.

--- a/compiler/rustc_hir/src/attrs/data_structures.rs
+++ b/compiler/rustc_hir/src/attrs/data_structures.rs
@@ -1589,6 +1589,9 @@ pub enum AttributeKind {
         reason: Option<Symbol>,
     },
 
+    /// Represents `#[splat]`
+    Splat(Span),
+
     /// Represents `#[stable]`, `#[unstable]` and `#[rustc_allowed_through_unstable_modules]`.
     Stability {
         stability: Stability,

--- a/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
+++ b/compiler/rustc_hir/src/attrs/encode_cross_crate.rs
@@ -192,6 +192,7 @@ impl AttributeKind {
             RustcUnsafeSpecializationMarker => No,
             Sanitize { .. } => No,
             ShouldPanic { .. } => No,
+            Splat(..) => Yes,
             Stability { .. } => Yes,
             TargetFeature { .. } => No,
             TestRunner(..) => Yes,

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -477,9 +477,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         base_ty: Unnormalized<'tcx, Ty<'tcx>>,
         base_fn_mode: CItemKind,
     ) -> Self {
-        // Skip normalization for opaques: the new solver would put the revealed
-        // hidden type into the `InferCtxt`'s `OpaqueTypeStorage` and trigger a
-        // delayed bug on drop (issue #156352).
+        // Skip normalization for opaques: even in `TypingMode::Borrowck` the body's own
+        // defining opaques still get revealed, leaving entries in `OpaqueTypeStorage` that
+        // ICE on `InferCtxt` drop (issue #156352).
         let base_ty = if base_ty.skip_norm_wip().has_opaque_types() {
             base_ty.skip_norm_wip()
         } else {
@@ -906,7 +906,10 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 help: None,
             },
 
-            // Reachable when the new solver reveals a body's defining opaque.
+            // Safety net for when normalization reveals a body's own defining opaque
+            // (e.g. `async extern fn`'s `impl Future` → `Coroutine`); the nicer
+            // "opaque types have no C equivalent" message comes from `visit_for_opaque_ty`
+            // in `check_type` before normalization (issue #156352).
             ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -468,12 +468,14 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         base_ty: Unnormalized<'tcx, Ty<'tcx>>,
         base_fn_mode: CItemKind,
     ) -> Self {
-        ImproperCTypesVisitor {
-            cx,
-            base_ty: maybe_normalize_erasing_regions(cx, base_ty),
-            base_fn_mode,
-            cache: FxHashSet::default(),
-        }
+        // Don't normalize opaques: the new solver populates OpaqueTypeStorage during
+        // normalization, causing a delayed bug on InferCtxt drop (issue #156352).
+        let base_ty = if base_ty.skip_norm_wip().has_opaque_types() {
+            base_ty.skip_norm_wip()
+        } else {
+            maybe_normalize_erasing_regions(cx, base_ty)
+        };
+        ImproperCTypesVisitor { cx, base_ty, base_fn_mode, cache: FxHashSet::default() }
     }
 
     /// Checks if the given indirection (box,ref,pointer) is "ffi-safe".
@@ -894,6 +896,16 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 help: None,
             },
 
+            // Can appear when the new solver reveals an opaque before the lint intercepts it.
+            ty::Closure(..)
+            | ty::CoroutineClosure(..)
+            | ty::Coroutine(..)
+            | ty::CoroutineWitness(..) => FfiUnsafe {
+                ty,
+                reason: msg!("closures and coroutines are not FFI-safe"),
+                help: None,
+            },
+
             ty::Param(..)
             | ty::Alias(ty::AliasTy {
                 kind: ty::Projection { .. } | ty::Inherent { .. } | ty::Free { .. },
@@ -902,10 +914,6 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             | ty::Infer(..)
             | ty::Bound(..)
             | ty::Error(_)
-            | ty::Closure(..)
-            | ty::CoroutineClosure(..)
-            | ty::Coroutine(..)
-            | ty::CoroutineWitness(..)
             | ty::Placeholder(..)
             | ty::FnDef(..) => bug!("unexpected type in foreign function: {:?}", ty),
         }
@@ -941,6 +949,11 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         state: VisitorState,
         ty: Unnormalized<'tcx, Ty<'tcx>>,
     ) -> FfiResult<'tcx> {
+        // Check before normalizing: the new solver can reveal opaques (e.g.
+        // `async extern fn` return → `Coroutine`), bypassing the opaque check below.
+        if let Some(res) = self.visit_for_opaque_ty(ty.skip_norm_wip()) {
+            return res;
+        }
         let ty = maybe_normalize_erasing_regions(self.cx, ty);
         if let Some(res) = self.visit_for_opaque_ty(ty) {
             return res;

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -147,7 +147,15 @@ fn maybe_normalize_erasing_regions<'tcx>(
     cx: &LateContext<'tcx>,
     value: Unnormalized<'tcx, Ty<'tcx>>,
 ) -> Ty<'tcx> {
-    cx.tcx.try_normalize_erasing_regions(cx.typing_env(), value).unwrap_or(value.skip_norm_wip())
+    // Use `TypingMode::Borrowck` so the new solver doesn't reveal opaques and
+    // leak `OpaqueTypeStorage` state on `InferCtxt` drop (issue #156352).
+    let typing_env = if let Some(body_id) = cx.enclosing_body {
+        let body_def_id = cx.tcx.hir_enclosing_body_owner(body_id.hir_id);
+        ty::TypingEnv::new(cx.param_env, ty::TypingMode::borrowck(cx.tcx, body_def_id))
+    } else {
+        cx.typing_env()
+    };
+    cx.tcx.try_normalize_erasing_regions(typing_env, value).unwrap_or(value.skip_norm_wip())
 }
 
 /// Check a variant of a non-exhaustive enum for improper ctypes
@@ -468,8 +476,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         base_ty: Unnormalized<'tcx, Ty<'tcx>>,
         base_fn_mode: CItemKind,
     ) -> Self {
-        // Don't normalize opaques: the new solver populates OpaqueTypeStorage during
-        // normalization, causing a delayed bug on InferCtxt drop (issue #156352).
+        // Skip normalization for opaques: the new solver would put the revealed
+        // hidden type into the `InferCtxt`'s `OpaqueTypeStorage` and trigger a
+        // delayed bug on drop (issue #156352).
         let base_ty = if base_ty.skip_norm_wip().has_opaque_types() {
             base_ty.skip_norm_wip()
         } else {
@@ -896,7 +905,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
                 help: None,
             },
 
-            // Can appear when the new solver reveals an opaque before the lint intercepts it.
+            // Reachable when the new solver reveals a body's defining opaque.
             ty::Closure(..)
             | ty::CoroutineClosure(..)
             | ty::Coroutine(..)
@@ -949,8 +958,9 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         state: VisitorState,
         ty: Unnormalized<'tcx, Ty<'tcx>>,
     ) -> FfiResult<'tcx> {
-        // Check before normalizing: the new solver can reveal opaques (e.g.
-        // `async extern fn` return → `Coroutine`), bypassing the opaque check below.
+        // Catch opaques before normalization so the new solver doesn't reveal them
+        // (e.g. `async extern fn` return → `Coroutine`) and we get the nicer
+        // "opaque types have no C equivalent" message.
         if let Some(res) = self.visit_for_opaque_ty(ty.skip_norm_wip()) {
             return res;
         }

--- a/compiler/rustc_lint/src/types/improper_ctypes.rs
+++ b/compiler/rustc_lint/src/types/improper_ctypes.rs
@@ -147,8 +147,9 @@ fn maybe_normalize_erasing_regions<'tcx>(
     cx: &LateContext<'tcx>,
     value: Unnormalized<'tcx, Ty<'tcx>>,
 ) -> Ty<'tcx> {
-    // Use `TypingMode::Borrowck` so the new solver doesn't reveal opaques and
-    // leak `OpaqueTypeStorage` state on `InferCtxt` drop (issue #156352).
+    // Use `TypingMode::Borrowck` so the new solver doesn't reveal opaque types since we're now
+    // past hir typeck. If we were to attempt to reveal more opaque types, dropping the
+    // `InferCtxt` would ICE (see #156352).
     let typing_env = if let Some(body_id) = cx.enclosing_body {
         let body_def_id = cx.tcx.hir_enclosing_body_owner(body_id.hir_id);
         ty::TypingEnv::new(cx.param_env, ty::TypingMode::borrowck(cx.tcx, body_def_id))

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -402,6 +402,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             AttributeKind::RustcUnsafeSpecializationMarker => (),
             AttributeKind::Sanitize { .. } => {}
             AttributeKind::ShouldPanic { .. } => (),
+            AttributeKind::Splat(..) => (),
             AttributeKind::Stability { .. } => (),
             AttributeKind::TestRunner(..) => (),
             AttributeKind::ThreadLocal => (),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1976,6 +1976,7 @@ symbols! {
         specialization,
         speed,
         spirv,
+        splat,
         spotlight,
         sqrtf16,
         sqrtf32,

--- a/tests/debuginfo/pretty-std.rs
+++ b/tests/debuginfo/pretty-std.rs
@@ -109,12 +109,15 @@
 //@ cdb-check:    [10]             : 103 'g' [Type: char]
 //@ cdb-check:    [11]             : 33 '!' [Type: char]
 
-//@ cdb-command: dx os_string
-// NOTE: OSString is WTF-8 encoded which Windows debuggers don't understand. Verify the UTF-8
-//       portion displays correctly.
-//@ cdb-check:os_string        : "IAMA OS string [...]" [Type: std::ffi::os_str::OsString]
-//@ cdb-check:    [<Raw View>]     [Type: std::ffi::os_str::OsString]
-//@ cdb-check:    [chars]          : "IAMA OS string [...]"
+// FIXME(#88840, #148743, #88796): since approx. Windows SDK 20348, the corresponding cdb (and/or
+// its underlying WinDbg engine) changed or regressed the `OsStr`/`OsString` visualization, and no
+// longer renders the emoji. Since approx. 26100, the output formatting of the string containing
+// UTF-8 (i.e. the multi-byte emoji grapheme) seems to have further regressed (e.g. the end
+// quotation mark is no longer shown and command output becomes garbled).
+//(DISABLED) @ cdb-command: dx os_string
+//(DISABLED) @ cdb-check:os_string        : "IAMA OS string 😃" [Type: std::ffi::os_str::OsString]
+//(DISABLED) @ cdb-check:    [<Raw View>]     [Type: std::ffi::os_str::OsString]
+//(DISABLED) @ cdb-check:    [chars]          : "IAMA OS string 😃"
 
 //@ cdb-command: dx some
 //@ cdb-check:some             : Some [Type: enum2$<core::option::Option<i16> >]

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -1291,6 +1291,12 @@ An assorted collection of tests that involves specific diagnostic spans.
 
 See [Tracking issue for specialization (RFC 1210) #31844](https://github.com/rust-lang/rust/issues/31844).
 
+## `tests/ui/splat`
+
+Tests for the `#![feature(splat)]` attribute.
+
+See [Tracking Issue for argument splatting #153629](https://github.com/rust-lang/rust/issues/153629).
+
 ## `tests/ui/stability-attribute/`
 
 Stability attributes used internally by the standard library: `#[stable()]` and `#[unstable()]`.

--- a/tests/ui/feature-gates/feature-gate-splat.rs
+++ b/tests/ui/feature-gates/feature-gate-splat.rs
@@ -1,0 +1,8 @@
+#[rustfmt::skip]
+fn tuple_args(
+    #[splat] //~ ERROR the `#[splat]` attribute is an experimental feature
+    (a, b, c): (u32, i8, char),
+) {
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-splat.stderr
+++ b/tests/ui/feature-gates/feature-gate-splat.stderr
@@ -1,0 +1,14 @@
+error[E0658]: the `#[splat]` attribute is an experimental feature
+  --> $DIR/feature-gate-splat.rs:3:5
+   |
+LL |     #[splat]
+   |     ^^^^^^^^
+   |
+   = note: see issue #153629 <https://github.com/rust-lang/rust/issues/153629> for more information
+   = help: add `#![feature(splat)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: the `#[splat]` attribute is experimental
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/lint/improper-ctypes/async-extern-fn-next-solver-issue-156352.rs
+++ b/tests/ui/lint/improper-ctypes/async-extern-fn-next-solver-issue-156352.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -Znext-solver=globally
+//@ edition: 2021
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/156352>.
+// `async extern "system" fn` was ICE-ing with the new solver because
+// `improper_ctypes_definitions` normalized the opaque return type all the way
+// to a `Coroutine`, which hit an unexpected `bug!`. After the fix the lint
+// fires with "opaque types have no C equivalent" instead of crashing.
+
+#![allow(improper_ctypes_definitions)]
+
+async extern "system" fn check_valid_subset(h: usize) {}
+
+fn main() {}

--- a/tests/ui/splat/splat-invalid.rs
+++ b/tests/ui/splat/splat-invalid.rs
@@ -1,0 +1,33 @@
+//! Test using `#[splat]` incorrectly, in ways not covered by other tests.
+
+#![allow(incomplete_features)]
+#![feature(splat)]
+#![feature(c_variadic)]
+
+fn multisplat_bad(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
+//~^ ERROR multiple `#[splat]`s are not allowed in the same function
+
+unsafe extern "C" fn splat_variadic(#[splat] (_a, _b): (u32, i8), varargs: ...) {}
+//~^ ERROR `...` and `#[splat]` are not allowed in the same function
+
+unsafe extern "C" fn splat_variadic2(varargs: ..., #[splat] (_a, _b): (u32, i8)) {}
+//~^ ERROR `...` and `#[splat]` are not allowed in the same function
+//~| ERROR `...` must be the last argument of a C-variadic function
+
+extern "C" {
+    fn splat_variadic3(#[splat] (_a, _b): (u32, i8), ...) {}
+    //~^ ERROR incorrect function inside `extern` block
+    //~| ERROR `...` and `#[splat]` are not allowed in the same function
+
+    fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
+    //~^ ERROR incorrect function inside `extern` block
+    //~| ERROR `...` and `#[splat]` are not allowed in the same function
+    //~| ERROR `...` must be the last argument of a C-variadic function
+
+    // FIXME(splat): tuple layouts are unspecified. Should this error in addition to
+    // the existing `improper_ctypes` lint?
+    #[expect(improper_ctypes)]
+    fn bar_2(#[splat] _: (u32, i8));
+}
+
+fn main() {}

--- a/tests/ui/splat/splat-invalid.stderr
+++ b/tests/ui/splat/splat-invalid.stderr
@@ -1,0 +1,77 @@
+error: multiple `#[splat]`s are not allowed in the same function
+  --> $DIR/splat-invalid.rs:7:19
+   |
+LL | fn multisplat_bad(#[splat] (_a, _b): (u32, i8), #[splat] (_c, _d): (u32, i8)) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `#[splat]` from all but one argument
+
+error: `...` and `#[splat]` are not allowed in the same function
+  --> $DIR/splat-invalid.rs:10:37
+   |
+LL | unsafe extern "C" fn splat_variadic(#[splat] (_a, _b): (u32, i8), varargs: ...) {}
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^
+   |
+   = help: remove `#[splat]` or remove `...`
+
+error: `...` must be the last argument of a C-variadic function
+  --> $DIR/splat-invalid.rs:13:38
+   |
+LL | unsafe extern "C" fn splat_variadic2(varargs: ..., #[splat] (_a, _b): (u32, i8)) {}
+   |                                      ^^^^^^^^^^^^
+
+error: `...` and `#[splat]` are not allowed in the same function
+  --> $DIR/splat-invalid.rs:13:38
+   |
+LL | unsafe extern "C" fn splat_variadic2(varargs: ..., #[splat] (_a, _b): (u32, i8)) {}
+   |                                      ^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `#[splat]` or remove `...`
+
+error: incorrect function inside `extern` block
+  --> $DIR/splat-invalid.rs:18:8
+   |
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     fn splat_variadic3(#[splat] (_a, _b): (u32, i8), ...) {}
+   |        ^^^^^^^^^^^^^^^ cannot have a body                 -- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: `...` and `#[splat]` are not allowed in the same function
+  --> $DIR/splat-invalid.rs:18:24
+   |
+LL |     fn splat_variadic3(#[splat] (_a, _b): (u32, i8), ...) {}
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^
+   |
+   = help: remove `#[splat]` or remove `...`
+
+error: incorrect function inside `extern` block
+  --> $DIR/splat-invalid.rs:22:8
+   |
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+...
+LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
+   |        ^^^^^^^^^^^^^^^ cannot have a body                 -- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: `...` must be the last argument of a C-variadic function
+  --> $DIR/splat-invalid.rs:22:24
+   |
+LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
+   |                        ^^^
+
+error: `...` and `#[splat]` are not allowed in the same function
+  --> $DIR/splat-invalid.rs:22:24
+   |
+LL |     fn splat_variadic4(..., #[splat] (_a, _b): (u32, i8)) {}
+   |                        ^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: remove `#[splat]` or remove `...`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/splat/splat-non-fn-arg.rs
+++ b/tests/ui/splat/splat-non-fn-arg.rs
@@ -1,0 +1,59 @@
+//! Test that using `#[splat]` on non-function-arguments is an error.
+
+#![allow(incomplete_features)]
+#![feature(splat)]
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on functions
+fn tuple_args_bad((a, b): (u32, i8)) {}
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on traits
+trait FooTraitBad {
+    fn tuple_1(_: (u32,));
+
+    fn tuple_4(self, _: (u32, i8, (), f32));
+}
+
+struct Foo;
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on inherent impl blocks
+impl Foo {
+    fn tuple_1_bad((a,): (u32,)) {}
+}
+
+impl Foo {
+    #[splat] //~ ERROR `#[splat]` attribute cannot be used on inherent methods
+    fn tuple_3_bad((a, b, c): (u32, i32, i8)) {}
+
+    #[splat] //~ ERROR `#[splat]` attribute cannot be used on inherent methods
+    fn tuple_2_bad(self, (a, b): (u32, i8)) -> u32 {
+        a
+    }
+}
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on trait impl blocks
+impl FooTraitBad for Foo {
+    fn tuple_1(_: (u32,)) {}
+
+    fn tuple_4(self, _: (u32, i8, (), f32)) {}
+}
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on foreign modules
+extern "C" {
+    fn foo_2(_: (u32, i8));
+}
+
+extern "C" {
+    #[splat] //~ ERROR `#[splat]` attribute cannot be used on foreign functions
+    fn bar_2_bad(_: (u32, i8));
+}
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on modules
+mod foo_mod {}
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on use statements
+use std::mem;
+
+#[splat] //~ ERROR `#[splat]` attribute cannot be used on structs
+struct FooStruct;
+
+fn main() {}

--- a/tests/ui/splat/splat-non-fn-arg.stderr
+++ b/tests/ui/splat/splat-non-fn-arg.stderr
@@ -1,0 +1,90 @@
+error: `#[splat]` attribute cannot be used on functions
+  --> $DIR/splat-non-fn-arg.rs:6:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on traits
+  --> $DIR/splat-non-fn-arg.rs:9:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on inherent impl blocks
+  --> $DIR/splat-non-fn-arg.rs:18:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on inherent methods
+  --> $DIR/splat-non-fn-arg.rs:24:5
+   |
+LL |     #[splat]
+   |     ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on inherent methods
+  --> $DIR/splat-non-fn-arg.rs:27:5
+   |
+LL |     #[splat]
+   |     ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on trait impl blocks
+  --> $DIR/splat-non-fn-arg.rs:33:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on foreign modules
+  --> $DIR/splat-non-fn-arg.rs:40:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on foreign functions
+  --> $DIR/splat-non-fn-arg.rs:46:5
+   |
+LL |     #[splat]
+   |     ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on modules
+  --> $DIR/splat-non-fn-arg.rs:50:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on use statements
+  --> $DIR/splat-non-fn-arg.rs:53:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: `#[splat]` attribute cannot be used on structs
+  --> $DIR/splat-non-fn-arg.rs:56:1
+   |
+LL | #[splat]
+   | ^^^^^^^^
+   |
+   = help: `#[splat]` can only be applied to function params
+
+error: aborting due to 11 previous errors
+


### PR DESCRIPTION
Successful merges:

 - rust-lang/rust#157503 (Disable `tests/debuginfo/pretty-std.rs` `OsString` cdb check)
 - rust-lang/rust#156399 (fix improper ctypes in Znext solver)
 - rust-lang/rust#157605 (Arg splat experiment - syntax impl)

<!-- homu-ignore:start -->
r? @ghost

[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=157503,156399,157605)
<!-- homu-ignore:end -->

