### PR TITLE
rustc_target: Add OpenEmbedded/Yocto Linux base targets

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1824,6 +1824,12 @@ supported_targets! {
     ("x86_64-unknown-linux-gnuasan", x86_64_unknown_linux_gnuasan),
     ("x86_64-unknown-linux-gnumsan", x86_64_unknown_linux_gnumsan),
     ("x86_64-unknown-linux-gnutsan", x86_64_unknown_linux_gnutsan),
+
+    ("aarch64-oe-linux-gnu", aarch64_oe_linux_gnu),
+    ("armv7-oe-linux-gnueabihf", armv7_oe_linux_gnueabihf),
+    ("i686-oe-linux-gnu", i686_oe_linux_gnu),
+    ("riscv64-oe-linux-gnu", riscv64_oe_linux_gnu),
+    ("x86_64-oe-linux-gnu", x86_64_oe_linux_gnu),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>

--- a/compiler/rustc_target/src/spec/targets/aarch64_oe_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_oe_linux_gnu.rs
@@ -1,0 +1,17 @@
+use crate::spec::{Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::aarch64_unknown_linux_gnu::target();
+
+    base.metadata = TargetMetadata {
+        description: Some("64-bit Linux (kernel 3.2+, glibc 2.17+) for yocto".into()),
+        tier: Some(3),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+
+    base.llvm_target = "aarch64-oe-linux-gnu".into();
+    base.options.linker = Some("aarch64-oe-linux-gcc".into());
+
+    base
+}

--- a/compiler/rustc_target/src/spec/targets/armv7_oe_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_oe_linux_gnueabihf.rs
@@ -1,0 +1,17 @@
+use crate::spec::{Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::armv7_unknown_linux_gnueabihf::target();
+
+    base.metadata = TargetMetadata {
+        description: Some("Armv7-A Linux, hardfloat (kernel 3.2, glibc 2.17) for yocto".into()),
+        tier: Some(3),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+
+    base.llvm_target = "armv7-oe-linux-gnueabihf".into();
+    base.options.linker = Some("arm-oe-linux-gnueabi-gcc".into());
+
+    base
+}

--- a/compiler/rustc_target/src/spec/targets/i686_oe_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_oe_linux_gnu.rs
@@ -1,0 +1,21 @@
+use crate::spec::{Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::i686_unknown_linux_gnu::target();
+
+    base.metadata = TargetMetadata {
+        description: Some("32-bit Linux (kernel 3.2, glibc 2.17+) for yocto".into()),
+        tier: Some(3),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+
+    base.llvm_target = "i686-oe-linux-gnu".into();
+
+    base.options.linker = Some("i686-oe-linux-gcc".into());
+
+    base.options.cpu = "core2".into();
+    base.options.features = "+sse3".into();
+
+    base
+}

--- a/compiler/rustc_target/src/spec/targets/riscv64_oe_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64_oe_linux_gnu.rs
@@ -1,0 +1,17 @@
+use crate::spec::{Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::riscv64gc_unknown_linux_gnu::target();
+
+    base.metadata = TargetMetadata {
+        description: Some("RISC-V Linux (kernel 4.20, glibc 2.29) for yocto".into()),
+        tier: Some(3),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+
+    base.llvm_target = "riscv64-oe-linux-gnu".into();
+    base.options.linker = Some("riscv64-oe-linux-gcc".into());
+
+    base
+}

--- a/compiler/rustc_target/src/spec/targets/x86_64_oe_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_oe_linux_gnu.rs
@@ -1,0 +1,17 @@
+use crate::spec::{Target, TargetMetadata};
+
+pub(crate) fn target() -> Target {
+    let mut base = super::x86_64_unknown_linux_gnu::target();
+
+    base.metadata = TargetMetadata {
+        description: Some("64-bit Linux (kernel 3.2+, glibc 2.17+) for yocto".into()),
+        tier: Some(3),
+        host_tools: Some(false),
+        std: Some(true),
+    };
+
+    base.llvm_target = "x86_64-oe-linux-gnu".into();
+    base.options.linker = Some("x86_64-oe-linux-gcc".into());
+
+    base
+}

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -103,6 +103,7 @@
     - [mips\*-mti-none-elf](platform-support/mips-mti-none-elf.md)
     - [mipsisa\*r6\*-unknown-linux-gnu\*](platform-support/mips-release-6.md)
     - [nvptx64-nvidia-cuda](platform-support/nvptx64-nvidia-cuda.md)
+    - [\*-oe-linux-gnu](platform-support/oe-linux-gnu.md)
     - [powerpc-unknown-openbsd](platform-support/powerpc-unknown-openbsd.md)
     - [powerpc-unknown-linux-gnuspe](platform-support/powerpc-unknown-linux-gnuspe.md)
     - [powerpc-unknown-linux-muslspe](platform-support/powerpc-unknown-linux-muslspe.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -267,6 +267,7 @@ target | std | host | notes
 -------|:---:|:----:|-------
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
+[`aarch64-oe-linux-gnu`](platform-support/oe-linux-gnu.md) | ✓ |  | ARM64 OpenEmbedded/Yocto Linux (GNU)
 [`aarch64-unknown-helenos`](platform-support/helenos.md) | ✓ |  | ARM64 HelenOS
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit
 [`aarch64-unknown-illumos`](platform-support/illumos.md) | ✓ | ✓ | ARM64 illumos
@@ -309,6 +310,7 @@ target | std | host | notes
 [`armv6-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | Armv6 FreeBSD
 [`armv6-unknown-netbsd-eabihf`](platform-support/netbsd.md) | ✓ | ✓ | Armv6 NetBSD w/hard-float
 [`armv6k-nintendo-3ds`](platform-support/armv6k-nintendo-3ds.md) | ? |  | Armv6k Nintendo 3DS, Horizon (Requires devkitARM toolchain)
+[`armv7-oe-linux-gnueabihf`](platform-support/oe-linux-gnu.md) | ✓ |  | ARMv7 OpenEmbedded/Yocto Linux (GNU)
 [`armv7-rtems-eabihf`](platform-support/armv7-rtems-eabihf.md) | ? |  | RTEMS OS for ARM BSPs
 [`armv7-sony-vita-newlibeabihf`](platform-support/armv7-sony-vita-newlibeabihf.md) | ✓ |  | Armv7-A Cortex-A9 Sony PlayStation Vita (requires VITASDK toolchain)
 [`armv7-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | Armv7-A FreeBSD
@@ -336,6 +338,7 @@ target | std | host | notes
 [`i586-unknown-netbsd`](platform-support/netbsd.md) | ✓ |  | 32-bit x86 (original Pentium) [^x86_32-floats-x87]
 [`i586-unknown-redox`](platform-support/redox.md) | ✓ |  | 32-bit x86 Redox OS (PentiumPro) [^x86_32-floats-x87]
 [`i686-apple-darwin`](platform-support/apple-darwin.md) | ✓ | ✓ | 32-bit macOS (10.12+, Sierra+, Penryn) [^x86_32-floats-return-ABI]
+[`i686-oe-linux-gnu`](platform-support/oe-linux-gnu.md) | ✓ |  | 32-bit x86 OpenEmbedded/Yocto Linux (GNU)
 [`i686-pc-nto-qnx700`](platform-support/nto-qnx.md) | * |  | 32-bit x86 QNX Neutrino 7.0 RTOS (Pentium 4) [^x86_32-floats-return-ABI]
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku (Pentium 4) [^x86_32-floats-return-ABI]
 [`i686-unknown-helenos`](platform-support/helenos.md) | ✓ |  | HelenOS IA-32 (see docs for pending issues)
@@ -405,6 +408,7 @@ target | std | host | notes
 [`riscv32imc-esp-espidf`](platform-support/esp-idf.md) | ✓ |  | RISC-V ESP-IDF
 [`riscv32imc-unknown-nuttx-elf`](platform-support/nuttx.md) | ✓ |  | RISC-V 32bit with NuttX
 [`riscv64-linux-android`](platform-support/android.md) | ? |  | RISC-V 64-bit Android
+[`riscv64-oe-linux-gnu`](platform-support/oe-linux-gnu.md) | ✓ |  | RISC-V OpenEmbedded/Yocto Linux (GNU)
 [`riscv64-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |
 `riscv64gc-unknown-freebsd` | ? |  | RISC-V FreeBSD
 `riscv64gc-unknown-fuchsia` | ? |  | RISC-V Fuchsia
@@ -442,6 +446,7 @@ target | std | host | notes
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
 [`x86_64-lynx-lynxos178`](platform-support/lynxos178.md) |  |  | x86_64 LynxOS-178
+[`x86_64-oe-linux-gnu`](platform-support/oe-linux-gnu.md) | ✓ |  | x86 64-bit OpenEmbedded/Yocto Linux (GNU)
 [`x86_64-pc-cygwin`](platform-support/x86_64-pc-cygwin.md) | ✓ |  | 64-bit x86 Cygwin |
 [`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
 [`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with new network stack (io-sock) |

--- a/src/doc/rustc/src/platform-support/oe-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/oe-linux-gnu.md
@@ -1,0 +1,41 @@
+# `*-oe-linux-gnu`
+
+**Tier: 3**
+
+Targets for OpenEmbedded/Yocto-based Linux systems.
+
+Target triplets available:
+
+* `x86_64-oe-linux-gnu`
+* `aarch64-oe-linux-gnu`
+* `i686-oe-linux-gnu`
+* `armv7-oe-linux-gnueabihf`
+* `riscv64-oe-linux-gnu`
+
+## Target maintainers
+
+[@DeepeshWR](https://github.com/DeepeshWR)
+
+## Requirements
+
+### Operating System
+
+These targets are intended for Linux systems built using the OpenEmbedded and Yocto Project build systems.
+
+### C Toolchain
+
+The targets use the architecture-specific OpenEmbedded GCC driver as the default linker and therefore require the corresponding OpenEmbedded cross-compilation toolchain to be available in the build environment.
+
+## Building
+
+These targets are intended for use with the OpenEmbedded/Yocto build system. They provide base target definitions from which downstream Yocto-generated targets may inherit.
+
+## Building Rust programs
+
+Rust does not currently ship precompiled artifacts for these targets.
+
+Downstream Yocto-generated targets may inherit from these base OpenEmbedded targets and customize metadata or vendor-specific configuration as needed.
+
+## Cross-compilation toolchains and C code
+
+The targets support linking with C code through the corresponding OpenEmbedded cross-compilation toolchains.

--- a/tests/assembly-llvm/targets/targets-elf.rs
+++ b/tests/assembly-llvm/targets/targets-elf.rs
@@ -28,6 +28,9 @@
 //@ revisions: aarch64_nintendo_switch_freestanding
 //@ [aarch64_nintendo_switch_freestanding] compile-flags: --target aarch64-nintendo-switch-freestanding
 //@ [aarch64_nintendo_switch_freestanding] needs-llvm-components: aarch64
+//@ revisions: aarch64_oe_linux_gnu
+//@ [aarch64_oe_linux_gnu] compile-flags: --target aarch64-oe-linux-gnu
+//@ [aarch64_oe_linux_gnu] needs-llvm-components: aarch64
 //@ revisions: aarch64_unknown_freebsd
 //@ [aarch64_unknown_freebsd] compile-flags: --target aarch64-unknown-freebsd
 //@ [aarch64_unknown_freebsd] needs-llvm-components: aarch64
@@ -163,6 +166,9 @@
 //@ revisions: armv7_linux_androideabi
 //@ [armv7_linux_androideabi] compile-flags: --target armv7-linux-androideabi
 //@ [armv7_linux_androideabi] needs-llvm-components: arm
+//@ revisions: armv7_oe_linux_gnueabihf
+//@ [armv7_oe_linux_gnueabihf] compile-flags: --target armv7-oe-linux-gnueabihf
+//@ [armv7_oe_linux_gnueabihf] needs-llvm-components: arm
 //@ revisions: armv7_rtems_eabihf
 //@ [armv7_rtems_eabihf] compile-flags: --target armv7-rtems-eabihf
 //@ [armv7_rtems_eabihf] needs-llvm-components: arm
@@ -268,6 +274,9 @@
 //@ revisions: i686_linux_android
 //@ [i686_linux_android] compile-flags: --target i686-linux-android
 //@ [i686_linux_android] needs-llvm-components: x86
+//@ revisions: i686_oe_linux_gnu
+//@ [i686_oe_linux_gnu] compile-flags: --target i686-oe-linux-gnu
+//@ [i686_oe_linux_gnu] needs-llvm-components: x86
 //@ revisions: i686_unknown_freebsd
 //@ [i686_unknown_freebsd] compile-flags: --target i686-unknown-freebsd
 //@ [i686_unknown_freebsd] needs-llvm-components: x86
@@ -499,6 +508,9 @@
 //@ revisions: riscv64_linux_android
 //@ [riscv64_linux_android] compile-flags: --target riscv64-linux-android
 //@ [riscv64_linux_android] needs-llvm-components: riscv
+//@ revisions: riscv64_oe_linux_gnu
+//@ [riscv64_oe_linux_gnu] compile-flags: --target riscv64-oe-linux-gnu
+//@ [riscv64_oe_linux_gnu] needs-llvm-components: riscv
 //@ revisions: riscv64_wrs_vxworks
 //@ [riscv64_wrs_vxworks] compile-flags: --target riscv64-wrs-vxworks
 //@ [riscv64_wrs_vxworks] needs-llvm-components: riscv
@@ -661,6 +673,9 @@
 //@ revisions: x86_64_lynx_lynxos178
 //@ [x86_64_lynx_lynxos178] compile-flags: --target x86_64-lynx-lynxos178
 //@ [x86_64_lynx_lynxos178] needs-llvm-components: x86
+//@ revisions: x86_64_oe_linux_gnu
+//@ [x86_64_oe_linux_gnu] compile-flags: --target x86_64-oe-linux-gnu
+//@ [x86_64_oe_linux_gnu] needs-llvm-components: x86
 //@ revisions: x86_64_pc_nto_qnx710
 //@ [x86_64_pc_nto_qnx710] compile-flags: --target x86_64-pc-nto-qnx710
 //@ [x86_64_pc_nto_qnx710] needs-llvm-components: x86


### PR DESCRIPTION
Add built-in OpenEmbedded/Yocto Linux targets for x86_64, i686, aarch64, armv7, and riscv64.

These targets inherit from the corresponding upstream Linux GNU targets and provide OpenEmbedded-specific target triples and default linker settings. They are intended to serve as base targets for downstream Yocto/OpenEmbedded-generated targets, allowing vendor-specific targets to override metadata (for example, TARGET_VENDOR) while reusing a common target configuration.

This reduces duplication in Yocto-based Rust integrations and avoids maintaining downstream copies of largely identical target specifications.

**Tier 3 Policy Notes**

To cover the Tier 3 requirements:

> A tier 3 target must have a designated developer or developers

These targets have a designated maintainer: @DeepeshWR, as documented in the platform support documentation added by this PR.

> Targets must use naming consistent with any existing targets

The targets follow the existing target naming conventions and are derived from the corresponding upstream Linux GNU targets:

```
x86_64-oe-linux-gnu
aarch64-oe-linux-gnu
i686-oe-linux-gnu
armv7-oe-linux-gnueabihf
riscv64-oe-linux-gnu
```

The oe vendor component identifies OpenEmbedded/Yocto-based systems while preserving the established architecture/OS/ABI naming scheme.

> Tier 3 targets may have unusual requirements to build or use, but must not create legal issues or impose onerous legal terms for the Rust project or for Rust developers or users

These targets do not introduce any additional legal requirements. They use the standard OpenEmbedded/Yocto cross-compilation toolchains and are intended to behave similarly to the corresponding Linux GNU targets.

> Tier 3 targets should attempt to implement as much of the standard libraries as possible and appropriate

These targets inherit from the corresponding Linux GNU targets and support the standard library in the same manner as their upstream counterparts.

> The target must provide documentation for the Rust community explaining how to build for the target

This PR adds platform-support documentation describing the targets, maintainership, requirements, and intended usage.

> Tier 3 targets must not impose burden on the authors of pull requests, or other developers in the community, to maintain the target

The targets are thin wrappers around existing Linux GNU targets and primarily provide canonical OpenEmbedded/Yocto target triples and default linker configuration. They do not require additional CI infrastructure or special maintenance beyond keeping them aligned with their upstream Linux GNU base targets.

> Patches adding or updating tier 3 targets must not break any existing tier 2 or tier 1 target, and must not knowingly break another tier 3 target without approval of either the compiler team or the maintainers of the other tier 3 target

Noted.

> Tier 3 targets must be able to produce assembly using at least one of rustc's supported backends from any host target

These targets use LLVM through the existing Rust code generation pipeline, just like their corresponding Linux GNU targets.

r? @davidtwco 