### PR TITLE
fix doc for unicode normalization faq on `casefold` APIs

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -733,7 +733,7 @@ impl str {
     /// assert_eq!(decomp.to_casefold_unnormalized(), "a\u{030A}");
     /// ```
     ///
-    /// [normalization]: https://www.unicode.org/faq/normalization
+    /// [normalization]: https://www.unicode.org/faq/normalization.html
     #[cfg(not(no_global_oom_handling))]
     #[rustc_allow_incoherent_impl]
     #[must_use = "this returns the case-folded string as a new String, \

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1647,7 +1647,7 @@ impl char {
     ///
     /// holds across languages.
     ///
-    /// [normalization]: https://www.unicode.org/faq/normalization
+    /// [normalization]: https://www.unicode.org/faq/normalization.html
     #[must_use = "this returns the case-folded character as a new iterator, \
                   without modifying the original"]
     #[unstable(feature = "casefold", issue = "154742")]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2902,7 +2902,7 @@ impl str {
     /// assert!(!comp.eq_ignore_case_unnormalized(decomp));
     /// ```
     ///
-    /// [normalization]: https://www.unicode.org/faq/normalization
+    /// [normalization]: https://www.unicode.org/faq/normalization.html
     #[unstable(feature = "casefold", issue = "154742")]
     #[must_use]
     #[inline]


### PR DESCRIPTION
APIs added in https://github.com/rust-lang/rust/pull/154742 have an outbound doc link to https://www.unicode.org/faq/normalization, but this URL appears to not exist.

The correct URL appears to be https://www.unicode.org/faq/normalization.html

cc @Jules-Bertholet 