### PR TITLE
Make Share::share final and improve docs

### DIFF
--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -293,21 +293,36 @@ pub macro Clone($item:item) {
 /// A trait for types whose [`Clone`] operation creates another alias to the same
 /// logical resource or shared state.
 ///
-/// `Share` marks types where cloning creates another handle, reference, or alias
-/// to the same logical resource or shared state, rather than an independent owned
-/// value. The distinction is semantic, not cost-based: implementing `Share` does
-/// not merely mean that cloning is cheap, constant-time, allocation-free, or
-/// convenient.
+/// `Share` refines the meaning of [`Clone`] for types where cloning a value
+/// creates another handle, reference, or alias to the same logical resource or
+/// shared state, rather than an independent owned value. The distinction is
+/// semantic, not operational: `Share` does not mean merely that cloning is
+/// cheap, constant-time, allocation-free, or convenient.
 ///
-/// Calling [`share`](Share::share) is equivalent to calling [`clone`](Clone::clone)
-/// for implementors, but communicates that the resulting value aliases the same
-/// underlying resource.
+/// `Share` is a third way to think about creating another usable value:
+///
+/// * [`Copy`] may duplicate a value implicitly.
+/// * [`Clone`] explicitly creates another value.
+/// * `Share` explicitly creates another value that aliases the same underlying
+///   logical resource or shared state.
+///
+/// `Share` is not a replacement for either [`Copy`] or [`Clone`], and neither
+/// trait implies it. For example, integers are [`Copy`] but not `Share`, because
+/// copying an integer creates an independent value. Likewise, not every cheap
+/// [`Clone`] implementation is `Share`.
 ///
 /// Shared references, `Rc<T>`, `Arc<T>`, `Sender<T>`, and `SyncSender<T>` are
 /// examples of types that can be shared this way. Types such as `Vec<T>`,
-/// `String`, and `Box<T>` are not `Share` even though they implement `Clone`,
-/// because cloning them creates another owned value rather than another handle
-/// to the same logical resource.
+/// `String`, `Box<T>`, owned collections, and similar owned values are not
+/// `Share`, even though they implement [`Clone`], because cloning them creates
+/// independent owned storage or value ownership. Mutable references (`&mut T`)
+/// are not `Share`.
+///
+/// Calling [`share`](Share::share) is equivalent to calling [`clone`](Clone::clone)
+/// for implementors, but communicates that the resulting value aliases the same
+/// underlying resource. The `share` method is final, so implementors should
+/// define the operation through [`Clone::clone`] and implement `Share` only when
+/// those cloning semantics are clone-as-alias semantics.
 ///
 /// # Examples
 ///
@@ -367,9 +382,11 @@ pub macro Clone($item:item) {
 pub trait Share: Clone {
     /// Creates another alias to the same underlying resource or shared state.
     ///
-    /// This is equivalent to calling [`Clone::clone`].
+    /// This is equivalent to calling [`Clone::clone`]. Use `share` at call
+    /// sites to make aliasing intent explicit; implementors define this
+    /// operation through [`Clone::clone`], not by overriding this method.
     #[unstable(feature = "share_trait", issue = "156756")]
-    fn share(&self) -> Self {
+    final fn share(&self) -> Self {
         Clone::clone(self)
     }
 }

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -316,7 +316,7 @@ pub macro Clone($item:item) {
 /// `String`, `Box<T>`, owned collections, and similar owned values are not
 /// `Share`, even though they implement [`Clone`], because cloning them creates
 /// independent owned storage or value ownership. Mutable references (`&mut T`)
-/// are not `Share`.
+/// are neither `Clone` nor `Share`, because you cannot have two active at once.
 ///
 /// Calling [`share`](Share::share) is equivalent to calling [`clone`](Clone::clone)
 /// for implementors, but communicates that the resulting value aliases the same

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -138,6 +138,7 @@
 #![feature(f16)]
 #![feature(f128)]
 #![feature(field_projections)]
+#![feature(final_associated_functions)]
 #![feature(freeze_impls)]
 #![feature(fundamental)]
 #![feature(funnel_shifts)]

--- a/tests/ui/share-trait/share-trait-final-method.rs
+++ b/tests/ui/share-trait/share-trait-final-method.rs
@@ -1,0 +1,21 @@
+#![feature(final_associated_functions)]
+#![feature(share_trait)]
+
+use std::clone::Share;
+
+struct Alias;
+
+impl Clone for Alias {
+    fn clone(&self) -> Self {
+        Alias
+    }
+}
+
+impl Share for Alias {
+    fn share(&self) -> Self {
+        //~^ ERROR cannot override `share` because it already has a `final` definition in the trait
+        Alias
+    }
+}
+
+fn main() {}

--- a/tests/ui/share-trait/share-trait-final-method.stderr
+++ b/tests/ui/share-trait/share-trait-final-method.stderr
@@ -1,0 +1,11 @@
+error: cannot override `share` because it already has a `final` definition in the trait
+  --> $DIR/share-trait-final-method.rs:15:5
+   |
+LL |     fn share(&self) -> Self {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `share` is marked final here
+  --> $SRC_DIR/core/src/clone.rs:LL:COL
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Tracking issue: rust-lang/rust#156756

This follows up on the initial unstable `Share` trait added in rust-lang/rust#156828.

The original API used an ordinary default method:

```rust
fn share(&self) -> Self {
    Clone::clone(self)
}
```

Niko pointed out that `share` should be final, since `Share` is meant to communicate the semantics of `Clone::clone` for clone-as-alias types, not provide a second independently-overridable operation.

`Share` remains unstable under `#![feature(share_trait)]`.

r? @nikomatsakis 